### PR TITLE
fix(misc): prevent ts-node from reading tsconfig when registering transpiler

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -77,6 +77,8 @@ export function getTsNodeTranspiler(
   const service = register({
     transpileOnly: true,
     compilerOptions: getTsNodeCompilerOptions(compilerOptions),
+    // we already read and provide the compiler options, so prevent ts-node from reading them again
+    skipProject: true,
   });
 
   const { transpiler, swc } = service.options;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When registering the `ts-node` transpiler, we provide the compiler options that were already read from the tsconfig file. Then, `ts-node` loads again the tsconfig file to read the same compiler options already provided.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When registering the `ts-node` transpiler we prevent `ts-node` from rereading the tsconfig file. The already provided compiler options are all that's needed.

Note: we should do something similar when registering the SWC transpiler (don't set the `SWC_NODE_PROJECT` env var), but there's currently an issue https://github.com/swc-project/swc-node/issues/716 where provided compiler options are just plainly ignored and the config is always read. While that issue was already addressed, the fix hasn't been released yet: https://github.com/swc-project/swc-node/issues/750. Even when it gets released, we probably can't rely on that unless we check which version it's installed in the workspace, because it might not contain the fix.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
