### PR TITLE
fix(linter): prevent dep-checks leaking when used outside nx

### DIFF
--- a/packages/eslint-plugin/src/utils/package-json-utils.ts
+++ b/packages/eslint-plugin/src/utils/package-json-utils.ts
@@ -17,16 +17,21 @@ export function getAllDependencies(
 export function getProductionDependencies(
   packageJsonPath: string
 ): Record<string, string> {
-  if (!globalThis.projPackageJsonDeps || !isTerminalRun()) {
+  if (
+    !globalThis.projPackageJsonDeps ||
+    !globalThis.projPackageJsonDeps[packageJsonPath] ||
+    !isTerminalRun()
+  ) {
     const packageJson = getPackageJson(packageJsonPath);
-    globalThis.projPackageJsonDeps = {
+    globalThis.projPackageJsonDeps = globalThis.projPackageJsonDeps || {};
+    globalThis.projPackageJsonDeps[packageJsonPath] = {
       ...packageJson.dependencies,
       ...packageJson.peerDependencies,
       ...packageJson.optionalDependencies,
     };
   }
 
-  return globalThis.projPackageJsonDeps;
+  return globalThis.projPackageJsonDeps[packageJsonPath];
 }
 
 export function getPackageJson(path: string): PackageJson {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20727
