### PR TITLE
chore(misc): re-enable convert-to-monorepo test to test without Nx plugins for now

### DIFF
--- a/e2e/nx-misc/src/workspace-legacy.test.ts
+++ b/e2e/nx-misc/src/workspace-legacy.test.ts
@@ -1,0 +1,49 @@
+import {
+  checkFilesExist,
+  cleanupProject,
+  newProject,
+  runCLI,
+  runE2ETests,
+  uniq,
+} from '@nx/e2e/utils';
+
+let proj: string;
+
+describe('@nx/workspace:convert-to-monorepo', () => {
+  beforeEach(() => {
+    proj = newProject({ packages: ['@nx/react', '@nx/js'] });
+  });
+
+  afterEach(() => cleanupProject());
+
+  it('should convert a standalone webpack and jest react project to a monorepo (legacy)', async () => {
+    const reactApp = uniq('reactapp');
+    runCLI(
+      `generate @nx/react:app ${reactApp} --rootProject=true --bundler=webpack --unitTestRunner=jest --e2eTestRunner=cypress --no-interactive`,
+      {
+        env: {
+          NX_ADD_PLUGINS: 'false',
+        },
+      }
+    );
+
+    runCLI('generate @nx/workspace:convert-to-monorepo --no-interactive', {
+      env: {
+        NX_ADD_PLUGINS: 'false',
+      },
+    });
+
+    checkFilesExist(
+      `apps/${reactApp}/src/main.tsx`,
+      `apps/e2e/cypress.config.ts`
+    );
+
+    expect(() => runCLI(`build ${reactApp}`)).not.toThrow();
+    expect(() => runCLI(`test ${reactApp}`)).not.toThrow();
+    expect(() => runCLI(`lint ${reactApp}`)).not.toThrow();
+    expect(() => runCLI(`lint e2e`)).not.toThrow();
+    if (runE2ETests()) {
+      expect(() => runCLI(`e2e e2e`)).not.toThrow();
+    }
+  });
+});

--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -1,18 +1,18 @@
 import {
   checkFilesExist,
-  newProject,
-  readJson,
   cleanupProject,
-  runCLI,
-  uniq,
-  updateFile,
-  readFile,
   exists,
-  tmpProjPath,
   getPackageManagerCommand,
   getSelectedPackageManager,
+  newProject,
+  readFile,
+  readJson,
+  runCLI,
   runCommand,
   runE2ETests,
+  tmpProjPath,
+  uniq,
+  updateFile,
 } from '@nx/e2e/utils';
 import { join } from 'path';
 
@@ -24,29 +24,6 @@ describe('@nx/workspace:convert-to-monorepo', () => {
   });
 
   afterEach(() => cleanupProject());
-
-  // TODO(crystal, @jaysoo): Investigate why this test is failing
-  xit('should convert a standalone webpack and jest react project to a monorepo', async () => {
-    const reactApp = uniq('reactapp');
-    runCLI(
-      `generate @nx/react:app ${reactApp} --rootProject=true --bundler=webpack --unitTestRunner=jest --e2eTestRunner=cypress --no-interactive`
-    );
-
-    runCLI('generate @nx/workspace:convert-to-monorepo --no-interactive');
-
-    checkFilesExist(
-      `apps/${reactApp}/src/main.tsx`,
-      `apps/e2e/cypress.config.ts`
-    );
-
-    expect(() => runCLI(`build ${reactApp}`)).not.toThrow();
-    expect(() => runCLI(`test ${reactApp}`)).not.toThrow();
-    expect(() => runCLI(`lint ${reactApp}`)).not.toThrow();
-    expect(() => runCLI(`lint e2e`)).not.toThrow();
-    if (runE2ETests()) {
-      expect(() => runCLI(`e2e e2e`)).not.toThrow();
-    }
-  });
 
   it('should be convert a standalone vite and playwright react project to a monorepo', async () => {
     const reactApp = uniq('reactapp');


### PR DESCRIPTION
The webpack config doesn't need to be updated for the most part, except for maybe `output.path`. All paths are relative and should continue to be.

e.g.

```js
const { NxWebpackPlugin } = require('@nx/webpack');
const { join } = require('path');

module.exports = {
  output: {
    path: join(__dirname,  './dist/demo'),
  },
  devServer: {
    port: 4200
  },
  plugins: [
    new NxWebpackPlugin({
      tsConfig: './tsconfig.app.json',
      main: './src/main.ts',
      index: './src/index.html',
      assets: ['./src/favicon.ico']
    })
  ],
};
```

We'll circle back to this with a proper design after Nx 18 release.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
