### PR TITLE
fix(testing): allows getJestProjects to fetch config information from inferred plugins

### DIFF
--- a/packages/jest/src/utils/config/get-jest-projects.spec.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.spec.ts
@@ -1,182 +1,200 @@
+import * as RetrieveWorkspaceFiles from 'nx/src/project-graph/utils/retrieve-workspace-files';
 import { getJestProjects } from './get-jest-projects';
-import * as Workspace from 'nx/src/project-graph/file-utils';
-import type { WorkspaceJsonConfiguration } from '@nx/devkit';
 
 describe('getJestProjects', () => {
-  test('single project', () => {
-    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
-      projects: {
-        'test-1': {
-          root: 'blah',
-          targets: {
-            test: {
-              executor: '@nx/jest:jest',
-              options: {
-                jestConfig: 'test/jest/config/location/jest.config.js',
-              },
-            },
-          },
-        },
-      },
-      version: 1,
-    };
-    jest
-      .spyOn(Workspace, 'readWorkspaceConfig')
-      .mockImplementation(() => mockedWorkspaceConfig);
-    const expectedResults = [
-      '<rootDir>/test/jest/config/location/jest.config.js',
-    ];
-    expect(getJestProjects()).toEqual(expectedResults);
-  });
-
-  test('custom target name', () => {
-    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
-      projects: {
-        'test-1': {
-          root: 'blah',
-          targets: {
-            'test-with-jest': {
-              executor: '@nx/jest:jest',
-              options: {
-                jestConfig: 'test/jest/config/location/jest.config.js',
-              },
-            },
-          },
-        },
-      },
-      version: 1,
-    };
-    jest
-      .spyOn(Workspace, 'readWorkspaceConfig')
-      .mockImplementation(() => mockedWorkspaceConfig);
-    const expectedResults = [
-      '<rootDir>/test/jest/config/location/jest.config.js',
-    ];
-    expect(getJestProjects()).toEqual(expectedResults);
-  });
-
-  test('root project', () => {
-    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
-      projects: {
-        'test-1': {
-          root: '.',
-          targets: {
-            test: {
-              executor: '@nx/jest:jest',
-              options: {
-                jestConfig: 'jest.config.app.js',
-              },
-            },
-          },
-        },
-      },
-      version: 1,
-    };
-    jest
-      .spyOn(Workspace, 'readWorkspaceConfig')
-      .mockImplementation(() => mockedWorkspaceConfig);
-    const expectedResults = ['<rootDir>/jest.config.app.js'];
-    expect(getJestProjects()).toEqual(expectedResults);
-  });
-
-  test('configuration set with unique jestConfig', () => {
-    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
-      projects: {
-        test: {
-          root: 'blah',
-          targets: {
-            'test-with-jest': {
-              executor: '@nx/jest:jest',
-              options: {
-                jestConfig: 'test/jest/config/location/jest.config.js',
-              },
-              configurations: {
-                prod: {
-                  jestConfig: 'configuration-specific/jest.config.js',
-                },
-              },
-            },
-          },
-        },
-      },
-      version: 1,
-    };
-    jest
-      .spyOn(Workspace, 'readWorkspaceConfig')
-      .mockImplementation(() => mockedWorkspaceConfig);
-    const expectedResults = [
-      '<rootDir>/test/jest/config/location/jest.config.js',
-      '<rootDir>/configuration-specific/jest.config.js',
-    ];
-    expect(getJestProjects()).toEqual(expectedResults);
-  });
-
-  test('configuration, set with same jestConfig on configuration', () => {
-    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
-      projects: {
-        test: {
-          root: 'blah',
-          targets: {
-            'test-with-jest': {
-              executor: '@nx/jest:jest',
-              options: {
-                jestConfig: 'test/jest/config/location/jest.config.js',
-              },
-              configurations: {
-                prod: {
+  test('single project', async () => {
+    const mockedWorkspaceConfig: Partial<RetrieveWorkspaceFiles.RetrievedGraphNodes> =
+      {
+        projects: {
+          'test-1': {
+            root: 'blah',
+            targets: {
+              test: {
+                executor: '@nx/jest:jest',
+                options: {
                   jestConfig: 'test/jest/config/location/jest.config.js',
                 },
               },
             },
           },
         },
-      },
-      version: 1,
-    };
+      };
     jest
-      .spyOn(Workspace, 'readWorkspaceConfig')
-      .mockImplementation(() => mockedWorkspaceConfig);
+      .spyOn(RetrieveWorkspaceFiles, 'retrieveProjectConfigurations')
+      .mockResolvedValue(
+        mockedWorkspaceConfig as RetrieveWorkspaceFiles.RetrievedGraphNodes
+      );
     const expectedResults = [
       '<rootDir>/test/jest/config/location/jest.config.js',
     ];
-    expect(getJestProjects()).toEqual(expectedResults);
+    const projects = await getJestProjects();
+    expect(projects).toEqual(expectedResults);
   });
 
-  test('other projects and targets that do not use the nrwl jest test runner', () => {
-    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
-      projects: {
-        otherTarget: {
-          root: 'test',
-          targets: {
-            test: {
-              executor: 'something else',
-              options: {},
-            },
-          },
-        },
-        test: {
-          root: 'blah',
-          targets: {
-            'test-with-jest': {
-              executor: 'something else',
-              options: {
-                jestConfig: 'something random',
-              },
-              configurations: {
-                prod: {
-                  jestConfig: 'configuration-specific/jest.config.js',
+  test('custom target name', async () => {
+    const mockedWorkspaceConfig: Partial<RetrieveWorkspaceFiles.RetrievedGraphNodes> =
+      {
+        projects: {
+          'test-1': {
+            root: 'blah',
+            targets: {
+              'test-with-jest': {
+                executor: '@nx/jest:jest',
+                options: {
+                  jestConfig: 'test/jest/config/location/jest.config.js',
                 },
               },
             },
           },
         },
-      },
-      version: 1,
-    };
+      };
     jest
-      .spyOn(Workspace, 'readWorkspaceConfig')
-      .mockImplementation(() => mockedWorkspaceConfig);
+      .spyOn(RetrieveWorkspaceFiles, 'retrieveProjectConfigurations')
+      .mockResolvedValue(
+        mockedWorkspaceConfig as RetrieveWorkspaceFiles.RetrievedGraphNodes
+      );
+    const expectedResults = [
+      '<rootDir>/test/jest/config/location/jest.config.js',
+    ];
+    const projects = await getJestProjects();
+    expect(projects).toEqual(expectedResults);
+  });
+
+  test('root project', async () => {
+    const mockedWorkspaceConfig: Partial<RetrieveWorkspaceFiles.RetrievedGraphNodes> =
+      {
+        projects: {
+          'test-1': {
+            root: '.',
+            targets: {
+              test: {
+                executor: '@nx/jest:jest',
+                options: {
+                  jestConfig: 'jest.config.app.js',
+                },
+              },
+            },
+          },
+        },
+      };
+
+    jest
+      .spyOn(RetrieveWorkspaceFiles, 'retrieveProjectConfigurations')
+      .mockResolvedValue(
+        mockedWorkspaceConfig as RetrieveWorkspaceFiles.RetrievedGraphNodes
+      );
+    const expectedResults = ['<rootDir>/jest.config.app.js'];
+    const projects = await getJestProjects();
+    expect(projects).toEqual(expectedResults);
+  });
+
+  test('configuration set with unique jestConfig', async () => {
+    const mockedWorkspaceConfig: Partial<RetrieveWorkspaceFiles.RetrievedGraphNodes> =
+      {
+        projects: {
+          test: {
+            root: 'blah',
+            targets: {
+              'test-with-jest': {
+                executor: '@nx/jest:jest',
+                options: {
+                  jestConfig: 'test/jest/config/location/jest.config.js',
+                },
+                configurations: {
+                  prod: {
+                    jestConfig: 'configuration-specific/jest.config.js',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+    jest
+      .spyOn(RetrieveWorkspaceFiles, 'retrieveProjectConfigurations')
+      .mockResolvedValue(
+        mockedWorkspaceConfig as RetrieveWorkspaceFiles.RetrievedGraphNodes
+      );
+    const expectedResults = [
+      '<rootDir>/test/jest/config/location/jest.config.js',
+      '<rootDir>/configuration-specific/jest.config.js',
+    ];
+    const projects = await getJestProjects();
+    expect(projects).toEqual(expectedResults);
+  });
+
+  test('configuration, set with same jestConfig on configuration', async () => {
+    const mockedWorkspaceConfig: Partial<RetrieveWorkspaceFiles.RetrievedGraphNodes> =
+      {
+        projects: {
+          test: {
+            root: 'blah',
+            targets: {
+              'test-with-jest': {
+                executor: '@nx/jest:jest',
+                options: {
+                  jestConfig: 'test/jest/config/location/jest.config.js',
+                },
+                configurations: {
+                  prod: {
+                    jestConfig: 'test/jest/config/location/jest.config.js',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+    jest
+      .spyOn(RetrieveWorkspaceFiles, 'retrieveProjectConfigurations')
+      .mockResolvedValue(
+        mockedWorkspaceConfig as RetrieveWorkspaceFiles.RetrievedGraphNodes
+      );
+    const expectedResults = [
+      '<rootDir>/test/jest/config/location/jest.config.js',
+    ];
+    const projects = await getJestProjects();
+    expect(projects).toEqual(expectedResults);
+  });
+
+  test('other projects and targets that do not use the nrwl jest test runner', async () => {
+    const mockedWorkspaceConfig: Partial<RetrieveWorkspaceFiles.RetrievedGraphNodes> =
+      {
+        projects: {
+          otherTarget: {
+            root: 'test',
+            targets: {
+              test: {
+                executor: 'something else',
+                options: {},
+              },
+            },
+          },
+          test: {
+            root: 'blah',
+            targets: {
+              'test-with-jest': {
+                executor: 'something else',
+                options: {
+                  jestConfig: 'something random',
+                },
+                configurations: {
+                  prod: {
+                    jestConfig: 'configuration-specific/jest.config.js',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+    jest
+      .spyOn(RetrieveWorkspaceFiles, 'retrieveProjectConfigurations')
+      .mockResolvedValue(
+        mockedWorkspaceConfig as RetrieveWorkspaceFiles.RetrievedGraphNodes
+      );
     const expectedResults = [];
-    expect(getJestProjects()).toEqual(expectedResults);
+    const projects = await getJestProjects();
+    expect(projects).toEqual(expectedResults);
   });
 });


### PR DESCRIPTION
After updating my codebase to use the new plugin inference system, I found that I could no longer run pnpm jest at the root of my repo.

This change allows the getJestProject methods to pull from retrieveProjectConfigurations in order to find all project config files.

## Current Behavior
When running `pnpm jest` at the root of the application, `getJestProjects` returns empty if there is not an explicit `test` target in the project.json

## Expected Behavior
Running `pnpm jest` should run all valid Jest projects in the repository.

This is my first contribution to NX, happy to make any changes necessary and would love feedback!