### PR TITLE
fix(module-federation): ensure the static remotes env var is used for task hashing #21390

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -359,7 +359,7 @@
     },
     "add-module-federation-env-var-to-target-defaults": {
       "cli": "nx",
-      "version": "17.8.0-beta.0",
+      "version": "18.0.0-beta.0",
       "description": "Add NX_MF_DEV_SERVER_STATIC_REMOTES to inputs for task hashing when '@nx/angular:webpack-browser' is used for Module Federation.",
       "factory": "./src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults"
     }

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -356,6 +356,12 @@
       },
       "description": "Add 'autoprefixer' as dev dependency when '@nx/angular:ng-packagr-lite' or '@nx/angular:package` is used.",
       "factory": "./src/migrations/update-17-3-0/add-autoprefixer-dependency"
+    },
+    "add-module-federation-env-var-to-target-defaults": {
+      "cli": "nx",
+      "version": "17.8.0-beta.0",
+      "description": "Add NX_MF_DEV_SERVER_STATIC_REMOTES to inputs for task hashing when '@nx/angular:webpack-browser' is used for Module Federation.",
+      "factory": "./src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -12,6 +12,7 @@ import remoteGenerator from '../remote/remote';
 import { setupMf } from '../setup-mf/setup-mf';
 import { updateSsrSetup } from './lib';
 import type { Schema } from './schema';
+import { addMfEnvToTargetDefaultInputs } from '../utils/add-mf-env-to-inputs';
 
 export async function host(tree: Tree, options: Schema) {
   return await hostInternal(tree, {
@@ -112,6 +113,8 @@ export async function hostInternal(tree: Tree, schema: Schema) {
       typescriptConfiguration,
     });
   }
+
+  addMfEnvToTargetDefaultInputs(tree);
 
   if (!options.skipFormat) {
     await formatFiles(tree);

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -12,6 +12,7 @@ import { setupMf } from '../setup-mf/setup-mf';
 import { findNextAvailablePort, updateSsrSetup } from './lib';
 import type { Schema } from './schema';
 import { swcHelpersVersion } from '@nx/js/src/utils/versions';
+import { addMfEnvToTargetDefaultInputs } from '../utils/add-mf-env-to-inputs';
 
 export async function remote(tree: Tree, options: Schema) {
   return await remoteInternal(tree, {
@@ -89,6 +90,8 @@ export async function remoteInternal(tree: Tree, schema: Schema) {
     });
     installTasks.push(ssrInstallTask);
   }
+
+  addMfEnvToTargetDefaultInputs(tree);
 
   if (!options.skipFormat) {
     await formatFiles(tree);

--- a/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
+++ b/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
@@ -1,0 +1,46 @@
+import { type Tree, readNxJson, updateNxJson } from '@nx/devkit';
+
+export function addMfEnvToTargetDefaultInputs(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  const webpackExecutor = '@nx/angular:webpack-browser';
+  const mfEnvVar = 'NX_MF_DEV_SERVER_STATIC_REMOTES';
+
+  let mfEnvVarExists = false;
+  if (nxJson.targetDefaults && webpackExecutor in nxJson.targetDefaults) {
+    const webpackExecutorTargetDefaults =
+      nxJson.targetDefaults[webpackExecutor];
+
+    if (webpackExecutorTargetDefaults.inputs) {
+      for (const webpackExecutorTargetDefaultsInput of webpackExecutorTargetDefaults.inputs) {
+        if (typeof webpackExecutorTargetDefaultsInput === 'object') {
+          const [key, value] = Object.entries(
+            webpackExecutorTargetDefaultsInput
+          )[0];
+
+          if (key === 'env' && value === mfEnvVar) {
+            mfEnvVarExists = true;
+            break;
+          }
+        }
+      }
+    } else {
+      nxJson.targetDefaults[webpackExecutor].inputs = [];
+    }
+  } else if (!nxJson.targetDefaults[webpackExecutor]) {
+    nxJson.targetDefaults[webpackExecutor] = {
+      inputs: [],
+    };
+  } else if (!nxJson.targetDefaults) {
+    nxJson.targetDefaults = {
+      [webpackExecutor]: {
+        inputs: [],
+      },
+    };
+  }
+
+  if (!mfEnvVarExists) {
+    nxJson.targetDefaults[webpackExecutor].inputs.push({ env: mfEnvVar });
+  }
+
+  updateNxJson(tree, nxJson);
+}

--- a/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
+++ b/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
@@ -5,42 +5,19 @@ export function addMfEnvToTargetDefaultInputs(tree: Tree) {
   const webpackExecutor = '@nx/angular:webpack-browser';
   const mfEnvVar = 'NX_MF_DEV_SERVER_STATIC_REMOTES';
 
+  nxJson.targetDefaults ??= {};
+  nxJson.targetDefaults[webpackExecutor] ??= {};
+  nxJson.targetDefaults[webpackExecutor].inputs ??= [];
+
   let mfEnvVarExists = false;
-  if (nxJson.targetDefaults && webpackExecutor in nxJson.targetDefaults) {
-    const webpackExecutorTargetDefaults =
-      nxJson.targetDefaults[webpackExecutor];
-
-    if (webpackExecutorTargetDefaults.inputs) {
-      for (const webpackExecutorTargetDefaultsInput of webpackExecutorTargetDefaults.inputs) {
-        if (typeof webpackExecutorTargetDefaultsInput === 'object') {
-          const [key, value] = Object.entries(
-            webpackExecutorTargetDefaultsInput
-          )[0];
-
-          if (key === 'env' && value === mfEnvVar) {
-            mfEnvVarExists = true;
-            break;
-          }
-        }
-      }
-    } else {
-      nxJson.targetDefaults[webpackExecutor].inputs = [];
+  for (const input of nxJson.targetDefaults[webpackExecutor].inputs) {
+    if (typeof input === 'object' && input['env'] === mfEnvVar) {
+      mfEnvVarExists = true;
+      break;
     }
-  } else if (!nxJson.targetDefaults[webpackExecutor]) {
-    nxJson.targetDefaults[webpackExecutor] = {
-      inputs: [],
-    };
-  } else if (!nxJson.targetDefaults) {
-    nxJson.targetDefaults = {
-      [webpackExecutor]: {
-        inputs: [],
-      },
-    };
   }
-
   if (!mfEnvVarExists) {
     nxJson.targetDefaults[webpackExecutor].inputs.push({ env: mfEnvVar });
+    updateNxJson(tree, nxJson);
   }
-
-  updateNxJson(tree, nxJson);
 }

--- a/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
+++ b/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
@@ -1,0 +1,123 @@
+import addMfEnvVarToTargetDefaults from './add-mf-env-var-to-target-defaults';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { addProjectConfiguration, readNxJson, updateNxJson } from '@nx/devkit';
+
+describe('addMfEnvVarToTargetDefaults', () => {
+  it('should add the executor and input when it does not exist', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'test', {
+      root: '',
+      targets: {
+        build: {
+          executor: '@nx/angular:webpack-browser',
+        },
+      },
+    });
+
+    tree.write('module-federation.config.ts', '');
+
+    // ACT
+    await addMfEnvVarToTargetDefaults(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "@nx/angular:webpack-browser": {
+          "inputs": [
+            {
+              "env": "NX_MF_DEV_SERVER_STATIC_REMOTES",
+            },
+          ],
+        },
+        "build": {
+          "cache": true,
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+
+  it('should not add the executor and input when no project uses it', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'test', {
+      root: '',
+      targets: {
+        build: {
+          executor: '@nx/angular:module-federation-dev-server',
+        },
+      },
+    });
+
+    // ACT
+    await addMfEnvVarToTargetDefaults(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+
+  it('should update the executor and input target default when it already exists', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'test', {
+      root: '',
+      targets: {
+        build: {
+          executor: '@nx/angular:webpack-browser',
+        },
+      },
+    });
+    tree.write('module-federation.config.ts', '');
+
+    let nxJson = readNxJson(tree);
+    nxJson = {
+      ...nxJson,
+      targetDefaults: {
+        ...nxJson.targetDefaults,
+        ['@nx/angular:webpack-browser']: {
+          inputs: ['^build'],
+        },
+      },
+    };
+
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    await addMfEnvVarToTargetDefaults(tree);
+
+    // ASSERT
+    nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "@nx/angular:webpack-browser": {
+          "inputs": [
+            "^build",
+            {
+              "env": "NX_MF_DEV_SERVER_STATIC_REMOTES",
+            },
+          ],
+        },
+        "build": {
+          "cache": true,
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+});

--- a/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
+++ b/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
@@ -3,6 +3,7 @@ import {
   type Tree,
   type ProjectConfiguration,
   joinPathFragments,
+  formatFiles,
 } from '@nx/devkit';
 import { addMfEnvToTargetDefaultInputs } from '../../generators/utils/add-mf-env-to-inputs';
 
@@ -11,6 +12,8 @@ export default async function (tree: Tree) {
     return;
   }
   addMfEnvToTargetDefaultInputs(tree);
+
+  await formatFiles(tree);
 }
 
 function isWebpackBrowserUsed(tree: Tree) {

--- a/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
+++ b/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
@@ -1,0 +1,35 @@
+import {
+  getProjects,
+  type Tree,
+  type ProjectConfiguration,
+  joinPathFragments,
+} from '@nx/devkit';
+import { addMfEnvToTargetDefaultInputs } from '../../generators/utils/add-mf-env-to-inputs';
+
+export default async function (tree: Tree) {
+  if (!isWebpackBrowserUsed(tree)) {
+    return;
+  }
+  addMfEnvToTargetDefaultInputs(tree);
+}
+
+function isWebpackBrowserUsed(tree: Tree) {
+  const projects = getProjects(tree);
+  for (const project of projects.values()) {
+    const targets = project.targets;
+    for (const [_, target] of Object.entries(targets)) {
+      if (
+        target.executor === '@nx/angular:webpack-browser' &&
+        (tree.exists(
+          joinPathFragments(project.root, 'module-federation.config.ts')
+        ) ||
+          tree.exists(
+            joinPathFragments(project.root, 'module-federation.config.js')
+          ))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -50,7 +50,7 @@
     },
     "add-module-federation-env-var-to-target-defaults": {
       "cli": "nx",
-      "version": "17.8.0-beta.0",
+      "version": "18.0.0-beta.0",
       "description": "Add NX_MF_DEV_SERVER_STATIC_REMOTES to inputs for task hashing when '@nx/webpack:webpack' is used for Module Federation.",
       "factory": "./src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults"
     }

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -47,6 +47,12 @@
       "version": "16.7.0-beta.2",
       "description": "Add @nx/react types to tsconfig types array",
       "implementation": "./src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings"
+    },
+    "add-module-federation-env-var-to-target-defaults": {
+      "cli": "nx",
+      "version": "17.8.0-beta.0",
+      "description": "Add NX_MF_DEV_SERVER_STATIC_REMOTES to inputs for task hashing when '@nx/webpack:webpack' is used for Module Federation.",
+      "factory": "./src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -20,6 +20,7 @@ import {
 import { setupSsrForHost } from './lib/setup-ssr-for-host';
 import { updateModuleFederationE2eProject } from './lib/update-module-federation-e2e-project';
 import { NormalizedSchema, Schema } from './schema';
+import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs';
 
 export async function hostGenerator(
   host: Tree,
@@ -113,6 +114,8 @@ export async function hostGeneratorInternal(
       joinPathFragments(options.appProjectRoot, 'tsconfig.lint.json')
     );
   }
+
+  addMfEnvToTargetDefaultInputs(host);
 
   if (!options.skipFormat) {
     await formatFiles(host);

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -21,6 +21,7 @@ import setupSsrGenerator from '../setup-ssr/setup-ssr';
 import { setupSsrForRemote } from './lib/setup-ssr-for-remote';
 import { setupTspathForRemote } from './lib/setup-tspath-for-remote';
 import { addRemoteToDynamicHost } from './lib/add-remote-to-dynamic-host';
+import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs';
 
 export function addModuleFederationFiles(
   host: Tree,
@@ -140,6 +141,8 @@ export async function remoteGeneratorInternal(host: Tree, schema: Schema) {
       pathToMFManifest
     );
   }
+
+  addMfEnvToTargetDefaultInputs(host);
 
   if (!options.skipFormat) {
     await formatFiles(host);

--- a/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
+++ b/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
@@ -1,0 +1,123 @@
+import addMfEnvVarToTargetDefaults from './add-mf-env-var-to-target-defaults';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { addProjectConfiguration, readNxJson, updateNxJson } from '@nx/devkit';
+
+describe('addMfEnvVarToTargetDefaults', () => {
+  it('should add the executor and input when it does not exist', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'test', {
+      root: '',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+        },
+      },
+    });
+    tree.write('module-federation.config.ts', '');
+
+    // ACT
+    await addMfEnvVarToTargetDefaults(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "@nx/webpack:webpack": {
+          "inputs": [
+            {
+              "env": "NX_MF_DEV_SERVER_STATIC_REMOTES",
+            },
+          ],
+        },
+        "build": {
+          "cache": true,
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+
+  it('should not add the executor and input when no project uses it', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'test', {
+      root: '',
+      targets: {
+        build: {
+          executor: '@nx/angular:module-federation-dev-server',
+        },
+      },
+    });
+
+    // ACT
+    await addMfEnvVarToTargetDefaults(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+
+  it('should update the executor and input target default when it already exists', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'test', {
+      root: '',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+        },
+      },
+    });
+
+    tree.write('module-federation.config.ts', '');
+
+    let nxJson = readNxJson(tree);
+    nxJson = {
+      ...nxJson,
+      targetDefaults: {
+        ...nxJson.targetDefaults,
+        ['@nx/webpack:webpack']: {
+          inputs: ['^build'],
+        },
+      },
+    };
+
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    await addMfEnvVarToTargetDefaults(tree);
+
+    // ASSERT
+    nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "@nx/webpack:webpack": {
+          "inputs": [
+            "^build",
+            {
+              "env": "NX_MF_DEV_SERVER_STATIC_REMOTES",
+            },
+          ],
+        },
+        "build": {
+          "cache": true,
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+});

--- a/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
+++ b/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
@@ -1,0 +1,35 @@
+import {
+  getProjects,
+  type Tree,
+  type ProjectConfiguration,
+  joinPathFragments,
+} from '@nx/devkit';
+import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs';
+
+export default async function (tree: Tree) {
+  if (!hasModuleFederationProject(tree)) {
+    return;
+  }
+  addMfEnvToTargetDefaultInputs(tree);
+}
+
+function hasModuleFederationProject(tree: Tree) {
+  const projects = getProjects(tree);
+  for (const project of projects.values()) {
+    const targets = project.targets;
+    for (const [_, target] of Object.entries(targets)) {
+      if (
+        target.executor === '@nx/webpack:webpack' &&
+        (tree.exists(
+          joinPathFragments(project.root, 'module-federation.config.ts')
+        ) ||
+          tree.exists(
+            joinPathFragments(project.root, 'module-federation.config.js')
+          ))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
+++ b/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
@@ -3,6 +3,7 @@ import {
   type Tree,
   type ProjectConfiguration,
   joinPathFragments,
+  formatFiles,
 } from '@nx/devkit';
 import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs';
 
@@ -11,6 +12,8 @@ export default async function (tree: Tree) {
     return;
   }
   addMfEnvToTargetDefaultInputs(tree);
+
+  await formatFiles(tree);
 }
 
 function hasModuleFederationProject(tree: Tree) {

--- a/packages/react/src/utils/add-mf-env-to-inputs.ts
+++ b/packages/react/src/utils/add-mf-env-to-inputs.ts
@@ -5,42 +5,19 @@ export function addMfEnvToTargetDefaultInputs(tree: Tree) {
   const webpackExecutor = '@nx/webpack:webpack';
   const mfEnvVar = 'NX_MF_DEV_SERVER_STATIC_REMOTES';
 
+  nxJson.targetDefaults ??= {};
+  nxJson.targetDefaults[webpackExecutor] ??= {};
+  nxJson.targetDefaults[webpackExecutor].inputs ??= [];
+
   let mfEnvVarExists = false;
-  if (nxJson.targetDefaults && webpackExecutor in nxJson.targetDefaults) {
-    const webpackExecutorTargetDefaults =
-      nxJson.targetDefaults[webpackExecutor];
-
-    if (webpackExecutorTargetDefaults.inputs) {
-      for (const webpackExecutorTargetDefaultsInput of webpackExecutorTargetDefaults.inputs) {
-        if (typeof webpackExecutorTargetDefaultsInput === 'object') {
-          const [key, value] = Object.entries(
-            webpackExecutorTargetDefaultsInput
-          )[0];
-
-          if (key === 'env' && value === mfEnvVar) {
-            mfEnvVarExists = true;
-            break;
-          }
-        }
-      }
-    } else {
-      nxJson.targetDefaults[webpackExecutor].inputs = [];
+  for (const input of nxJson.targetDefaults[webpackExecutor].inputs) {
+    if (typeof input === 'object' && input['env'] === mfEnvVar) {
+      mfEnvVarExists = true;
+      break;
     }
-  } else if (!nxJson.targetDefaults[webpackExecutor]) {
-    nxJson.targetDefaults[webpackExecutor] = {
-      inputs: [],
-    };
-  } else if (!nxJson.targetDefaults) {
-    nxJson.targetDefaults = {
-      [webpackExecutor]: {
-        inputs: [],
-      },
-    };
   }
-
   if (!mfEnvVarExists) {
     nxJson.targetDefaults[webpackExecutor].inputs.push({ env: mfEnvVar });
+    updateNxJson(tree, nxJson);
   }
-
-  updateNxJson(tree, nxJson);
 }

--- a/packages/react/src/utils/add-mf-env-to-inputs.ts
+++ b/packages/react/src/utils/add-mf-env-to-inputs.ts
@@ -1,0 +1,46 @@
+import { type Tree, readNxJson, updateNxJson } from '@nx/devkit';
+
+export function addMfEnvToTargetDefaultInputs(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  const webpackExecutor = '@nx/webpack:webpack';
+  const mfEnvVar = 'NX_MF_DEV_SERVER_STATIC_REMOTES';
+
+  let mfEnvVarExists = false;
+  if (nxJson.targetDefaults && webpackExecutor in nxJson.targetDefaults) {
+    const webpackExecutorTargetDefaults =
+      nxJson.targetDefaults[webpackExecutor];
+
+    if (webpackExecutorTargetDefaults.inputs) {
+      for (const webpackExecutorTargetDefaultsInput of webpackExecutorTargetDefaults.inputs) {
+        if (typeof webpackExecutorTargetDefaultsInput === 'object') {
+          const [key, value] = Object.entries(
+            webpackExecutorTargetDefaultsInput
+          )[0];
+
+          if (key === 'env' && value === mfEnvVar) {
+            mfEnvVarExists = true;
+            break;
+          }
+        }
+      }
+    } else {
+      nxJson.targetDefaults[webpackExecutor].inputs = [];
+    }
+  } else if (!nxJson.targetDefaults[webpackExecutor]) {
+    nxJson.targetDefaults[webpackExecutor] = {
+      inputs: [],
+    };
+  } else if (!nxJson.targetDefaults) {
+    nxJson.targetDefaults = {
+      [webpackExecutor]: {
+        inputs: [],
+      },
+    };
+  }
+
+  if (!mfEnvVarExists) {
+    nxJson.targetDefaults[webpackExecutor].inputs.push({ env: mfEnvVar });
+  }
+
+  updateNxJson(tree, nxJson);
+}


### PR DESCRIPTION
- fix(react): ensure the static remotes env var is used for task hashing
- fix(angular): ensure the static remotes env var is used for task hashing

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When a remote is built and served via the `module-federation-dev-server` an env var is used point to a single file server, allowing for increased performance benefits locally.
However, this env var isn't taken into consideration when the task hash is calculated, leading to false positives.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the env var is added to the executor inputs in target defaults in nx.json. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21390
