### PR TITLE
docs(misc): update plugins overview pages for inferred targets

### DIFF
--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -1,3 +1,8 @@
+---
+title: Overview of the Nx Cypress Plugin
+description: The Nx Plugin for Cypress contains executors and generators that support e2e testing with Cypress. This page also explains how to configure Cypress on your Nx workspace.
+---
+
 Cypress is a test runner built for the modern web. It has a lot of great features:
 
 - Time travel
@@ -7,33 +12,73 @@ Cypress is a test runner built for the modern web. It has a lot of great feature
 - Network traffic control
 - Screenshots and videos
 
-## Setting Up Cypress
+## Setting Up @nx/cypress
 
 > Info about [Cypress Component Testing can be found here](/recipes/cypress/cypress-component-testing)
 >
 > Info about [using Cypress and Storybook can be found here](/recipes/storybook/overview-react#cypress-tests-for-storiesbook)
 
-If the `@nx/cypress` package is not installed, install the version that matches your `nx` package version.
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/cypress` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/cypress` by running the following command:
 
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/cypress
+```
+
+This will install the correct version of `@nx/cypress`.
+
+### How @nx/cypress Infers Tasks
+
+The `@nx/cypress` plugin will create a task for any project that has a Cypress configuration file present. Any of the following files will be recognized as a Cypress configuration file:
+
+- `cypress.config.js`
+- `cypress.config.ts`
+- `cypress.config.mjs`
+- `cypress.config.mts`
+- `cypress.config.cjs`
+- `cypress.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/cypress Configuration
+
+The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/cypress/plugin",
+      "options": {
+        "ciTargetName": "e2e-ci",
+        "targetName": "e2e",
+        "componentTestingTargetName": "component-test"
+      }
+    }
+  ]
+}
+```
+
+- The `targetName`, `ciTargetName` and `componentTestingTargetName` options control the namea of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci` and `component-test`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/cypress` package with your package manager and then run the `init` generator.
 
 ```shell
 npm add -D @nx/cypress
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/cypress
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/cypress
+nx g @nx/cypress:init
 ```
 
 {% /tab %}

--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -84,6 +84,10 @@ nx g @nx/cypress:init
 {% /tab %}
 {% /tabs %}
 
+### Splitting E2E tasks by file
+
+The `@nx/cypress/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
+
 ## E2E Testing
 
 By default, when creating a new frontend application, Nx will use Cypress to create the e2e tests project.

--- a/docs/generated/packages/jest/documents/overview.md
+++ b/docs/generated/packages/jest/documents/overview.md
@@ -1,10 +1,83 @@
+---
+title: Overview of the Nx Jest Plugin
+description: The Nx Plugin for Jest contains executors and generators that support testing projects using Jest. This page also explains how to configure Jest on your Nx workspace.
+---
+
 [Jest](https://jestjs.io/) is an open source test runner created by Facebook. It has a lot of great features:
 
 - Immersive watch mode for providing near instant feedback when developing tests.
 - Snapshot testing for validating features.
 - Great built-in reporter for printing out test results.
 
-## Setting up Jest
+## Setting Up @nx/jest
+
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/jest` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/jest` by running the following command:
+
+{% tabs %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/jest
+```
+
+This will install the correct version of `@nx/jest`.
+
+### How @nx/jest Infers Tasks
+
+The `@nx/jest` plugin will create a task for any project that has an Jest configuration file present. Any of the following files will be recognized as an Jest configuration file:
+
+- `jest.config.js`
+- `jest.config.ts`
+- `jest.config.mjs`
+- `jest.config.mts`
+- `jest.config.cjs`
+- `jest.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/jest Configuration
+
+The `@nx/jest/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/jest/plugin",
+      "options": {
+        "targetName": "test"
+      }
+    }
+  ]
+}
+```
+
+- The `targetName` option controls the name of the inferred Jest tasks. The default name is `test`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/jest` package with your package manager and then run the `init` generator.
+
+```shell
+npm add -D @nx/jest
+nx g @nx/jest:init
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Using Jest
+
+### Generate a new project set up with Jest
 
 By default, Nx will use Jest when creating applications and libraries.
 
@@ -12,41 +85,9 @@ By default, Nx will use Jest when creating applications and libraries.
 nx g @nx/web:app frontend
 ```
 
-### Adding Jest to an Existing Project
+### Add Jest to a project
 
-Add Jest to a project using the `configuration` generator from `@nx/jest`.
-
-First, install `@nx/jest`, if not already installed using your preferred package manager.
-
-{% callout type="note" title="Keep Nx Package Versions In Sync" %}
-Make sure to install the `@nx/jest` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
-{% /callout %}
-
-{% tabs %}
-{% tab label="npm" %}
-
-```shell
-npm add -D @nx/jest
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/jest
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/jest
-```
-
-{% /tab %}
-{% /tabs %}
-
-Once installed, run the `configuration` generator
+Run the `configuration` generator
 
 ```shell
 nx g @nx/jest:configuration --project=<project-name>
@@ -55,8 +96,6 @@ nx g @nx/jest:configuration --project=<project-name>
 > Hint: You can use the `--dry-run` flag to see what will be generated.
 
 Replacing `<project-name>` with the name of the project you're wanting to add Jest too.
-
-## Using Jest
 
 ### Testing Applications
 

--- a/docs/generated/packages/next/documents/overview.md
+++ b/docs/generated/packages/next/documents/overview.md
@@ -1,3 +1,8 @@
+---
+title: Overview of the Nx Next.js Plugin
+description: The Nx Next.js plugin contains executors and generators for managing Next.js applications and libraries within an Nx workspace. This page also explains how to configure Next.js on your Nx workspace.
+---
+
 When using Next.js in Nx, you get the out-of-the-box support for TypeScript, Cypress, and Jest. No need to configure anything: watch mode, source maps, and typings just work.
 
 The Next.js plugin contains executors and generators for managing Next.js applications and libraries within an Nx workspace. It provides:
@@ -6,35 +11,78 @@ The Next.js plugin contains executors and generators for managing Next.js applic
 - Integration with building, serving, and exporting a Next.js application.
 - Integration with React libraries within the workspace.
 
-## Setting up Next.js
+## Setting up @nx/next
 
-To create a new Nx workspace with Next.js, run `npx create-nx-workspace@latest --preset=next`.
+To create a new Nx workspace with Next.js, run:
 
-To add Next.js to an existing Nx workspace, install the `@nx/next` package. Make sure to install the version that matches your `nx` version.
+```shell
+npx create-nx-workspace@latest --preset=next
+```
+
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/next` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/next` by running the following command:
 
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/next
+```
+
+This will install the correct version of `@nx/next`.
+
+### How @nx/next Infers Tasks
+
+The `@nx/next` plugin will create a task for any project that has a Next.js configuration file present. Any of the following files will be recognized as a Next.js configuration file:
+
+- `next.config.js`
+- `next.config.mjs`
+- `next.config.cjs`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/next Configuration
+
+The `@nx/next/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/next/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "devTargetName": "dev",
+        "startTargetName": "start"
+      }
+    }
+  ]
+}
+```
+
+- The `buildTargetName`, `devTargetName` and `startTargetName` options control the names of the inferred Next.js tasks. The default names are `build`, `dev` and `start`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/next` package with your package manager and then run the `init` generator.
 
 ```shell
 npm add -D @nx/next
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/next
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/next
+nx g @nx/next:init
 ```
 
 {% /tab %}
 {% /tabs %}
