### PR TITLE
fix(core): properly disconnect daemon & reject promise

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -267,6 +267,12 @@ export class DaemonClient {
               `If you get this error again, check for any errors in the daemon process logs found in: ${DAEMON_OUTPUT_LOG_FILE}`,
             ],
           });
+          this._daemonStatus = DaemonStatus.DISCONNECTED;
+          this.currentReject?.(
+            daemonProcessException(
+              'Daemon process terminated and closed the connection'
+            )
+          );
           process.exit(1);
         }
       },


### PR DESCRIPTION
this is important so that the daemon disconnects even when process.exit(1) is overridden like it is
in nx console
