### PR TITLE
fix(core): cannot read property kind of undefined

### DIFF
--- a/packages/workspace/src/generators/move/lib/__snapshots__/update-imports.spec.ts.snap
+++ b/packages/workspace/src/generators/move/lib/__snapshots__/update-imports.spec.ts.snap
@@ -32,6 +32,8 @@ exports[`updateImports should update dynamic imports 1`] = `
 exports[`updateImports should update imports and reexports 1`] = `
 "
         import { MyClass } from '@proj/my-destination';
+        
+        export { MyClass };
         export { MyOtherClass } from '@proj/my-destination';
         
         export class MyExtendedClass extends MyClass {};

--- a/packages/workspace/src/generators/move/lib/update-imports.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.spec.ts
@@ -238,6 +238,8 @@ describe('updateImports', () => {
       importerFilePath,
       `
         import { MyClass } from '@proj/my-source';
+        
+        export { MyClass };
         export { MyOtherClass } from '@proj/my-source';
         
         export class MyExtendedClass extends MyClass {};

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -195,7 +195,7 @@ function updateImportDeclarations(
   const changes: StringChange[] = [];
 
   for (const { moduleSpecifier } of importDecls) {
-    if (tsModule.isStringLiteral(moduleSpecifier)) {
+    if (moduleSpecifier && tsModule.isStringLiteral(moduleSpecifier)) {
       changes.push(...updateModuleSpecifier(moduleSpecifier, from, to));
     }
   }


### PR DESCRIPTION

## Current Behavior

When running `nx g mv ...`, if an updated files exports don't include a moduleSpecifier (e.g `export { MyClass };`), the generator fails with `Cannot read property "kind" of undefined`.

## Expected Behavior

The generator should ignore those exports, as there is no need to update the module specifier if it doesn't exist.

## Related Issue(s)

I didn't open an issue.

I updated the tests, made sure the updated snapshot was correct and tried locally in my own workspace.
