### PR TITLE
fix(nextjs): Custom server should work with Crystal

### DIFF
--- a/e2e/next-core/src/next.test.ts
+++ b/e2e/next-core/src/next.test.ts
@@ -149,6 +149,40 @@ describe('Next.js Applications', () => {
       checkExport: false,
     });
   }, 300_000);
+
+  it('should support --custom-server flag (swc)', async () => {
+    const appName = uniq('app');
+
+    runCLI(`generate @nx/next:app ${appName} --no-interactive --custom-server`);
+
+    checkFilesExist(`apps/${appName}/server/main.ts`);
+
+    const result = runCLI(`build ${appName}`);
+
+    checkFilesExist(`dist/apps/${appName}/server/main.js`);
+
+    expect(result).toContain(
+      `Successfully ran target build for project ${appName}`
+    );
+  }, 300_000);
+
+  it('should support --custom-server flag (tsc)', async () => {
+    const appName = uniq('app');
+
+    runCLI(
+      `generate @nx/next:app ${appName} --swc=false --no-interactive --custom-server`
+    );
+
+    checkFilesExist(`apps/${appName}/server/main.ts`);
+
+    const result = runCLI(`build ${appName}`);
+
+    checkFilesExist(`dist/apps/${appName}/server/main.js`);
+
+    expect(result).toContain(
+      `Successfully ran target build for project ${appName}`
+    );
+  }, 300_000);
 });
 
 function getData(port, path = ''): Promise<any> {

--- a/packages/next/src/generators/custom-server/custom-server.spec.ts
+++ b/packages/next/src/generators/custom-server/custom-server.spec.ts
@@ -5,16 +5,7 @@ import { applicationGenerator } from '../application/application';
 describe('app', () => {
   let tree: Tree;
 
-  let originalEnv: string;
   beforeAll(() => {
-    originalEnv = process.env.NX_ADD_PLUGINS;
-    process.env.NX_ADD_PLUGINS = 'false';
-  });
-  afterAll(() => {
-    process.env.NX_ADD_PLUGINS = originalEnv;
-  });
-
-  beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
   });
 

--- a/packages/next/src/generators/custom-server/files/server/main.ts__tmpl__
+++ b/packages/next/src/generators/custom-server/files/server/main.ts__tmpl__
@@ -2,9 +2,8 @@
  * This is only a minimal custom server to get started.
  * You may want to consider using Express or another server framework, and enable security features such as CORS.
  *
- * For more examples, see the Next.js repo:
- * - Express: https://github.com/vercel/next.js/tree/canary/examples/custom-server-express
- * - Hapi: https://github.com/vercel/next.js/tree/canary/examples/custom-server-hapi
+ * For an example, see the Next.js repo:
+ * Node - https://github.com/vercel/next.js/blob/canary/examples/custom-server
  */
 import { createServer } from 'http';
 import { parse } from 'node:url';
@@ -15,7 +14,8 @@ import next from 'next';
 // - The environment variable is set by `@nx/next:server` when running the dev server.
 // - The fallback `__dirname` is for production builds.
 // - Feel free to change this to suit your needs.
-const dir = process.env.NX_NEXT_DIR || path.join(__dirname, '..');
+
+const dir = process.env.NX_NEXT_DIR || <%- hasPlugin ? `path.join(__dirname, '${projectPathFromDist}')` : `path.join(__dirname, '..')`; %> 
 const dev = process.env.NODE_ENV === 'development';
 
 // HTTP Server options:

--- a/packages/next/src/generators/custom-server/files/tsconfig.server.json__tmpl__
+++ b/packages/next/src/generators/custom-server/files/tsconfig.server.json__tmpl__
@@ -4,7 +4,9 @@
     "module": "commonjs",
     "noEmit": false,
     "incremental": true,
+    <% if(hasPlugin && compiler === 'tsc') { %>
     "tsBuildInfoFile": "<%= offsetFromRoot %>tmp/buildcache/<%= projectRoot %>/server",
+    <% } %>
     "types": [
       "node"
     ]

--- a/packages/next/src/utils/add-swc-to-custom-server.ts
+++ b/packages/next/src/utils/add-swc-to-custom-server.ts
@@ -4,6 +4,7 @@ import {
   installPackagesTask,
   joinPathFragments,
   readJson,
+  updateJson,
 } from '@nx/devkit';
 import { swcCliVersion, swcCoreVersion, swcNodeVersion } from './versions';
 import { addSwcConfig } from '@nx/js/src/utils/swc/add-swc-config';
@@ -21,7 +22,16 @@ export function configureForSwc(tree: Tree, projectRoot: string) {
     rootPackageJson.devDependencies?.['@swc/cli'];
 
   if (!tree.exists(swcConfigPath)) {
-    addSwcConfig(tree, swcConfigPath);
+    addSwcConfig(tree, projectRoot);
+  }
+
+  if (tree.exists(swcConfigPath)) {
+    updateJson(tree, swcConfigPath, (json) => {
+      return {
+        ...json,
+        exclude: [...json.exclude, '.*.d.ts$'],
+      };
+    });
   }
 
   if (!hasSwcDepedency || !hasSwcCliDependency) {


### PR DESCRIPTION
When Project Crystal became the default the next `custom-server` generator was not working properly.

This should now work with inferred targets.