### PR TITLE
cleanup(angular): e2es should add targetDefaults when using buildable libs

### DIFF
--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -323,6 +323,28 @@ describe('Angular Projects', () => {
       return config;
     });
 
+    // update the nx.json
+    updateJson('nx.json', (config) => {
+      config.targetDefaults ??= {};
+      config.targetDefaults['@nx/angular:webpack-browser'] ??= {
+        cache: true,
+        dependsOn: [`^build`],
+        inputs:
+          config.namedInputs && 'production' in config.namedInputs
+            ? ['production', '^production']
+            : ['default', '^default'],
+      };
+      config.targetDefaults['@nx/angular:browser-esbuild'] ??= {
+        cache: true,
+        dependsOn: [`^build`],
+        inputs:
+          config.namedInputs && 'production' in config.namedInputs
+            ? ['production', '^production']
+            : ['default', '^default'],
+      };
+      return config;
+    });
+
     // ACT
     const libOutput = runCLI(`build ${app1} --configuration=development`);
     const esbuildLibOutput = runCLI(

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -103,7 +103,7 @@ export function executeWebpackBrowserBuilder(
     switchMap(({ executeBrowserBuilder }) =>
       executeBrowserBuilder(delegateBuilderOptions, context as any, {
         webpackConfiguration: (baseWebpackConfig) => {
-          if (!buildLibsFromSource) {
+          if (!buildLibsFromSource && delegateBuilderOptions.watch) {
             const workspaceDependencies = dependencies
               .filter((dep) => !isNpmProject(dep.node))
               .map((dep) => dep.node.name);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
targetDefaults are set an executor level now, meaning when the executor is changed to support buildable libs, the target defaults are not being picked up. This has an issue with dependsOn for build dependencies

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure target defaults are set correctly to allow build dependencies to be built first

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
