### PR TITLE
fix(core): read all targets from package json when defining target defaults

### DIFF
--- a/packages/nx/src/plugins/target-defaults/target-defaults-plugin.ts
+++ b/packages/nx/src/plugins/target-defaults/target-defaults-plugin.ts
@@ -9,7 +9,10 @@ import {
 import { readJsonFile } from '../../utils/fileutils';
 import { combineGlobPatterns } from '../../utils/globs';
 import { NxPluginV2 } from '../../utils/nx-plugin';
-import { PackageJson } from '../../utils/package-json';
+import {
+  PackageJson,
+  readTargetsFromPackageJson,
+} from '../../utils/package-json';
 import { getGlobPatternsFromPackageManagerWorkspaces } from '../package-json-workspaces';
 
 /**
@@ -58,16 +61,11 @@ export const TargetDefaultsPlugin: NxPluginV2 = {
       const packageJson = readJsonOrNull<PackageJson>(
         join(ctx.workspaceRoot, root, 'package.json')
       );
-      const includedScripts = packageJson?.nx?.includedScripts;
       const projectDefinedTargets = new Set([
-        ...Object.keys(packageJson?.scripts ?? {}).filter((script) => {
-          if (includedScripts) {
-            return includedScripts.includes(script);
-          }
-          return true;
-        }),
         ...Object.keys(projectJson?.targets ?? {}),
-        ...Object.keys(packageJson?.nx?.targets ?? {}),
+        ...(packageJson
+          ? Object.keys(readTargetsFromPackageJson(packageJson))
+          : []),
       ]);
 
       const executorToTargetMap = getExecutorToTargetMap(

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -1,9 +1,5 @@
-import { buildTargetFromScript, PackageJson } from './package-json';
-import { join } from 'path';
 import { ProjectGraph, ProjectGraphProjectNode } from '../config/project-graph';
-import { readJsonFile } from './fileutils';
 import { readCachedProjectGraph } from '../project-graph/project-graph';
-import { TargetConfiguration } from '../config/workspace-json-project-json';
 
 export function projectHasTarget(
   project: ProjectGraphProjectNode,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`targetDefaults` doesn't respect targets from package.json if they are not actually in the config file, making it s.t. they can't be applied to nx release

## Expected Behavior
`targetDefaults` reads targets using the shared helper

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