+
+## Using @nx/next
 
 ### Creating Applications
 

--- a/docs/generated/packages/nuxt/documents/overview.md
+++ b/docs/generated/packages/nuxt/documents/overview.md
@@ -5,7 +5,7 @@ description: The Nx Plugin for Nuxt contains generators for managing Nuxt applic
 
 The Nx plugin for [Nuxt](https://nuxt.com/).
 
-## Setting up a new Nx workspace with Nuxt
+## Setting up a new Nx workspace with @nx/nuxt
 
 You can create a new workspace that uses Nuxt with one of the following commands:
 
@@ -15,43 +15,38 @@ You can create a new workspace that uses Nuxt with one of the following commands
 npx create-nx-workspace@latest --preset=nuxt
 ```
 
-## Add Nuxt to an existing workspace
+### Installation
 
-There are a number of ways to use Nuxt in your existing workspace.
-
-### Install the `@nx/nuxt` plugin
-
-{% tabs %}
-{% tab label="npm" %}
-
-```shell
-npm add -D @nx/nuxt
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/nuxt
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/nuxt
-```
-
-{% /tab %}
-{% /tabs %}
-
-### Enable Inferred Tasks
-
-{% callout type="note" title="Inferred Tasks" %}
-In Nx version 17.3, the `@nx/nuxt` plugin can create [inferred tasks](/concepts/inferred-tasks) for projects that have a Nuxt configuration file present. This means you can run `nx build my-project`, `nx serve my-project` and `nx test my-project` for that project, even if there is no `build`, `serve` or `test` targets defined in `package.json` or `project.json`.
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/nuxt` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
 {% /callout %}
 
-To enable inferred targets, add `@nx/nuxt/plugin` to the `plugins` array in `nx.json`.
+In any Nx workspace, you can install `@nx/nuxt` by running the following command:
+
+```shell
+nx add @nx/nuxt
+```
+
+This will install the correct version of `@nx/nuxt`.
+
+### How @nx/nuxt Infers Tasks
+
+The `@nx/nuxt` plugin will create a task for any project that has an Nuxt configuration file present. Any of the following files will be recognized as an Nuxt configuration file:
+
+- `nuxt.config.js`
+- `nuxt.config.ts`
+- `nuxt.config.mjs`
+- `nuxt.config.mts`
+- `nuxt.config.cjs`
+- `nuxt.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/nuxt Configuration
+
+The `@nx/nuxt/plugin` is configured in the `plugins` array in `nx.json`.
 
 ```json {% fileName="nx.json" %}
 {
@@ -68,26 +63,9 @@ To enable inferred targets, add `@nx/nuxt/plugin` to the `plugins` array in `nx.
 }
 ```
 
-### Task Inference Process
+- The `buildTargetName`, `testTargetName` and `serveTargetName` options control the names of the inferred Vite tasks. The default names are `build`, `test` and `serve`.
 
-#### Identify Valid Projects
-
-The `@nx/nuxt/plugin` plugin will create a target for any project that has a Nuxt configuration file present. Any of the following files will be recognized as a Nuxt configuration file:
-
-- `nuxt.config.js`
-- `nuxt.config.ts`
-- `nuxt.config.mjs`
-- `nuxt.config.mts`
-- `nuxt.config.cjs`
-- `nuxt.config.cts`
-
-#### Name the Inferred Task
-
-Once a Nuxt configuration file has been identified, the tasks are created with the name you specify under `buildTargetName`, `serveTargetName` or `testTargetName` in the `nx.json` `plugins` array. The default names for the inferred tasks are `build`, `serve` and `test`.
-
-#### View and Edit Inferred Tasks
-
-To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line. Nx Console also provides a quick way to override the settings of an inferred task.
+## Using Nuxt
 
 ### Generate a new Nuxt app
 

--- a/docs/generated/packages/playwright/documents/overview.md
+++ b/docs/generated/packages/playwright/documents/overview.md
@@ -78,6 +78,10 @@ nx g @nx/playwright:init
 {% /tab %}
 {% /tabs %}
 
+### Splitting E2E tasks by file
+
+The `@nx/playwright/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
+
 ## E2E Testing
 
 By default, when creating a new frontend application, Nx will prompt for which e2e test runner to use. Select `playwright` or pass in the arg `--e2eTestRunner=playwright`

--- a/docs/generated/packages/playwright/documents/overview.md
+++ b/docs/generated/packages/playwright/documents/overview.md
@@ -1,3 +1,8 @@
+---
+title: Overview of the Nx Playwright Plugin
+description: The Nx Plugin for Playwright contains executors and generators that support e2e testing with Playwright. This page also explains how to configure Playwright on your Nx workspace.
+---
+
 Playwright is a modern web test runner. With included features such as:
 
 - Cross browser support, including mobile browsers
@@ -6,29 +11,68 @@ Playwright is a modern web test runner. With included features such as:
 - Test generation
 - Screenshots and videos
 
-## Setting Up Playwright
+## Setting Up @nx/playwright
 
-If the `@nx/playwright` package is not installed, install the version that matches your `nx` package version.
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/playwright` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/playwright` by running the following command:
 
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/playwright
+```
+
+This will install the correct version of `@nx/playwright`.
+
+### How @nx/playwright Infers Tasks
+
+The `@nx/playwright` plugin will create a task for any project that has a Playwright configuration file present. Any of the following files will be recognized as a Playwright configuration file:
+
+- `playwright.config.js`
+- `playwright.config.ts`
+- `playwright.config.mjs`
+- `playwright.config.mts`
+- `playwright.config.cjs`
+- `playwright.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/playwright Configuration
+
+The `@nx/playwright/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/playwright/plugin",
+      "options": {
+        "ciTargetName": "e2e-ci",
+        "targetName": "e2e"
+      }
+    }
+  ]
+}
+```
+
+- The `targetName` and `ciTargetName` options control the namea of the inferred Playwright tasks. The default names are `e2e` and `e2e-ci`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/playwright` package with your package manager and then run the `init` generator.
 
 ```shell
 npm add -D @nx/playwright
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/playwright
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/playwright
+nx g @nx/playwright:init
 ```
 
 {% /tab %}

--- a/docs/generated/packages/remix/documents/overview.md
+++ b/docs/generated/packages/remix/documents/overview.md
@@ -1,3 +1,8 @@
+---
+title: Overview of the Nx Remix Plugin
+description: The Nx Plugin for Remix contains executors, generators, and utilities for managing Remix applications and libraries within an Nx workspace.
+---
+
 The Nx Plugin for Remix contains executors, generators, and utilities for managing Remix applications and libraries
 within an Nx workspace. It provides:
 
@@ -10,49 +15,40 @@ within an Nx workspace. It provides:
   - Meta
 - Utilities for automatic workspace refactoring.
 
-## Setting up the Remix plugin
+## Setting up @nx/remix
+
+### Installation
 
 {% callout type="note" title="Keep Nx Package Versions In Sync" %}
-Make sure to install the `@nx/remix` version that matches the version of `nx` in your repository. If the version
-numbers get out of sync, you can encounter some difficult to debug errors. You
-can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+Make sure to install the `@nx/remix` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
 {% /callout %}
 
