### PR TITLE
chore(misc): re-enable nx init tests

### DIFF
--- a/e2e/nx-init/src/nx-init-react.test.ts
+++ b/e2e/nx-init/src/nx-init-react.test.ts
@@ -64,8 +64,7 @@ describe('nx init (for React - legacy)', () => {
     checkFilesExist(`dist/apps/${appName}/index.html`);
   });
 
-  // TODO(crystal, @jaysoo): Investigate why this is failing
-  xit('should convert to an integrated workspace with Vite', () => {
+  it('should convert to an integrated workspace with Vite', () => {
     // TODO investigate why this is broken
     const originalPM = process.env.SELECTED_PM;
     process.env.SELECTED_PM = originalPM === 'pnpm' ? 'yarn' : originalPM;
@@ -97,8 +96,7 @@ describe('nx init (for React - legacy)', () => {
     process.env.SELECTED_PM = originalPM;
   });
 
-  // TODO(crystal, @jaysoo): Investigate why this is failing
-  xit('should convert to an integrated workspace with Vite with custom port', () => {
+  it('should convert to an integrated workspace with Vite with custom port', () => {
     // TODO investigate why this is broken
     const originalPM = process.env.SELECTED_PM;
     process.env.SELECTED_PM = originalPM === 'pnpm' ? 'yarn' : originalPM;


### PR DESCRIPTION
They are passing locally, maybe fixed by another PR?

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
