### PR TITLE
fix(js): set the unsafeHttpWhitelist when the set has any items

### DIFF
--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -192,7 +192,7 @@ function setYarnUnsafeHttpWhitelist(
   currentWhitelist: Set<string>,
   options: VerdaccioExecutorSchema
 ) {
-  if (currentWhitelist.size > 1) {
+  if (currentWhitelist.size > 0) {
     execSync(
       `yarn config set unsafeHttpWhitelist --json '${JSON.stringify(
         Array.from(currentWhitelist)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When starting a local registry, the verdaccio executor does not set the whitelist if `localhost` is the only item in the list.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When starting a local registry, the verdaccio executor does set the whitelist if `localhost` is the only item in the list.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
