### PR TITLE
fix(nextjs): move `next/constants` from top-level import to when it is needed

### DIFF
--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -15,7 +15,6 @@ import { existsSync, readdirSync } from 'fs';
 
 import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
-import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 import { getLockFileName } from '@nx/js';
 
 export interface NextPluginOptions {
@@ -155,6 +154,7 @@ function getStartTargetConfig(options: NextPluginOptions, projectRoot: string) {
 
 async function getOutputs(projectRoot, nextConfig) {
   let dir = '.next';
+  const { PHASE_PRODUCTION_BUILD } = require('next/constants');
 
   if (typeof nextConfig === 'function') {
     // Works for both async and sync functions.


### PR DESCRIPTION
If you create a new Nx workspace without `@nx/next` plugin, then run `nx add @nx/next` it will error out due to a missing `next/constants` import. This is because `next` has not been installed via the init generator yet.

## Current Behavior

`nx add @nx/next` should breaks.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx add @nx/next` should work.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
