### PR TITLE
fix(core): propagate `verbose` flag when running `init` generator dur…

### DIFF
--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -118,7 +118,10 @@ async function initializePlugin(
     await runNxAsync(
       `g ${pkgName}:${initGenerator} --keepExistingVersions${
         updatePackageScripts ? ' --updatePackageScripts' : ''
-      }`
+      }`,
+      {
+        silent: !options.verbose,
+      }
     );
   } catch (e) {
     spinner.fail();


### PR DESCRIPTION
…ing `nx add` command

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When using the new `nx add <plugin>` to install a plugin (as  `devDependencies`) and initializes it (if  a `init`  generator exists),
any raw error thrown when calling that generator, **is not sent back to user**, even if the `--verbose`  flag is provided to the `nx add` command.

Instead, a generic and not so useful **" >  NX   Failed to initialize @nxrocks/nx-spring-boot. Please check the error above for more details."** is displayed...

Here is an example: 

```shell
$ npx nx add @nxrocks/nx-spring-boot@latest --verbose

✔ Installing @nxrocks/nx-spring-boot@latest...
✖ Initializing @nxrocks/nx-spring-boot...

Command failed: npx nx g @nxrocks/nx-spring-boot:project --keepExistingVersions


 >  NX   Failed to initialize @nxrocks/nx-spring-boot. Please check the error above for more details.

``` 

After manually tweaking the `@node_modules/nx/src/command-line/add/add.js` file, to consider the --verbose flag, I managed to get more helpful insight about the actual underlying error that occurred in my `init` generator (here, the generator was expecting a required "name" option that was, of course, not provided)

Here is output, when that flag was considered:

```shell
AzureAD+TineKondo@LAVA-1T8QJS3 MINGW64 /d/Workspace/git/nx18 (main)
$ npx nx add @nxrocks/nx-spring-boot@latest --verbose

✔ Installing @nxrocks/nx-spring-boot@latest...
⠹ Initializing @nxrocks/nx-spring-boot...
>  NX  Generating @nxrocks/nx-spring-boot:project


 >  NX   Required property 'name' is missing


✖ Initializing @nxrocks/nx-spring-boot...

Command failed: npx nx g @nxrocks/nx-spring-boot:project --keepExistingVersions


 >  NX   Failed to initialize @nxrocks/nx-spring-boot. Please check the error above for more details.

```
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Propagate the `--verbose`  flag when running the `init` generator, so that more information can be output to user if calling that generator failed for some reason.

If not provided at all, or provided with `--verbose=false`,  no extra log is printed (current behavior)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
