### PR TITLE
fix(workspace): explicitly call `complete-ci-run` in generated CI config

### DIFF
--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -32,6 +32,7 @@ jobs:
 
       - script: npx nx-cloud record -- nx format:check --base=$(BASE_SHA) --head=$(HEAD_SHA)
       - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t=lint,test,build
+      - script: npx nx-cloud complete-ci-run
 "
 `;
 
@@ -58,6 +59,7 @@ pipelines:
 
                 - npx nx-cloud record -- nx format:check
                 - npx nx affected -t=lint,test,build
+                - npx nx-cloud complete-ci-run
 "
 `;
 
@@ -84,6 +86,7 @@ jobs:
 
       - run: npx nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
       - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD -t=lint,test,build
+      - run: npx nx-cloud complete-ci-run
 
 workflows:
   version: 2
@@ -129,6 +132,7 @@ jobs:
 
       - run: npx nx-cloud record -- nx format:check
       - run: npx nx affected -t=lint,test,build
+      - run: npx nx-cloud complete-ci-run
 "
 `;
 
@@ -167,6 +171,7 @@ jobs:
 
       - run: npx nx-cloud record -- nx format:check
       - run: npx nx affected -t=lint,test,build
+      - run: npx nx-cloud complete-ci-run
 "
 `;
 
@@ -192,6 +197,7 @@ CI:
 
     - npx nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
     - npx nx affected --base=$NX_BASE --head=$NX_HEAD -t=lint,test,build
+    - npx nx-cloud complete-ci-run
 "
 `;
 
@@ -231,6 +237,7 @@ jobs:
 
       - script: pnpm exec nx-cloud record -- nx format:check --base=$(BASE_SHA) --head=$(HEAD_SHA)
       - script: pnpm exec nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t=lint,test,build
+      - script: pnpm exec nx-cloud complete-ci-run
 "
 `;
 
@@ -259,6 +266,7 @@ pipelines:
 
                 - pnpm exec nx-cloud record -- nx format:check
                 - pnpm exec nx affected -t=lint,test,build
+                - pnpm exec nx-cloud complete-ci-run
 "
 `;
 
@@ -288,6 +296,7 @@ jobs:
 
       - run: pnpm exec nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
       - run: pnpm exec nx affected --base=$NX_BASE --head=$NX_HEAD -t=lint,test,build
+      - run: pnpm exec nx-cloud complete-ci-run
 
 workflows:
   version: 2
@@ -336,6 +345,7 @@ jobs:
 
       - run: pnpm exec nx-cloud record -- nx format:check
       - run: pnpm exec nx affected -t=lint,test,build
+      - run: pnpm exec nx-cloud complete-ci-run
 "
 `;
 
@@ -377,6 +387,7 @@ jobs:
 
       - run: pnpm exec nx-cloud record -- nx format:check
       - run: pnpm exec nx affected -t=lint,test,build
+      - run: pnpm exec nx-cloud complete-ci-run
 "
 `;
 
@@ -404,6 +415,7 @@ CI:
 
     - pnpm exec nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
     - pnpm exec nx affected --base=$NX_BASE --head=$NX_HEAD -t=lint,test,build
+    - pnpm exec nx-cloud complete-ci-run
 "
 `;
 
@@ -441,6 +453,7 @@ jobs:
 
       - script: yarn nx-cloud record -- nx format:check --base=$(BASE_SHA) --head=$(HEAD_SHA)
       - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t=lint,test,build
+      - script: yarn nx-cloud complete-ci-run
 "
 `;
 
@@ -467,6 +480,7 @@ pipelines:
 
                 - yarn nx-cloud record -- nx format:check
                 - yarn nx affected -t=lint,test,build
+                - yarn nx-cloud complete-ci-run
 "
 `;
 
@@ -493,6 +507,7 @@ jobs:
 
       - run: yarn nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
       - run: yarn nx affected --base=$NX_BASE --head=$NX_HEAD -t=lint,test,build
+      - run: yarn nx-cloud complete-ci-run
 
 workflows:
   version: 2
@@ -538,6 +553,7 @@ jobs:
 
       - run: yarn nx-cloud record -- nx format:check
       - run: yarn nx affected -t=lint,test,build
+      - run: yarn nx-cloud complete-ci-run
 "
 `;
 
@@ -576,6 +592,7 @@ jobs:
 
       - run: yarn nx-cloud record -- nx format:check
       - run: yarn nx affected -t=lint,test,build
+      - run: yarn nx-cloud complete-ci-run
 "
 `;
 
@@ -601,6 +618,7 @@ CI:
 
     - yarn nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
     - yarn nx affected --base=$NX_BASE --head=$NX_HEAD -t=lint,test,build
+    - yarn nx-cloud complete-ci-run
 "
 `;
 

--- a/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
@@ -32,3 +32,4 @@ jobs:
 
       - script: <%= packageManagerPrefix %> nx-cloud record -- nx format:check --base=$(BASE_SHA) --head=$(HEAD_SHA)
       - script: <%= packageManagerPrefix %> nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t=lint,test,build
+      - script: <%= packageManagerPrefix %> nx-cloud complete-ci-run

--- a/packages/workspace/src/generators/ci-workflow/files/bitbucket-pipelines/bitbucket-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/bitbucket-pipelines/bitbucket-pipelines.yml__tmpl__
@@ -23,3 +23,4 @@ pipelines:
 
                 - <%= packageManagerPrefix %> nx-cloud record -- nx format:check
                 - <%= packageManagerPrefix %> nx affected -t=lint,test,build
+                - <%= packageManagerPrefix %> nx-cloud complete-ci-run

--- a/packages/workspace/src/generators/ci-workflow/files/circleci/.circleci/config.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/circleci/.circleci/config.yml__tmpl__
@@ -24,6 +24,7 @@ jobs:
 
       - run: <%= packageManagerPrefix %> nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
       - run: <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD -t=lint,test,build
+      - run: <%= packageManagerPrefix %> nx-cloud complete-ci-run
 
 workflows:
   version: 2

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -36,3 +36,4 @@ jobs:
 
       - run: <%= packageManagerPrefix %> nx-cloud record -- nx format:check
       - run: <%= packageManagerPrefix %> nx affected -t=lint,test,build
+      - run: <%= packageManagerPrefix %> nx-cloud complete-ci-run

--- a/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
@@ -22,3 +22,4 @@ variables:
 
     - <%= packageManagerPrefix %> nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
     - <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD -t=lint,test,build
+    - <%= packageManagerPrefix %> nx-cloud complete-ci-run


### PR DESCRIPTION
We will remove this for 18.1, when heartbeat should be released

## Current Behavior
Generated workflow configurations will not report status to cloud correctly

## Expected Behavior
Generated workflow configurations will report status to cloud correctly

