### PR TITLE
fix(nx-dev): add colors to ms logo

### DIFF
--- a/nx-dev/ui-home/src/lib/logo-cloud.tsx
+++ b/nx-dev/ui-home/src/lib/logo-cloud.tsx
@@ -117,10 +117,25 @@ export function LogoCloud(): JSX.Element {
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
             fill="currentColor"
-            className="h-12 w-12 text-[#5E5E5E] dark:text-slate-600"
+            className="h-12 w-12"
           >
             <title>Microsoft</title>
-            <path d="M0 0v11.408h11.408V0zm12.594 0v11.408H24V0zM0 12.594V24h11.408V12.594zm12.594 0V24H24V12.594z" />
+            <path
+              d="M0 0v11.408h11.408V0zm12.594"
+              className="text-[#F65314] dark:text-slate-600"
+            />
+            <path
+              d="M12.594 0v11.408H24V0zM0"
+              className="text-[#7CBB00] dark:text-slate-600"
+            />
+            <path
+              d="M0 12.594V24h11.408V12.594zm12.594"
+              className="text-[#00A1F1] dark:text-slate-600"
+            />
+            <path
+              d="M12.594 12.594V24H24V12.594z"
+              className="text-[#FFBB00] dark:text-slate-600"
+            />
           </svg>
         </div>
         <div className="col-span-1 flex items-center justify-center">


### PR DESCRIPTION
The same should be applied to Wallmart, React Query, and American Airlines

## Current Behavior
![Screenshot 2024-02-12 at 22 27 22](https://github.com/nrwl/nx/assets/881612/ce958b9e-5c25-4d51-8f5d-4458bfd1e403)


## Expected Behavior
![Screenshot 2024-02-12 at 22 27 44](https://github.com/nrwl/nx/assets/881612/50f4a7c2-d2a0-45ca-b7a4-f530fb055e41)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
