### PR TITLE
fix(testing): ensure baseUrl is not passed to playwright cli

### DIFF
--- a/packages/playwright/migrations.json
+++ b/packages/playwright/migrations.json
@@ -5,6 +5,12 @@
       "version": "17.3.1-beta.0",
       "description": "Add project property to playwright config",
       "implementation": "./src/migrations/update-17-3-1/add-project-to-config"
+    },
+    "18-1-0-remove-baseUrl-from-project-json": {
+      "cli": "nx",
+      "version": "18.1.0-beta.3",
+      "description": "Remove invalid baseUrl option from @nx/playwright:playwright targets in project.json.",
+      "implementation": "./src/migrations/update-18-1-0/remove-baseUrl-from-project-json"
     }
   }
 }

--- a/packages/playwright/src/migrations/update-18-1-0/remove-baseUrl-from-project-json.spec.ts
+++ b/packages/playwright/src/migrations/update-18-1-0/remove-baseUrl-from-project-json.spec.ts
@@ -1,0 +1,176 @@
+import {
+  addProjectConfiguration,
+  readNxJson,
+  readProjectConfiguration,
+  updateNxJson,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import removeBaseUrlFromProjectJson from './remove-baseUrl-from-project-json';
+
+describe('removeBaseUrlFromProjectJson', () => {
+  describe('--projects', () => {
+    it('should not update if the project is correct', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      const project = {
+        $schema: 'node_modules/nx/schemas/project-schema.json',
+        name: 'test',
+        root: '.',
+        sourceRoot: '',
+        targets: {
+          e2e: {
+            executor: '@nx/playwright:playwright',
+          },
+        },
+      };
+
+      addProjectConfiguration(tree, 'test', project);
+
+      // ACT
+      await removeBaseUrlFromProjectJson(tree);
+
+      // ASSERT
+      const maybeUpdatedProject = readProjectConfiguration(tree, 'test');
+      expect(maybeUpdatedProject).toMatchInlineSnapshot(`
+              {
+                "$schema": "node_modules/nx/schemas/project-schema.json",
+                "name": "test",
+                "root": ".",
+                "sourceRoot": "",
+                "targets": {
+                  "e2e": {
+                    "executor": "@nx/playwright:playwright",
+                  },
+                },
+              }
+          `);
+    });
+
+    it('should remove baseUrl from target options', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      const project = {
+        $schema: 'node_modules/nx/schemas/project-schema.json',
+        name: 'test',
+        root: '.',
+        sourceRoot: '',
+        targets: {
+          e2e: {
+            executor: '@nx/playwright:playwright',
+            options: {
+              baseUrl: 'http://localhost:4200',
+            },
+          },
+        },
+      };
+
+      addProjectConfiguration(tree, 'test', project);
+
+      // ACT
+      await removeBaseUrlFromProjectJson(tree);
+
+      // ASSERT
+      const maybeUpdatedProject = readProjectConfiguration(tree, 'test');
+      expect(maybeUpdatedProject.targets['e2e'].options).toMatchInlineSnapshot(
+        `{}`
+      );
+    });
+
+    it('should remove baseUrl from target options and configurations', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      const project = {
+        $schema: 'node_modules/nx/schemas/project-schema.json',
+        name: 'test',
+        root: '.',
+        sourceRoot: '',
+        targets: {
+          e2e: {
+            executor: '@nx/playwright:playwright',
+            options: {
+              baseUrl: 'http://localhost:4200',
+            },
+            configurations: {
+              production: {
+                baseUrl: 'https://mytest.com',
+              },
+            },
+          },
+        },
+      };
+
+      addProjectConfiguration(tree, 'test', project);
+
+      // ACT
+      await removeBaseUrlFromProjectJson(tree);
+
+      // ASSERT
+      const maybeUpdatedProject = readProjectConfiguration(tree, 'test');
+      expect(maybeUpdatedProject.targets['e2e'].options).toMatchInlineSnapshot(
+        `{}`
+      );
+      expect(
+        maybeUpdatedProject.targets['e2e'].configurations['production']
+      ).toMatchInlineSnapshot(`{}`);
+    });
+  });
+
+  describe('--nx.json', () => {
+    it('should remove baseUrl from targetDefaults in nx.json', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults['@nx/playwright:playwright'] = {
+        options: {
+          baseUrl: 'http://localhost:4200',
+        },
+        configurations: {
+          ci: {
+            baseUrl: 'http://localhost:4201',
+          },
+        },
+      };
+      nxJson.targetDefaults['e2e'] = {
+        executor: '@nx/playwright:playwright',
+        options: {
+          baseUrl: 'http://localhost:4200',
+        },
+        configurations: {
+          ci: {
+            baseUrl: 'http://localhost:4201',
+          },
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      // ACT
+      await removeBaseUrlFromProjectJson(tree);
+
+      // ASSERT
+      const maybeUpdatedNxJson = readNxJson(tree);
+      expect(maybeUpdatedNxJson.targetDefaults).toMatchInlineSnapshot(`
+        {
+          "@nx/playwright:playwright": {
+            "configurations": {
+              "ci": {},
+            },
+            "options": {},
+          },
+          "build": {
+            "cache": true,
+          },
+          "e2e": {
+            "configurations": {
+              "ci": {},
+            },
+            "executor": "@nx/playwright:playwright",
+            "options": {},
+          },
+          "lint": {
+            "cache": true,
+          },
+        }
+      `);
+    });
+  });
+});

