### PR TITLE
feat(angular): add generator to convert targets to use the esbuild-based application executor

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -6790,6 +6790,14 @@
                 "disableCollapsible": false
               },
               {
+                "id": "convert-to-application-executor",
+                "path": "/nx-api/angular/generators/convert-to-application-executor",
+                "name": "convert-to-application-executor",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
+              },
+              {
                 "id": "directive",
                 "path": "/nx-api/angular/generators/directive",
                 "name": "directive",

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -178,7 +178,7 @@
         "type": "generator"
       },
       "/nx-api/angular/generators/convert-to-application-executor": {
-        "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+        "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. _Note: this is only supported in Angular versions >= 17.0.0_.",
         "file": "generated/packages/angular/generators/convert-to-application-executor.json",
         "hidden": false,
         "name": "convert-to-application-executor",

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -177,6 +177,15 @@
         "path": "/nx-api/angular/generators/component-test",
         "type": "generator"
       },
+      "/nx-api/angular/generators/convert-to-application-executor": {
+        "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+        "file": "generated/packages/angular/generators/convert-to-application-executor.json",
+        "hidden": false,
+        "name": "convert-to-application-executor",
+        "originalFilePath": "/packages/angular/src/generators/convert-to-application-executor/schema.json",
+        "path": "/nx-api/angular/generators/convert-to-application-executor",
+        "type": "generator"
+      },
       "/nx-api/angular/generators/directive": {
         "description": "Generate an Angular directive.",
         "file": "generated/packages/angular/generators/directive.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -173,6 +173,15 @@
         "type": "generator"
       },
       {
+        "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+        "file": "generated/packages/angular/generators/convert-to-application-executor.json",
+        "hidden": false,
+        "name": "convert-to-application-executor",
+        "originalFilePath": "/packages/angular/src/generators/convert-to-application-executor/schema.json",
+        "path": "angular/generators/convert-to-application-executor",
+        "type": "generator"
+      },
+      {
         "description": "Generate an Angular directive.",
         "file": "generated/packages/angular/generators/directive.json",
         "hidden": false,

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -173,7 +173,7 @@
         "type": "generator"
       },
       {
-        "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+        "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. _Note: this is only supported in Angular versions >= 17.0.0_.",
         "file": "generated/packages/angular/generators/convert-to-application-executor.json",
         "hidden": false,
         "name": "convert-to-application-executor",

--- a/docs/generated/packages/angular/generators/convert-to-application-executor.json
+++ b/docs/generated/packages/angular/generators/convert-to-application-executor.json
@@ -5,7 +5,7 @@
     "$schema": "http://json-schema.org/schema",
     "$id": "NxAngularConvertToApplicationExecutorGenerator",
     "cli": "nx",
-    "title": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+    "title": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. _Note: this is only supported in Angular versions >= 17.0.0_.",
     "description": "Converts a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. If the converted target is using one of the `@nx/angular` executors, the `@nx/angular:application` executor will be used. Otherwise, the `@angular-devkit/build-angular:application` builder will be used.",
     "type": "object",
     "properties": {
@@ -25,7 +25,7 @@
     "additionalProperties": false,
     "presets": []
   },
-  "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+  "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. _Note: this is only supported in Angular versions >= 17.0.0_.",
   "implementation": "/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts",
   "aliases": [],
   "hidden": false,

--- a/docs/generated/packages/angular/generators/convert-to-application-executor.json
+++ b/docs/generated/packages/angular/generators/convert-to-application-executor.json
@@ -1,0 +1,39 @@
+{
+  "name": "convert-to-application-executor",
+  "factory": "./src/generators/convert-to-application-executor/convert-to-application-executor",
+  "schema": {
+    "$schema": "http://json-schema.org/schema",
+    "$id": "NxAngularConvertToApplicationExecutorGenerator",
+    "cli": "nx",
+    "title": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+    "description": "Converts a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+    "type": "object",
+    "properties": {
+      "project": {
+        "type": "string",
+        "description": "Name of the Angular application project to convert. It has to contain a target using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors. If not specified, all projects with such targets will be converted.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-priority": "important"
+      },
+      "useNxExecutor": {
+        "description": "Convert targets to use the `@nx/angular:application` executor instead of the `@angular-devkit/build-angular:application` builder.",
+        "type": "boolean",
+        "default": true
+      },
+      "skipFormat": {
+        "description": "Skip formatting files.",
+        "type": "boolean",
+        "default": false,
+        "x-priority": "internal"
+      }
+    },
+    "additionalProperties": false,
+    "presets": []
+  },
+  "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+  "implementation": "/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/angular/src/generators/convert-to-application-executor/schema.json",
+  "type": "generator"
+}

--- a/docs/generated/packages/angular/generators/convert-to-application-executor.json
+++ b/docs/generated/packages/angular/generators/convert-to-application-executor.json
@@ -6,7 +6,7 @@
     "$id": "NxAngularConvertToApplicationExecutorGenerator",
     "cli": "nx",
     "title": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
-    "description": "Converts a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+    "description": "Converts a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. If the converted target is using one of the `@nx/angular` executors, the `@nx/angular:application` executor will be used. Otherwise, the `@angular-devkit/build-angular:application` builder will be used.",
     "type": "object",
     "properties": {
       "project": {
@@ -14,11 +14,6 @@
         "description": "Name of the Angular application project to convert. It has to contain a target using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors. If not specified, all projects with such targets will be converted.",
         "$default": { "$source": "argv", "index": 0 },
         "x-priority": "important"
-      },
-      "useNxExecutor": {
-        "description": "Convert targets to use the `@nx/angular:application` executor instead of the `@angular-devkit/build-angular:application` builder.",
-        "type": "boolean",
-        "default": true
       },
       "skipFormat": {
         "description": "Skip formatting files.",

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -343,6 +343,7 @@
       - [component-cypress-spec](/nx-api/angular/generators/component-cypress-spec)
       - [component-story](/nx-api/angular/generators/component-story)
       - [component-test](/nx-api/angular/generators/component-test)
+      - [convert-to-application-executor](/nx-api/angular/generators/convert-to-application-executor)
       - [directive](/nx-api/angular/generators/directive)
       - [federate-module](/nx-api/angular/generators/federate-module)
       - [init](/nx-api/angular/generators/init)

--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -39,6 +39,11 @@
       "schema": "./src/generators/component-test/schema.json",
       "description": "Creates a cypress component test file for a component."
     },
+    "convert-to-application-executor": {
+      "factory": "./src/generators/convert-to-application-executor/convert-to-application-executor",
+      "schema": "./src/generators/convert-to-application-executor/schema.json",
+      "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder."
+    },
     "directive": {
       "factory": "./src/generators/directive/directive",
       "schema": "./src/generators/directive/schema.json",

--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -42,7 +42,7 @@
     "convert-to-application-executor": {
       "factory": "./src/generators/convert-to-application-executor/convert-to-application-executor",
       "schema": "./src/generators/convert-to-application-executor/schema.json",
-      "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder."
+      "description": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. _Note: this is only supported in Angular versions >= 17.0.0_."
     },
     "directive": {
       "factory": "./src/generators/directive/directive",

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.spec.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.spec.ts
@@ -127,6 +127,30 @@ describe('convert-to-application-executor generator', () => {
     expect(project.targets.build.options.polyfills).toStrictEqual(['zone.js']);
   });
 
+  it('should update "outputs"', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'app1',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          outputs: ['{options.outputPath}'],
+          options: {
+            outputPath: 'dist/app1',
+            resourcesOutputPath: 'media',
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    expect(project.targets.build.outputs).toStrictEqual([
+      '{options.outputPath.base}',
+    ]);
+  });
+
   it('should replace "outputPath" to string if "resourcesOutputPath" is set to "media"', async () => {
     addProjectConfiguration(tree, 'app1', {
       root: 'app1',

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.spec.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.spec.ts
@@ -16,9 +16,120 @@ describe('convert-to-application-executor generator', () => {
     jest.spyOn(logger, 'warn').mockImplementation(() => {});
   });
 
-  it(`should replace 'outputPath' to string if 'resourcesOutputPath' is set to 'media'`, async () => {
+  it.each`
+    executor                                           | expected
+    ${'@angular-devkit/build-angular:browser'}         | ${'@angular-devkit/build-angular:application'}
+    ${'@angular-devkit/build-angular:browser-esbuild'} | ${'@angular-devkit/build-angular:application'}
+    ${'@nx/angular:webpack-browser'}                   | ${'@nx/angular:application'}
+    ${'@nx/angular:browser-esbuild'}                   | ${'@nx/angular:application'}
+  `(
+    'should replace "$executor" with "$expected"',
+    async ({ executor, expected }) => {
+      addProjectConfiguration(tree, 'app1', {
+        root: 'app1',
+        projectType: 'application',
+        targets: { build: { executor } },
+      });
+
+      await convertToApplicationExecutor(tree, {});
+
+      const project = readProjectConfiguration(tree, 'app1');
+      expect(project.targets.build.executor).toBe(expected);
+    }
+  );
+
+  it('should not convert the target when using a custom webpack config', async () => {
     addProjectConfiguration(tree, 'app1', {
-      root: '/project/lib',
+      root: 'app1',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@nx/angular:webpack-browser',
+          options: {
+            customWebpackConfig: {
+              path: 'app1/webpack.config.js',
+            },
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    expect(project.targets.build.executor).toBe('@nx/angular:webpack-browser');
+    expect(project.targets.build.options.customWebpackConfig).toStrictEqual({
+      path: 'app1/webpack.config.js',
+    });
+  });
+
+  it('should rename "main" to "browser"', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'app1',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            main: 'app1/main.ts',
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    expect(project.targets.build.options.browser).toBe('app1/main.ts');
+    expect(project.targets.build.options.main).toBeUndefined();
+  });
+
+  it('should rename "ngswConfigPath" to "serviceWorker"', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'app1',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            ngswConfigPath: 'app1/ngsw-config.json',
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    expect(project.targets.build.options.serviceWorker).toBe(
+      'app1/ngsw-config.json'
+    );
+    expect(project.targets.build.options.ngswConfigPath).toBeUndefined();
+  });
+
+  it('should convert a string value for "polyfills" to an array', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'app1',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            polyfills: 'zone.js',
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    expect(project.targets.build.options.polyfills).toStrictEqual(['zone.js']);
+  });
+
+  it('should replace "outputPath" to string if "resourcesOutputPath" is set to "media"', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'app1',
       projectType: 'application',
       targets: {
         build: {
@@ -39,9 +150,9 @@ describe('convert-to-application-executor generator', () => {
     expect(resourcesOutputPath).toBeUndefined();
   });
 
-  it(`should set 'outputPath.media' if 'resourcesOutputPath' is set and is not 'media'`, async () => {
+  it('should set "outputPath.media" if "resourcesOutputPath" is set and is not "media"', async () => {
     addProjectConfiguration(tree, 'app1', {
-      root: '/project/lib',
+      root: 'app1',
       projectType: 'application',
       targets: {
         build: {
@@ -62,9 +173,9 @@ describe('convert-to-application-executor generator', () => {
     expect(resourcesOutputPath).toBeUndefined();
   });
 
-  it(`should remove 'browser' portion from 'outputPath'`, async () => {
+  it('should remove "browser" portion from "outputPath"', async () => {
     addProjectConfiguration(tree, 'app1', {
-      root: '/project/lib',
+      root: 'app1',
       projectType: 'application',
       targets: {
         build: {
@@ -84,5 +195,38 @@ describe('convert-to-application-executor generator', () => {
       base: 'dist/app1',
       media: 'resources',
     });
+  });
+
+  it('should remove unsupported options', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'app1',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {},
+          configurations: {
+            development: {
+              buildOptimizer: false,
+              vendorChunk: true,
+              commonChunk: true,
+            },
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    expect(
+      project.targets.build.configurations.development.buildOptimizer
+    ).toBeUndefined();
+    expect(
+      project.targets.build.configurations.development.vendorChunk
+    ).toBeUndefined();
+    expect(
+      project.targets.build.configurations.development.commonChunk
+    ).toBeUndefined();
   });
 });

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.spec.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.spec.ts
@@ -1,0 +1,88 @@
+import {
+  addProjectConfiguration,
+  logger,
+  readProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { convertToApplicationExecutor } from './convert-to-application-executor';
+
+describe('convert-to-application-executor generator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    jest.spyOn(logger, 'info').mockImplementation(() => {});
+    jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  it(`should replace 'outputPath' to string if 'resourcesOutputPath' is set to 'media'`, async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: '/project/lib',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            outputPath: 'dist/app1',
+            resourcesOutputPath: 'media',
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    const { outputPath, resourcesOutputPath } = project.targets.build.options;
+    expect(outputPath).toStrictEqual({ base: 'dist/app1' });
+    expect(resourcesOutputPath).toBeUndefined();
+  });
+
+  it(`should set 'outputPath.media' if 'resourcesOutputPath' is set and is not 'media'`, async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: '/project/lib',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            outputPath: 'dist/app1',
+            resourcesOutputPath: 'resources',
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    const { outputPath, resourcesOutputPath } = project.targets.build.options;
+    expect(outputPath).toStrictEqual({ base: 'dist/app1', media: 'resources' });
+    expect(resourcesOutputPath).toBeUndefined();
+  });
+
+  it(`should remove 'browser' portion from 'outputPath'`, async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: '/project/lib',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            outputPath: 'dist/app1/browser',
+            resourcesOutputPath: 'resources',
+          },
+        },
+      },
+    });
+
+    await convertToApplicationExecutor(tree, {});
+
+    const project = readProjectConfiguration(tree, 'app1');
+    expect(project.targets.build.options.outputPath).toStrictEqual({
+      base: 'dist/app1',
+      media: 'resources',
+    });
+  });
+});

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.spec.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.spec.ts
@@ -2,6 +2,7 @@ import {
   addProjectConfiguration,
   logger,
   readProjectConfiguration,
+  updateJson,
   type Tree,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -252,5 +253,63 @@ describe('convert-to-application-executor generator', () => {
     expect(
       project.targets.build.configurations.development.commonChunk
     ).toBeUndefined();
+  });
+
+  describe('compat', () => {
+    it('should not convert outputs to the object notation when angular version is lower that 17.1.0', async () => {
+      updateJson(tree, 'package.json', (json) => {
+        json.dependencies['@angular/core'] = '17.0.0';
+        return json;
+      });
+      addProjectConfiguration(tree, 'app1', {
+        root: 'app1',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: '@angular-devkit/build-angular:browser',
+            outputs: ['{options.outputPath}'],
+            options: {
+              outputPath: 'dist/app1',
+            },
+          },
+        },
+      });
+
+      await convertToApplicationExecutor(tree, {});
+
+      const project = readProjectConfiguration(tree, 'app1');
+      expect(project.targets.build.outputs).toStrictEqual([
+        '{options.outputPath}',
+      ]);
+      expect(project.targets.build.options.outputPath).toBe('dist/app1');
+    });
+
+    it('should remove trailing "/browser" from output path when angular version is lower that 17.1.0', async () => {
+      updateJson(tree, 'package.json', (json) => {
+        json.dependencies['@angular/core'] = '17.0.0';
+        return json;
+      });
+      addProjectConfiguration(tree, 'app1', {
+        root: 'app1',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: '@angular-devkit/build-angular:browser',
+            outputs: ['{options.outputPath}'],
+            options: {
+              outputPath: 'dist/app1/browser',
+            },
+          },
+        },
+      });
+
+      await convertToApplicationExecutor(tree, {});
+
+      const project = readProjectConfiguration(tree, 'app1');
+      expect(project.targets.build.outputs).toStrictEqual([
+        '{options.outputPath}',
+      ]);
+      expect(project.targets.build.options.outputPath).toBe('dist/app1');
+    });
   });
 });

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
@@ -187,7 +187,7 @@ async function convertProjectTargets(
       ...(serverTsConfigJson.files ?? []),
     ]);
 
-    // Server file will be added later by the means of the ssr schematic.
+    // Server file will be added later by the setup-ssr generator
     files.delete('server.ts');
 
     browserTsConfigJson.files = Array.from(files);

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
@@ -299,3 +299,5 @@ function getTargetsToConvert(targets: Record<string, TargetConfiguration>): {
 
   return { buildTargetName, serverTargetName };
 }
+
+export default convertToApplicationExecutor;

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
@@ -107,6 +107,12 @@ async function convertProjectTargets(
   const buildTarget = project.targets[buildTargetName];
   buildTarget.executor = newExecutor;
 
+  if (buildTarget.outputs) {
+    buildTarget.outputs = buildTarget.outputs.map((output) =>
+      output === '{options.outputPath}' ? '{options.outputPath.base}' : output
+    );
+  }
+
   for (const [, options] of allTargetOptions(buildTarget)) {
     if (options['index'] === '') {
       options['index'] = false;

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
@@ -1,0 +1,333 @@
+import {
+  formatFiles,
+  getProjects,
+  installPackagesTask,
+  logger,
+  readJson,
+  updateProjectConfiguration,
+  type ProjectConfiguration,
+  type TargetConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { dirname, join } from 'node:path/posix';
+import { allTargetOptions } from '../../utils/targets';
+import { setupSsr } from '../setup-ssr/setup-ssr';
+import { validateProject } from '../utils/validations';
+import type { GeneratorOptions } from './schema';
+
+const executorsToConvert = new Set([
+  '@angular-devkit/build-angular:browser',
+  '@angular-devkit/build-angular:browser-esbuild',
+  '@nx/angular:webpack-browser',
+  '@nx/angular:browser-esbuild',
+]);
+const serverTargetExecutors = new Set([
+  '@angular-devkit/build-angular:server',
+  '@nx/angular:webpack-server',
+]);
+const redundantExecutors = new Set([
+  '@angular-devkit/build-angular:server',
+  '@angular-devkit/build-angular:prerender',
+  '@angular-devkit/build-angular:app-shell',
+  '@angular-devkit/build-angular:ssr-dev-server',
+  '@nx/angular:webpack-server',
+]);
+
+export async function convertToApplicationExecutor(
+  tree: Tree,
+  options: GeneratorOptions
+) {
+  options.useNxExecutor ??= true;
+
+  let didAnySucceed = false;
+  if (options.project) {
+    const project = validateProject(tree, options.project);
+    didAnySucceed = await convertProjectTargets(
+      tree,
+      project,
+      options.useNxExecutor,
+      true
+    );
+  } else {
+    const projects = getProjects(tree);
+    for (const [, project] of projects) {
+      logger.info(`Converting project "${project.name}"...`);
+      const success = await convertProjectTargets(
+        tree,
+        project,
+        options.useNxExecutor
+      );
+
+      if (success) {
+        logger.info(`Project "${project.name}" converted successfully.`);
+      } else {
+        logger.info(
+          `Project "${project.name}" could not be converted. See above for more information.`
+        );
+      }
+      logger.info('');
+      didAnySucceed = didAnySucceed || success;
+    }
+  }
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+
+  return didAnySucceed ? () => installPackagesTask(tree) : () => {};
+}
+
+async function convertProjectTargets(
+  tree: Tree,
+  project: ProjectConfiguration,
+  useNxExecutor: boolean,
+  isProvidedProject = false
+): Promise<boolean> {
+  function warnIfProvided(message: string): void {
+    if (isProvidedProject) {
+      logger.warn(message);
+    }
+  }
+
+  if (project.projectType !== 'application') {
+    warnIfProvided(
+      `The provided project "${project.name}" is not an application. Skipping conversion.`
+    );
+    return false;
+  }
+
+  const { buildTargetName, serverTargetName } = getTargetsToConvert(
+    project.targets,
+    useNxExecutor
+  );
+  if (!buildTargetName) {
+    warnIfProvided(
+      `The provided project "${project.name}" does not have any targets using on of the ` +
+        `'@angular-devkit/build-angular:browser', '@angular-devkit/build-angular:browser-esbuild', ` +
+        `'@nx/angular:browser' and '@nx/angular:browser-esbuild' executors. Skipping conversion.`
+    );
+    return false;
+  }
+
+  const newExecutor = useNxExecutor
+    ? '@nx/angular:application'
+    : '@angular-devkit/build-angular:application';
+
+  const buildTarget = project.targets[buildTargetName];
+  buildTarget.executor = newExecutor;
+
+  for (const [, options] of allTargetOptions(buildTarget)) {
+    if (options['index'] === '') {
+      options['index'] = false;
+    }
+
+    // Rename and transform options
+    options['browser'] = options['main'];
+    if (serverTargetName && typeof options['browser'] === 'string') {
+      options['server'] = dirname(options['browser']) + '/main.server.ts';
+    }
+    options['serviceWorker'] =
+      options['ngswConfigPath'] ?? options['serviceWorker'];
+
+    if (typeof options['polyfills'] === 'string') {
+      options['polyfills'] = [options['polyfills']];
+    }
+
+    let outputPath = options['outputPath'];
+    if (typeof outputPath === 'string') {
+      if (!/\/browser\/?$/.test(outputPath)) {
+        logger.warn(
+          `The output location of the browser build has been updated from "${outputPath}" to ` +
+            `"${join(outputPath, 'browser')}". ` +
+            'You might need to adjust your deployment pipeline or, as an alternative, ' +
+            'set outputPath.browser to "" in order to maintain the previous functionality.'
+        );
+      } else {
+        outputPath = outputPath.replace(/\/browser\/?$/, '');
+      }
+
+      options['outputPath'] = {
+        base: outputPath,
+      };
+
+      if (typeof options['resourcesOutputPath'] === 'string') {
+        const media = options['resourcesOutputPath'].replaceAll('/', '');
+        if (media && media !== 'media') {
+          options['outputPath'] = {
+            base: outputPath,
+            media: media,
+          };
+        }
+      }
+    }
+
+    // Delete removed options
+    delete options['deployUrl'];
+    delete options['vendorChunk'];
+    delete options['commonChunk'];
+    delete options['resourcesOutputPath'];
+    delete options['buildOptimizer'];
+    delete options['main'];
+    delete options['ngswConfigPath'];
+    if (!useNxExecutor) {
+      delete options['buildLibsFromSource'];
+    }
+  }
+
+  // Merge browser and server tsconfig
+  if (serverTargetName) {
+    const browserTsConfigPath = buildTarget?.options?.tsConfig;
+    const serverTsConfigPath = project.targets['server']?.options?.tsConfig;
+
+    if (typeof browserTsConfigPath !== 'string') {
+      logger.warn(
+        `Cannot update project "${project.name}" to use the application executor ` +
+          `as the browser tsconfig cannot be located.`
+      );
+    }
+
+    if (typeof serverTsConfigPath !== 'string') {
+      logger.warn(
+        `Cannot update project "${project.name}" to use the application executor ` +
+          `as the server tsconfig cannot be located.`
+      );
+    }
+
+    const browserTsConfigJson = readJson(tree, browserTsConfigPath);
+    const serverTsConfigJson = readJson(tree, serverTsConfigPath);
+
+    const files = new Set([
+      ...(browserTsConfigJson.files ?? []),
+      ...(serverTsConfigJson.files ?? []),
+    ]);
+
+    // Server file will be added later by the means of the ssr schematic.
+    files.delete('server.ts');
+
+    browserTsConfigJson.files = Array.from(files);
+    browserTsConfigJson.compilerOptions ?? {};
+    browserTsConfigJson.compilerOptions.types = Array.from(
+      new Set([
+        ...(browserTsConfigJson.compilerOptions.types ?? []),
+        ...(serverTsConfigJson.compilerOptions?.types ?? []),
+      ])
+    );
+
+    // Delete server tsconfig
+    tree.delete(serverTsConfigPath);
+  }
+
+  // Update project main tsconfig
+  const projectRootTsConfigPath = join(project.root, 'tsconfig.json');
+  if (tree.exists(projectRootTsConfigPath)) {
+    const rootTsConfigJson = readJson(tree, projectRootTsConfigPath);
+    rootTsConfigJson.compilerOptions ?? {};
+    rootTsConfigJson.compilerOptions.esModuleInterop = true;
+    rootTsConfigJson.compilerOptions.downlevelIteration = undefined;
+    rootTsConfigJson.compilerOptions.allowSyntheticDefaultImports = undefined;
+  }
+
+  // Update server file
+  const ssrMainFile = project.targets['server']?.options?.['main'];
+  if (typeof ssrMainFile === 'string') {
+    tree.delete(ssrMainFile);
+    await setupSsr(tree, { project: project.name, skipFormat: true });
+  }
+
+  // Delete all redundant targets
+  for (const [targetName, target] of Object.entries(project.targets)) {
+    if (redundantExecutors.has(target.executor)) {
+      delete project.targets[targetName];
+    }
+  }
+
+  updateProjectConfiguration(tree, project.name, project);
+  return true;
+}
+
+function getTargetsToConvert(
+  targets: Record<string, TargetConfiguration>,
+  useNxExecutor: boolean
+): {
+  buildTargetName?: string;
+  serverTargetName?: string;
+} {
+  let buildTargetName: string;
+  let serverTargetName: string;
+  for (const target of Object.keys(targets)) {
+    if (
+      targets[target].executor === '@nx/angular:application' ||
+      targets[target].executor === '@angular-devkit/build-angular:application'
+    ) {
+      logger.warn(
+        'The project is already using the application builder. Skipping conversion.'
+      );
+      return {};
+    }
+
+    // build target
+    if (executorsToConvert.has(targets[target].executor)) {
+      for (const [, options] of allTargetOptions(targets[target])) {
+        if (options.deployUrl) {
+          logger.warn(
+            `The project is using the "deployUrl" option which is not available in the application builder. Skipping conversion.`
+          );
+          return {};
+        }
+        if (options.customWebpackConfig) {
+          logger.warn(
+            `The project is using a custom webpack configuration which is not supported by the esbuild-based ${
+              useNxExecutor
+                ? '@nx/angular:application executor'
+                : '@angular-devkit/build-angular:application builder'
+            }. Skipping conversion.`
+          );
+          return {};
+        }
+        if (options.plugins && !useNxExecutor) {
+          logger.warn(
+            `The project is using custom esbuild plugins that could only be migrated when ` +
+              `converting to the "@nx/angular:application" executor. Skipping conversion.`
+          );
+          return {};
+        }
+      }
+
+      if (buildTargetName) {
+        logger.warn(
+          'The project has more than one build target. Skipping conversion.'
+        );
+        return {};
+      }
+      buildTargetName = target;
+    }
+
+    // server target
+    if (serverTargetExecutors.has(targets[target].executor)) {
+      if (targets[target].executor === '@nx/angular:webpack-server') {
+        for (const [, options] of allTargetOptions(targets[target])) {
+          if (options.customWebpackConfig) {
+            logger.warn(
+              `The project is using a custom webpack configuration which is not supported by the esbuild-based ${
+                useNxExecutor
+                  ? '@nx/angular:application executor'
+                  : '@angular-devkit/build-angular:application builder'
+              }. Skipping conversion.`
+            );
+            return {};
+          }
+        }
+      }
+
+      if (serverTargetName) {
+        logger.warn(
+          'The project has more than one server target. Skipping conversion.'
+        );
+        return {};
+      }
+      serverTargetName = target;
+    }
+  }
+
+  return { buildTargetName, serverTargetName };
+}

--- a/packages/angular/src/generators/convert-to-application-executor/schema.d.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/schema.d.ts
@@ -1,5 +1,4 @@
 export interface GeneratorOptions {
   project?: string;
-  useNxExecutor?: boolean;
   skipFormat?: boolean;
 }

--- a/packages/angular/src/generators/convert-to-application-executor/schema.d.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/schema.d.ts
@@ -1,0 +1,5 @@
+export interface GeneratorOptions {
+  project?: string;
+  useNxExecutor?: boolean;
+  skipFormat?: boolean;
+}

--- a/packages/angular/src/generators/convert-to-application-executor/schema.json
+++ b/packages/angular/src/generators/convert-to-application-executor/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxAngularConvertToApplicationExecutorGenerator",
+  "cli": "nx",
+  "title": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+  "description": "Converts a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Name of the Angular application project to convert. It has to contain a target using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors. If not specified, all projects with such targets will be converted.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-priority": "important"
+    },
+    "useNxExecutor": {
+      "description": "Convert targets to use the `@nx/angular:application` executor instead of the `@angular-devkit/build-angular:application` builder.",
+      "type": "boolean",
+      "default": true
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/angular/src/generators/convert-to-application-executor/schema.json
+++ b/packages/angular/src/generators/convert-to-application-executor/schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema",
   "$id": "NxAngularConvertToApplicationExecutorGenerator",
   "cli": "nx",
-  "title": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+  "title": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. _Note: this is only supported in Angular versions >= 17.0.0_.",
   "description": "Converts a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. If the converted target is using one of the `@nx/angular` executors, the `@nx/angular:application` executor will be used. Otherwise, the `@angular-devkit/build-angular:application` builder will be used.",
   "type": "object",
   "properties": {

--- a/packages/angular/src/generators/convert-to-application-executor/schema.json
+++ b/packages/angular/src/generators/convert-to-application-executor/schema.json
@@ -3,7 +3,7 @@
   "$id": "NxAngularConvertToApplicationExecutorGenerator",
   "cli": "nx",
   "title": "Converts projects to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
-  "description": "Converts a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder.",
+  "description": "Converts a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. If the converted target is using one of the `@nx/angular` executors, the `@nx/angular:application` executor will be used. Otherwise, the `@angular-devkit/build-angular:application` builder will be used.",
   "type": "object",
   "properties": {
     "project": {
@@ -14,11 +14,6 @@
         "index": 0
       },
       "x-priority": "important"
-    },
-    "useNxExecutor": {
-      "description": "Convert targets to use the `@nx/angular:application` executor instead of the `@angular-devkit/build-angular:application` builder.",
-      "type": "boolean",
-      "default": true
     },
     "skipFormat": {
       "description": "Skip formatting files.",

--- a/packages/angular/src/generators/setup-ssr/lib/add-hydration.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/add-hydration.spec.ts
@@ -1,0 +1,159 @@
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { addHydration } from './add-hydration';
+
+describe('add-hydration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app1', {
+      root: 'app1',
+      sourceRoot: 'app1/src',
+      projectType: 'application',
+      targets: {},
+    });
+  });
+
+  it('should add "provideClientHydration" for standalone config', () => {
+    tree.write(
+      'app1/src/app/app.config.ts',
+      `import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { appRoutes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(appRoutes)],
+};
+`
+    );
+
+    addHydration(tree, { project: 'app1', standalone: true });
+
+    expect(tree.read('app1/src/app/app.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { ApplicationConfig } from '@angular/core';
+      import { provideRouter } from '@angular/router';
+      import { appRoutes } from './app.routes';
+      import { provideClientHydration } from '@angular/platform-browser';
+
+      export const appConfig: ApplicationConfig = {
+        providers: [provideClientHydration(),provideRouter(appRoutes)],
+      };
+      "
+    `);
+  });
+
+  it('should not duplicate "provideClientHydration" for standalone config', () => {
+    tree.write(
+      'app1/src/app/app.config.ts',
+      `import { ApplicationConfig } from '@angular/core';
+import { provideClientHydration } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { appRoutes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideClientHydration(), provideRouter(appRoutes)],
+};
+`
+    );
+
+    addHydration(tree, { project: 'app1', standalone: true });
+
+    expect(tree.read('app1/src/app/app.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { ApplicationConfig } from '@angular/core';
+      import { provideClientHydration } from '@angular/platform-browser';
+      import { provideRouter } from '@angular/router';
+      import { appRoutes } from './app.routes';
+
+      export const appConfig: ApplicationConfig = {
+        providers: [provideClientHydration(), provideRouter(appRoutes)],
+      };
+      "
+    `);
+  });
+
+  it('should add "provideClientHydration" for non-standalone config', () => {
+    tree.write(
+      'app1/src/app/app.module.ts',
+      `import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { AppComponent } from './app.component';
+import { appRoutes } from './app.routes';
+import { NxWelcomeComponent } from './nx-welcome.component';
+
+@NgModule({
+  declarations: [AppComponent, NxWelcomeComponent],
+  imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+`
+    );
+
+    addHydration(tree, { project: 'app1', standalone: false });
+
+    expect(tree.read('app1/src/app/app.module.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { NgModule } from '@angular/core';
+      import { BrowserModule, provideClientHydration } from '@angular/platform-browser';
+      import { RouterModule } from '@angular/router';
+      import { AppComponent } from './app.component';
+      import { appRoutes } from './app.routes';
+      import { NxWelcomeComponent } from './nx-welcome.component';
+
+      @NgModule({
+        declarations: [AppComponent, NxWelcomeComponent],
+        imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
+        bootstrap: [AppComponent],
+        providers: [provideClientHydration()],
+      })
+      export class AppModule {}
+      "
+    `);
+  });
+
+  it('should not duplicate "provideClientHydration" for non-standalone config', () => {
+    tree.write(
+      'app1/src/app/app.module.ts',
+      `import { NgModule } from '@angular/core';
+import { BrowserModule, provideClientHydration } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { AppComponent } from './app.component';
+import { appRoutes } from './app.routes';
+import { NxWelcomeComponent } from './nx-welcome.component';
+
+@NgModule({
+  declarations: [AppComponent, NxWelcomeComponent],
+  imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
+  bootstrap: [AppComponent],
+  providers: [provideClientHydration()],
+})
+export class AppModule {}
+`
+    );
+
+    addHydration(tree, { project: 'app1', standalone: false });
+
+    expect(tree.read('app1/src/app/app.module.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { NgModule } from '@angular/core';
+      import { BrowserModule, provideClientHydration } from '@angular/platform-browser';
+      import { RouterModule } from '@angular/router';
+      import { AppComponent } from './app.component';
+      import { appRoutes } from './app.routes';
+      import { NxWelcomeComponent } from './nx-welcome.component';
+
+      @NgModule({
+        declarations: [AppComponent, NxWelcomeComponent],
+        imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
+        bootstrap: [AppComponent],
+        providers: [provideClientHydration()],
+      })
+      export class AppModule {}
+      "
+    `);
+  });
+});

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -84,7 +84,9 @@ export function updateProjectConfigForBrowserBuilder(
 
   projectConfig.targets.server = {
     dependsOn: ['build'],
-    executor: '@angular-devkit/build-angular:server',
+    executor: buildTarget.executor.startsWith('@angular-devkit/build-angular:')
+      ? '@angular-devkit/build-angular:server'
+      : '@nx/angular:webpack-server',
     options: {
       outputPath: joinPathFragments(baseOutputPath, 'server'),
       main: joinPathFragments(projectConfig.root, schema.serverFileName),

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.ts
@@ -27,7 +27,8 @@ export async function setupSsr(tree: Tree, schema: Schema) {
 
   const { targets } = readProjectConfiguration(tree, options.project);
   const isUsingApplicationBuilder =
-    targets.build.executor === '@angular-devkit/build-angular:application';
+    targets.build.executor === '@angular-devkit/build-angular:application' ||
+    targets.build.executor === '@nx/angular:application';
 
   addDependencies(tree, isUsingApplicationBuilder);
   generateSSRFiles(tree, options, isUsingApplicationBuilder);

--- a/packages/angular/src/generators/utils/validations.ts
+++ b/packages/angular/src/generators/utils/validations.ts
@@ -1,10 +1,7 @@
-import type { ProjectConfiguration, Tree } from '@nx/devkit';
+import type { Tree } from '@nx/devkit';
 import { getProjects } from '@nx/devkit';
 
-export function validateProject(
-  tree: Tree,
-  projectName: string
-): ProjectConfiguration {
+export function validateProject(tree: Tree, projectName: string): void {
   const projects = getProjects(tree);
 
   if (!projects.has(projectName)) {
@@ -12,6 +9,4 @@ export function validateProject(
       `Project "${projectName}" does not exist! Please provide an existing project name.`
     );
   }
-
-  return projects.get(projectName)!;
 }

--- a/packages/angular/src/generators/utils/validations.ts
+++ b/packages/angular/src/generators/utils/validations.ts
@@ -1,7 +1,10 @@
-import type { Tree } from '@nx/devkit';
+import type { ProjectConfiguration, Tree } from '@nx/devkit';
 import { getProjects } from '@nx/devkit';
 
-export function validateProject(tree: Tree, projectName: string): void {
+export function validateProject(
+  tree: Tree,
+  projectName: string
+): ProjectConfiguration {
   const projects = getProjects(tree);
 
   if (!projects.has(projectName)) {
@@ -9,4 +12,6 @@ export function validateProject(tree: Tree, projectName: string): void {
       `Project "${projectName}" does not exist! Please provide an existing project name.`
     );
   }
+
+  return projects.get(projectName)!;
 }

--- a/packages/angular/src/migrations/update-17-1-0/replace-nguniversal-engines.ts
+++ b/packages/angular/src/migrations/update-17-1-0/replace-nguniversal-engines.ts
@@ -5,7 +5,6 @@ import {
   readJson,
   removeDependenciesFromPackageJson,
   visitNotIgnoredFiles,
-  type TargetConfiguration,
   type Tree,
 } from '@nx/devkit';
 import { dirname, relative } from 'path';
@@ -13,6 +12,7 @@ import {
   getInstalledPackageVersionInfo,
   versions,
 } from '../../generators/utils/version-utils';
+import { allTargetOptions } from '../../utils/targets';
 import { getProjectsFilteredByDependencies } from '../utils/projects';
 
 const UNIVERSAL_PACKAGES = [
@@ -139,24 +139,6 @@ export default async function (tree: Tree) {
   );
 
   await formatFiles(tree);
-}
-
-function* allTargetOptions<T>(
-  target: TargetConfiguration<T>
-): Iterable<[string | undefined, T]> {
-  if (target.options) {
-    yield [undefined, target.options];
-  }
-
-  if (!target.configurations) {
-    return;
-  }
-
-  for (const [name, options] of Object.entries(target.configurations)) {
-    if (options !== undefined) {
-      yield [name, options];
-    }
-  }
 }
 
 const TOKENS_FILE_CONTENT = `

--- a/packages/angular/src/utils/targets.ts
+++ b/packages/angular/src/utils/targets.ts
@@ -1,0 +1,19 @@
+import { TargetConfiguration } from '@nx/devkit';
+
+export function* allTargetOptions<T>(
+  target: TargetConfiguration<T>
+): Iterable<[string | undefined, T]> {
+  if (target.options) {
+    yield [undefined, target.options];
+  }
+
+  if (!target.configurations) {
+    return;
+  }
+
+  for (const [name, options] of Object.entries(target.configurations)) {
+    if (options !== undefined) {
+      yield [name, options];
+    }
+  }
+}


### PR DESCRIPTION
Adds the `convert-to-application-executor` generator that allows converting a project or all projects using one of the `@angular-devkit/build-angular:browser`, `@angular-devkit/build-angular:browser-esbuild`, `@nx/angular:browser` and `@nx/angular:browser-esbuild` executors to use the `@nx/angular:application` executor or the `@angular-devkit/build-angular:application` builder. If the converted target is using one of the `@nx/angular` executors, the `@nx/angular:application` executor will be used. Otherwise, the `@angular-devkit/build-angular:application` builder will be used.

Some restrictions apply and the project(s) won't be converted if any of the following conditions is met:

- Target uses a custom webpack configuration
- Target uses the unsupported `deployUrl` option
- There is more than one target for the browser or server builds

Additionally, the generator can only be run on workspaces using Angular v17.0.0 or greater.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
