### PR TITLE
fix(linter): fixes a bug where the random order of hashes causes wron…

### DIFF
--- a/packages/eslint/src/executors/lint/hasher.ts
+++ b/packages/eslint/src/executors/lint/hasher.ts
@@ -50,6 +50,10 @@ export default async function run(
       hashes.push(res.details.nodes[d]);
     }
   }
+  // The hashes in res.details are in a random order causing cache mismatches even if the various hashes are equal.
+  // Sorting the hashes prevents this from happening
+  hashes.sort();
+
   return {
     value: hashArray([command, selfSource, ...hashes, tags]),
     details: {


### PR DESCRIPTION
…g cache mismatches

The hasher returns a list of hashes whose order is random on each run. This causes the overall hash of the run to be different, resulting in cache mismatches. This commit sorts the list of hashes, fixing the issue as the overall hash is matching again.