### PR TITLE
fix(core): nextjs-standalone generates package scripts consistent with create-next-app

### DIFF
--- a/packages/workspace/src/generators/new/__snapshots__/generate-workspace-files.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/generate-workspace-files.spec.ts.snap
@@ -1706,6 +1706,62 @@ It will show tasks that you can run with Nx.
 "
 `;
 
+exports[`@nx/workspace:generateWorkspaceFiles should create package scripts for angular-standalone preset 1`] = `
+{
+  "build": "nx build",
+  "start": "nx serve",
+  "test": "nx test",
+}
+`;
+
+exports[`@nx/workspace:generateWorkspaceFiles should create package scripts for nextjs-standalone preset 1`] = `
+{
+  "build": "nx build",
+  "dev": "nx dev",
+  "start": "nx start",
+  "test": "nx test",
+}
+`;
+
+exports[`@nx/workspace:generateWorkspaceFiles should create package scripts for node-standalone preset 1`] = `
+{
+  "build": "nx build",
+  "start": "nx serve",
+  "test": "nx test",
+}
+`;
+
+exports[`@nx/workspace:generateWorkspaceFiles should create package scripts for nuxt-standalone preset 1`] = `
+{
+  "build": "nx build",
+  "start": "nx serve",
+  "test": "nx test",
+}
+`;
+
+exports[`@nx/workspace:generateWorkspaceFiles should create package scripts for react-standalone preset 1`] = `
+{
+  "build": "nx build",
+  "start": "nx serve",
+  "test": "nx test",
+}
+`;
+
+exports[`@nx/workspace:generateWorkspaceFiles should create package scripts for ts-standalone preset 1`] = `
+{
+  "build": "nx build",
+  "test": "nx test",
+}
+`;
+
+exports[`@nx/workspace:generateWorkspaceFiles should create package scripts for vue-standalone preset 1`] = `
+{
+  "build": "nx build",
+  "start": "nx serve",
+  "test": "nx test",
+}
+`;
+
 exports[`@nx/workspace:generateWorkspaceFiles should recommend vscode extensions (angular) 1`] = `
 [
   "nrwl.angular-console",

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -230,4 +230,25 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     const pnpm = tree.read('/proj/pnpm-workspace.yaml').toString();
     expect(pnpm).toContain('packages/*');
   });
+
+  it.each([
+    Preset.ReactStandalone,
+    Preset.VueStandalone,
+    Preset.NuxtStandalone,
+    Preset.AngularStandalone,
+    Preset.NodeStandalone,
+    Preset.NextJsStandalone,
+    Preset.TsStandalone,
+  ])('should create package scripts for %s preset', async (preset) => {
+    await generateWorkspaceFiles(tree, {
+      name: 'proj',
+      directory: 'proj',
+      preset,
+      defaultBase: 'main',
+      appName: 'demo',
+      isCustomPreset: false,
+    });
+
+    expect(readJson(tree, 'proj/package.json').scripts).toMatchSnapshot();
+  });
 });

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -58,6 +58,7 @@ function setPresetProperty(tree: Tree, options: NormalizedSchema) {
     return json;
   });
 }
+
 function createNxJson(
   tree: Tree,
   { directory, defaultBase, preset }: NormalizedSchema
@@ -163,13 +164,23 @@ function addNpmScripts(tree: Tree, options: NormalizedSchema) {
     options.preset === Preset.ReactStandalone ||
     options.preset === Preset.VueStandalone ||
     options.preset === Preset.NuxtStandalone ||
-    options.preset === Preset.NodeStandalone ||
-    options.preset === Preset.NextJsStandalone
+    options.preset === Preset.NodeStandalone
   ) {
     updateJson(tree, join(options.directory, 'package.json'), (json) => {
       Object.assign(json.scripts, {
         start: 'nx serve',
         build: 'nx build',
+        test: 'nx test',
+      });
+      return json;
+    });
+  }
+  if (options.preset === Preset.NextJsStandalone) {
+    updateJson(tree, join(options.directory, 'package.json'), (json) => {
+      Object.assign(json.scripts, {
+        dev: 'nx dev',
+        build: 'nx build',
+        start: 'nx start',
         test: 'nx test',
       });
       return json;


### PR DESCRIPTION
This PR fixes the package scripts generated by `create-nx-workspace` when picking the Next.js standalone option.

The scripts should be the same as running `create-next-app` then running `nx init`.

```
"scripts": {
    "dev": "nx dev",
    "build": "nx build",
    "start": "nx start"
}
```

## Current Behavior

`npm start` fails since `nx serve` is not a target for Next.js.

## Expected Behavior
`npm start` runs the production server, and `npm run dev` runs the devserver.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
