### PR TITLE
Project found in root path

### DIFF
--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -19,7 +19,7 @@ import { dirname, join, relative } from 'path';
 import { getLockFileName } from '@nx/js';
 
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
@@ -27,6 +27,7 @@ import { NX_PLUGIN_OPTIONS } from '../utils/constants';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 import { hashObject } from 'nx/src/devkit-internals';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 export interface CypressPluginOptions {
   ciTargetName?: string;
@@ -93,12 +94,8 @@ async function createNodesInternal(
   options = normalizeOptions(options);
   const projectRoot = dirname(configFilePath);
 
-  // Do not create a project if package.json and project.json isn't there.
-  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-  if (
-    !siblingFiles.includes('package.json') &&
-    !siblingFiles.includes('project.json')
-  ) {
+  // Configurations will be generated only if project exists at projectRoot
+  if (!projectFoundInRootPath(projectRoot, context)) {
     return {};
   }
 

--- a/packages/detox/src/plugins/plugin.ts
+++ b/packages/detox/src/plugins/plugin.ts
@@ -11,9 +11,10 @@ import {
 import { dirname, join } from 'path';
 import { getLockFileName } from '@nx/js';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 export interface DetoxPluginOptions {
   buildTargetName?: string;
@@ -46,9 +47,8 @@ export const createNodes: CreateNodes<DetoxPluginOptions> = [
     options = normalizeOptions(options);
     const projectRoot = dirname(configFilePath);
 
-    // Do not create a project if project.json isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (!siblingFiles.includes('project.json')) {
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context)) {
       return {};
     }
 

--- a/packages/devkit/src/utils/project-found-in-root-path.spec.ts
+++ b/packages/devkit/src/utils/project-found-in-root-path.spec.ts
@@ -1,0 +1,101 @@
+import { projectFoundInRootPath } from './project-found-in-root-path';
+import { CreateNodesContext } from 'nx/src/project-graph/plugins';
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+
+describe('projectFoundInRootPath', () => {
+  let context: CreateNodesContext;
+  let tempFs: TempFs;
+
+  beforeEach(async () => {
+    tempFs = new TempFs('workspace-tests');
+
+    context = {
+      nxJsonConfiguration: {},
+      workspaceRoot: tempFs.tempDir,
+      configFiles: [],
+    };
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    tempFs.cleanup();
+  });
+
+  describe('project.json', () => {
+    it('should be a project if path contains a project.json file', async () => {
+      // GIVEN
+      const projectRoot = 'apps/my-app';
+      await tempFs.createFiles({
+        [`${projectRoot}/project.json`]: '{}',
+      });
+      //TEST
+      const projectFound = projectFoundInRootPath(projectRoot, context);
+      // EXPECT
+      expect(projectFound).toBeTruthy();
+    });
+  });
+
+  describe('package.json', () => {
+    it('should be a project if path contains a package.json file and present in root workspaces', async () => {
+      // GIVEN
+      const projectRoot = 'apps/my-app';
+      await tempFs.createFiles({
+        'package.json': `{"workspaces": ["${projectRoot}"]}`,
+        [`${projectRoot}/package.json`]: '{}',
+      });
+      //TEST
+      const projectFound = projectFoundInRootPath(projectRoot, context);
+      // EXPECT
+      expect(projectFound).toBeTruthy();
+    });
+
+    it('should not be a project if path contains a package.json file but not present in root workspaces', async () => {
+      // GIVEN
+      const projectRoot = 'apps/my-app';
+      await tempFs.createFiles({
+        [`${projectRoot}/package.json`]: '{}',
+      });
+      //TEST
+      const projectFound = projectFoundInRootPath(projectRoot, context);
+      // EXPECT
+      expect(projectFound).toBeFalsy();
+    });
+  });
+
+  describe('additionalProjectFile', () => {
+    it('should be a project if path contains a custom project file', async () => {
+      // GIVEN
+      const projectRoot = 'apps/my-app';
+      await tempFs.createFiles({
+        [`${projectRoot}/my-custom-project-file.json`]: '{}',
+      });
+      //TEST
+      const projectFound = projectFoundInRootPath(projectRoot, context, [
+        'my-custom-project-file.json',
+      ]);
+      // EXPECT
+      expect(projectFound).toBeTruthy();
+    });
+
+    it('should not be a project if path does not contain a custom project file', async () => {
+      // GIVEN
+      const projectRoot = 'apps/my-app';
+      await tempFs.createFiles({
+        [`${projectRoot}/something-else.json`]: '{}',
+      });
+      //TEST
+      const projectFound = projectFoundInRootPath(projectRoot, context, [
+        'my-custom-project-file.json',
+      ]);
+      // EXPECT
+      expect(projectFound).toBeFalsy();
+    });
+  });
+
+  it('should not be a project if path does not contain project.json, package.json or any additional files', () => {
+    //TEST
+    const projectFound = projectFoundInRootPath('', context);
+    // EXPECT
+    expect(projectFound).toBeFalsy();
+  });
+});

--- a/packages/devkit/src/utils/project-found-in-root-path.ts
+++ b/packages/devkit/src/utils/project-found-in-root-path.ts
@@ -1,0 +1,54 @@
+import {
+  type CreateNodesContext,
+  joinPathFragments,
+} from 'nx/src/devkit-exports';
+import { join } from 'path';
+import { readdirSync } from 'fs';
+import { minimatch } from 'minimatch';
+import {
+  combineGlobPatterns,
+  getGlobPatternsFromPackageManagerWorkspaces,
+} from 'nx/src/devkit-internals';
+
+export function projectFoundInRootPath(
+  rootPath: string,
+  context: CreateNodesContext,
+  additionalProjectFiles: string[] = []
+): boolean {
+  const siblingFiles = readdirSync(join(context.workspaceRoot, rootPath));
+  const rootPathIsWorkspaceRoot = rootPath === '' || rootPath === '.';
+
+  const containProjectJsonFile = siblingFiles.includes('project.json');
+  const containPackageJsonFile = siblingFiles.includes('package.json');
+  // if additional files provided, check that one exist in the path
+  const containAdditionalProjectFile = additionalProjectFiles.some(
+    (additionalFile) => siblingFiles.includes(additionalFile)
+  );
+
+  // Path is not considered as a project if it does not contain any project files
+  if (
+    !containProjectJsonFile &&
+    !containPackageJsonFile &&
+    !containAdditionalProjectFile
+  ) {
+    return false;
+  }
+
+  // Path is not considered as a project if the package.json is specified but not part of the root workspaces
+  if (
+    !containProjectJsonFile &&
+    !containAdditionalProjectFile &&
+    containPackageJsonFile &&
+    !rootPathIsWorkspaceRoot
+  ) {
+    const path = joinPathFragments(rootPath, 'package.json');
+
+    const packageManagerWorkspacesGlob = combineGlobPatterns(
+      getGlobPatternsFromPackageManagerWorkspaces(context.workspaceRoot)
+    );
+
+    return minimatch(path, packageManagerWorkspacesGlob);
+  }
+
+  return true;
+}

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -6,16 +6,16 @@ import {
   NxJsonConfiguration,
   readJsonFile,
   TargetConfiguration,
-  workspaceRoot,
   writeJsonFile,
 } from '@nx/devkit';
 import { dirname, join } from 'path';
 import { getLockFileName } from '@nx/js';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 export interface ExpoPluginOptions {
   startTargetName?: string;
@@ -58,12 +58,8 @@ export const createNodes: CreateNodes<ExpoPluginOptions> = [
     options = normalizeOptions(options);
     const projectRoot = dirname(configFilePath);
 
-    // Do not create a project if package.json or project.json or metro.config.js isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') ||
-      !siblingFiles.includes('metro.config.js')
-    ) {
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context, ['metro.config.js'])) {
       return {};
     }
     const appConfig = await getAppConfig(configFilePath, context);

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -45,7 +45,6 @@
     "jest-config": "^29.4.1",
     "jest-resolve": "^29.4.1",
     "jest-util": "^29.4.1",
-    "minimatch": "9.0.3",
     "resolve.exports": "1.1.0",
     "tslib": "^2.3.0",
     "yargs-parser": "21.1.1"

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -11,12 +11,13 @@ import {
 import { dirname, join } from 'path';
 
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getLockFileName } from '@nx/js';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 export interface NextPluginOptions {
   buildTargetName?: string;
@@ -53,14 +54,11 @@ export const createNodes: CreateNodes<NextPluginOptions> = [
   async (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
 
-    // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
-    ) {
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context)) {
       return {};
     }
+
     options = normalizeOptions(options);
 
     const hash = await calculateHashForCreateNodes(

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -11,10 +11,11 @@ import {
 import { dirname, isAbsolute, join, relative } from 'path';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getLockFileName } from '@nx/js';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 const cachePath = join(workspaceDataDirectory, 'nuxt.hash');
 const targetsCache = readTargetsCache();
@@ -50,12 +51,9 @@ export const createNodes: CreateNodes<NuxtPluginOptions> = [
   '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',
   async (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
-    // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
-    ) {
+
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context)) {
       return {};
     }
 

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -26,4 +26,6 @@ export { retrieveProjectConfigurations } from './project-graph/utils/retrieve-wo
 export { LoadedNxPlugin } from './project-graph/plugins/internal-api';
 export * from './project-graph/error-types';
 export { registerTsProject } from './plugins/js/utils/register';
+export { combineGlobPatterns } from './utils/globs';
+export { getGlobPatternsFromPackageManagerWorkspaces } from './plugins/package-json';
 export { interpolate } from './tasks-runner/utils';

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { dirname, join, relative } from 'path';
 
 import {
@@ -26,6 +26,7 @@ import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { getLockFileName } from '@nx/js';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 import { hashObject } from 'nx/src/hasher/file-hasher';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 const pmc = getPackageManagerCommand();
 
@@ -100,12 +101,8 @@ async function createNodesInternal(
 ) {
   const projectRoot = dirname(configFilePath);
 
-  // Do not create a project if package.json and project.json isn't there.
-  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-  if (
-    !siblingFiles.includes('package.json') &&
-    !siblingFiles.includes('project.json')
-  ) {
+  // Configurations will be generated only if project exists at projectRoot
+  if (!projectFoundInRootPath(projectRoot, context)) {
     return {};
   }
 

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -12,10 +12,11 @@ import {
 import { dirname, join } from 'path';
 import { getLockFileName } from '@nx/js';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 export interface ReactNativePluginOptions {
   startTargetName?: string;
@@ -57,12 +58,8 @@ export const createNodes: CreateNodes<ReactNativePluginOptions> = [
     options = normalizeOptions(options);
     const projectRoot = dirname(configFilePath);
 
-    // Do not create a project if package.json or project.json or metro.config.js isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') ||
-      !siblingFiles.includes('metro.config.js')
-    ) {
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context, ['metro.config.js'])) {
       return {};
     }
     const appConfig = await getAppConfig(configFilePath, context);

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -16,6 +16,7 @@ import { type AppConfig } from '@remix-run/dev';
 import { dirname, join } from 'path';
 import { existsSync, readdirSync } from 'fs';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 const cachePath = join(workspaceDataDirectory, 'remix.hash');
 const targetsCache = readTargetsCache();
@@ -53,13 +54,14 @@ export const createNodes: CreateNodes<RemixPluginOptions> = [
   async (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
     const fullyQualifiedProjectRoot = join(context.workspaceRoot, projectRoot);
-    // Do not create a project if package.json and project.json isn't there
     const siblingFiles = readdirSync(fullyQualifiedProjectRoot);
+
+    // Configurations will be generated only if project exists at projectRoot
     if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json') &&
-      !siblingFiles.includes('vite.config.ts') &&
-      !siblingFiles.includes('vite.config.js')
+      !projectFoundInRootPath(projectRoot, context, [
+        'vite.config.ts',
+        'vite.config.js',
+      ])
     ) {
       return {};
     }

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -1,6 +1,6 @@
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { basename, dirname, join } from 'path';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 import {
   type CreateDependencies,
   type CreateNodes,
@@ -15,6 +15,7 @@ import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash
 import { getLockFileName } from '@nx/js';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { type RollupOptions } from 'rollup';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 const cachePath = join(workspaceDataDirectory, 'rollup.hash');
 const targetsCache = readTargetsCache();
@@ -47,13 +48,9 @@ export const createNodes: CreateNodes<RollupPluginOptions> = [
   '**/rollup.config.{js,cjs,mjs}',
   async (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
-    const fullyQualifiedProjectRoot = join(context.workspaceRoot, projectRoot);
-    // Do not create a project if package.json and project.json do not exist
-    const siblingFiles = readdirSync(fullyQualifiedProjectRoot);
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
-    ) {
+
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context, ['tsconfig.json'])) {
       return {};
     }
 

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -2,21 +2,22 @@ import {
   CreateDependencies,
   CreateNodes,
   CreateNodesContext,
-  TargetConfiguration,
   detectPackageManager,
   joinPathFragments,
   parseJson,
   readJsonFile,
+  TargetConfiguration,
   writeJsonFile,
 } from '@nx/devkit';
 import { dirname, join } from 'path';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { getLockFileName } from '@nx/js';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 import type { StorybookConfig } from '@storybook/types';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 export interface StorybookPluginOptions {
   buildStorybookTargetName?: string;
@@ -62,12 +63,8 @@ export const createNodes: CreateNodes<StorybookPluginOptions> = [
       projectRoot = '.';
     }
 
-    // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
-    ) {
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context)) {
       return {};
     }
 

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -15,12 +15,13 @@ import {
 } from '@nx/devkit';
 import { dirname, isAbsolute, join, relative } from 'path';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { getLockFileName } from '@nx/js';
 import { loadViteDynamicImport } from '../utils/executor-utils';
 import { hashObject } from 'nx/src/hasher/file-hasher';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 const pmc = getPackageManagerCommand();
 
@@ -88,12 +89,9 @@ async function createNodesInternal(
   targetsCache: Record<string, ViteTargets>
 ) {
   const projectRoot = dirname(configFilePath);
-  // Do not create a project if package.json and project.json isn't there.
-  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-  if (
-    !siblingFiles.includes('package.json') &&
-    !siblingFiles.includes('project.json')
-  ) {
+
+  // Configurations will be generated only if project exists at projectRoot
+  if (!projectFoundInRootPath(projectRoot, context)) {
     return {};
   }
 

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -17,12 +17,13 @@ import {
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { getLockFileName, getRootTsConfigPath } from '@nx/js';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import { readWebpackOptions } from '../utils/webpack/read-webpack-options';
 import { resolveUserDefinedWebpackConfig } from '../utils/webpack/resolve-user-defined-webpack-config';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 const pmc = getPackageManagerCommand();
 
@@ -99,11 +100,7 @@ async function createNodesInternal(
   const projectRoot = dirname(configFilePath);
 
   // Do not create a project if package.json and project.json isn't there.
-  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-  if (
-    !siblingFiles.includes('package.json') &&
-    !siblingFiles.includes('project.json')
-  ) {
+  if (!projectFoundInRootPath(projectRoot, context)) {
     return {};
   }
 

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/__snapshots__/generator.spec.ts.snap
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/__snapshots__/generator.spec.ts.snap
@@ -68,6 +68,7 @@ import { getRootTsConfigPath } from '@nx/js';
 import { readTargetDefaultsForTarget } from 'nx/src/project-graph/utils/project-configuration-utils';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { readdirSync } from 'fs';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 export interface EslintPluginOptions {
   targetName?: string;
@@ -78,12 +79,8 @@ export const createNodes: CreateNodes<EslintPluginOptions> = [
   (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
 
-    // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
-    ) {
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context)) {
       return {};
     }
 

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/files/src/plugins/plugin.ts.template
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/files/src/plugins/plugin.ts.template
@@ -10,7 +10,7 @@ import { getRootTsConfigPath } from '@nx/js';
 
 import { readTargetDefaultsForTarget } from 'nx/src/project-graph/utils/project-configuration-utils';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { readdirSync } from 'fs';
+import { projectFoundInRootPath } from '@nx/devkit/src/utils/project-found-in-root-path';
 
 export interface <%= className %>PluginOptions {
   targetName?: string;
@@ -21,12 +21,8 @@ export const createNodes: CreateNodes<<%= className %>PluginOptions> = [
   (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
 
-    // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
-    ) {
+    // Configurations will be generated only if project exists at projectRoot
+    if (!projectFoundInRootPath(projectRoot, context)) {
       return {};
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Before generating tasks and configurations, multiple plugins validate that paths matching the glob pattern are considered as projects.

For vite, test `project.json` and `package.json`:
```ts
    // Do not create a project if package.json and project.json isn't there.
    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
    if (
      !siblingFiles.includes('package.json') &&
      !siblingFiles.includes('project.json')
    ) {
      return {};
    }
```

For detox, test only `project.json`:
```ts
    // Do not create a project if project.json isn't there.
    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
    if (!siblingFiles.includes('project.json')) {
      return {};
    }
```

For Jest, test `project.json`, `package.json` and for `package.json` the fact that it is present in root `workspaces`:
```ts
const packageManagerWorkspacesGlob = combineGlobPatterns(
      getGlobPatternsFromPackageManagerWorkspaces(context.workspaceRoot)
    );

    // Do not create a project if package.json and project.json isn't there.
    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
    if (
      !siblingFiles.includes('package.json') &&
      !siblingFiles.includes('project.json')
    ) {
      return {};
    } else if (
      !siblingFiles.includes('project.json') &&
      siblingFiles.includes('package.json')
    ) {
      const path = joinPathFragments(projectRoot, 'package.json');

      const isPackageJsonProject = minimatch(
        path,
        packageManagerWorkspacesGlob
      );

      if (!isPackageJsonProject) {
        return {};
      }
    }
```

## Expected Behavior
Use a common way, a common utility to centralize that filter.

## Caveats
I would like to contribute more to Nx, so I undertook a cleanup without being certain of its usefulness. I completely understand if it's not :)

Here are some questions that come to my mind while doing it:

* I am not sure if all plugins should adhere to the same rule.
* I am not fond of having to expose two new functions outside of the `devkit-internals`.
* I dislike having to add the `minimatch` dependency to the` package.json` of `@nx/devkit.`

