### PR TITLE
fix(misc): do not print formatting errors while setting up nx cloud in nx init

### DIFF
--- a/docs/generated/packages/nx/generators/connect-to-nx-cloud.json
+++ b/docs/generated/packages/nx/generators/connect-to-nx-cloud.json
@@ -18,6 +18,11 @@
         "type": "string",
         "description": "Name of Nx Cloud installation invoker (ex. user, add-nx-to-monorepo, create-nx-workspace, nx-upgrade",
         "default": "user"
+      },
+      "hideFormatLogs": {
+        "type": "boolean",
+        "description": "Hide formatting logs",
+        "x-priority": "internal"
       }
     },
     "additionalProperties": false,

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -97,7 +97,7 @@ export async function initHandler(options: InitArgs): Promise<void> {
   if (useNxCloud) {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     execSync(
-      `${pmc.exec} nx g nx:connect-to-nx-cloud --installationSource=nx-init-pcv3 --quiet --no-interactive`,
+      `${pmc.exec} nx g nx:connect-to-nx-cloud --installationSource=nx-init-pcv3 --quiet --hideFormatLogs --no-interactive`,
       {
         stdio: [0, 1, 2],
         cwd: repoRoot,

--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
@@ -7,7 +7,10 @@ import type * as Prettier from 'prettier';
  * @param tree - the file system tree
  */
 export async function formatChangedFilesWithPrettierIfAvailable(
-  tree: Tree
+  tree: Tree,
+  options?: {
+    silent?: boolean;
+  }
 ): Promise<void> {
   let prettier: typeof Prettier;
   try {
@@ -51,7 +54,9 @@ export async function formatChangedFilesWithPrettierIfAvailable(
             | string)
         );
       } catch (e) {
-        console.warn(`Could not format ${file.path}. Error: "${e.message}"`);
+        if (!options?.silent) {
+          console.warn(`Could not format ${file.path}. Error: "${e.message}"`);
+        }
       }
     })
   );

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -95,6 +95,7 @@ function printSuccessMessage(url: string) {
 interface ConnectToNxCloudOptions {
   analytics: boolean;
   installationSource: string;
+  hideFormatLogs?: boolean;
 }
 
 function addNxCloudOptionsToNxJson(
@@ -135,7 +136,9 @@ export async function connectToNxCloud(
 
     addNxCloudOptionsToNxJson(tree, nxJson, r.token);
 
-    await formatChangedFilesWithPrettierIfAvailable(tree);
+    await formatChangedFilesWithPrettierIfAvailable(tree, {
+      silent: schema.hideFormatLogs,
+    });
 
     return () => printSuccessMessage(r.url);
   }

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json
@@ -15,6 +15,11 @@
       "type": "string",
       "description": "Name of Nx Cloud installation invoker (ex. user, add-nx-to-monorepo, create-nx-workspace, nx-upgrade",
       "default": "user"
+    },
+    "hideFormatLogs": {
+      "type": "boolean",
+      "description": "Hide formatting logs",
+      "x-priority": "internal"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running `nx init`, if there's a formatting error while setting up Nx Cloud, the error is logged and the generation succeeds. The formatting operation is not a critical one for a non-Nx repo that's being migrated. It would be cleaner if any formatting issues were silently ignored.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `nx init` should silently ignore formatting errors while setting up Nx Cloud.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
