### PR TITLE
fix(core): yargs array-like prompts initial field is number

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -498,7 +498,7 @@ async function determineNoneOptions(
             name: 'No',
           },
         ],
-        initial: 'Yes' as any,
+        initial: 0,
       },
     ]);
     js = reply.ts === 'No';
@@ -584,7 +584,7 @@ async function determineReactOptions(
       {
         name: 'style',
         message: `Default stylesheet format`,
-        initial: 'css' as any,
+        initial: 0,
         type: 'autocomplete',
         choices: [
           {
@@ -680,7 +680,7 @@ async function determineVueOptions(
       {
         name: 'style',
         message: `Default stylesheet format`,
-        initial: 'css' as any,
+        initial: 0,
         type: 'autocomplete',
         choices: [
           {
@@ -759,7 +759,7 @@ async function determineAngularOptions(
             message: 'Webpack [ https://webpack.js.org/ ]',
           },
         ],
-        initial: 'esbuild' as any,
+        initial: 0,
       },
     ]);
     bundler = reply.bundler;
@@ -772,7 +772,7 @@ async function determineAngularOptions(
       {
         name: 'style',
         message: `Default stylesheet format`,
-        initial: 'css' as any,
+        initial: 0,
         type: 'autocomplete',
         choices: [
           {
@@ -803,7 +803,7 @@ async function determineAngularOptions(
           'Do you want to enable Server-Side Rendering (SSR) and Static Site Generation (SSG/Prerendering)?',
         type: 'autocomplete',
         choices: [{ name: 'Yes' }, { name: 'No' }],
-        initial: 'No' as any,
+        initial: 1,
       },
     ]);
     ssr = reply.ssr === 'Yes';
@@ -880,7 +880,7 @@ async function determineNodeOptions(
             name: 'No',
           },
         ],
-        initial: 'No' as any,
+        initial: 1,
       },
     ]);
     docker = reply.docker === 'Yes';
@@ -904,7 +904,7 @@ async function determinePackageBasedOrIntegratedOrStandalone(): Promise<
       type: 'autocomplete',
       name: 'workspaceType',
       message: `Package-based monorepo, integrated monorepo, or standalone project?`,
-      initial: 'package-based' as any,
+      initial: 0,
       choices: [
         {
           name: 'package-based',
@@ -945,7 +945,7 @@ async function determineStandaloneOrMonorepo(): Promise<
       type: 'autocomplete',
       name: 'workspaceType',
       message: `Integrated monorepo, or standalone project?`,
-      initial: 'standalone' as any,
+      initial: 1,
       choices: [
         {
           name: 'integrated',
@@ -1022,7 +1022,7 @@ async function determineReactFramework(
           message: 'React Native  [ https://reactnative.dev/ ]',
         },
       ],
-      initial: 'none' as any,
+      initial: 0,
     },
   ]);
   return reply.framework;
@@ -1075,7 +1075,7 @@ async function determineNextAppDir(
           name: 'No',
         },
       ],
-      initial: 'Yes' as any,
+      initial: 0,
     },
   ]);
   return reply.nextAppDir === 'Yes';
@@ -1098,7 +1098,7 @@ async function determineNextSrcDir(
           name: 'No',
         },
       ],
-      initial: 'Yes' as any,
+      initial: 0,
     },
   ]);
   return reply.nextSrcDir === 'Yes';
@@ -1126,7 +1126,7 @@ async function determineVueFramework(
           message: 'Nuxt          [ https://nuxt.com/ ]',
         },
       ],
