### PR TITLE
fix(react): disable react refresh overlay

### DIFF
--- a/packages/react/plugins/nx-react-webpack-plugin/lib/apply-react-config.ts
+++ b/packages/react/plugins/nx-react-webpack-plugin/lib/apply-react-config.ts
@@ -59,7 +59,7 @@ function addHotReload(
     }
 
     const ReactRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
-    config.plugins.push(new ReactRefreshPlugin());
+    config.plugins.push(new ReactRefreshPlugin({ overlay: false }));
   }
 }
 


### PR DESCRIPTION
## Current Behavior
Currently when a user runs into a compile/runtime error in react application 2 error overlays will show. One from react-refresh-plugin and the second one from webpack-dev-server (which is enabled by default)
![image](https://github.com/nrwl/nx/assets/19208948/c6be47bc-3ffd-4148-bdc6-18b59affae7f)
![image](https://github.com/nrwl/nx/assets/19208948/65ebe2a4-ed47-4feb-b289-645f3e2303cc)

### Steps to reproduce

This is reproducible using both webpack config types when the react refresh plugin is applied to the configuration.
1. create fresh nx react app with webpack
2. add `hot: true`in webpack dev server configuration, so react-refresh-plugin gets applied
3. anywhere in the app code throw an error i.e.
```
useEffect(() => {
  setTimeout(() => {
    throw new Error('test');
  }, 1000);
}, []);
```
4. observe 2 error overlays shown
Or clone the repo https://github.com/zoran995/nx-react-error-overlay, branch main is using nx enhanced config, branch default-config is using plain webpack config. Here is also a codesandbox showcasing an issue https://codesandbox.io/p/github/zoran995/nx-react-error-overlay/main?file=%2Fapps%2Forg%2Fsrc%2Fapp%2Fapp.tsx&import=true

## Expected Behavior
Only one error should be shown to the user, and this is the actual configuration of the plugin that is used by react scripts. I went with not exposing another config option for nx react webpack plugin as there is already an option to configure webpack dev server error overlay and most of the react community is used to have the react-refresh one disabled.