-Adding the Remix plugin to an existing Nx workspace can be done with the following:
+In any Nx workspace, you can install `@nx/remix` by running the following command:
 
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
 
 ```shell
-npm add -D @nx/remix
+nx add @nx/remix
 ```
 
-{% /tab %}
-{% tab label="yarn" %}
+This will install the correct version of `@nx/remix`.
 
-```shell
-yarn add -D @nx/remix
-```
+### How @nx/remix Infers Tasks
 
-{% /tab %}
-{% tab label="pnpm" %}
+The `@nx/remix` plugin will create a task for any project that has a Remix configuration file present. Any of the following files will be recognized as a Remix configuration file:
 
-```shell
-pnpm add -D @nx/remix
-```
+- `remix.config.js`
+- `remix.config.mjs`
+- `remix.config.cjs`
 
-{% /tab %}
-{% /tabs %}
+### View Inferred Tasks
 
-### Enabled Inferred Tasks
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
 
-{% callout type="note" title="Inferred Tasks" %}
-In Nx version 17.3, the `@nx/remix` plugin can create [inferred tasks](/concepts/inferred-tasks) for projects that have a Remix configuration file present. This means you can run `nx build my-project`, `nx serve my-project`, `nx start my-project` or `nx typecheck my-project` for that project, even if there are no `build`, `serve`, `start` or `typecheck` tasks defined in `package.json` or `project.json`.
-{% /callout %}
+### @nx/remix Configuration
 
-#### Setup
-
-To enable inferred tasks, add `@nx/remix/plugin` to the `plugins` array in `nx.json`.
+The `@nx/remix/plugin` is configured in the `plugins` array in `nx.json`.
 
 ```json {% fileName="nx.json" %}
 {
@@ -70,23 +66,20 @@ To enable inferred tasks, add `@nx/remix/plugin` to the `plugins` array in `nx.j
 }
 ```
 
-### Task Inference Process
+- The `buildTargetName`, `serveTargetName`, `startTargetName` and `typecheckTargetName` options control the names of the inferred Remix tasks. The default names are `build`, `serve`, `start` and `typecheck`.
 
-#### Identify Valid Projects
+{% /tab %}
+{% tab label="Nx < 18" %}
 
-The `@nx/remix/plugin` plugin will create a task for any project that has a Remix configuration file present. Any of the following files will be recognized as a Remix configuration file:
+Install the `@nx/remix` package with your package manager and then run the `init` generator.
 
-- `remix.config.js`
-- `remix.config.mjs`
-- `remix.config.cjs`
+```shell
+npm add -D @nx/remix
+nx g @nx/remix:init
+```
 
-#### Name the Inferred Task
-
-Once a Remix configuration file has been identified, the targets are created with the name you specify under `buildTargetName`, `serveTargetName`, `startTargetName` or `typecheckTargetName` in the `nx.json` `plugins` array. The default names for the inferred tasks are `build`, `serve`, `start` and `typecheck`.
-
-#### View and Edit Inferred Tasks
-
-To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line. Nx Console also provides a quick way to override the settings of an inferred task.
+{% /tab %}
+{% /tabs %}
 
 ## Using the Remix Plugin
 

--- a/docs/generated/packages/storybook/documents/overview.md
+++ b/docs/generated/packages/storybook/documents/overview.md
@@ -9,43 +9,41 @@ This guide will briefly walk you through using Storybook within an Nx workspace.
 
 ## Setting Up Storybook
 
-### Add the Storybook plugin
+### Installation
 
 {% callout type="note" title="Keep Nx Package Versions In Sync" %}
 Make sure to install the `@nx/storybook` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
 {% /callout %}
 
+In any Nx workspace, you can install `@nx/storybook` by running the following command:
+
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
 
 ```shell
-npm add -D @nx/storybook
+nx add @nx/storybook
 ```
 
-{% /tab %}
-{% tab label="yarn" %}
+This will install the correct version of `@nx/storybook`.
 
-```shell
-yarn add -D @nx/storybook
-```
+### How @nx/storybook Infers Tasks
 
-{% /tab %}
-{% tab label="pnpm" %}
+The `@nx/storybook` plugin will create a task for any project that has a Storybook configuration file present. Any of the following files will be recognized as a Storybook configuration file:
 
-```shell
-pnpm add -D @nx/storybook
-```
+- `.storybook/main.js`
+- `.storybook/main.ts`
+- `.storybook/main.cjs`
+- `.storybook/main.cts`
+- `.storybook/main.mjs`
+- `.storybook/main.mts`
 
-{% /tab %}
-{% /tabs %}
+### View Inferred Tasks
 
-### Enable Inferred Tasks
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
 
-{% callout type="note" title="Inferred Tasks" %}
-In Nx version 17.3, the `@nx/storybook` plugin can create [inferred tasks](/concepts/inferred-tasks) for projects that have a Storybook configuration file present. This means you can run `nx storybook my-project`, `nx build-storybook my-project`, `nx test-storybook my-project` and `nx static-storybook my-project` for that project, even if there is no `storybook`, `build-storybook`, `test-storybook` or `static-storybook` targets defined in `package.json` or `project.json`.
-{% /callout %}
+### @nx/storybook Configuration
 
-To enable inferred targets, add `@nx/storybook/plugin` to the `plugins` array in `nx.json`.
+The `@nx/storybook/plugin` is configured in the `plugins` array in `nx.json`.
 
 ```json {% fileName="nx.json" %}
 {
@@ -63,26 +61,20 @@ To enable inferred targets, add `@nx/storybook/plugin` to the `plugins` array in
 }
 ```
 
-### Task Inference Process
+- The `builtStorybookTargetName`, `serveStorybookTargetName`, `testStorybookTargetName` and `staticStorybookTargetName` options control the names of the inferred Storybook tasks. The default names are `build-storybook`, `storybook`, `test-storybook` and `static-storybook`.
 
-#### Identify Valid Projects
+{% /tab %}
+{% tab label="Nx < 18" %}
 
-The `@nx/storybook/plugin` plugin will create a target for any project that has a Storybook configuration file present. Any of the following files will be recognized as a Storybook configuration file:
+Install the `@nx/storybook` package with your package manager and then run the `init` generator.
 
-- `.storybook/main.js`
-- `.storybook/main.ts`
-- `.storybook/main.cjs`
-- `.storybook/main.cts`
-- `.storybook/main.mjs`
-- `.storybook/main.mts`
+```shell
+npm add -D @nx/storybook
+nx g @nx/storybook:init
+```
 
-#### Name the Inferred Task
-
-Once a Storybook configuration file has been identified, the targets are created with the name you specify under `buildStorybookTargetName`, `serveStorybookTargetName`, `testStorybookTargetName` or `staticStorybookTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `storybook`, `build-storybook`, `test-storybook` and `static-storybook`.
-
-#### View and Edit Inferred Tasks
-
-To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line. Nx Console also provides a quick way to override the settings of an inferred task.
+{% /tab %}
+{% /tabs %}
 
 ## Using Storybook
 

