### PR TITLE
fix(misc): support ts-node options in tsconfig files

### DIFF
--- a/packages/nx/src/project-graph/plugins/loader.ts
+++ b/packages/nx/src/project-graph/plugins/loader.ts
@@ -98,11 +98,14 @@ export function registerPluginTSTranspiler() {
     : {};
   const cleanupFns = [
     registerTsConfigPaths(tsConfigName),
-    registerTranspiler({
-      experimentalDecorators: true,
-      emitDecoratorMetadata: true,
-      ...tsConfig.options,
-    }),
+    registerTranspiler(
+      {
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+        ...tsConfig.options,
+      },
+      tsConfig.raw
+    ),
   ];
   unregisterPluginTSTranspiler = () => {
     cleanupFns.forEach((fn) => fn?.());


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The tsconfig.json is no longer being read by ts-node, and the ts-node specific options are also not being passed to ts-node.

## Expected Behavior

The `"ts-node"` specific options should be read from the tsconfig.json files, ideally through the entire `extends` chain. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21695 - this PR doesnt read through the extends chain, but it solves my use case, where the options are in the `tsconfig.base.json` file. We can document that limitation, and I think it's a clear tradeoff.
