### PR TITLE
feat(nextjs): use global NX_GRAPH_CREATION in withNx plugin to guard against graph creation during create nodes

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -112,12 +112,12 @@ function withNx(
     const { PHASE_PRODUCTION_SERVER, PHASE_DEVELOPMENT_SERVER } = await import(
       'next/constants'
     );
-    if (
-      PHASE_PRODUCTION_SERVER === phase ||
-      !process.env.NX_TASK_TARGET_TARGET
-    ) {
-      // If we are running an already built production server, just return the configuration.
-      // NOTE: Avoid any `require(...)` or `import(...)` statements here. Development dependencies are not available at production runtime.
+    // Two scenarios where we want to skip graph creation:
+    // 1. Running production server means the build is already done so we just need to start the Next.js server.
+    // 2. During graph creation (i.e. create nodes), we won't have a graph to read, and it is not needed anyway since it's a build-time concern.
+    //
+    // NOTE: Avoid any `require(...)` or `import(...)` statements here. Development dependencies are not available at production runtime.
+    if (PHASE_PRODUCTION_SERVER === phase || global.NX_GRAPH_CREATION) {
       const { nx, ...validNextConfig } = _nextConfig;
       return {
         distDir: '.next',
@@ -126,21 +126,19 @@ function withNx(
     } else {
       const {
         createProjectGraphAsync,
-        readCachedProjectGraph,
         joinPathFragments,
         offsetFromRoot,
         workspaceRoot,
       } = require('@nx/devkit');
 
-      let graph = readCachedProjectGraph();
-      if (!graph) {
-        try {
-          graph = await createProjectGraphAsync();
-        } catch (e) {
-          throw new Error(
-            'Could not create project graph. Please ensure that your workspace is valid.'
-          );
-        }
+      let graph: ProjectGraph;
+      try {
+        graph = await createProjectGraphAsync();
+      } catch (e) {
+        throw new Error(
+          'Could not create project graph. Please ensure that your workspace is valid.',
+          { cause: e }
+        );
       }
 
       const originalTarget = {


### PR DESCRIPTION
The Next.js `withNx` plugin should be checking `global.NX_GRAPH_CREATION` to check if it is invoked during graph creation.

Also removes the `readCachedProjectGraph` call and just use `createProjectGraphAsync` since the former would throw if cached graph doesn't exist anyway.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
