### PR TITLE
fix(release): logging improvements

### DIFF
--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -12,7 +12,6 @@ import { FsTree, Tree } from '../../generators/tree';
 import { registerTsProject } from '../../plugins/js/utils/register';
 import { createProjectGraphAsync } from '../../project-graph/project-graph';
 import { interpolate } from '../../tasks-runner/utils';
-import { logger } from '../../utils/logger';
 import { output } from '../../utils/output';
 import { handleErrors } from '../../utils/params';
 import { joinPathFragments } from '../../utils/path';
@@ -474,12 +473,6 @@ async function applyChangesAndExit(
   // Run any post-git tasks in series
   for (const postGitTask of postGitTasks) {
     await postGitTask(latestCommit);
-  }
-
-  if (args.dryRun) {
-    logger.warn(
-      `\nNOTE: The "dryRun" flag means no changelogs were actually created.`
-    );
   }
 
   return 0;

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -1,5 +1,6 @@
 import { Argv, CommandModule, showHelp } from 'yargs';
 import { readNxJson } from '../../project-graph/file-utils';
+import { logger } from '../../utils/logger';
 import {
   OutputStyle,
   RunManyOptions,
@@ -159,15 +160,18 @@ const releaseCommand: CommandModule<NxReleaseArgs, ReleaseOptions> = {
         }
         return true;
       }),
-  handler: (args) =>
-    import('./release')
-      .then((m) => m.releaseCLIHandler(args))
-      .then((versionDataOrExitCode) => {
-        if (typeof versionDataOrExitCode === 'number') {
-          return process.exit(versionDataOrExitCode);
-        }
-        process.exit(0);
-      }),
+  handler: async (args) => {
+    const release = await import('./release');
+    const result = await release.releaseCLIHandler(args);
+    if (args.dryRun) {
+      logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
+    }
+
+    if (typeof result === 'number') {
+      process.exit(result);
+    }
+    process.exit(0);
+  },
 };
 
 const versionCommand: CommandModule<NxReleaseArgs, VersionOptions> = {
@@ -195,15 +199,18 @@ const versionCommand: CommandModule<NxReleaseArgs, VersionOptions> = {
             'Whether or not to stage the changes made by this command. Useful when combining this command with changelog generation.',
         })
     ),
-  handler: (args) =>
-    import('./version')
-      .then((m) => m.releaseVersionCLIHandler(args))
-      .then((versionDataOrExitCode) => {
-        if (typeof versionDataOrExitCode === 'number') {
-          return process.exit(versionDataOrExitCode);
-        }
-        process.exit(0);
-      }),
+  handler: async (args) => {
+    const release = await import('./version');
+    const result = await release.releaseVersionCLIHandler(args);
+    if (args.dryRun) {
+      logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
+    }
+
+    if (typeof result === 'number') {
+      process.exit(result);
+    }
+    process.exit(0);
+  },
 };
 
 const changelogCommand: CommandModule<NxReleaseArgs, ChangelogOptions> = {
@@ -254,10 +261,16 @@ const changelogCommand: CommandModule<NxReleaseArgs, ChangelogOptions> = {
         })
     ),
   handler: async (args) => {
-    const status = await (
-      await import('./changelog')
-    ).releaseChangelogCLIHandler(args);
-    process.exit(status);
+    const release = await import('./changelog');
+    const result = await release.releaseChangelogCLIHandler(args);
+    if (args.dryRun) {
+      logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
+    }
+
+    if (typeof result === 'number') {
+      process.exit(result);
+    }
+    process.exit(0);
   },
 };
 
@@ -284,6 +297,10 @@ const publishCommand: CommandModule<NxReleaseArgs, PublishOptions> = {
     const status = await (
       await import('./publish')
     ).releasePublishCLIHandler(coerceParallelOption(withOverrides(args, 2)));
+    if (args.dryRun) {
+      logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
+    }
+
     process.exit(status);
   },
 };

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -10,7 +10,6 @@ import {
   createOverrides,
   readGraphFileFromGraphArg,
 } from '../../utils/command-line-utils';
-import { logger } from '../../utils/logger';
 import { handleErrors } from '../../utils/params';
 import { projectHasTarget } from '../../utils/project-graph-utils';
 import { generateGraph } from '../graph/graph';
@@ -118,12 +117,6 @@ export async function releasePublish(
     if (status !== 0) {
       overallExitStatus = status || 1;
     }
-  }
-
-  if (_args.dryRun) {
-    logger.warn(
-      `\nNOTE: The "dryRun" flag means no projects were actually published.`
-    );
   }
 
   return overallExitStatus;

--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -150,15 +150,13 @@ export async function release(
   if (shouldPublish) {
     await releasePublish(args);
   } else {
-    console.log('Skipped publishing packages.');
+    output.logSingleLine('Skipped publishing packages.');
   }
 
   return versionResult;
 }
 
 async function promptForPublish(): Promise<boolean> {
-  console.log('\n');
-
   try {
     const reply = await prompt<{ confirmation: boolean }>([
       {
@@ -169,7 +167,6 @@ async function promptForPublish(): Promise<boolean> {
     ]);
     return reply.confirmation;
   } catch (e) {
-    console.log('\n');
     // Handle the case where the user exits the prompt with ctrl+c
     return false;
   }

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -10,7 +10,6 @@ import {
 import {
   NxJsonConfiguration,
   joinPathFragments,
-  logger,
   output,
   workspaceRoot,
 } from '../../devkit-exports';
@@ -281,10 +280,6 @@ export async function releaseVersion(
       }
     }
 
-    if (args.dryRun) {
-      logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
-    }
-
     return {
       // An overall workspace version cannot be relevant when filtering to independent projects
       workspaceVersion: undefined,
@@ -420,10 +415,6 @@ export async function releaseVersion(
         verbose: args.verbose,
       });
     }
-  }
-
-  if (args.dryRun) {
-    logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
   }
 
   return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `nx release` logs do not consistently use the Nx output logger
- `nx release` prints duplicate dry run messages
- `nx release` does not exit when ctrl+c is pressed on the github release recovery step

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `nx release` logs consistently use the Nx output logger
- `nx release` prints a single dry run message at the end of the execution
- `nx release` does exits with code 1 when ctrl+c is pressed on the github release recovery step

