### PR TITLE
fix(core): include nx/nuxt in migrations

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -125,6 +125,7 @@
       "@nrwl/next",
       "@nx/node",
       "@nrwl/node",
+      "@nx/nuxt",
       "@nx/playwright",
       "@nx/plugin",
       "@nrwl/nx-plugin",

--- a/packages/nx/src/utils/plugins/core-plugins.ts
+++ b/packages/nx/src/utils/plugins/core-plugins.ts
@@ -53,6 +53,10 @@ export function fetchCorePlugins(): CorePlugin[] {
       capabilities: 'executors,generators',
     },
     {
+      name: '@nx/nuxt',
+      capabilities: 'generators',
+    },
+    {
       name: 'nx',
       capabilities: 'executors',
     },


### PR DESCRIPTION
Make sure `@nx/nuxt` is included in migrations
