### PR TITLE
cleanup(misc): cleanup misc e2e tests

### DIFF
--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -126,7 +126,7 @@ describe('Angular Projects', () => {
     );
 
     // check e2e tests
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       const e2eResults = runCLI(`e2e ${app1}-e2e`);
       expect(e2eResults).toContain('All specs passed!');
       expect(await killPort(4200)).toBeTruthy();
@@ -152,15 +152,14 @@ describe('Angular Projects', () => {
     await killProcessAndPorts(esbProcess.pid, appPort);
   }, 1000000);
 
-  // TODO: enable this when tests are passing again.
-  xit('should successfully work with playwright for e2e tests', async () => {
+  it('should successfully work with playwright for e2e tests', async () => {
     const app = uniq('app');
 
     runCLI(
       `generate @nx/angular:app ${app} --e2eTestRunner=playwright --project-name-and-root-format=as-provided --no-interactive`
     );
 
-    if (runE2ETests()) {
+    if (runE2ETests('playwright')) {
       const e2eResults = runCLI(`e2e ${app}-e2e`);
       expect(e2eResults).toContain(
         `Successfully ran target e2e for project ${app}-e2e`

--- a/e2e/angular-extensions/src/cypress-component-tests.test.ts
+++ b/e2e/angular-extensions/src/cypress-component-tests.test.ts
@@ -42,7 +42,7 @@ describe('Angular Cypress Component Tests', () => {
     runCLI(
       `generate @nx/angular:cypress-component-configuration --project=${appName} --generate-tests --no-interactive`
     );
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       expect(runCLI(`component-test ${appName}`)).toContain(
         'All specs passed!'
       );
@@ -53,7 +53,7 @@ describe('Angular Cypress Component Tests', () => {
     runCLI(
       `generate @nx/angular:cypress-component-configuration --project=${usedInAppLibName} --generate-tests --no-interactive`
     );
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       expect(runCLI(`component-test ${usedInAppLibName}`)).toContain(
         'All specs passed!'
       );
@@ -73,7 +73,7 @@ describe('Angular Cypress Component Tests', () => {
     runCLI(
       `generate @nx/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests --build-target=${appName}:build --no-interactive`
     );
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       expect(runCLI(`component-test ${buildableLibName}`)).toContain(
         'All specs passed!'
       );
@@ -95,7 +95,7 @@ describe('Angular Cypress Component Tests', () => {
       }
     );
 
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       expect(runCLI(`component-test ${buildableLibName}`)).toContain(
         'All specs passed!'
       );
@@ -111,7 +111,7 @@ describe('Angular Cypress Component Tests', () => {
 
     updateBuilableLibTestsToAssertAppStyles(appName, buildableLibName);
 
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       expect(runCLI(`component-test ${buildableLibName}`)).toContain(
         'All specs passed!'
       );
@@ -123,7 +123,7 @@ describe('Angular Cypress Component Tests', () => {
     checkFilesExist('tailwind.config.js');
     checkFilesDoNotExist(`${buildableLibName}/tailwind.config.js`);
 
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       expect(runCLI(`component-test ${buildableLibName}`)).toContain(
         'All specs passed!'
       );

--- a/e2e/angular-module-federation/src/module-federation.test.ts
+++ b/e2e/angular-module-federation/src/module-federation.test.ts
@@ -376,7 +376,7 @@ describe('Angular Module Federation', () => {
     const buildRemoteOutput = runCLI(`build ${remote}`);
     expect(buildRemoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e --no-watch`,
         (output) => output.includes('All specs passed!')
@@ -468,7 +468,7 @@ describe('Angular Module Federation', () => {
     const buildRemoteOutput = runCLI(`build ${remote}`);
     expect(buildRemoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e --no-watch`,
         (output) => output.includes('All specs passed!')

--- a/e2e/cypress/src/cypress-legacy.test.ts
+++ b/e2e/cypress/src/cypress-legacy.test.ts
@@ -40,7 +40,7 @@ describe('Cypress E2E Test runner (legacy)', () => {
     TEN_MINS_MS
   );
 
-  xit(
+  it(
     `should allow CT and e2e in same project - react`,
     async () => {
       const appName = uniq(`react-cy-app`);


### PR DESCRIPTION
- Reenables some previously disabled e2e tests
- Filters e2e test runner to setup when running generated e2e tests

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
