### PR TITLE
feat(vite): add vitest.workspace.ts at root

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -200,6 +200,7 @@ exports[`app generated files content - as-provided general application should cr
   ".eslintignore",
   "my-app/.eslintrc.json",
   "my-app/tsconfig.spec.json",
+  "vitest.workspace.ts",
   "my-app/vitest.config.ts",
   "my-app-e2e/project.json",
   "my-app-e2e/src/e2e/app.cy.ts",

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -38,6 +38,11 @@ export default defineConfig({
 "
 `;
 
+exports[`vitest generator tsconfig should add vitest.workspace.ts at the root 1`] = `
+"export default ['**/*/vite.config.ts', '**/*/vitest.config.ts'];
+"
+`;
+
 exports[`vitest generator vite.config should create correct vite.config.ts file for apps 1`] = `
 "/// <reference types='vitest' />
 import { defineConfig } from 'vite';

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -46,10 +46,8 @@ export async function vitestGeneratorInternal(
 ) {
   const tasks: GeneratorCallback[] = [];
 
-  const { targets, root, projectType } = readProjectConfiguration(
-    tree,
-    schema.project
-  );
+  const { root, projectType } = readProjectConfiguration(tree, schema.project);
+  const isRootProject = root === '.';
 
   tasks.push(await jsInitGenerator(tree, { ...schema, skipFormat: true }));
   const initTask = await initGenerator(tree, {
@@ -117,6 +115,22 @@ export async function vitestGeneratorInternal(
     coverageProviderDependency
   );
   tasks.push(installCoverageProviderTask);
+
+  // Setup workspace config file (https://vitest.dev/guide/workspace.html)
+  if (
+    !isRootProject &&
+    !tree.exists(`vitest.workspace.ts`) &&
+    !tree.exists(`vitest.workspace.js`) &&
+    !tree.exists(`vitest.workspace.json`) &&
+    !tree.exists(`vitest.projects.ts`) &&
+    !tree.exists(`vitest.projects.js`) &&
+    !tree.exists(`vitest.projects.json`)
+  ) {
+    tree.write(
+      'vitest.workspace.ts',
+      `export default ['**/*/vite.config.ts', '**/*/vitest.config.ts'];`
+    );
+  }
 
   if (!schema.skipFormat) {
     await formatFiles(tree);

--- a/packages/vite/src/utils/test-utils.ts
+++ b/packages/vite/src/utils/test-utils.ts
@@ -137,8 +137,8 @@ export function mockViteReactAppGenerator(tree: Tree): Tree {
   return tree;
 }
 
-export function mockReactAppGenerator(tree: Tree): Tree {
-  const appName = 'my-test-react-app';
+export function mockReactAppGenerator(tree: Tree, userAppName?: string): Tree {
+  const appName = userAppName ?? 'my-test-react-app';
 
   tree.write(
     `apps/${appName}/src/main.tsx`,

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -159,5 +159,6 @@ exports[`application generator should set up project correctly with given option
   "test/tsconfig.spec.json",
   "test/vite.config.ts",
   "tsconfig.base.json",
+  "vitest.workspace.ts",
 ]
 `;


### PR DESCRIPTION
As per: https://vitest.dev/guide/workspace.html

* No need to add `name` in `vite(st).config.ts`, it works without name, too (example repo: https://github.com/mandarini/vitest-workspace-nx)
* No need for particular helper to collect all projects that use vitest, we can use the `'**/*/vite.config.ts', '**/*/vitest.config.ts'` globs

