### PR TITLE
fix(js): set moduleResolution to Node10 so it is compatible with CommonJS module

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -112,6 +112,7 @@ export function getTranspiler(compilerOptions: CompilerOptions) {
 
   compilerOptions.lib = ['es2021'];
   compilerOptions.module = ts.ModuleKind.CommonJS;
+  compilerOptions.moduleResolution = ts.ModuleResolutionKind.Node10;
   compilerOptions.target = ts.ScriptTarget.ES2021;
   compilerOptions.inlineSourceMap = true;
   compilerOptions.skipLibCheck = true;


### PR DESCRIPTION
Since we set module to be `CommonJS` when transpiling `.ts` config files, it will fail if the workspace uses `moduleResolution` that is incompatible with `CommonJS`.

When you run any Nx command you'll get an error such as:

```
{
  stack: 'Error: Unable to create nodes for playwright.config.ts using plugin @nx/playwright/plugin. \n' +
    '\n' +
    '\t Inner Error: TSError: ⨯ Unable to compile TypeScript:\n' +
    "error TS5095: Option 'bundler' can only be used when 'module' is set to 'es2015' or later.\n" +
    '\n' +
    '    at createTSError (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:859:12)\n' +
    '    at reportTSError (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:863:19)\n' +
    '    at /Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1379:34\n' +
    '    at Object.compile (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1458:13)\n' +
    '    at Module.m._compile (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1617:30)\n' +
    '    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)\n' +
    '    at Object.require.extensions.<computed> [as .ts] (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1621:12)\n' +
    '    at Module.load (node:internal/modules/cjs/loader:1207:32)\n' +
    '    at Function.Module._load (node:internal/modules/cjs/loader:1023:12)\n' +
    '    at Module.require (node:internal/modules/cjs/loader:1235:19)\n' +
    '    at /Users/leosvel/code/playground/foo/node_modules/nx/src/project-graph/utils/project-configuration-utils.js:156:35\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
    '    at async Promise.all (index 0)\n' +
    '    at async Promise.all (index 3)\n' +
    '    at async createProjectConfigurations (/Users/leosvel/code/playground/foo/node_modules/nx/src/project-graph/utils/retrieve-workspace-files.js:89:62)\n' +
    '    at async processFilesAndCreateAndSerializeProjectGraph (/Users/leosvel/code/playground/foo/node_modules/nx/src/daemon/server/project-graph-incremental-recomputation.js:140:28)\n' +
    '    at async getCachedSerializedProjectGraphPromise (/Users/leosvel/code/playground/foo/node_modules/nx/src/daemon/server/project-graph-incremental-recomputation.js:43:16)\n' +
    '    at async handleRequestProjectGraph (/Users/leosvel/code/playground/foo/node_modules/nx/src/daemon/server/handle-request-project-graph.js:12:24)\n' +
    '    at async handleResult (/Users/leosvel/code/playground/foo/node_modules/nx/src/daemon/server/server.js:110:16)\n' +
    '    at async handleMessage (/Users/leosvel/code/playground/foo/node_modules/nx/src/daemon/server/server.js:81:9)',
  message: 'Unable to create nodes for playwright.config.ts using plugin @nx/playwright/plugin. \n' +
    '\n' +
    '\t Inner Error: TSError: ⨯ Unable to compile TypeScript:\n' +
    "error TS5095: Option 'bundler' can only be used when 'module' is set to 'es2015' or later.\n" +
    '\n' +
    '    at createTSError (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:859:12)\n' +
    '    at reportTSError (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:863:19)\n' +
    '    at /Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1379:34\n' +
    '    at Object.compile (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1458:13)\n' +
    '    at Module.m._compile (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1617:30)\n' +
    '    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)\n' +
    '    at Object.require.extensions.<computed> [as .ts] (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1621:12)\n' +
    '    at Module.load (node:internal/modules/cjs/loader:1207:32)\n' +
    '    at Function.Module._load (node:internal/modules/cjs/loader:1023:12)\n' +
    '    at Module.require (node:internal/modules/cjs/loader:1235:19)\n' +
    '\n' +
    'Because of the error the Nx daemon process has exited. The next Nx command is going to restart the daemon process.\n' +
    'If the error persists, please run "nx reset".',
  cause: {
    stack: 'TSError: ⨯ Unable to compile TypeScript:\n' +
      "error TS5095: Option 'bundler' can only be used when 'module' is set to 'es2015' or later.\n" +
      '\n' +
      '    at createTSError (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:859:12)\n' +
      '    at reportTSError (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:863:19)\n' +
      '    at /Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1379:34\n' +
      '    at Object.compile (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1458:13)\n' +
      '    at Module.m._compile (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1617:30)\n' +
      '    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)\n' +
      '    at Object.require.extensions.<computed> [as .ts] (/Users/leosvel/code/playground/foo/node_modules/ts-node/src/index.ts:1621:12)\n' +
      '    at Module.load (node:internal/modules/cjs/loader:1207:32)\n' +
      '    at Function.Module._load (node:internal/modules/cjs/loader:1023:12)\n' +
      '    at Module.require (node:internal/modules/cjs/loader:1235:19)',
    message: '⨯ Unable to compile TypeScript:\n' +
      "error TS5095: Option 'bundler' can only be used when 'module' is set to 'es2015' or later.\n"
  }
}
```

## Current Behavior

Workspaces with `moduleResolution: 'bundler'` or `esnext`, etc. will error out when transpiling `.ts` config files like `playwright.config.ts`

## Expected Behavior

`.ts` config files should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
