### PR TITLE
fix(core): plugin pool should not clobber promises when called multiple times

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -13,11 +13,8 @@ import {
 } from './nx-deps-cache';
 import { applyImplicitDependencies } from './utils/implicit-project-dependencies';
 import { normalizeProjectNodes } from './utils/normalize-project-nodes';
-import {
-  isNxPluginV1,
-  isNxPluginV2,
-  loadNxPlugins,
-} from './plugins/internal-api';
+import { loadNxPlugins } from './plugins/internal-api';
+import { isNxPluginV1, isNxPluginV2 } from './plugins/utils';
 import { CreateDependenciesContext } from './plugins';
 import { getRootTsConfigPath } from '../plugins/js/utils/typescript';
 import {

--- a/packages/nx/src/project-graph/plugins/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/messaging.ts
@@ -30,16 +30,12 @@ export interface PluginWorkerLoadResult {
       };
 }
 
-export interface PluginWorkerShutdownMessage {
-  type: 'shutdown';
-  payload: undefined;
-}
-
 export interface PluginWorkerCreateNodesMessage {
   type: 'createNodes';
   payload: {
     configFiles: string[];
     context: CreateNodesContext;
+    tx: string;
   };
 }
 
@@ -49,10 +45,12 @@ export interface PluginWorkerCreateNodesResult {
     | {
         success: true;
         result: Awaited<ReturnType<RemotePlugin['createNodes'][1]>>;
+        tx: string;
       }
     | {
         success: false;
         error: string;
+        tx: string;
       };
 }
 
@@ -60,6 +58,7 @@ export interface PluginCreateDependenciesMessage {
   type: 'createDependencies';
   payload: {
     context: CreateDependenciesContext;
+    tx: string;
   };
 }
 
@@ -69,10 +68,12 @@ export interface PluginCreateDependenciesResult {
     | {
         dependencies: ReturnType<RemotePlugin['createDependencies']>;
         success: true;
+        tx: string;
       }
     | {
         success: false;
         error: string;
+        tx: string;
       };
 }
 
@@ -81,6 +82,7 @@ export interface PluginWorkerProcessProjectGraphMessage {
   payload: {
     graph: ProjectGraph;
     ctx: ProjectGraphProcessorContext;
+    tx: string;
   };
 }
 
@@ -90,16 +92,17 @@ export interface PluginWorkerProcessProjectGraphResult {
     | {
         graph: ProjectGraph;
         success: true;
+        tx: string;
       }
     | {
         success: false;
         error: string;
+        tx: string;
       };
 }
 
 export type PluginWorkerMessage =
   | PluginWorkerLoadMessage
-  | PluginWorkerShutdownMessage
   | PluginWorkerCreateNodesMessage
   | PluginCreateDependenciesMessage
   | PluginWorkerProcessProjectGraphMessage;

--- a/packages/nx/src/project-graph/plugins/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/plugin-pool.ts
@@ -10,7 +10,18 @@ import { PluginWorkerResult, consumeMessage, createMessage } from './messaging';
 
 const pool: ChildProcess[] = [];
 
