### PR TITLE
fix(release): filtering publish by project or group should exclude task deps

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -20,6 +20,7 @@ expect.addSnapshotSerializer({
         .replaceAll(tmpProjPath(), '')
         .replaceAll('/private/', '')
         .replaceAll(/my-pkg-\d+/g, '{project-name}')
+        .replaceAll(' in /{project-name}', ' in {project-name}')
         .replaceAll(
           /integrity:\s*.*/g,
           'integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -28,6 +28,7 @@ expect.addSnapshotSerializer({
         .replaceAll(/\d*B  index\.js/g, 'XXB  index.js')
         .replaceAll(/\d*B  project\.json/g, 'XXB  project.json')
         .replaceAll(/\d*B package\.json/g, 'XXXB package.json')
+        .replaceAll(/\d*B CHANGELOG\.md/g, 'XXXB CHANGELOG.md')
         .replaceAll(/size:\s*\d*\s?B/g, 'size: XXXB')
         .replaceAll(/\d*\.\d*\s?kB/g, 'XXX.XXX kb')
         // Normalize the version title date
@@ -581,6 +582,234 @@ describe('nx release - independent projects', () => {
 
       // Ensure no git operations were performed
       expect(runCommand(`git rev-parse HEAD`).trim()).toEqual(updatedHeadSHA);
+    });
+  });
+
+  describe('publish', () => {
+    beforeEach(() => {
+      updateJson('nx.json', () => {
+        return {
+          release: {
+            projectsRelationship: 'independent',
+            groups: {
+              group1: {
+                projects: [pkg1, pkg2],
+              },
+              group2: {
+                projects: [pkg3],
+              },
+            },
+          },
+        };
+      });
+    });
+
+    it('should only run the publish task for the filtered projects', async () => {
+      // Should only contain 1 project
+      expect(runCLI(`release publish -p ${pkg1} -d`)).toMatchInlineSnapshot(`
+
+        >  NX   Your filter "{project-name}" matched the following projects:
+
+        - {project-name} (release group "group1")
+
+
+        >  NX   Running target nx-release-publish for project {project-name}:
+
+        - {project-name}
+
+        With additional flags:
+        --dryRun=true
+
+
+
+        > nx run {project-name}:nx-release-publish
+
+
+        📦  @proj/{project-name}@999.9.9-version-git-operations-test.3
+        === Tarball Contents ===
+
+        XXXB CHANGELOG.md
+        XXB  index.js
+        XXXB package.json
+        XXB  project.json
+        === Tarball Details ===
+        name:          @proj/{project-name}
+        version:       999.9.9-version-git-operations-test.3
+        filename:      proj-{project-name}-999.9.9-version-git-operations-test.3.tgz
+        package size: XXXB
+        unpacked size: XXXB
+        shasum:        {SHASUM}
+        integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        total files:   4
+
+        Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+
+
+
+        >  NX   Successfully ran target nx-release-publish for project {project-name}
+
+
+
+      `);
+
+      // Should only contain 2 projects
+      expect(runCLI(`release publish -p ${pkg1} -p ${pkg3} -d`))
+        .toMatchInlineSnapshot(`
+
+        >  NX   Your filter "{project-name},{project-name}" matched the following projects:
+
+        - {project-name} (release group "group1")
+        - {project-name} (release group "group2")
+
+
+        >  NX   Running target nx-release-publish for project {project-name}:
+
+        - {project-name}
+
+        With additional flags:
+        --dryRun=true
+
+
+
+        > nx run {project-name}:nx-release-publish
+
+
+        📦  @proj/{project-name}@999.9.9-version-git-operations-test.3
+        === Tarball Contents ===
+
+        XXXB CHANGELOG.md
+        XXB  index.js
+        XXXB package.json
+        XXB  project.json
+        === Tarball Details ===
+        name:          @proj/{project-name}
+        version:       999.9.9-version-git-operations-test.3
+        filename:      proj-{project-name}-999.9.9-version-git-operations-test.3.tgz
+        package size: XXXB
+        unpacked size: XXXB
+        shasum:        {SHASUM}
+        integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        total files:   4
+
+        Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+
+
+
+        >  NX   Successfully ran target nx-release-publish for project {project-name}
+
+
+
+        >  NX   Running target nx-release-publish for project {project-name}:
+
+        - {project-name}
+
+        With additional flags:
+        --dryRun=true
+
+
+
+        > nx run {project-name}:nx-release-publish
+
+        Skipped package "@proj/{project-name}" from project "{project-name}", because it has \`"private": true\` in {project-name}/package.json
+
+
+
+        >  NX   Successfully ran target nx-release-publish for project {project-name}
+
+
+
+      `);
+    });
+
+    it('should only run the publish task for the filtered projects', async () => {
+      // Should only contain the 2 projects from group1
+      expect(runCLI(`release publish -g group1 -d`)).toMatchInlineSnapshot(`
+
+        >  NX   Running target nx-release-publish for 2 projects:
+
+        - {project-name}
+        - {project-name}
+
+        With additional flags:
+        --dryRun=true
+
+
+
+        > nx run {project-name}:nx-release-publish
+
+
+        📦  @proj/{project-name}@999.9.9-version-git-operations-test.3
+        === Tarball Contents ===
+
+        XXXB CHANGELOG.md
+        XXB  index.js
+        XXXB package.json
+        XXB  project.json
+        === Tarball Details ===
+        name:          @proj/{project-name}
+        version:       999.9.9-version-git-operations-test.3
+        filename:      proj-{project-name}-999.9.9-version-git-operations-test.3.tgz
+        package size: XXXB
+        unpacked size: XXXB
+        shasum:        {SHASUM}
+        integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        total files:   4
+
+        Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+
+        > nx run {project-name}:nx-release-publish
+
+
+        📦  @proj/{project-name}@999.9.9-version-git-operations-test.3
+        === Tarball Contents ===
+
+        XXXB CHANGELOG.md
+        XXB  index.js
+        XXXB package.json
+        XXB  project.json
+        === Tarball Details ===
+        name:          @proj/{project-name}
+        version:       999.9.9-version-git-operations-test.3
+        filename:      proj-{project-name}-999.9.9-version-git-operations-test.3.tgz
+        package size: XXXB
+        unpacked size: XXXB
+        shasum:        {SHASUM}
+        integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        total files:   4
+
+        Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+
+
+
+        >  NX   Successfully ran target nx-release-publish for 2 projects
+
+
+
+      `);
+
+      // Should only contain the 1 project from group2
+      expect(runCLI(`release publish -g group2 -d`)).toMatchInlineSnapshot(`
+
+          >  NX   Running target nx-release-publish for project {project-name}:
+
+          - {project-name}
+
+          With additional flags:
+          --dryRun=true
+
+
+
+          > nx run {project-name}:nx-release-publish
+
+          Skipped package "@proj/{project-name}" from project "{project-name}", because it has \`"private": true\` in {project-name}/package.json
+
+
+
+          >  NX   Successfully ran target nx-release-publish for project {project-name}
+
+
+
+      `);
     });
   });
 

--- a/e2e/release/src/private-js-packages.test.ts
+++ b/e2e/release/src/private-js-packages.test.ts
@@ -144,7 +144,7 @@ describe('nx release - private JS packages', () => {
 
     `);
 
-    // This will include the private package publish output as it is a dependency
+    // This will not include the private package dependency because we are filtering to specifically publicPkg2
     const publicPkg2PublishOutput = runCLI(`release publish -p ${publicPkg2}`);
     expect(publicPkg2PublishOutput).toMatchInlineSnapshot(`
 
@@ -153,15 +153,11 @@ describe('nx release - private JS packages', () => {
       - {public-project-name}
 
 
-      >  NX   Running target nx-release-publish for project {public-project-name} and 1 task it depends on:
+      >  NX   Running target nx-release-publish for project {public-project-name}:
 
       - {public-project-name}
 
 
-
-      > nx run {private-project-name}:nx-release-publish
-
-      Skipped package "@proj/{private-project-name}" from project "{private-project-name}", because it has \`"private": true\` in {private-project-name}/package.json
 
       > nx run {public-project-name}:nx-release-publish
 
@@ -186,7 +182,33 @@ describe('nx release - private JS packages', () => {
 
 
 
-      >  NX   Successfully ran target nx-release-publish for project {public-project-name} and 1 task it depends on
+      >  NX   Successfully ran target nx-release-publish for project {public-project-name}
+
+
+
+    `);
+
+    const privatePkgPublishOutput = runCLI(`release publish -p ${privatePkg}`);
+    expect(privatePkgPublishOutput).toMatchInlineSnapshot(`
+
+      >  NX   Your filter "{private-project-name}" matched the following projects:
+
+      - {private-project-name}
+
+
+      >  NX   Running target nx-release-publish for project {private-project-name}:
+
+      - {private-project-name}
+
+
+
+      > nx run {private-project-name}:nx-release-publish
+
+      Skipped package "@proj/{private-project-name}" from project "{private-project-name}", because it has \`"private": true\` in {private-project-name}/package.json
+
+
+
+      >  NX   Successfully ran target nx-release-publish for project {private-project-name}
 
 
 

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -69,6 +69,13 @@ export async function releasePublish(args: PublishOptions): Promise<void> {
     process.exit(1);
   }
 
+  /**
+   * If the user is filtering to a subset of projects or groups, we should not run the publish task
+   * for dependencies, because that could cause projects outset of the filtered set to be published.
+   */
+  const shouldExcludeTaskDependencies =
+    _args.projects?.length > 0 || _args.groups?.length > 0;
+
   if (args.projects?.length) {
     /**
      * Run publishing for all remaining release groups and filtered projects within them
@@ -78,7 +85,8 @@ export async function releasePublish(args: PublishOptions): Promise<void> {
         _args,
         projectGraph,
         nxJson,
-        Array.from(releaseGroupToFilteredProjects.get(releaseGroup))
+        Array.from(releaseGroupToFilteredProjects.get(releaseGroup)),
+        shouldExcludeTaskDependencies
       );
     }
 
@@ -93,7 +101,8 @@ export async function releasePublish(args: PublishOptions): Promise<void> {
       _args,
       projectGraph,
       nxJson,
-      releaseGroup.projects
+      releaseGroup.projects,
+      shouldExcludeTaskDependencies
     );
   }
 
@@ -110,7 +119,8 @@ async function runPublishOnProjects(
   args: PublishOptions & { __overrides_unparsed__: string[] },
   projectGraph: ProjectGraph,
   nxJson: NxJsonConfiguration,
-  projectNames: string[]
+  projectNames: string[],
+  shouldExcludeTaskDependencies: boolean
 ) {
   const projectsToRun: ProjectGraphProjectNode[] = projectNames.map(
     (projectName) => projectGraph.nodes[projectName]
@@ -173,7 +183,10 @@ async function runPublishOnProjects(
       overrides,
       null,
       {},
-      { excludeTaskDependencies: false, loadDotEnvFiles: true }
+      {
+        excludeTaskDependencies: shouldExcludeTaskDependencies,
+        loadDotEnvFiles: true,
+      }
     );
 
     if (status !== 0) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx-release-publish` target depends on the `nx-release-publish` target of its deps and executes the full task graph irrespective of release level filtering.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When filtering by group or projects as part of release, only the `nx-release-publish` target of projects within the filtered subset will be executed.

This behaviour has been verified on the Fluent UI repo with @Hotell 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21116
