### PR TITLE
feat(core): add migration to disable adding plugins automatically in existing workspaces

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -82,6 +82,13 @@
       "version": "17.3.0-beta.6",
       "description": "Updates the nx wrapper.",
       "implementation": "./src/migrations/update-17-3-0/update-nxw"
+    },
+    "18.0.0-disable-adding-plugins-for-existing-workspaces": {
+      "cli": "nx",
+      "version": "18.0.0-beta.2",
+      "description": "Updates .env to disabled adding plugins when generating projects in an existing Nx workspace",
+      "implementation": "./src/migrations/update-18-0-0/disable-crystal-for-existing-workspaces",
+      "x-repair-skip": true
     }
   }
 }

--- a/packages/nx/src/command-line/repair/repair.ts
+++ b/packages/nx/src/command-line/repair/repair.ts
@@ -12,16 +12,21 @@ export async function repair(
   }
   const verbose = process.env.NX_VERBOSE_LOGGING === 'true';
   return handleErrors(verbose, async () => {
-    const nxMigrations = Object.entries(migrationsJson.generators).map(
-      ([name, migration]) => {
-        return {
-          package: 'nx',
-          cli: 'nx',
-          name,
-          description: migration.description,
-          version: migration.version,
-        } as const;
-      }
+    const nxMigrations = Object.entries(migrationsJson.generators).reduce(
+      (agg, [name, migration]) => {
+        const skip = migration['x-repair-skip'];
+        if (!skip) {
+          agg.push({
+            package: 'nx',
+            cli: 'nx',
+            name,
+            description: migration.description,
+            version: migration.version,
+          } as const);
+        }
+        return agg;
+      },
+      []
     );
 
     const migrations = [...nxMigrations, ...extraMigrations];

--- a/packages/nx/src/migrations/update-18-0-0/disable-crysal-for-existing-workspaces.spec.ts
+++ b/packages/nx/src/migrations/update-18-0-0/disable-crysal-for-existing-workspaces.spec.ts
@@ -1,0 +1,29 @@
+import { createTree } from '../../generators/testing-utils/create-tree';
+import migrate from './disable-crystal-for-existing-workspaces';
+
+describe('disable crystal for existing workspaces', () => {
+  it("should create a .env if it doesn't exist", () => {
+    const tree = createTree();
+    migrate(tree);
+    expect(tree.read('.env', 'utf-8')).toMatchInlineSnapshot(`
+      "# Nx 18 enables using plugins to infer targets by default
+      # This is disabled for existing workspaces to maintain compatibility
+      # For more info, see: https://nx.dev/concepts/inferred-tasks
+      NX_ADD_PLUGINS=false"
+    `);
+  });
+
+  it('should update an existing .env', () => {
+    const tree = createTree();
+    tree.write('.env', 'FOO=bar');
+    migrate(tree);
+    expect(tree.read('.env', 'utf-8')).toMatchInlineSnapshot(`
+      "FOO=bar
+
+      # Nx 18 enables using plugins to infer targets by default
+      # This is disabled for existing workspaces to maintain compatibility
+      # For more info, see: https://nx.dev/concepts/inferred-tasks
+      NX_ADD_PLUGINS=false"
+    `);
+  });
+});

--- a/packages/nx/src/migrations/update-18-0-0/disable-crystal-for-existing-workspaces.ts
+++ b/packages/nx/src/migrations/update-18-0-0/disable-crystal-for-existing-workspaces.ts
@@ -1,0 +1,33 @@
+import { Tree } from '../../generators/tree';
+import { logger } from '../../utils/logger';
+import ignore from 'ignore';
+
+export default function migrate(tree: Tree) {
+  const ig = ignore();
+  try {
+    ig.add(tree.read('.gitignore', 'utf-8'));
+    if (ig.ignores('.env')) {
+      logger.warn(
+        'NX The NX_ADD_PLUGINS=false environment variable was added to your .env file for backwards compatibility. However, your .env is ignored by git. Other contributors should add this key to their .env file or ensure that the environment variable is true when generating code with Nx.'
+      );
+    }
+  } catch {}
+
+  if (!tree.exists('.env')) {
+    tree.write('.env', '');
+  }
+
+  const dotenv = tree.read('.env', 'utf-8');
+  const newDotenvContents = [
+    '# Nx 18 enables using plugins to infer targets by default',
+    '# This is disabled for existing workspaces to maintain compatibility',
+    '# For more info, see: https://nx.dev/concepts/inferred-tasks',
+    'NX_ADD_PLUGINS=false',
+  ];
+
+  if (dotenv.length) {
+    newDotenvContents.unshift(dotenv, '');
+  }
+
+  tree.write('.env', newDotenvContents.join('\n'));
+}

--- a/packages/nx/src/migrations/update-18-0-0/disable-crystal-for-existing-workspaces.ts
+++ b/packages/nx/src/migrations/update-18-0-0/disable-crystal-for-existing-workspaces.ts
@@ -8,7 +8,7 @@ export default function migrate(tree: Tree) {
     ig.add(tree.read('.gitignore', 'utf-8'));
     if (ig.ignores('.env')) {
       logger.warn(
-        'NX The NX_ADD_PLUGINS=false environment variable was added to your .env file for backwards compatibility. However, your .env is ignored by git. Other contributors should add this key to their .env file or ensure that the environment variable is true when generating code with Nx.'
+        'NX The NX_ADD_PLUGINS=false environment variable was added to your .env file for backwards compatibility. However, your .env is ignored by git. Other contributors should add this key to their .env file or ensure that the environment variable is set to false when generating code with Nx.'
       );
     }
   } catch {}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Adding inferences plugins by default can have unexpected side effects for users with a customized workspace

## Expected Behavior
Existing workspaces must manually enable any plugins they would like, or opt in otherwise.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
