### PR TITLE
docs(nextjs): Update nextjs deployment with Crystal

### DIFF
--- a/docs/shared/recipes/deployment/deploy-nextjs-to-vercel.md
+++ b/docs/shared/recipes/deployment/deploy-nextjs-to-vercel.md
@@ -17,7 +17,7 @@ npx nx build tuskdesk --prod
 4. Toggle the override switch for the output directory. Point it to the `.next` directory inside the built app:
 
 ```shell
-dist/apps/tuskdesk/.next
+apps/tuskdesk/.next
 ```
 
 Therefore, our full configuration (based on a repo called "nx-workspace" and a project called "tuskdesk") will look like this:


### PR DESCRIPTION
With Crystal we no longer generate `.next` artifact inside the `dist/` folder.

It is now synonymous with how Nextjs CLI generates it's artifacts i.e. _inside of the app directory_
Fixes: #21849