### PR TITLE
fix(core): pass the full resolved path of ts-node/esm when reloading the CLI

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -236,7 +236,7 @@ function execArgvWithExperimentalLoaderOptions() {
     ...process.execArgv,
     '--no-warnings',
     '--experimental-loader',
-    'ts-node/esm',
+    require.resolve('ts-node/esm'),
   ];
 }
 


### PR DESCRIPTION
When we reload the process for Node 18 in order to support ESM `.ts` files, we need to pass the fully resolved path. Otherwise, the `--loader ts-node/esm` option may error out when it is not hoisted.

## Current Behavior
If you try to run Nx CLI in a repo that does not have `ts-node` hoisted to the top-level `node_modules`, it will error out like this:

```Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ts-node' imported from /private/tmp/tic-tac-toe-playwright/
Did you mean to import ts-node@10.9.1_@swc+core@1.3.107_@types+node@18.19.14_typescript@5.3.3/node_modules/ts-node/esm.mjs?
    at new NodeError (node:internal/errors:405:5)
    at packageResolve (node:internal/modules/esm/resolve:890:9)
    at moduleResolve (node:internal/modules/esm/resolve:939:20)
    at defaultResolve (node:internal/modules/esm/resolve:1132:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:835:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:524:22)
    at loadModulesInIsolation (node:internal/process/esm_loader:92:34)
    at initializeLoader (node:internal/process/esm_loader:61:25) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx CLI should reload correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
