### PR TITLE
feat(release): interpolate workspaceRoot in changelog path

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -762,7 +762,7 @@ describe('nx release - independent projects', () => {
         integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         total files:   4
 
-        Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+        Would publish to ${e2eRegistryUrl} with tag "latest", but [dry-run] was set
 
 
 
@@ -871,7 +871,7 @@ describe('nx release - independent projects', () => {
           integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
           total files:   4
 
-          Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+          Would publish to ${e2eRegistryUrl} with tag "latest", but [dry-run] was set
 
 
 

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -629,6 +629,10 @@ async function applyChangesAndExit(
 function resolveChangelogRenderer(
   changelogRendererPath: string
 ): ChangelogRenderer {
+  const interpolatedChangelogRendererPath = interpolate(changelogRendererPath, {
+    workspaceRoot,
+  });
+
   // Try and load the provided (or default) changelog renderer
   let changelogRenderer: ChangelogRenderer;
   let cleanupTranspiler = () => {};
@@ -637,7 +641,7 @@ function resolveChangelogRenderer(
     if (rootTsconfigPath) {
       cleanupTranspiler = registerTsProject(rootTsconfigPath);
     }
-    const r = require(changelogRendererPath);
+    const r = require(interpolatedChangelogRendererPath);
     changelogRenderer = r.default || r;
   } catch {
   } finally {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`workspaceRoot` is not interpolated in the changelog renderer path.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`workspaceRoot` is interpolated in the changelog renderer path, allowing for more simple local changelog renderers.