### PR TITLE
feat(remix): add playwright option for e2eTestRunner

### DIFF
--- a/docs/generated/packages/remix/generators/application.json
+++ b/docs/generated/packages/remix/generators/application.json
@@ -45,7 +45,7 @@
       },
       "e2eTestRunner": {
         "type": "string",
-        "enum": ["cypress", "none"],
+        "enum": ["cypress", "playwright", "none"],
         "default": "cypress",
         "description": "Test runner to use for e2e tests"
       },

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -144,7 +144,7 @@ export default function Index() {
 "
 `;
 
-exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --e2eTestRunner should generate an e2e application for the app 1`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --e2eTestRunner should generate a cypress e2e application for the app 1`] = `
 "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 
 import { defineConfig } from 'cypress';
@@ -154,6 +154,79 @@ export default defineConfig({
     ...nxE2EPreset(__filename, { cypressDir: 'src' }),
     baseUrl: 'http://localhost:4200',
   },
+});
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --e2eTestRunner should generate a playwright e2e application for the app 1`] = `
+"import { defineConfig, devices } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
+
+import { workspaceRoot } from '@nx/devkit';
+
+// For CI, you may want to set BASE_URL to the deployed application.
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  ...nxE2EPreset(__filename, { testDir: './src' }),
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    baseURL,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm exec nx serve test',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    cwd: workspaceRoot,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    // Uncomment for mobile browsers support
+    /* {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    }, */
+
+    // Uncomment for branded browsers
+    /* {
+      name: 'Microsoft Edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    },
+    {
+      name: 'Google Chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    } */
+  ],
 });
 "
 `;
@@ -549,7 +622,7 @@ export default function Index() {
 "
 `;
 
-exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --e2eTestRunner should generate an e2e application for the app 1`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --e2eTestRunner should generate a cypress e2e application for the app 1`] = `
 "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 
 import { defineConfig } from 'cypress';
@@ -559,6 +632,79 @@ export default defineConfig({
     ...nxE2EPreset(__filename, { cypressDir: 'src' }),
     baseUrl: 'http://localhost:4200',
   },
+});
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --e2eTestRunner should generate a playwright e2e application for the app 1`] = `
+"import { defineConfig, devices } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
+
+import { workspaceRoot } from '@nx/devkit';
+
+// For CI, you may want to set BASE_URL to the deployed application.
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  ...nxE2EPreset(__filename, { testDir: './src' }),
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    baseURL,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm exec nx serve test',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    cwd: workspaceRoot,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    // Uncomment for mobile browsers support
+    /* {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    }, */
+
+    // Uncomment for branded browsers
+    /* {
+      name: 'Microsoft Edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    },
+    {
+      name: 'Google Chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    } */
+  ],
 });
 "
 `;
@@ -810,7 +956,7 @@ export default function Index() {
 "
 `;
 
-exports[`Remix Application Standalone Project Repo --e2eTestRunner should generate an e2e application for the app 1`] = `
+exports[`Remix Application Standalone Project Repo --e2eTestRunner should generate a cypress e2e application for the app 1`] = `
 "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 
 import { defineConfig } from 'cypress';
@@ -1155,5 +1301,78 @@ exports[`Remix Application Standalone Project Repo should create the application
     }
   ]
 }
