### PR TITLE
docs(nx-cloud): add troubleshooting section for "ci execution failed"

### DIFF
--- a/docs/generated/manifests/ci.json
+++ b/docs/generated/manifests/ci.json
@@ -676,6 +676,29 @@
         "tags": []
       },
       {
+        "id": "troubleshooting",
+        "name": "Troubleshooting",
+        "description": "Learn how to solve common issues in Nx Cloud.",
+        "mediaImage": "",
+        "file": "",
+        "itemList": [
+          {
+            "id": "ci-execution-failed",
+            "name": "CI Execution Failed",
+            "description": "",
+            "mediaImage": "",
+            "file": "nx-cloud/troubleshooting/ci-execution-failed",
+            "itemList": [],
+            "isExternal": false,
+            "path": "/ci/recipes/troubleshooting/ci-execution-failed",
+            "tags": []
+          }
+        ],
+        "isExternal": false,
+        "path": "/ci/recipes/troubleshooting",
+        "tags": []
+      },
+      {
         "id": "other",
         "name": "Other",
         "description": "Learn how to set up Nx Cloud for your workspace.",
@@ -1222,6 +1245,40 @@
     "itemList": [],
     "isExternal": false,
     "path": "/ci/recipes/on-premise/advanced-config",
+    "tags": []
+  },
+  "/ci/recipes/troubleshooting": {
+    "id": "troubleshooting",
+    "name": "Troubleshooting",
+    "description": "Learn how to solve common issues in Nx Cloud.",
+    "mediaImage": "",
+    "file": "",
+    "itemList": [
+      {
+        "id": "ci-execution-failed",
+        "name": "CI Execution Failed",
+        "description": "",
+        "mediaImage": "",
+        "file": "nx-cloud/troubleshooting/ci-execution-failed",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/ci/recipes/troubleshooting/ci-execution-failed",
+        "tags": []
+      }
+    ],
+    "isExternal": false,
+    "path": "/ci/recipes/troubleshooting",
+    "tags": []
+  },
+  "/ci/recipes/troubleshooting/ci-execution-failed": {
+    "id": "ci-execution-failed",
+    "name": "CI Execution Failed",
+    "description": "",
+    "mediaImage": "",
+    "file": "nx-cloud/troubleshooting/ci-execution-failed",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/ci/recipes/troubleshooting/ci-execution-failed",
     "tags": []
   },
   "/ci/recipes/other": {

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -6145,6 +6145,23 @@
             "disableCollapsible": false
           },
           {
+            "name": "Troubleshooting",
+            "path": "/ci/recipes/troubleshooting",
+            "id": "troubleshooting",
+            "isExternal": false,
+            "children": [
+              {
+                "name": "CI Execution Failed",
+                "path": "/ci/recipes/troubleshooting/ci-execution-failed",
+                "id": "ci-execution-failed",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
+              }
+            ],
+            "disableCollapsible": false
+          },
+          {
             "name": "Other",
             "path": "/ci/recipes/other",
             "id": "other",
@@ -6540,6 +6557,31 @@
         "name": "Advanced Configuration",
         "path": "/ci/recipes/on-premise/advanced-config",
         "id": "advanced-config",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Troubleshooting",
+        "path": "/ci/recipes/troubleshooting",
+        "id": "troubleshooting",
+        "isExternal": false,
+        "children": [
+          {
+            "name": "CI Execution Failed",
+            "path": "/ci/recipes/troubleshooting/ci-execution-failed",
+            "id": "ci-execution-failed",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          }
+        ],
+        "disableCollapsible": false
+      },
+      {
+        "name": "CI Execution Failed",
+        "path": "/ci/recipes/troubleshooting/ci-execution-failed",
+        "id": "ci-execution-failed",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/map.json
+++ b/docs/map.json
@@ -1900,6 +1900,18 @@
               ]
             },
             {
+              "name": "Troubleshooting",
+              "id": "troubleshooting",
+              "description": "Learn how to solve common issues in Nx Cloud.",
+              "itemList": [
+                {
+                  "name": "CI Execution Failed",
+                  "id": "ci-execution-failed",
+                  "file": "nx-cloud/troubleshooting/ci-execution-failed"
+                }
+              ]
+            },
+            {
               "name": "Other",
               "id": "other",
               "description": "Learn how to set up Nx Cloud for your workspace.",

--- a/docs/nx-cloud/reference/nx-cloud-cli.md
+++ b/docs/nx-cloud/reference/nx-cloud-cli.md
@@ -86,7 +86,7 @@ individual commands as follows:
 
 ## npx nx-cloud stop-all-agents
 
-Same as `npx nx-cloud complete-ci-run` and `npx nx-cloud complete-run-group`.
+Same as `npx nx-cloud complete-ci-run`.
 
 This command tells Nx Cloud to terminate all agents associated with this CI pipeline execution.
 Invoking this command is not needed anymore. New versions of Nx Cloud can track when the main job terminates

--- a/docs/nx-cloud/troubleshooting/ci-execution-failed.md
+++ b/docs/nx-cloud/troubleshooting/ci-execution-failed.md
@@ -1,0 +1,62 @@
+# Understanding 'CI Execution Failed'
+
+## Task Runner-Related
+
+### No additional tasks detected
+
+Nx Cloud is not aware of any more tasks to distribute. This can occur if Nx Cloud thinks it is done receiving tasks to distribute and all existing tasks have been completed.
+
+If you are receiving this error before your full pipeline has completed, consider using [--stop-agents-after](https://nx.dev/ci/reference/nx-cloud-cli#stopagentsafter) with the target set to the last target run in your pipeline.
+
+### The Nx Cloud heartbeat process failed to report its status in time
+
+While running in CI environments, Nx Cloud spawns a background process called the "heartbeat" to help maintain status synchronization between itself and external platforms. When the heartbeat process does not report to Nx Cloud for 30 seconds or longer, Nx Cloud assumes something has gone wrong and terminates the current CI Pipeline Execution.
+
+This behavior can be disabled by setting the [--require-explicit-completion](https://nx.dev/ci/reference/nx-cloud-cli#requireexplicitcompletion) flag to `true` on your `nx-cloud start-ci-run` command.
+
+### A command was issued to stop all Nx Cloud agents
+
+Nx Cloud provides two commands to forcibly stop agents, [stop-all-agents and complete-ci-run](https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-stopallagents).
+
+Once these commands are invoked, the current CI Pipeline Execution is closed and can no longer receive new work.
+
+### Nx Cloud agents were stopped due to an error
+
+Nx Cloud detected a failed task in the current CI Pipeline Execution and has halted further execution.
+
+This behavior can be disabled by setting the [--stop-agents-on-failure](https://nx.dev/ci/reference/nx-cloud-cli#stopagentsonfailure) flag to `false` on your `nx-cloud start-ci-run` command.
+
+## Nx Agents-Related
+
+### Failed to start Nx Agents workflow
+
+Nx Cloud was unable to start the agents workflow with the configuration provided to `nx-cloud start-ci-run`. View the CI Pipeline Execution in the Nx Cloud UI for additional details.
+
+### Unable to get workflow status from Nx Agents
+
+Nx Cloud was unable to communicate with the Nx Agents assigned to a workflow for the current CI Pipeline Execution. View the CI Pipeline Execution in the Nx Cloud UI for additional details.
+
+## Status Reconciliation-Related
+
+### One or more workflows were cancelled
+
+The current CI Pipeline Execution had a workflow cancelled due to either:
+
+- a manual request in the Nx Cloud UI, or
+- a push to the same branch that already had a running workflow.
+
+### One or more workflows encountered a critical error
+
+The current CI Pipeline Execution encountered a critical error in a child execution environment. View the CI Pipeline Execution in the Nx Cloud UI for additional details.
+
+### One or more workflows failed
+
+The current CI Pipeline Execution had at least one workflow with failed steps.
+
+### One or more workflows encountered an error
+
+The current CI Pipeline Execution had at least one workflow that executed tasks which failed. See also: [Nx Cloud agents were stopped due to an error](#nx-cloud-agents-were-stopped-due-to-an-error)
+
+### One or more workflows timed out
+
+The current CI Pipeline Execution had at least one workflow that exceeded the timeout duration. View the CI Pipeline Execution in the Nx Cloud UI for additional details.

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -305,6 +305,8 @@
       - [Authenticate via SAML](/ci/recipes/on-premise/auth-saml)
       - [Authenticate via SAML on Managed Version](/ci/recipes/on-premise/auth-saml-managed)
       - [Advanced Configuration](/ci/recipes/on-premise/advanced-config)
+    - [Troubleshooting](/ci/recipes/troubleshooting)
+      - [CI Execution Failed](/ci/recipes/troubleshooting/ci-execution-failed)
     - [Other](/ci/recipes/other)
       - [Record Non-Nx Commands](/ci/recipes/other/record-commands)
       - [Prepare applications for deployment via CI](/ci/recipes/other/ci-deployment)


### PR DESCRIPTION
## Current Behavior
No docs on Nx Cloud failure modes

## Expected Behavior
Docs we can link from task runner on failures

