### PR TITLE
chore(repo): enable e2e splitting for nx-dev-e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
             pids+=($!)
 
             (pnpm nx affected --targets=lint,test,build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &&
-            pnpm nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
+            pnpm nx affected --targets=e2e,e2e-ci --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
             pids+=($!)
 
             for pid in "${pids[@]}"; do

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -19,6 +19,7 @@ launch-templates:
           PATHS: |
             node_modules
             ~/.cache/Cypress
+            ~/.cache/ms-playwright
             ~/.pnpm-store
             ~/.sdkman
             ~/.sdkman/candidates/gradle
@@ -35,8 +36,10 @@ launch-templates:
         script: |
           pnpm install --frozen-lockfile
 
-      - name: Install Cypress
-        script: pnpm exec cypress install
+      - name: Install Browsers
+        script: |
+          pnpm exec cypress install
+          pnpm exec playwright install
 
       - name: Install Rust
         script: |

--- a/nx-dev/nx-dev-e2e/playwright.config.ts
+++ b/nx-dev/nx-dev-e2e/playwright.config.ts
@@ -1,27 +1,47 @@
 import { defineConfig, devices } from '@playwright/test';
-import { nxE2EPreset } from '@nx/playwright/preset';
+
+/*
+ * NOTE: We're not using the `nxE2EPreset` from `@nx/playwright` because there is an issue with `nx-ignore` + nx repo + crystal.
+ *
+ * The problem is specific to Nx repo, because of the following incompatible combination:
+ * 1. `nx-ignore` only installs nx + necessary plugins (as defined in nx.json).
+ * 2. `@nx/playwright/plugin` registers tsconfig-paths, thus `@nx/devkit` and `nx` packages are read from source
+ *    e.g. packages/devkit rather than node_modules/@nx/devkit
+ * 3. When `@nx/playwright/plugin` reads this config file (playwright.config.ts), it eventually loads `packages/devkit` instead of `node_modules/@nx/devkit`.
+ *
+ * Then, you will see an error like this:
+ * Unable to create nodes for nx-dev/nx-dev-e2e/playwright.config.ts using plugin @nx/playwright/plugin.
+ * 	 Inner Error: Error: Cannot find module 'fs-extra'
+ * Require stack:
+ * - /vercel/path0/packages/nx/src/project-graph/nx-deps-cache.ts
+ * - /vercel/path0/packages/nx/src/project-graph/project-graph.ts
+ * - /vercel/path0/packages/nx/src/config/workspaces.ts
+ * - /vercel/path0/packages/nx/src/devkit-exports.ts
+ * - /vercel/path0/packages/devkit/index.ts
+ *
+ * Again, this is specific to Nx repo only, because we both install nx + plugins to node_modules, but they are also mapped to source in tsconfig paths.
+ */
 
 // nx-ignore-next-line
-import { workspaceRoot } from '@nx/devkit';
-
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
-
-const preset = nxE2EPreset(__filename, { testDir: './src' });
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  ...preset,
-  // CI default is 'dot', which doesn't show error output in CI.
-  // use list so errors are visible in CI logs
-  reporter: process.env.CI ? 'list' : preset.reporter,
+  testDir: './src',
+  outputDir: '../../dist/.playwright/nx-dev-e2e/test-output',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'list',
   // how long the entire suite can run, prevent CI from timing out
   globalTimeout: process.env.CI ? 1_800_000 : undefined,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -34,25 +54,14 @@ export default defineConfig({
   },
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm exec nx run nx-dev:serve:production',
+    command: 'pnpm exec nx run nx-dev:next-start',
     url: 'http://localhost:4200',
     reuseExistingServer: !process.env.CI,
-    cwd: workspaceRoot,
   },
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-    },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
     },
   ],
 });

--- a/nx-dev/nx-dev-e2e/project.json
+++ b/nx-dev/nx-dev-e2e/project.json
@@ -4,21 +4,7 @@
   "sourceRoot": "nx-dev/nx-dev-e2e/src",
   "projectType": "application",
   "targets": {
-    "lint": {},
-    "e2e": {
-      "dependsOn": [
-        {
-          "target": "build-base",
-          "dependencies": true
-        }
-      ],
-      "executor": "@nx/playwright:playwright",
-      "outputs": ["{workspaceRoot}/dist/.playwright/nx-dev/nx-dev-e2e"],
-      "options": {
-        "config": "nx-dev/nx-dev-e2e/playwright.config.ts",
-        "project": ["chromium"]
-      }
-    }
+    "lint": {}
   },
   "tags": ["scope:nx-dev", "type:e2e"],
   "implicitDependencies": ["nx-dev"]

