### PR TITLE
fix(misc): identify usage of playwright correctly when running nx init

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -117,7 +117,7 @@ const npmPackageToPluginMap: Record<string, string> = {
   // Testing tools
   jest: '@nx/jest',
   cypress: '@nx/cypress',
-  playwright: '@nx/playwright',
+  '@playwright/test': '@nx/playwright',
   next: '@nx/next',
   nuxt: '@nx/nuxt',
 };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The usage of Playwright is identified by checking if the `playwright` package is installed, but the correct package is `@playwright/test`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The usage of Playwright should be identified by checking if the `@playwright/test` package is installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
