### PR TITLE
fix(angular): import rxjs operators from 'rxjs/operators' for backwards compatibility

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -21,7 +21,8 @@ import {
   getRemotes,
 } from '@nx/webpack/src/utils/module-federation';
 import { fork } from 'child_process';
-import { combineLatest, concatMap, from, switchMap } from 'rxjs';
+import { combineLatest, from } from 'rxjs';
+import { concatMap, switchMap } from 'rxjs/operators';
 
 export function executeModuleFederationDevServerBuilder(
   schema: Schema,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21128 
