### PR TITLE
fix(core): do not append node_module paths in `run-script` executor

### DIFF
--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -1,10 +1,8 @@
-import { getPackageManagerCommand } from '../../utils/package-manager';
-import type { ExecutorContext } from '../../config/misc-interfaces';
 import * as path from 'path';
-import { env as appendLocalEnv } from 'npm-run-path';
+import type { ExecutorContext } from '../../config/misc-interfaces';
 import { runCommand } from '../../native';
 import { PseudoTtyProcess } from '../../utils/child-process';
-import { signalToCode } from '../../utils/exit-codes';
+import { getPackageManagerCommand } from '../../utils/package-manager';
 
 export interface RunScriptOptions {
   script: string;
@@ -25,10 +23,7 @@ export default async function (
             context.root,
             context.projectsConfigurations.projects[context.projectName].root
           ),
-          {
-            ...process.env,
-            ...appendLocalEnv(),
-          }
+          process.env
         )
       );
       cp.onExit((code) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running nx with package.json scripts, tasks that should fail do not fail

## Expected Behavior
tasks should now properly fail when running through package.json scripts.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21431
