### PR TITLE
fix(core): run migrations ordered by their target version

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1367,8 +1367,19 @@ export async function executeMigrations(
   const depsBeforeMigrations = getStringifiedPackageJsonDeps(root);
 
   const migrationsWithNoChanges: typeof migrations = [];
+  const sortedMigrations = migrations.sort((a, b) => {
+    // special case for the split configuration migration to run first
+    if (a.name === '15-7-0-split-configuration-into-project-json-files') {
+      return -1;
+    }
+    if (b.name === '15-7-0-split-configuration-into-project-json-files') {
+      return 1;
+    }
 
-  for (const m of migrations) {
+    return lt(a.version, b.version) ? -1 : 1;
+  });
+
+  for (const m of sortedMigrations) {
     try {
       const { collection, collectionPath } = readMigrationCollection(
         m.package,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Most of the time, all migrations of a given plugin are run ordered by their target version. This can be problematic sometimes when a migration of a plugin checks stuff from another plugin.

Such an issue occurred and is explained in https://github.com/nrwl/nx/issues/20407#issuecomment-1938867247:

- the `update-tsconfig-spec-jest` migration from the `@nx/angular` package targets the version `15.9.0-beta.3`
- that migration checks targets with the `@nrwl/jest:jest` executor to perform an update to the `tsconfig.spec.json`
- the `update-16-0-0-add-nx-packages` migration from the `@nx/jest` package targets the version `16.0.0-beta.1`
- that migration renames and replaces all occurrences of `@nrwl/jest` with `@nx/jest`
- the `@nx/jest` package migrations run before the `@nx/angular` package migrations

Note how `@nrwl/jest:jest` will be replaced `@nx/jest:jest` before running the `update-tsconfig-spec-jest` migration from the `@nx/angular` package, even though that migration was written/released and targets a lower version of Nx. That migration shouldn't know about the `@nx/*` scoped packages because it was written for a version where the rescoping hadn't occurred yet.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migrations should be run ordered by their target version regardless of the plugin they are for.

Note: the `15-7-0-split-configuration-into-project-json-files` migration from `@nx/workspace` is a special case that's meant to run first.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
