### PR TITLE
fix(misc): make sure to add e2e crystal plugin

### DIFF
--- a/packages/angular/src/generators/ng-add/migrators/projects/__snapshots__/e2e.migrator.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/migrators/projects/__snapshots__/e2e.migrator.spec.ts.snap
@@ -20,7 +20,10 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+    ...nxE2EPreset(__filename, {
+      cypressDir: 'src',
+      webServerCommands: { default: 'nx run app1:serve' },
+    }),
     baseUrl: 'http://localhost:4200',
   },
 });
@@ -100,7 +103,10 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+    ...nxE2EPreset(__filename, {
+      cypressDir: 'src',
+      webServerCommands: { default: 'nx run app1:serve' },
+    }),
     baseUrl: 'http://localhost:4200',
   },
 });

--- a/packages/cypress/src/generators/configuration/configuration.spec.ts
+++ b/packages/cypress/src/generators/configuration/configuration.spec.ts
@@ -118,29 +118,22 @@ describe('Cypress e2e configuration', () => {
         import { defineConfig } from 'cypress';
 
         export default defineConfig({
-          e2e: { ...nxE2EPreset(__filename, { cypressDir: 'src' }) },
+          e2e: {
+            ...nxE2EPreset(__filename, {
+              cypressDir: 'src',
+              webServerCommands: {
+                default: 'nx run my-app:serve',
+                production: 'nx run my-app:serve:production',
+              },
+              ciWebServerCommand: 'nx run my-app:serve-static',
+            }),
+          },
         });
         "
       `);
-      expect(readProjectConfiguration(tree, 'my-app').targets.e2e)
-        .toMatchInlineSnapshot(`
-        {
-          "configurations": {
-            "ci": {
-              "devServerTarget": "my-app:serve-static",
-            },
-            "production": {
-              "devServerTarget": "my-app:serve:production",
-            },
-          },
-          "executor": "@nx/cypress:cypress",
-          "options": {
-            "cypressConfig": "apps/my-app/cypress.config.ts",
-            "devServerTarget": "my-app:serve",
-            "testingType": "e2e",
-          },
-        }
-      `);
+      expect(
+        readProjectConfiguration(tree, 'my-app').targets.e2e
+      ).toMatchInlineSnapshot(`undefined`);
 
       expect(readJson(tree, 'apps/my-app/tsconfig.json'))
         .toMatchInlineSnapshot(`
@@ -185,7 +178,16 @@ describe('Cypress e2e configuration', () => {
         import { defineConfig } from 'cypress';
 
         export default defineConfig({
-          e2e: { ...nxE2EPreset(__filename, { cypressDir: 'cypress' }) },
+          e2e: {
+            ...nxE2EPreset(__filename, {
+              cypressDir: 'cypress',
+              webServerCommands: {
+                default: 'nx run my-app:serve',
+                production: 'nx run my-app:serve:production',
+              },
+              ciWebServerCommand: 'nx run my-app:serve-static',
+            }),
+          },
         });
         "
       `);
@@ -208,7 +210,14 @@ describe('Cypress e2e configuration', () => {
 
         export default defineConfig({
           e2e: {
-            ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+            ...nxE2EPreset(__filename, {
+              cypressDir: 'src',
+              webServerCommands: {
+                default: 'nx run my-app:serve',
+                production: 'nx run my-app:serve:production',
+              },
+              ciWebServerCommand: 'nx run my-app:serve-static',
+            }),
             baseUrl: 'http://localhost:4200',
           },
         });
@@ -318,15 +327,6 @@ describe('Cypress e2e configuration', () => {
         addPlugin: true,
       });
       assertCypressFiles(tree, 'libs/my-lib/src/e2e', 'js');
-
-      expect(readProjectConfiguration(tree, 'my-lib').targets['e2e'].options)
-        .toMatchInlineSnapshot(`
-        {
-          "baseUrl": "http://localhost:4200",
-          "cypressConfig": "libs/my-lib/cypress.config.js",
-          "testingType": "e2e",
-        }
-      `);
     });
 
     it('should not override eslint settings if preset', async () => {
@@ -394,7 +394,7 @@ describe('Cypress e2e configuration', () => {
         project: 'my-lib',
         devServerTarget: 'my-app:serve',
         directory: 'cypress',
-        addPlugin: true,
+        addPlugin: false,
       });
       assertCypressFiles(tree, 'libs/my-lib/cypress');
       expect(
@@ -412,7 +412,7 @@ describe('Cypress e2e configuration', () => {
       await cypressE2EConfigurationGenerator(tree, {
         project: 'my-app',
         port: 0,
-        addPlugin: true,
+        addPlugin: false,
       });
 
       expect(readProjectConfiguration(tree, 'my-app').targets['e2e'].options)

--- a/packages/cypress/src/generators/configuration/configuration.ts
+++ b/packages/cypress/src/generators/configuration/configuration.ts
@@ -27,7 +27,7 @@ import { addLinterToCyProject } from '../../utils/add-linter';
 import { addDefaultE2EConfig } from '../../utils/config';
 import { installedCypressVersion } from '../../utils/cypress-version';
 import { typesNodeVersion, viteVersion } from '../../utils/versions';
-import cypressInitGenerator from '../init/init';
+import cypressInitGenerator, { addPlugin } from '../init/init';
 import { addBaseCypressSetup } from '../base-setup/base-setup';
 
 export interface CypressE2EConfigSchema {
@@ -67,7 +67,7 @@ export async function configurationGeneratorInternal(
   options: CypressE2EConfigSchema
 ) {
   const opts = normalizeOptions(tree, options);
-
+  opts.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';
   const tasks: GeneratorCallback[] = [];
 
   if (!installedCypressVersion()) {
@@ -76,10 +76,12 @@ export async function configurationGeneratorInternal(
       await cypressInitGenerator(tree, {
         ...opts,
         skipFormat: true,
-        addPlugin: options.addPlugin,
       })
     );
+  } else if (opts.addPlugin) {
+    addPlugin(tree);
   }
+
   const projectGraph = await createProjectGraphAsync();
   const nxJson = readNxJson(tree);
   const hasPlugin = nxJson.plugins?.some((p) =>
@@ -96,7 +98,6 @@ export async function configurationGeneratorInternal(
   const linterTask = await addLinterToCyProject(tree, {
     ...opts,
     cypressDir: opts.directory,
-    addPlugin: opts.addPlugin,
   });
   tasks.push(linterTask);
 
@@ -151,7 +152,6 @@ In this case you need to provide a devServerTarget,'<projectName>:<targetName>[:
 
   return {
     ...options,
-    addPlugin: options.addPlugin ?? process.env.NX_ADD_PLUGINS !== 'false',
     bundler: options.bundler ?? 'webpack',
     rootProject: options.rootProject ?? projectConfig.root === '.',
     linter: options.linter ?? Linter.EsLint,

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -283,6 +283,8 @@ async function normalizeOptions(
 
   options.linter = options.linter || Linter.EsLint;
   options.bundler = options.bundler || 'webpack';
+  options.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';
+
   return {
     ...options,
     // other generators depend on the rootProject flag down stream

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -55,7 +55,7 @@ function updateDependencies(tree: Tree, options: Schema) {
   return runTasksInSerial(...tasks);
 }
 
-function addPlugin(tree: Tree) {
+export function addPlugin(tree: Tree) {
   const nxJson = readNxJson(tree);
   nxJson.plugins ??= [];
 
@@ -105,7 +105,6 @@ export async function cypressInitGeneratorInternal(
   options: Schema
 ) {
   updateProductionFileset(tree);
-
   options.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';
 
   if (options.addPlugin) {

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -151,7 +151,11 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+    ...nxE2EPreset(__filename, {
+      cypressDir: 'src',
+      webServerCommands: { default: 'nx run test:serve:development' },
+      ciWebServerCommand: 'nx run test:serve-static',
+    }),
     baseUrl: 'http://localhost:4200',
   },
 });
@@ -661,7 +665,11 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+    ...nxE2EPreset(__filename, {
+      cypressDir: 'src',
+      webServerCommands: { default: 'nx run test:serve:development' },
+      ciWebServerCommand: 'nx run test:serve-static',
+    }),
     baseUrl: 'http://localhost:4200',
   },
 });
@@ -1027,7 +1035,11 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+    ...nxE2EPreset(__filename, {
+      cypressDir: 'src',
+      webServerCommands: { default: 'nx run test:serve:development' },
+      ciWebServerCommand: 'nx run test:serve-static',
+    }),
     baseUrl: 'http://localhost:4200',
   },
 });

--- a/packages/vue/src/generators/application/application.ts
+++ b/packages/vue/src/generators/application/application.ts
@@ -28,6 +28,8 @@ export async function applicationGeneratorInternal(
   _options: Schema
 ): Promise<GeneratorCallback> {
   const options = await normalizeOptions(tree, _options);
+  options.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';
+
   const tasks: GeneratorCallback[] = [];
 
   addProjectConfiguration(tree, options.name, {

--- a/packages/vue/src/generators/application/lib/add-e2e.ts
+++ b/packages/vue/src/generators/application/lib/add-e2e.ts
@@ -64,6 +64,7 @@ export async function addE2e(
         implicitDependencies: [options.projectName],
       });
       return configurationGenerator(tree, {
+        ...options,
         project: options.e2eProjectName,
         skipFormat: true,
         skipPackageJson: options.skipPackageJson,


### PR DESCRIPTION
* `opts.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';` was missing from a couple of places
* this resulted in also React not setting up `cypress` with Crystal
* If Nx detected cypress was already installed, it would not add the plugin, even if the `addPlugin` was `true`
* Playwright was not being set for Vue also because we were not passing the `options.addPlugin` down to the playwright config generator