### PR TITLE
fix(node): Increase timeout for CI

### DIFF
--- a/e2e/node/src/node-webpack.test.ts
+++ b/e2e/node/src/node-webpack.test.ts
@@ -103,7 +103,7 @@ describe('Node Applications + webpack', () => {
           output.includes(`should rebuild lib`)
         );
       },
-      { timeout: 30_000, ms: 200 }
+      { timeout: 60_000, ms: 200 }
     );
 
     serveProcess.kill();


### PR DESCRIPTION
This has a chance to fail sometimes. 

Let's increase the timeout so that CI doesn't miss the update hence making it throw the error.
