### PR TITLE
fix(js): swc exclude config may not a array

### DIFF
--- a/packages/js/src/utils/swc/inline.ts
+++ b/packages/js/src/utils/swc/inline.ts
@@ -7,6 +7,11 @@ export function generateTmpSwcrc(
   tmpSwcrcPath: string
 ) {
   const swcrc = readJsonFile(swcrcPath);
+  swcrc['exclude'] ??= [];
+
+  if (!Array.isArray(swcrc['exclude'])) {
+    swcrc['exclude'] = [swcrc['exclude']];
+  }
 
   swcrc['exclude'] = swcrc['exclude'].concat(
     Object.values(inlineProjectGraph.externals).map(


### PR DESCRIPTION
[swc config is not required](https://swc.rs/docs/configuration/compilation#exclude)

## Current Behavior
if not configed `"exclude"` will get a error
```text
TypeError: Cannot read properties of undefined (reading 'concat')
    at generateTmpSwcrc (/Users/hongxu/repos/smallfish/node_modules/@nrwl/js/src/utils/swc/inline.js:7:41)
```

## Expected Behavior
give a default value for swc exclude if nx must need it
