### PR TITLE
chore(repo): bump timeout for next-core e2e test

### DIFF
--- a/e2e/next-core/src/next.test.ts
+++ b/e2e/next-core/src/next.test.ts
@@ -203,7 +203,7 @@ describe('Next.js Applications', () => {
           ...nxE2EPreset(__filename, {
             cypressDir: 'src',
             webServerCommands: { default: 'nx run ${appName}:start' },
-            webServerConfig: { timeout: 25_000 },
+            webServerConfig: { timeout: 120_000 },
             ciWebServerCommand: 'nx run ${appName}:serve-static',
           }),
           baseUrl: 'http://localhost:3000',


### PR DESCRIPTION
This test is flaking out very often on master, and makes PRs hard to merge.

e.g. https://staging.nx.app/runs/0B3jz1uKfj
## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
