### PR TITLE
fix(core): handle spaces when launching nxFork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,6 +1561,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-filterer-ignore",
  "watchexec-signals",
+ "winapi",
  "xxhash-rust",
 ]
 

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -44,6 +44,9 @@ swc_ecma_visit = "0.93.0"
 swc_ecma_ast = "0.107.0"
 crossterm = "0.27.0"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["fileapi"] }
+
 [lib]
 crate-type = ['cdylib']
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When trying to call `nxFork` in a directory that has a space, script interpreters are unable to locate the file because it parses the space as a separate argument

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We now wrap nxFork arguments that have a space with double quotes on unix, and use the `GetShortPathNameW` Windows API to get the directory short name in Windows. 
> The command that gets built for `nxFork` will look like these:
> * Windows: `node C:\dev\triage\TESTSP~1\NODE_M~1\nx\src\TASKS-~1\fork.js \\.\pipe\nx\C:\Users\jon\AppData\Local\Temp\b4f70514e449658222c6\fp11424.sock test:build:production`
> * Unix: `node "/workspaces/test space/nx" /temp/f11424.sock test:build:production`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/21462
