### PR TITLE
chore(core): fix loading config files with swc

### DIFF
--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -1,9 +1,8 @@
-import { dirname, extname, join } from 'path';
+import { dirname, extname, join, relative } from 'path';
 import { existsSync, readdirSync } from 'fs';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { workspaceRoot } from 'nx/src/devkit-exports';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { registerTsProject } from 'nx/src/plugins/js/utils/register';
+import { requireNx } from '../../nx';
+
+const { workspaceRoot, registerTsProject } = requireNx();
 
 export let dynamicImport = new Function(
   'modulePath',
@@ -22,7 +21,12 @@ export async function loadConfigFile<T extends object = any>(
         ? join(dirname(configFilePath), 'tsconfig.json')
         : getRootTsConfigPath();
       if (tsConfigPath) {
-        const unregisterTsProject = registerTsProject(tsConfigPath);
+        const unregisterTsProject = registerTsProject(
+          tsConfigPath,
+          undefined,
+          // TODO(@AgentEnder): Remove this hack to make sure that e2e loads properly for next.js
+          relative(workspaceRoot, dirname(configFilePath)) === 'e2e'
+        );
         try {
           module = await load(configFilePath);
         } finally {

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -20,3 +20,4 @@ export {
   createProjectRootMappingsFromProjectConfigurations,
   findProjectForPath,
 } from './project-graph/utils/find-project-for-path';
+export { registerTsProject } from './plugins/js/utils/register';

--- a/packages/playwright/plugin.ts
+++ b/packages/playwright/plugin.ts
@@ -1,1 +1,5 @@
-export { createNodes, PlaywrightPluginOptions } from './src/plugins/plugin';
+export {
+  createNodes,
+  PlaywrightPluginOptions,
+  createDependencies,
+} from './src/plugins/plugin';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When we use `swc-node` to load ts files, we may not register the actual config which is requested.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

swc node is used properly to load ts files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
