### PR TITLE
fix(core): setting up .nx inside gradle shouldn't throw

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -48,7 +48,7 @@ export async function initHandler(options: InitArgs): Promise<void> {
     }
     generateDotNxSetup(version);
     // invokes the wrapper, thus invoking the initial installation process
-    runNxSync('');
+    runNxSync('--version', { stdio: 'ignore' });
     return;
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The v2 version of init is missing a `--version` flag on the initial call through nxw. This tries to run `nx` bare, which errors on a missing target.

## Expected Behavior
The v2 version of init passes `--version`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
