### PR TITLE
feat(angular): update jest-preset-angular version

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1630,6 +1630,22 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "18.1.0-jest": {
+      "version": "18.1.0-beta.1",
+      "requires": {
+        "@angular-devkit/build-angular": ">=15.0.0 <18.0.0",
+        "@angular/compiler-cli": ">=15.0.0 <18.0.0",
+        "@angular/core": ">=15.0.0 <18.0.0",
+        "@angular/platform-browser-dynamic": ">=15.0.0 <18.0.0",
+        "jest": "^29.0.0"
+      },
+      "packages": {
+        "jest-preset-angular": {
+          "version": "~14.0.2",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -23,7 +23,7 @@ export const postcssUrlVersion = '~10.1.3';
 export const autoprefixerVersion = '^10.4.0';
 export const tsNodeVersion = '10.9.1';
 
-export const jestPresetAngularVersion = '~13.1.4';
+export const jestPresetAngularVersion = '~14.0.2';
 export const typesNodeVersion = '18.16.9';
 export const jasmineMarblesVersion = '^0.9.2';
 


### PR DESCRIPTION
Updates the `jest-preset-angular` version to support the signal-based inputs (developer preview feature) introduced in Angular v17.1.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
