### PR TITLE
fix(nextjs): Add missing e2e-ci target for cypress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ CHANGELOG.md
 
 # Next.js
 .next
+out
 
 # Angular Cache
 .angular

--- a/docs/generated/packages/next/documents/overview.md
+++ b/docs/generated/packages/next/documents/overview.md
@@ -60,7 +60,8 @@ The `@nx/next/plugin` is configured in the `plugins` array in `nx.json`.
       "options": {
         "buildTargetName": "build",
         "devTargetName": "dev",
-        "startTargetName": "start"
+        "startTargetName": "start",
+        "serveStaticTargetName": "serve-static"
       }
     }
   ]
@@ -70,6 +71,10 @@ The `@nx/next/plugin` is configured in the `plugins` array in `nx.json`.
 - The `buildTargetName` option controls the name of Next.js' compilation task which compiles the application for production deployment. The default name is `build`.
 - The `devTargetName` option controls the name of Next.js' development serve task which starts the application in development mode. The default name is `dev`.
 - The `startTargetName` option controls the name of Next.js' production serve task which starts the application in production mode. The default name is `start`.
+- The `serveStaticTargetName` option controls the name of Next.js' static export task which exports the application to static HTML files. The default name is `serve-static`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
 
 {% /tab %}
 {% tab label="Nx < 18" %}
@@ -246,8 +251,49 @@ const nextConfig = {
   nx: {
     svgr: false,
   },
+  output: 'export',
 };
 ```
+
+After setting the output to `export`, you can run the `build` command to generate the static HTML files.
+
+```shell
+nx build my-next-app
+```
+
+You can then check your project folder for the `out` folder which contains the static HTML files.
+
+```shell
+├── index.d.ts
+├── jest.config.ts
+├── next-env.d.ts
+├── next.config.js
+├── out
+├── project.json
+├── public
+├── specs
+├── src
+├── tsconfig.json
+└── tsconfig.spec.json
+```
+
+#### E2E testing
+
+You can perform end-to-end (E2E) testing on static HTML files using a test runner like Cypress. When you create a Next.js application, Nx automatically creates a `serve-static` target. This target is designed to serve the static HTML files produced by the build command.
+
+This feature is particularly useful for testing in continuous integration (CI) pipelines, where resources may be constrained. Unlike the `dev` and `start` targets, `serve-static` does not require a Next.js server to operate, making it more efficient and faster by eliminating background processes, such as file change monitoring.
+
+To utilize the `serve-static` target for testing, run the following command:
+
+```shell
+nx serve-static my-next-app-e2e
+```
+
+This command performs several actions:
+
+1. It will build the Next.js application and generate the static HTML files.
+2. It will serve the static HTML files using a simple HTTP server.
+3. It will run the Cypress tests against the served static HTML files.
 
 ### Deploying Next.js Applications
 

--- a/docs/shared/packages/next/plugin-overview.md
+++ b/docs/shared/packages/next/plugin-overview.md
@@ -60,7 +60,8 @@ The `@nx/next/plugin` is configured in the `plugins` array in `nx.json`.
       "options": {
         "buildTargetName": "build",
         "devTargetName": "dev",
-        "startTargetName": "start"
+        "startTargetName": "start",
+        "serveStaticTargetName": "serve-static"
       }
     }
   ]
@@ -70,6 +71,10 @@ The `@nx/next/plugin` is configured in the `plugins` array in `nx.json`.
 - The `buildTargetName` option controls the name of Next.js' compilation task which compiles the application for production deployment. The default name is `build`.
 - The `devTargetName` option controls the name of Next.js' development serve task which starts the application in development mode. The default name is `dev`.
 - The `startTargetName` option controls the name of Next.js' production serve task which starts the application in production mode. The default name is `start`.
+- The `serveStaticTargetName` option controls the name of Next.js' static export task which exports the application to static HTML files. The default name is `serve-static`.
+
+{% /tab %}
+{% tab label="Nx < 18" %}
 
 {% /tab %}
 {% tab label="Nx < 18" %}
@@ -246,8 +251,49 @@ const nextConfig = {
   nx: {
     svgr: false,
   },
+  output: 'export',
 };
 ```
