### PR TITLE
fix(core): do not create new targets from target defaults when packag…

### DIFF
--- a/packages/nx/src/plugins/target-defaults/target-defaults-plugin.ts
+++ b/packages/nx/src/plugins/target-defaults/target-defaults-plugin.ts
@@ -58,12 +58,16 @@ export const TargetDefaultsPlugin: NxPluginV2 = {
       const packageJson = readJsonOrNull<PackageJson>(
         join(ctx.workspaceRoot, root, 'package.json')
       );
-      const projectDefinedTargets = new Set(
-        Object.keys({
-          ...packageJson?.scripts,
-          ...projectJson?.targets,
-        })
-      );
+      const includedScripts = packageJson?.nx?.includedScripts;
+      const projectDefinedTargets = new Set([
+        ...Object.keys(packageJson?.scripts ?? {}).filter((script) => {
+          if (includedScripts) {
+            return includedScripts.includes(script);
+          }
+          return true;
+        }),
+        ...Object.keys(projectJson?.targets ?? {}),
+      ]);
 
       const executorToTargetMap = getExecutorToTargetMap(
         packageJson,


### PR DESCRIPTION
…e.json script is not included

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Targets from Target defaults are added when the script is not included in the includedScripts array

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Targets from Target defaults are not added when the script is not included in the includedScripts array

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
