### PR TITLE
docs(nx-cloud): fix syntax for launch template example

### DIFF
--- a/docs/nx-cloud/reference/launch-templates.md
+++ b/docs/nx-cloud/reference/launch-templates.md
@@ -34,7 +34,8 @@ launch-templates:
       - name: Print path
         script: echo $PATH # will include my-folder
       - name: Define env var for a step
-        env: MY_ENV_VAR=for-step
+        env:
+          MY_ENV_VAR: 'for-step'
         script: echo $MY_ENV_VAR # will print for-step
 ```
 


### PR DESCRIPTION
The current example results in an error:

```
Critical error
There was an issue parsing the provided yaml file. Please review it for invalid fields or typos.
```
This happens because one of the`env` entries is invalid.

```
env: MY_ENV_VAR=for-step
```

For example: https://cloud.nx.app/cipes/65d638ffd2adb16a45caff8f

## Current Behavior
The example fails.

## Expected Behavior
The example works.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
