### PR TITLE
fix(core): module federation migration for project with no targets

### DIFF
--- a/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
+++ b/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
@@ -19,7 +19,7 @@ export default async function (tree: Tree) {
 function isWebpackBrowserUsed(tree: Tree) {
   const projects = getProjects(tree);
   for (const project of projects.values()) {
-    const targets = project.targets;
+    const targets = project.targets || {};
     for (const [_, target] of Object.entries(targets)) {
       if (
         target.executor === '@nx/angular:webpack-browser' &&

--- a/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
+++ b/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.ts
@@ -19,7 +19,7 @@ export default async function (tree: Tree) {
 function hasModuleFederationProject(tree: Tree) {
   const projects = getProjects(tree);
   for (const project of projects.values()) {
-    const targets = project.targets;
+    const targets = project.targets || {};
     for (const [_, target] of Object.entries(targets)) {
       if (
         target.executor === '@nx/webpack:webpack' &&


### PR DESCRIPTION
The `add-mf-env-var-to-target-defaults` migration was failing when there is a project with no targets.