### PR TITLE
fix(release): skip lock file update if workspaces are not enabled

### DIFF
--- a/docs/generated/devkit/README.md
+++ b/docs/generated/devkit/README.md
@@ -122,6 +122,7 @@ It only uses language primitives and immutable objects
 - [glob](../../devkit/documents/glob)
 - [hashArray](../../devkit/documents/hashArray)
 - [installPackagesTask](../../devkit/documents/installPackagesTask)
+- [isWorkspacesEnabled](../../devkit/documents/isWorkspacesEnabled)
 - [joinPathFragments](../../devkit/documents/joinPathFragments)
 - [moveFilesToNewDirectory](../../devkit/documents/moveFilesToNewDirectory)
 - [names](../../devkit/documents/names)

--- a/docs/generated/devkit/isWorkspacesEnabled.md
+++ b/docs/generated/devkit/isWorkspacesEnabled.md
@@ -1,0 +1,16 @@
+# Function: isWorkspacesEnabled
+
+▸ **isWorkspacesEnabled**(`packageManager?`, `root?`): `boolean`
+
+Returns true if the workspace is using npm workspaces, yarn workspaces, or pnpm workspaces.
+
+#### Parameters
+
+| Name             | Type                                                      | Default value   | Description                                                                                 |
+| :--------------- | :-------------------------------------------------------- | :-------------- | :------------------------------------------------------------------------------------------ |
+| `packageManager` | [`PackageManager`](../../devkit/documents/PackageManager) | `undefined`     | The package manager to use. If not provided, it will be detected based on the lock file.    |
+| `root`           | `string`                                                  | `workspaceRoot` | The directory the commands will be ran inside of. Defaults to the current workspace's root. |
+
+#### Returns
+
+`boolean`

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -122,6 +122,7 @@ It only uses language primitives and immutable objects
 - [glob](../../devkit/documents/glob)
 - [hashArray](../../devkit/documents/hashArray)
 - [installPackagesTask](../../devkit/documents/installPackagesTask)
