### PR TITLE
fix(graph): don't show open config button on nx.dev & refactor tooltips

### DIFF
--- a/graph/ui-graph/src/lib/tooltip-service.ts
+++ b/graph/ui-graph/src/lib/tooltip-service.ts
@@ -7,11 +7,9 @@ import {
 } from '@nx/graph/ui-tooltips';
 import { TooltipEvent } from './interfaces';
 import { GraphInteractionEvents } from './graph-interaction-events';
-import { getExternalApiService } from '@nx/graph/shared';
 
 export class GraphTooltipService {
   private subscribers: Set<Function> = new Set();
-  private externalApiService = getExternalApiService();
 
   constructor(graph: GraphService) {
     graph.listen((event: GraphInteractionEvents) => {
@@ -28,22 +26,13 @@ export class GraphTooltipService {
             tags: event.data.tags,
             type: event.data.type,
             description: event.data.description,
+            renderMode: graph.renderMode,
           });
           break;
         case 'TaskNodeClick':
-          const runTaskCallback =
-            graph.renderMode === 'nx-console'
-              ? () =>
-                  this.externalApiService.postEvent({
-                    type: 'run-task',
-                    payload: {
-                      taskId: event.data.id,
-                    },
-                  })
-              : undefined;
           this.openTaskNodeTooltip(event.ref, {
             ...event.data,
-            runTaskCallback,
+            renderMode: graph.renderMode,
           });
           if (graph.getTaskInputs) {
             graph.getTaskInputs(event.data.id).then((inputs) => {
@@ -53,7 +42,7 @@ export class GraphTooltipService {
               ) {
                 this.openTaskNodeTooltip(event.ref, {
                   ...event.data,
-                  runTaskCallback,
+                  renderMode: graph.renderMode,
                   inputs,
                 });
               }
@@ -61,23 +50,13 @@ export class GraphTooltipService {
           }
           break;
         case 'EdgeClick':
-          const callback =
-            graph.renderMode === 'nx-console'
-              ? (url) =>
-                  this.externalApiService.postEvent({
-                    type: 'file-click',
-                    payload: {
-                      sourceRoot: event.data.sourceRoot,
-                      file: url,
-                    },
-                  })
-              : undefined;
           this.openEdgeToolTip(event.ref, {
             type: event.data.type,
             target: event.data.target,
             source: event.data.source,
             fileDependencies: event.data.fileDependencies,
-            fileClickCallback: callback,
+            renderMode: graph.renderMode,
+            sourceRoot: event.data.sourceRoot,
           });
           break;
       }

--- a/graph/ui-graph/src/lib/util-cytoscape/project-edge.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/project-edge.ts
@@ -9,6 +9,8 @@ export interface ProjectEdgeDataDefinition extends cy.NodeDataDefinition {
   source: string;
   target: string;
   type: 'static' | 'dynamic' | 'implicit';
+  sourceRoot?: string;
+  fileDependencies?: { fileName: string }[];
 }
 
 export class ProjectEdge {

--- a/graph/ui-graph/src/lib/util-cytoscape/render-graph.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/render-graph.ts
@@ -223,12 +223,10 @@ export class RenderGraph {
       const node = event.target;
 
       let ref: VirtualElement = node.popperRef(); // used only for positioning
-
       this.broadcast({
         type: 'ProjectNodeClick',
         ref,
         id: node.id(),
-
         data: {
           id: node.id(),
           type: node.data('type'),
@@ -249,7 +247,6 @@ export class RenderGraph {
         type: 'TaskNodeClick',
         ref,
         id: node.id(),
-
         data: {
           id: node.id(),
           label: node.data('label'),
@@ -270,7 +267,6 @@ export class RenderGraph {
         type: 'EdgeClick',
         ref,
         id: edge.id(),
-
         data: {
           id: edge.id(),
           type: edge.data('type'),

--- a/graph/ui-tooltips/src/lib/project-edge-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/project-edge-tooltip.tsx
@@ -6,7 +6,9 @@ export interface ProjectEdgeNodeTooltipProps {
   target: string;
   fileDependencies: Array<{ fileName: string }>;
   description?: string;
-  fileClickCallback: (fileName: string) => void;
+  renderMode?: 'nx-console' | 'nx-docs';
+  sourceRoot?: string;
+  fileClickCallback?: (fileName: string) => void;
 }
 
 export function ProjectEdgeNodeTooltip({

--- a/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
@@ -4,7 +4,6 @@ import {
 } from '@heroicons/react/24/outline';
 import { Tag } from '@nx/graph/ui-components';
 import { ReactNode } from 'react';
-import { useEnvironmentConfig } from '@nx/graph/shared';
 
 export interface ProjectNodeToolTipProps {
   type: 'app' | 'lib' | 'e2e';
@@ -12,8 +11,7 @@ export interface ProjectNodeToolTipProps {
   tags: string[];
   description?: string;
   openConfigCallback?: () => void;
-  isNxConsole?: boolean;
-
+  renderMode?: 'nx-console' | 'nx-docs';
   children?: ReactNode | ReactNode[];
 }
 
@@ -24,30 +22,32 @@ export function ProjectNodeToolTip({
   children,
   description,
   openConfigCallback,
-  isNxConsole,
+  renderMode,
 }: ProjectNodeToolTipProps) {
   return (
     <div className="text-sm text-slate-700 dark:text-slate-400">
       <h4 className="flex justify-between items-center gap-4">
         <div className="flex items-center">
           <Tag className="mr-3">{type}</Tag>
-          <span className="font-mono">{id}</span>
+          <span className="font-mono mr-3">{id}</span>
         </div>
-        <button
-          className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
-          title={
-            isNxConsole
-              ? 'Open project details in editor'
-              : 'Open project details'
-          }
-          onClick={openConfigCallback}
-        >
-          {isNxConsole ? (
-            <PencilSquareIcon className="h-5 w-5" />
-          ) : (
-            <DocumentMagnifyingGlassIcon className="h-5 w-5" />
-          )}
-        </button>
+        {openConfigCallback && (
+          <button
+            className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
+            title={
+              renderMode === 'nx-console'
+                ? 'Open project details in editor'
+                : 'Open project details'
+            }
+            onClick={openConfigCallback}
+          >
+            {renderMode === 'nx-console' ? (
+              <PencilSquareIcon className="h-5 w-5" />
+            ) : (
+              <DocumentMagnifyingGlassIcon className="h-5 w-5" />
+            )}
+          </button>
+        )}
       </h4>
       {tags.length > 0 ? (
         <p className="my-2">

--- a/graph/ui-tooltips/src/lib/task-node-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/task-node-tooltip.tsx
@@ -12,9 +12,8 @@ export interface TaskNodeTooltipProps {
   runTaskCallback?: () => void;
   description?: string;
   inputs?: Record<string, string[]>;
-  isNxConsole?: boolean;
   openConfigCallback?: () => void;
-
+  renderMode?: 'nx-console' | 'nx-docs';
   children?: ReactNode | ReactNode[];
 }
 
@@ -22,8 +21,8 @@ export function TaskNodeTooltip({
   id,
   executor,
   description,
-  runTaskCallback: runTargetCallback,
-  isNxConsole,
+  renderMode,
+  runTaskCallback,
   openConfigCallback,
   children,
 }: TaskNodeTooltipProps) {
@@ -33,33 +32,35 @@ export function TaskNodeTooltip({
         <div className="flex grow items-center justify-between">
           <div className="flex items-center">
             <Tag className="mr-3">{executor}</Tag>
-            <span className="font-mono">{id}</span>
+            <span className="font-mono mr-3">{id}</span>
           </div>
-          <button
-            className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
-            title={
-              isNxConsole
-                ? 'Open project details in editor'
-                : 'Open project details'
-            }
-            onClick={openConfigCallback}
-          >
-            {isNxConsole ? (
-              <PencilSquareIcon className="h-5 w-5" />
-            ) : (
-              <DocumentMagnifyingGlassIcon className="h-5 w-5" />
-            )}
-          </button>
+          {openConfigCallback && (
+            <button
+              className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
+              title={
+                renderMode === 'nx-console'
+                  ? 'Open project details in editor'
+                  : 'Open project details'
+              }
+              onClick={openConfigCallback}
+            >
+              {renderMode === 'nx-console' ? (
+                <PencilSquareIcon className="h-5 w-5" />
+              ) : (
+                <DocumentMagnifyingGlassIcon className="h-5 w-5" />
+              )}
+            </button>
+          )}
         </div>
-        {runTargetCallback ? (
+        {runTaskCallback && (
           <button
             className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
             title="Run Task"
-            onClick={runTargetCallback}
+            onClick={runTaskCallback}
           >
             <PlayIcon className="h-5 w-5" />
           </button>
-        ) : undefined}
+        )}
       </h4>
       {description ? <p className="mt-4">{description}</p> : null}
       {children}


### PR DESCRIPTION
Before: 
<img width="251" alt="image" src="https://github.com/nrwl/nx/assets/34165455/d5aa6f10-d79b-48b4-9a5f-9cc9ee2b447c">

After: 
<img width="264" alt="image" src="https://github.com/nrwl/nx/assets/34165455/9b2961c8-3276-4d15-9038-1a69c6470bd6">

I also refactored parts of the tooltip flow so that all actions (opening config, running a task in console, ...) are specified in the same place.
