### PR TITLE
feat(release): support version prefix for dependents

### DIFF
--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -149,6 +149,7 @@ To fix this you will either need to add a package.json file at that location, or
       });
 
       outputSpy.mockRestore();
+      expect(processExitSpy).toHaveBeenCalledWith(1);
 
       stubProcessExit = false;
     });
@@ -869,6 +870,7 @@ Valid values are: "auto", "", "~", "^"`,
       });
 
       outputSpy.mockRestore();
+      expect(processExitSpy).toHaveBeenCalledWith(1);
 
       stubProcessExit = false;
     });

--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -821,6 +821,35 @@ To fix this you will either need to add a package.json file at that location, or
         }
       `);
     });
+
+    it(`should exit with code one and print guidance for invalid prefix values`, async () => {
+      const processSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+        return undefined as never;
+      });
+      const outputSpy = jest.spyOn(output, 'error').mockImplementation(() => {
+        return undefined as never;
+      });
+
+      await releaseVersionGenerator(tree, {
+        projects: Object.values(projectGraph.nodes), // version all projects
+        projectGraph,
+        specifier: 'major',
+        currentVersionResolver: 'disk',
+        releaseGroup: createReleaseGroup('fixed'),
+        versionPrefix: '$',
+      });
+
+      expect(outputSpy).toHaveBeenCalledWith({
+        title: `Invalid value for version.generatorOptions.versionPrefix: "$"
+        
+Valid values are: "auto", "", "~", "^"`,
+      });
+
+      expect(processSpy).toHaveBeenCalledWith(1);
+
+      processSpy.mockRestore();
+      outputSpy.mockRestore();
+    });
   });
 });
 

