### PR TITLE
feat(release): allow overriding generator and generatorOptions per project

### DIFF
--- a/docs/generated/devkit/ProjectConfiguration.md
+++ b/docs/generated/devkit/ProjectConfiguration.md
@@ -11,6 +11,7 @@ Project configuration
 - [name](../../devkit/documents/ProjectConfiguration#name): string
 - [namedInputs](../../devkit/documents/ProjectConfiguration#namedinputs): Object
 - [projectType](../../devkit/documents/ProjectConfiguration#projecttype): ProjectType
+- [release](../../devkit/documents/ProjectConfiguration#release): Object
 - [root](../../devkit/documents/ProjectConfiguration#root): string
 - [sourceRoot](../../devkit/documents/ProjectConfiguration#sourceroot): string
 - [tags](../../devkit/documents/ProjectConfiguration#tags): string[]
@@ -77,6 +78,20 @@ Named inputs targets can refer to reduce duplication
 • `Optional` **projectType**: [`ProjectType`](../../devkit/documents/ProjectType)
 
 Project type
+
+---
+
+### release
+
+• `Optional` **release**: `Object`
+
+Project specific configuration for `nx release`
+
+#### Type declaration
+
+| Name       | Type                                                                             |
+| :--------- | :------------------------------------------------------------------------------- |
+| `version?` | `Pick`\<`NxReleaseVersionConfiguration`, `"generator"` \| `"generatorOptions"`\> |
 
 ---
 

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -42,6 +42,7 @@ export const allowedProjectExtensions = [
   'root',
   'sourceRoot',
   'projectType',
+  'release',
 ] as const;
 
 // If we pass props on the workspace that angular doesn't know about,
@@ -132,7 +133,7 @@ function mockReadJsonWorkspace(
         ...options,
         allowedProjectExtensions: allowedProjectExtensions as CheckHasKeys<
           typeof allowedProjectExtensions,
-          keyof Omit<ProjectConfiguration, 'targets' | 'generators' | 'release'>
+          keyof Omit<ProjectConfiguration, 'targets' | 'generators'>
         >,
         allowedWorkspaceExtensions: allowedWorkspaceExtensions as CheckHasKeys<
           typeof allowedWorkspaceExtensions,

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -132,7 +132,7 @@ function mockReadJsonWorkspace(
         ...options,
         allowedProjectExtensions: allowedProjectExtensions as CheckHasKeys<
           typeof allowedProjectExtensions,
-          keyof Omit<ProjectConfiguration, 'targets' | 'generators'>
+          keyof Omit<ProjectConfiguration, 'targets' | 'generators' | 'release'>
         >,
         allowedWorkspaceExtensions: allowedWorkspaceExtensions as CheckHasKeys<
           typeof allowedWorkspaceExtensions,

--- a/packages/nx/src/command-line/release/utils/batch-projects-by-generator-config.spec.ts
+++ b/packages/nx/src/command-line/release/utils/batch-projects-by-generator-config.spec.ts
@@ -1,0 +1,192 @@
+import { ProjectGraph } from '../../../config/project-graph';
+import { ReleaseGroupWithName } from '../config/filter-release-groups';
+import { batchProjectsByGeneratorConfig } from './batch-projects-by-generator-config';
+
+describe('batchProjectsByGeneratorConfig()', () => {
+  it('should work for multiple levels of generatorOptions nesting and should not be key order dependent', () => {
+    const projectGraph = getProjectGraph();
+
+    const releaseGroup: ReleaseGroupWithName = {
+      projects: ['foo', 'bar', 'baz', 'qux'],
+      version: {
+        // qux will be the only one that has a different generator
+        generator: '@nx/js:release-version',
+        // overridden at the project level by foo and bar (see getProjectGraph() below)
+        generatorOptions: {},
+      },
+    } as any; // we don't care about the other properties for this test
+
+    expect(
+      batchProjectsByGeneratorConfig(projectGraph, releaseGroup, [
+        'foo',
+        'bar',
+        'baz',
+        'qux',
+      ])
+    ).toMatchInlineSnapshot(`
+      Map {
+        "["@nx/js:release-version",{"bar":"string","foo":true,"o":{"nested2":[],"nested1":false},"arr":["1",2,false]}]" => [
+          "foo",
+          "bar",
+        ],
+        "["@nx/js:release-version",{}]" => [
+          "baz",
+        ],
+        "["@nx/some:other-generator",{}]" => [
+          "qux",
+        ],
+      }
+    `);
+  });
+});
+
+/**
+ * Taken from a real workspace in which the generatorOptions config for foo and bar are intentionally
+ * functionally identical but ordered differently to ensure they will be batched together correctly.
+ */
+function getProjectGraph(): ProjectGraph {
+  return {
+    dependencies: {},
+    nodes: {
+      bar: {
+        name: 'bar',
+        type: 'lib',
+        data: {
+          root: 'packages/bar',
+          name: 'bar',
+          targets: {
+            test: {
+              executor: 'nx:run-script',
+              options: {
+                script: 'test',
+              },
+              configurations: {},
+            },
+            'nx-release-publish': {
+              dependsOn: ['^nx-release-publish'],
+              executor: '@nx/js:release-publish',
+              options: {},
+              configurations: {},
+            },
+          },
+          sourceRoot: 'packages/bar',
+          projectType: 'library',
+          release: {
+            version: {
+              generatorOptions: {
+                arr: ['1', 2, false],
+                foo: true,
+                bar: 'string',
+                o: {
+                  nested1: false,
+                  nested2: [],
+                },
+              },
+            },
+          },
+          implicitDependencies: [],
+          tags: [],
+        },
+      },
+      baz: {
+        name: 'baz',
+        type: 'lib',
+        data: {
+          root: 'packages/baz',
+          name: 'baz',
+          targets: {
+            test: {
+              executor: 'nx:run-script',
+              options: {
+                script: 'test',
+              },
+              configurations: {},
+            },
+            'nx-release-publish': {
+              dependsOn: ['^nx-release-publish'],
+              executor: '@nx/js:release-publish',
+              options: {},
+              configurations: {},
+            },
+          },
+          sourceRoot: 'packages/baz',
+          projectType: 'library',
+          implicitDependencies: [],
+          tags: [],
+        },
+      },
+      foo: {
+        name: 'foo',
+        type: 'lib',
+        data: {
+          root: 'packages/foo',
+          name: 'foo',
+          targets: {
+            test: {
+              executor: 'nx:run-script',
+              options: {
+                script: 'test',
+              },
+              configurations: {},
+            },
+            'nx-release-publish': {
+              dependsOn: ['^nx-release-publish'],
+              executor: '@nx/js:release-publish',
+              options: {},
+              configurations: {},
+            },
+          },
+          sourceRoot: 'packages/foo',
+          projectType: 'library',
+          release: {
+            version: {
+              generatorOptions: {
+                bar: 'string',
+                foo: true,
+                o: {
+                  nested2: [],
+                  nested1: false,
+                },
+                arr: ['1', 2, false],
+              },
+            },
+          },
+          implicitDependencies: [],
+          tags: [],
+        },
+      },
+      qux: {
+        name: 'qux',
+        type: 'lib',
+        data: {
+          root: 'packages/qux',
+          name: 'qux',
+          targets: {
+            test: {
+              executor: 'nx:run-script',
+              options: {
+                script: 'test',
+              },
+              configurations: {},
+            },
+            'nx-release-publish': {
+              dependsOn: ['^nx-release-publish'],
+              executor: '@nx/js:release-publish',
+              options: {},
+              configurations: {},
+            },
+          },
+          sourceRoot: 'packages/qux',
+          projectType: 'library',
+          release: {
+            version: {
+              generator: '@nx/some:other-generator',
+            },
+          },
+          implicitDependencies: [],
+          tags: [],
+        },
+      },
+    },
+  };
+}

--- a/packages/nx/src/command-line/release/utils/batch-projects-by-generator-config.ts
+++ b/packages/nx/src/command-line/release/utils/batch-projects-by-generator-config.ts
@@ -1,0 +1,45 @@
+import { ProjectGraph } from '../../../config/project-graph';
+import { deepEquals } from '../../../utils/json-diff';
+import { ReleaseGroupWithName } from '../config/filter-release-groups';
+
+/**
+ * To be most efficient with our invocations of runVersionOnProjects, we want to batch projects by their generator and generator options
+ * within any given release group.
+ */
+export function batchProjectsByGeneratorConfig(
+  projectGraph: ProjectGraph,
+  releaseGroup: ReleaseGroupWithName,
+  projectNamesToBatch: string[]
+) {
+  const configBatches = new Map<string, string[]>();
+  for (const projectName of projectNamesToBatch) {
+    const project = projectGraph.nodes[projectName];
+    const generator =
+      project.data.release?.version?.generator ||
+      releaseGroup.version.generator;
+    const generatorOptions = {
+      ...releaseGroup.version.generatorOptions,
+      ...project.data.release?.version?.generatorOptions,
+    };
+
+    let found = false;
+    for (const [key, projects] of configBatches) {
+      const [existingGenerator, existingOptions] = JSON.parse(key);
+      if (
+        generator === existingGenerator &&
+        deepEquals(generatorOptions, existingOptions)
+      ) {
+        projects.push(projectName);
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      configBatches.set(JSON.stringify([generator, generatorOptions]), [
+        projectName,
+      ]);
+    }
+  }
+  return configBatches;
+}

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -31,6 +31,7 @@ import {
   ReleaseGroupWithName,
   filterReleaseGroups,
 } from './config/filter-release-groups';
+import { batchProjectsByGeneratorConfig } from './utils/batch-projects-by-generator-config';
 import { gitAdd, gitTag } from './utils/git';
 import { printDiff } from './utils/print-changes';
 import {
@@ -132,7 +133,7 @@ export async function releaseVersion(
   const versionData: VersionData = {};
   const commitMessage: string | undefined =
     args.gitCommitMessage || nxReleaseConfig.version.git.commitMessage;
-  const changedLockFiles = new Set<string>();
+  const additionalChangedFiles = new Set<string>();
   const generatorCallbacks: (() => Promise<void>)[] = [];
 
   if (args.projects?.length) {
@@ -141,41 +142,55 @@ export async function releaseVersion(
      */
     for (const releaseGroup of releaseGroups) {
       const releaseGroupName = releaseGroup.name;
-
-      // Resolve the generator data for the current release group
-      const generatorData = resolveGeneratorData({
-        ...extractGeneratorCollectionAndName(
-          `release-group "${releaseGroupName}"`,
-          releaseGroup.version.generator
-        ),
-        configGeneratorOptions: releaseGroup.version.generatorOptions,
-        projects,
-      });
-
       const releaseGroupProjectNames = Array.from(
         releaseGroupToFilteredProjects.get(releaseGroup)
       );
-
-      const generatorCallback = await runVersionOnProjects(
+      const projectBatches = batchProjectsByGeneratorConfig(
         projectGraph,
-        nxJson,
-        args,
-        tree,
-        generatorData,
-        releaseGroupProjectNames,
         releaseGroup,
-        versionData
+        // Only batch based on the filtered projects within the release group
+        releaseGroupProjectNames
       );
 
-      generatorCallbacks.push(async () =>
-        (
-          await generatorCallback(tree, {
+      for (const [
+        generatorConfigString,
+        projectNames,
+      ] of projectBatches.entries()) {
+        const [generatorName, generatorOptions] = JSON.parse(
+          generatorConfigString
+        );
+        // Resolve the generator for the batch and run versioning on the projects within the batch
+        const generatorData = resolveGeneratorData({
+          ...extractGeneratorCollectionAndName(
+            `batch "${JSON.stringify(
+              projectNames
+            )}" for release-group "${releaseGroupName}"`,
+            generatorName
+          ),
+          configGeneratorOptions: generatorOptions,
+          // all project data from the project graph (not to be confused with projectNamesToRunVersionOn)
+          projects,
+        });
+        const generatorCallback = await runVersionOnProjects(
+          projectGraph,
+          nxJson,
+          args,
+          tree,
+          generatorData,
+          projectNames,
+          releaseGroup,
+          versionData
+        );
+        // Capture the callback so that we can run it after flushing the changes to disk
+        generatorCallbacks.push(async () => {
+          const changedFiles = await generatorCallback(tree, {
             dryRun: !!args.dryRun,
             verbose: !!args.verbose,
-            generatorOptions: releaseGroup.version.generatorOptions,
-          })
-        ).forEach((f) => changedLockFiles.add(f))
-      );
+            generatorOptions,
+          });
+          changedFiles.forEach((f) => additionalChangedFiles.add(f));
+        });
+      }
     }
 
     // Resolve any git tags as early as possible so that we can hard error in case of any duplicates before reaching the actual git command
@@ -197,7 +212,7 @@ export async function releaseVersion(
 
     const changedFiles = [
       ...tree.listChanges().map((f) => f.path),
-      ...changedLockFiles,
+      ...additionalChangedFiles,
     ];
 
     // No further actions are necessary in this scenario (e.g. if conventional commits detected no changes)
@@ -261,37 +276,52 @@ export async function releaseVersion(
    */
   for (const releaseGroup of releaseGroups) {
     const releaseGroupName = releaseGroup.name;
-
-    // Resolve the generator data for the current release group
-    const generatorData = resolveGeneratorData({
-      ...extractGeneratorCollectionAndName(
-        `release-group "${releaseGroupName}"`,
-        releaseGroup.version.generator
-      ),
-      configGeneratorOptions: releaseGroup.version.generatorOptions,
-      projects,
-    });
-
-    const callback = await runVersionOnProjects(
+    const projectBatches = batchProjectsByGeneratorConfig(
       projectGraph,
-      nxJson,
-      args,
-      tree,
-      generatorData,
-      releaseGroup.projects,
       releaseGroup,
-      versionData
+      // Batch based on all projects within the release group
+      releaseGroup.projects
     );
 
-    generatorCallbacks.push(async () =>
-      (
-        await callback(tree, {
+    for (const [
+      generatorConfigString,
+      projectNames,
+    ] of projectBatches.entries()) {
+      const [generatorName, generatorOptions] = JSON.parse(
+        generatorConfigString
+      );
+      // Resolve the generator for the batch and run versioning on the projects within the batch
+      const generatorData = resolveGeneratorData({
+        ...extractGeneratorCollectionAndName(
+          `batch "${JSON.stringify(
+            projectNames
+          )}" for release-group "${releaseGroupName}"`,
+          generatorName
+        ),
+        configGeneratorOptions: generatorOptions,
+        // all project data from the project graph (not to be confused with projectNamesToRunVersionOn)
+        projects,
+      });
+      const generatorCallback = await runVersionOnProjects(
+        projectGraph,
+        nxJson,
+        args,
+        tree,
+        generatorData,
+        projectNames,
+        releaseGroup,
+        versionData
+      );
+      // Capture the callback so that we can run it after flushing the changes to disk
+      generatorCallbacks.push(async () => {
+        const changedFiles = await generatorCallback(tree, {
           dryRun: !!args.dryRun,
           verbose: !!args.verbose,
-          generatorOptions: releaseGroup.version.generatorOptions,
-        })
-      ).forEach((f) => changedLockFiles.add(f))
-    );
+          generatorOptions,
+        });
+        changedFiles.forEach((f) => additionalChangedFiles.add(f));
+      });
+    }
   }
 
   // Resolve any git tags as early as possible so that we can hard error in case of any duplicates before reaching the actual git command
@@ -325,7 +355,7 @@ export async function releaseVersion(
 
   const changedFiles = [
     ...tree.listChanges().map((f) => f.path),
-    ...changedLockFiles,
+    ...additionalChangedFiles,
   ];
 
   // No further actions are necessary in this scenario (e.g. if conventional commits detected no changes)

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -54,7 +54,7 @@ interface NxInstallationConfiguration {
 /**
  * **ALPHA**
  */
-interface NxReleaseVersionConfiguration {
+export interface NxReleaseVersionConfiguration {
   generator?: string;
   generatorOptions?: Record<string, unknown>;
   /**

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -1,4 +1,7 @@
-import type { NxJsonConfiguration } from './nx-json';
+import type {
+  NxJsonConfiguration,
+  NxReleaseVersionConfiguration,
+} from './nx-json';
 
 /**
  * @deprecated use ProjectsConfigurations or NxJsonConfiguration
@@ -98,6 +101,16 @@ export interface ProjectConfiguration {
    * List of tags used by enforce-module-boundaries / project graph
    */
   tags?: string[];
+
+  /**
+   * Project specific configuration for `nx release`
+   */
+  release?: {
+    version?: Pick<
+      NxReleaseVersionConfiguration,
+      'generator' | 'generatorOptions'
+    >;
+  };
 }
 
 export interface TargetDependencyConfig {

--- a/packages/nx/src/utils/json-diff.ts
+++ b/packages/nx/src/utils/json-diff.ts
@@ -103,7 +103,7 @@ function getJsonValue(path: string[], json: any): void | any {
   return curr;
 }
 
-function deepEquals(a: any, b: any): boolean {
+export function deepEquals(a: any, b: any): boolean {
   if (a === b) {
     return true;
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A new release group is always required, even when only configuring the specific generator or generatorOptions

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Release groups can focus on groups of versioning strategies, rather than differences in technology stack etc

The logic will intelligently batch the projects within the release group based on their combination of generator name and generator options to ensure the minimal number of separate invocations (normalizing different key orders within `generatorOptions`)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
