### PR TITLE
fix(nest): ensure dependencies are installed when generating nest libraries

### DIFF
--- a/packages/nest/src/generators/application/application.ts
+++ b/packages/nest/src/generators/application/application.ts
@@ -5,12 +5,12 @@ import { applicationGenerator as nodeApplicationGenerator } from '@nx/node';
 import { initGenerator } from '../init/init';
 import {
   createFiles,
-  ensureDependencies,
   normalizeOptions,
   toNodeApplicationGeneratorOptions,
   updateTsConfig,
 } from './lib';
 import type { ApplicationGeneratorOptions } from './schema';
+import { ensureDependencies } from '../../utils/ensure-dependencies';
 
 export async function applicationGenerator(
   tree: Tree,

--- a/packages/nest/src/generators/application/lib/index.ts
+++ b/packages/nest/src/generators/application/lib/index.ts
@@ -1,4 +1,3 @@
 export * from './create-files';
-export * from './ensure-dependencies';
 export * from './normalize-options';
 export * from './update-tsconfig';

--- a/packages/nest/src/generators/library/library.ts
+++ b/packages/nest/src/generators/library/library.ts
@@ -1,7 +1,6 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { formatFiles, runTasksInSerial } from '@nx/devkit';
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
-import { addDependencies } from '../init/lib';
 import {
   addExportsToBarrelFile,
   addProject,
@@ -14,6 +13,7 @@ import {
 import type { LibraryGeneratorOptions } from './schema';
 import initGenerator from '../init/init';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
+import { ensureDependencies } from '../../utils/ensure-dependencies';
 
 export async function libraryGenerator(
   tree: Tree,
@@ -33,6 +33,7 @@ export async function libraryGeneratorInternal(
   const options = await normalizeOptions(tree, rawOptions);
   await jsLibraryGenerator(tree, toJsLibraryGeneratorOptions(options));
   const initTask = await initGenerator(tree, rawOptions);
+  const depsTask = ensureDependencies(tree);
   deleteFiles(tree, options);
   createFiles(tree, options);
   addExportsToBarrelFile(tree, options);
@@ -46,6 +47,7 @@ export async function libraryGeneratorInternal(
   return runTasksInSerial(
     ...[
       initTask,
+      depsTask,
       () => {
         logShowProjectCommand(options.projectName);
       },

--- a/packages/nest/src/utils/ensure-dependencies.ts
+++ b/packages/nest/src/utils/ensure-dependencies.ts
@@ -5,7 +5,7 @@ import {
   reflectMetadataVersion,
   rxjsVersion,
   tsLibVersion,
-} from '../../../utils/versions';
+} from './versions';
 
 export function ensureDependencies(tree: Tree): GeneratorCallback {
   return addDependenciesToPackageJson(


### PR DESCRIPTION
When a Node lib is generated without an app, we don't ensure that dependencies are installed. This PR adds those installs to the lib generator.

In practice, this should not happen since the workspace must have an app if it is adding a lib, but for correctness we need the ensure.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
