### PR TITLE
fix(core): log watch filters after the initial path check

### DIFF
--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -56,10 +56,11 @@ impl Filterer for WatchFilterer {
         let transformed = transform_event(watch_event);
         let event = transformed.as_ref().unwrap_or(watch_event);
 
-        trace!(?event, "checking if event is valid");
         if !self.filter_event(event, priority) {
             return Ok(false);
         }
+
+        trace!(?event, "checking if event is valid");
 
         //
         // Tags will be a Vec that contains multiple types of information for a given event


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when `NX_VERBOSE_LOGGING` is on, the daemon.log gets flooded with entries, and when the file updates, the watcher picks up the changes and then goes into a loop.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Log the watcher events after the path has been checked by the git ignore rules

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
