### PR TITLE
fix(nuxt): add all target names when adding vite plugin

### DIFF
--- a/packages/nuxt/src/generators/init/lib/utils.ts
+++ b/packages/nuxt/src/generators/init/lib/utils.ts
@@ -74,7 +74,11 @@ export function addPlugin(tree: Tree) {
     nxJson.plugins.push({
       plugin: '@nx/vite/plugin',
       options: {
+        buildTargetName: 'build',
+        previewTargetName: 'preview',
         testTargetName: 'test',
+        serveTargetName: 'serve',
+        serveStaticTargetName: 'serve-static',
       },
     });
   }


### PR DESCRIPTION
When adding the `vite` plugin, we should always add all the target names. Even if we only use it for `vitest`, we should show the user the names of the other targets we may be inferring. Because if the user, after generating `nuxt` with `vitest`, generates a `vite` library/app, the plugin will not be "re-added" and the target names will not be exposed, even though our plugin creates them (where relevant) since we pass default names for the targets anyway.