### PR TITLE
fix(testing): cleanup e2e atomization plugins

### DIFF
--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -3,7 +3,7 @@ import { dirname, join, relative } from 'path';
 import { lstatSync } from 'fs';
 
 import vitePreprocessor from '../src/plugins/preprocessor-vite';
-import { NX_PLUGIN_OPTIONS } from '../src/utils/symbols';
+import { NX_PLUGIN_OPTIONS } from '../src/utils/constants';
 
 import { exec } from 'child_process';
 import { request as httpRequest } from 'http';

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -18,7 +18,7 @@ import { existsSync, readdirSync } from 'fs';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
-import { NX_PLUGIN_OPTIONS } from '../utils/symbols';
+import { NX_PLUGIN_OPTIONS } from '../utils/constants';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 
 export interface CypressPluginOptions {

--- a/packages/cypress/src/utils/constants.ts
+++ b/packages/cypress/src/utils/constants.ts
@@ -1,4 +1,4 @@
 /**
  * Key used to store options used by the nx plugin for @nx/cypress.
  */
-export const NX_PLUGIN_OPTIONS = Symbol('Nx Plugin Options');
+export const NX_PLUGIN_OPTIONS = '__NxPluginOptions__';

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -7,6 +7,7 @@ import {
   CreateNodesContext,
   detectPackageManager,
   joinPathFragments,
+  normalizePath,
   readJsonFile,
   TargetConfiguration,
   writeJsonFile,
@@ -157,7 +158,9 @@ async function buildPlaywrightTargets(
     const dependsOn: TargetConfiguration['dependsOn'] = [];
     forEachTestFile(
       (testFile) => {
-        const relativeToProjectRoot = relative(projectRoot, testFile);
+        const relativeToProjectRoot = normalizePath(
+          relative(projectRoot, testFile)
+        );
         const targetName = `${options.ciTargetName}--${relativeToProjectRoot}`;
         targets[targetName] = {
           ...ciBaseTargetConfig,


### PR DESCRIPTION
For playwright, paths need to be normalized when generating per-file targets. For cypress, we can't use a signal to note the options because it changes when we bust the require cache

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
