### PR TITLE
feat(core): add option to disable log grouping on CI

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -399,6 +399,7 @@ jobs:
           NX_E2E_VERBOSE_LOGGING: 'true'
           NX_PERF_LOGGING: 'false'
           NX_DAEMON: 'true'
+          NX_SKIP_LOG_GROUPING: 'true'
 
       - name: Save matrix config in file
         if: ${{ always() }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -297,6 +297,7 @@ jobs:
           NX_E2E_VERBOSE_LOGGING: 'true'
           NX_PERF_LOGGING: 'false'
           NX_DAEMON: 'true'
+          NX_SKIP_LOG_GROUPING: 'true'
 
       - name: Save matrix config in file
         if: ${{ always() }}

--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -27,6 +27,7 @@ The following environment variables are ones that you can set to change the beha
 | NX_PREFER_TS_NODE                | boolean | If set to `true`, Nx will use ts-node for local execution of plugins even if `@swc-node/register` is installed.                                                                                                                        |
 | NX_IGNORE_CYCLES                 | boolean | If set to `true`, Nx will ignore errors created by a task graph circular dependency. Can be overriden on the command line with `--nxIgnoreCycles`                                                                                      |
 | NX_BATCH_MODE                    | boolean | If set to `true`, Nx will run task(s) in batches for executors which support batches.                                                                                                                                                  |
+| NX_SKIP_LOG_GROUPING             | boolean | If set to `true`, Nx will not group command's logs on CI.                                                                                                                                                                              |
 
 Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators.
 

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -241,7 +241,10 @@ class CLIOutput {
       message,
       taskStatus
     );
-    if (process.env.GITHUB_ACTIONS) {
+    if (
+      process.env.NX_SKIP_LOG_GROUPING !== 'true' &&
+      process.env.GITHUB_ACTIONS
+    ) {
       const icon = this.getStatusIcon(taskStatus);
       commandOutputWithStatus = `${GH_GROUP_PREFIX}${icon} ${commandOutputWithStatus}`;
     }
@@ -252,7 +255,10 @@ class CLIOutput {
     this.addNewline();
     this.writeToStdOut(output);
 
-    if (process.env.GITHUB_ACTIONS) {
+    if (
+      process.env.NX_SKIP_LOG_GROUPING !== 'true' &&
+      process.env.GITHUB_ACTIONS
+    ) {
       this.writeToStdOut(GH_GROUP_SUFFIX);
     }
   }


### PR DESCRIPTION
This PR fixes a lot of failing `e2e-release` tests on github nightly.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
