### PR TITLE
fix(core): fix socket dir removal for macos

### DIFF
--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -71,6 +71,6 @@ function createSocketDir() {
 
 export function removeSocketDir() {
   try {
-    rmdirSync(socketDir);
+    rmdirSync(socketDir, { recursive: true });
   } catch (e) {}
 }


### PR DESCRIPTION


## Current Behavior
Running `nx reset` often fails for our E2E tests on Mac with 
```
Error: ENOTEMPTY: directory not empty, rmdir '/private/var/.../nx/proj/.nx/cache'
```

## Expected Behavior
This change ensures the `rmdirSync` behaves like `rm -r` and clears the folder even if not empty.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
