### PR TITLE
feat(core): forward options for run command

### DIFF
--- a/e2e/nx-misc/src/extras.test.ts
+++ b/e2e/nx-misc/src/extras.test.ts
@@ -153,6 +153,21 @@ describe('Extra Nx Misc Tests', () => {
       expect(result).toContain('--var1=a');
     }, 120000);
 
+    it('should pass unknown options', async () => {
+      updateJson(join('libs', mylib, 'project.json'), (config) => {
+        config.targets.echo = {
+          command: 'echo',
+          options: {
+            var1: 'a',
+          },
+        };
+        return config;
+      });
+
+      const result = runCLI(`run ${mylib}:echo`, { silent: true });
+      expect(result).toContain('--var1 a');
+    }, 120000);
+
     it('should interpolate provided arguments', async () => {
       const echoTarget = uniq('echo');
       updateJson(join('libs', mylib, 'project.json'), (config) => {

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -190,6 +190,16 @@ describe('Run Commands', () => {
       ).toEqual('echo --additional-arg');
     });
 
+    it('should add forward unknown options when forwardAllArgs is true', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { unknownOptions: { hello: 123 }, parsedArgs: { hello: 123 } } as any,
+          true
+        )
+      ).toEqual('echo --hello 123');
+    });
+
     it('should add all args and unparsed args when forwardAllArgs is true', () => {
       expect(
         interpolateArgsIntoCommand(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

when the target is:
```
    "dev": {
      "options": {
        "port": 4200
      }
    }
```

it does not override the port

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

now it will override the command options, it will run dev with port 4200.

current behaviour is the same, when args is specified, it will take the args, it will run dev with port 4566.
```
  "dev": {
      "options": {
        "args": ["--port", "4566"],
        "port": 4200
      }
    }
```

or when running dev with flag passed in, like run `nx dev ... --port 3300`, it will take the port regardless what specified in project.json.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