+"
+`;
+
+exports[`Remix Application Standalone Project Repo should generate a playwright e2e application for the app 1`] = `
+"import { defineConfig, devices } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
+
+import { workspaceRoot } from '@nx/devkit';
+
+// For CI, you may want to set BASE_URL to the deployed application.
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  ...nxE2EPreset(__filename, { testDir: './src' }),
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    baseURL,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm exec nx serve test',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    cwd: workspaceRoot,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    // Uncomment for mobile browsers support
+    /* {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    }, */
+
+    // Uncomment for branded browsers
+    /* {
+      name: 'Microsoft Edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    },
+    {
+      name: 'Google Chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    } */
+  ],
+});
 "
 `;

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -103,7 +103,7 @@ describe('Remix Application', () => {
     });
 
     describe('--e2eTestRunner', () => {
-      it('should generate an e2e application for the app', async () => {
+      it('should generate a cypress e2e application for the app', async () => {
         // ARRANGE
         const tree = createTreeWithEmptyWorkspace();
 
@@ -120,6 +120,24 @@ describe('Remix Application', () => {
 
         expect(tree.read('e2e/cypress.config.ts', 'utf-8')).toMatchSnapshot();
       });
+    });
+
+    it('should generate a playwright e2e application for the app', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+
+      // ACT
+      await applicationGenerator(tree, {
+        name: 'test',
+        e2eTestRunner: 'playwright',
+        rootProject: true,
+        addPlugin: true,
+      });
+
+      // ASSERT
+      expectTargetsToBeCorrect(tree, '.');
+
+      expect(tree.read('e2e/playwright.config.ts', 'utf-8')).toMatchSnapshot();
     });
   });
 
@@ -294,7 +312,7 @@ describe('Remix Application', () => {
       });
 
       describe('--e2eTestRunner', () => {
-        it('should generate an e2e application for the app', async () => {
+        it('should generate a cypress e2e application for the app', async () => {
           // ARRANGE
           const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
@@ -311,6 +329,26 @@ describe('Remix Application', () => {
 
           expect(
             tree.read(`${appDir}-e2e/cypress.config.ts`, 'utf-8')
+          ).toMatchSnapshot();
+        });
+
+        it('should generate a playwright e2e application for the app', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+          // ACT
+          await applicationGenerator(tree, {
+            name: 'test',
+            e2eTestRunner: 'playwright',
+            projectNameAndRootFormat,
+            addPlugin: true,
+          });
+
+          // ASSERT
+          expectTargetsToBeCorrect(tree, appDir);
+
+          expect(
+            tree.read(`${appDir}-e2e/playwright.config.ts`, 'utf-8')
           ).toMatchSnapshot();
         });
       });

--- a/packages/remix/src/generators/application/lib/add-e2e.ts
+++ b/packages/remix/src/generators/application/lib/add-e2e.ts
@@ -1,0 +1,86 @@
+import {
+  type Tree,
+  addProjectConfiguration,
+  joinPathFragments,
+  readProjectConfiguration,
+  updateProjectConfiguration,
+  ensurePackage,
+  getPackageManagerCommand,
+} from '@nx/devkit';
+import { type NormalizedSchema } from './normalize-options';
+import { getPackageVersion } from '../../../utils/versions';
+
+export async function addE2E(tree: Tree, options: NormalizedSchema) {
+  if (options.e2eTestRunner === 'cypress') {
+    const { configurationGenerator } = ensurePackage<
+      typeof import('@nx/cypress')
+    >('@nx/cypress', getPackageVersion(tree, 'nx'));
+
+    addFileServerTarget(tree, options, 'serve-static');
+
+    addProjectConfiguration(tree, options.e2eProjectName, {
+      projectType: 'application',
+      root: options.e2eProjectRoot,
+      sourceRoot: joinPathFragments(options.e2eProjectRoot, 'src'),
+      targets: {},
+      tags: [],
+      implicitDependencies: [options.projectName],
+    });
+
+    return await configurationGenerator(tree, {
+      project: options.e2eProjectName,
+      directory: 'src',
+      skipFormat: true,
+      devServerTarget: `${options.projectName}:serve:development`,
+      baseUrl: 'http://localhost:4200',
+      addPlugin: options.addPlugin,
+    });
+  } else if (options.e2eTestRunner === 'playwright') {
+    const { configurationGenerator } = ensurePackage<
+      typeof import('@nx/playwright')
+    >('@nx/playwright', getPackageVersion(tree, 'nx'));
+
+    addProjectConfiguration(tree, options.e2eProjectName, {
+      projectType: 'application',
+      root: options.e2eProjectRoot,
+      sourceRoot: joinPathFragments(options.e2eProjectRoot, 'src'),
+      targets: {},
+      tags: [],
+      implicitDependencies: [options.projectName],
+    });
+
+    return configurationGenerator(tree, {
+      project: options.e2eProjectName,
+      skipFormat: true,
+      skipPackageJson: false,
+      directory: 'src',
+      js: false,
+      linter: options.linter,
+      setParserOptionsProject: false,
+      webServerCommand: `${getPackageManagerCommand().exec} nx serve ${
+        options.name
+      }`,
+      webServerAddress: 'http://localhost:4200',
+      rootProject: options.rootProject,
+      addPlugin: options.addPlugin,
+    });
+  } else {
+    return () => {};
+  }
+}
+
+function addFileServerTarget(
+  tree: Tree,
+  options: NormalizedSchema,
+  targetName: string
+) {
+  const projectConfig = readProjectConfiguration(tree, options.projectName);
+  projectConfig.targets[targetName] = {
+    executor: '@nx/web:file-server',
+    options: {
+      buildTarget: `${options.projectName}:build`,
+      port: 4200,
+    },
+  };
+  updateProjectConfiguration(tree, options.projectName, projectConfig);
+}

--- a/packages/remix/src/generators/application/lib/index.ts
+++ b/packages/remix/src/generators/application/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './normalize-options';
 export * from './update-unit-test-config';
+export * from './add-e2e';

--- a/packages/remix/src/generators/application/schema.d.ts
+++ b/packages/remix/src/generators/application/schema.d.ts
@@ -9,7 +9,7 @@ export interface NxRemixGeneratorSchema {
   projectNameAndRootFormat?: ProjectNameAndRootFormat;
   linter?: Linter;
   unitTestRunner?: 'vitest' | 'jest' | 'none';
-  e2eTestRunner?: 'cypress' | 'none';
+  e2eTestRunner?: 'cypress' | 'playwright' | 'none';
   skipFormat?: boolean;
   rootProject?: boolean;
   addPlugin?: boolean;

--- a/packages/remix/src/generators/application/schema.json
+++ b/packages/remix/src/generators/application/schema.json
@@ -45,7 +45,7 @@
     },
     "e2eTestRunner": {
       "type": "string",
-      "enum": ["cypress", "none"],
+      "enum": ["cypress", "playwright", "none"],
       "default": "cypress",
       "description": "Test runner to use for e2e tests"
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We only offer `cypress` for the e2e test runner for Remix applications

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should offer both `cypress` and `playwright` for the e2e test runner for Remix applications

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
