### PR TITLE
feat(cypress): simplify inferred cypress command

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -73,10 +73,10 @@ describe('@nx/cypress/plugin', () => {
             "targets": {
               "e2e": {
                 "cache": true,
-                "command": "cypress run --config-file cypress.config.js --e2e",
+                "command": "cypress run",
                 "configurations": {
                   "production": {
-                    "command": "cypress run --config-file cypress.config.js --e2e --env webServerCommand="nx run my-app:serve:production"",
+                    "command": "cypress run --env webServerCommand="nx run my-app:serve:production"",
                   },
                 },
                 "inputs": [
@@ -132,7 +132,7 @@ describe('@nx/cypress/plugin', () => {
             "targets": {
               "component-test": {
                 "cache": true,
-                "command": "cypress open --config-file cypress.config.js --component",
+                "command": "cypress open --component",
                 "inputs": [
                   "default",
                   "^production",
@@ -190,10 +190,10 @@ describe('@nx/cypress/plugin', () => {
             "targets": {
               "e2e": {
                 "cache": true,
-                "command": "cypress run --config-file cypress.config.js --e2e",
+                "command": "cypress run",
                 "configurations": {
                   "production": {
-                    "command": "cypress run --config-file cypress.config.js --e2e --env webServerCommand="my-app:serve:production"",
+                    "command": "cypress run --env webServerCommand="my-app:serve:production"",
                   },
                 },
                 "inputs": [
@@ -239,7 +239,7 @@ describe('@nx/cypress/plugin', () => {
               },
               "e2e-ci--src/test.cy.ts": {
                 "cache": true,
-                "command": "cypress run --config-file cypress.config.js --e2e --env webServerCommand="my-app:serve-static" --spec src/test.cy.ts",
+                "command": "cypress run --env webServerCommand="my-app:serve-static" --spec src/test.cy.ts",
                 "inputs": [
                   "default",
                   "^production",

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -57,7 +57,7 @@ export const createDependencies: CreateDependencies = () => {
 };
 
 export const createNodes: CreateNodes<CypressPluginOptions> = [
-  '**/cypress.config.{js,ts,mjs,mts,cjs,cts}',
+  '**/cypress.config.{js,ts,mjs,cjs}',
   (configFilePath, options, context) => {
     options = normalizeOptions(options);
     const projectRoot = dirname(configFilePath);
@@ -157,15 +157,13 @@ function buildCypressTargets(
   const webServerCommands: Record<string, string> =
     pluginPresetOptions?.webServerCommands;
 
-  const relativeConfigPath = relative(projectRoot, configFilePath);
-
   const namedInputs = getNamedInputs(projectRoot, context);
 
   const targets: Record<string, TargetConfiguration> = {};
 
   if ('e2e' in cypressConfig) {
     targets[options.targetName] = {
-      command: `cypress run --config-file ${relativeConfigPath} --e2e`,
+      command: `cypress run`,
       options: { cwd: projectRoot },
       cache: true,
       inputs: getInputs(namedInputs),
@@ -182,7 +180,7 @@ function buildCypressTargets(
         webServerCommands ?? {}
       )) {
         targets[options.targetName].configurations[configuration] = {
-          command: `cypress run --config-file ${relativeConfigPath} --e2e --env webServerCommand="${webServerCommand}"`,
+          command: `cypress run --env webServerCommand="${webServerCommand}"`,
         };
       }
     }
@@ -215,7 +213,7 @@ function buildCypressTargets(
           outputs,
           inputs,
           cache: true,
-          command: `cypress run --config-file ${relativeConfigPath} --e2e --env webServerCommand="${ciWebServerCommand}" --spec ${relativeSpecFilePath}`,
+          command: `cypress run --env webServerCommand="${ciWebServerCommand}" --spec ${relativeSpecFilePath}`,
           options: {
             cwd: projectRoot,
           },
@@ -241,7 +239,7 @@ function buildCypressTargets(
   if ('component' in cypressConfig) {
     // This will not override the e2e target if it is the same
     targets[options.componentTestingTargetName] ??= {
-      command: `cypress open --config-file ${relativeConfigPath} --component`,
+      command: `cypress open --component`,
       options: { cwd: projectRoot },
       cache: true,
       inputs: getInputs(namedInputs),
@@ -259,7 +257,7 @@ function getCypressConfig(
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 
   let module: any;
-  if (['.ts', '.mts', '.cts'].includes(extname(configFilePath))) {
+  if (extname(configFilePath) === '.ts') {
     const tsConfigPath = getRootTsConfigPath();
 
     if (tsConfigPath) {


### PR DESCRIPTION
This PR makes the inferred Cypress commands simpler. There is no need to pass `--e2e` since it is on by default, and `--config-file` is not needed since we're only standard config file names.


Also removes `.mts` and `.cts` file names from being picked up since they are no valid, and Cypress will not run with them, even if you pass `--config-file=cypress.config.mts`.