### PR TITLE
fix(release): fix --first-release with conventional commits and independent projects

### DIFF
--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -187,7 +187,7 @@ export async function gitCommit({
   let hasStagedFiles = false;
   try {
     // This command will error if there are staged changes
-    await execCommand('git', ['diff-index', '--quiet', 'HEAD']);
+    await execCommand('git', ['diff-index', '--quiet', 'HEAD', '--cached']);
   } catch {
     hasStagedFiles = true;
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `nx release` tries to commit changes when there are changed files on disk, but no staged changes. This causes the commit git operation to error.
- `nx release --first-release` fails on the first release for a repo configured with conventionalCommits: true and independent projects relationship. (The command still assumes a previous git tag exists)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `nx release` does not try to commit changes when there are no staged changes, regardless of other changes on disk.
- `nx release --first-release` indicates to the version generator that it should not assume a previous git tag exists. Instead, the first git commit in the repo is used, which is consistent with the changelog behavior on the first release.