### PR TITLE
fix(vue): import vue libs in other libs - fix ts2307

### DIFF
--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -134,6 +134,37 @@ exports[`lib should add vue, vite and vitest to package.json 1`] = `
 }
 `;
 
+exports[`lib should add vue, vite and vitest to package.json 2`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "types": ["vite/client"]
+  },
+  "exclude": [
+    "src/**/__tests__/*",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.vue",
+    "src/**/*.test.vue"
+  ],
+  "include": [
+    "src/**/*.js",
+    "src/**/*.jsx",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue"
+  ]
+}
+"
+`;
+
 exports[`lib should generate files 1`] = `
 {
   "extends": [
@@ -174,5 +205,7 @@ exports[`lib should ignore test files in tsconfig.lib.json 1`] = `
   "src/**/*.test.js",
   "src/**/*.spec.jsx",
   "src/**/*.test.jsx",
+  "src/**/*.spec.vue",
+  "src/**/*.test.vue",
 ]
 `;

--- a/packages/vue/src/generators/library/files/tsconfig.lib.json__tmpl__
+++ b/packages/vue/src/generators/library/files/tsconfig.lib.json__tmpl__
@@ -2,16 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "types": [],
-    "lib": [
-      "ES2016",
-      "DOM",
-      "DOM.Iterable"
-      ],
   },
   "exclude": [
     "src/**/__tests__/*", 
@@ -22,7 +13,9 @@
     "src/**/*.spec.js", 
     "src/**/*.test.js", 
     "src/**/*.spec.jsx", 
-    "src/**/*.test.jsx"
+    "src/**/*.test.jsx",
+    "src/**/*.spec.vue",
+    "src/**/*.test.vue"
     ],
   "include": [
     "src/**/*.js", 

--- a/packages/vue/src/generators/library/library.spec.ts
+++ b/packages/vue/src/generators/library/library.spec.ts
@@ -78,6 +78,7 @@ describe('lib', () => {
   it('should add vue, vite and vitest to package.json', async () => {
     await libraryGenerator(tree, defaultSchema);
     expect(readJson(tree, '/package.json')).toMatchSnapshot();
+    expect(tree.read('my-lib/tsconfig.lib.json', 'utf-8')).toMatchSnapshot();
   });
 
   it('should update root tsconfig.base.json', async () => {


### PR DESCRIPTION
closed #21109

Remove extra, not needed, settings from `tsconfig.lib.json`, so that ts does not show error on vscode when importing a vue library inside another vue library.

Importing does not show error on apps, since apps do not have these settings in `tsconfig.app.json`.
