### PR TITLE
docs(misc): add e2e split within nx 18 tab

### DIFF
--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -71,6 +71,10 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
 
 - The `targetName`, `ciTargetName` and `componentTestingTargetName` options control the namea of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci` and `component-test`.
 
+### Splitting E2E tasks by file
+
+The `@nx/cypress/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
+
 {% /tab %}
 {% tab label="Nx < 18" %}
 
@@ -82,10 +86,6 @@ npm add -D @nx/cypress
 
 {% /tab %}
 {% /tabs %}
-
-### Splitting E2E tasks by file
-
-The `@nx/cypress/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
 
 ## E2E Testing
 

--- a/docs/generated/packages/playwright/documents/overview.md
+++ b/docs/generated/packages/playwright/documents/overview.md
@@ -65,6 +65,10 @@ The `@nx/playwright/plugin` is configured in the `plugins` array in `nx.json`.
 
 - The `targetName` and `ciTargetName` options control the namea of the inferred Playwright tasks. The default names are `e2e` and `e2e-ci`.
 
+### Splitting E2E tasks by file
+
+The `@nx/playwright/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
+
 {% /tab %}
 {% tab label="Nx < 18" %}
 
@@ -76,10 +80,6 @@ npm add -D @nx/playwright
 
 {% /tab %}
 {% /tabs %}
-
-### Splitting E2E tasks by file
-
-The `@nx/playwright/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
 
 ## E2E Testing
 

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -71,6 +71,10 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
 
 - The `targetName`, `ciTargetName` and `componentTestingTargetName` options control the namea of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci` and `component-test`.
 
+### Splitting E2E tasks by file
+
+The `@nx/cypress/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
+
 {% /tab %}
 {% tab label="Nx < 18" %}
 
@@ -82,10 +86,6 @@ npm add -D @nx/cypress
 
 {% /tab %}
 {% /tabs %}
-
-### Splitting E2E tasks by file
-
-The `@nx/cypress/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
 
 ## E2E Testing
 

--- a/docs/shared/packages/playwright/playwright-plugin.md
+++ b/docs/shared/packages/playwright/playwright-plugin.md
@@ -65,6 +65,10 @@ The `@nx/playwright/plugin` is configured in the `plugins` array in `nx.json`.
 
 - The `targetName` and `ciTargetName` options control the namea of the inferred Playwright tasks. The default names are `e2e` and `e2e-ci`.
 
+### Splitting E2E tasks by file
+
+The `@nx/playwright/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
+
 {% /tab %}
 {% tab label="Nx < 18" %}
 
@@ -76,10 +80,6 @@ npm add -D @nx/playwright
 
 {% /tab %}
 {% /tabs %}
-
-### Splitting E2E tasks by file
-
-The `@nx/playwright/plugin` will automatically split your e2e tasks by file. You can read more about this feature [here](/ci/concepts/split-e2e-tasks).
 
 ## E2E Testing
 


### PR DESCRIPTION
Accidentally I put the "split e2e" link outside the tabs
