### PR TITLE
fix(nextjs): src package.json should not be copied to output folder

### DIFF
--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -77,10 +77,13 @@ export function createNextConfigFile(
   );
   for (const moduleFile of moduleFilesToCopy) {
     ensureDirSync(dirname(join(context.root, options.outputPath, moduleFile)));
-    copyFileSync(
-      join(context.root, projectRoot, moduleFile),
-      join(context.root, options.outputPath, moduleFile)
-    );
+    // We already generate a build version of package.json in the dist folder.
+    if (moduleFile !== 'package.json') {
+      copyFileSync(
+        join(context.root, projectRoot, moduleFile),
+        join(context.root, options.outputPath, moduleFile)
+      );
+    }
   }
 }
 


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Inside the source directory `src/[my-app]/` if it contains a `package.json` that is used / imported into your next config this would result in the generated `package.json` which has dependencies for your build artifact to be overwritten by the `src/[my-app]/package.json`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The generated `package.json` should be present. Should you need details from the source as a part of the build artifact this can be done via a post-build script.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21535
