### PR TITLE
fix(core): target defaults from specifier should not be clobbered by name based target defaults

### DIFF
--- a/packages/nx/src/plugins/target-defaults/target-defaults-plugin.spec.ts
+++ b/packages/nx/src/plugins/target-defaults/target-defaults-plugin.spec.ts
@@ -295,5 +295,67 @@ describe('target-defaults plugin', () => {
         }
       `);
     });
+
+    it('should not be overridden by target name based default', () => {
+      memfs.vol.fromJSON(
+        {
+          'project.json': JSON.stringify({
+            name: 'root',
+            targets: {
+              echo: {
+                executor: 'nx:run-commands',
+                options: {
+                  command: 'echo 1',
+                },
+              },
+              echo2: {
+                executor: 'nx:run-commands',
+                options: {
+                  command: 'echo 2',
+                },
+              },
+            },
+          }),
+        },
+        '/root'
+      );
+
+      context.nxJsonConfiguration.targetDefaults = {
+        'nx:run-commands': {
+          options: {
+            cwd: '{projectRoot}',
+          },
+        },
+        echo: {},
+      };
+
+      expect(createNodesFn('project.json', undefined, context))
+        .toMatchInlineSnapshot(`
+        {
+          "projects": {
+            ".": {
+              "targets": {
+                "echo": {
+                  "options": {
+                    "cwd": "{projectRoot}",
+                  },
+                },
+                "echo2": {
+                  "options": {
+                    "cwd": "{projectRoot}",
+                  },
+                },
+                "nx:run-commands": {
+                  "options": {
+                    "cwd": "{projectRoot}",
+                  },
+                  Symbol(ONLY_MODIFIES_EXISTING_TARGET): true,
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
   });
 });

--- a/packages/nx/src/plugins/target-defaults/target-defaults-plugin.ts
+++ b/packages/nx/src/plugins/target-defaults/target-defaults-plugin.ts
@@ -85,9 +85,13 @@ export const TargetDefaultsPlugin: NxPluginV2 = {
         targetNames.add(defaultSpecifier);
 
         for (const targetName of targetNames) {
-          modifiedTargets[targetName] = structuredClone(
-            targetDefaults[defaultSpecifier]
-          );
+          // Prevents `build` from overwriting `@nx/js:tsc` if both are present
+          // and build is specified later in the ordering.
+          if (!modifiedTargets[targetName] || targetName !== defaultSpecifier) {
+            modifiedTargets[targetName] = JSON.parse(
+              JSON.stringify(targetDefaults[defaultSpecifier])
+            );
+          }
           // TODO: Remove this after we figure out a way to define new targets
           // in target defaults
           if (!projectDefinedTargets.has(targetName)) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Its possible for a target default defined as "build" to overwrite the defaults defined by "@nx/js:tsc".

## Expected Behavior
Executor based defaults have priority

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21526
Fixes #21477

