### PR TITLE
fix(core): clarify error log when a project exists in a directory

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -59,7 +59,7 @@ export function addProjectConfiguration(
 
   if (tree.exists(projectConfigFile)) {
     throw new Error(
-      `Cannot create a new project ${projectName} at ${projectConfiguration.root}. It already exists.`
+      `Cannot create a new project ${projectName} at ${projectConfiguration.root}. A project already exists in this directory.`
     );
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The error log when adding a project to a directory that already contains a project is ambiguous. It could refer to either the project name itself already existing or a project existing in the directory. 
It's very confusing.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Clarify that Nx found a project existing in the directory removing the ambiguity.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