-const pidMap = new Map<number, string>();
+const pidMap = new Map<number, { name: string; pending: Set<string> }>();
+
+// transaction id (tx) -> Promise, Resolver, Rejecter
+// Makes sure that we can resolve the correct promise when the worker sends back the result
+const promiseBank = new Map<
+  string,
+  {
+    promise: Promise<unknown>;
+    resolver: (result: any) => void;
+    rejecter: (err: any) => void;
+  }
+>();
 
 export function loadRemoteNxPlugin(plugin: PluginConfiguration, root: string) {
   // this should only really be true when running unit tests within
@@ -55,23 +66,22 @@ export async function shutdownPluginWorkers() {
   // Marks the workers as shutdown so that we don't report unexpected exits
   pluginWorkersShutdown = true;
 
-  const promises = [];
+  logger.verbose(`[plugin-pool] shutting down workers`);
+
+  const pending = pool
+    .map(({ pid }) => Array.from(pidMap.get(pid)?.pending))
+    .flat();
+
+  if (pending.length > 0) {
+    logger.verbose(
+      `[plugin-pool] waiting for ${pending.length} pending operations to complete`
+    );
+    await Promise.all(pending.map((tx) => promiseBank.get(tx)?.promise));
+  }
 
   for (const p of pool) {
-    p.send(createMessage({ type: 'shutdown', payload: undefined }), (error) => {
-      if (error) {
-        // This occurs when the worker is already dead, and we can ignore it
-      } else {
-        promises.push(
-          // Create a promise that resolves when the worker exits
-          new Promise<void>((res, rej) => {
-            p.once('exit', () => res());
-          })
-        );
-      }
-    });
+    p.kill('SIGINT');
   }
-  return Promise.all(promises);
 }
 
 /**
@@ -86,25 +96,6 @@ function createWorkerHandler(
   onload: (plugin: RemotePlugin) => void,
   onloadError: (err?: unknown) => void
 ) {
-  // We store resolver and rejecter functions in the outer scope so that we can
-  // resolve/reject the promise from the message handler. The flow is something like:
-  // 1. plugin api called
-  // 2. remote plugin sends message to worker, creates promise and stores resolver/rejecter
-  // 3. worker performs API request
-  // 4. worker sends result back to main process
-  // 5. main process resolves/rejects promise based on result
-
-  let createNodesResolver: (
-    result: Awaited<ReturnType<RemotePlugin['createNodes'][1]>>
-  ) => void | undefined;
-  let createNodesRejecter: (err: unknown) => void | undefined;
-  let createDependenciesResolver: (
-    result: ReturnType<RemotePlugin['createDependencies']>
-  ) => void | undefined;
-  let createDependenciesRejecter: (err: unknown) => void | undefined;
-  let processProjectGraphResolver: (updatedGraph: ProjectGraph) => void;
-  let processProjectGraphRejecter: (err: unknown) => void | undefined;
-
   let pluginName: string;
 
   return function (message: string) {
@@ -119,51 +110,69 @@ function createWorkerHandler(
         if (result.success) {
           const { name, createNodesPattern } = result;
           pluginName = name;
-          pidMap.set(worker.pid, name);
+          const pending = new Set<string>();
+          pidMap.set(worker.pid, { name, pending });
           onload({
             name,
             createNodes: createNodesPattern
               ? [
                   createNodesPattern,
                   (configFiles, ctx) => {
-                    return new Promise((res, rej) => {
+                    return new Promise(function (res, rej) {
+                      const tx =
+                        pluginName + ':createNodes:' + performance.now();
                       worker.send(
                         createMessage({
                           type: 'createNodes',
-                          payload: { configFiles, context: ctx },
+                          payload: { configFiles, context: ctx, tx },
                         })
                       );
-                      createNodesResolver = res;
-                      createNodesRejecter = rej;
+                      pending.add(tx);
+                      promiseBank.set(tx, {
+                        promise: this,
+                        resolver: res,
+                        rejecter: rej,
+                      });
                     });
                   },
                 ]
               : undefined,
             createDependencies: result.hasCreateDependencies
               ? (opts, ctx) => {
-                  return new Promise((res, rej) => {
+                  return new Promise(function (res, rej) {
+                    const tx = pluginName + ':createNodes:' + performance.now();
                     worker.send(
                       createMessage({
                         type: 'createDependencies',
-                        payload: { context: ctx },
+                        payload: { context: ctx, tx },
                       })
                     );
-                    createDependenciesResolver = res;
-                    createDependenciesRejecter = rej;
+                    pending.add(tx);
+                    promiseBank.set(tx, {
+                      promise: this,
+                      resolver: res,
+                      rejecter: rej,
+                    });
                   });
                 }
               : undefined,
             processProjectGraph: result.hasProcessProjectGraph
               ? (graph, ctx) => {
-                  return new Promise((res, rej) => {
+                  return new Promise(function (res, rej) {
+                    const tx =
+                      pluginName + ':processProjectGraph:' + performance.now();
                     worker.send(
                       createMessage({
                         type: 'processProjectGraph',
-                        payload: { graph, ctx },
+                        payload: { graph, ctx, tx },
                       })
                     );
-                    processProjectGraphResolver = res;
-                    processProjectGraphRejecter = rej;
+                    pending.add(tx);
+                    promiseBank.set(tx, {
+                      promise: this,
+                      resolver: res,
+                      rejecter: rej,
+                    });
                   });
                 }
               : undefined,
@@ -172,32 +181,35 @@ function createWorkerHandler(
           onloadError(result.error);
         }
       },
-      createDependenciesResult: (result) => {
+      createDependenciesResult: ({ tx, ...result }) => {
+        const { resolver, rejecter } = promiseBank.get(tx);
         if (result.success) {
-          createDependenciesResolver(result.dependencies);
-          createDependenciesResolver = undefined;
+          resolver(result.dependencies);
         } else if (result.success === false) {
-          createDependenciesRejecter(result.error);
-          createDependenciesRejecter = undefined;
+          rejecter(result.error);
         }
+        pidMap.get(worker.pid)?.pending.delete(tx);
+        promiseBank.delete(tx);
       },
-      createNodesResult: (payload) => {
-        if (payload.success) {
-          createNodesResolver(payload.result);
-          createNodesResolver = undefined;
-        } else if (payload.success === false) {
-          createNodesRejecter(payload.error);
-          createNodesRejecter = undefined;
-        }
-      },
-      processProjectGraphResult: (result) => {
+      createNodesResult: ({ tx, ...result }) => {
+        const { resolver, rejecter } = promiseBank.get(tx);
         if (result.success) {
-          processProjectGraphResolver(result.graph);
-          processProjectGraphResolver = undefined;
+          resolver(result.result);
         } else if (result.success === false) {
-          processProjectGraphRejecter(result.error);
-          processProjectGraphRejecter = undefined;
+          rejecter(result.error);
         }
+        pidMap.get(worker.pid)?.pending.delete(tx);
+        promiseBank.delete(tx);
+      },
+      processProjectGraphResult: ({ tx, ...result }) => {
+        const { resolver, rejecter } = promiseBank.get(tx);
+        if (result.success) {
+          resolver(result.graph);
+        } else if (result.success === false) {
+          rejecter(result.error);
+        }
+        pidMap.get(worker.pid)?.pending.delete(tx);
+        promiseBank.delete(tx);
       },
     });
   };
@@ -206,6 +218,14 @@ function createWorkerHandler(
 function workerOnExitHandler(worker: ChildProcess) {
   return () => {
     if (!pluginWorkersShutdown) {
+      pidMap.get(worker.pid)?.pending.forEach((tx) => {
+        const { rejecter } = promiseBank.get(tx);
+        rejecter(
+          `[Nx] plugin worker ${
+            pidMap.get(worker.pid) ?? worker.pid
+          } exited unexpectedly`
+        );
+      });
       shutdownPluginWorkers();
       throw new Error(
         `[Nx] plugin worker ${

--- a/packages/nx/src/project-graph/plugins/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/plugin-worker.ts
@@ -45,51 +45,45 @@ process.on('message', async (message: string) => {
         };
       }
     },
-    shutdown: async () => {
-      process.exit(0);
-    },
-    createNodes: async ({ configFiles, context }) => {
+    createNodes: async ({ configFiles, context, tx }) => {
       try {
         const result = await runCreateNodesInParallel(configFiles, context);
         return {
           type: 'createNodesResult',
-          payload: { result, success: true },
+          payload: { result, success: true, tx },
         };
       } catch (e) {
         return {
           type: 'createNodesResult',
-          payload: { success: false, error: e.stack },
+          payload: { success: false, error: e.stack, tx },
         };
       }
     },
-    createDependencies: async (payload) => {
+    createDependencies: async ({ context, tx }) => {
       try {
-        const result = await plugin.createDependencies(
-          pluginOptions,
-          payload.context
-        );
+        const result = await plugin.createDependencies(pluginOptions, context);
         return {
           type: 'createDependenciesResult',
-          payload: { dependencies: result, success: true },
+          payload: { dependencies: result, success: true, tx },
         };
       } catch (e) {
         return {
           type: 'createDependenciesResult',
-          payload: { success: false, error: e.stack },
+          payload: { success: false, error: e.stack, tx },
         };
       }
     },
-    processProjectGraph: async ({ graph, ctx }) => {
+    processProjectGraph: async ({ graph, ctx, tx }) => {
       try {
         const result = await plugin.processProjectGraph(graph, ctx);
         return {
           type: 'processProjectGraphResult',
-          payload: { graph: result, success: true },
+          payload: { graph: result, success: true, tx },
         };
       } catch (e) {
         return {
           type: 'processProjectGraphResult',
-          payload: { success: false, error: e.stack },
+          payload: { success: false, error: e.stack, tx },
         };
       }
     },

--- a/packages/nx/src/project-graph/plugins/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/plugin-worker.ts
@@ -4,8 +4,12 @@ import { PluginWorkerMessage, consumeMessage } from './messaging';
 import { PluginConfiguration } from '../../config/nx-json';
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
 import { retrieveProjectConfigurationsWithoutPluginInference } from '../utils/retrieve-workspace-files';
-import { CreateNodesResultWithContext, NormalizedPlugin } from './internal-api';
+import type {
+  CreateNodesResultWithContext,
+  NormalizedPlugin,
+} from './internal-api';
 import { CreateNodesContext } from './public-api';
+import { CreateNodesError } from './utils';
 
 global.NX_GRAPH_CREATION = true;
 
@@ -116,34 +120,28 @@ function runCreateNodesInParallel(
     CreateNodesResultWithContext | Promise<CreateNodesResultWithContext>
   > = configFiles.map((file) => {
     performance.mark(`${plugin.name}:createNodes:${file} - start`);
-    const value = plugin.createNodes[1](file, pluginOptions, context);
-    if (value instanceof Promise) {
-      return value
-        .catch((e) => {
-          performance.mark(`${plugin.name}:createNodes:${file} - end`);
-          throw new Error(
-            `Unable to create nodes for ${file} using plugin ${plugin.name}.`,
-            e
-          );
-        })
-        .then((r) => {
-          performance.mark(`${plugin.name}:createNodes:${file} - end`);
-          performance.measure(
-            `${plugin.name}:createNodes:${file}`,
-            `${plugin.name}:createNodes:${file} - start`,
-            `${plugin.name}:createNodes:${file} - end`
-          );
-          return { ...r, pluginName: plugin.name, file };
-        });
-    } else {
-      performance.mark(`${plugin.name}:createNodes:${file} - end`);
-      performance.measure(
-        `${plugin.name}:createNodes:${file}`,
-        `${plugin.name}:createNodes:${file} - start`,
-        `${plugin.name}:createNodes:${file} - end`
-      );
-      return { ...value, pluginName: plugin.name, file };
-    }
+    // Result is either static or a promise, using Promise.resolve lets us
+    // handle both cases with same logic
+    const value = Promise.resolve(
+      plugin.createNodes[1](file, pluginOptions, context)
+    );
+    return value
+      .catch((e) => {
+        performance.mark(`${plugin.name}:createNodes:${file} - end`);
+        throw new CreateNodesError(
+          `Unable to create nodes for ${file} using plugin ${plugin.name}.`,
+          e
+        );
+      })
+      .then((r) => {
+        performance.mark(`${plugin.name}:createNodes:${file} - end`);
+        performance.measure(
+          `${plugin.name}:createNodes:${file}`,
+          `${plugin.name}:createNodes:${file} - start`,
+          `${plugin.name}:createNodes:${file} - end`
+        );
+        return { ...r, pluginName: plugin.name, file };
+      });
   });
   return Promise.all(promises);
 }

--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -1,0 +1,61 @@
+import { dirname } from 'node:path';
+
+import { toProjectName } from '../../config/workspaces';
+import { combineGlobPatterns } from '../../utils/globs';
+
+import type { NxPluginV1 } from '../../utils/nx-plugin.deprecated';
+import type { NormalizedPlugin, RemotePlugin } from './internal-api';
+import type { NxPlugin, NxPluginV2 } from './public-api';
+
+export function isNxPluginV2(plugin: NxPlugin): plugin is NxPluginV2 {
+  return 'createNodes' in plugin || 'createDependencies' in plugin;
+}
+
+export function isNxPluginV1(
+  plugin: NxPlugin | RemotePlugin
+): plugin is NxPluginV1 {
+  return 'processProjectGraph' in plugin || 'projectFilePatterns' in plugin;
+}
+
+export function normalizeNxPlugin(plugin: NxPlugin): NormalizedPlugin {
+  if (isNxPluginV2(plugin)) {
+    return plugin;
+  }
+  if (isNxPluginV1(plugin) && plugin.projectFilePatterns) {
+    return {
+      ...plugin,
+      createNodes: [
+        `*/**/${combineGlobPatterns(plugin.projectFilePatterns)}`,
+        (configFilePath) => {
+          const root = dirname(configFilePath);
+          return {
+            projects: {
+              [root]: {
+                name: toProjectName(configFilePath),
+                targets: plugin.registerProjectTargets?.(configFilePath),
+              },
+            },
+          };
+        },
+      ],
+    };
+  }
+  return plugin;
+}
+
+export class CreateNodesError extends Error {
+  constructor(msg, cause: Error | unknown) {
+    const message = `${msg} ${
+      !cause
+        ? ''
+        : cause instanceof Error
+        ? `\n\n\t Inner Error: ${cause.stack}`
+        : cause
+    }`;
+    // These errors are thrown during a JS callback which is invoked via rust.
+    // The errors messaging gets lost in the rust -> js -> rust transition, but
+    // logging the error here will ensure that it is visible in the console.
+    console.error(message);
+    super(message, { cause });
+  }
+}

--- a/packages/nx/src/project-graph/plugins/worker-api.ts
+++ b/packages/nx/src/project-graph/plugins/worker-api.ts
@@ -27,7 +27,7 @@ import { logger } from '../../utils/logger';
 
 import type * as ts from 'typescript';
 import { extname } from 'node:path';
-import { NormalizedPlugin, normalizeNxPlugin } from './internal-api';
+import { normalizeNxPlugin } from './utils';
 import { NxPlugin } from './public-api';
 
 export type LoadedNxPlugin = {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Plugin Pool / Plugin worker exhibits some weird behavior in following cases:
- Workers shutdown when promise is pending (results in Nx hanging)
- CreateNodes is called again when promise is still pending (can result in createNodesResolver is undefined error)

## Expected Behavior
Promises are resolved by proper result message and we wait for pending promises before killing the workers.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