--- a/packages/playwright/src/migrations/update-18-1-0/remove-baseUrl-from-project-json.ts
+++ b/packages/playwright/src/migrations/update-18-1-0/remove-baseUrl-from-project-json.ts
@@ -1,0 +1,65 @@
+import {
+  formatFiles,
+  readNxJson,
+  readProjectConfiguration,
+  type Tree,
+  updateNxJson,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+
+export default async function (tree: Tree) {
+  forEachExecutorOptions(
+    tree,
+    '@nx/playwright:playwright',
+    (options, projectName, targetName, configurationName) => {
+      if (options?.['baseUrl']) {
+        const project = readProjectConfiguration(tree, projectName);
+        if (configurationName) {
+          delete project.targets[targetName].configurations[configurationName][
+            'baseUrl'
+          ];
+        } else {
+          delete project.targets[targetName].options['baseUrl'];
+        }
+
+        updateProjectConfiguration(tree, projectName, project);
+      }
+    }
+  );
+
+  const nxJson = readNxJson(tree);
+  for (const [targetNameOrExecutor, target] of Object.entries(
+    nxJson.targetDefaults
+  )) {
+    if (
+      targetNameOrExecutor === '@nx/playwright:playwright' ||
+      (target.executor && target.executor === '@nx/playwright:playwright')
+    ) {
+      let updated = false;
+      if (target.options?.['baseUrl']) {
+        delete nxJson.targetDefaults[targetNameOrExecutor].options['baseUrl'];
+        updated = true;
+      }
+
+      if (target.configurations) {
+        for (const [configurationName, configuration] of Object.entries(
+          target.configurations
+        )) {
+          if (configuration['baseUrl']) {
+            delete nxJson.targetDefaults[targetNameOrExecutor].configurations[
+              configurationName
+            ]['baseUrl'];
+            updated = true;
+          }
+        }
+      }
+
+      if (updated) {
+        updateNxJson(tree, nxJson);
+      }
+    }
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Playwright does not support `--base-url` as a CLI argument.
Some of our generators have generated `baseUrl` as an option to the `@nx:/playwright:playwright` executor.
When executed, this causes an error.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure that `baseUrl` does not get added to the CLI args if it exists in the project.json
Add a migration to remove `baseUrl` if it already exists in the project.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
