### PR TITLE
fix(remix): tsconfigs were being incorrectly generated causing errors #21002

### DIFF
--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -323,6 +323,6 @@ function expectTargetsToBeCorrect(tree: Tree, projectRoot: string) {
   expect(targets.start.command).toEqual('remix-serve build/index.js');
   expect(targets.start.options.cwd).toEqual(projectRoot);
   expect(targets.typecheck).toBeTruthy();
-  expect(targets.typecheck.command).toEqual('tsc');
+  expect(targets.typecheck.command).toEqual('tsc --project tsconfig.app.json');
   expect(targets.typecheck.options.cwd).toEqual(projectRoot);
 }

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -78,7 +78,7 @@ export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
         },
       },
       typecheck: {
-        command: `tsc`,
+        command: `tsc --project tsconfig.app.json`,
         options: {
           cwd: options.projectRoot,
         },

--- a/packages/remix/src/generators/application/files/common/tsconfig.app.json__tmpl__
+++ b/packages/remix/src/generators/application/files/common/tsconfig.app.json__tmpl__
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "remix.env.d.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "app/**/*.js",
+    "app/**/*.jsx"
+  ],
+  "exclude": [
+    "tests/**/*.spec.ts",
+    "tests/**/*.test.ts",
+    "tests/**/*.spec.tsx",
+    "tests/**/*.test.tsx",
+    "tests/**/*.spec.js",
+    "tests/**/*.test.js",
+    "tests/**/*.spec.jsx",
+    "tests/**/*.test.jsx"
+  ]
+}

--- a/packages/remix/src/generators/application/files/common/tsconfig.json__tmpl__
+++ b/packages/remix/src/generators/application/files/common/tsconfig.json__tmpl__
@@ -1,18 +1,24 @@
 {
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
-  "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2019"],
-    "isolatedModules": true,
-    "esModuleInterop": true,
-    "jsx": "react-jsx",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "target": "ES2019",
-    "strict": true,
-    "allowJs": true,
-    "forceConsistentCasingInFileNames": true,
-    // Remix takes care of building everything in `remix build`.
-    "noEmit": true
-  }
+      "lib": ["DOM", "DOM.Iterable", "ES2019"],
+      "isolatedModules": true,
+      "esModuleInterop": true,
+      "jsx": "react-jsx",
+      "moduleResolution": "node",
+      "resolveJsonModule": true,
+      "target": "ES2019",
+      "strict": true,
+      "allowJs": true,
+      "forceConsistentCasingInFileNames": true,
+      // Remix takes care of building everything in `remix build`.
+      "noEmit": true
+    },
+    "include": [],
+    "files": [],
+    "references": [
+      {
+        "path": "./tsconfig.app.json"
+      }
+    ]
 }

--- a/packages/remix/src/generators/application/lib/update-unit-test-config.ts
+++ b/packages/remix/src/generators/application/lib/update-unit-test-config.ts
@@ -3,6 +3,7 @@ import {
   joinPathFragments,
   stripIndents,
   type Tree,
+  updateJson,
   workspaceRoot,
 } from '@nx/devkit';
 import {
@@ -55,6 +56,32 @@ export function updateUnitTestConfig(
         .replace('jest.preset.js', 'jest.preset.cjs')
     );
   }
+
+  const pathToTsConfigSpec = joinPathFragments(
+    pathToRoot,
+    `tsconfig.spec.json`
+  );
+
+  updateJson(tree, pathToTsConfigSpec, (json) => {
+    json.includes = [
+      'vite.config.ts',
+      'vitest.config.ts',
+      'app/**/*.ts',
+      'app/**/*.tsx',
+      'app/**/*.js',
+      'app/**/*.jsx',
+      'tests/**/*.spec.ts',
+      'tests/**/*.test.ts',
+      'tests/**/*.spec.tsx',
+      'tests/**/*.test.tsx',
+      'tests/**/*.spec.js',
+      'tests/**/*.test.js',
+      'tests/**/*.spec.jsx',
+      'tests/**/*.test.jsx',
+    ];
+
+    return json;
+  });
 
   return addDependenciesToPackageJson(
     tree,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not set up the tsconfigs for Remix correctly, especially when we add a `tsconfig.spec.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Fix the tsconfigs that are generated to be more correct and prevent errors

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21002
