### PR TITLE
fix(core): add missing prettier dependency

### DIFF
--- a/packages/nx/.eslintrc.json
+++ b/packages/nx/.eslintrc.json
@@ -95,7 +95,6 @@
               "memfs", // used in mock for handling .node files in tests
               "events", // This is coming from @storybook/builder-manager since it uses the browser polyfill
               "process", // This is coming from @storybook/builder-manager since it uses the browser polyfill
-              "prettier", // This is coming from @storybook/builder-manager since it uses the browser polyfill
               "util" // This is coming from @storybook/builder-manager since it uses the browser polyfill
             ]
           }

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -55,6 +55,7 @@
     "minimatch": "9.0.3",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",
+    "prettier": "^2.6.2",
     "semver": "^7.5.3",
     "string-width": "^4.2.3",
     "strong-log-transformer": "^2.1.0",


### PR DESCRIPTION
Prettier is used in format command and there fore must be explicitly specified in the package.json

cc @jaysoo 

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
