### PR TITLE
fix(remix): use twStyles as import to prevent conflicts

### DIFF
--- a/packages/remix/src/generators/setup-tailwind/__snapshots__/setup-tailwind.impl.spec.ts.snap
+++ b/packages/remix/src/generators/setup-tailwind/__snapshots__/setup-tailwind.impl.spec.ts.snap
@@ -31,8 +31,8 @@ exports[`setup-tailwind generator should add a js tailwind config to an applicat
   Scripts,
   ScrollRestoration,
 } from '@remix-run/react';
-import styles from './tailwind.css';
-export const links = () => [{ rel: 'stylesheet', href: styles }];
+import twStyles from './tailwind.css';
+export const links = () => [{ rel: 'stylesheet', href: twStyles }];
 export const meta = () => [
   {
     charset: 'utf-8',
@@ -115,8 +115,10 @@ import {
   Scripts,
   ScrollRestoration,
 } from '@remix-run/react';
-import styles from './tailwind.css';
-export const links: LinksFunction = () => [{ rel: 'stylesheet', href: styles }];
+import twStyles from './tailwind.css';
+export const links: LinksFunction = () => [
+  { rel: 'stylesheet', href: twStyles },
+];
 
 export const meta: MetaFunction = () => [
   {

--- a/packages/remix/src/generators/setup-tailwind/setup-tailwind.impl.ts
+++ b/packages/remix/src/generators/setup-tailwind/setup-tailwind.impl.ts
@@ -41,9 +41,9 @@ export default async function setupTailwind(
   upsertLinksFunction(
     tree,
     pathToRoot,
-    'styles',
+    'twStyles',
     './tailwind.css',
-    `{ rel: "stylesheet", href: styles }`
+    `{ rel: "stylesheet", href: twStyles }`
   );
 
   addDependenciesToPackageJson(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When `@nx/remix:setup-tailwind` is run, we generate `styles` import in the root of the application.

This can conflict with any existing `styles` import.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add `tw_` prefix to import to indicate more clearly that these styles are related to Tailwind and to prevent any potential conflicts.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
