### PR TITLE
fix(js): add @swc/helpers when initializing js plugin since it is needed by other plugins

### DIFF
--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -19,6 +19,7 @@ import {
   prettierVersion,
   supportedTypescriptVersions,
   swcCoreVersion,
+  swcHelpersVersion,
   swcNodeVersion,
   typescriptVersion,
 } from '../../utils/versions';
@@ -77,6 +78,7 @@ export async function initGenerator(
     // we prefer to use SWC, and fallback to ts-node for workspaces that don't use SWC.
     '@swc-node/register': swcNodeVersion,
     '@swc/core': swcCoreVersion,
+    '@swc/helpers': swcHelpersVersion,
   };
 
   if (!schema.js && !schema.keepExistingVersions) {

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -164,6 +164,7 @@ exports[`@nx/storybook:configuration for Storybook v7 dependencies should add an
     "@storybook/testing-library": "^0.2.2",
     "@swc-node/register": "~1.6.7",
     "@swc/core": "~1.3.85",
+    "@swc/helpers": "~0.5.2",
     "@types/jest": "^29.4.0",
     "@types/node": "18.16.9",
     "@typescript-eslint/eslint-plugin": "^6.13.2",

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -111,6 +111,7 @@ exports[`lib should add vue, vite and vitest to package.json 1`] = `
     "@nx/web": "0.0.1",
     "@swc-node/register": "~1.6.7",
     "@swc/core": "~1.3.85",
+    "@swc/helpers": "~0.5.2",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
     "@vitejs/plugin-vue": "^4.5.0",


### PR DESCRIPTION
When `@nx/js:init` generator is called, we are missing `@swc/helpers`, which means transpiling files using `@swc-node/register` won't work. 

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We install `@swc/core` and `@swc-node/register` but not `@swc/helpers`, so transpiling `.ts` config file (e.g. `cypress.config.ts`) will fail unless user installs helpers manually.

## Expected Behavior
Plugins should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
