### PR TITLE
fix(nextjs): Svg should work when svgr is true in next config

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -333,40 +333,22 @@ export function getNextConfig(
 
       // Default SVGR support to be on for projects.
       if (nx?.svgr !== false) {
-        config.module.rules.push({
-          test: /\.svg$/,
-          oneOf: [
-            // If coming from JS/TS file, then transform into React component using SVGR.
-            {
-              issuer: /\.[jt]sx?$/,
-              use: [
-                {
-                  loader: require.resolve('@svgr/webpack'),
-                  options: {
-                    svgo: false,
-                    titleProp: true,
-                    ref: true,
-                  },
-                },
-                {
-                  loader: require.resolve('url-loader'),
-                  options: {
-                    limit: 10000, // 10kB
-                    name: '[name].[hash:7].[ext]',
-                  },
-                },
-              ],
-            },
-            // Fallback to plain URL loader if someone just imports the SVG and references it on the <img src> tag
-            {
-              loader: require.resolve('url-loader'),
-              options: {
-                limit: 10000, // 10kB
-                name: '[name].[hash:7].[ext]',
-              },
-            },
-          ],
-        });
+        config.module.rules.push(
+          // Apply rule for svg imports ending in ?url
+          {
+            test: /\.svg$/i,
+            type: 'asset',
+            resourceQuery: /url/, // apply to *.svg?url
+          },
+
+          // Convert all other svg imports to React components
+          {
+            test: /\.svg$/i,
+            issuer: /\.[jt]sx?$/,
+            resourceQuery: { not: [/url/] },
+            use: ['@svgr/webpack'],
+          }
+        );
       }
 
       return userWebpack(config, options);


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When we set svgr to true and we have a svg resource loaded serving that app fails to load.

```js
const nextConfig = {
  nx: {
    // Set this to true if you would like to use SVGR
    // See: https://github.com/gregberge/svgr
    svgr: true,
  },
};
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When `svgr` is set to `true` and there is a svgr resource the app should not fail to load.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20972
