### PR TITLE
docs(webpack): update webpack config docs to show basic vs enhanced flavors

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -1935,7 +1935,7 @@
             "isExternal": false,
             "children": [
               {
-                "name": "How to configure webpack on your Nx workspace",
+                "name": "How to configure Webpack in your Nx workspace",
                 "path": "/recipes/webpack/webpack-config-setup",
                 "id": "webpack-config-setup",
                 "isExternal": false,
@@ -3464,7 +3464,7 @@
         "isExternal": false,
         "children": [
           {
-            "name": "How to configure webpack on your Nx workspace",
+            "name": "How to configure Webpack in your Nx workspace",
             "path": "/recipes/webpack/webpack-config-setup",
             "id": "webpack-config-setup",
             "isExternal": false,
@@ -3483,7 +3483,7 @@
         "disableCollapsible": false
       },
       {
-        "name": "How to configure webpack on your Nx workspace",
+        "name": "How to configure Webpack in your Nx workspace",
         "path": "/recipes/webpack/webpack-config-setup",
         "id": "webpack-config-setup",
         "isExternal": false,

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -2646,7 +2646,7 @@
         "itemList": [
           {
             "id": "webpack-config-setup",
-            "name": "How to configure webpack on your Nx workspace",
+            "name": "How to configure Webpack in your Nx workspace",
             "description": "A guide on how to configure webpack on your Nx workspace, and instructions on how to customize your webpack configuration",
             "mediaImage": "",
             "file": "shared/packages/webpack/webpack-config-setup",
@@ -4741,7 +4741,7 @@
     "itemList": [
       {
         "id": "webpack-config-setup",
-        "name": "How to configure webpack on your Nx workspace",
+        "name": "How to configure Webpack in your Nx workspace",
         "description": "A guide on how to configure webpack on your Nx workspace, and instructions on how to customize your webpack configuration",
         "mediaImage": "",
         "file": "shared/packages/webpack/webpack-config-setup",
@@ -4768,7 +4768,7 @@
   },
   "/recipes/webpack/webpack-config-setup": {
     "id": "webpack-config-setup",
-    "name": "How to configure webpack on your Nx workspace",
+    "name": "How to configure Webpack in your Nx workspace",
     "description": "A guide on how to configure webpack on your Nx workspace, and instructions on how to customize your webpack configuration",
     "mediaImage": "",
     "file": "shared/packages/webpack/webpack-config-setup",

--- a/docs/map.json
+++ b/docs/map.json
@@ -850,7 +850,7 @@
               "itemList": [
                 {
                   "id": "webpack-config-setup",
-                  "name": "How to configure webpack on your Nx workspace",
+                  "name": "How to configure Webpack in your Nx workspace",
                   "description": "A guide on how to configure webpack on your Nx workspace, and instructions on how to customize your webpack configuration",
                   "file": "shared/packages/webpack/webpack-config-setup"
                 },

--- a/docs/shared/packages/webpack/webpack-config-setup.md
+++ b/docs/shared/packages/webpack/webpack-config-setup.md
@@ -1,172 +1,199 @@
 ---
-title: How to configure webpack on your Nx workspace
+title: Configure Webpack in your Nx workspace
 description: A guide on how to configure webpack on your Nx workspace, and instructions on how to customize your webpack configuration
 ---
 
-# Configure webpack on your Nx workspace
+# Configure Webpack in your Nx workspace
 
-You can configure Webpack using a `webpack.config.js` file in your project. You can set the path to this file in your `project.json` file, in the `build` target options:
+You can configure Webpack using a [`webpack.config.js`](https://webpack.js.org/concepts/configuration/) file in your project. Nx infers the `build` and `serve` targets from your webpack configuration as long as you have `@nx/webpack/plugin` added to your `nx.json`.
 
-```json
-//...
-"my-app": {
-    "targets": {
-        //...
-        "build": {
-            "executor": "@nx/webpack:webpack",
-            //...
-            "options": {
-                //...
-                "webpackConfig": "apps/my-app/webpack.config.js"
-            },
-            "configurations": {
-                ...
-            }
-        },
+```json5 {% fileName="nx.json" %}
+"plugins": [
+  {
+    "plugin": "@nx/webpack/plugin",
+    "options": {
+      "buildTargetName": "build",
+      "serveTargetName": "serve"
     }
+  }
+]
+```
+
+If you are using the [`@nx/webpack:webpack`](/nx-api/webpack/executors/webpack) executor, the path to your webpack config is set in the `webpackConfig` option in your `project.json` file.
+
+```json5 {% fileName="project.json" highlightLines=["7"] %}
+"my-app": {
+  "targets": {
+    //...
+    "build": {
+      "executor": "@nx/webpack:webpack",
+      "options": {
+        "webpackConfig": "apps/my-app/webpack.config.js",
+        //...
+      },
+      // ...
+    },
+  }
 }
 ```
 
-In that file, you can add the necessary configuration for Webpack. You can read more on how to configure webpack in the [Webpack documentation](https://webpack.js.org/concepts/configuration/).
+In the webpack config file, you can add the necessary configuration for Webpack. Read more on how to configure Webpack in the [Webpack documentation](https://webpack.js.org/concepts/configuration/).
 
-## Using webpack with `isolatedConfig`
+## Basic and Nx-enhanced configuration files
 
-Setting `isolatedConfig` to `true` in your `project.json` file means that Nx will not apply the Nx webpack plugins automatically. In that case, the Nx plugins need to be applied in the project's `webpack.config.js` file (e.g. `withNx`, `withReact`, etc.). So don't forget to also specify the path to your webpack config file (using the `webpackConfig` option).
+Nx supports two flavors of Webpack configuration files:
 
-Note that this is the new default setup for webpack in the latest version of Nx.
+1. [_Basic_](#basic-configuration-for-nx) (or standard) Webpack configuration. The file exports a Webpack config object, or one of the [standard configuration types](https://webpack.js.org/configuration/configuration-types).
+2. [_Nx-enhanced_](#nxenhanced-configuration-with-composable-plugins) Webpack configuration. The file exports a function that takes in a Webpack configuration object, plus the [`@nx/webpack:webpack`](/nx-api/webpack/executors/webpack) options and context, and returns an updated Webpack configuration object.
 
-Set `isolatedConfig` to `true` in your `project.json` file in the `build` target options like this:
-
-```json
-//...
-"my-app": {
-    "targets": {
-        //...
-        "build": {
-            "executor": "@nx/webpack:webpack",
-            //...
-            "options": {
-                //...
-                "webpackConfig": "apps/my-app/webpack.config.js",
-                "isolatedConfig": true
-            },
-            "configurations": {
-                ...
-            }
-        },
-    }
-}
-```
-
-Now, you need to manually add the Nx webpack plugins in your `webpack.config.js` file for Nx to work properly. Let's see how to do that.
+The basic configuration works with Webpack CLI, whereas the Nx-enhanced configuration requires the use of the `@nx/webpack:webpack` executor.
 
 ### Basic configuration for Nx
 
-You should start with a basic webpack configuration for Nx in your project, that looks like this:
+{% callout type="info" title="Module federation support" %}
+Currently, Nx module federation requires an enhanced Webpack configuration file an the use of the `withModuleFederation` plugin. See the next section for more details.
+{% /callout %}
 
-```js {% fileName="apps/my-app/webpack.config.js" %}
-const { composePlugins, withNx } = require('@nx/webpack');
+A basic Webpack configuration was introduced in Nx 18, and it looks like this:
 
-module.exports = composePlugins(withNx(), (config, { options, context }) => {
-  // customize webpack config here
-  return config;
-});
+```js {% fileName="apps/demo/webpack.config.js" %}
+const { NxWebpackPlugin } = require('@nx/webpack');
+const { join } = require('path');
+
+module.exports = {
+  output: {
+    path: join(__dirname, '../../dist/apps/demo'),
+  },
+  devServer: {
+    port: 4200,
+  },
+  plugins: [
+    new NxWebpackPlugin({
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      index: './src/index.html',
+      styles: ['./src/styles.css'],
+      outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',
+      optimization: process.env['NODE_ENV'] === 'production',
+    }),
+  ],
+};
 ```
 
-The `withNx()` plugin adds the necessary configuration for Nx to work with Webpack. The `composePlugins` function allows you to add other plugins to the configuration.
+The [`NxWebpackPlugin`](/recipes/webpack/webpack-plugins#nxwebpackplugin) plugin takes a `main` entry file and produces a bundle in the output directory as defined in `output.path`. You can also pass the `index` option if it is a webapp, which will handle outputting scripts and stylesheets in the output file. Note that `NxWebpackPlugin` is optional, and you can bring your own Webpack configuration without using it or any plugins from `@nx/webpack`.
 
-#### The `composePlugins` function
+For more information, see the [Webpack plugins guide](/recipes/webpack/webpack-plugins).
 
-The `composePlugins` function takes a list of plugins and a function, and returns a webpack `Configuration` object. The `composePlugins` function is an enhanced version of the [webpack configuration function](https://webpack.js.org/configuration/configuration-types/#exporting-a-function), which allows you to add plugins to the configuration, and provides you with a function which accepts two arguments:
+### Nx-enhanced configuration with composable plugins
 
-1. `config`: The webpack configuration object.
-2. An object with the following properties:
-   - `options`: The options passed to the `@nx/webpack:webpack` executor.
-   - `context`: The context passed of the `@nx/webpack:webpack` executor.
+{% callout type="info" title="Non-standard webpack config" %}
+Nx-enhanced configuration, via `composePlugins` and [`withNx`](/recipes/webpack/webpack-plugins#withnx) functions, requires the usage of `@nx/webpack:webpack` executor in your `project.json` file. This flavor of configuration do not work with the Webpack CLI.
+{% /callout %}
 
-This gives you the ability to customize the webpack configuration as needed, and make use of the options and context passed to the executor, as well.
+Nx supports a function to be returned from the Webpack configuration file. This function is a composable plugin that is understood by the `@nx/webpack:webpack` executor. The enhanced configuration looks something like this:
 
-### Add configurations for other functionalities
+```js {% fileName="apps/demo/webpack.config.js" %}
+const { composePlugins, withNx } = require('@nx/webpack');
 
-In addition to the basic configuration, you can add configurations for other frameworks or features. The `@nx/webpack` package provides plugins such as `withWeb` and `withReact`. This plugins provide features such as TS support, CSS support, JSX support, etc. You can read more about how these plugins work and how to use them in our [Webpack Plugins guide](/recipes/webpack/webpack-plugins).
+module.exports = composePlugins(
+  // Default Nx composable plugin
+  withNx(),
+  // Custom composable plugin
+  (config, { options, context }) => {
+    // `config` is the Webpack configuration object
+    // `options` is the options passed to the `@nx/webpack:webpack` executor
+    // `context` is the context passed to the `@nx/webpack:webpack` executor
+    // customize configuration here
+    return config;
+  }
+);
+```
 
-You may still reconfigure everything manually, without using the Nx plugins. However, these plugins ensure that you have the necessary configuration for Nx to work with your project.
+There are two advantages of this approach:
 
-## Customize your Webpack config
+1. You can chain multiple plugins together using the `composePlugins` function. Each plugin can update the webpack configuration as needed.
+2. You gain access to the target options and executor context within the webpack configuration file.
 
-For most apps, the default configuration of webpack is sufficient, but sometimes you need to tweak a setting in your webpack config. This guide explains how to make a small change without taking on the maintenance burden of the entire webpack config.
+This gives you the ability to customize the Webpack configuration as needed, and make use of the options and context passed to the executor, as well.
 
-### Configure webpack for React projects
+#### Additional composable plugins for Nx
 
-React projects use the `@nx/react` package to build their apps. This package provides a `withReact` plugin that adds the necessary configuration for React to work with webpack. You can use this plugin to add the necessary configuration to your webpack config.
+In addition to the `withNx` composable plugin, Nx provides other composable plugins such as `withWeb`, `withReact`, and `withModuleFederation`. You can read more about how these plugins work and how to use them in our [Webpack plugins guide](/recipes/webpack/webpack-plugins).
 
-```js {% fileName="apps/my-app/webpack.config.js" %}
+## Customize your Webpack configuration
+
+For most apps, the default configuration of Webpack is sufficient, but sometimes you need to tweak a setting in your Webpack config. This guide explains how to make a small change without taking on the maintenance burden of the entire webpack config.
+
+### Configure Webpack for React projects
+
+React projects use the `@nx/react` package to build their apps. This package provides `NxReactWebpackPlugin` and a `withReact` composable plugin that adds the necessary configuration for React to work with Webpack. The `NxReactWebpackPlugin` is used in a basic Webpack configuration file, whereas `withReact` is requires a Nx-enhanced Webpack configuration file.
+
+{% tabs %}
+{% tab label="Basic Webpack configuration" %}
+
+```js {% fileName="apps/demo/app/webpack.config.js" %}
+const { NxWebpackPlugin } = require('@nx/webpack');
+const { NxReactWebpackPlugin } = require('@nx/react');
+const { join } = require('path');
+
+module.exports = {
+  output: {
+    path: join(__dirname, '../../dist/apps/demo'),
+  },
+  devServer: {
+    port: 4200,
+  },
+  plugins: [
+    new NxWebpackPlugin({
+      tsConfig: './tsconfig.app.json',
+      compiler: 'swc',
+      main: './src/main.tsx',
+      index: '.src/index.html',
+      styles: ['./src/styles.css'],
+      outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',
+      optimization: process.env['NODE_ENV'] === 'production',
+    }),
+    new NxReactWebpackPlugin({
+      // Uncomment this line if you don't want to use SVGR
+      // See: https://react-svgr.com/
+      // svgr: false
+    }),
+  ],
+};
+```
+
+{% /tab %}
+{% tab label="Nx-enhanced Webpack configuration" %}
+
+```js {% fileName="apps/demo/app/webpack.config.js" %}
 const { composePlugins, withNx } = require('@nx/webpack');
 const { withReact } = require('@nx/react');
 
-// Nx plugins for webpack.
+// Nx composable plugins for webpack.
 module.exports = composePlugins(
   withNx(),
   withReact(),
   (config, { options, context }) => {
-    // Update the webpack config as needed here.
+    // Update the webpack configuration as needed here.
     // e.g. config.plugins.push(new MyPlugin())
     return config;
   }
 );
 ```
 
-### Add a CSS loader to your webpack config
-
-To add the `css-loader` to your config, install it and add the rule.
-
-{% tabs %}
-{% tab label="npm" %}
-
-```shell
-npm add -D css-loader
-```
-
 {% /tab %}
-{% tab label="yarn" %}
 
-```shell
-yarn add -D css-loader
-```
-
-{% /tab %}
-{% tab label="pnpm" %}
-
-```shell
-pnpm add -D css-loader
-```
-
-{% /tab %}
 {% /tabs %}
 
-```js {% fileName="apps/my-app/webpack.config.js" %}
-const { composePlugins, withNx } = require('@nx/webpack');
-const { merge } = require('webpack-merge');
+### Configure Webpack for Module Federation
 
-module.exports = composePlugins(withNx(), (config, { options, context }) => {
-  return merge(config, {
-    module: {
-      rules: [
-        {
-          test: /\.css$/i,
-          use: ['style-loader', 'css-loader'],
-        },
-      ],
-    },
-  });
-});
-```
-
-### Configure webpack for Module Federation
+{% callout type="info" title="Non-standard webpack config" %}
+`composePlugins`, `withNx`, and `withModuleFederation` do not work with the Webpack CLI and requires the use of the `@nx/webpack:webpack` executor.
+{% /callout %}
 
 If you use the [Module Federation](/concepts/module-federation/faster-builds-with-module-federation) support
 from `@nx/angular` or `@nx/react` then
-you can customize your webpack configuration as follows.
+you can customize your Webpack configuration as follows.
 
 ```js {% fileName="apps/my-app/webpack.config.js" %}
 const { composePlugins, withNx } = require('@nx/webpack');
@@ -188,12 +215,12 @@ module.exports = composePlugins(
 );
 ```
 
-Reference the [webpack documentation](https://webpack.js.org/configuration/) for details on the structure of the webpack
-config object.
+Reference the [Webpack documentation](https://webpack.js.org/configuration/) for details on the structure of the Webpack
+configuration object.
 
-### Configure webpack for Next.js Applications
+### Configure Webpack for Next.js Applications
 
-Next.js supports webpack customization in the `next.config.js` file.
+Next.js supports Webpack customization in the `next.config.js` file.
 
 ```js {% fileName="next.config.js" %}
 const { withNx } = require('@nx/next/plugins/with-nx');

--- a/docs/shared/packages/webpack/webpack-plugins.md
+++ b/docs/shared/packages/webpack/webpack-plugins.md
@@ -5,26 +5,372 @@ description: A guide for webpack plugins that are provided by Nx.
 
 # Webpack plugins
 
-Nx uses enhanced webpack configuration files (e.g. `webpack.config.js`). These configuration files export a _plugin_ that takes in a webpack
-[configuration](https://webpack.js.org/configuration/) object and returns an updated configuration object. Plugins are used by Nx to add
-functionality to the webpack build.
+Nx provides two types of Webpack plugins:
 
-This guide contains information on the plugins provided by Nx. For more information on customizing webpack configuration, refer to the
-[Nx Webpack configuration guide](/recipes/webpack/webpack-config-setup).
+1. [_Basic_](#basic-plugins) plugins that work in a
+   standard [webpack configuration](https://webpack.js.org/configuration/) file.
+2. [_Nx-enhanced_](#nxenhanced-plugins) plugins that work with
+   the [`@nx/webpack:webpack`](/nx-api/webpack/executors/webpack) executor.
 
-## withNx
+The basic plugins are used in Nx 18 to provide seamless integration with the Webpack CLI. Prior to Nx 18, apps are
+generated with Nx-enhanced plugins and require `@nx/webpack:webpack` executor to be used.
 
-The `withNx` plugin provides common configuration for the build, including TypeScript support and linking workspace libraries (via tsconfig paths).
+This guide contains information on the plugins provided by Nx. For more information on webpack configuration and the
+difference between basic and Nx-enhanced configuration, refer to
+the [Nx Webpack configuration guide](/recipes/webpack/webpack-config-setup).
 
-### Options
+## Basic plugins
 
-#### skipTypeChecking
+The basic plugins work with a standard webpack configuration file by adding them to the `plugins` option.
+
+### NxWebpackPlugin
+
+The `NxWebpackPlugin` plugin provides common configuration for the build, including TypeScript support and linking
+workspace libraries (via tsconfig paths).
+
+#### Options
+
+##### tsConfig
+
+Type: `string`
+
+The tsconfig file for the project. e.g. `tsconfig.json`.
+
+##### main
+
+Type: `string`
+
+The entry point for the bundle. e.g. `src/main.ts`.
+
+##### additionalEntryPoints
+
+Type: `Array<{ entryName: string; entryPath: string; }>`
+
+Secondary entry points for the bundle.
+
+#### assets
+
+Type: `string[]`
+
+Assets to be copied over to the output path.
+
+##### babelConfig
+
+Type: `string`
+
+Babel configuration file if compiler is babel.
+
+##### babelUpwardRootMode
+
+Type: `boolean`
+If true, Babel will look for a babel.config.json up the directory tree.
+
+##### baseHref
+
+Type: `string`
+
+Set `<base href>` for the resulting index.html.
+
+##### compiler
+
+Type: `'babel' | 'swc' | 'tsc'`
+
+The compiler to use. Default is `babel` and requires a `.babelrc` file.
+
+##### crossOrigin
+
+Type: `'none' | 'anonymous' | 'use-credentials'`
+
+Set `crossorigin` attribute on the `script` and `link` tags.
+
+##### deleteOutputPath
+
+Type: `boolean`
+
+Delete the output path before building.
+
+##### deployUrl
+
+Type: `string`
+
+The deploy path for the application. e.g. `/my-app/`
+
+##### externalDependencies
+
+Type: `'all' | 'none' | string[]`
+
+Define external packages that will not be bundled. Use `all` to exclude all 3rd party packages, and `none` to bundle all
+packages. Use an array to exclude specific packages from the bundle. Default is `none`.
+
+##### extractCss
+
+Type: `boolean`
+
+Extract CSS as an external file. Default is `true`.
+
+##### extractLicenses
+
+Type: `boolean`
+Extract licenses from 3rd party modules and add them to the output.
+
+##### fileReplacements
+
+Type: `FileReplacement[]`
+
+Replace files at build time. e.g. `[{ "replace": "src/a.dev.ts", "with": "src/a.prod.ts" }]`
+
+##### generateIndexHtml
+
+Type: `boolean`
+
+Generate an `index.html` file if `index.html` is passed. Default is `true`
+
+##### generatePackageJson
+
+Type: `boolean`
+
+Generate a `package.json` file for the bundle. Useful for Node applications.
+
+##### index
+
+Type: `string`
+
+Path to the `index.html`.
+
+##### memoryLimit
+
+Type: `number`
+
+Set the memory limit for the type-checking process. Default is `2048`.
+
+##### namedChunks
+
+Type: `boolean`
+
+Use the source file name in output chunks. Useful for development or for Node.
+
+##### optimization
+
+Type: `boolean`
+
+Optimize the bundle using Terser.
+
+##### outputFileName
+
+Type: `string`
+
+Specify the output filename for the bundle. Useful for Node applications that use `@nx/js:node` to serve.
+
+##### outputHashing
+
+Type: `'none' | 'all'`
+
+Use file hashes in the output filenames. Recommended for production web applications.
+
+##### outputPath
+
+Type: `string`
+
+Override `output.path` in webpack configuration. This setting is not recommended and exists for backwards compatibility.
+
+##### poll
+
+Type: `number`
+
+Override `watchOptions.poll` in webpack configuration. This setting is not recommended and exists for backwards
+compatibility.
+
+##### polyfills
+
+Type: `string`
+
+The polyfill file to use. Useful for supporting legacy browsers. e.g. `src/polyfills.ts`
+
+##### postcssConfig
+
+Type: `string`
+Manually set the PostCSS configuration file. By default, PostCSS will look for `postcss.config.js` in the directory.
+
+##### progress
+
+Type: `boolean`
+
+Display build progress in the terminal.
+
+##### runtimeChunk
+
+Type: `boolean`
+
+Add an additional chunk for the Webpack runtime. Defaults to `true` when `target === 'web'`.
+
+##### scripts
+
+Type: `string[]`
+
+External scripts that will be included before the main application entry.
+
+##### skipTypeChecking
+
+Type: `boolean`
+
+Skip type checking. Default is `false`.
+
+##### sourceMap
+
+Type: `boolean | 'hidden'`
+
+Generate source maps.
+
+##### ssr
+
+Type: `boolean`
+
+When `true`, `process.env.NODE_ENV` will be excluded from the bundle. Useful for building a web application to run in a
+Node environment.
+
+##### statsJson
+
+Type: `boolean`
+
+Generate a `stats.json` file which can be analyzed using tools such as `webpack-bundle-analyzer`.
+
+##### stylePreprocessorOptions
+
+Type: `object`
+
+Options for the style preprocessor. e.g. `{ "includePaths": [] }` for SASS.
+
+##### styles
+
+Type: `string[]`
+
+External stylesheets that will be included with the application.
+
+##### subresourceIntegrity
+
+Type: `boolean`
+
+Enables the use of subresource integrity validation.
+
+##### target
+
+Type: `string | string[]`
+
+Override the `target` option in webpack configuration. This setting is not recommended and exists for backwards
+compatibility.
+
+##### transformers
+
+Type: `TransformerEntry[]`
+
+List of TypeScript Compiler Transformers Plugins.
+
+##### vendorChunk
+
+Type: `boolean`
+
+Generate a separate vendor chunk for 3rd party packages.
+
+##### verbose
+
+Type: `boolean`
+
+Log additional information for debugging purposes.
+
+##### watch
+
+Type: `boolean`
+
+Watch for file changes.
+
+#### Example
+
+```js
+const { NxWebpackPlugin } = require('@nx/webpack');
+const { join } = require('path');
+
+module.exports = {
+  output: {
+    path: join(__dirname, '../../dist/apps/demo'),
+  },
+  devServer: {
+    port: 4200,
+  },
+  plugins: [
+    new NxWebpackPlugin({
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      index: './src/index.html',
+      styles: ['./src/styles.css'],
+      outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',
+      optimization: process.env['NODE_ENV'] === 'production',
+    }),
+  ],
+};
+```
+
+### NxReactWebpackPlugin
+
+#### Options
+
+##### svgr
+
+Type: `boolean`
+
+Enables or disables [React SVGR](https://react-svgr.com/). Default is `true`.
+
+#### Example
+
+```js
+const { NxReactWebpackPlugin } = require('@nx/react');
+const { join } = require('path');
+
+module.exports = {
+  // ...
+  plugins: [
+    new NxReactWebpackPlugin({
+      svgr: false,
+    }),
+  ],
+};
+```
+
+## Nx-enhanced plugins
+
+The Nx-enhanced plugins work with `@nx/webpack:webpack` executor and receive the target options and context from the
+executor. These are used prior to Nx 18, and are still used when using [Module Federation](/concepts/module-federation/module-federation-and-nx).
+
+The plugins are used in conjunction with `composePlugins` utility to generate a final Webpack configuration object, once all of the plugins have applied their changes.
+
+```js {% fileName="webpack.config.js" %}
+const { composePlugins } = require('@nx/webpack');
+
+function myCustomPlugin() {
+  // `options` and `context` are the target options and
+  // `@nx/webpack:webpack` executor context respectively.
+  return (webpackConfig, { options, context }) => {
+    // Do something with the config.
+    return webpackConfig;
+  };
+}
+
+module.export = composePlugins(withNx(), withReact(), myCustomPlugin());
+```
+
+### withNx
+
+The `withNx` plugin provides common configuration for the build, including TypeScript support and linking workspace
+libraries (via tsconfig paths).
+
+#### Options
+
+##### skipTypeChecking
 
 Type: `boolean`
 
 Disable type checks (useful to speed up builds).
 
-### Example
+#### Example
 
 ```js
 const { composePlugins, withNx } = require('@nx/webpack');
@@ -35,31 +381,33 @@ module.exports = composePlugins(withNx(), (config) => {
 });
 ```
 
-## withWeb
+### withWeb
 
-The `withWeb` plugin adds support for CSS/SASS/Less stylesheets, assets (such as images and fonts), and `index.html` processing.
+The `withWeb` plugin adds support for CSS/SASS/Less stylesheets, assets (such as images and fonts), and `index.html`
+processing.
 
-### Options
+#### Options
 
-#### baseHref
+##### baseHref
 
 Type: `string`
 
 Base URL for the application being built.
 
-#### crossOrigin
+##### crossOrigin
 
 Type: `'none' | 'anonymous' | 'use-credentials'`
 
-"The `crossorigin` attribute to use for generated javascript script tags. One of 'none' | 'anonymous' | 'use-credentials'."
+"The `crossorigin` attribute to use for generated javascript script tags. One of 'none' | 'anonymous' | '
+use-credentials'."
 
-#### deployUrl
+##### deployUrl
 
 Type: `string`
 
 URL where the application will be deployed.
 
-#### extractCss
+##### extractCss
 
 Type: `boolean`
 
@@ -69,39 +417,42 @@ Extract CSS into a `.css` file.
 
 Type: `boolean`
 
-Generates `index.html` file to the output path. This can be turned off if using a webpack plugin to generate HTML such as `html-webpack-plugin`.
+Generates `index.html` file to the output path. This can be turned off if using a webpack plugin to generate HTML such
+as `html-webpack-plugin`.
 
-#### index
+##### index
 
 Type: `string`
 
 HTML File which will be contain the application.
 
-#### postcssConfig
+##### postcssConfig
 
 Type: `string`
 
-Set a path (relative to workspace root) to a PostCSS config that applies to the app and all libs. Defaults to `undefined`, which auto-detects postcss.config.js files in each `app`.
+Set a path (relative to workspace root) to a PostCSS config that applies to the app and all libs. Defaults
+to `undefined`, which auto-detects postcss.config.js files in each `app`.
 
-#### scripts
+##### scripts
 
 Type: `string[]`
 
 Paths to scripts (relative to workspace root) which will be included before the main application entry.
 
-#### stylePreprocessorOptions
+##### stylePreprocessorOptions
 
 Type: `{ includePaths: string[] }`
 
-Options to pass to style preprocessors. `includePaths` is a list of paths that are included (e.g. workspace libs with stylesheets).
+Options to pass to style preprocessors. `includePaths` is a list of paths that are included (e.g. workspace libs with
+stylesheets).
 
-#### styles
+##### styles
 
 Type: `string[]`
 
 Paths to stylesheets (relative to workspace root) which will be included with the application.
 
-#### subresourceIntegrity
+##### subresourceIntegrity
 
 Type: `boolean`
 
@@ -126,21 +477,22 @@ module.exports = composePlugins(
 );
 ```
 
-## withReact
+### withReact
 
-The `withReact` plugin adds support for React JSX, [SVGR](https://react-svgr.com/), and [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin)
+The `withReact` plugin adds support for React JSX, [SVGR](https://react-svgr.com/),
+and [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin)
 
-### Options
+#### Options
 
 The options are the same as [`withWeb`](#withweb) plus the following.
 
-#### svgr
+##### svgr
 
 Type: `undefined|false`
 
 SVGR allows SVG files to be imported as React components. Set this to `false` to disable this behavior.
 
-### Example
+#### Example
 
 ```js
 const { composePlugins, withNx } = require('@nx/webpack');
@@ -160,36 +512,40 @@ module.exports = composePlugins(
 );
 ```
 
-## withModuleFederation and withModuleFederationForSSR
+### withModuleFederation and withModuleFederationForSSR
 
-The `withModuleFederation` and `withModuleFederationForSSR` plugins add module federation support to the webpack build. These plugins use
+The `withModuleFederation` and `withModuleFederationForSSR` plugins add module federation support to the webpack build.
+These plugins use
 [`ModuleFederationPlugin`](https://webpack.js.org/concepts/module-federation/) and provide a simpler API through Nx.
 
-For more information, refer to the [Module Federation recipe](/concepts/module-federation/faster-builds-with-module-federation).
+For more information, refer to
+the [Module Federation recipe](/concepts/module-federation/faster-builds-with-module-federation).
 
-### Options
+#### Options
 
-Both `withModuleFederation` and `withModuleFederationForSSR` share the same options. The `withModuleFederation` plugin is for the browser, and the `withModuleFederationForSSR` plugin is used on the server-side (Node).
+Both `withModuleFederation` and `withModuleFederationForSSR` share the same options. The `withModuleFederation` plugin
+is for the browser, and the `withModuleFederationForSSR` plugin is used on the server-side (Node).
 
-#### name
+##### name
 
 Type: `string`
 
 The name of the host/remote application.
 
-#### remotes
+##### remotes
 
 Type: `Aray<string[] | [remoteName: string, remoteUrl: string]>`
 
-For _host_ to specify all _remote_ applications. If a string is used, Nx will match it with a matching remote in the workspace.
+For _host_ to specify all _remote_ applications. If a string is used, Nx will match it with a matching remote in the
+workspace.
 
 Use `[<name>, <url>]` to specify the exact URL of the remote, rather than what's in the remote's `project.json` file.
 
-#### library
+##### library
 
 Type: `{ type: string; name: string }`
 
-#### exposes
+##### exposes
 
 Type: `Record<string, string>`
 
@@ -199,25 +555,32 @@ e.g.
 
 ```js
 exposes: {
-  './Module': '<app-root>/src/remote-entry.ts',
-},
+  './Module'
+:
+  '<app-root>/src/remote-entry.ts',
+}
+,
 ```
 
-#### shared
+##### shared
 
 Type: `Function`
 
-Takes a library name and the current [share configuration](https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints), and returns one of
+Takes a library name and the
+current [share configuration](https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints), and returns one
+of
 
 - `false` - Exclude this library from shared.
 - `undefined` - Keep Nx sharing defaults.
-- `SharedLibraryConfig` - Override Nx sharing defaults with [custom configuration](https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints).
+- `SharedLibraryConfig` - Override Nx sharing defaults
+  with [custom configuration](https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints).
 
-#### additionalShared
+##### additionalShared
 
 Type: `Array<string |{ libraryName: string; sharedConfig: SharedLibraryConfig }>`
 
-Shared libraries in addition to the ones that Nx detects automatically. Items match [`ModuleFederationPlugin`'s sharing configuration](https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints).
+Shared libraries in addition to the ones that Nx detects automatically. Items
+match [`ModuleFederationPlugin`'s sharing configuration](https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints).
 
 {% tabs %}
 {% tab label="React Module Federation" %}

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -133,7 +133,7 @@
     - [Vite](/recipes/vite)
       - [Configure Vite on your Nx workspace](/recipes/vite/configure-vite)
     - [Webpack](/recipes/webpack)
-      - [How to configure webpack on your Nx workspace](/recipes/webpack/webpack-config-setup)
+      - [How to configure Webpack in your Nx workspace](/recipes/webpack/webpack-config-setup)
       - [Webpack plugins](/recipes/webpack/webpack-plugins)
     - [Module Federation](/recipes/module-federation)
       - [How to create a Module Federation Host Application](/recipes/module-federation/create-a-host)


### PR DESCRIPTION
This PR updates the webpack docs to show usage of `NxWebpackPlugin` in basic/standar configs, versus `withNx` and `composePlugins` in Nx-enhanced configs.

This is needed because Nx Crystal will generate with `NxWebpackPlugin` and `NxReactWebpackPlugin` by default unless module federation is used. But existing projects will use the enhanced style since we don't plan to migrate them yet.


## TODO
- [x] Update `Configure Webpack in you Nx workspace` page (https://nx-dev-git-docs-webpack-config-nrwl.vercel.app/recipes/webpack/webpack-config-setup)
- [x] Update `Webpack plugins` page to also show options for `NxWebpackPlugin` and `NxReactWebpackPlugin` (https://nx-dev-git-docs-webpack-config-nrwl.vercel.app/recipes/webpack/webpack-plugins)