### PR TITLE
fix(storybook): add storybook-static to gitignore for pcv3

### DIFF
--- a/packages/storybook/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/storybook/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@nx/storybook:init should not add storybook-static to .gitignore if it already exists 1`] = `
+"
+    storybook-static
+    dist
+    node_modules
+  "
+`;

--- a/packages/storybook/src/generators/init/init.spec.ts
+++ b/packages/storybook/src/generators/init/init.spec.ts
@@ -11,8 +11,30 @@ describe('@nx/storybook:init', () => {
 
   it('should add build-storybook to cacheable operations', async () => {
     await initGenerator(tree, {});
-
     const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
     expect(nxJson.targetDefaults['build-storybook'].cache).toEqual(true);
+  });
+
+  it('should add storybook-static to .gitignore', async () => {
+    process.env.NX_PCV3 = 'true';
+    tree.write('.gitignore', '');
+    await initGenerator(tree, {});
+    expect(tree.read('.gitignore', 'utf-8')).toContain('storybook-static');
+    delete process.env.NX_PCV3;
+  });
+
+  it('should not add storybook-static to .gitignore if it already exists', async () => {
+    process.env.NX_PCV3 = 'true';
+    tree.write(
+      '.gitignore',
+      `
+    storybook-static
+    dist
+    node_modules
+  `
+    );
+    await initGenerator(tree, {});
+    expect(tree.read('.gitignore', 'utf-8')).toMatchSnapshot();
+    delete process.env.NX_PCV3;
   });
 });

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -19,6 +19,7 @@ import {
 } from '../../utils/utilities';
 import { nxVersion, storybookVersion } from '../../utils/versions';
 import { Schema } from './schema';
+import { updateGitignore } from './lib/update-gitignore';
 
 function checkDependenciesInstalled(
   host: Tree,
@@ -92,6 +93,7 @@ function moveToDevDependencies(tree: Tree): GeneratorCallback {
 export async function initGenerator(tree: Tree, schema: Schema) {
   if (process.env.NX_PCV3 === 'true') {
     addPlugin(tree);
+    updateGitignore(tree);
   } else {
     addCacheableOperation(tree);
   }

--- a/packages/storybook/src/generators/init/lib/update-gitignore.ts
+++ b/packages/storybook/src/generators/init/lib/update-gitignore.ts
@@ -1,0 +1,15 @@
+import { Tree } from '@nx/devkit';
+
+export function updateGitignore(tree: Tree) {
+  if (!tree.exists('.gitignore')) {
+    return;
+  }
+  const gitignore = tree.read('.gitignore', 'utf-8');
+
+  const regex = /storybook-static/gm;
+  const hasStorybookStatic = regex.test(gitignore ?? '');
+  if (hasStorybookStatic) {
+    return;
+  }
+  tree.write('.gitignore', `${gitignore}\n\nstorybook-static`);
+}


### PR DESCRIPTION
add storybook-static to gitignore for pcv3

i added it in `init`, because maybe someone adds nx to their non-nx workspace and they don't have storybook-static in their gitignore, we want to add it there