### PR TITLE
fix(node): support `index.js` in `[module]` for esbuild wrapper

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -260,10 +260,16 @@ Module._resolveFilename = function(request, parent) {
       const match = request.match(re);
 
       if (match?.groups) {
-        const candidate = path.join(distPath, entry.pattern.replace("*", ""), match.groups.rest + ".js");
-        if (isFile(candidate)) {
-          found = candidate;
-        }
+        const fileName = match.groups.rest;
+
+        const basePath = path.join(distPath, entry.pattern.replace("*", ""));
+
+        const possibleFiles = [
+          [fileName, "index.js"], // name/index.js
+          [fileName + ".js"],     // name.js
+        ].map((x) => path.join(basePath, ...x));
+
+        found = possibleFiles.find(isFile);
       }
 
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Related: #15154 

## Current Behavior
Using esbuild (webpack doesn't have this issue to my knowledge):

When looking for some package: `@team/example`
With the tsconfig
```json
{
  ...
  "compilerOptions": {
    ...
    "paths": {
      "@team/example": ["packages/example/src/index.ts"],
      "@team/example/*": ["packages/example/src/*"],
    }
  }
}
```
With a folder structure like:
```text
example
└── src
    ├── foo
    │   └── index.ts
    └── index.ts
```
Under a wildcard resolution like
```ts
// apps/myapp/src/main.ts
import { foo } from '@team/example/foo'
console.log(foo)
```
When you try to run the app, you get the following error:
```bash
$ nx serve myapp
Error: Cannot find module '@team/example/foo'
```

This is because the current esbuild wrapper only looks for a `logger.js` file.

## Expected Behavior
The resolution wrapper should search for both a `logger.js` and `logger/index.js` file.
