### PR TITLE
fix(graph): fix expand when using external api

### DIFF
--- a/graph/client/src/app/external-api-impl.ts
+++ b/graph/client/src/app/external-api-impl.ts
@@ -81,10 +81,8 @@ export class ExternalApiImpl extends ExternalApi {
     }
   }
 
-  async openProjectDetails(projectName: string, targetName?: string) {
-    await this.router.navigate(
-      `/project-details/${encodeURIComponent(projectName)}`
-    );
+  openProjectDetails(projectName: string, targetName?: string) {
+    this.router.navigate(`/project-details/${encodeURIComponent(projectName)}`);
     if (targetName) {
       this.focusTargetInProjectDetails(targetName);
     }

--- a/graph/project-details/src/lib/project-details-wrapper.tsx
+++ b/graph/project-details/src/lib/project-details-wrapper.tsx
@@ -95,13 +95,13 @@ export function ProjectDetailsWrapper(props: ProjectDetailsProps) {
 
   const handleTargetCollapse = useCallback(
     (targetName: string) => {
+      const expandedSections = searchParams.get('expanded')?.split(',') || [];
+      if (!expandedSections.includes(targetName)) return;
+      const newExpandedSections = expandedSections.filter(
+        (section) => section !== targetName
+      );
       setSearchParams(
         (currentSearchParams) => {
-          const expandedSections =
-            currentSearchParams.get('expanded')?.split(',') || [];
-          const newExpandedSections = expandedSections.filter(
-            (section) => section !== targetName
-          );
           updateSearchParams(currentSearchParams, newExpandedSections);
           return currentSearchParams;
         },
@@ -111,38 +111,34 @@ export function ProjectDetailsWrapper(props: ProjectDetailsProps) {
         }
       );
     },
-    [setSearchParams]
+    [setSearchParams, searchParams]
   );
 
   const handleTargetExpand = useCallback(
     (targetName: string) => {
+      const expandedSections = searchParams.get('expanded')?.split(',') || [];
+      if (expandedSections.includes(targetName)) return;
+      expandedSections.push(targetName);
       setSearchParams(
         (currentSearchParams) => {
-          const expandedSections =
-            currentSearchParams.get('expanded')?.split(',') || [];
-          if (!expandedSections.includes(targetName)) {
-            expandedSections.push(targetName);
-            updateSearchParams(currentSearchParams, expandedSections);
-          }
+          updateSearchParams(currentSearchParams, expandedSections);
           return currentSearchParams;
         },
         { replace: true, preventScrollReset: true }
       );
     },
-    [setSearchParams]
+    [setSearchParams, searchParams]
   );
 
-  // On initial render, expand the sections that are included in the URL search params.
-  const isExpandedHandled = useRef(false);
   useLayoutEffect(() => {
     if (!props.project.data.targets) return;
-    if (isExpandedHandled.current) return;
-    isExpandedHandled.current = true;
 
     const expandedSections = searchParams.get('expanded')?.split(',') || [];
     for (const targetName of Object.keys(props.project.data.targets)) {
       if (expandedSections.includes(targetName)) {
         projectDetailsRef.current?.expandTarget(targetName);
+      } else {
+        projectDetailsRef.current?.collapseTarget(targetName);
       }
     }
   }, [searchParams, props.project.data.targets, projectDetailsRef]);

--- a/graph/shared/src/lib/external-api.ts
+++ b/graph/shared/src/lib/external-api.ts
@@ -6,6 +6,8 @@ import type {
 } from 'nx/src/command-line/graph/graph';
 
 export abstract class ExternalApi {
+  abstract openProjectDetails(projectName: string, targetName?: string): void;
+
   abstract focusProject(projectName: string): void;
 
   abstract toggleSelectProject(projectName: string): void;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

the flow is:
- when page is initialized -> triggers useLayoutChange -> collapse and expand sections based on search params
- when external api got call -> search params change -> triggers useLayoutChange -> collapse and expand sections based on search params
- when click on the section -> going to call collapse and expand handler -> setSearchParams -> still triggers useLayoutChange, but should not do anything

remove isExpandedHandled because it prevents external api triggers the useLayoutChange

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