--- a/docs/generated/packages/vite/documents/overview.md
+++ b/docs/generated/packages/vite/documents/overview.md
@@ -16,7 +16,7 @@ Why should you use this plugin?
 
 Read more about Vite and Vitest in the [Vite documentation](https://vitejs.dev/).
 
-## Setting up a new Nx workspace with Vite
+## Setting up a new Nx workspace with @nx/vite
 
 Here's an example on how to create a new React app with Vite
 
@@ -24,9 +24,81 @@ Here's an example on how to create a new React app with Vite
 npx create-nx-workspace@latest --preset=react-standalone --bundler=vite
 ```
 
-## Add Vite to an existing workspace
+### Installation
 
-There are a number of ways to use Vite in your existing workspace.
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/vite` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/vite` by running the following command:
+
+{% tabs %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/vite
+```
+
+This will install the correct version of `@nx/vite`.
+
+### How @nx/vite Infers Tasks
+
+The `@nx/vite` plugin will create a task for any project that has a Vite configuration file present. Any of the following files will be recognized as a Vite configuration file:
+
+- `vite.config.js`
+- `vite.config.ts`
+- `vite.config.mjs`
+- `vite.config.mts`
+- `vite.config.cjs`
+- `vite.config.cts`
+- `vitest.config.js`
+- `vitest.config.ts`
+- `vitest.config.mjs`
+- `vitest.config.mts`
+- `vitest.config.cjs`
+- `vitest.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/vite Configuration
+
+The `@nx/vite/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "previewTargetName": "preview",
+        "testTargetName": "test",
+        "serveTargetName": "serve",
+        "serveStaticTargetName": "serve-static"
+      }
+    }
+  ]
+}
+```
+
+- The `buildTargetName`, `previewTargetName`, `testTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Vite tasks. The default names are `build`, `preview`, `test`, `serve` and `serve-static`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/vite` package with your package manager and then run the `init` generator.
+
+```shell
+npm add -D @nx/vite
+nx g @nx/vite:init
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Using @nx/vite
 
 ### Generate a new project using Vite
 
@@ -55,101 +127,3 @@ nx g @nx/web:app my-app --bundler=vite
 You can use the `@nx/vite:configuration` generator to change your React or Web project to use Vite.js. This generator will modify your project's configuration to use Vite.js, and it will also install all the necessary dependencies, including the `@nx/vite` plugin..
 
 You can read more about this generator on the [`@nx/vite:configuration`](/nx-api/vite/generators/configuration) generator page.
-
-### Initialize Vite
-
-If you do not want to create any new projects or convert any existing projects yet, you can still use Nx to install all the necessary dependencies for Vite.js. This, for example, could be useful if you want to set up Vite.js manually for a project.
-
-#### Install the `@nx/vite` plugin
-
-{% callout type="note" title="Keep Nx Package Versions In Sync" %}
-Make sure to install the `@nx/vite` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
-{% /callout %}
-
-{% tabs %}
-{% tab label="npm" %}
-
-```shell
-npm add -D @nx/vite
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/vite
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/vite
-```
-
-{% /tab %}
-{% /tabs %}
-
-#### Enable Inferred Tasks
-
-{% callout type="note" title="Inferred Tasks" %}
-In Nx version 17.3, the `@nx/vite` plugin can create [inferred tasks](/concepts/inferred-tasks) for projects that have a Vite configuration file present. This means you can run `nx build my-project`, `nx serve my-project`, `nx preview my-project`, `nx serve-static my-project` and `nx test my-project` for that project, even if there is no `build`, `serve`, `preview`, `serve-static` or `test` targets defined in `package.json` or `project.json`.
-{% /callout %}
-
-To enable inferred tasks, add `@nx/vite/plugin` to the `plugins` array in `nx.json`.
-
-```json {% fileName="nx.json" %}
-{
-  "plugins": [
-    {
-      "plugin": "@nx/vite/plugin",
-      "options": {
-        "buildTargetName": "build",
-        "previewTargetName": "preview",
-        "testTargetName": "test",
-        "serveTargetName": "serve",
-        "serveStaticTargetName": "serve-static"
-      }
-    }
-  ]
-}
-```
-
-#### Task Inference Process
-
-##### Identify Valid Projects
-
-The `@nx/vite/plugin` plugin will create a target for any project that has a Vite configuration file present. Any of the following files will be recognized as a Vite configuration file:
-
-- `vite.config.js`
-- `vite.config.ts`
-- `vite.config.mjs`
-- `vite.config.mts`
-- `vite.config.cjs`
-- `vite.config.cts`
-- `vitest.config.js`
-- `vitest.config.ts`
-- `vitest.config.mjs`
-- `vitest.config.mts`
-- `vitest.config.cjs`
-- `vitest.config.cts`
-
-##### Name the Inferred Task
-
-Once a Vite configuration file has been identified, the targets are created with the name you specify under `buildTargetName`, `serveTargetName`, `previewTargetName`, `serveStaticTargetName` or `testTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `build`, `serve`, `preview`, `serve-static` and `test`.
-
-##### View and Edit Inferred Tasks
-
-To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line. Nx Console also provides a quick way to override the settings of an inferred task.
-
-#### Ask Nx to install the necessary dependencies
-
-After you install the plugin, you can automatically initialize the project with Vite using an Nx generator:
-
-```bash
-nx g @nx/vite:init
-```
-
-{% callout type="note" title="Choosing a framework" %}
-You will notice that the generator will ask you of the framework you are planning to use. This is just to make sure that the right dependencies are installed. You can always install manually any other dependencies you need.
-{% /callout %}

--- a/docs/generated/packages/webpack/documents/overview.md
+++ b/docs/generated/packages/webpack/documents/overview.md
@@ -25,6 +25,73 @@ npx create-nx-workspace@latest --preset=react-standalone --bundler=webpack
 npx create-nx-workspace@latest --preset=react-monorepo --bundler=webpack
 ```
 
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/webpack` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/webpack` by running the following command:
+
+{% tabs %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/webpack
+```
+
+This will install the correct version of `@nx/webpack`.
+
+### How @nx/webpack Infers Tasks
+
+The `@nx/webpack` plugin will create a task for any project that has a Webpack configuration file present. Any of the following files will be recognized as a Webpack configuration file:
+
+- `webpack.config.js`
+- `webpack.config.ts`
+- `webpack.config.mjs`
+- `webpack.config.mts`
+- `webpack.config.cjs`
+- `webpack.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/webpack Configuration
+
+The `@nx/webpack/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/webpack/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "previewTargetName": "preview",
+        "serveTargetName": "serve",
+        "serveStaticTargetName": "serve-static"
+      }
+    }
+  ]
+}
+```
+
+- The `buildTargetName`, `previewTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Webpack tasks. The default names are `build`, `preview`, `serve` and `serve-static`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/webpack` package with your package manager and then run the `init` generator.
+
+```shell
+npm add -D @nx/webpack
+nx g @nx/webpack:init
+```
+
+{% /tab %}
+{% /tabs %}
+
 ## Generate a new project using Webpack
 
 You can generate a [React](/nx-api/react) application or a [Web](/nx-api/web) application that uses Webpack in an existing Nx workspace. The [`@nx/react:app`](/nx-api/react/generators/application), [`@nx/node:app`](/nx-api/node/generators/application) and [`@nx/web:app`](/nx-api/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nx/webpack` plugin.

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -1,3 +1,8 @@
+---
+title: Overview of the Nx Cypress Plugin
+description: The Nx Plugin for Cypress contains executors and generators that support e2e testing with Cypress. This page also explains how to configure Cypress on your Nx workspace.
+---
+
 Cypress is a test runner built for the modern web. It has a lot of great features:
 
 - Time travel
@@ -7,33 +12,73 @@ Cypress is a test runner built for the modern web. It has a lot of great feature
 - Network traffic control
 - Screenshots and videos
 
-## Setting Up Cypress
+## Setting Up @nx/cypress
 
 > Info about [Cypress Component Testing can be found here](/recipes/cypress/cypress-component-testing)
 >
 > Info about [using Cypress and Storybook can be found here](/recipes/storybook/overview-react#cypress-tests-for-storiesbook)
 
-If the `@nx/cypress` package is not installed, install the version that matches your `nx` package version.
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/cypress` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/cypress` by running the following command:
 
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/cypress
+```
+
+This will install the correct version of `@nx/cypress`.
+
+### How @nx/cypress Infers Tasks
+
+The `@nx/cypress` plugin will create a task for any project that has a Cypress configuration file present. Any of the following files will be recognized as a Cypress configuration file:
+
+- `cypress.config.js`
+- `cypress.config.ts`
+- `cypress.config.mjs`
+- `cypress.config.mts`
+- `cypress.config.cjs`
+- `cypress.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/cypress Configuration
+
+The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/cypress/plugin",
+      "options": {
+        "ciTargetName": "e2e-ci",
+        "targetName": "e2e",
+        "componentTestingTargetName": "component-test"
+      }
+    }
+  ]
+}
+```
+
+- The `targetName`, `ciTargetName` and `componentTestingTargetName` options control the namea of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci` and `component-test`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/cypress` package with your package manager and then run the `init` generator.
 
 ```shell
 npm add -D @nx/cypress
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/cypress
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/cypress
+nx g @nx/cypress:init
 ```
 
 {% /tab %}

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -84,6 +84,10 @@ nx g @nx/cypress:init
 {% /tab %}
 {% /tabs %}
 
+### Splitting E2E tasks by file
+
+The `@nx/cypress/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
+
 ## E2E Testing
 
 By default, when creating a new frontend application, Nx will use Cypress to create the e2e tests project.

--- a/docs/shared/packages/jest/jest-plugin.md
+++ b/docs/shared/packages/jest/jest-plugin.md
@@ -1,10 +1,83 @@
+---
+title: Overview of the Nx Jest Plugin
+description: The Nx Plugin for Jest contains executors and generators that support testing projects using Jest. This page also explains how to configure Jest on your Nx workspace.
+---
+
 [Jest](https://jestjs.io/) is an open source test runner created by Facebook. It has a lot of great features:
 
 - Immersive watch mode for providing near instant feedback when developing tests.
 - Snapshot testing for validating features.
 - Great built-in reporter for printing out test results.
 
-## Setting up Jest
+## Setting Up @nx/jest
+
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/jest` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/jest` by running the following command:
+
+{% tabs %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/jest
+```
+
+This will install the correct version of `@nx/jest`.
+
+### How @nx/jest Infers Tasks
+
+The `@nx/jest` plugin will create a task for any project that has an Jest configuration file present. Any of the following files will be recognized as an Jest configuration file:
+
+- `jest.config.js`
+- `jest.config.ts`
+- `jest.config.mjs`
+- `jest.config.mts`
+- `jest.config.cjs`
+- `jest.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/jest Configuration
+
+The `@nx/jest/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/jest/plugin",
+      "options": {
+        "targetName": "test"
+      }
+    }
+  ]
+}
+```
+
+- The `targetName` option controls the name of the inferred Jest tasks. The default name is `test`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/jest` package with your package manager and then run the `init` generator.
+
+```shell
+npm add -D @nx/jest
+nx g @nx/jest:init
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Using Jest
+
+### Generate a new project set up with Jest
 
 By default, Nx will use Jest when creating applications and libraries.
 
@@ -12,41 +85,9 @@ By default, Nx will use Jest when creating applications and libraries.
 nx g @nx/web:app frontend
 ```
 
