### PR TITLE
fix(vite): import esbuild before loading config to keep it in cache

### DIFF
--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -96,6 +96,15 @@ async function buildViteTargets(
     context.workspaceRoot,
     configFilePath
   );
+
+  // Workaround for the `build$3 is not a function` error that we sometimes see in agents.
+  // This should be removed later once we address the issue properly
+  try {
+    const importEsbuild = () => new Function('return import("esbuild")')();
+    await importEsbuild();
+  } catch {
+    // do nothing
+  }
   const { resolveConfig } = await loadViteDynamicImport();
   const viteConfig = await resolveConfig(
     {


### PR DESCRIPTION
This is a workaround for the `build$3` error from Vite when the `esbuild` module loaded from ESM exports nothing.

We're trying this patch temporarily to work around an issue during `resolveConfig` call from `vite` package.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
