### PR TITLE
fix(testing): increase the default timeout to 15s for the dev server to start

### DIFF
--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -167,7 +167,7 @@ function waitForServer(
     let pollTimeout: NodeJS.Timeout | null;
     const { protocol } = new URL(url);
 
-    const timeoutDuration = webServerConfig?.timeout ?? 10 * 1000;
+    const timeoutDuration = webServerConfig?.timeout ?? 15 * 1000;
     const timeout = setTimeout(() => {
       clearTimeout(pollTimeout);
       reject(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The default timeout for waiting for the dev server started by the Cypress preset is 10s. This default timeout seems a bit low and some of our e2e test cases (not big apps or doing anything crazy) sometimes fail due to taking a bit longer.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The default timeout for waiting for the dev server started by the Cypress preset should be a bit higher to cover more apps by default and without the need to configure the timeout.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
