### PR TITLE
fix(nuxt): init generator should add @nx/vite to dependencies

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -33,7 +33,8 @@
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
     "@nx/eslint": "file:../eslint",
-    "@nx/vue": "file:../vue"
+    "@nx/vue": "file:../vue",
+    "@nx/vite": "file:../vite"
   },
   "peerDependencies": {},
   "publishConfig": {

--- a/packages/nuxt/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/nuxt/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`init should install required dependencies 1`] = `
   "dependencies": {},
   "devDependencies": {
     "@nx/nuxt": "0.0.1",
+    "@nx/vite": "0.0.1",
     "nuxt": "^3.10.0",
   },
   "name": "@proj/source",

--- a/packages/nuxt/src/generators/init/lib/utils.ts
+++ b/packages/nuxt/src/generators/init/lib/utils.ts
@@ -14,6 +14,7 @@ export function updateDependencies(host: Tree, schema: InitSchema) {
     {
       '@nx/nuxt': nxVersion,
       nuxt: nuxtVersion,
+      '@nx/vite': nxVersion,
     },
     undefined,
     schema.keepExistingVersions


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/nuxt:init` generator will add `@nx/vite/plugin` to the `plugins: []` in `nx.json` when Crystal is turned on.
However, if the workspace does not already have `@nx/vite` installed, the graph will fallover during construction, preventing subsequent `nx` commands from executing. 


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure that the `@nx/nuxt:init` generator adds `@nx/vite` to the workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
