### PR TITLE
fix(core): fix sending sigint to child tasks with the new psuedo tty …

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,8 @@ packages/nx/src/plugins/js/lock-file/__fixtures__/**/*.*
 packages/**/schematics/**/files/**/*.html
 packages/**/generators/**/files/**/*.html
 packages/nx/src/native/**/*.rs
+packages/nx/src/native/index.js
+packages/nx/src/native/index.d.ts
 nx-dev/nx-dev/.next/
 nx-dev/nx-dev/public/documentation
 graph/client/src/assets/environment.js

--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -3,6 +3,8 @@ import type { ExecutorContext } from '../../config/misc-interfaces';
 import * as path from 'path';
 import { env as appendLocalEnv } from 'npm-run-path';
 import { runCommand } from '../../native';
+import { PseudoTtyProcess } from '../../utils/child-process';
+import { signalToCode } from '../../utils/exit-codes';
 
 export interface RunScriptOptions {
   script: string;
@@ -16,20 +18,24 @@ export default async function (
   const pm = getPackageManagerCommand();
   try {
     await new Promise<void>((res, rej) => {
-      const cp = runCommand(
-        pm.run(options.script, options.__unparsed__.join(' ')),
-        path.join(
-          context.root,
-          context.projectsConfigurations.projects[context.projectName].root
-        ),
-        {
-          ...process.env,
-          ...appendLocalEnv(),
-        }
+      const cp = new PseudoTtyProcess(
+        runCommand(
+          pm.run(options.script, options.__unparsed__.join(' ')),
+          path.join(
+            context.root,
+            context.projectsConfigurations.projects[context.projectName].root
+          ),
+          {
+            ...process.env,
+            ...appendLocalEnv(),
+          }
+        )
       );
       cp.onExit((code) => {
         if (code === 0) {
           res();
+        } else if (code >= 128) {
+          process.exit(code);
         } else {
           rej();
         }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -148,7 +148,7 @@ export interface FileMap {
 export function testOnlyTransferFileMap(projectFiles: Record<string, Array<FileData>>, nonProjectFiles: Array<FileData>): NxWorkspaceFilesExternals
 export class ChildProcess {
   kill(): void
-  onExit(callback: (code: number) => void): void
+  onExit(callback: (message: string) => void): void
   onOutput(callback: (message: string) => void): void
 }
 export class ImportResult {

--- a/packages/nx/src/native/tests/command.spec.ts
+++ b/packages/nx/src/native/tests/command.spec.ts
@@ -28,7 +28,7 @@ describe('runCommand', () => {
     });
 
     childProcess.onExit(() => {
-      expect(output.trim()).toEqual('hello world');
+      expect(output.trim()).toContain('hello world');
       done();
     });
   });
@@ -41,9 +41,7 @@ describe('runCommand', () => {
       // check to make sure that we have ansi sequence characters only available in tty terminals
     });
     childProcess.onExit((_) => {
-      expect(JSON.stringify(output)).toMatchInlineSnapshot(
-        `""\\u001b[33mtrue\\u001b[39m""`
-      );
+      expect(JSON.stringify(output)).toContain('\\u001b[33mtrue\\u001b[39m');
       done();
     });
   });

--- a/packages/nx/src/utils/child-process.ts
+++ b/packages/nx/src/utils/child-process.ts
@@ -76,14 +76,36 @@ export async function runNxAsync(
   });
 }
 
+function messageToCode(message: string): number {
+  if (message.startsWith('Terminated by ')) {
+    switch (message.replace('Terminated by ', '').trim()) {
+      case 'Termination':
+        return 143;
+      case 'Interrupt':
+        return 130;
+      default:
+        return 128;
+    }
+  } else if (message.startsWith('Exited with code ')) {
+    return parseInt(message.replace('Exited with code ', '').trim());
+  } else if (message === 'Success') {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+
 export class PseudoTtyProcess {
   isAlive = true;
 
   exitCallbacks = [];
 
   constructor(private childProcess: ChildProcess) {
-    childProcess.onExit((exitCode) => {
+    childProcess.onExit((message) => {
       this.isAlive = false;
+
+      const exitCode = messageToCode(message);
+
       this.exitCallbacks.forEach((cb) => cb(exitCode));
     });
   }

--- a/packages/nx/src/utils/exit-codes.ts
+++ b/packages/nx/src/utils/exit-codes.ts
@@ -1,0 +1,16 @@
+/**
+ * Translates NodeJS signals to numeric exit code
+ * @param signal
+ */
+export function signalToCode(signal: NodeJS.Signals): number {
+  switch (signal) {
+    case 'SIGHUP':
+      return 128 + 1;
+    case 'SIGINT':
+      return 128 + 2;
+    case 'SIGTERM':
+      return 128 + 15;
+    default:
+      return 128;
+  }
+}


### PR DESCRIPTION
…processes

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When Ctrl + C is sent to the terminal after running Nx, the signals are being sent straight to the psuedo terminal processes instead of Nx.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When Ctrl + C is sent to the terminal after running Nx, the signals are sent straight to the psuedo terminal processes which will bubble them back up for Nx to exit with the signal.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
