### PR TITLE
docs(core): split e2e tasks existing repo

### DIFF
--- a/docs/nx-cloud/features/split-e2e-tasks.md
+++ b/docs/nx-cloud/features/split-e2e-tasks.md
@@ -27,6 +27,10 @@ nx add @nx/playwright
 
 This command will register the appropriate plugin in the `plugins` array of `nx.json`.
 
+## Manual Configuration
+
+If you are already using the `@nx/cypress` or `@nx/playwright` plugin, you need to manually add the appropriate configuration to the `plugins` array of `nx.json`. The configuration settings can be found on the [Cypress](/nx-api/cypress#nxcypress-configuration) or [Playwright](/nx-api/playwright#nxplaywright-configuration) plugin docs.
+
 ## Usage
 
 You can view the available tasks in the graph:

--- a/docs/shared/concepts/inferred-tasks.md
+++ b/docs/shared/concepts/inferred-tasks.md
@@ -18,7 +18,7 @@ The plugin then configures tasks with a name that you specified in the plugin's 
 
 The `@nx/webpack` plugin creates tasks named `build`, `serve` and `preview` by default and it automatically sets the task caching settings based on the values in the webpack configuration files.
 
-### What Is Inferred
+## What Is Inferred
 
 Nx plugins infer the following properties by analyzing the tool configuration.
 


### PR DESCRIPTION
Note for splitting e2e tasks for existing repos