### PR TITLE
fix(js): babel preset should also check for JEST_WORKER_ID to transpile to CJS

### DIFF
--- a/packages/js/babel.ts
+++ b/packages/js/babel.ts
@@ -52,7 +52,7 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
         // For Jest tests, NODE_ENV is set as 'test' and we only want to set target as Node.
         // All other options will fail in Jest since Node does not support some ES features
         // such as import syntax.
-        isTest || process.env.NODE_ENV === 'test'
+        isTest || process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID
           ? { targets: { node: 'current' }, loose: true }
           : {
               // Allow importing core-js in entrypoint and use browserslist to select polyfills.


### PR DESCRIPTION
This PR fixes a longstanding issue with `@nx/js/babel` where `NODE_ENV` being anything other than `test` will cause errors due to modules being transpiled as ESM (and Jest not able to run it).

Previously, our `@nx/jest:jest` executor guarantees this `NODE_ENV` is `test`, but now with Project Crystal we are skipping the executor. To know whether we're in Jest context, we should check the `JEST_WORKER_ID` which is always set when using Jest runner.

For example, if you generate an app and run Jest with `NODE_ENV` set to anything else you'll see an error.

```
npx nx g @nx/react:app jest-app --unitTestRunner=jest
NODE_ENV=development npx nx test jest-app # ERROR!
```

## Current Behavior
Setting `NODE_ENV` to anything other than `test` will result in test failure.

## Expected Behavior
Our test setup should be resilient against `NODE_ENV` not being `test`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
