### PR TITLE
fix(core): remove implementation detail from warning

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -136,7 +136,7 @@ async function runInParallel(
     const r = await Promise.race(procs);
     if (!r.result) {
       process.stderr.write(
-        `Warning: run-commands command "${r.command}" exited with non-zero status code`
+        `Warning: command "${r.command}" exited with non-zero status code`
       );
       return false;
     } else {
@@ -148,7 +148,7 @@ async function runInParallel(
     if (failed.length > 0) {
       failed.forEach((f) => {
         process.stderr.write(
-          `Warning: run-commands command "${f.command}" exited with non-zero status code`
+          `Warning: command "${f.command}" exited with non-zero status code`
         );
       });
       return false;
@@ -200,7 +200,7 @@ async function runSerially(
     );
     if (!success) {
       process.stderr.write(
-        `Warning: run-commands command "${c.command}" exited with non-zero status code`
+        `Warning: command "${c.command}" exited with non-zero status code`
       );
       return false;
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When `command` driven target fails we show warning which includes implementation detail (the fact that we use `run-commands` under-the-hood, which might not be clear to user). This information is obsolete and might confuse user.

```
Warning: run-commands command "eslint ." exited with non-zero status code
```

## Expected Behavior
Remove implementation detail from the warning message:

```
Warning: command "eslint ." exited with non-zero status code
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
