### PR TITLE
chore(nextjs): remove tests that are unnecessary

### DIFF
--- a/e2e/next-extensions/src/utils.ts
+++ b/e2e/next-extensions/src/utils.ts
@@ -34,12 +34,6 @@ export async function checkApp(
   expect(buildResult).toContain(`Successfully ran target build`);
   checkFilesExist(`${appsDir}/${appName}/.next/build-manifest.json`);
 
-  // TODO(crystal, @ndcunningham): Investigate if this file is correct
-  // const packageJson = readJson(`${appsDir}/${appName}/.next/package.json`);
-  // expect(packageJson.dependencies.react).toBeDefined();
-  // expect(packageJson.dependencies['react-dom']).toBeDefined();
-  // expect(packageJson.dependencies.next).toBeDefined();
-
   if (opts.checkE2E && runE2ETests()) {
     const e2eResults = runCLI(
       `e2e ${appName}-e2e --no-watch --configuration=production`


### PR DESCRIPTION
The `package.json` check is not needed since we're not testing our executor here (just Next.js CLI), and we already cover  the legacy executor cases in the `e2e-next-core` suite.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
