### PR TITLE
fix(react): ensure playwright configuration is using correct port in app gen

### DIFF
--- a/packages/react/src/generators/application/lib/add-e2e.ts
+++ b/packages/react/src/generators/application/lib/add-e2e.ts
@@ -49,7 +49,7 @@ export async function addE2e(
         bundler: options.bundler === 'rspack' ? 'webpack' : options.bundler,
         skipFormat: true,
         devServerTarget: `${options.projectName}:serve`,
-        baseUrl: 'http://localhost:4200',
+        baseUrl: `http://localhost:${options.devServerPort ?? 4200}`,
         jsx: true,
         rootProject: options.rootProject,
         webServerCommands: hasNxBuildPlugin
@@ -85,7 +85,7 @@ export async function addE2e(
         webServerCommand: `${getPackageManagerCommand().exec} nx serve ${
           options.name
         }`,
-        webServerAddress: 'http://localhost:4200',
+        webServerAddress: `http://localhost:${options.devServerPort ?? 4200}`,
         rootProject: options.rootProject,
         addPlugin: options.addPlugin,
       });

--- a/packages/react/src/generators/host/lib/update-module-federation-e2e-project.ts
+++ b/packages/react/src/generators/host/lib/update-module-federation-e2e-project.ts
@@ -11,11 +11,13 @@ export function updateModuleFederationE2eProject(
 ) {
   try {
     let projectConfig = readProjectConfiguration(host, options.e2eProjectName);
-    projectConfig.targets.e2e.options = {
-      ...projectConfig.targets.e2e.options,
-      baseUrl: `http://localhost:${options.devServerPort}`,
-    };
-    updateProjectConfiguration(host, options.e2eProjectName, projectConfig);
+    if (projectConfig.targets.e2e.executor !== '@nx/playwright:playwright') {
+      projectConfig.targets.e2e.options = {
+        ...projectConfig.targets.e2e.options,
+        baseUrl: `http://localhost:${options.devServerPort}`,
+      };
+      updateProjectConfiguration(host, options.e2eProjectName, projectConfig);
+    }
   } catch {
     // nothing
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When selecting playwright as the e2e test runner for module federation applications it generates an incorrect playwright config.
It only points at :4200 which will be incorrect for remote applications.

This causes playwright to wait for a dev server port to open which will never open.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the correct port in app gen when configuring playwright to allow for successful e2e setup.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
