### PR TITLE
fix(release): do not restart the daemon when skipLockFileUpdate is set

### DIFF
--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -27,7 +27,7 @@ import {
   deriveNewSemverVersion,
   validReleaseVersionPrefixes,
 } from 'nx/src/command-line/release/version';
-import { daemonClient } from 'nx/src/daemon/client/client';
+
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import * as ora from 'ora';
 import { relative } from 'path';
@@ -500,29 +500,7 @@ To fix this you will either need to add a package.json file at that location, or
       data: versionData,
       callback: async (tree, opts) => {
         const cwd = tree.root;
-
-        const isDaemonEnabled = daemonClient.enabled();
-        if (isDaemonEnabled) {
-          // temporarily stop the daemon, as it will error if the lock file is updated
-          await daemonClient.stop();
-        }
-
-        const updatedFiles = updateLockFile(cwd, opts);
-
-        if (isDaemonEnabled) {
-          try {
-            await daemonClient.startInBackground();
-          } catch (e) {
-            // If the daemon fails to start, we don't want to prevent the user from continuing, so we just log the error and move on
-            if (opts.verbose) {
-              output.warn({
-                title:
-                  'Unable to restart the Nx Daemon. It will be disabled until you run "nx reset"',
-                bodyLines: [e.message],
-              });
-            }
-          }
-        }
+        const updatedFiles = await updateLockFile(cwd, opts);
         return updatedFiles;
       },
     };

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createProjectGraphAsync, workspaceRoot } from '@nx/devkit';
+import * as chalk from 'chalk';
 import { execSync } from 'node:child_process';
 import { rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -7,7 +8,6 @@ import { URL } from 'node:url';
 import { isRelativeVersionKeyword } from 'nx/src/command-line/release/utils/semver';
 import { ReleaseType, inc, major, parse } from 'semver';
 import * as yargs from 'yargs';
-import * as chalk from 'chalk';
 
 const LARGE_BUFFER = 1024 * 1000000;
 
@@ -58,6 +58,9 @@ const LARGE_BUFFER = 1024 * 1000000;
     if (options.dryRun) {
       versionCommand += ' --dry-run';
     }
+    if (isVerboseLogging) {
+      versionCommand += ' --verbose';
+    }
     console.log(`> ${versionCommand}`);
     execSync(versionCommand, {
       stdio: isVerboseLogging ? [0, 1, 2] : 'ignore',
@@ -94,6 +97,9 @@ const LARGE_BUFFER = 1024 * 1000000;
     }
     if (options.dryRun) {
       changelogCommand += ' --dry-run';
+    }
+    if (isVerboseLogging) {
+      changelogCommand += ' --verbose';
     }
     console.log(`> ${changelogCommand}`);
     execSync(changelogCommand, {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The daemon is always restarted after `nx release version`. Verbose logging is not propagated down to the nx release subcommands in the `nx-release` script.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The daemon is not restarted after `nx release version` if `skipLockFileUpdate` is set. Verbose logging is propagated down to the subcommands in the `nx-release` script.
