### PR TITLE
fix(misc): ensure swc transpiler process required files

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -209,13 +209,22 @@ function readCompilerOptions(tsConfigPath): CompilerOptions {
   const preferTsNode = process.env.NX_PREFER_TS_NODE === 'true';
 
   if (swcNodeInstalled && !preferTsNode) {
-    const {
-      readDefaultTsConfig,
-    }: typeof import('@swc-node/register/read-default-tsconfig') = require('@swc-node/register/read-default-tsconfig');
-    return readDefaultTsConfig(tsConfigPath);
+    return readCompilerOptionsWithSwc(tsConfigPath);
   } else {
     return readCompilerOptionsWithTypescript(tsConfigPath);
   }
+}
+
+function readCompilerOptionsWithSwc(tsConfigPath) {
+  const {
+    readDefaultTsConfig,
+  }: typeof import('@swc-node/register/read-default-tsconfig') = require('@swc-node/register/read-default-tsconfig');
+  const compilerOptions = readDefaultTsConfig(tsConfigPath);
+  // This is returned in compiler options for some reason, but not part of the typings.
+  // @swc-node/register filters the files to transpile based on it, but it can be limiting when processing
+  // files not part of the received tsconfig included files (e.g. shared helpers, or config files not in source, etc.).
+  delete compilerOptions.files;
+  return compilerOptions;
 }
 
 function readCompilerOptionsWithTypescript(tsConfigPath) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When having `@swc-node/register@1.8.0` installed, loading a config (or similar files needing transpilation in-process) might error complaining about invalid syntax or import statements used outside of a module.

This happens because, in version 1.8.0 of the `@swc-node/register` package, a fix was released where the utility now correctly uses the provided compiler options. The Nx helper to register the TS transpiler uses the `@swc-node/register/read-default-tsconfig#readDefaultTsConfig` to read those compiler options, and that utility returns an additional `files` property which, if present, is used by the `@swc-node/register/register#register` function to filter files out from processing. This is all fine, but while the Nx helper reads the compiler options (and hence the TS project `files`) from the provided tsconfig file (normally a project-specific one), it sets the `SWC_NODE_PROJECT` to the root tsconfig file. This means that before `@swc-node/register@1.8.0`, the compiler options read from the project's tsconfig file were ignored and the root tsconfig file was always used, so effectively getting all files in the workspaces as part of the TS program. With `@swc-node/register@1.8.0` now the project's tsconfig file compiler options are used and only the files included in that tsconfig file are part of the program.

The above is not aligned with the `ts-node` transpilation, where the project's tsconfig file compiler options are correctly used, and the files are not a factor.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Loading a config (or similar files needing transpilation in-process) should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21639 
Fixes #21643 
