### PR TITLE
fix(remix): should add remix plugin to nx.json on init correctly

### DIFF
--- a/packages/remix/src/generators/init/init.spec.ts
+++ b/packages/remix/src/generators/init/init.spec.ts
@@ -1,6 +1,7 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { readJson } from '@nx/devkit';
 import initGenerator from './init';
+import { remixInitGeneratorInternal } from './init';
 
 describe('Remix Init Generator', () => {
   it('should setup the workspace and add dependencies', async () => {
@@ -8,9 +9,8 @@ describe('Remix Init Generator', () => {
     const tree = createTreeWithEmptyWorkspace();
 
     // ACT
-    await initGenerator(tree, {
-      addPlugin: true,
-    });
+    // Should default to adding the plugin
+    await remixInitGeneratorInternal(tree, {});
 
     // ASSERT
     const pkgJson = readJson(tree, 'package.json');
@@ -25,6 +25,34 @@ describe('Remix Init Generator', () => {
           "@remix-run/dev": "^2.3.0",
         }
       `);
+
+    const nxJson = readJson(tree, 'nx.json');
+    expect(nxJson).toMatchInlineSnapshot(`
+      {
+        "affected": {
+          "defaultBase": "main",
+        },
+        "plugins": [
+          {
+            "options": {
+              "buildTargetName": "build",
+              "serveTargetName": "serve",
+              "startTargetName": "start",
+              "typecheckTargetName": "typecheck",
+            },
+            "plugin": "@nx/remix/plugin",
+          },
+        ],
+        "targetDefaults": {
+          "build": {
+            "cache": true,
+          },
+          "lint": {
+            "cache": true,
+          },
+        },
+      }
+    `);
   });
 
   describe('NX_ADD_PLUGINS=false', () => {

--- a/packages/remix/src/generators/init/init.ts
+++ b/packages/remix/src/generators/init/init.ts
@@ -62,6 +62,7 @@ export async function remixInitGeneratorInternal(tree: Tree, options: Schema) {
     tasks.push(installTask);
   }
 
+  options.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';
   if (options.addPlugin) {
     addPlugin(tree);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running `nx init` in a non-Nx Remix repo does not always add the plugin to the `nx.json`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running `nx init` should add the remix plugin to `nx.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
