### PR TITLE
fix(webpack): fix webpack plugin issues and e2e tests

### DIFF
--- a/e2e/webpack/src/webpack.legacy.test.ts
+++ b/e2e/webpack/src/webpack.legacy.test.ts
@@ -1,10 +1,12 @@
 import {
+  checkFilesExist,
   cleanupProject,
   killProcessAndPorts,
   newProject,
   runCLI,
   runCommandUntil,
   uniq,
+  updateFile,
 } from '@nx/e2e/utils';
 import { ChildProcess } from 'child_process';
 
@@ -64,5 +66,40 @@ describe('Webpack Plugin (legacy)', () => {
     if (process && process.pid) {
       await killProcessAndPorts(process.pid, port);
     }
+  });
+
+  // Issue: https://github.com/nrwl/nx/issues/20179
+  it('should allow main/styles entries to be spread within composePlugins() function (#20179)', () => {
+    const appName = uniq('app');
+    runCLI(`generate @nx/web:app ${appName} --bundler webpack`);
+    updateFile(`apps/${appName}/src/main.ts`, `console.log('Hello');\n`);
+
+    updateFile(
+      `apps/${appName}/webpack.config.js`,
+      `
+        const { composePlugins, withNx, withWeb } = require('@nx/webpack');
+        module.exports = composePlugins(withNx(), withWeb(), (config) => {
+          return {
+            ...config,
+            entry: {
+              main: [...config.entry.main],
+              styles: [...config.entry.styles],
+            }
+          };
+        });
+      `
+    );
+
+    expect(() => {
+      runCLI(`build ${appName} --outputHashing none`);
+    }).not.toThrow();
+    checkFilesExist(`dist/${appName}/styles.css`);
+
+    expect(() => {
+      runCLI(`build ${appName} --outputHashing none --extractCss false`);
+    }).not.toThrow();
+    expect(() => {
+      checkFilesExist(`dist/${appName}/styles.css`);
+    }).toThrow();
   });
 });

--- a/e2e/webpack/src/webpack.test.ts
+++ b/e2e/webpack/src/webpack.test.ts
@@ -15,8 +15,7 @@ describe('Webpack Plugin', () => {
   beforeAll(() => newProject());
   afterAll(() => cleanupProject());
 
-  // TODO(crystal, @jaysoo): Investigate why this test is failing
-  xit('should be able to setup project to build node programs with webpack and different compilers', async () => {
+  it('should be able to setup project to build node programs with webpack and different compilers', async () => {
     const myPkg = uniq('my-pkg');
     runCLI(`generate @nx/js:lib ${myPkg} --bundler=none`);
     updateFile(`libs/${myPkg}/src/index.ts`, `console.log('Hello');\n`);
@@ -29,13 +28,31 @@ describe('Webpack Plugin', () => {
     updateFile(
       `libs/${myPkg}/webpack.config.js`,
       `
-const { composePlugins, withNx } = require('@nx/webpack');
+      const path  = require('path');
+      const { NxWebpackPlugin } = require('@nx/webpack');
+      
+      class DebugPlugin {
+        apply(compiler) {
+          console.log('scriptType is ' + compiler.options.output.scriptType);
+        }
+      }
 
-module.exports = composePlugins(withNx(), (config) => {
-  console.log('scriptType is ' + config.output.scriptType);
-  return config;
-});
-`
+      module.exports = {
+        target: 'node',
+        output: {
+          path: path.join(__dirname, '../../dist/libs/${myPkg}')
+        },
+        plugins: [
+          new NxWebpackPlugin({
+            compiler: 'tsc',
+            main: './src/index.ts',
+            tsConfig: './tsconfig.lib.json',
+            outputHashing: 'none',
+            optimization: false,
+          }),
+          new DebugPlugin()
+        ]
+      };`
     );
 
     rmDist();
@@ -142,40 +159,4 @@ module.exports = composePlugins(withNx(), (config) => {
     let output = runCommand(`node dist/${appName}/main.js`);
     expect(output).toMatch(/Hello/);
   }, 500_000);
-
-  // Issue: https://github.com/nrwl/nx/issues/20179
-  // TODO(crystal, @jaysoo): Investigate why this test is failing
-  xit('should allow main/styles entries to be spread within composePlugins() function (#20179)', () => {
-    const appName = uniq('app');
-    runCLI(`generate @nx/web:app ${appName} --bundler webpack`);
-    updateFile(`apps/${appName}/src/main.ts`, `console.log('Hello');\n`);
-
-    updateFile(
-      `apps/${appName}/webpack.config.js`,
-      `
-        const { composePlugins, withNx, withWeb } = require('@nx/webpack');
-        module.exports = composePlugins(withNx(), withWeb(), (config) => {
-          return {
-            ...config,
-            entry: {
-              main: [...config.entry.main],
-              styles: [...config.entry.styles],
-            }
-          };
-        });
-      `
-    );
-
-    expect(() => {
-      runCLI(`build ${appName} --outputHashing none`);
-    }).not.toThrow();
-    checkFilesExist(`dist/apps/${appName}/styles.css`);
-
-    expect(() => {
-      runCLI(`build ${appName} --outputHashing none --extractCss false`);
-    }).not.toThrow();
-    expect(() => {
-      checkFilesExist(`dist/apps/${appName}/styles.css`);
-    }).toThrow();
-  });
 });

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
@@ -92,7 +92,7 @@ export function normalizeOptions(
     sourceMap: options.sourceMap ?? !isProd,
     sourceRoot,
     styles: options.styles ?? [],
-    target: options.target ?? 'web',
+    target: options.target,
     targetName,
     vendorChunk: options.vendorChunk ?? !isProd,
   };

--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -25,6 +25,7 @@ export function withNx(
       {
         ...options,
         ...pluginOptions,
+        target: options.target ?? 'web',
         assets: options.assets
           ? options.assets
           : pluginOptions.assets


### PR DESCRIPTION
This PR fixes the two failing webpack e2e tests One test required two small fixes:

1. `NxWebpackPlugin` - Should not override user's `config.target` with `'web'`
2. `@nx/webpack:configuration`- Generator had wrong `output.path` and was nested it under `<proj>/dist/<proj>` rather than `dist/<proj>`.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