--- a/nx-dev/nx-dev/next-sitemap.config.js
+++ b/nx-dev/nx-dev/next-sitemap.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
   siteUrl: process.env.SITE_URL || 'https://nx.dev',

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -3,6 +3,8 @@ const { withNx } = require('@nx/next/plugins/with-nx');
 const redirectRules = require('./redirect-rules');
 
 module.exports = withNx({
+  // This is technically invalid, but we need to update our Vercel setting it order to change this.
+  distDir: '../../dist/nx-dev/nx-dev/.next',
   // For both client and server
   env: {
     VERCEL: process.env.VERCEL,

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -4,15 +4,26 @@
   "sourceRoot": "nx-dev/nx-dev",
   "projectType": "application",
   "targets": {
+    "next-build": {
+      "dependsOn": ["copy-docs"]
+    },
+    "next-dev": {
+      "dependsOn": ["copy-docs"],
+      "options": {
+        "args": "--port 4200"
+      }
+    },
+    "next-start": {
+      "options": {
+        "args": "--port 4200"
+      }
+    },
     "build": {
-      "dependsOn": [
-        {
-          "target": "build-base"
-        }
-      ],
+      "dependsOn": ["next-build"],
       "executor": "nx:run-commands",
       "options": {
         "commands": [
+          "ls -lsa dist/nx-dev/nx-dev/.next",
           "nx run nx-dev:sitemap",
           "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/internal-link-checker.ts"
         ],
@@ -24,14 +35,13 @@
         "{workspaceRoot}/scripts/tsconfig.scripts.json",
         "{workspaceRoot}/scripts/documentation/internal-link-checker.ts"
       ],
-      "outputs": ["{workspaceRoot}/dist/nx-dev/nx-dev"]
+      "outputs": [
+        "{workspaceRoot}/dist/nx-dev/nx-dev/.next",
+        "{workspaceRoot}/dist/nx-dev/nx-dev/.next/!(cache)"
+      ]
     },
     "sitemap": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist/nx-dev/nx-dev/public"],
-      "options": {
-        "command": "pnpm next-sitemap --config ./nx-dev/nx-dev/next-sitemap.config.js"
-      }
+      "command": "pnpm next-sitemap --config ./nx-dev/nx-dev/next-sitemap.config.js"
     },
     "sync-documentation": {
       "executor": "nx:run-commands",
@@ -47,21 +57,6 @@
         "command": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/open-graph/generate-images.ts"
       }
     },
-    "build-base": {
-      "executor": "@nx/next:build",
-      "dependsOn": ["copy-docs"],
-      "outputs": ["{options.outputPath}"],
-      "options": {
-        "root": "nx-dev/nx-dev",
-        "outputPath": "dist/nx-dev/nx-dev"
-      },
-      "configurations": {
-        "development": {
-          "outputPath": "nx-dev/nx-dev"
-        },
-        "production": {}
-      }
-    },
     "copy-docs": {
       "inputs": ["{workspaceRoot}/docs/**/*"],
       "outputs": ["{projectRoot}/public/documentation"],
@@ -75,29 +70,10 @@
       "options": {
         "commands": [
           "nx watch --projects=docs -- nx run nx-dev:copy-docs",
-          "nx run nx-dev:serve"
+          "nx run nx-dev:next-dev"
         ],
         "parallel": true
       }
-    },
-    "serve": {
-      "executor": "@nx/next:server",
-      "dependsOn": ["copy-docs"],
-      "options": {
-        "buildTarget": "nx-dev:build-base",
-        "dev": true
-      },
-      "configurations": {
-        "production": {
-          "buildTarget": "nx-dev:build-base:production",
-          "dev": false
-        },
-        "development": {
-          "buildTarget": "nx-dev:build-base:development",
-          "dev": true
-        }
-      },
-      "defaultConfiguration": "development"
     },
     "deploy-build": {
       "executor": "nx:run-commands",
@@ -127,12 +103,6 @@
         ],
         "color": true,
         "parallel": false
-      }
-    },
-    "export": {
-      "executor": "@nx/next:export",
-      "options": {
-        "buildTarget": "nx-dev:build:production"
       }
     },
     "lint": {},

--- a/nx.json
+++ b/nx.json
@@ -210,7 +210,24 @@
       }
     }
   },
-  "plugins": ["@monodon/rust"],
+  "plugins": [
+    "@monodon/rust",
+    {
+      "plugin": "@nx/next/plugin",
+      "options": {
+        "buildTargetName": "next-build",
+        "devTargetName": "next-dev",
+        "startTargetName": "next-start"
+      }
+    },
+    {
+      "plugin": "@nx/playwright/plugin",
+      "options": {
+        "targetName": "pw-e2e",
+        "ciTargetName": "e2e-ci"
+      }
+    }
+  ],
   "nxCloudAccessToken": "YmZiOWQyNzctOThiZC00MjYwLWI3YTAtZDA3MDg4YWY1YTExfHJlYWQ=",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,


### PR DESCRIPTION
This PR uses inferred targets from `@nx/next/plugin` and `@nx/playwright` plugin to serve and e2e test the `nx-dev` app.
