### PR TITLE
fix(nextjs): avoid path error on dev  server creation

### DIFF
--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -25,7 +25,8 @@ export default async function* serveExecutor(
   );
   const projectRoot = context.workspace.projects[context.projectName].root;
   // This is required for the default custom server to work. See the @nx/next:app generator.
-  const nextDir = resolve(context.root, buildOptions.outputPath);
+  const nextDir =
+    !options.dev && resolve(context.root, buildOptions.outputPath);
   process.env.NX_NEXT_DIR ??= options.dev ? projectRoot : nextDir;
 
   if (options.customServerTarget) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When trying to start a dev server on an app by `nx start <ap-name>` (that under the hood is executing `@nx/next:server`) it started failing (presumibily after [this update](https://github.com/nrwl/nx/commit/605d65acd2845756eabd9b9d97bec2a75ef26d54)). This is the error being displayed 👇🏼 

```
>  NX   The "paths[1]" argument must be of type string. Received undefined


TypeError [ERR_INVALID_ARG_TYPE]: The "paths[1]" argument must be of type string. Received undefined
    at validateString (node:internal/validators:162:11)
    at resolve (node:path:1101:7)
    at serveExecutor (/Users/javierabia/Endlessstudio/GFW/frontend/node_modules/@nx/next/src/executors/server/server.impl.js:14:40)
    at serveExecutor.next (<anonymous>)
    at getLastValueFromAsyncIterableIterator (/Users/user/frontend/node_modules/nx/src/utils/async-iterator.js:13:27)
    at iteratorToProcessStatusCode (/Users/userfrontend/node_modules/nx/src/command-line/run/run.js:43:94)
    at /Users/user/frontend/node_modules/nx/src/command-line/run/run.js:169:16
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async handleErrors (/Users/user/frontend/node_modules/nx/src/utils/params.js:9:16)
    at async process.<anonymous> (/Users/user/frontend/node_modules/nx/bin/run-executor.js:59:28)
```


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This error gets bypassed, since the server does not try to resolve the path in the `dev` environment.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
