### PR TITLE
fix(vite): PCV3 multiple targets

### DIFF
--- a/e2e/vite/src/vite-pcv3.test.ts
+++ b/e2e/vite/src/vite-pcv3.test.ts
@@ -2,6 +2,7 @@ import {
   cleanupProject,
   killProcessAndPorts,
   newProject,
+  readJson,
   runCLI,
   runCommandUntil,
   uniq,
@@ -15,64 +16,102 @@ describe('@nx/vite/plugin', () => {
   let proj: string;
   let originalEnv: string;
 
-  beforeAll(() => {
-    originalEnv = process.env.NX_PCV3;
-    process.env.NX_PCV3 = 'true';
-    proj = newProject({
-      packages: ['@nx/react', '@nx/vue'],
-    });
-    runCLI(
-      `generate @nx/react:app ${myApp} --bundler=vite --unitTestRunner=vitest`
-    );
-    runCLI(`generate @nx/vue:app ${myVueApp} --unitTestRunner=vitest`);
-  });
-
-  afterAll(() => {
-    process.env.NODE_ENV = originalEnv;
-    cleanupProject();
-  });
-
-  describe('build and test React app', () => {
-    it('should build application', () => {
-      const result = runCLI(`build ${myApp}`);
-      expect(result).toContain('Successfully ran target build');
-    }, 200_000);
-
-    it('should test application', () => {
-      const result = runCLI(`test ${myApp}`);
-      expect(result).toContain('Successfully ran target test');
-    }, 200_000);
-  });
-  describe('build and test Vue app', () => {
-    it('should build application', () => {
-      const result = runCLI(`build ${myVueApp}`);
-      expect(result).toContain('Successfully ran target build');
-    }, 200_000);
-
-    it('should test application', () => {
-      const result = runCLI(`test ${myVueApp}`);
-      expect(result).toContain('Successfully ran target test');
-    }, 200_000);
-  });
-
-  it('should run serve-static', async () => {
-    let process: ChildProcess;
-    const port = 8081;
-
-    try {
-      process = await runCommandUntil(
-        `serve-static ${myApp} --port=${port}`,
-        (output) => {
-          return output.includes(`http://localhost:${port}`);
-        }
+  describe('with react', () => {
+    beforeAll(() => {
+      originalEnv = process.env.NX_PCV3;
+      process.env.NX_PCV3 = 'true';
+      proj = newProject({
+        packages: ['@nx/react', '@nx/vue'],
+      });
+      runCLI(
+        `generate @nx/react:app ${myApp} --bundler=vite --unitTestRunner=vitest`
       );
-    } catch (err) {
-      console.error(err);
-    }
+      runCLI(`generate @nx/vue:app ${myVueApp} --unitTestRunner=vitest`);
+    });
 
-    // port and process cleanup
-    if (process && process.pid) {
-      await killProcessAndPorts(process.pid, port);
-    }
+    afterAll(() => {
+      process.env.NODE_ENV = originalEnv;
+      cleanupProject();
+    });
+
+    describe('build and test React app', () => {
+      it('should build application', () => {
+        const result = runCLI(`build ${myApp}`);
+        expect(result).toContain('Successfully ran target build');
+      }, 200_000);
+
+      it('should test application', () => {
+        const result = runCLI(`test ${myApp}`);
+        expect(result).toContain('Successfully ran target test');
+      }, 200_000);
+    });
+    describe('build and test Vue app', () => {
+      it('should build application', () => {
+        const result = runCLI(`build ${myVueApp}`);
+        expect(result).toContain('Successfully ran target build');
+      }, 200_000);
+
+      it('should test application', () => {
+        const result = runCLI(`test ${myVueApp}`);
+        expect(result).toContain('Successfully ran target test');
+      }, 200_000);
+    });
+
+    it('should run serve-static', async () => {
+      let process: ChildProcess;
+      const port = 8081;
+
+      try {
+        process = await runCommandUntil(
+          `serve-static ${myApp} --port=${port}`,
+          (output) => {
+            return output.includes(`http://localhost:${port}`);
+          }
+        );
+      } catch (err) {
+        console.error(err);
+      }
+
+      // port and process cleanup
+      if (process && process.pid) {
+        await killProcessAndPorts(process.pid, port);
+      }
+    });
+  });
+
+  describe('react with vitest only', () => {
+    const reactVitest = uniq('reactVitest');
+
+    beforeAll(() => {
+      originalEnv = process.env.NX_PCV3;
+      process.env.NX_PCV3 = 'true';
+      proj = newProject({
+        packages: ['@nx/vite', '@nx/react'],
+      });
+      runCLI(
+        `generate @nx/react:app ${reactVitest} --bundler=webpack --unitTestRunner=vitest --e2eTestRunner=none --projectNameAndRootFormat=as-provided`
+      );
+    });
+
+    afterAll(() => {
+      process.env.NODE_ENV = originalEnv;
+      cleanupProject();
+    });
+
+    it('should contain targets build, test and lint', () => {
+      const nxJson = readJson('nx.json');
+
+      const vitePlugin = nxJson.plugins.find(
+        (p) => p.plugin === '@nx/vite/plugin'
+      );
+      expect(vitePlugin).toBeDefined();
+      expect(vitePlugin.options.buildTargetName).toEqual('build');
+      expect(vitePlugin.options.testTargetName).toEqual('test');
+    });
+
+    it('project.json should not contain test target', () => {
+      const projectJson = readJson(`${reactVitest}/project.json`);
+      expect(projectJson.targets.test).toBeUndefined();
+    });
   });
 });

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -40,6 +40,11 @@ export async function vitestGenerator(
     schema.project
   );
 
+  tasks.push(await jsInitGenerator(tree, { ...schema, skipFormat: true }));
+  const initTask = await initGenerator(tree, { skipFormat: true });
+  tasks.push(initTask);
+  tasks.push(ensureDependencies(tree, schema));
+
   const nxJson = readNxJson(tree);
   const hasPluginCheck = nxJson.plugins?.some(
     (p) =>
@@ -54,11 +59,6 @@ export async function vitestGenerator(
       'test';
     addOrChangeTestTarget(tree, schema, testTarget);
   }
-
-  tasks.push(await jsInitGenerator(tree, { ...schema, skipFormat: true }));
-  const initTask = await initGenerator(tree, { skipFormat: true });
-  tasks.push(initTask);
-  tasks.push(ensureDependencies(tree, schema));
 
   if (!schema.skipViteConfig) {
     if (schema.uiFramework === 'react') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently when we add we only add `vitest` as the test runner, with PCV3 enabled.
```shell
nx g @nx/react:app acme --bundler=webpack --unitTestRunner=vitest
```
 if it is being added for the first time to `nx.json` it will also add a target to `project.json`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Once PCV3 is enabled it should not add a test target to `project.json`

