### PR TITLE
feat(release): add formal entrypoint for programmatic API at nx/release

### DIFF
--- a/docs/shared/core-features/manage-releases.md
+++ b/docs/shared/core-features/manage-releases.md
@@ -73,11 +73,7 @@ For the maximum control and power over your release process, it is recommended t
 Here is a full working example of creating a custom script which processes its own CLI arguments (with `--dry-run` true by default) and then calls the `nx release` programmatic API.
 
 ```ts {% fileName="tools/scripts/release.ts" %}
-import {
-  releaseChangelog,
-  releasePublish,
-  releaseVersion,
-} from 'nx/src/command-line/release';
+import { releaseChangelog, releasePublish, releaseVersion } from 'nx/release';
 import * as yargs from 'yargs';
 
 (async () => {

--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -1,7 +1,7 @@
-import type { GitCommit } from '../src/command-line/release/utils/git';
+import type { GitCommit } from '../../src/command-line/release/utils/git';
 import defaultChangelogRenderer from './index';
 
-jest.mock('../src/project-graph/file-map-utils', () => ({
+jest.mock('../../src/project-graph/file-map-utils', () => ({
   createFileMapUsingProjectGraph: jest.fn().mockImplementation(() => {
     return Promise.resolve({
       allWorkspaceFiles: [],

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -1,11 +1,11 @@
 import { major } from 'semver';
-import type { GitCommit } from '../src/command-line/release/utils/git';
+import type { GitCommit } from '../../src/command-line/release/utils/git';
 import {
   RepoSlug,
   formatReferences,
-} from '../src/command-line/release/utils/github';
-import { getCommitsRelevantToProjects } from '../src/command-line/release/utils/shared';
-import type { ProjectGraph } from '../src/config/project-graph';
+} from '../../src/command-line/release/utils/github';
+import { getCommitsRelevantToProjects } from '../../src/command-line/release/utils/shared';
+import type { ProjectGraph } from '../../src/config/project-graph';
 
 // axios types and values don't seem to match
 import _axios = require('axios');

--- a/packages/nx/release/index.ts
+++ b/packages/nx/release/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @public Programmatic API for nx release
+ */
+export {
+  release,
+  releaseChangelog,
+  releasePublish,
+  releaseVersion,
+} from '../src/command-line/release';

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -2,7 +2,7 @@ import * as chalk from 'chalk';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { valid } from 'semver';
 import { dirSync } from 'tmp';
-import type { ChangelogRenderer } from '../../../changelog-renderer';
+import type { ChangelogRenderer } from '../../../release/changelog-renderer';
 import { readNxJson } from '../../config/nx-json';
 import {
   ProjectGraph,

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -69,7 +69,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -142,7 +142,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -218,7 +218,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -310,7 +310,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -392,7 +392,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -470,7 +470,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -561,7 +561,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -655,7 +655,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -677,7 +677,7 @@ describe('createNxReleaseConfig()', () => {
                     "commitReferences": true,
                     "versionTitleDate": true,
                   },
-                  "renderer": "nx/changelog-renderer",
+                  "renderer": "nx/release/changelog-renderer",
                 },
                 "projects": [
                   "lib-a",
@@ -746,7 +746,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -829,7 +829,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -914,7 +914,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1012,7 +1012,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1088,7 +1088,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1176,7 +1176,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1198,7 +1198,7 @@ describe('createNxReleaseConfig()', () => {
                     "commitReferences": true,
                     "versionTitleDate": true,
                   },
-                  "renderer": "nx/changelog-renderer",
+                  "renderer": "nx/release/changelog-renderer",
                 },
                 "projects": [
                   "nx",
@@ -1346,7 +1346,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": false,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
               "workspaceChangelog": {
                 "createRelease": false,
@@ -1357,7 +1357,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1379,7 +1379,7 @@ describe('createNxReleaseConfig()', () => {
                     "commitReferences": false,
                     "versionTitleDate": true,
                   },
-                  "renderer": "nx/changelog-renderer",
+                  "renderer": "nx/release/changelog-renderer",
                 },
                 "projects": [
                   "lib-a",
@@ -1445,7 +1445,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
               "workspaceChangelog": {
                 "createRelease": false,
@@ -1456,7 +1456,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1478,7 +1478,7 @@ describe('createNxReleaseConfig()', () => {
                     "commitReferences": true,
                     "versionTitleDate": true,
                   },
-                  "renderer": "nx/changelog-renderer",
+                  "renderer": "nx/release/changelog-renderer",
                 },
                 "projects": [
                   "lib-a",
@@ -1545,7 +1545,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1651,7 +1651,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
               "workspaceChangelog": {
                 "createRelease": false,
@@ -1662,7 +1662,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1684,7 +1684,7 @@ describe('createNxReleaseConfig()', () => {
                     "commitReferences": true,
                     "versionTitleDate": true,
                   },
-                  "renderer": "nx/changelog-renderer",
+                  "renderer": "nx/release/changelog-renderer",
                 },
                 "projects": [
                   "lib-a",
@@ -1720,7 +1720,7 @@ describe('createNxReleaseConfig()', () => {
                     "commitReferences": true,
                     "versionTitleDate": true,
                   },
-                  "renderer": "nx/changelog-renderer",
+                  "renderer": "nx/release/changelog-renderer",
                 },
                 "projects": [
                   "nx",
@@ -1799,7 +1799,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
               "workspaceChangelog": {
                 "createRelease": "github",
@@ -1810,7 +1810,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -1832,7 +1832,7 @@ describe('createNxReleaseConfig()', () => {
                     "commitReferences": true,
                     "versionTitleDate": true,
                   },
-                  "renderer": "nx/changelog-renderer",
+                  "renderer": "nx/release/changelog-renderer",
                 },
                 "projects": [
                   "lib-b",
@@ -1855,7 +1855,7 @@ describe('createNxReleaseConfig()', () => {
                     "commitReferences": true,
                     "versionTitleDate": true,
                   },
-                  "renderer": "nx/changelog-renderer",
+                  "renderer": "nx/release/changelog-renderer",
                 },
                 "projects": [
                   "lib-a",
@@ -2189,7 +2189,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -2284,7 +2284,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -2369,7 +2369,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -2453,7 +2453,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -2545,7 +2545,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {
@@ -2627,7 +2627,7 @@ describe('createNxReleaseConfig()', () => {
                   "commitReferences": true,
                   "versionTitleDate": true,
                 },
-                "renderer": "nx/changelog-renderer",
+                "renderer": "nx/release/changelog-renderer",
               },
             },
             "git": {

--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -156,7 +156,7 @@ export async function createNxReleaseConfig(
         entryWhenNoChanges:
           'This was a version bump only, there were no code changes.',
         file: '{workspaceRoot}/CHANGELOG.md',
-        renderer: 'nx/changelog-renderer',
+        renderer: 'nx/release/changelog-renderer',
         renderOptions: {
           authors: true,
           commitReferences: true,
@@ -170,7 +170,7 @@ export async function createNxReleaseConfig(
             file: '{projectRoot}/CHANGELOG.md',
             entryWhenNoChanges:
               'This was a version bump only for {projectName} to align it with other projects, there were no code changes.',
-            renderer: 'nx/changelog-renderer',
+            renderer: 'nx/release/changelog-renderer',
             renderOptions: {
               authors: true,
               commitReferences: true,
@@ -202,7 +202,7 @@ export async function createNxReleaseConfig(
       entryWhenNoChanges:
         'This was a version bump only for {projectName} to align it with other projects, there were no code changes.',
       file: '{projectRoot}/CHANGELOG.md',
-      renderer: 'nx/changelog-renderer',
+      renderer: 'nx/release/changelog-renderer',
       renderOptions: {
         authors: true,
         commitReferences: true,

--- a/packages/nx/src/command-line/release/utils/shared.spec.ts
+++ b/packages/nx/src/command-line/release/utils/shared.spec.ts
@@ -96,7 +96,7 @@ describe('shared', () => {
               entryWhenNoChanges:
                 'This was a version bump only for {projectName} to align it with other projects, there were no code changes.',
               file: '{projectRoot}/CHANGELOG.md',
-              renderer: 'nx/changelog-renderer',
+              renderer: 'nx/release/changelog-renderer',
               renderOptions: { authors: true },
             },
             releaseTagPattern: '{projectName}-{version}',

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 
-import type { ChangelogRenderOptions } from '../../changelog-renderer';
+import type { ChangelogRenderOptions } from '../../release/changelog-renderer';
 import { readJsonFile } from '../utils/fileutils';
 import { PackageManager } from '../utils/package-manager';
 import { workspaceRoot } from '../utils/workspace-root';
@@ -109,7 +109,7 @@ export interface NxReleaseChangelogConfiguration {
    * A path to a valid changelog renderer function used to transform commit messages and other metadata into
    * the final changelog (usually in markdown format). Its output can be modified using the optional `renderOptions`.
    *
-   * By default, the renderer is set to "nx/changelog-renderer" which nx provides out of the box.
+   * By default, the renderer is set to "nx/release/changelog-renderer" which nx provides out of the box.
    */
   renderer?: string;
   renderOptions?: ChangelogRenderOptions;

--- a/packages/nx/src/migrations/update-17-3-0/nx-release-path.spec.ts
+++ b/packages/nx/src/migrations/update-17-3-0/nx-release-path.spec.ts
@@ -1,0 +1,104 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { Tree } from '../../generators/tree';
+import { readJson, writeJson } from '../../generators/utils/json';
+import nxReleasePath from './nx-release-path';
+
+describe('nxReleasePath', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should update changelog renderer references', () => {
+    writeJson(tree, 'nx.json', {
+      $schema: './node_modules/nx/schemas/nx-schema.json',
+      release: {
+        changelog: {
+          git: {
+            commit: true,
+            tag: true,
+          },
+          workspaceChangelog: {
+            createRelease: 'github',
+            renderer: 'nx/changelog-renderer',
+          },
+          projectChangelogs: {
+            renderer: 'nx/changelog-renderer',
+          },
+        },
+        version: {
+          generatorOptions: {
+            currentVersionResolver: 'git-tag',
+            specifierSource: 'conventional-commits',
+          },
+        },
+      },
+    });
+
+    tree.write(
+      'some-script.js',
+      `
+      import { releaseVersion } from 'nx/src/command-line/release';
+      const { releaseChangelog } = require("nx/src/command-line/release");
+    `
+    );
+
+    // these should not be updated, only the formalized programmatic API
+    tree.write(
+      'some-other-file.ts',
+      `
+      import { foo } from 'nx/src/command-line/release/nested/thing';
+      const { releaseChangelog } = require("nx/src/command-line/release/another/nested/thing");
+    `
+    );
+
+    nxReleasePath(tree);
+
+    // intentionally unchanged
+    expect(tree.read('some-other-file.ts').toString('utf-8'))
+      .toMatchInlineSnapshot(`
+      "
+            import { foo } from 'nx/src/command-line/release/nested/thing';
+            const { releaseChangelog } = require("nx/src/command-line/release/another/nested/thing");
+          "
+    `);
+
+    // programmatic API should be updated to nx/release
+    expect(tree.read('some-script.js').toString('utf-8'))
+      .toMatchInlineSnapshot(`
+      "
+            import { releaseVersion } from 'nx/release';
+            const { releaseChangelog } = require("nx/release");
+          "
+    `);
+
+    // nx/changelog-renderer references should be updated to nx/release/changelog-renderer
+    expect(readJson(tree, 'nx.json')).toMatchInlineSnapshot(`
+      {
+        "$schema": "./node_modules/nx/schemas/nx-schema.json",
+        "release": {
+          "changelog": {
+            "git": {
+              "commit": true,
+              "tag": true,
+            },
+            "projectChangelogs": {
+              "renderer": "nx/release/changelog-renderer",
+            },
+            "workspaceChangelog": {
+              "createRelease": "github",
+              "renderer": "nx/release/changelog-renderer",
+            },
+          },
+          "version": {
+            "generatorOptions": {
+              "currentVersionResolver": "git-tag",
+              "specifierSource": "conventional-commits",
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/nx/src/migrations/update-17-3-0/nx-release-path.ts
+++ b/packages/nx/src/migrations/update-17-3-0/nx-release-path.ts
@@ -1,0 +1,52 @@
+import { join, relative, sep } from 'node:path';
+import { Tree } from '../../generators/tree';
+import { getIgnoreObject } from '../../utils/ignore';
+
+export default function nxReleasePath(tree: Tree) {
+  visitNotIgnoredFiles(tree, '', (file) => {
+    console.log({ file });
+    const contents = tree.read(file).toString('utf-8');
+    if (
+      // the deep import usage should be replaced by the new location
+      contents.includes('nx/src/command-line/release') ||
+      // changelog-renderer has moved into nx/release
+      contents.includes('nx/changelog-renderer')
+    ) {
+      const finalContents = contents
+        // replace instances of old changelog renderer location
+        .replace(/nx\/changelog-renderer/g, 'nx/release/changelog-renderer')
+        // replace instances of deep import for programmatic API (only perform the replacement if an actual import by checking for trailing ' or ")
+        .replace(/nx\/src\/command-line\/release(['"])/g, 'nx/release$1');
+      tree.write(file, finalContents);
+    }
+  });
+}
+
+// Adapted from devkit
+export function visitNotIgnoredFiles(
+  tree: Tree,
+  dirPath: string = tree.root,
+  visitor: (path: string) => void
+): void {
+  const ig = getIgnoreObject();
+  dirPath = normalizePathRelativeToRoot(dirPath, tree.root);
+  if (dirPath !== '' && ig?.ignores(dirPath)) {
+    return;
+  }
+  for (const child of tree.children(dirPath)) {
+    const fullPath = join(dirPath, child);
+    if (ig?.ignores(fullPath)) {
+      continue;
+    }
+    if (tree.isFile(fullPath)) {
+      visitor(fullPath);
+    } else {
+      visitNotIgnoredFiles(tree, fullPath, visitor);
+    }
+  }
+}
+
+// Copied from devkit
+function normalizePathRelativeToRoot(path: string, root: string): string {
+  return relative(root, join(root, path)).split(sep).join('/');
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The programmatic API for nx release is accessed via a deep import, and the default changelog-renderer has an unnecessarily isolated entry point.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The import location for release related concerns is formalized to be `nx/release`, initially starting with reexporting the programmatic API for nx release. Types and utils will follow here in due course once we feel they are worthy of "promotion".

The default changelog-renderer location (which the vast majority of users never see nor reference in their configs) has moved into the `nx/release` directory.

There is a migration to update any existing usage based on the old locations.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21029


