### PR TITLE
fix(webpack): require ForkTsCheckerWebpackPlugin only as required

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -19,7 +19,6 @@ import { createLoaderFromCompiler } from './compiler-loaders';
 import { NormalizedNxWebpackPluginOptions } from '../nx-webpack-plugin-options';
 import TerserPlugin = require('terser-webpack-plugin');
 import nodeExternals = require('webpack-node-externals');
-import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const IGNORED_WEBPACK_WARNINGS = [
   /The comment file/i,
@@ -223,6 +222,7 @@ function applyNxDependentConfig(
   };
 
   if (!options?.skipTypeChecking) {
+    const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
     plugins.push(
       new ForkTsCheckerWebpackPlugin({
         typescript: {


### PR DESCRIPTION
There is an issue when `ForkTsCheckerWebpackPlugin` is required, it then calls `require('process')` which messes up SIGINT, etc. for child processes running through Rust.

This change mitigates the issue, which we will still fix in a subsequent PR.

## Current Behavior
<!-- This is the behavior we have today -->

On some environments `^C` cannot kill the Nx process.

## Expected Behavior
`^C` should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