+
+After setting the output to `export`, you can run the `build` command to generate the static HTML files.
+
+```shell
+nx build my-next-app
+```
+
+You can then check your project folder for the `out` folder which contains the static HTML files.
+
+```shell
+├── index.d.ts
+├── jest.config.ts
+├── next-env.d.ts
+├── next.config.js
+├── out
+├── project.json
+├── public
+├── specs
+├── src
+├── tsconfig.json
+└── tsconfig.spec.json
+```
+
+#### E2E testing
+
+You can perform end-to-end (E2E) testing on static HTML files using a test runner like Cypress. When you create a Next.js application, Nx automatically creates a `serve-static` target. This target is designed to serve the static HTML files produced by the build command.
+
+This feature is particularly useful for testing in continuous integration (CI) pipelines, where resources may be constrained. Unlike the `dev` and `start` targets, `serve-static` does not require a Next.js server to operate, making it more efficient and faster by eliminating background processes, such as file change monitoring.
+
+To utilize the `serve-static` target for testing, run the following command:
+
+```shell
+nx serve-static my-next-app-e2e
+```
+
+This command performs several actions:
+
+1. It will build the Next.js application and generate the static HTML files.
+2. It will serve the static HTML files using a simple HTTP server.
+3. It will run the Cypress tests against the served static HTML files.
 
 ### Deploying Next.js Applications
 

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -197,6 +197,12 @@ function withNx(
             : joinPathFragments(outputDir, '.next');
       }
 
+      // If we are running a static serve of the Next.js app, we need to change the output to 'export' and the distDir to 'out'.
+      if (process.env.NX_SERVE_STATIC_BUILD_RUNNING === 'true') {
+        nextConfig.output = 'export';
+        nextConfig.distDir = 'out';
+      }
+
       const userWebpackConfig = nextConfig.webpack;
 
       const { createWebpackConfig } = require('@nx/next/src/utils/config');

--- a/packages/next/src/generators/custom-server/custom-server.spec.ts
+++ b/packages/next/src/generators/custom-server/custom-server.spec.ts
@@ -28,7 +28,7 @@ describe('app', () => {
   });
 
   it('should create a custom server with swc', async () => {
-    const name = uniq('custom-server');
+    const name = uniq('custom-server-swc');
 
     await applicationGenerator(tree, {
       name,

--- a/packages/next/src/generators/init/lib/add-plugin.ts
+++ b/packages/next/src/generators/init/lib/add-plugin.ts
@@ -20,6 +20,7 @@ export function addPlugin(tree: Tree) {
       buildTargetName: 'build',
       devTargetName: 'dev',
       startTargetName: 'start',
+      serveStaticTargetName: 'serve-static',
     },
   });
 

--- a/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -35,6 +35,14 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
             "cwd": "my-app",
           },
         },
