### PR TITLE
fix(angular): fix dev-server validation for esbuildMiddleware

### DIFF
--- a/packages/angular/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/angular/src/builders/dev-server/dev-server.impl.ts
@@ -53,7 +53,7 @@ export function executeDevServerBuilder(
   rawOptions: Schema,
   context: import('@angular-devkit/architect').BuilderContext
 ) {
-  if (rawOptions.esbuildMiddleware) {
+  if (rawOptions.esbuildMiddleware?.length > 0) {
     const { major: angularMajorVersion, version: angularVersion } =
       getInstalledAngularVersionInfo();
     if (angularMajorVersion < 17) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/angular:dev-server` executor throws an error when the Angular version is lower than 17.0.0 even though the `esbuildMiddleware` options is not provided.

This happens because the Angular CLI schema parser converts an `undefined` array option to an empty array.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/angular:dev-server` executor should not throw when the `esbuildMiddleware` option is not provided.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21410 
