### PR TITLE
fix(core): exit with sigint when sigint is received

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -484,7 +484,7 @@ export class ForkedProcessTaskRunner {
         }
       });
       // we exit here because we don't need to write anything to cache.
-      process.exit();
+      process.exit(this.signalToCode('SIGINT'));
     });
     process.on('SIGTERM', () => {
       this.processes.forEach((p) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When Nx is interrupted while running tasks with Ctrl + C, the process incorrectly exits 0 (success)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When Nx interrupted while running tasks with Ctrl + C, the process correctly exists with 130 (SIGINT) 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
