### PR TITLE
docs(core): split e2e tasks

### DIFF
--- a/docs/generated/manifests/ci.json
+++ b/docs/generated/manifests/ci.json
@@ -286,6 +286,28 @@
         "tags": ["distribute-task-execution"]
       },
       {
+        "id": "split-e2e-tasks",
+        "name": "Automatically Split E2E Tasks by File",
+        "description": "",
+        "mediaImage": "",
+        "file": "nx-cloud/concepts/split-e2e-tasks",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/ci/concepts/split-e2e-tasks",
+        "tags": []
+      },
+      {
+        "id": "flaky-tasks",
+        "name": "Identify and Re-run Flaky Tasks",
+        "description": "",
+        "mediaImage": "",
+        "file": "nx-cloud/concepts/flaky-tasks",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/ci/concepts/flaky-tasks",
+        "tags": []
+      },
+      {
         "id": "cache-security",
         "name": "Cache Security",
         "description": "",
@@ -333,6 +355,28 @@
     "isExternal": false,
     "path": "/ci/concepts/parallelization-distribution",
     "tags": ["distribute-task-execution"]
+  },
+  "/ci/concepts/split-e2e-tasks": {
+    "id": "split-e2e-tasks",
+    "name": "Automatically Split E2E Tasks by File",
+    "description": "",
+    "mediaImage": "",
+    "file": "nx-cloud/concepts/split-e2e-tasks",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/ci/concepts/split-e2e-tasks",
+    "tags": []
+  },
+  "/ci/concepts/flaky-tasks": {
+    "id": "flaky-tasks",
+    "name": "Identify and Re-run Flaky Tasks",
+    "description": "",
+    "mediaImage": "",
+    "file": "nx-cloud/concepts/flaky-tasks",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/ci/concepts/flaky-tasks",
+    "tags": []
   },
   "/ci/concepts/cache-security": {
     "id": "cache-security",

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5762,6 +5762,22 @@
             "disableCollapsible": false
           },
           {
+            "name": "Automatically Split E2E Tasks by File",
+            "path": "/ci/concepts/split-e2e-tasks",
+            "id": "split-e2e-tasks",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
+            "name": "Identify and Re-run Flaky Tasks",
+            "path": "/ci/concepts/flaky-tasks",
+            "id": "flaky-tasks",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
             "name": "Cache Security",
             "path": "/ci/concepts/cache-security",
             "id": "cache-security",
@@ -5792,6 +5808,22 @@
         "name": "Parallelization and Distribution",
         "path": "/ci/concepts/parallelization-distribution",
         "id": "parallelization-distribution",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Automatically Split E2E Tasks by File",
+        "path": "/ci/concepts/split-e2e-tasks",
+        "id": "split-e2e-tasks",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Identify and Re-run Flaky Tasks",
+        "path": "/ci/concepts/flaky-tasks",
+        "id": "flaky-tasks",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/map.json
+++ b/docs/map.json
@@ -1719,6 +1719,16 @@
               "file": "nx-cloud/concepts/parallelization-distribution"
             },
             {
+              "name": "Automatically Split E2E Tasks by File",
+              "id": "split-e2e-tasks",
+              "file": "nx-cloud/concepts/split-e2e-tasks"
+            },
+            {
+              "name": "Identify and Re-run Flaky Tasks",
+              "id": "flaky-tasks",
+              "file": "nx-cloud/concepts/flaky-tasks"
+            },
+            {
               "name": "Cache Security",
               "id": "cache-security",
               "file": "nx-cloud/concepts/cache-security"

--- a/docs/nx-cloud/concepts/flaky-tasks.md
+++ b/docs/nx-cloud/concepts/flaky-tasks.md
@@ -1,0 +1,13 @@
+# Identify and Re-run Flaky Tasks
+
+Sometimes there are tasks in CI that fail or succeed without any related code changes. These tasks are called flaky tasks. Because the cause of the flakiness can be difficult to determine, developers will typically re-run CI in the hopes that another run will cause the task to succeed and allow them to merge their PR. Every time a developer has to do this, it is harming their productivity and the productivity of the company as a whole.
+
+Nx is perfectly positioned to detect which tasks are flaky and, with [Nx Agents](/ci/features/nx-agents), automatically re-run the flaky task in a new agent so that developers can have confidence that a failed CI pipeline is a real failure.
+
+## Identify Flaky Tasks
+
+Nx creates a hash of all the inputs for a task whenever it is run. If Nx ever encounters a task that fails with a particular set of inputs and then succeeds with those same inputs, Nx knows for a fact that the task is flaky. Nx can't know with certainty when the task has been fixed to no longer be flaky, so if a particular task has no flakiness incidents for 2 weeks, the `flaky` flag is removed for that task.
+
+## Re-run Flaky Tasks
+
+When a flaky task fails in CI, Nx will automatically send that task to a new agent and run it again (up to 3 tries in total). Its important to run the task on a new agent to ensure that the agent itself or the other tasks that were run on that agent are not the reason for the flakiness.

--- a/docs/nx-cloud/concepts/split-e2e-tasks.md
+++ b/docs/nx-cloud/concepts/split-e2e-tasks.md
@@ -1,0 +1,58 @@
+# Automatically Split E2E Tasks by File
+
+In almost every codebase, e2e tests are the largest portion of the CI pipeline. Typically, e2e tests are grouped by application so that whenever an application's code changes, all the e2e tests for that application are run. These large groupings of e2e tests make caching and distribution less effective. Also, because e2e tests deal with a lot of integration code, they are at a much higher risk to be flaky.
+
+You could manually address these problems by splitting your e2e tests into smaller tasks, but this requires developer time to maintain and adds additional configuration overhead to your codebase. Or, you could allow Nx to automatically split your Cypress or Playwright e2e tests by file.
+
+## Set up
+
+To enable automatically split e2e tasks, you need to turn on [inferred tasks](/concepts/inferred-tasks) for the [@nx/cypress](/nx-api/cypress) or [@nx/playwright](/nx-api/playwright) plugins. Run this command to set up inferred tasks:
+
+{% tabs %}
+{% tab label="Cypress" %}
+
+```shell
+nx add @nx/cypress
+```
+
+{% /tab %}
+{% tab label="Playwright" %}
+
+```shell
+nx add @nx/playwright
+```
+
+{% /tab %}
+{% /tabs %}
+
+This command will register the appropriate plugin in the `plugins` array of `nx.json`.
+
+## Usage
+
+You can view the available tasks in the graph:
+
+```shell
+nx graph
+```
+
+You'll see that there are tasks named `e2e`, `e2e-ci` and a task for each e2e test file.
+
+Developers can run all e2e tests locally the same way as usual:
+
+```shell
+nx e2e my-project-e2e
+```
+
+You can update your CI pipeline to run `e2e-ci`, which will automatically run all the inferred tasks for the individual e2e test files. Run it like this:
+
+```shell
+nx e2e-ci my-project-e2e
+```
+
+## Benefits
+
+Smaller e2e tasks enable the following benefits:
+
+- Nx's cache can be used for all the e2e tasks that succeeded and only the failed tasks need to be re-run
+- Distributed Task Execution allows your e2e tests to be run on multiple machines simultaneously, which reduces the total time of the CI pipeline
+- Nx Agents can [automatically re-run failed flaky e2e tests](/ci/concepts/flaky-tasks) on a separate agent without a developer needing to manually re-run the CI pipeline

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -282,6 +282,8 @@
     - [The Building Blocks of Fast CI](/ci/concepts/building-blocks-fast-ci)
     - [Reduce Wasted Time in CI](/ci/concepts/reduce-waste)
     - [Parallelization and Distribution](/ci/concepts/parallelization-distribution)
+    - [Automatically Split E2E Tasks by File](/ci/concepts/split-e2e-tasks)
+    - [Identify and Re-run Flaky Tasks](/ci/concepts/flaky-tasks)
     - [Cache Security](/ci/concepts/cache-security)
   - [Recipes](/ci/recipes)
     - [Set Up CI](/ci/recipes/set-up)


### PR DESCRIPTION
Adds guides for splitting e2e tasks and re-running flaky tasks