### PR TITLE
fix(nuxt): turn on autoimport

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -47,7 +47,7 @@ export default defineNuxtConfig({
     },
   },
   imports: {
-    autoImport: false,
+    autoImport: true,
   },
 
   vite: {
@@ -234,7 +234,7 @@ export default defineNuxtConfig({
     },
   },
   imports: {
-    autoImport: false,
+    autoImport: true,
   },
 
   css: ['~/assets/css/styles.css'],
@@ -272,7 +272,7 @@ export default defineNuxtConfig({
     },
   },
   imports: {
-    autoImport: false,
+    autoImport: true,
   },
 
   css: ['~/assets/css/styles.less'],
@@ -310,7 +310,7 @@ export default defineNuxtConfig({
     },
   },
   imports: {
-    autoImport: false,
+    autoImport: true,
   },
 
   css: ['~/assets/css/styles.scss'],
@@ -348,7 +348,7 @@ export default defineNuxtConfig({
     },
   },
   imports: {
-    autoImport: false,
+    autoImport: true,
   },
 
   vite: {

--- a/packages/nuxt/src/generators/application/files/nuxt.config.ts__tmpl__
+++ b/packages/nuxt/src/generators/application/files/nuxt.config.ts__tmpl__
@@ -18,7 +18,7 @@ export default defineNuxtConfig({
     },
   },
   imports: {
-    autoImport: false,
+    autoImport: true,
   },
   <% if (style !== 'none') { %>
   css: ['~/assets/css/styles.<%= style %>'],


### PR DESCRIPTION
Turn on `autoimport` for nuxt, no reason why it's turned off.
