### PR TITLE
fix(core): remove logic to reload process with esm loader for Node 18

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -13,27 +13,6 @@ import * as Mod from 'module';
  */
 
 export function initLocal(workspace: WorkspaceTypeAndRoot) {
-  // If module.register is not available, we need to restart the process with the experimental ESM loader.
-  // Otherwise, usage of `registerTsProject` will not work for `.ts` files using ESM.
-  // TODO: Remove this once Node 18 is out of LTS (March 2024).
-  if (shouldRestartWithExperimentalTsEsmLoader()) {
-    const child = require('child_process').fork(
-      require.resolve('./nx'),
-      process.argv.slice(2),
-      {
-        env: {
-          ...process.env,
-          RESTARTED_WITH_EXPERIMENTAL_TS_ESM_LOADER: '1',
-        },
-        execArgv: execArgvWithExperimentalLoaderOptions(),
-      }
-    );
-    child.on('close', (code: number | null) => {
-      if (code !== 0 && code !== null) process.exit(code);
-    });
-    return;
-  }
-
   process.env.NX_CLI_SET = 'true';
 
   try {
@@ -214,37 +193,4 @@ function monkeyPatchRequire() {
     }
     // do some side-effect of your own
   };
-}
-
-function shouldRestartWithExperimentalTsEsmLoader(): boolean {
-  // Already restarted with experimental loader
-  if (process.env.RESTARTED_WITH_EXPERIMENTAL_TS_ESM_LOADER === '1')
-    return false;
-  const nodeVersion = parseInt(process.versions.node.split('.')[0]);
-  // `--experimental-loader` is only supported in Nodejs >= 16 so there is no point restarting for older versions
-  if (nodeVersion < 16) return false;
-  // Node 20.6.0 adds `module.register`, otherwise we need to restart process with "--experimental-loader ts-node/esm".
-  return (
-    !require('node:module').register &&
-    moduleResolves('ts-node/esm') &&
-    moduleResolves('typescript')
-  );
-}
-
-function execArgvWithExperimentalLoaderOptions() {
-  return [
-    ...process.execArgv,
-    '--no-warnings',
-    '--experimental-loader',
-    require.resolve('ts-node/esm'),
-  ];
-}
-
-function moduleResolves(packageName: string) {
-  try {
-    require.resolve(packageName);
-    return true;
-  } catch {
-    return false;
-  }
 }


### PR DESCRIPTION
It seems problematic to reload the process when we may not need to. The reload is only really needed for workspaces/projects with `type: 'module` in `package.json` file.

By reverting this, we may break new Nx projects using ESM + `.ts` config files that are not on Node 20. The workaround for those projects is to use Node 20, or manually run Node with `--loader ts-node/esm` themselves. If it becomes a wide-spread issue we can look at a better solution then.

## Current Behavior
Node 18 restarts with `--loader ts-node/esm` that may lead to problems in some environments.

## Expected Behavior
Don't restart with `--loader ts-node/esm` for Node 18.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