+- [isWorkspacesEnabled](../../devkit/documents/isWorkspacesEnabled)
 - [joinPathFragments](../../devkit/documents/joinPathFragments)
 - [moveFilesToNewDirectory](../../devkit/documents/moveFilesToNewDirectory)
 - [names](../../devkit/documents/names)

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -139,9 +139,6 @@ describe('nx release - independent projects', () => {
         "scripts": {
 
 
-        NX   Updating {package-manager} lock file
-
-
         NX   Staging changed files with git
 
 
@@ -172,9 +169,6 @@ describe('nx release - independent projects', () => {
 
         }
         +
-
-
-        NX   Updating {package-manager} lock file
 
 
         NX   Staging changed files with git
@@ -211,9 +205,6 @@ describe('nx release - independent projects', () => {
         -     "@proj/{project-name}": "0.0.0"
         +     "@proj/{project-name}": "999.9.9-package.3"
         }
-
-
-        NX   Updating {package-manager} lock file
 
 
         NX   Staging changed files with git
@@ -255,15 +246,12 @@ describe('nx release - independent projects', () => {
         "scripts": {
 
 
-        NX   Updating {package-manager} lock file
-
-        Updating {lock-file} with the following command:
-        {lock-file-command}
+        Skipped lock file update because {package-manager} workspaces are not enabled.
 
         NX   Committing changes with git
 
         Staging files in git with the following command:
-        git add {project-name}/package.json {lock-file}
+        git add {project-name}/package.json
 
         Committing files in git with the following command:
         git commit --message chore(release): publish --message - project: {project-name} 999.9.9-version-git-operations-test.2
@@ -363,20 +351,14 @@ describe('nx release - independent projects', () => {
         "scripts": {
 
 
-        NX   Updating {package-manager} lock file
+        Skipped lock file update because {package-manager} workspaces are not enabled.
 
-        Updating {lock-file} with the following command:
-        {lock-file-command}
-
-        NX   Updating {package-manager} lock file
-
-        Updating {lock-file} with the following command:
-        {lock-file-command}
+        Skipped lock file update because {package-manager} workspaces are not enabled.
 
         NX   Committing changes with git
 
         Staging files in git with the following command:
-        git add {project-name}/package.json {project-name}/package.json {project-name}/package.json {lock-file}
+        git add {project-name}/package.json {project-name}/package.json {project-name}/package.json
 
         Committing files in git with the following command:
         git commit --message chore(release): publish --message - project: {project-name} 999.9.9-version-git-operations-test.3 --message - project: {project-name} 999.9.9-version-git-operations-test.3 --message - release-group: fixed 999.9.9-version-git-operations-test.3

--- a/e2e/release/src/lock-file-updates.test.ts
+++ b/e2e/release/src/lock-file-updates.test.ts
@@ -150,7 +150,7 @@ describe('nx release lock file updates', () => {
     expect(filesChanges).toMatchInlineSnapshot(`
       {project-name}/package.json
       {project-name}/package.json
-      {project-name}/package.json 
+      {project-name}/package.json
 
     `);
   });

--- a/packages/js/src/generators/release-version/utils/update-lock-file.ts
+++ b/packages/js/src/generators/release-version/utils/update-lock-file.ts
@@ -2,6 +2,7 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
   getPackageManagerVersion,
+  isWorkspacesEnabled,
   output,
 } from '@nx/devkit';
 import { execSync } from 'child_process';
@@ -41,6 +42,16 @@ export async function updateLockFile(
     if (verbose) {
       console.log(
         '\nSkipped lock file update because it is not necessary for Yarn Classic.'
+      );
+    }
+    return [];
+  }
+
+  const workspacesEnabled = isWorkspacesEnabled(packageManager, cwd);
+  if (!workspacesEnabled) {
+    if (verbose) {
+      console.log(
+        `\nSkipped lock file update because ${packageManager} workspaces are not enabled.`
       );
     }
     return [];

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -100,6 +100,7 @@ export {
   getPackageManagerCommand,
   detectPackageManager,
   getPackageManagerVersion,
+  isWorkspacesEnabled
 } from './utils/package-manager';
 
 /**

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -100,7 +100,7 @@ export {
   getPackageManagerCommand,
   detectPackageManager,
   getPackageManagerVersion,
-  isWorkspacesEnabled
+  isWorkspacesEnabled,
 } from './utils/package-manager';
 
 /**

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -1,7 +1,9 @@
 import * as fs from 'fs';
 import * as configModule from '../config/configuration';
+import * as projectGraphFileUtils from '../project-graph/file-utils';
 import {
   detectPackageManager,
+  isWorkspacesEnabled,
   modifyYarnRcToFitNewDirectory,
   modifyYarnRcYmlToFitNewDirectory,
 } from './package-manager';
@@ -73,6 +75,46 @@ describe('package-manager', () => {
       const packageManager = detectPackageManager();
       expect(packageManager).toEqual('npm');
       expect(fs.existsSync).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe('isWorkspacesEnabled', () => {
+    it('should return true if package manager is pnpm and pnpm-workspace.yaml exists', () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValueOnce(true);
+      expect(isWorkspacesEnabled('pnpm')).toEqual(true);
+    });
+
+    it('should return false if package manager is pnpm and pnpm-workspace.yaml does not exist', () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValueOnce(false);
+      expect(isWorkspacesEnabled('pnpm')).toEqual(false);
+    });
+
+    it('should return true if package manager is yarn and workspaces exists in package.json', () => {
+      jest
+        .spyOn(projectGraphFileUtils, 'readPackageJson')
+        .mockReturnValueOnce({ workspaces: ['packages/*'] });
+      expect(isWorkspacesEnabled('yarn')).toEqual(true);
+    });
+
+    it('should return false if package manager is yarn and workspaces does not exist in package.json', () => {
+      jest
+        .spyOn(projectGraphFileUtils, 'readPackageJson')
+        .mockReturnValueOnce({});
+      expect(isWorkspacesEnabled('yarn')).toEqual(false);
+    });
+
+    it('should return true if package manager is npm and workspaces exists in package.json', () => {
+      jest
+        .spyOn(projectGraphFileUtils, 'readPackageJson')
+        .mockReturnValueOnce({ workspaces: ['packages/*'] });
+      expect(isWorkspacesEnabled('npm')).toEqual(true);
+    });
+
+    it('should return false if package manager is npm and workspaces does not exist in package.json', () => {
+      jest
+        .spyOn(projectGraphFileUtils, 'readPackageJson')
+        .mockReturnValueOnce({});
+      expect(isWorkspacesEnabled('npm')).toEqual(false);
     });
   });
 

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -6,8 +6,9 @@ import { gte, lt } from 'semver';
 import { dirSync } from 'tmp';
 import { promisify } from 'util';
 import { readNxJson } from '../config/configuration';
+import { readPackageJson } from '../project-graph/file-utils';
 import { readFileIfExisting, writeJsonFile } from './fileutils';
-import { readModulePackageJson } from './package-json';
+import { PackageJson, readModulePackageJson } from './package-json';
 import { workspaceRoot } from './workspace-root';
 
 const execAsync = promisify(exec);
@@ -41,6 +42,22 @@ export function detectPackageManager(dir: string = ''): PackageManager {
       ? 'pnpm'
       : 'npm')
   );
+}
+
+/**
+ * Returns true if the workspace is using npm workspaces, yarn workspaces, or pnpm workspaces.
+ */
+export function isWorkspacesEnabled(
+  packageManager: PackageManager = detectPackageManager(),
+  root: string = workspaceRoot
+): boolean {
+  if (packageManager === 'pnpm') {
+    return existsSync(join(root, 'pnpm-workspace.yaml'));
+  }
+
+  // yarn and pnpm both use the same 'workspaces' property in package.json
+  const packageJson: PackageJson = readPackageJson();
+  return !!packageJson?.workspaces;
 }
 
 /**

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -46,6 +46,8 @@ export function detectPackageManager(dir: string = ''): PackageManager {
 
 /**
  * Returns true if the workspace is using npm workspaces, yarn workspaces, or pnpm workspaces.
+ * @param packageManager The package manager to use. If not provided, it will be detected based on the lock file.
+ * @param root The directory the commands will be ran inside of. Defaults to the current workspace's root.
  */
 export function isWorkspacesEnabled(
   packageManager: PackageManager = detectPackageManager(),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx release` will always try to update the root lock file after the version step.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx release` will only try to update the root lock file if npm, yarn, or pnpm workspaces are enabled.