### PR TITLE
fix(core): Add missing migration from playwright

### DIFF
--- a/packages/playwright/migrations.json
+++ b/packages/playwright/migrations.json
@@ -1,3 +1,10 @@
 {
-  "generators": {}
+  "generators": {
+    "17-3-1-add-project-to-config": {
+      "cli": "nx",
+      "version": "17.3.1-beta.0",
+      "description": "Add project property to playwright config",
+      "implementation": "./src/migrations/update-17-3-1/add-project-to-config"
+    }
+  }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -32,6 +32,7 @@
     "directory": "packages/playwright"
   },
   "dependencies": {
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "@nx/devkit": "file:../devkit",
     "@nx/eslint": "file:../eslint",
     "@nx/js": "file:../js",

--- a/packages/playwright/src/migrations/update-17-3-1/__snapshots__/add-project-to-config.spec.ts.snap
+++ b/packages/playwright/src/migrations/update-17-3-1/__snapshots__/add-project-to-config.spec.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`update-nx-next-dependency should not update playwright.config.ts if projects is already defined 1`] = `
+"import { defineConfig } from '@playwright/test';
+              import { nxE2EPreset } from '@nx/playwright/preset';
+  
+              import { workspaceRoot } from '@nx/devkit';
+  
+              const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+  
+              export default defineConfig({
+                  ...nxE2EPreset(__filename, { testDir: './src' }),
+                  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+                  use: {
+                    baseURL,
+                    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+                    trace: 'on-first-retry',
+                  },
+                  /* Run your local dev server before starting the tests */
+                  webServer: {
+                    command: 'npx nx serve acme',
+                    url: 'http://localhost:4200',
+                    reuseExistingServer: !process.env.CI,
+                    cwd: workspaceRoot,
+                  },
+                  projects: []
+                });
+                "
+`;
+
+exports[`update-nx-next-dependency should update playwright.config.ts 1`] = `
+"import { defineConfig, devices } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
+import { workspaceRoot } from '@nx/devkit';
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+export default defineConfig({ ...nxE2EPreset(__filename, { testDir: './src' }),
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+        baseURL,
+        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+        trace: 'on-first-retry',
+    },
+    /* Run your local dev server before starting the tests */
+    webServer: {
+        command: 'npx nx serve acme',
+        url: 'http://localhost:4200',
+        reuseExistingServer: !process.env.CI,
+        cwd: workspaceRoot,
+    }, projects: [
+        { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+        { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+        { name: "webkit", use: { ...devices["Desktop Safari"] } }
+    ] });
+"
+`;

--- a/packages/playwright/src/migrations/update-17-3-1/add-project-to-config.spec.ts
+++ b/packages/playwright/src/migrations/update-17-3-1/add-project-to-config.spec.ts
@@ -1,0 +1,91 @@
+import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+
+import update from './add-project-to-config';
+
+describe('update-nx-next-dependency', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should update playwright.config.ts', async () => {
+    addProjectConfiguration(tree, 'acme', {
+      root: 'acme',
+    });
+
+    tree.write(
+      'acme/playwright.config.ts',
+      `import { defineConfig } from '@playwright/test';
+            import { nxE2EPreset } from '@nx/playwright/preset';
+
+            import { workspaceRoot } from '@nx/devkit';
+
+            const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+
+            export default defineConfig({
+                ...nxE2EPreset(__filename, { testDir: './src' }),
+                /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+                use: {
+                  baseURL,
+                  /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+                  trace: 'on-first-retry',
+                },
+                /* Run your local dev server before starting the tests */
+                webServer: {
+                  command: 'npx nx serve acme',
+                  url: 'http://localhost:4200',
+                  reuseExistingServer: !process.env.CI,
+                  cwd: workspaceRoot,
+                }
+              });
+              `
+    );
+    await update(tree);
+
+    const content = tree.read('acme/playwright.config.ts', 'utf-8');
+    expect(content).toContain('projects: [');
+    expect(content).toMatchSnapshot();
+  });
+
+  it('should not update playwright.config.ts if projects is already defined', async () => {
+    addProjectConfiguration(tree, 'acme', {
+      root: 'acme',
+    });
+
+    tree.write(
+      'acme/playwright.config.ts',
+      `import { defineConfig } from '@playwright/test';
+              import { nxE2EPreset } from '@nx/playwright/preset';
+  
+              import { workspaceRoot } from '@nx/devkit';
+  
+              const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+  
+              export default defineConfig({
+                  ...nxE2EPreset(__filename, { testDir: './src' }),
+                  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+                  use: {
+                    baseURL,
+                    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+                    trace: 'on-first-retry',
+                  },
+                  /* Run your local dev server before starting the tests */
+                  webServer: {
+                    command: 'npx nx serve acme',
+                    url: 'http://localhost:4200',
+                    reuseExistingServer: !process.env.CI,
+                    cwd: workspaceRoot,
+                  },
+                  projects: []
+                });
+                `
+    );
+    await update(tree);
+    expect(tree.read('acme/playwright.config.ts', 'utf-8')).toContain(
+      'projects: []'
+    );
+    expect(tree.read('acme/playwright.config.ts', 'utf-8')).toMatchSnapshot();
+  });
+});

