### PR TITLE
fix(core): temporary use forked portable_pty to inherit cursor position for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,9 +482,8 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "filedescriptor"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+version = "0.8.3"
+source = "git+https://github.com/cammisuli/wezterm#3db3f2d05f7188af9c7527214605f18332fac06d"
 dependencies = [
  "libc",
  "thiserror",
@@ -1660,8 +1659,7 @@ dependencies = [
 [[package]]
 name = "portable-pty"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+source = "git+https://github.com/cammisuli/wezterm#3db3f2d05f7188af9c7527214605f18332fac06d"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@jest/reporters": "^29.4.1",
     "@jest/test-result": "^29.4.1",
     "@jest/types": "^29.4.1",
-    "@monodon/rust": "1.3.2",
+    "@monodon/rust": "1.3.3",
     "@napi-rs/cli": "2.14.0",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/common": "^9.0.0",

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -4,6 +4,7 @@ version = '0.1.0'
 edition = '2021'
 
 [dependencies]
+portable-pty = { git = "https://github.com/cammisuli/wezterm" }
 anyhow = "1.0.71"
 colored = "2"
 crossbeam-channel = '0.5'
@@ -17,7 +18,6 @@ ignore-files = "2.0.0"
 itertools = "0.10.5"
 once_cell = "1.18.0"
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-portable-pty = "0.8.1"
 napi = { version = '2.12.6', default-features = false, features = [
     'anyhow',
     'napi4',

--- a/packages/nx/src/native/command.rs
+++ b/packages/nx/src/native/command.rs
@@ -95,6 +95,12 @@ impl ChildProcess {
 
         std::thread::spawn(move || {
             while let Ok(content) = rx.recv() {
+                // windows will add `ESC[6n` to the beginning of the output,
+                // we dont want to store this ANSI code in cache, because replays will cause issues
+                // remove it before sending it to js
+                #[cfg(windows)]
+                let content = content.replace("\x1B[6n", "");
+
                 callback_tsfn.call(content, NonBlocking);
             }
         });

--- a/packages/nx/src/native/command.rs
+++ b/packages/nx/src/native/command.rs
@@ -14,9 +14,6 @@ use napi::{Env, JsFunction};
 use portable_pty::{ChildKiller, CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use tracing::trace;
 
-#[cfg(target_os = "windows")]
-static CURSOR_POSITION: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-
 fn command_builder() -> CommandBuilder {
     if cfg!(target_os = "windows") {
         let comspec = std::env::var("COMSPEC");
@@ -159,34 +156,18 @@ pub fn run_command(
         let mut reader = BufReader::new(reader);
         let mut buffer = [0; 8 * 1024];
 
-        let mut strip_clear_code = cfg!(target_os = "windows");
-
         while let Ok(n) = reader.read(&mut buffer) {
             if n == 0 {
                 break;
             }
 
-            let mut content = String::from_utf8_lossy(&buffer[..n]).to_string();
-            if strip_clear_code {
-                strip_clear_code = false;
-                // remove clear screen
-                content = content.replacen("\x1B[2J", "", 1);
-                // remove cursor position 1,1
-                content = content.replacen("\x1B[H", "", 1);
-            }
+            let content = &buffer[..n];
+            message_tx
+                .send(String::from_utf8_lossy(content).to_string())
+                .ok();
 
-            #[cfg(target_os = "windows")]
-            {
-                let regex = CURSOR_POSITION.get_or_init(|| {
-                    regex::Regex::new(r"\x1B\[\d+;\d+H")
-                        .expect("failed to compile CURSOR ansi regex")
-                });
-                content = regex.replace_all(&content, "").to_string();
-            }
-
-            message_tx.send(content.to_string()).ok();
             if !quiet {
-                stdout.write_all(content.as_bytes()).ok();
+                stdout.write_all(content).ok();
                 stdout.flush().ok();
             }
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,8 +228,8 @@ devDependencies:
     specifier: ^29.4.1
     version: 29.5.0
   '@monodon/rust':
-    specifier: 1.3.2
-    version: 1.3.2(@swc-node/register@1.6.8)(@swc/core@1.3.86)(@types/node@18.19.8)(typescript@5.3.3)(verdaccio@5.15.4)
+    specifier: 1.3.3
+    version: 1.3.3(@swc-node/register@1.6.8)(@swc/core@1.3.86)(@types/node@18.19.8)(typescript@5.3.3)(verdaccio@5.15.4)
   '@napi-rs/cli':
     specifier: 2.14.0
     version: 2.14.0
@@ -6394,8 +6394,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@monodon/rust@1.3.2(@swc-node/register@1.6.8)(@swc/core@1.3.86)(@types/node@18.19.8)(typescript@5.3.3)(verdaccio@5.15.4):
-    resolution: {integrity: sha512-WcI8y0s8mVngdF/nwvki5EP3LS7YDnIxZyMcU34iVT6flVexcipN2F89e0pLb8ER9yS2AaMyvuDyX1JlqDi9bg==}
+  /@monodon/rust@1.3.3(@swc-node/register@1.6.8)(@swc/core@1.3.86)(@types/node@18.19.8)(typescript@5.3.3)(verdaccio@5.15.4):
+    resolution: {integrity: sha512-rDzKRAxlh5ohZSBTXrSt4vt++ZfZZuZ+6/XwrOohsfm8NTxd37JvkXH2nBLrNkqhcej0NiR/T2R/lpPKR7UEFQ==}
     dependencies:
       '@ltd/j-toml': 1.38.0
       '@nx/devkit': 17.1.2(nx@17.1.2)
@@ -24939,7 +24939,7 @@ packages:
       fs-extra: 11.2.0
       glob: 7.1.4
       ignore: 5.3.1
-      jest-diff: 29.5.0
+      jest-diff: 29.7.0
       js-yaml: 4.1.0
       jsonc-parser: 3.2.0
       lines-and-columns: 2.0.3


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Some output on Windows becomes mangled because of ANSI codes that the Conpty adds. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Uses a forked portable_pty library to set the position of the cursor to inherit so that destructive ansi codes are not added. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
