### PR TITLE
fix(core): exponential backoff retry on cache put fail

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -277,17 +277,19 @@ export class Cache {
   private tryAndRetry<T>(fn: () => Promise<T>): Promise<T> {
     let attempts = 0;
     const baseTimeout = 100;
+    // Generate a random number between 2 and 4 to raise to the power of attempts
+    const baseExponent = Math.random() * 2 + 2;
     const _try = async () => {
       try {
         attempts++;
         return await fn();
       } catch (e) {
-        if (attempts === 12) {
+        if (attempts === 10) {
           // After enough attempts, throw the error
           throw e;
         }
         await new Promise((res) =>
-          setTimeout(res, baseTimeout * 2 ** attempts)
+          setTimeout(res, baseTimeout * baseExponent ** attempts)
         );
         return await _try();
       }

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -276,7 +276,7 @@ export class Cache {
 
   private tryAndRetry<T>(fn: () => Promise<T>): Promise<T> {
     let attempts = 0;
-    const baseTimeout = 100;
+    const baseTimeout = 5;
     // Generate a random number between 2 and 4 to raise to the power of attempts
     const baseExponent = Math.random() * 2 + 2;
     const _try = async () => {
@@ -284,13 +284,12 @@ export class Cache {
         attempts++;
         return await fn();
       } catch (e) {
-        if (attempts === 10) {
+        // Max time is 5 * 4^3 = 20480ms
+        if (attempts === 6) {
           // After enough attempts, throw the error
           throw e;
         }
-        await new Promise((res) =>
-          setTimeout(res, baseTimeout * baseExponent ** attempts)
-        );
+        await new Promise((res) => setTimeout(res, baseExponent ** attempts));
         return await _try();
       }
     };

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -282,7 +282,7 @@ export class Cache {
         attempts++;
         return await fn();
       } catch (e) {
-        if (attempts === 10) {
+        if (attempts === 12) {
           // After enough attempts, throw the error
           throw e;
         }

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -286,7 +286,9 @@ export class Cache {
           // After enough attempts, throw the error
           throw e;
         }
-        await new Promise((res) => setTimeout(res, baseTimeout * attempts));
+        await new Promise((res) =>
+          setTimeout(res, baseTimeout * 2 ** attempts)
+        );
         return await _try();
       }
     };


### PR DESCRIPTION
This PR fixes the same issue as #7349, but implements a more resilient and less aggressive retry strategy. I regularly get cache errors on my pipeline, because I share the same local cache (i.e. EFS) between multiple EC2 agents. This is hard to reproduce since it's a race condition on my custom set-up. Given that this change won't affect the normal performance (since it's just an edge case), I think this change would be a nice-to-have.