### PR TITLE
chore(vite): revert comment about `closeAllConnections`

### DIFF
--- a/packages/vite/src/executors/preview-server/preview-server.impl.ts
+++ b/packages/vite/src/executors/preview-server/preview-server.impl.ts
@@ -183,7 +183,7 @@ function closeServer(server?: Record<string, any>): Promise<void> {
       const { httpServer } = server;
       if (httpServer['closeAllConnections']) {
         // https://github.com/vitejs/vite/pull/14834
-        // closeAllConnections was added in Node v19.2.0
+        // closeAllConnections was added in Node v18.2.0
         // typically is "as http.Server" but no reason
         // to import http just for this
         (httpServer as any).closeAllConnections();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
It seems the comment was accidentally modified.

<img width="915" alt="image" src="https://github.com/nrwl/nx/assets/2607019/5d624c94-0636-4d3b-a341-ed8fd2736f81">

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should be `// closeAllConnections was added in Node v18.2.0`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
 #21430