-### Adding Jest to an Existing Project
+### Add Jest to a project
 
-Add Jest to a project using the `configuration` generator from `@nx/jest`.
-
-First, install `@nx/jest`, if not already installed using your preferred package manager.
-
-{% callout type="note" title="Keep Nx Package Versions In Sync" %}
-Make sure to install the `@nx/jest` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
-{% /callout %}
-
-{% tabs %}
-{% tab label="npm" %}
-
-```shell
-npm add -D @nx/jest
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/jest
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/jest
-```
-
-{% /tab %}
-{% /tabs %}
-
-Once installed, run the `configuration` generator
+Run the `configuration` generator
 
 ```shell
 nx g @nx/jest:configuration --project=<project-name>
@@ -55,8 +96,6 @@ nx g @nx/jest:configuration --project=<project-name>
 > Hint: You can use the `--dry-run` flag to see what will be generated.
 
 Replacing `<project-name>` with the name of the project you're wanting to add Jest too.
-
-## Using Jest
 
 ### Testing Applications
 

--- a/docs/shared/packages/next/plugin-overview.md
+++ b/docs/shared/packages/next/plugin-overview.md
@@ -1,3 +1,8 @@
+---
+title: Overview of the Nx Next.js Plugin
+description: The Nx Next.js plugin contains executors and generators for managing Next.js applications and libraries within an Nx workspace. This page also explains how to configure Next.js on your Nx workspace.
+---
+
 When using Next.js in Nx, you get the out-of-the-box support for TypeScript, Cypress, and Jest. No need to configure anything: watch mode, source maps, and typings just work.
 
 The Next.js plugin contains executors and generators for managing Next.js applications and libraries within an Nx workspace. It provides:
@@ -6,35 +11,78 @@ The Next.js plugin contains executors and generators for managing Next.js applic
 - Integration with building, serving, and exporting a Next.js application.
 - Integration with React libraries within the workspace.
 
-## Setting up Next.js
+## Setting up @nx/next
 
-To create a new Nx workspace with Next.js, run `npx create-nx-workspace@latest --preset=next`.
+To create a new Nx workspace with Next.js, run:
 
-To add Next.js to an existing Nx workspace, install the `@nx/next` package. Make sure to install the version that matches your `nx` version.
+```shell
+npx create-nx-workspace@latest --preset=next
+```
+
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/next` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/next` by running the following command:
 
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/next
+```
+
+This will install the correct version of `@nx/next`.
+
+### How @nx/next Infers Tasks
+
+The `@nx/next` plugin will create a task for any project that has a Next.js configuration file present. Any of the following files will be recognized as a Next.js configuration file:
+
+- `next.config.js`
+- `next.config.mjs`
+- `next.config.cjs`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/next Configuration
+
+The `@nx/next/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/next/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "devTargetName": "dev",
+        "startTargetName": "start"
+      }
+    }
+  ]
+}
+```
+
+- The `buildTargetName`, `devTargetName` and `startTargetName` options control the names of the inferred Next.js tasks. The default names are `build`, `dev` and `start`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/next` package with your package manager and then run the `init` generator.
 
 ```shell
 npm add -D @nx/next
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/next
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/next
+nx g @nx/next:init
 ```
 
 {% /tab %}
 {% /tabs %}
+
+## Using @nx/next
 
 ### Creating Applications
 

--- a/docs/shared/packages/nuxt/nuxt-plugin.md
+++ b/docs/shared/packages/nuxt/nuxt-plugin.md
@@ -5,7 +5,7 @@ description: The Nx Plugin for Nuxt contains generators for managing Nuxt applic
 
 The Nx plugin for [Nuxt](https://nuxt.com/).
 
-## Setting up a new Nx workspace with Nuxt
+## Setting up a new Nx workspace with @nx/nuxt
 
 You can create a new workspace that uses Nuxt with one of the following commands:
 
@@ -15,43 +15,38 @@ You can create a new workspace that uses Nuxt with one of the following commands
 npx create-nx-workspace@latest --preset=nuxt
 ```
 
