### PR TITLE
feat(core): provide a hint when project.json has empty targets

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -62,6 +62,7 @@ exports[`app generated files content - as-provided general application should co
   "$schema": "../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "my-app/src",
+  "// targets": "to see all targets run: nx show project my-app --web",
   "targets": {}
 }
 "

--- a/packages/nx/src/generators/utils/project-configuration.spec.ts
+++ b/packages/nx/src/generators/utils/project-configuration.spec.ts
@@ -21,7 +21,6 @@ const projectConfiguration: ProjectConfiguration = {
   name: 'test',
   root: 'libs/test',
   sourceRoot: 'libs/test/src',
-  targets: {},
 };
 
 describe('project configuration', () => {
@@ -32,7 +31,32 @@ describe('project configuration', () => {
   });
 
   it('should create project.json file when adding a project if standalone is true', () => {
-    addProjectConfiguration(tree, 'test', projectConfiguration);
+    addProjectConfiguration(tree, 'test', {
+      ...projectConfiguration,
+      targets: {
+        test: {},
+      },
+    });
+
+    expect(readProjectConfiguration(tree, 'test')).toMatchInlineSnapshot(`
+      {
+        "$schema": "../../node_modules/nx/schemas/project-schema.json",
+        "name": "test",
+        "root": "libs/test",
+        "sourceRoot": "libs/test/src",
+        "targets": {
+          "test": {},
+        },
+      }
+    `);
+    expect(tree.exists('libs/test/project.json')).toBeTruthy();
+  });
+
+  it('should add a comment to show project details when targets are missing', () => {
+    addProjectConfiguration(tree, 'test', {
+      ...projectConfiguration,
+      targets: {},
+    });
 
     expect(readProjectConfiguration(tree, 'test')).toMatchInlineSnapshot(`
       {
@@ -43,7 +67,54 @@ describe('project configuration', () => {
         "targets": {},
       }
     `);
-    expect(tree.exists('libs/test/project.json')).toBeTruthy();
+
+    expect(tree.read('libs/test/project.json', 'utf-8')).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "$schema": "../../node_modules/nx/schemas/project-schema.json",
+        "sourceRoot": "libs/test/src",
+        "// targets": "to see all targets run: nx show project test --web",
+        "targets": {}
+      }
+      "
+    `);
+
+    // Adding a target removes the "// targets" comment.
+    updateProjectConfiguration(tree, 'test', {
+      ...projectConfiguration,
+      targets: {
+        test: {},
+      },
+    });
+
+    expect(tree.read('libs/test/project.json', 'utf-8')).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "$schema": "../../node_modules/nx/schemas/project-schema.json",
+        "sourceRoot": "libs/test/src",
+        "targets": {
+          "test": {}
+        }
+      }
+      "
+    `);
+
+    // Emptying out targets add "// targets" comment back.
+    updateProjectConfiguration(tree, 'test', {
+      ...projectConfiguration,
+      targets: {},
+    });
+
+    expect(tree.read('libs/test/project.json', 'utf-8')).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "$schema": "../../node_modules/nx/schemas/project-schema.json",
+        "sourceRoot": "libs/test/src",
+        "// targets": "to see all targets run: nx show project test --web",
+        "targets": {}
+      }
+      "
+    `);
   });
 
   it('should update project.json file when updating a project', () => {

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -64,6 +64,9 @@ export function addProjectConfiguration(
   }
 
   delete (projectConfiguration as any).$schema;
+
+  handleEmptyTargets(projectName, projectConfiguration);
+
   writeJson(tree, projectConfigFile, {
     name: projectName,
     $schema: getRelativeProjectJsonSchemaPath(tree, projectConfiguration),
@@ -94,6 +97,7 @@ export function updateProjectConfiguration(
       `Cannot update Project ${projectName} at ${projectConfiguration.root}. It either doesn't exist yet, or may not use project.json for configuration. Use \`addProjectConfiguration()\` instead if you want to create a new project.`
     );
   }
+  handleEmptyTargets(projectName, projectConfiguration);
   writeJson(tree, projectConfigFile, {
     name: projectConfiguration.name ?? projectName,
     $schema: getRelativeProjectJsonSchemaPath(tree, projectConfiguration),
@@ -192,7 +196,7 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
     '**/project.json',
     'project.json',
     ...getGlobPatternsFromPackageManagerWorkspaces(tree.root, (p) =>
-      readJson(tree, p)
+      readJson(tree, p, { expectComments: true })
     ),
   ];
   const projectGlobPatterns = configurationGlobs([
@@ -327,4 +331,23 @@ function toNewFormat(w: any): ProjectsConfigurations {
     w.version = 2;
   }
   return w;
+}
+
+function handleEmptyTargets(
+  projectName: string,
+  projectConfiguration: ProjectConfiguration
+): void {
+  if (
+    projectConfiguration.targets &&
+    !Object.keys(projectConfiguration.targets).length
+  ) {
+    // Re-order `targets` to appear after the `// target` comment.
+    delete projectConfiguration.targets;
+    projectConfiguration[
+      '// targets'
+    ] = `to see all targets run: nx show project ${projectName} --web`;
+    projectConfiguration.targets = {};
+  } else {
+    delete projectConfiguration['// targets'];
+  }
 }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -303,6 +303,9 @@ export function readProjectConfigurationsFromRootMap(
   const errors: Map<string, string[]> = new Map();
 
   for (const [root, configuration] of projectRootMap.entries()) {
+    // We're setting `// targets` as a comment `targets` is empty due to Project Crystal.
+    // Strip it before returning configuration for usage.
+    if (configuration['// targets']) delete configuration['// targets'];
     if (!configuration.name) {
       try {
         const { name } = readJsonFile(join(root, 'package.json'));


### PR DESCRIPTION
With Project Crystal, new projects are generated with empty targets in `project.json`. This is confusing for users that expect targets to be defined in `project.json` or `nx.json`.

This PR ensures that whenever the targets in `project.json` are empty, we add a hint for the user:

```
{
  "// targets": "to see all targets run: nx show project <name> --web`",
  "targets" {}
}
```