### PR TITLE
chore(repo): only run steps within publish.yml if not on fork

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'nrwl' }}
     strategy:
       fail-fast: false
       matrix:
@@ -157,6 +158,7 @@ jobs:
           if-no-files-found: error
 
   build-freebsd:
+     if: ${{ github.repository_owner == 'nrwl' }}
      runs-on: macos-13-large
      name: Build FreeBSD
      timeout-minutes: 45


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

The build steps of publish.yml run on forked repos

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

No steps of publish.yml run on forked repos, although sadly on our side we cannot stop the job from triggering on the forks.

We were already using `if: ${{ github.repository_owner == 'nrwl' }}` on the publish step, it was just a question of applying it to all steps