### PR TITLE
chore(repo): install lsof and other e2e deps

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -21,7 +21,10 @@ launch-templates:
             ~/.cache/Cypress
             ~/.pnpm-store
           BASE_BRANCH: 'master'
-
+      - name: Install e2e deps
+        script: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates lsof
       - name: Install Pnpm
         script: |
           npm install -g @pnpm/exe@8.7.4


### PR DESCRIPTION
`lsof` and `ca-certificates` are also installed on the [main circle agent](https://github.com/nrwl/nx/blob/master/.circleci/config.yml#L96)

and some agents are failing with this error:

```
{
  "stdout": "",
  "stderr": "sh: 1: lsof: not found\n\nUsage:\n kill [options] <pid> [...]\n\nOptions:\n <pid> [...]            send signal to every <pid> listed\n -<signal>, -s, --signal <signal>\n                        specify the <signal> to be sent\n -q, --queue <value>    integer value to be sent with the signal\n -l, --list=[<signal>]  list all signal names, or convert one to a name\n -L, --table            list all signal names in a nice table\n\n -h, --help     display this help and exit\n -V, --version  output version information and exit\n\nFor more details see kill(1).\n",
  "cmd": "lsof -i tcp:4200 | grep LISTEN | awk '{print $2}' | xargs kill -9",
  "code": 123
}
```