### PR TITLE
fix(vite): deep file resolution in nx-tsconfig-paths.plugin.ts

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -1,4 +1,4 @@
-import { stripIndents, workspaceRoot } from '@nx/devkit';
+import { joinPathFragments, stripIndents, workspaceRoot } from '@nx/devkit';
 import { existsSync } from 'node:fs';
 import { relative, join, resolve } from 'node:path';
 import {
@@ -153,8 +153,14 @@ There should at least be a tsconfig.base.json or tsconfig.json in the root of th
       const normalizedImport = alias.replace(/\/\*$/, '');
 
       if (importPath.startsWith(normalizedImport)) {
-        const path = (tsconfig.absoluteBaseUrl, paths[0].replace(/\/\*$/, ''));
-        resolvedFile = findFile(importPath.replace(normalizedImport, path));
+        const joinedPath = joinPathFragments(
+          tsconfig.absoluteBaseUrl,
+          paths[0].replace(/\/\*$/, '')
+        );
+
+        resolvedFile = findFile(
+          importPath.replace(normalizedImport, joinedPath)
+        );
       }
     }
 


### PR DESCRIPTION
Deep file resolution fails when trying to use tsconfig paths like:

"paths": {
  "@org/sdk/*": ["libs/sdk/src/lib/*"],
}

And importing:

import thing from '@org/sdk/thing';

TS is happy with this but vite fails to resolve.

I could be missing something but the original code doesn't actually use tsconfig.absoluteBaseUrl so path resolution fails as the relative path is used.

## Current Behavior
Deep file resolution fails when trying to use tsconfig paths like:

```
"paths": {
  "@org/sdk/*": ["libs/sdk/src/lib/*"],
}
```

And importing:

`import thing from '@org/sdk/thing';`

TS is happy with this but vite fails to resolve the file.

## Expected Behavior
The import path should be resolved taking into account the project structure.

Fixes #21512
