### PR TITLE
fix(remix): the output path should respect the remix.config.js in crystal

### DIFF
--- a/e2e/remix/tests/nx-remix.test.ts
+++ b/e2e/remix/tests/nx-remix.test.ts
@@ -47,7 +47,7 @@ describe('Remix E2E Tests', () => {
         expect(result).toContain('Successfully ran target build');
 
         // TODO(colum): uncomment line below when fixed
-        checkFilesExist(`dist/apps/sub/${plugin}/build/index.js`);
+        checkFilesExist(`apps/sub/${plugin}/build/index.js`);
       }, 120000);
 
       it('should create src in the specified directory --projectNameAndRootFormat=as-provided', async () => {
@@ -58,7 +58,7 @@ describe('Remix E2E Tests', () => {
 
         const result = runCLI(`build ${plugin}`);
         expect(result).toContain('Successfully ran target build');
-        checkFilesExist(`dist/subdir/build/index.js`);
+        checkFilesExist(`subdir/build/index.js`);
       }, 120000);
     });
 

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -17,10 +17,11 @@ exports[`@nx/remix/plugin non-root project should create nodes 1`] = `
             "^production",
           ],
           "options": {
-            "outputPath": "{workspaceRoot}/dist/my-app",
+            "outputPath": "my-app",
           },
           "outputs": [
-            "{options.outputPath}",
+            "{workspaceRoot}/my-app/build",
+            "{workspaceRoot}/my-app/public/build",
           ],
         },
         "serve": {
@@ -72,10 +73,11 @@ exports[`@nx/remix/plugin root project should create nodes 1`] = `
             "^production",
           ],
           "options": {
-            "outputPath": "{workspaceRoot}/dist",
+            "outputPath": ".",
           },
           "outputs": [
-            "{options.outputPath}",
+            "{workspaceRoot}/build",
+            "{workspaceRoot}/public/build",
           ],
         },
         "serve": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Remix plugin currently forces output to go to dist/ folder


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Remix plugin should respect the remix.config.js file


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
