### PR TITLE
fix(release): versionPrefix should default to auto

### DIFF
--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -845,6 +845,63 @@ To fix this you will either need to add a package.json file at that location, or
       `);
     });
 
+    it('should use the behavior of "auto" by default', async () => {
+      expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+        '0.0.1'
+      );
+      await releaseVersionGenerator(tree, {
+        projects: Object.values(projectGraph.nodes), // version all projects
+        projectGraph,
+        specifier: '9.9.9',
+        currentVersionResolver: 'disk',
+        releaseGroup: createReleaseGroup('fixed'),
+        versionPrefix: undefined,
+      });
+      expect(readJson(tree, 'libs/my-lib/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "my-lib",
+          "version": "9.9.9",
+        }
+      `);
+
+      expect(
+        readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "my-lib": "~9.9.9",
+          },
+          "name": "project-with-dependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(tree, 'libs/project-with-devDependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "^9.9.9",
+          },
+          "name": "project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+      expect(
+        readJson(
+          tree,
+          'libs/another-project-with-devDependency-on-my-pkg/package.json'
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "9.9.9",
+          },
+          "name": "another-project-with-devDependency-on-my-pkg",
+          "version": "9.9.9",
+        }
+      `);
+    });
+
     it(`should exit with code one and print guidance for invalid prefix values`, async () => {
       stubProcessExit = true;
 

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -439,9 +439,13 @@ To fix this you will either need to add a package.json file at that location, or
             'package.json'
           ),
           (json) => {
-            let versionPrefix = options.versionPrefix || '';
+            // Auto (i.e.infer existing) by default
+            let versionPrefix = options.versionPrefix ?? 'auto';
+
             // For auto, we infer the prefix based on the current version of the dependent
             if (versionPrefix === 'auto') {
+              versionPrefix = ''; // we don't want to end up printing auto
+
               const current =
                 json[dependentProject.dependencyCollection][packageName];
               if (current) {


### PR DESCRIPTION
This was accidentally missed in https://github.com/nrwl/nx/pull/21209

## Current Behavior
<!-- This is the behavior we have today -->

Empty prefix is still the default

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Auto (infer existing prefix) is the default

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