--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -538,6 +538,290 @@ To fix this you will either need to add a package.json file at that location, or
       `);
     });
   });
+
+  describe('dependent version prefix', () => {
+    beforeEach(() => {
+      projectGraph = createWorkspaceWithPackageDependencies(tree, {
+        'my-lib': {
+          projectRoot: 'libs/my-lib',
+          packageName: 'my-lib',
+          version: '0.0.1',
+          packageJsonPath: 'libs/my-lib/package.json',
+          localDependencies: [],
+        },
+        'project-with-dependency-on-my-pkg': {
+          projectRoot: 'libs/project-with-dependency-on-my-pkg',
+          packageName: 'project-with-dependency-on-my-pkg',
+          version: '0.0.1',
+          packageJsonPath:
+            'libs/project-with-dependency-on-my-pkg/package.json',
+          localDependencies: [
+            {
+              projectName: 'my-lib',
+              dependencyCollection: 'dependencies',
+              version: '~0.0.1', // already has ~
+            },
+          ],
+        },
+        'project-with-devDependency-on-my-pkg': {
+          projectRoot: 'libs/project-with-devDependency-on-my-pkg',
+          packageName: 'project-with-devDependency-on-my-pkg',
+          version: '0.0.1',
+          packageJsonPath:
+            'libs/project-with-devDependency-on-my-pkg/package.json',
+          localDependencies: [
+            {
+              projectName: 'my-lib',
+              dependencyCollection: 'devDependencies',
+              version: '^0.0.1', // already has ^
+            },
+          ],
+        },
+        'another-project-with-devDependency-on-my-pkg': {
+          projectRoot: 'libs/another-project-with-devDependency-on-my-pkg',
+          packageName: 'another-project-with-devDependency-on-my-pkg',
+          version: '0.0.1',
+          packageJsonPath:
+            'libs/another-project-with-devDependency-on-my-pkg/package.json',
+          localDependencies: [
+            {
+              projectName: 'my-lib',
+              dependencyCollection: 'devDependencies',
+              version: '0.0.1', // has no prefix
+            },
+          ],
+        },
+      });
+    });
+
+    it('should work with an empty prefix', async () => {
+      expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+        '0.0.1'
+      );
+      await releaseVersionGenerator(tree, {
+        projects: Object.values(projectGraph.nodes), // version all projects
+        projectGraph,
+        specifier: '9.9.9',
+        currentVersionResolver: 'disk',
+        releaseGroup: createReleaseGroup('fixed'),
+        versionPrefix: '',
+      });
+      expect(readJson(tree, 'libs/my-lib/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "my-lib",
+          "version": "9.9.9",
+        }
+      `);
+
+      expect(
+        readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "my-lib": "9.9.9",
+          },
+          "name": "project-with-dependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(tree, 'libs/project-with-devDependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "9.9.9",
+          },
+          "name": "project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(
+          tree,
+          'libs/another-project-with-devDependency-on-my-pkg/package.json'
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "9.9.9",
+          },
+          "name": "another-project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+    });
+
+    it('should work with a ^ prefix', async () => {
+      expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+        '0.0.1'
+      );
+      await releaseVersionGenerator(tree, {
+        projects: Object.values(projectGraph.nodes), // version all projects
+        projectGraph,
+        specifier: '9.9.9',
+        currentVersionResolver: 'disk',
+        releaseGroup: createReleaseGroup('fixed'),
+        versionPrefix: '^',
+      });
+      expect(readJson(tree, 'libs/my-lib/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "my-lib",
+          "version": "9.9.9",
+        }
+      `);
+
+      expect(
+        readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "my-lib": "^9.9.9",
+          },
+          "name": "project-with-dependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(tree, 'libs/project-with-devDependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "^9.9.9",
+          },
+          "name": "project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(
+          tree,
+          'libs/another-project-with-devDependency-on-my-pkg/package.json'
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "^9.9.9",
+          },
+          "name": "another-project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+    });
+
+    it('should work with a ~ prefix', async () => {
+      expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+        '0.0.1'
+      );
+      await releaseVersionGenerator(tree, {
+        projects: Object.values(projectGraph.nodes), // version all projects
+        projectGraph,
+        specifier: '9.9.9',
+        currentVersionResolver: 'disk',
+        releaseGroup: createReleaseGroup('fixed'),
+        versionPrefix: '~',
+      });
+      expect(readJson(tree, 'libs/my-lib/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "my-lib",
+          "version": "9.9.9",
+        }
+      `);
+
+      expect(
+        readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "my-lib": "~9.9.9",
+          },
+          "name": "project-with-dependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(tree, 'libs/project-with-devDependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "~9.9.9",
+          },
+          "name": "project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(
+          tree,
+          'libs/another-project-with-devDependency-on-my-pkg/package.json'
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "~9.9.9",
+          },
+          "name": "another-project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+    });
+
+    it('should respect any existing prefix when set to "auto"', async () => {
+      expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+        '0.0.1'
+      );
+      await releaseVersionGenerator(tree, {
+        projects: Object.values(projectGraph.nodes), // version all projects
+        projectGraph,
+        specifier: '9.9.9',
+        currentVersionResolver: 'disk',
+        releaseGroup: createReleaseGroup('fixed'),
+        versionPrefix: 'auto',
+      });
+      expect(readJson(tree, 'libs/my-lib/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "my-lib",
+          "version": "9.9.9",
+        }
+      `);
+
+      expect(
+        readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "my-lib": "~9.9.9",
+          },
+          "name": "project-with-dependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(tree, 'libs/project-with-devDependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "^9.9.9",
+          },
+          "name": "project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(
+          tree,
+          'libs/another-project-with-devDependency-on-my-pkg/package.json'
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "9.9.9",
+          },
+          "name": "another-project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+    });
+  });
 });
 
 function createReleaseGroup(

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -48,12 +48,15 @@ export async function releaseVersionGenerator(
       options.specifier = options.specifier.replace(/^v/, '');
     }
 
-    if (validReleaseVersionPrefixes.indexOf(options.versionPrefix) === -1) {
+    if (
+      options.versionPrefix &&
+      validReleaseVersionPrefixes.indexOf(options.versionPrefix) === -1
+    ) {
       throw new Error(
         `Invalid value for version.generatorOptions.versionPrefix: "${
           options.versionPrefix
         }"
-        
+
 Valid values are: ${validReleaseVersionPrefixes
           .map((s) => `"${s}"`)
           .join(', ')}`

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -377,7 +377,7 @@ To fix this you will either need to add a package.json file at that location, or
       versionData[projectName] = {
         currentVersion,
         dependentProjects,
-        newVersion: null, // will stay as null in the final result the case that no changes are detected
+        newVersion: null, // will stay as null in the final result in the case that no changes are detected
       };
 
       if (!specifier) {
@@ -423,8 +423,23 @@ To fix this you will either need to add a package.json file at that location, or
             'package.json'
           ),
           (json) => {
-            json[dependentProject.dependencyCollection][packageName] =
-              newVersion;
+            let versionPrefix = options.versionPrefix || '';
+            // For auto, we infer the prefix based on the current version of the dependent
+            if (versionPrefix === 'auto') {
+              const current =
+                json[dependentProject.dependencyCollection][packageName];
+              if (current) {
+                const prefixMatch = current.match(/^[~^]/);
+                if (prefixMatch) {
+                  versionPrefix = prefixMatch[0];
+                } else {
+                  versionPrefix = '';
+                }
+              }
+            }
+            json[dependentProject.dependencyCollection][
+              packageName
+            ] = `${versionPrefix}${newVersion}`;
             return json;
           }
         );

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -21,6 +21,7 @@ import { isValidSemverSpecifier } from 'nx/src/command-line/release/utils/semver
 import {
   VersionData,
   deriveNewSemverVersion,
+  validReleaseVersionPrefixes,
 } from 'nx/src/command-line/release/version';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import * as ora from 'ora';
@@ -45,6 +46,18 @@ export async function releaseVersionGenerator(
       }
       // The node semver library classes a leading `v` as valid, but we want to ensure it is not present in the final version
       options.specifier = options.specifier.replace(/^v/, '');
+    }
+
+    if (validReleaseVersionPrefixes.indexOf(options.versionPrefix) === -1) {
+      throw new Error(
+        `Invalid value for version.generatorOptions.versionPrefix: "${
+          options.versionPrefix
+        }"
+        
+Valid values are: ${validReleaseVersionPrefixes
+          .map((s) => `"${s}"`)
+          .join(', ')}`
+      );
     }
 
     if (options.firstRelease) {

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -45,6 +45,8 @@ import {
 export { deriveNewSemverVersion } from './utils/semver';
 export type { VersionData } from './utils/shared';
 
+export const validReleaseVersionPrefixes = ['auto', '', '~', '^'];
+
 export interface ReleaseVersionGeneratorSchema {
   // The projects being versioned in the current execution
   projects: ProjectGraphProjectNode[];
@@ -59,7 +61,7 @@ export interface ReleaseVersionGeneratorSchema {
   fallbackCurrentVersionResolver?: 'disk';
   firstRelease?: boolean;
   // auto means the existing prefix will be preserved, and is the default behavior
-  versionPrefix?: 'auto' | '' | '~' | '^';
+  versionPrefix?: typeof validReleaseVersionPrefixes[number];
 }
 
 export interface NxReleaseVersionResult {

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -58,6 +58,8 @@ export interface ReleaseVersionGeneratorSchema {
   currentVersionResolverMetadata?: Record<string, unknown>;
   fallbackCurrentVersionResolver?: 'disk';
   firstRelease?: boolean;
+  // auto means the existing prefix will be preserved, and is the default behavior
+  versionPrefix?: 'auto' | '' | '~' | '^';
 }
 
 export interface NxReleaseVersionResult {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The version applied to dependents will always be exact.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The version applied to dependents will take into any existing `~` or `^` prefix by default, and can be forced to use one or the other or no prefix at all via config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21044
