### PR TITLE
docs(nextjs): Update Next.js docs to add inferred targets

### DIFF
--- a/docs/generated/packages/next/documents/overview.md
+++ b/docs/generated/packages/next/documents/overview.md
@@ -8,11 +8,59 @@ The Next.js plugin contains executors and generators for managing Next.js applic
 
 ## Setting up Next.js
 
-To create a new Nx workspace with Next.js, run `npx create-nx-workspace@latest --preset=next`.
-
-To add Next.js to an existing Nx workspace, install the `@nx/next` package. Make sure to install the version that matches your `nx` version.
+In any workspace, you can install `@nx/next` by running the following command:
 
 {% tabs %}
+
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/next
+```
+
+This will install the correct version of `@nx/next`.
+
+### How @nx/next Infers Tasks
+
+The `@nx/next` plugin will create tasks for any project that has a Next.js configuration file preset. Any of the following files will be recognized as a Next.js configuration file:
+
+- `next.config.js`
+- `next.config.cjs`
+- `next.config.mjs`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project <project-name> --web` in your command line.
+
+### @nx/next Configuration
+
+The `@nx/next/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/next/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "devTargetName": "dev",
+        "startTargetName": "start"
+      }
+    }
+  ]
+}
+```
+
+- The `buildTargetName` option controls the name of Next.js' compilation task which compiles the application for production deployment. The default name is `build`.
+- The `devTargetName` option controls the name of Next.js' development serve task which starts the application in development mode. The default name is `dev`.
+- The `startTargetName` option controls the name of Next.js' production serve task which starts the application in production mode. The default name is `start`.
+
+{% /tab %}
+
+{% tab label="Nx < 18" %}
+
+{% tabs %}
+
 {% tab label="npm" %}
 
 ```shell
@@ -33,6 +81,8 @@ yarn add -D @nx/next
 pnpm add -D @nx/next
 ```
 
+{% /tab %}
+{% /tabs %}
 {% /tab %}
 {% /tabs %}
 
@@ -79,13 +129,37 @@ Nx generates components with tests by default. For pages, you can pass the `--wi
 
 ### Serving Next.js Applications
 
+{% tabs %}
+
+{% tab label="Nx 18+" %}
+
+You can serve a Next.js application `my-new-app` for development:
+
+```shell
+  nx dev my-new-app
+```
+
+To serve a Next.js application for production:
+
+```shell
+  nx start my-new-app
+```
+
+This will start the server at http://localhost:3000 by default.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
 You can run `nx serve my-new-app` to serve a Next.js application called `my-new-app` for development. This will start the dev server at http://localhost:4200.
 
 To serve a Next.js application for production, add the `--prod` flag to the serve command:
 
 ```shell
-nx serve my-new-app --prod
+  nx serve my-new-app --prod
 ```
+
+{% /tab %}
+{% /tabs %}
 
 ### Using an Nx Library in your Application
 
@@ -165,10 +239,15 @@ The library in `dist` is publishable to npm or a private registry.
 
 ### Static HTML Export
 
-Next.js applications can be statically exported with:
+Next.js applications can be statically exported by changing th eoutput inside your Next.js configuration file.
 
-```shell
-nx export my-new-app
+```js {% fileName="apps/my-next-app/next.config.js" %}
+const nextConfig = {
+  output: 'export',
+  nx: {
+    svgr: false,
+  },
+};
 ```
 
 ### Deploying Next.js Applications

--- a/docs/shared/packages/next/plugin-overview.md
+++ b/docs/shared/packages/next/plugin-overview.md
@@ -8,11 +8,59 @@ The Next.js plugin contains executors and generators for managing Next.js applic
 
 ## Setting up Next.js
 
-To create a new Nx workspace with Next.js, run `npx create-nx-workspace@latest --preset=next`.
-
-To add Next.js to an existing Nx workspace, install the `@nx/next` package. Make sure to install the version that matches your `nx` version.
+In any workspace, you can install `@nx/next` by running the following command:
 
 {% tabs %}
+
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/next
+```
+
+This will install the correct version of `@nx/next`.
+
+### How @nx/next Infers Tasks
+
+The `@nx/next` plugin will create tasks for any project that has a Next.js configuration file preset. Any of the following files will be recognized as a Next.js configuration file:
+
+- `next.config.js`
+- `next.config.cjs`
+- `next.config.mjs`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project <project-name> --web` in your command line.
+
+### @nx/next Configuration
+
+The `@nx/next/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/next/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "devTargetName": "dev",
+        "startTargetName": "start"
+      }
+    }
+  ]
+}
+```
+
+- The `buildTargetName` option controls the name of Next.js' compilation task which compiles the application for production deployment. The default name is `build`.
+- The `devTargetName` option controls the name of Next.js' development serve task which starts the application in development mode. The default name is `dev`.
+- The `startTargetName` option controls the name of Next.js' production serve task which starts the application in production mode. The default name is `start`.
+
+{% /tab %}
+
+{% tab label="Nx < 18" %}
+
+{% tabs %}
+
 {% tab label="npm" %}
 
 ```shell
@@ -33,6 +81,8 @@ yarn add -D @nx/next
 pnpm add -D @nx/next
 ```
 
+{% /tab %}
+{% /tabs %}
 {% /tab %}
 {% /tabs %}
 
@@ -79,13 +129,37 @@ Nx generates components with tests by default. For pages, you can pass the `--wi
 
 ### Serving Next.js Applications
 
+{% tabs %}
+
+{% tab label="Nx 18+" %}
+
+You can serve a Next.js application `my-new-app` for development:
+
+```shell
+  nx dev my-new-app
+```
+
+To serve a Next.js application for production:
+
+```shell
+  nx start my-new-app
+```
+
+This will start the server at http://localhost:3000 by default.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
 You can run `nx serve my-new-app` to serve a Next.js application called `my-new-app` for development. This will start the dev server at http://localhost:4200.
 
 To serve a Next.js application for production, add the `--prod` flag to the serve command:
 
 ```shell
-nx serve my-new-app --prod
+  nx serve my-new-app --prod
 ```
+
+{% /tab %}
+{% /tabs %}
 
 ### Using an Nx Library in your Application
 
@@ -165,10 +239,15 @@ The library in `dist` is publishable to npm or a private registry.
 
 ### Static HTML Export
 
-Next.js applications can be statically exported with:
+Next.js applications can be statically exported by changing th eoutput inside your Next.js configuration file.
 
-```shell
-nx export my-new-app
+```js {% fileName="apps/my-next-app/next.config.js" %}
+const nextConfig = {
+  output: 'export',
+  nx: {
+    svgr: false,
+  },
+};
 ```
 
 ### Deploying Next.js Applications


### PR DESCRIPTION
Update Next.js overview documentation to add inferred targets.

[Preview](https://nx-dev-git-fork-ndcunningham-docs-inferred-targets-nextjs-nrwl.vercel.app/nx-api/next)