### PR TITLE
feat(core): guide users to view the graph after nx init

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -104,6 +104,14 @@ export async function initHandler(options: InitArgs): Promise<void> {
       }
     );
   }
+
+  output.log({
+    title: '👀 Explore the Graph of Your Workspace',
+    bodyLines: [
+      `Run "nx graph" to show the graph of the workspace. It will show tasks that you can run with Nx.`,
+      `Read this guide on exploring the graph: https://nx.dev/core-features/explore-graph`,
+    ],
+  });
 }
 
 const npmPackageToPluginMap: Record<string, string> = {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
After `nx init`, we will have created inferred targets about the project(s) in the repo, however, we do not show any information that will help users find this until they intentionally go looking.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Add a log after `nx init` to guide users to use the graph to find out about how nx is handling their projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
