### PR TITLE
docs(testing): fix example in cypress overview for configuration generator

### DIFF
--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -95,18 +95,18 @@ By default, when creating a new frontend application, Nx will use Cypress to cre
 nx g @nx/web:app frontend
 ```
 
-### Creating a Cypress E2E project for an existing project
+### Configure Cypress for an existing project
 
-To generate an E2E project based on an existing project, run the following generator
+To configure Cypress for an existing project, run the following generator
 
 ```shell
-nx g @nx/cypress:configuration your-app-name-e2e --project=your-app-name
+nx g @nx/cypress:configuration --project=your-app-name
 ```
 
-Optionally, you can use the `--baseUrl` option if you don't want cypress plugin to serve `your-app-name`.
+Optionally, you can use the `--baseUrl` option if you don't want the Cypress plugin to serve `your-app-name`.
 
 ```shell
-nx g @nx/cypress:configuration your-app-name-e2e --baseUrl=http://localhost:4200
+nx g @nx/cypress:configuration --project=your-app-name --baseUrl=http://localhost:4200
 ```
 
 Replace `your-app-name` with the app's name as defined in your `tsconfig.base.json` file or the `name` property of your `package.json`.

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -95,18 +95,18 @@ By default, when creating a new frontend application, Nx will use Cypress to cre
 nx g @nx/web:app frontend
 ```
 
-### Creating a Cypress E2E project for an existing project
+### Configure Cypress for an existing project
 
-To generate an E2E project based on an existing project, run the following generator
+To configure Cypress for an existing project, run the following generator
 
 ```shell
-nx g @nx/cypress:configuration your-app-name-e2e --project=your-app-name
+nx g @nx/cypress:configuration --project=your-app-name
 ```
 
-Optionally, you can use the `--baseUrl` option if you don't want cypress plugin to serve `your-app-name`.
+Optionally, you can use the `--baseUrl` option if you don't want the Cypress plugin to serve `your-app-name`.
 
 ```shell
-nx g @nx/cypress:configuration your-app-name-e2e --baseUrl=http://localhost:4200
+nx g @nx/cypress:configuration --project=your-app-name --baseUrl=http://localhost:4200
 ```
 
 Replace `your-app-name` with the app's name as defined in your `tsconfig.base.json` file or the `name` property of your `package.json`.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Cypress plugin Overview has an example for the `configuration` generator stating that can be used to create a new E2E project.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Cypress plugin Overview has an example for the `configuration` generator should state that the generator can be used to configure Cypress for an existing project.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
