### PR TITLE
fix(release): skip prompt for publish when no version created

### DIFF
--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -140,8 +140,17 @@ export async function release(
     }
   }
 
-  let shouldPublish = !!args.yes && !args.skipPublish;
-  const shouldPromptPublishing = !args.yes && !args.skipPublish && !args.dryRun;
+  let hasNewVersion = false;
+  // null means that all projects are versioned together but there were no changes
+  if (versionResult.workspaceVersion !== null) {
+    hasNewVersion = Object.values(versionResult.projectsVersionData).some(
+      (version) => version.newVersion !== null
+    );
+  }
+
+  let shouldPublish = !!args.yes && !args.skipPublish && hasNewVersion;
+  const shouldPromptPublishing =
+    !args.yes && !args.skipPublish && !args.dryRun && hasNewVersion;
 
   if (shouldPromptPublishing) {
     shouldPublish = await promptForPublish();


### PR DESCRIPTION
## Current Behavior

Running `nx release` prompt "Do you want to publish these versions?" even if no version was created during the process.

## Expected Behavior

Skip prompt and publish if no version was created.

## Related Issue(s)
N/A
