### PR TITLE
fix(linter): adjust terminal run check for crystal

### DIFF
--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -248,9 +248,9 @@ describe('Linter', () => {
       const libC = uniq('tslib-c');
 
       beforeAll(() => {
-        runCLI(`generate @nx/js:lib ${libA}`);
-        runCLI(`generate @nx/js:lib ${libB}`);
-        runCLI(`generate @nx/js:lib ${libC}`);
+        runCLI(`generate @nx/js:lib ${libA} --bundler=none`);
+        runCLI(`generate @nx/js:lib ${libB} --bundler=none`);
+        runCLI(`generate @nx/js:lib ${libC} --bundler=none`);
 
         /**
          * create tslib-a structure
@@ -402,8 +402,7 @@ describe('Linter', () => {
         );
       });
 
-      // TODO(crystal, @meeroslav): Investigate why this is failing
-      xit('should fix noRelativeOrAbsoluteImportsAcrossLibraries', () => {
+      it('should fix noRelativeOrAbsoluteImportsAcrossLibraries', () => {
         const stdout = runCLI(`lint ${libB}`, {
           silenceError: true,
         });
@@ -447,6 +446,17 @@ describe('Linter', () => {
           ];
           return json;
         });
+        process.env.NX_E2E_EDITOR = 'code';
+      });
+
+      afterAll(() => {
+        updateJson(`libs/${mylib}/.eslintrc.json`, (json) => {
+          json.overrides = json.overrides.filter(
+            (o) => o.parser !== 'jsonc-eslint-parser'
+          );
+          return json;
+        });
+        delete process.env.NX_E2E_EDITOR;
       });
 
       // TODO(crystal, @meeroslav): Investigate why this is failing

--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -196,10 +196,10 @@ describe('Linter', () => {
         eslint.overrides[0].rules[
           '@nx/enforce-module-boundaries'
         ][1].depConstraints = [
-          { sourceTag: 'validtag', onlyDependOnLibsWithTags: ['validtag'] },
-          ...eslint.overrides[0].rules['@nx/enforce-module-boundaries'][1]
-            .depConstraints,
-        ];
+            { sourceTag: 'validtag', onlyDependOnLibsWithTags: ['validtag'] },
+            ...eslint.overrides[0].rules['@nx/enforce-module-boundaries'][1]
+              .depConstraints,
+          ];
         updateFile('.eslintrc.json', JSON.stringify(eslint, null, 2));
 
         const tsConfig = readJson('tsconfig.base.json');
@@ -462,8 +462,7 @@ describe('Linter', () => {
         });
       });
 
-      // TODO(crystal, @meeroslav): Investigate why this is failing
-      xit('should report dependency check issues', () => {
+      it('should report dependency check issues', () => {
         const rootPackageJson = readJson('package.json');
         const nxVersion = rootPackageJson.devDependencies.nx;
         const tslibVersion = rootPackageJson.dependencies['tslib'];
@@ -476,7 +475,7 @@ describe('Linter', () => {
           `libs/${mylib}/src/lib/${mylib}.ts`,
           (content) =>
             `import { names } from '@nx/devkit';\n\n` +
-            content.replace(/=> .*;/, `=> names(${mylib}).className;`)
+            content.replace(/=> .*;/, `=> names('${mylib}').className;`)
         );
 
         // output should now report missing dependency

--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -196,10 +196,10 @@ describe('Linter', () => {
         eslint.overrides[0].rules[
           '@nx/enforce-module-boundaries'
         ][1].depConstraints = [
-            { sourceTag: 'validtag', onlyDependOnLibsWithTags: ['validtag'] },
-            ...eslint.overrides[0].rules['@nx/enforce-module-boundaries'][1]
-              .depConstraints,
-          ];
+          { sourceTag: 'validtag', onlyDependOnLibsWithTags: ['validtag'] },
+          ...eslint.overrides[0].rules['@nx/enforce-module-boundaries'][1]
+            .depConstraints,
+        ];
         updateFile('.eslintrc.json', JSON.stringify(eslint, null, 2));
 
         const tsConfig = readJson('tsconfig.base.json');

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
@@ -416,7 +416,7 @@ export function hasBuildExecutor(
   );
 }
 
-const ESLINT_REGEX = /node_modules.*[\/\\]eslint$/;
+const ESLINT_REGEX = /node_modules.*[\/\\]eslint(?:\.js)?$/;
 const JEST_REGEX = /node_modules\/.bin\/jest$/; // when we run unit tests in jest
 const NRWL_CLI_REGEX = /nx[\/\\]bin[\/\\]run-executor\.js$/;
 


### PR DESCRIPTION
The terminal command when running manually was
```
node_modules/.bin/eslint
```
But when running with PCv3 is 
```
node_modules/eslint/bin/eslint.js
```

This leads to command not being detected as a terminal run and re-fetching package.json from disk even after applying `fix` during the eslint runtime.

## Current Behavior
The `isTerminalRun` check does not work correctly for Crystal since the argument has a different format than expected.

## Expected Behavior
The `isTerminalRun` should properly check if the command is ran in the terminal.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
