### PR TITLE
chore(core): website branches by major version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -273,9 +273,9 @@ jobs:
         # Publish docs only on a full release
         if: ${{ !github.event.release.prerelease }}
         run: |
-          # Publish docs only when publishing the latest version
-          if [ "$(git describe --tags `git rev-list --tags --max-count=1`)" = "$GITHUB_REF_NAME" ]; then
+          # The GITHUB_REF_NAME is a full version (i.e. 17.3.2). The branchName will only use the major version number.
+          # We will publish docs to the website branch based on the current tag (i.e. website-17)
+          branchName=website-${$GITHUB_REF_NAME%.*.*}
           # We force recreate the branch in order to always be up to date and avoid merge conflicts within the automated workflow
-          git branch -f website
-          git push -f origin website
-          fi
+          git branch -f $branchName
+          git push -f origin $branchName


### PR DESCRIPTION
Updates the publish flow to create a `website-X` branch when a new version of Nx is released.

The previous flow does not behave correctly when `17.3.2` is published after `18.0.0`.  In that scenario, the `website` branch was overwritten with the `17.3.2` content.

In the new flow, when `17.3.2` is released, it will update the `website-17` branch and when `18.0.0` is released, it will update the `website-18` branch.

Because there will now be separate branches for each major version of Nx, there are 2 consequences:
1. Every time there is a major version bump, we'll need to update `nx.dev` to point to the new `website-X` branch
2. We can fairly easily create archived website urls for `16.nx.dev`, `17.nx.dev`, etc.  For people to access old versions of the docs.