### PR TITLE
chore(repo): exclude master commits from commit linting

### DIFF
--- a/scripts/commit-lint.js
+++ b/scripts/commit-lint.js
@@ -3,10 +3,42 @@
 const { types, scopes } = require('./commitizen.js');
 
 console.log('🐟🐟🐟 Validating git commit message 🐟🐟🐟');
-const gitMessage = require('child_process')
-  .execSync('git log -1 --no-merges')
+
+const childProcess = require('child_process');
+
+let gitLogCmd = 'git log -1 --no-merges';
+
+const gitRemotes = childProcess
+  .execSync('git remote -v')
   .toString()
-  .trim();
+  .trim()
+  .split('\n');
+const upstreamRemote = gitRemotes.find((remote) =>
+  remote.includes('nrwl/nx.git')
+);
+if (upstreamRemote) {
+  const upstreamRemoteIdentifier = upstreamRemote.split('\t')[0].trim();
+  console.log(`Comparing against remote ${upstreamRemoteIdentifier}`);
+  const currentBranch = childProcess
+    .execSync('git branch --show-current')
+    .toString()
+    .trim();
+
+  // exclude all commits already present in upstream/master
+  gitLogCmd =
+    gitLogCmd + ` ${currentBranch} ^${upstreamRemoteIdentifier}/master`;
+} else {
+  console.error(
+    'No upstream remote found for nrwl/nx.git. Skipping comparison against upstream master.'
+  );
+}
+
+const gitMessage = childProcess.execSync(gitLogCmd).toString().trim();
+
+if (!gitMessage) {
+  console.log('No commits found. Skipping commit message validation.');
+  process.exit(0);
+}
 
 const allowedTypes = types.map((type) => type.value).join('|');
 const allowedScopes = scopes.map((scope) => scope.value).join('|');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Commit lint step fails when a commit merged in from master is malformed

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Commit lint step excludes commits already in master when an upstream nrwl/nx.git repo is defined.
