### PR TITLE
fix(nextjs): Add missing support swc for custom server

### DIFF
--- a/packages/next/src/generators/custom-server/custom-server.spec.ts
+++ b/packages/next/src/generators/custom-server/custom-server.spec.ts
@@ -1,0 +1,56 @@
+import { Tree, readJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import { applicationGenerator } from '../application/application';
+
+describe('app', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should create a custom server', async () => {
+    const name = uniq('custom-server');
+
+    await applicationGenerator(tree, {
+      name,
+      style: 'css',
+      projectNameAndRootFormat: 'as-provided',
+      customServer: true,
+    });
+
+    const projectConfig = readJson(tree, `${name}/project.json`);
+
+    expect(tree.exists(`${name}/server/main.ts`)).toBeTruthy();
+    expect(tree.exists(`${name}/tsconfig.server.json`)).toBeTruthy();
+    expect(projectConfig.targets['build-custom-server']).toBeTruthy();
+    expect(projectConfig.targets['serve-custom-server']).toBeTruthy();
+  });
+
+  it('should create a custom server with swc', async () => {
+    const name = uniq('custom-server');
+
+    await applicationGenerator(tree, {
+      name,
+      style: 'css',
+      projectNameAndRootFormat: 'as-provided',
+      customServer: true,
+      swc: true,
+    });
+
+    const projectConfig = readJson(tree, `${name}/project.json`);
+    const packageJson = readJson(tree, `package.json`);
+
+    expect(tree.exists(`${name}/.swcrc`)).toBeTruthy();
+    expect(projectConfig.targets['build-custom-server'].executor).toEqual(
+      '@nx/js:swc'
+    );
+    expect(packageJson.devDependencies['@swc/core']).toBeTruthy();
+    expect(packageJson.devDependencies['@swc/cli']).toBeTruthy();
+    expect(packageJson.devDependencies['@swc-node/register']).toBeTruthy();
+  });
+});
+
+function uniq(name: string) {
+  return `${name}-${(Math.random() * 10000).toFixed(0)}`;
+}

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -9,11 +9,12 @@ import {
 } from '@nx/devkit';
 import { CustomServerSchema } from './schema';
 import { join } from 'path';
+import { configureForSwc } from '../../utils/add-swc-to-custom-server';
 
 export async function customServerGenerator(
   host: Tree,
   options: CustomServerSchema
-): Promise<void> {
+) {
   const project = readProjectConfiguration(host, options.project);
 
   if (
@@ -64,7 +65,7 @@ export async function customServerGenerator(
   project.targets.serve.configurations.production.customServerTarget = `${options.project}:serve-custom-server:production`;
 
   project.targets['build-custom-server'] = {
-    executor: '@nx/js:tsc',
+    executor: options.compiler === 'tsc' ? '@nx/js:tsc' : '@nx/js:swc',
     defaultConfiguration: 'production',
     options: {
       outputPath,
@@ -113,4 +114,8 @@ export async function customServerGenerator(
     json.targetDefaults['build-custom-server'].cache ??= true;
     return json;
   });
+
+  if (options.compiler === 'swc') {
+    return configureForSwc(host, project.root);
+  }
 }

--- a/packages/next/src/utils/add-swc-to-custom-server.ts
+++ b/packages/next/src/utils/add-swc-to-custom-server.ts
@@ -1,0 +1,43 @@
+import {
+  Tree,
+  addDependenciesToPackageJson,
+  installPackagesTask,
+  joinPathFragments,
+  readJson,
+} from '@nx/devkit';
+import { swcCliVersion, swcCoreVersion, swcNodeVersion } from './versions';
+import { addSwcConfig } from '@nx/js/src/utils/swc/add-swc-config';
+
+export function configureForSwc(tree: Tree, projectRoot: string) {
+  const swcConfigPath = joinPathFragments(projectRoot, '.swcrc');
+  const rootPackageJson = readJson(tree, 'package.json');
+
+  const hasSwcDepedency =
+    rootPackageJson.dependencies?.['@swc/core'] ||
+    rootPackageJson.devDependencies?.['@swc/core'];
+
+  const hasSwcCliDependency =
+    rootPackageJson.dependencies?.['@swc/cli'] ||
+    rootPackageJson.devDependencies?.['@swc/cli'];
+
+  if (!tree.exists(swcConfigPath)) {
+    addSwcConfig(tree, swcConfigPath);
+  }
+
+  if (!hasSwcDepedency || !hasSwcCliDependency) {
+    addSwcDependencies(tree);
+    return () => installPackagesTask(tree);
+  }
+}
+
+function addSwcDependencies(tree: Tree) {
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      '@swc-node/register': swcNodeVersion,
+      '@swc/cli': swcCliVersion,
+      '@swc/core': swcCoreVersion,
+    }
+  );
+}

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -7,3 +7,8 @@ export const lessLoader = '11.1.0';
 export const emotionServerVersion = '11.11.0';
 export const babelPluginStyledComponentsVersion = '1.10.7';
 export const tsLibVersion = '^2.3.0';
+
+export const swcCliVersion = '~0.1.62';
+export const swcCoreVersion = '~1.3.85';
+export const swcHelpersVersion = '~0.5.2';
+export const swcNodeVersion = '~1.6.7';


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When you generate a custom server with `--swc` enabled it uses `@nx/jsc:tsc` as the executor for building the server

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

1. It should use `@nx/js:swc` for building the custom server.
2. It should install swc dependencies if missing.
3. It should generate a `.swcrc` file

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21217
