### PR TITLE
fix(core): plugins should not be registered twice and should respect shutdown queue

### DIFF
--- a/packages/nx/src/project-graph/plugins/internal-api.ts
+++ b/packages/nx/src/project-graph/plugins/internal-api.ts
@@ -44,7 +44,7 @@ export type RemotePlugin =
 // holding resolved nx plugin objects.
 // Allows loaded plugins to not be reloaded when
 // referenced multiple times.
-export const nxPluginCache: Map<unknown, RemotePlugin> = new Map();
+export const nxPluginCache: Map<unknown, Promise<RemotePlugin>> = new Map();
 
 export async function loadNxPlugins(
   plugins: PluginConfiguration[],
@@ -78,12 +78,12 @@ export async function loadNxPlugin(
   const cacheKey = JSON.stringify(plugin);
 
   if (nxPluginCache.has(cacheKey)) {
-    return nxPluginCache.get(cacheKey)!;
+    return await nxPluginCache.get(cacheKey)!;
   }
 
-  const loadedPlugin = await loadRemoteNxPlugin(plugin, root);
-  nxPluginCache.set(cacheKey, loadedPlugin);
-  return loadedPlugin;
+  const loadingPlugin = loadRemoteNxPlugin(plugin, root);
+  nxPluginCache.set(cacheKey, loadingPlugin);
+  return await loadingPlugin;
 }
 
 export async function getDefaultPlugins(root: string) {

--- a/packages/nx/src/project-graph/plugins/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/plugin-pool.ts
@@ -121,61 +121,43 @@ function createWorkerHandler(
               ? [
                   createNodesPattern,
                   (configFiles, ctx) => {
-                    return new Promise(function (res, rej) {
-                      const tx =
-                        pluginName + ':createNodes:' + performance.now();
+                    const tx = pluginName + ':createNodes:' + performance.now();
+                    return registerPendingPromise(tx, pending, () => {
                       worker.send(
                         createMessage({
                           type: 'createNodes',
                           payload: { configFiles, context: ctx, tx },
                         })
                       );
-                      pending.add(tx);
-                      promiseBank.set(tx, {
-                        promise: this,
-                        resolver: res,
-                        rejecter: rej,
-                      });
                     });
                   },
                 ]
               : undefined,
             createDependencies: result.hasCreateDependencies
               ? (opts, ctx) => {
-                  return new Promise(function (res, rej) {
-                    const tx = pluginName + ':createNodes:' + performance.now();
+                  const tx =
+                    pluginName + ':createDependencies:' + performance.now();
+                  return registerPendingPromise(tx, pending, () => {
                     worker.send(
                       createMessage({
                         type: 'createDependencies',
                         payload: { context: ctx, tx },
                       })
                     );
-                    pending.add(tx);
-                    promiseBank.set(tx, {
-                      promise: this,
-                      resolver: res,
-                      rejecter: rej,
-                    });
                   });
                 }
               : undefined,
             processProjectGraph: result.hasProcessProjectGraph
               ? (graph, ctx) => {
-                  return new Promise(function (res, rej) {
-                    const tx =
-                      pluginName + ':processProjectGraph:' + performance.now();
+                  const tx =
+                    pluginName + ':processProjectGraph:' + performance.now();
+                  return registerPendingPromise(tx, pending, () => {
                     worker.send(
                       createMessage({
                         type: 'processProjectGraph',
                         payload: { graph, ctx, tx },
                       })
                     );
-                    pending.add(tx);
-                    promiseBank.set(tx, {
-                      promise: this,
-                      resolver: res,
-                      rejecter: rej,
-                    });
                   });
                 }
               : undefined,
@@ -254,4 +236,32 @@ function getPendingPromises(
     }
   }
   return pendingTxs;
+}
+
+function registerPendingPromise(
+  tx: string,
+  pending: Set<string>,
+  callback: () => void
+): Promise<any> {
+  let resolver, rejecter;
+
+  const promise = new Promise((res, rej) => {
+    resolver = res;
+    rejecter = rej;
+
+    callback();
+  }).then((val) => {
+    // Remove the promise from the pending set
+    pending.delete(tx);
+    // Return the original value
+    return val;
+  });
+
+  pending.add(tx);
+  promiseBank.set(tx, {
+    promise,
+    resolver,
+    rejecter,
+  });
+  return promise;
 }


### PR DESCRIPTION
Fixes two issues:

- Plugins could be registered twice if first one is not finished loading when called second time
- Plugin worker shutdown didn't properly listen to plugin events