### PR TITLE
fix(nextjs): nextjs standalone playwright linting

### DIFF
--- a/e2e/next-extensions/src/next-playwright-standalone-eslint.test.ts
+++ b/e2e/next-extensions/src/next-playwright-standalone-eslint.test.ts
@@ -1,0 +1,36 @@
+import {
+  cleanupProject,
+  fileExists,
+  getSelectedPackageManager,
+  runCLI,
+  runCreateWorkspace,
+  uniq,
+} from '@nx/e2e/utils';
+
+// This test exists as coverage for a previous regression
+describe('nextjs standalone playwright linting', () => {
+  const packageManager = getSelectedPackageManager() || 'pnpm';
+
+  afterEach(() => cleanupProject());
+
+  it('should work', async () => {
+    const wsName = uniq('next');
+    const appName = uniq('app');
+    runCreateWorkspace(wsName, {
+      preset: 'nextjs-standalone',
+      style: 'css',
+      nextAppDir: true,
+      nextSrcDir: true,
+      appName,
+      packageManager,
+      e2eTestRunner: 'playwright',
+    });
+    // Ensure that the expected standalone setup is correct
+    expect(fileExists('.eslintrc.base.json')).toBe(false);
+
+    const output = runCLI(`lint ${appName}`);
+    expect(output).toContain(
+      `Successfully ran target lint for project ${appName}`
+    );
+  });
+});

--- a/packages/next/src/generators/application/lib/add-e2e.ts
+++ b/packages/next/src/generators/application/lib/add-e2e.ts
@@ -52,6 +52,7 @@ export async function addE2e(host: Tree, options: NormalizedSchema) {
       implicitDependencies: [options.projectName],
     });
     return configurationGenerator(host, {
+      rootProject: options.rootProject,
       project: options.e2eProjectName,
       skipFormat: true,
       skipPackageJson: options.skipPackageJson,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A standalone nextjs workspace, when playwright is the chose e2e test runner, cannot run eslint.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

A standalone nextjs workspace, when playwright is the chose e2e test runner, can run eslint.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
