### PR TITLE
fix(core): fix compilerOptions may not exist

### DIFF
--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -64,6 +64,7 @@ export function addTsConfigPath(
   lookupPaths: string[]
 ) {
   updateJson(tree, getRootTsConfigPathInTree(tree), (json) => {
+    json.compilerOptions ??= {};
     const c = json.compilerOptions;
     c.paths ??= {};
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when you run `nx add @nx/js` and then `nx g @nx/js:lib`, sometimes compilerOptions does not exist in the tsconfig.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
