### PR TITLE
fix(core): do not run pty in run-script when we're not TTY

### DIFF
--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -3,6 +3,7 @@ import type { ExecutorContext } from '../../config/misc-interfaces';
 import { runCommand } from '../../native';
 import { PseudoTtyProcess } from '../../utils/child-process';
 import { getPackageManagerCommand } from '../../utils/package-manager';
+import { execSync } from 'child_process';
 
 export interface RunScriptOptions {
   script: string;
@@ -15,29 +16,50 @@ export default async function (
 ) {
   const pm = getPackageManagerCommand();
   try {
-    await new Promise<void>((res, rej) => {
-      const cp = new PseudoTtyProcess(
-        runCommand(
-          pm.run(options.script, options.__unparsed__.join(' ')),
-          path.join(
-            context.root,
-            context.projectsConfigurations.projects[context.projectName].root
-          ),
-          process.env
-        )
-      );
-      cp.onExit((code) => {
-        if (code === 0) {
-          res();
-        } else if (code >= 128) {
-          process.exit(code);
-        } else {
-          rej();
-        }
-      });
-    });
+    let command = pm.run(options.script, options.__unparsed__.join(' '));
+    let cwd = path.join(
+      context.root,
+      context.projectsConfigurations.projects[context.projectName].root
+    );
+    let env = process.env;
+    if (process.stdout.isTTY) {
+      await ptyProcess(command, cwd, env);
+    } else {
+      nodeProcess(command, cwd, env);
+    }
     return { success: true };
   } catch (e) {
     return { success: false };
   }
+}
+
+function nodeProcess(
+  command: string,
+  cwd: string,
+  env: Record<string, string>
+) {
+  execSync(command, {
+    stdio: ['inherit', 'inherit', 'inherit'],
+    cwd,
+    env,
+  });
+}
+
+async function ptyProcess(
+  command: string,
+  cwd: string,
+  env: Record<string, string>
+) {
+  return new Promise<void>((res, rej) => {
+    const cp = new PseudoTtyProcess(runCommand(command, cwd, env));
+    cp.onExit((code) => {
+      if (code === 0) {
+        res();
+      } else if (code >= 128) {
+        process.exit(code);
+      } else {
+        rej();
+      }
+    });
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When we try to call run-many within a CI environment (or anywhere without TTY) that has scripts to execute, we try to run scripts in a pty which causes `^D\b\b` outputs

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When we detect that there is not TTY we should fall back to running a node process in run-script

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
