### PR TITLE
fix(core): remove deprecated recursive rmdir with rm -rf

### DIFF
--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -4,7 +4,7 @@
  * and where we create the actual unix socket/named pipe for the daemon.
  */
 import { statSync, writeFileSync } from 'fs';
-import { ensureDirSync, rmdirSync } from 'fs-extra';
+import { ensureDirSync, rmSync } from 'fs-extra';
 import { join } from 'path';
 import { projectGraphCacheDirectory } from '../utils/cache-directory';
 import { createHash } from 'crypto';
@@ -71,6 +71,6 @@ function createSocketDir() {
 
 export function removeSocketDir() {
   try {
-    rmdirSync(socketDir, { recursive: true });
+    rmSync(socketDir, { recursive: true, force: true });
   } catch (e) {}
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Using rmdirSync with recursive shows deprecation message

## Expected Behavior
We should be using rmSync as instructed by the deprecation message

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
