### PR TITLE
feat(nuxt): export storybook generator

### DIFF
--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -2,3 +2,4 @@ export * from './src/utils/versions';
 export { applicationGenerator } from './src/generators/application/application';
 export { type InitSchema } from './src/generators/init/schema';
 export { nuxtInitGenerator } from './src/generators/init/init';
+export { storybookConfigurationGenerator } from './src/generators/storybook-configuration/configuration';


### PR DESCRIPTION
export storybook generator so it can be programatically consumed.  It's the same for the @nx/vue library

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There's no way to run the storybook configuration in another generator

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
I want to run the storybook configuration in a generator. It's the same behaviour as in the @nx/vue package.