-      initial: 'none' as any,
+      initial: 0,
     },
   ]);
   return reply.framework;

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -104,7 +104,7 @@ export async function determinePackageManager(
         {
           name: 'packageManager',
           message: `Which package manager to use`,
-          initial: 'npm' as any,
+          initial: 0,
           type: 'autocomplete',
           choices: [
             { name: 'npm', message: 'NPM' },

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -7,7 +7,7 @@ const messageOptions = {
     {
       code: 'enable-nx-cloud',
       message: `Do you want Nx Cloud to make your CI fast?`,
-      initial: 'github',
+      initial: 1,
       choices: [
         { value: 'yes', name: 'Yes, enable Nx Cloud' },
         { value: 'github', name: 'Yes, configure Nx Cloud for GitHub Actions' },
@@ -22,7 +22,7 @@ const messageOptions = {
     {
       code: 'set-up-ci',
       message: `Set up CI with caching, distribution and test deflaking`,
-      initial: 'github',
+      initial: 0,
       choices: [
         { value: 'github', name: 'Yes, for GitHub Actions with Nx Cloud' },
         { value: 'circleci', name: 'Yes, for CircleCI with Nx Cloud' },
@@ -38,7 +38,7 @@ const messageOptions = {
     {
       code: 'enable-caching',
       message: `Would you like remote caching to make your build faster?`,
-      initial: 'yes',
+      initial: 0,
       choices: [
         { value: 'yes', name: 'Yes' },
         { value: 'skip', name: 'Skip for now' },

--- a/packages/devkit/src/generators/artifact-name-and-directory-utils.ts
+++ b/packages/devkit/src/generators/artifact-name-and-directory-utils.ts
@@ -129,7 +129,7 @@ async function determineFormat(
         name: derivedSelectedValue,
       },
     ],
-    initial: 'as-provided' as any,
+    initial: 0,
   }).then(({ format }) =>
     format === asProvidedSelectedValue ? 'as-provided' : 'derived'
   );

--- a/packages/devkit/src/generators/project-name-and-root-utils.ts
+++ b/packages/devkit/src/generators/project-name-and-root-utils.ts
@@ -171,7 +171,7 @@ async function determineFormat(
         name: derivedSelectedValue,
       },
     ],
-    initial: 'as-provided' as any,
+    initial: 0,
   }).then(({ format }) =>
     format === asProvidedSelectedValue ? 'as-provided' : 'derived'
   );

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -194,7 +194,7 @@ async function detectPlugins(): Promise<
           name: 'No',
         },
       ],
-      initial: 'Yes' as any,
+      initial: 0,
     },
   ]).then((r) => r.updatePackageScripts === 'Yes');
 

--- a/packages/nx/src/command-line/release/utils/github.ts
+++ b/packages/nx/src/command-line/release/utils/github.ts
@@ -118,7 +118,7 @@ export async function createOrUpdateGithubRelease(
             name: 'No',
           },
         ],
-        initial: 'Yes' as any,
+        initial: 0,
       },
     ]).catch(() => {
       return { open: 'No' };

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -7,7 +7,7 @@ const messageOptions = {
     {
       code: 'enable-caching',
       message: `Would you like remote caching to make your build faster?`,
-      initial: 'yes',
+      initial: 0,
       choices: [
         { value: 'yes', name: 'Yes' },
         { value: 'skip', name: 'Skip for now' },
@@ -21,7 +21,7 @@ const messageOptions = {
     {
       code: 'connect-to-view-logs',
       message: `To view the logs, Nx needs to connect your workspace to Nx Cloud and upload the most recent run details`,
-      initial: 'yes',
+      initial: 0,
       choices: [
         {
           value: 'yes',

--- a/packages/workspace/src/generators/move/lib/normalize-schema.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.ts
@@ -221,7 +221,7 @@ async function determineFormat(
         name: derivedSelectedValue,
       },
     ],
-    initial: 'as-provided' as any,
+    initial: 0,
   }).then(({ format }) =>
     format === asProvidedSelectedValue ? 'as-provided' : 'derived'
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We set string to `initial` field of yargs prompt for arrays, which accidentally works most of the time because it cannot be parsed to expected number so the 0 is used.

## Expected Behavior
The array-like prompts expect number as `initial` in order to work properly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
