### PR TITLE
fix(core): nx cloud prompt during migrate doesn't skip connection

### DIFF
--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -67,7 +67,8 @@ export async function connectToNxCloudCommand(): Promise<boolean> {
 
 export async function connectToNxCloudWithPrompt(command: string) {
   const setNxCloud = await nxCloudPrompt('setupNxCloud');
-  const useCloud = setNxCloud ? await connectToNxCloudCommand() : false;
+  const useCloud =
+    setNxCloud === 'yes' ? await connectToNxCloudCommand() : false;
   await recordStat({
     command,
     nxVersion,


### PR DESCRIPTION
## Current Behavior
The migrate prompt for Nx Cloud always connects to Nx Cloud, regardless of answer.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The migrate prompt for Nx Cloud skips the Nx Cloud connection when requested.