--- a/packages/playwright/src/migrations/update-17-3-1/add-project-to-config.ts
+++ b/packages/playwright/src/migrations/update-17-3-1/add-project-to-config.ts
@@ -1,0 +1,198 @@
+import { Tree, getProjects, joinPathFragments } from '@nx/devkit';
+import * as ts from 'typescript';
+import { tsquery } from '@phenomnomnominal/tsquery';
+
+export default async function update(tree: Tree) {
+  const projects = getProjects(tree);
+  projects.forEach((project) => {
+    // Check if the project contains playwright config
+    const configPath = joinPathFragments(project.root, 'playwright.config.ts');
+    if (tree.exists(configPath)) {
+      addProjectIfExists(tree, joinPathFragments(configPath));
+    }
+  });
+}
+
+function addProjectIfExists(tree: Tree, configFilePath: string) {
+  const configFileContent = tree.read(configFilePath, 'utf-8');
+
+  const sourceFile = tsquery.ast(configFileContent);
+  const printer = ts.createPrinter();
+
+  const updatedStatements = updateOrCreateImportStatement(
+    sourceFile,
+    '@playwright/test',
+    ['devices']
+  );
+
+  const exportAssignment = tsquery.query(
+    sourceFile,
+    'ExportAssignment'
+  )[0] as ts.ExportAssignment;
+  if (!exportAssignment) {
+    // No export found in the file
+    return;
+  }
+
+  const exportAssignemntObject = exportAssignment.expression;
+  if (
+    !(
+      ts.isCallExpression(exportAssignemntObject) &&
+      exportAssignemntObject.getText(sourceFile).startsWith('defineConfig') &&
+      exportAssignemntObject.arguments.length > 0
+    )
+  ) {
+    // Export is not a call expression with defineConfig ex. export default defineConfig({ ... })
+    return;
+  }
+  let firstArgument = exportAssignemntObject.arguments[0];
+  if (!ts.isObjectLiteralExpression(firstArgument)) {
+    // First argument is not an object literal ex. defineConfig('foo')
+    return;
+  }
+  const projectProperty = tsquery.query(
+    exportAssignemntObject,
+    'PropertyAssignment > Identifier[name="projects"]'
+  )[0] as ts.PropertyAssignment;
+  if (projectProperty) {
+    // Projects property already exists in the config
+    return;
+  }
+
+  // Add projects property to the config
+  const projectsArray = ts.factory.createArrayLiteralExpression(
+    [
+      createProperty('chromium', 'Desktop Chrome'),
+      createProperty('firefox', 'Desktop Firefox'),
+      createProperty('webkit', 'Desktop Safari'),
+    ],
+    true
+  );
+
+  const newProjectsProperty = ts.factory.createPropertyAssignment(
+    'projects',
+    projectsArray
+  );
+
+  const newObj = ts.factory.createObjectLiteralExpression([
+    ...firstArgument.properties,
+    newProjectsProperty,
+  ]);
+
+  const newCallExpression = ts.factory.updateCallExpression(
+    exportAssignemntObject,
+    exportAssignemntObject.expression,
+    exportAssignemntObject.typeArguments,
+    [newObj]
+  );
+
+  const newExportAssignment = ts.factory.updateExportAssignment(
+    exportAssignment,
+    exportAssignment.modifiers,
+    newCallExpression
+  );
+
+  const transformedStatements = updatedStatements.map((statement) => {
+    return statement === exportAssignment ? newExportAssignment : statement;
+  }) as ts.Statement[];
+
+  const transformedSourceFile = ts.factory.updateSourceFile(
+    sourceFile,
+    transformedStatements
+  );
+
+  const updatedConfigFileContent = printer.printFile(transformedSourceFile);
+  tree.write(configFilePath, updatedConfigFileContent);
+}
+
+function createProperty(name: string, device: string) {
+  return ts.factory.createObjectLiteralExpression([
+    ts.factory.createPropertyAssignment(
+      'name',
+      ts.factory.createStringLiteral(name)
+    ),
+    ts.factory.createPropertyAssignment(
+      'use',
+      ts.factory.createObjectLiteralExpression([
+        ts.factory.createSpreadAssignment(
+          ts.factory.createElementAccessExpression(
+            ts.factory.createIdentifier('devices'),
+            ts.factory.createStringLiteral(device)
+          )
+        ),
+      ])
+    ),
+  ]);
+}
+
+function updateOrCreateImportStatement(
+  sourceFile: ts.SourceFile,
+  moduleName: string,
+  importNames: string[]
+): ts.Statement[] {
+  let importDeclarationFound = false;
+  const newStatements = sourceFile.statements.map((statement) => {
+    if (
+      ts.isImportDeclaration(statement) &&
+      statement.moduleSpecifier.getText(sourceFile) === `'${moduleName}'`
+    ) {
+      importDeclarationFound = true;
+      const existingSpecifiers =
+        statement.importClause?.namedBindings &&
+        ts.isNamedImports(statement.importClause.namedBindings)
+          ? statement.importClause.namedBindings.elements.map(
+              (e) => e.name.text
+            )
+          : [];
+      // Merge with new import names, avoiding duplicates
+      const mergedImportNames = Array.from(
+        new Set([...existingSpecifiers, ...importNames])
+      );
+
+      // Create new import specifiers
+      const importSpecifiers = mergedImportNames.map((name) =>
+        ts.factory.createImportSpecifier(
+          false,
+          undefined,
+          ts.factory.createIdentifier(name)
+        )
+      );
+
+      return ts.factory.updateImportDeclaration(
+        statement,
+        statement.modifiers,
+        ts.factory.createImportClause(
+          false,
+          undefined,
+          ts.factory.createNamedImports(importSpecifiers)
+        ),
+        statement.moduleSpecifier,
+        undefined
+      );
+    }
+    return statement;
+  });
+
+  if (!importDeclarationFound) {
+    const importDeclaration = ts.factory.createImportDeclaration(
+      undefined,
+      ts.factory.createImportClause(
+        false,
+        undefined,
+        ts.factory.createNamedImports(
+          importNames.map((name) =>
+            ts.factory.createImportSpecifier(
+              false,
+              undefined,
+              ts.factory.createIdentifier(name)
+            )
+          )
+        )
+      ),
+      ts.factory.createStringLiteral(moduleName)
+    );
+    newStatements.push(importDeclaration);
+  }
+
+  return newStatements;
+}


### PR DESCRIPTION
This is a follow-up to this previous PR: https://github.com/nrwl/nx/pull/21188

The migration is missing so users who were depending on the `projects` which was removed from `@nx/playwright` will be broken when they update.

This PR fixes that.