### PR TITLE
fix(misc): pin generated vite version to ~5.0.0 to avoid issues with storybook

### DIFF
--- a/e2e/nuxt/src/nuxt.test.ts
+++ b/e2e/nuxt/src/nuxt.test.ts
@@ -12,7 +12,7 @@ describe('Nuxt Plugin', () => {
 
   beforeAll(() => {
     newProject({
-      packages: ['@nx/nuxt', '@nx/storybook'],
+      packages: ['@nx/nuxt'],
       unsetProjectNameAndRootFormat: false,
     });
     runCLI(

--- a/e2e/storybook/src/storybook.test.ts
+++ b/e2e/storybook/src/storybook.test.ts
@@ -16,7 +16,7 @@ describe('Storybook generators and executors for monorepos', () => {
   let proj;
   beforeAll(async () => {
     proj = newProject({
-      packages: ['@nx/react', '@nx/storybook'],
+      packages: ['@nx/react'],
       unsetProjectNameAndRootFormat: false,
     });
     runCLI(

--- a/e2e/vue/src/vue-storybook.test.ts
+++ b/e2e/vue/src/vue-storybook.test.ts
@@ -15,7 +15,7 @@ describe('Storybook generators and executors for Vue projects', () => {
     originalEnv = process.env.NX_ADD_PLUGINS;
     process.env.NX_ADD_PLUGINS = 'true';
     proj = newProject({
-      packages: ['@nx/vue', '@nx/storybook'],
+      packages: ['@nx/vue'],
       unsetProjectNameAndRootFormat: false,
     });
     runCLI(

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -5,5 +5,5 @@ export const cypressViteDevServerVersion = '^2.2.1';
 export const cypressVersion = '^13.0.0';
 export const cypressWebpackVersion = '^2.0.0';
 export const webpackHttpPluginVersion = '^5.5.0';
-export const viteVersion = '^5.0.0';
+export const viteVersion = '~5.0.0';
 export const htmlWebpackPluginVersion = '^5.5.0';

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -8,6 +8,6 @@ export const tsLibVersion = '^2.3.0';
 
 export const storybookVersion = '^7.5.3';
 export const reactVersion = '^18.2.0';
-export const viteVersion = '^5.0.0';
+export const viteVersion = '~5.0.0';
 
 export const coreJsVersion = '^3.6.5';

--- a/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`@nx/vite:init dependencies for package.json should add required package
     "@nx/web": "0.0.1",
     "@vitest/ui": "^1.0.4",
     "existing": "1.0.0",
-    "vite": "^5.0.0",
+    "vite": "~5.0.0",
     "vitest": "^1.0.4",
   },
   "name": "@proj/source",

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = require('../../package.json').version;
-export const viteVersion = '^5.0.0';
+export const viteVersion = '~5.0.0';
 export const vitestVersion = '^1.0.4';
 export const vitePluginReactVersion = '^4.2.0';
 export const vitePluginReactSwcVersion = '^3.5.0';

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -196,7 +196,7 @@ exports[`lib should add vue, vite and vitest to package.json 1`] = `
     "jsdom": "~22.1.0",
     "prettier": "^2.6.2",
     "typescript": "~5.3.2",
-    "vite": "^5.0.0",
+    "vite": "~5.0.0",
     "vitest": "^1.0.4",
     "vue-tsc": "^1.8.8",
   },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The recently released Vite 5.1.0 (and 5.1.1 released afterward) causes Storybook builds to fail with an error like:

```
e2e-nuxt: => Failed to build the preview
e2e-nuxt: Error: Unexpected early exit. This happens when Promises returned by plugins cannot resolve. Unfinished hook action(s) on exit:
e2e-nuxt: (vite:esbuild) transform "./.storybook/preview.ts"
e2e-nuxt: (vite:esbuild) transform "./src/components/NxWelcome.stories.ts"
e2e-nuxt: (vite:esbuild) transform "./src/components/one/one.stories.ts"
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Storybook builds with Vite should work. The generated Vite version is restricted to `~5.0.0` to prevent issues until they are fixed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
