### PR TITLE
fix(angular): do not add target defaults for the ng-packagr-lite executor when generating non-buildable library

### DIFF
--- a/packages/angular/src/generators/library/lib/add-project.ts
+++ b/packages/angular/src/generators/library/lib/add-project.ts
@@ -8,11 +8,6 @@ export function addProject(
   tree: Tree,
   libraryOptions: NormalizedSchema['libraryOptions']
 ) {
-  const executor = libraryOptions.publishable
-    ? '@nx/angular:package'
-    : '@nx/angular:ng-packagr-lite';
-
-  addBuildTargetDefaults(tree, executor);
   const project: AngularProjectConfiguration = {
     name: libraryOptions.name,
     root: libraryOptions.projectRoot,
@@ -20,28 +15,33 @@ export function addProject(
     prefix: libraryOptions.prefix,
     tags: libraryOptions.parsedTags,
     projectType: 'library',
-    targets: {
-      build:
-        libraryOptions.buildable || libraryOptions.publishable
-          ? {
-              executor,
-              outputs: ['{workspaceRoot}/dist/{projectRoot}'],
-              options: {
-                project: `${libraryOptions.projectRoot}/ng-package.json`,
-              },
-              configurations: {
-                production: {
-                  tsConfig: `${libraryOptions.projectRoot}/tsconfig.lib.prod.json`,
-                },
-                development: {
-                  tsConfig: `${libraryOptions.projectRoot}/tsconfig.lib.json`,
-                },
-              },
-              defaultConfiguration: 'production',
-            }
-          : undefined,
-    },
+    targets: {},
   };
+
+  if (libraryOptions.buildable || libraryOptions.publishable) {
+    const executor = libraryOptions.publishable
+      ? '@nx/angular:package'
+      : '@nx/angular:ng-packagr-lite';
+
+    addBuildTargetDefaults(tree, executor);
+
+    project.targets.build = {
+      executor,
+      outputs: ['{workspaceRoot}/dist/{projectRoot}'],
+      options: {
+        project: `${libraryOptions.projectRoot}/ng-package.json`,
+      },
+      configurations: {
+        production: {
+          tsConfig: `${libraryOptions.projectRoot}/tsconfig.lib.prod.json`,
+        },
+        development: {
+          tsConfig: `${libraryOptions.projectRoot}/tsconfig.lib.json`,
+        },
+      },
+      defaultConfiguration: 'production',
+    };
+  }
 
   addProjectConfiguration(tree, libraryOptions.name, project);
   return project;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21909 