-## Add Nuxt to an existing workspace
+### Installation
 
-There are a number of ways to use Nuxt in your existing workspace.
-
-### Install the `@nx/nuxt` plugin
-
-{% tabs %}
-{% tab label="npm" %}
-
-```shell
-npm add -D @nx/nuxt
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/nuxt
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/nuxt
-```
-
-{% /tab %}
-{% /tabs %}
-
-### Enable Inferred Tasks
-
-{% callout type="note" title="Inferred Tasks" %}
-In Nx version 17.3, the `@nx/nuxt` plugin can create [inferred tasks](/concepts/inferred-tasks) for projects that have a Nuxt configuration file present. This means you can run `nx build my-project`, `nx serve my-project` and `nx test my-project` for that project, even if there is no `build`, `serve` or `test` targets defined in `package.json` or `project.json`.
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/nuxt` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
 {% /callout %}
 
-To enable inferred targets, add `@nx/nuxt/plugin` to the `plugins` array in `nx.json`.
+In any Nx workspace, you can install `@nx/nuxt` by running the following command:
+
+```shell
+nx add @nx/nuxt
+```
+
+This will install the correct version of `@nx/nuxt`.
+
+### How @nx/nuxt Infers Tasks
+
+The `@nx/nuxt` plugin will create a task for any project that has an Nuxt configuration file present. Any of the following files will be recognized as an Nuxt configuration file:
+
+- `nuxt.config.js`
+- `nuxt.config.ts`
+- `nuxt.config.mjs`
+- `nuxt.config.mts`
+- `nuxt.config.cjs`
+- `nuxt.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/nuxt Configuration
+
+The `@nx/nuxt/plugin` is configured in the `plugins` array in `nx.json`.
 
 ```json {% fileName="nx.json" %}
 {
@@ -68,26 +63,9 @@ To enable inferred targets, add `@nx/nuxt/plugin` to the `plugins` array in `nx.
 }
 ```
 
-### Task Inference Process
+- The `buildTargetName`, `testTargetName` and `serveTargetName` options control the names of the inferred Vite tasks. The default names are `build`, `test` and `serve`.
 
-#### Identify Valid Projects
-
-The `@nx/nuxt/plugin` plugin will create a target for any project that has a Nuxt configuration file present. Any of the following files will be recognized as a Nuxt configuration file:
-
-- `nuxt.config.js`
-- `nuxt.config.ts`
-- `nuxt.config.mjs`
-- `nuxt.config.mts`
-- `nuxt.config.cjs`
-- `nuxt.config.cts`
-
-#### Name the Inferred Task
-
-Once a Nuxt configuration file has been identified, the tasks are created with the name you specify under `buildTargetName`, `serveTargetName` or `testTargetName` in the `nx.json` `plugins` array. The default names for the inferred tasks are `build`, `serve` and `test`.
-
-#### View and Edit Inferred Tasks
-
-To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line. Nx Console also provides a quick way to override the settings of an inferred task.
+## Using Nuxt
 
 ### Generate a new Nuxt app
 

--- a/docs/shared/packages/playwright/playwright-plugin.md
+++ b/docs/shared/packages/playwright/playwright-plugin.md
@@ -78,6 +78,10 @@ nx g @nx/playwright:init
 {% /tab %}
 {% /tabs %}
 
+### Splitting E2E tasks by file
+
+The `@nx/playwright/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
+
 ## E2E Testing
 
 By default, when creating a new frontend application, Nx will prompt for which e2e test runner to use. Select `playwright` or pass in the arg `--e2eTestRunner=playwright`

--- a/docs/shared/packages/playwright/playwright-plugin.md
+++ b/docs/shared/packages/playwright/playwright-plugin.md
@@ -1,3 +1,8 @@
+---
+title: Overview of the Nx Playwright Plugin
+description: The Nx Plugin for Playwright contains executors and generators that support e2e testing with Playwright. This page also explains how to configure Playwright on your Nx workspace.
+---
+
 Playwright is a modern web test runner. With included features such as:
 
 - Cross browser support, including mobile browsers
@@ -6,29 +11,68 @@ Playwright is a modern web test runner. With included features such as:
 - Test generation
 - Screenshots and videos
 
-## Setting Up Playwright
+## Setting Up @nx/playwright
 
-If the `@nx/playwright` package is not installed, install the version that matches your `nx` package version.
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/playwright` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/playwright` by running the following command:
 
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/playwright
+```
+
+This will install the correct version of `@nx/playwright`.
+
+### How @nx/playwright Infers Tasks
+
+The `@nx/playwright` plugin will create a task for any project that has a Playwright configuration file present. Any of the following files will be recognized as a Playwright configuration file:
+
+- `playwright.config.js`
+- `playwright.config.ts`
+- `playwright.config.mjs`
+- `playwright.config.mts`
+- `playwright.config.cjs`
+- `playwright.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/playwright Configuration
+
+The `@nx/playwright/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/playwright/plugin",
+      "options": {
+        "ciTargetName": "e2e-ci",
+        "targetName": "e2e"
+      }
+    }
+  ]
+}
+```
+
+- The `targetName` and `ciTargetName` options control the namea of the inferred Playwright tasks. The default names are `e2e` and `e2e-ci`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/playwright` package with your package manager and then run the `init` generator.
 
 ```shell
 npm add -D @nx/playwright
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/playwright
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/playwright
+nx g @nx/playwright:init
 ```
 
 {% /tab %}

--- a/docs/shared/packages/remix/remix-plugin.md
+++ b/docs/shared/packages/remix/remix-plugin.md
@@ -1,3 +1,8 @@
+---
+title: Overview of the Nx Remix Plugin
+description: The Nx Plugin for Remix contains executors, generators, and utilities for managing Remix applications and libraries within an Nx workspace.
+---
+
 The Nx Plugin for Remix contains executors, generators, and utilities for managing Remix applications and libraries
 within an Nx workspace. It provides:
 
@@ -10,49 +15,40 @@ within an Nx workspace. It provides:
   - Meta
 - Utilities for automatic workspace refactoring.
 
-## Setting up the Remix plugin
+## Setting up @nx/remix
+
+### Installation
 
 {% callout type="note" title="Keep Nx Package Versions In Sync" %}
-Make sure to install the `@nx/remix` version that matches the version of `nx` in your repository. If the version
-numbers get out of sync, you can encounter some difficult to debug errors. You
-can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+Make sure to install the `@nx/remix` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
 {% /callout %}
 
-Adding the Remix plugin to an existing Nx workspace can be done with the following:
+In any Nx workspace, you can install `@nx/remix` by running the following command:
 
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
 
 ```shell
