### PR TITLE
fix(testing): jest should handle root jest.preset.cjs

### DIFF
--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -17,6 +17,7 @@ import {
 } from '@nx/devkit';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { JestPluginOptions } from '../../plugins/plugin';
+import { isPresetCjs } from '../../utils/config/is-preset-cjs';
 
 const schemaDefaults = {
   setupFile: 'none',
@@ -84,9 +85,11 @@ export async function configurationGeneratorInternal(
     tasks.push(ensureDependencies(tree, options));
   }
 
-  await createJestConfig(tree, options);
+  const presetExt = isPresetCjs(tree) ? 'cjs' : 'js';
+
+  await createJestConfig(tree, options, presetExt);
   checkForTestTarget(tree, options);
-  createFiles(tree, options);
+  createFiles(tree, options, presetExt);
   updateTsConfig(tree, options);
   updateVsCodeRecommendedExtensions(tree);
 

--- a/packages/jest/src/generators/configuration/files-angular/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/configuration/files-angular/jest.config.ts__tmpl__
@@ -1,7 +1,7 @@
 /* eslint-disable */
 <% if(js){ %>module.exports =<% } else{ %>export default<% } %> {
   displayName: '<%= project %>',
-  preset: '<%= offsetFromRoot %>jest.preset.js',
+  preset: '<%= offsetFromRoot %>jest.preset.<%= presetExt %>',
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],<% if(testEnvironment) { %>
   testEnvironment: '<%= testEnvironment %>',<% } %>
   coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>',

--- a/packages/jest/src/generators/configuration/files/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/configuration/files/jest.config.ts__tmpl__
@@ -1,7 +1,7 @@
 /* eslint-disable */
 <% if(js){ %>module.exports =<% } else{ %>export default<% } %> {
   displayName: '<%= project %>',
-  preset: '<%= offsetFromRoot %>jest.preset.js',<% if(setupFile !== 'none') { %>
+  preset: '<%= offsetFromRoot %>jest.preset.<%= presetExt %>',<% if(setupFile !== 'none') { %>
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],<% } %><% if(testEnvironment) { %>
   testEnvironment: '<%= testEnvironment %>',<% } %><% if(skipSerializers){ %>
   transform: {

--- a/packages/jest/src/generators/configuration/lib/create-files.ts
+++ b/packages/jest/src/generators/configuration/lib/create-files.ts
@@ -7,7 +7,11 @@ import {
 import { join } from 'path';
 import { NormalizedJestProjectSchema } from '../schema';
 
-export function createFiles(tree: Tree, options: NormalizedJestProjectSchema) {
+export function createFiles(
+  tree: Tree,
+  options: NormalizedJestProjectSchema,
+  presetExt: 'cjs' | 'js'
+) {
   const projectConfig = readProjectConfiguration(tree, options.project);
 
   const filesFolder =
@@ -42,6 +46,7 @@ export function createFiles(tree: Tree, options: NormalizedJestProjectSchema) {
     rootProject: options.rootProject,
     projectRoot: options.rootProject ? options.project : projectConfig.root,
     offsetFromRoot: offsetFromRoot(projectConfig.root),
+    presetExt,
   });
 
   if (options.setupFile === 'none') {

--- a/packages/jest/src/generators/configuration/lib/create-jest-config.spec.ts
+++ b/packages/jest/src/generators/configuration/lib/create-jest-config.spec.ts
@@ -46,7 +46,7 @@ describe('createJestConfig', () => {
   });
 
   it('should generate files with --js flag', async () => {
-    await createJestConfig(tree, { js: true });
+    await createJestConfig(tree, { js: true }, 'js');
 
     expect(tree.exists('jest.config.js')).toBeTruthy();
     expect(
@@ -58,7 +58,7 @@ describe('createJestConfig', () => {
   });
 
   it('should generate files ', async () => {
-    await createJestConfig(tree, {});
+    await createJestConfig(tree, {}, 'js');
 
     expect(tree.exists('jest.config.ts')).toBeTruthy();
     expect(
@@ -92,13 +92,13 @@ export default {
 `;
     tree.write('jest.config.ts', expected);
 
-    await createJestConfig(tree, {});
+    await createJestConfig(tree, {}, 'js');
 
     expect(tree.read('jest.config.ts', 'utf-8')).toEqual(expected);
   });
 
   it('should make js jest files', async () => {
-    await createJestConfig(tree, { js: true });
+    await createJestConfig(tree, { js: true }, 'js');
 
     expect(tree.exists('jest.config.js')).toBeTruthy();
     expect(tree.exists('jest.preset.js')).toBeTruthy();
@@ -106,7 +106,7 @@ export default {
 
   describe('root project', () => {
     it('should not add a monorepo jest.config.ts  to the project', async () => {
-      await createJestConfig(tree, { rootProject: true });
+      await createJestConfig(tree, { rootProject: true }, 'js');
 
       expect(tree.exists('jest.config.ts')).toBeFalsy();
     });
@@ -143,7 +143,7 @@ export default {
 `
       );
 
-      await createJestConfig(tree, { rootProject: false });
+      await createJestConfig(tree, { rootProject: false }, 'js');
 
       expect(tree.exists('jest.config.app.ts')).toBeTruthy();
       expect(tree.read('jest.config.app.ts', 'utf-8')).toMatchInlineSnapshot(`
@@ -210,7 +210,7 @@ module.exports = {
 `
       );
 
-      await createJestConfig(tree, { js: true, rootProject: false });
+      await createJestConfig(tree, { js: true, rootProject: false }, 'js');
 
       expect(tree.exists('jest.config.app.js')).toBeTruthy();
       expect(tree.read('jest.config.js', 'utf-8'))

--- a/packages/jest/src/generators/configuration/lib/create-jest-config.ts
+++ b/packages/jest/src/generators/configuration/lib/create-jest-config.ts
@@ -13,12 +13,13 @@ import type { NormalizedJestProjectSchema } from '../schema';
 
 export async function createJestConfig(
   tree: Tree,
-  options: Partial<NormalizedJestProjectSchema>
+  options: Partial<NormalizedJestProjectSchema>,
+  presetExt: 'cjs' | 'js'
 ) {
-  if (!tree.exists('jest.preset.js')) {
+  if (!tree.exists(`jest.preset.${presetExt}`)) {
     // preset is always js file.
     tree.write(
-      `jest.preset.js`,
+      `jest.preset.${presetExt}`,
       `
       const nxPreset = require('@nx/jest/preset').default;
 

--- a/packages/jest/src/utils/config/find-root-jest-files.ts
+++ b/packages/jest/src/utils/config/find-root-jest-files.ts
@@ -17,5 +17,9 @@ export function findRootJestPreset(tree: Tree): string | null {
     return 'jest.preset.js';
   }
 
+  if (tree.exists('jest.preset.cjs')) {
+    return 'jest.preset.cjs';
+  }
+
   return null;
 }

--- a/packages/jest/src/utils/config/is-preset-cjs.ts
+++ b/packages/jest/src/utils/config/is-preset-cjs.ts
@@ -1,0 +1,14 @@
+import { type Tree, readJson } from '@nx/devkit';
+
+export function isPresetCjs(tree: Tree) {
+  if (tree.exists('jest.preset.cjs')) {
+    return true;
+  }
+
+  const rootPkgJson = readJson(tree, 'package.json');
+  if (rootPkgJson.type && rootPkgJson.type === 'module') {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Jest Configuration generator only generates `jest.preset.js` files, and only creates `jest.config` files that point to `jest.preset.js`.

If root `package.json` has `type: module` then the `jest.preset` needs to be `.cjs`.

If a `jest.preset.cjs` already exists, instead of using the `jest.preset.cjs` in the `jest.config` files, it will still create and try to point to `jest.preset.js`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Ensure Jest Configuration supports `jest.preset.js` and `jest.preset.cjs`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
