### PR TITLE
fix(remix): required property in schema should be project

### DIFF
--- a/docs/generated/packages/remix/generators/storybook-configuration.json
+++ b/docs/generated/packages/remix/generators/storybook-configuration.json
@@ -82,7 +82,7 @@
         "description": "Add a Storybook Test-Runner target."
       }
     },
-    "required": ["name"],
+    "required": ["project"],
     "presets": []
   },
   "description": "Generates a Storybook configuration for a Remix application",

--- a/packages/remix/src/generators/storybook-configuration/schema.json
+++ b/packages/remix/src/generators/storybook-configuration/schema.json
@@ -85,5 +85,5 @@
       "description": "Add a Storybook Test-Runner target."
     }
   },
-  "required": ["name"]
+  "required": ["project"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The schema for the remix/storybook-configuration generator states that the required property is name, however name is only an alias for project. 


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`project` should be marked as the required property.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20948