-npm add -D @nx/remix
+nx add @nx/remix
 ```
 
-{% /tab %}
-{% tab label="yarn" %}
+This will install the correct version of `@nx/remix`.
 
-```shell
-yarn add -D @nx/remix
-```
+### How @nx/remix Infers Tasks
 
-{% /tab %}
-{% tab label="pnpm" %}
+The `@nx/remix` plugin will create a task for any project that has a Remix configuration file present. Any of the following files will be recognized as a Remix configuration file:
 
-```shell
-pnpm add -D @nx/remix
-```
+- `remix.config.js`
+- `remix.config.mjs`
+- `remix.config.cjs`
 
-{% /tab %}
-{% /tabs %}
+### View Inferred Tasks
 
-### Enabled Inferred Tasks
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
 
-{% callout type="note" title="Inferred Tasks" %}
-In Nx version 17.3, the `@nx/remix` plugin can create [inferred tasks](/concepts/inferred-tasks) for projects that have a Remix configuration file present. This means you can run `nx build my-project`, `nx serve my-project`, `nx start my-project` or `nx typecheck my-project` for that project, even if there are no `build`, `serve`, `start` or `typecheck` tasks defined in `package.json` or `project.json`.
-{% /callout %}
+### @nx/remix Configuration
 
-#### Setup
-
-To enable inferred tasks, add `@nx/remix/plugin` to the `plugins` array in `nx.json`.
+The `@nx/remix/plugin` is configured in the `plugins` array in `nx.json`.
 
 ```json {% fileName="nx.json" %}
 {
@@ -70,23 +66,20 @@ To enable inferred tasks, add `@nx/remix/plugin` to the `plugins` array in `nx.j
 }
 ```
 
-### Task Inference Process
+- The `buildTargetName`, `serveTargetName`, `startTargetName` and `typecheckTargetName` options control the names of the inferred Remix tasks. The default names are `build`, `serve`, `start` and `typecheck`.
 
-#### Identify Valid Projects
+{% /tab %}
+{% tab label="Nx < 18" %}
 
-The `@nx/remix/plugin` plugin will create a task for any project that has a Remix configuration file present. Any of the following files will be recognized as a Remix configuration file:
+Install the `@nx/remix` package with your package manager and then run the `init` generator.
 
-- `remix.config.js`
-- `remix.config.mjs`
-- `remix.config.cjs`
+```shell
+npm add -D @nx/remix
+nx g @nx/remix:init
+```
 
-#### Name the Inferred Task
-
-Once a Remix configuration file has been identified, the targets are created with the name you specify under `buildTargetName`, `serveTargetName`, `startTargetName` or `typecheckTargetName` in the `nx.json` `plugins` array. The default names for the inferred tasks are `build`, `serve`, `start` and `typecheck`.
-
-#### View and Edit Inferred Tasks
-
-To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line. Nx Console also provides a quick way to override the settings of an inferred task.
+{% /tab %}
+{% /tabs %}
 
 ## Using the Remix Plugin
 

--- a/docs/shared/packages/storybook/plugin-overview.md
+++ b/docs/shared/packages/storybook/plugin-overview.md
@@ -9,43 +9,41 @@ This guide will briefly walk you through using Storybook within an Nx workspace.
 
 ## Setting Up Storybook
 
-### Add the Storybook plugin
+### Installation
 
 {% callout type="note" title="Keep Nx Package Versions In Sync" %}
 Make sure to install the `@nx/storybook` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
 {% /callout %}
 
+In any Nx workspace, you can install `@nx/storybook` by running the following command:
+
 {% tabs %}
-{% tab label="npm" %}
+{% tab label="Nx 18+" %}
 
 ```shell
-npm add -D @nx/storybook
+nx add @nx/storybook
 ```
 
-{% /tab %}
-{% tab label="yarn" %}
+This will install the correct version of `@nx/storybook`.
 
-```shell
-yarn add -D @nx/storybook
-```
+### How @nx/storybook Infers Tasks
 
-{% /tab %}
-{% tab label="pnpm" %}
+The `@nx/storybook` plugin will create a task for any project that has a Storybook configuration file present. Any of the following files will be recognized as a Storybook configuration file:
 
-```shell
-pnpm add -D @nx/storybook
-```
+- `.storybook/main.js`
+- `.storybook/main.ts`
+- `.storybook/main.cjs`
+- `.storybook/main.cts`
+- `.storybook/main.mjs`
+- `.storybook/main.mts`
 
-{% /tab %}
-{% /tabs %}
+### View Inferred Tasks
 
-### Enable Inferred Tasks
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
 
-{% callout type="note" title="Inferred Tasks" %}
-In Nx version 17.3, the `@nx/storybook` plugin can create [inferred tasks](/concepts/inferred-tasks) for projects that have a Storybook configuration file present. This means you can run `nx storybook my-project`, `nx build-storybook my-project`, `nx test-storybook my-project` and `nx static-storybook my-project` for that project, even if there is no `storybook`, `build-storybook`, `test-storybook` or `static-storybook` targets defined in `package.json` or `project.json`.
-{% /callout %}
+### @nx/storybook Configuration
 
-To enable inferred targets, add `@nx/storybook/plugin` to the `plugins` array in `nx.json`.
+The `@nx/storybook/plugin` is configured in the `plugins` array in `nx.json`.
 
 ```json {% fileName="nx.json" %}
 {
@@ -63,26 +61,20 @@ To enable inferred targets, add `@nx/storybook/plugin` to the `plugins` array in
 }
 ```
 
-### Task Inference Process
+- The `builtStorybookTargetName`, `serveStorybookTargetName`, `testStorybookTargetName` and `staticStorybookTargetName` options control the names of the inferred Storybook tasks. The default names are `build-storybook`, `storybook`, `test-storybook` and `static-storybook`.
 
-#### Identify Valid Projects
+{% /tab %}
+{% tab label="Nx < 18" %}
 
-The `@nx/storybook/plugin` plugin will create a target for any project that has a Storybook configuration file present. Any of the following files will be recognized as a Storybook configuration file:
+Install the `@nx/storybook` package with your package manager and then run the `init` generator.
 
-- `.storybook/main.js`
-- `.storybook/main.ts`
-- `.storybook/main.cjs`
-- `.storybook/main.cts`
-- `.storybook/main.mjs`
-- `.storybook/main.mts`
+```shell
+npm add -D @nx/storybook
+nx g @nx/storybook:init
+```
 
-#### Name the Inferred Task
-
-Once a Storybook configuration file has been identified, the targets are created with the name you specify under `buildStorybookTargetName`, `serveStorybookTargetName`, `testStorybookTargetName` or `staticStorybookTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `storybook`, `build-storybook`, `test-storybook` and `static-storybook`.
-
-#### View and Edit Inferred Tasks
-
-To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line. Nx Console also provides a quick way to override the settings of an inferred task.
+{% /tab %}
+{% /tabs %}
 
 ## Using Storybook
 

--- a/docs/shared/packages/vite/vite-plugin.md
+++ b/docs/shared/packages/vite/vite-plugin.md
@@ -16,7 +16,7 @@ Why should you use this plugin?
 
 Read more about Vite and Vitest in the [Vite documentation](https://vitejs.dev/).
 
-## Setting up a new Nx workspace with Vite
+## Setting up a new Nx workspace with @nx/vite
 
 Here's an example on how to create a new React app with Vite
 
@@ -24,9 +24,81 @@ Here's an example on how to create a new React app with Vite
 npx create-nx-workspace@latest --preset=react-standalone --bundler=vite
 ```
 
-## Add Vite to an existing workspace
+### Installation
 
-There are a number of ways to use Vite in your existing workspace.
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/vite` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/vite` by running the following command:
+
+{% tabs %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/vite
+```
+
+This will install the correct version of `@nx/vite`.
+
+### How @nx/vite Infers Tasks
+
+The `@nx/vite` plugin will create a task for any project that has a Vite configuration file present. Any of the following files will be recognized as a Vite configuration file:
+
+- `vite.config.js`
+- `vite.config.ts`
+- `vite.config.mjs`
+- `vite.config.mts`
+- `vite.config.cjs`
+- `vite.config.cts`
+- `vitest.config.js`
+- `vitest.config.ts`
+- `vitest.config.mjs`
+- `vitest.config.mts`
+- `vitest.config.cjs`
+- `vitest.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/vite Configuration
+
+The `@nx/vite/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "previewTargetName": "preview",
+        "testTargetName": "test",
+        "serveTargetName": "serve",
+        "serveStaticTargetName": "serve-static"
+      }
+    }
+  ]
+}
+```
+
+- The `buildTargetName`, `previewTargetName`, `testTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Vite tasks. The default names are `build`, `preview`, `test`, `serve` and `serve-static`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/vite` package with your package manager and then run the `init` generator.
+
+```shell
+npm add -D @nx/vite
+nx g @nx/vite:init
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Using @nx/vite
 
 ### Generate a new project using Vite
 
@@ -55,101 +127,3 @@ nx g @nx/web:app my-app --bundler=vite
 You can use the `@nx/vite:configuration` generator to change your React or Web project to use Vite.js. This generator will modify your project's configuration to use Vite.js, and it will also install all the necessary dependencies, including the `@nx/vite` plugin..
 
 You can read more about this generator on the [`@nx/vite:configuration`](/nx-api/vite/generators/configuration) generator page.
-
-### Initialize Vite
-
-If you do not want to create any new projects or convert any existing projects yet, you can still use Nx to install all the necessary dependencies for Vite.js. This, for example, could be useful if you want to set up Vite.js manually for a project.
-
-#### Install the `@nx/vite` plugin
-
-{% callout type="note" title="Keep Nx Package Versions In Sync" %}
-Make sure to install the `@nx/vite` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
-{% /callout %}
-
-{% tabs %}
-{% tab label="npm" %}
-
-```shell
-npm add -D @nx/vite
-```
-
-{% /tab %}
-{% tab label="yarn" %}
-
-```shell
-yarn add -D @nx/vite
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D @nx/vite
-```
-
-{% /tab %}
-{% /tabs %}
-
-#### Enable Inferred Tasks
-
-{% callout type="note" title="Inferred Tasks" %}
-In Nx version 17.3, the `@nx/vite` plugin can create [inferred tasks](/concepts/inferred-tasks) for projects that have a Vite configuration file present. This means you can run `nx build my-project`, `nx serve my-project`, `nx preview my-project`, `nx serve-static my-project` and `nx test my-project` for that project, even if there is no `build`, `serve`, `preview`, `serve-static` or `test` targets defined in `package.json` or `project.json`.
-{% /callout %}
-
-To enable inferred tasks, add `@nx/vite/plugin` to the `plugins` array in `nx.json`.
-
-```json {% fileName="nx.json" %}
-{
-  "plugins": [
-    {
-      "plugin": "@nx/vite/plugin",
-      "options": {
-        "buildTargetName": "build",
-        "previewTargetName": "preview",
-        "testTargetName": "test",
-        "serveTargetName": "serve",
-        "serveStaticTargetName": "serve-static"
-      }
-    }
-  ]
-}
-```
-
-#### Task Inference Process
-
-##### Identify Valid Projects
-
-The `@nx/vite/plugin` plugin will create a target for any project that has a Vite configuration file present. Any of the following files will be recognized as a Vite configuration file:
-
-- `vite.config.js`
-- `vite.config.ts`
-- `vite.config.mjs`
-- `vite.config.mts`
-- `vite.config.cjs`
-- `vite.config.cts`
-- `vitest.config.js`
-- `vitest.config.ts`
-- `vitest.config.mjs`
-- `vitest.config.mts`
-- `vitest.config.cjs`
-- `vitest.config.cts`
-
-##### Name the Inferred Task
-
-Once a Vite configuration file has been identified, the targets are created with the name you specify under `buildTargetName`, `serveTargetName`, `previewTargetName`, `serveStaticTargetName` or `testTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `build`, `serve`, `preview`, `serve-static` and `test`.
-
-##### View and Edit Inferred Tasks
-
-To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line. Nx Console also provides a quick way to override the settings of an inferred task.
-
-#### Ask Nx to install the necessary dependencies
-
-After you install the plugin, you can automatically initialize the project with Vite using an Nx generator:
-
-```bash
-nx g @nx/vite:init
-```
-
-{% callout type="note" title="Choosing a framework" %}
-You will notice that the generator will ask you of the framework you are planning to use. This is just to make sure that the right dependencies are installed. You can always install manually any other dependencies you need.
-{% /callout %}

--- a/docs/shared/packages/webpack/plugin-overview.md
+++ b/docs/shared/packages/webpack/plugin-overview.md
@@ -25,6 +25,73 @@ npx create-nx-workspace@latest --preset=react-standalone --bundler=webpack
 npx create-nx-workspace@latest --preset=react-monorepo --bundler=webpack
 ```
 
+### Installation
+
+{% callout type="note" title="Keep Nx Package Versions In Sync" %}
+Make sure to install the `@nx/webpack` version that matches the version of `nx` in your repository. If the version numbers get out of sync, you can encounter some difficult to debug errors. You can [fix Nx version mismatches with this recipe](/recipes/tips-n-tricks/keep-nx-versions-in-sync).
+{% /callout %}
+
+In any Nx workspace, you can install `@nx/webpack` by running the following command:
+
+{% tabs %}
+{% tab label="Nx 18+" %}
+
+```shell
+nx add @nx/webpack
+```
+
+This will install the correct version of `@nx/webpack`.
+
+### How @nx/webpack Infers Tasks
+
+The `@nx/webpack` plugin will create a task for any project that has a Webpack configuration file present. Any of the following files will be recognized as a Webpack configuration file:
+
+- `webpack.config.js`
+- `webpack.config.ts`
+- `webpack.config.mjs`
+- `webpack.config.mts`
+- `webpack.config.cjs`
+- `webpack.config.cts`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
+
+### @nx/webpack Configuration
+
+The `@nx/webpack/plugin` is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/webpack/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "previewTargetName": "preview",
+        "serveTargetName": "serve",
+        "serveStaticTargetName": "serve-static"
+      }
+    }
+  ]
+}
+```
+
+- The `buildTargetName`, `previewTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Webpack tasks. The default names are `build`, `preview`, `serve` and `serve-static`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/webpack` package with your package manager and then run the `init` generator.
+
+```shell
+npm add -D @nx/webpack
+nx g @nx/webpack:init
+```
+
+{% /tab %}
+{% /tabs %}
+
 ## Generate a new project using Webpack
 
 You can generate a [React](/nx-api/react) application or a [Web](/nx-api/web) application that uses Webpack in an existing Nx workspace. The [`@nx/react:app`](/nx-api/react/generators/application), [`@nx/node:app`](/nx-api/node/generators/application) and [`@nx/web:app`](/nx-api/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nx/webpack` plugin.


### PR DESCRIPTION
Update overview pages to include inferred targets docs:
- vite
- nuxt
- cypress
- webpack
- storybook
- playwright
- jest
- next
- remix