### PR TITLE
fix(misc): fix buildable libs utils calculating dependent projects from task graph

### DIFF
--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -258,7 +258,7 @@ export function calculateDependenciesFromTaskGraph(
     const depTask = taskGraph.tasks[taskName];
     const depProjectNode = projectGraph.nodes?.[depTask.target.project];
     if (depProjectNode?.type !== 'lib') {
-      return null;
+      continue;
     }
 
     let outputs = getOutputsForTargetAndConfiguration(


### PR DESCRIPTION
Fixes an issue where calculating the dependent projects from the task graph would incorrectly return `null`.

Related comment: https://github.com/nrwl/nx/issues/21395#issuecomment-1942000825

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
