### PR TITLE
fix(js): Adds mjs files to prettierrcNameOptions

### DIFF
--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -103,8 +103,10 @@ export async function initGenerator(
     '.prettierrc.json5',
     '.prettierrc.js',
     '.prettierrc.cjs',
+    '.prettierrc.mjs',
     'prettier.config.js',
     'prettier.config.cjs',
+    'prettier.config.mjs',
     '.prettierrc.toml',
   ];
 

--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -104,10 +104,10 @@ export async function initGenerator(
     '.prettierrc.js',
     '.prettierrc.cjs',
     '.prettierrc.mjs',
+    '.prettierrc.toml',
     'prettier.config.js',
     'prettier.config.cjs',
     'prettier.config.mjs',
-    '.prettierrc.toml',
   ];
 
   if (prettierrcNameOptions.every((name) => !tree.exists(name))) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when running a generator, it does not check for the existence of a prettier.config.mjs or .prettierrc.mjs file

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When using a generator, it check for the existence of all config file names specified in the docs. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


Fixes https://github.com/nrwl/nx/issues/21795

adds .mjs file names to checks