### PR TITLE
chore(repo): bump the binning agents provisioning

### DIFF
--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,4 +1,4 @@
 distributes-on:
-  small-changeset: 4 linux-medium
-  medium-changeset: 8 linux-medium
+  small-changeset: 8 linux-medium
+  medium-changeset: 10 linux-medium
   large-changeset: 12 linux-medium


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

PR Size Binning is mislabeling some runs which should be large as small sometimes... resulting in some large changesets running for a long time with only 4 agents.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

For now, while we investigate the issues, this PR bumps the agents provisioned to 8 even for the small size and 10 for the medium size so we can easily see the difference. This should cause the large changesets to run no slower than they used to before.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
