### PR TITLE
fix(webpack): surface original error when remotes fail to start

### DIFF
--- a/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -192,9 +192,12 @@ export async function* moduleFederationDevServerExecutor(
             `NX All remotes started, server ready at http://localhost:${options.port}`
           );
           next({ success: true, baseUrl: `http://localhost:${options.port}` });
-        } catch {
+        } catch (err) {
           throw new Error(
-            `Timed out waiting for remote to start. Check above for any errors.`
+            `Failed to start remotes. Check above for any errors.`,
+            {
+              cause: err,
+            }
           );
         } finally {
           done();

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -337,9 +337,12 @@ export default async function* moduleFederationDevServer(
 
           logger.info(`NX All remotes started, server ready at ${baseUrl}`);
           next({ success: true, baseUrl: baseUrl });
-        } catch {
+        } catch (err) {
           throw new Error(
-            `Timed out waiting for remote to start. Check above for any errors.`
+            `Failed to start remotes. Check above for any errors.`,
+            {
+              cause: err,
+            }
           );
         } finally {
           done();


### PR DESCRIPTION
When serving federated host and remote apps, the error from remote serve is swallowed. This prevents further debugging if the error is unexpected.

## Current Behavior
Original error is not swallowed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Original error should be shown.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
