### PR TITLE
feat(react-native): add optional syncDeps param to storybook executor

### DIFF
--- a/packages/react-native/src/executors/storybook/schema.d.ts
+++ b/packages/react-native/src/executors/storybook/schema.d.ts
@@ -2,4 +2,5 @@ export interface ReactNativeStorybookOptions {
   searchDir: string[];
   outputFile: string;
   pattern: string;
+  syncDeps?: boolean;
 }

--- a/packages/react-native/src/executors/storybook/storybook.impl.ts
+++ b/packages/react-native/src/executors/storybook/storybook.impl.ts
@@ -20,6 +20,8 @@ export default async function* reactNativeStorybookExecutor(
   options: ReactNativeStorybookOptions,
   context: ExecutorContext
 ): AsyncGenerator<{ success: boolean }> {
+  const { syncDeps: isSyncDepsEnabled = true } = options;
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
   logger.info(
@@ -37,7 +39,7 @@ export default async function* reactNativeStorybookExecutor(
   );
   const projectPackageJson = readJsonFile<PackageJson>(packageJsonPath);
 
-  if (fileExists(packageJsonPath))
+  if (fileExists(packageJsonPath) && isSyncDepsEnabled)
     displayNewlyAddedDepsMessage(
       context.projectName,
       await syncDeps(

--- a/packages/react-native/src/executors/storybook/storybook.impl.ts
+++ b/packages/react-native/src/executors/storybook/storybook.impl.ts
@@ -39,7 +39,7 @@ export default async function* reactNativeStorybookExecutor(
   );
   const projectPackageJson = readJsonFile<PackageJson>(packageJsonPath);
 
-  if (fileExists(packageJsonPath) && isSyncDepsEnabled)
+  if (isSyncDepsEnabled && fileExists(packageJsonPath))
     displayNewlyAddedDepsMessage(
       context.projectName,
       await syncDeps(


### PR DESCRIPTION
closed #22009

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
storybook executor runs syncDeps automatically without option to disable it

## Expected Behavior
as per #22009 we might need to disable syncDeps step at some circumstances.

