### PR TITLE
feat(core): support --use-agents and --no-agents

### DIFF
--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -26,6 +26,7 @@ export interface RunOptions {
   cloud: boolean;
   dte: boolean;
   batch: boolean;
+  useAgents: boolean;
 }
 
 export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
@@ -90,6 +91,11 @@ export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
     .options('dte', {
       type: 'boolean',
       hidden: true,
+    })
+    .options('useAgents', {
+      type: 'boolean',
+      hidden: true,
+      alias: 'agents',
     }) as Argv<Omit<RunOptions, 'exclude' | 'batch'>> as any;
 }
 


### PR DESCRIPTION
## Current Behavior
No yargs support for these args, so they are not propagated to the cloud runner

## Expected Behavior
These args and their negations can be propagated to the cloud runner