+        "my-serve-static": {
+          "executor": "@nx/web:file-server",
+          "options": {
+            "buildTarget": "my-build",
+            "port": 3000,
+            "staticFilePath": "{projectRoot}/out",
+          },
+        },
         "my-start": {
           "command": "next start",
           "dependsOn": [
@@ -83,6 +91,14 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
           "command": "next dev",
           "options": {
             "cwd": ".",
+          },
+        },
+        "serve-static": {
+          "executor": "@nx/web:file-server",
+          "options": {
+            "buildTarget": "build",
+            "port": 3000,
+            "staticFilePath": "{projectRoot}/out",
           },
         },
         "start": {

--- a/packages/next/src/plugins/plugin.spec.ts
+++ b/packages/next/src/plugins/plugin.spec.ts
@@ -34,6 +34,7 @@ describe('@nx/next/plugin', () => {
           buildTargetName: 'build',
           devTargetName: 'dev',
           startTargetName: 'start',
+          serveStaticTargetName: 'serve-static',
         },
         context
       );
@@ -73,6 +74,7 @@ describe('@nx/next/plugin', () => {
           buildTargetName: 'my-build',
           devTargetName: 'my-serve',
           startTargetName: 'my-start',
+          serveStaticTargetName: 'my-serve-static',
         },
         context
       );

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -21,6 +21,7 @@ export interface NextPluginOptions {
   buildTargetName?: string;
   devTargetName?: string;
   startTargetName?: string;
+  serveStaticTargetName?: string;
 }
 
 const cachePath = join(projectGraphCacheDirectory, 'next.hash');
@@ -62,7 +63,6 @@ export const createNodes: CreateNodes<NextPluginOptions> = [
     ) {
       return {};
     }
-
     options = normalizeOptions(options);
 
     const hash = calculateHashForCreateNodes(projectRoot, options, context, [
@@ -106,6 +106,9 @@ async function buildNextTargets(
   targets[options.devTargetName] = getDevTargetConfig(projectRoot);
 
   targets[options.startTargetName] = getStartTargetConfig(options, projectRoot);
+
+  targets[options.serveStaticTargetName] = getStaticServeTargetConfig(options);
+
   return targets;
 }
 
@@ -147,6 +150,19 @@ function getStartTargetConfig(options: NextPluginOptions, projectRoot: string) {
       cwd: projectRoot,
     },
     dependsOn: [options.buildTargetName],
+  };
+
+  return targetConfig;
+}
+
+function getStaticServeTargetConfig(options: NextPluginOptions) {
+  const targetConfig: TargetConfiguration = {
+    executor: '@nx/web:file-server',
+    options: {
+      buildTarget: options.buildTargetName,
+      staticFilePath: '{projectRoot}/out',
+      port: 3000,
+    },
   };
 
   return targetConfig;
@@ -196,6 +212,7 @@ function normalizeOptions(options: NextPluginOptions): NextPluginOptions {
   options.buildTargetName ??= 'build';
   options.devTargetName ??= 'dev';
   options.startTargetName ??= 'start';
+  options.serveStaticTargetName ??= 'serve-static';
   return options;
 }
 

--- a/packages/next/src/utils/add-gitignore-entry.ts
+++ b/packages/next/src/utils/add-gitignore-entry.ts
@@ -12,7 +12,7 @@ export function addGitIgnoreEntry(host: Tree) {
   ig.add(host.read('.gitignore', 'utf-8'));
 
   if (!ig.ignores('apps/example/.next')) {
-    content = `${content}\n\n# Next.js\n.next\n`;
+    content = `${content}\n\n# Next.js\n.next\nout\n`;
   }
 
   host.write('.gitignore', content);

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -149,6 +149,12 @@ export default async function* fileServerExecutor(
     const run = () => {
       if (!running) {
         running = true;
+        /**
+         * Expose a variable to the build target to know if it's being run by the serve-static executor
+         * This is useful because a config might need to change if it's being run by serve-static without the user's input
+         * or if being ran by another executor (eg. E2E tests)
+         * */
+        process.env.NX_SERVE_STATIC_BUILD_RUNNING = 'true';
         try {
           const args = getBuildTargetCommand(options, context);
           execFileSync(pmCmd, args, {
@@ -159,6 +165,7 @@ export default async function* fileServerExecutor(
             `Build target failed: ${chalk.bold(options.buildTarget)}`
           );
         } finally {
+          process.env.NX_SERVE_STATIC_BUILD_RUNNING = undefined;
           running = false;
         }
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, we have no way of running a static server for Next.js while running `e2e` tests.
Which should help reduce time with running test suites especially on CI.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Have targets to run static files for e2e tests.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
