### PR TITLE
cleanup(testing): re-enable cypress e2e tests

### DIFF
--- a/e2e/cypress/src/cypress-legacy.test.ts
+++ b/e2e/cypress/src/cypress-legacy.test.ts
@@ -9,8 +9,7 @@ import {
 
 const TEN_MINS_MS = 600_000;
 
-// TODO(crystal, @leosvelperez): Still need to investigate why this is failing on CI
-xdescribe('Cypress E2E Test runner (legacy)', () => {
+describe('Cypress E2E Test runner (legacy)', () => {
   beforeAll(() => {
     newProject({ packages: ['@nx/angular', '@nx/react'] });
   });

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -12,8 +12,8 @@ import {
 } from '@nx/e2e/utils';
 
 const TEN_MINS_MS = 600_000;
-// TODO(crystal, @leosvelperez): Still need to investigate why this is failing on CI
-xdescribe('Cypress E2E Test runner', () => {
+
+describe('Cypress E2E Test runner', () => {
   const myapp = uniq('myapp');
 
   beforeAll(() => {

--- a/e2e/utils/process-utils.ts
+++ b/e2e/utils/process-utils.ts
@@ -13,14 +13,15 @@ export const promisifiedTreeKill: (
 
 export async function killPort(port: number): Promise<boolean> {
   if (await portCheck(port)) {
+    let killPortResult;
     try {
       logInfo(`Attempting to close port ${port}`);
-      await kill(port);
+      killPortResult = await kill(port);
       await new Promise<void>((resolve) =>
         setTimeout(() => resolve(), KILL_PORT_DELAY)
       );
       if (await portCheck(port)) {
-        logError(`Port ${port} still open`);
+        logError(`Port ${port} still open`, JSON.stringify(killPortResult));
       } else {
         logSuccess(`Port ${port} successfully closed`);
         return true;


### PR DESCRIPTION
- Re-enables the `e2e-cypress` tests
- Adds extra logging for when a port can't be killed for easier troubleshooting in the future

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
