### PR TITLE
fix(core): do not watch temporary vite files

### DIFF
--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -39,7 +39,13 @@ impl Watcher {
         use_ignore: Option<bool>,
     ) -> Watcher {
         // always have these globs come before the additional globs
-        let mut globs = vec![".git/".into(), "node_modules/".into(), ".nx/".into()];
+        let mut globs = vec![
+            ".git/".into(),
+            "node_modules/".into(),
+            ".nx/".into(),
+            "vitest.config.ts.timestamp*.mjs".into(),
+            "vite.config.ts.timestamp*.mjs".into(),
+        ];
         if let Some(additional_globs) = additional_globs {
             globs.extend(additional_globs);
         }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

To load `vite.config.ts` files and `vitest.config.ts`, `vite` bundles the files into the `cwd` temporarily.

Our Vite plugin does this... and triggers a recalculation of the project graph... which again loads a `vite.config.ts` file... which causes an infinite loop of creating this file and recalculating the graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

These temporary files are ignored by Nx's file water to avoid this infinite loop.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
