### PR TITLE
fix(angular): update setup-ssr generator to support the outputPath object variant

### DIFF
--- a/packages/angular/src/generators/setup-ssr/files/server/application-builder/__serverFileName__
+++ b/packages/angular/src/generators/setup-ssr/files/server/application-builder/__serverFileName__
@@ -9,7 +9,7 @@ import <% if (standalone) { %>bootstrap<% } else { %>{ <%= rootModuleClassName %
 export function app(): express.Express {
   const server = express();
   const serverDistFolder = dirname(fileURLToPath(import.meta.url));
-  const browserDistFolder = resolve(serverDistFolder, '../browser');
+  const browserDistFolder = resolve(serverDistFolder, '../<%= browserBundleOutputPath %>');
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
   const commonEngine = new CommonEngine();

--- a/packages/angular/src/generators/setup-ssr/lib/add-server-file.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/add-server-file.ts
@@ -1,0 +1,57 @@
+import type { Tree } from '@nx/devkit';
+import {
+  generateFiles,
+  joinPathFragments,
+  readProjectConfiguration,
+} from '@nx/devkit';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
+import type { Schema } from '../schema';
+import { DEFAULT_BROWSER_DIR } from './constants';
+
+export function addServerFile(
+  tree: Tree,
+  schema: Schema,
+  isUsingApplicationBuilder: boolean
+) {
+  const { root: projectRoot, targets } = readProjectConfiguration(
+    tree,
+    schema.project
+  );
+  const { outputPath } = targets.build.options;
+  const browserBundleOutputPath = isUsingApplicationBuilder
+    ? getApplicationBuilderBrowserOutputPath(outputPath)
+    : outputPath;
+
+  const pathToFiles = joinPathFragments(__dirname, '..', 'files');
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+
+  generateFiles(
+    tree,
+    joinPathFragments(
+      pathToFiles,
+      'server',
+      ...(isUsingApplicationBuilder
+        ? ['application-builder']
+        : angularMajorVersion >= 17
+        ? ['server-builder', 'v17+']
+        : ['server-builder', 'pre-v17'])
+    ),
+    projectRoot,
+    { ...schema, browserBundleOutputPath, tpl: '' }
+  );
+}
+
+function getApplicationBuilderBrowserOutputPath(
+  outputPath: string | { browser: string }
+): string {
+  if (outputPath) {
+    if (typeof outputPath === 'string') {
+      // when `outputPath` is a string, it's the base path, so we return the default browser path
+      return DEFAULT_BROWSER_DIR;
+    }
+
+    return outputPath.browser ?? DEFAULT_BROWSER_DIR;
+  }
+
+  return DEFAULT_BROWSER_DIR;
+}

--- a/packages/angular/src/generators/setup-ssr/lib/constants.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/constants.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_BROWSER_DIR = 'browser';
+export const DEFAULT_MEDIA_DIR = 'media';
+export const DEFAULT_SERVER_DIR = 'server';

--- a/packages/angular/src/generators/setup-ssr/lib/generate-files.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/generate-files.ts
@@ -17,26 +17,31 @@ export function generateSSRFiles(
     tree,
     schema.project
   );
-  const baseOutputPath = targets.build.options.outputPath;
-  const browserBundleOutputPath = joinPathFragments(baseOutputPath, 'browser');
+
+  if (
+    targets.server ||
+    (isUsingApplicationBuilder && targets.build.options?.server !== undefined)
+  ) {
+    // server has already been added
+    return;
+  }
 
   const pathToFiles = joinPathFragments(__dirname, '..', 'files');
-  const { version: angularVersion, major: angularMajorVersion } =
-    getInstalledAngularVersionInfo(tree);
+  const { version: angularVersion } = getInstalledAngularVersionInfo(tree);
 
   if (schema.standalone) {
     generateFiles(
       tree,
       joinPathFragments(pathToFiles, 'standalone'),
       projectRoot,
-      { ...schema, browserBundleOutputPath, tpl: '' }
+      { ...schema, tpl: '' }
     );
   } else {
     generateFiles(
       tree,
       joinPathFragments(pathToFiles, 'ngmodule', 'base'),
       projectRoot,
-      { ...schema, browserBundleOutputPath, tpl: '' }
+      { ...schema, tpl: '' }
     );
 
     if (lt(angularVersion, '15.2.0')) {
@@ -44,23 +49,8 @@ export function generateSSRFiles(
         tree,
         joinPathFragments(pathToFiles, 'ngmodule', 'pre-v15-2'),
         projectRoot,
-        { ...schema, browserBundleOutputPath, tpl: '' }
+        { ...schema, tpl: '' }
       );
     }
   }
-
-  generateFiles(
-    tree,
-    joinPathFragments(
-      pathToFiles,
-      'server',
-      ...(isUsingApplicationBuilder
-        ? ['application-builder']
-        : angularMajorVersion >= 17
-        ? ['server-builder', 'v17+']
-        : ['server-builder', 'pre-v17'])
-    ),
-    projectRoot,
-    { ...schema, browserBundleOutputPath, tpl: '' }
-  );
 }

--- a/packages/angular/src/generators/setup-ssr/lib/generate-server-ts-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/generate-server-ts-config.ts
@@ -16,15 +16,15 @@ export function setServerTsConfigOptionsForApplicationBuilder(
   const tsConfigPath = targets.build.options.tsConfig;
 
   updateJson(tree, tsConfigPath, (json) => {
-    json.files ??= [];
-    json.files.push(
-      joinPathFragments('src', options.main),
-      joinPathFragments(options.serverFileName)
-    );
+    const files = new Set(json.files ?? []);
+    files.add(joinPathFragments('src', options.main));
+    files.add(joinPathFragments(options.serverFileName));
+    json.files = Array.from(files);
 
     json.compilerOptions ??= {};
-    json.compilerOptions.types ??= [];
-    json.compilerOptions.types.push('node');
+    const types = new Set(json.compilerOptions.types ?? []);
+    types.add('node');
+    json.compilerOptions.types = Array.from(types);
 
     return json;
   });

--- a/packages/angular/src/generators/setup-ssr/lib/index.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './add-dependencies';
+export * from './add-server-file';
 export * from './generate-files';
 export * from './generate-server-ts-config';
 export * from './normalize-options';

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -5,6 +5,7 @@ import type {
 import type { Tree } from '@nx/devkit';
 import {
   joinPathFragments,
+  logger,
   readNxJson,
   readProjectConfiguration,
   updateNxJson,
@@ -12,6 +13,11 @@ import {
 } from '@nx/devkit';
 import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { Schema } from '../schema';
+import {
+  DEFAULT_BROWSER_DIR,
+  DEFAULT_MEDIA_DIR,
+  DEFAULT_SERVER_DIR,
+} from './constants';
 
 export function updateProjectConfigForApplicationBuilder(
   tree: Tree,
@@ -20,7 +26,33 @@ export function updateProjectConfigForApplicationBuilder(
   const project = readProjectConfiguration(tree, options.project);
   const buildTarget = project.targets.build;
 
+  let outputPath = buildTarget.options?.outputPath;
+  if (
+    outputPath &&
+    typeof outputPath !== 'string' &&
+    outputPath.browser === ''
+  ) {
+    const base = outputPath.base as string;
+    logger.warn(
+      `The output location of the browser build has been updated from "${base}" to "${joinPathFragments(
+        base,
+        DEFAULT_BROWSER_DIR
+      )}".
+          You might need to adjust your deployment pipeline.`
+    );
+
+    if (
+      (outputPath.media && outputPath.media !== DEFAULT_MEDIA_DIR) ||
+      (outputPath.server && outputPath.server !== DEFAULT_SERVER_DIR)
+    ) {
+      delete outputPath.browser;
+    } else {
+      outputPath = outputPath.base;
+    }
+  }
+
   buildTarget.options ??= {};
+  buildTarget.options.outputPath = outputPath;
   buildTarget.options.server = joinPathFragments(
     project.sourceRoot ?? joinPathFragments(project.root, 'src'),
     options.main

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.ts
@@ -8,6 +8,7 @@ import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import {
   addDependencies,
   addHydration,
+  addServerFile,
   generateSSRFiles,
   generateTsConfigServerJsonForBrowserBuilder,
   normalizeOptions,
@@ -50,6 +51,8 @@ export async function setupSsr(tree: Tree, schema: Schema) {
     updateProjectConfigForBrowserBuilder(tree, options);
     generateTsConfigServerJsonForBrowserBuilder(tree, options);
   }
+
+  addServerFile(tree, options, isUsingApplicationBuilder);
 
   if (!options.skipFormat) {
     await formatFiles(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `setup-ssr` generator doesn't support the `outputPath` object variant introduced in Angular v17.1.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `setup-ssr` generator should support the `outputPath` object variant introduced in Angular v17.1.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
