### PR TITLE
fix(js): swc executor should support inlining on windows

### DIFF
--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -83,4 +83,5 @@ export interface NormalizedSwcExecutorOptions
   swcExclude: string[];
   skipTypeCheck: boolean;
   swcCliOptions: SwcCliOptions;
+  tmpSwcrcPath: string;
 }

--- a/packages/js/src/utils/swc/get-swcrc-path.ts
+++ b/packages/js/src/utils/swc/get-swcrc-path.ts
@@ -6,7 +6,19 @@ export function getSwcrcPath(
   contextRoot: string,
   projectRoot: string
 ) {
-  return options.swcrc
+  const swcrcPath = options.swcrc
     ? join(contextRoot, options.swcrc)
     : join(contextRoot, projectRoot, '.swcrc');
+
+  const tmpSwcrcPath = join(
+    contextRoot,
+    projectRoot,
+    'tmp',
+    '.generated.swcrc'
+  );
+
+  return {
+    swcrcPath,
+    tmpSwcrcPath,
+  };
 }

--- a/packages/js/src/utils/swc/inline.ts
+++ b/packages/js/src/utils/swc/inline.ts
@@ -3,7 +3,8 @@ import type { InlineProjectGraph } from '../inline';
 
 export function generateTmpSwcrc(
   inlineProjectGraph: InlineProjectGraph,
-  swcrcPath: string
+  swcrcPath: string,
+  tmpSwcrcPath: string
 ) {
   const swcrc = readJsonFile(swcrcPath);
 
@@ -14,7 +15,6 @@ export function generateTmpSwcrc(
     'node_modules/**/*.ts$'
   );
 
-  const tmpSwcrcPath = `tmp${swcrcPath}`;
   writeJsonFile(tmpSwcrcPath, swcrc);
 
   return tmpSwcrcPath;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nx/js:swc` executor does not support inlining on Windows due to file path issues


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Support windows for swc inlining

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
