### PR TITLE
fix(graph): fix openen project details with expanded target from external api

### DIFF
--- a/graph/client/src/app/external-api-impl.ts
+++ b/graph/client/src/app/external-api-impl.ts
@@ -81,8 +81,10 @@ export class ExternalApiImpl extends ExternalApi {
     }
   }
 
-  openProjectDetails(projectName: string, targetName?: string) {
-    this.router.navigate(`/project-details/${encodeURIComponent(projectName)}`);
+  async openProjectDetails(projectName: string, targetName?: string) {
+    await this.router.navigate(
+      `/project-details/${encodeURIComponent(projectName)}`
+    );
     if (targetName) {
       this.focusTargetInProjectDetails(targetName);
     }


### PR DESCRIPTION
This fixes the PDV integration in console which uses this feature.
The location was being reloaded before the navigation completed.