### PR TITLE
fix(react): setup-ssr generator should not read the graph for a project that doesnt exist

### DIFF
--- a/e2e/react-module-federation/src/react-module-federation.test.ts
+++ b/e2e/react-module-federation/src/react-module-federation.test.ts
@@ -134,8 +134,7 @@ describe('React Module Federation', () => {
       }
     }, 500_000);
 
-    // TODO(crystal, @columferry): Fix this once we fix SSR
-    xit('should generate host and remote apps with ssr', async () => {
+    it('should generate host and remote apps with ssr', async () => {
       const shell = uniq('shell');
       const remote1 = uniq('remote1');
       const remote2 = uniq('remote2');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `host` and `remote` generators with `--ssr`, the `setup-ssr` generator tries to read the project graph to get information about these projects.

As the projects have not yet been fully generated, the project graph does not contain these nodes.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Attempt to read the `projectConfig` from `project.json` before trying to check the graph.

NOTE: There needs to be a way for us to get the project graph for a node that has not been fully generated for cases when a Crystal project is in the process of being generated, will have inferred targets, but a subsequent generator will need information about the config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
