### PR TITLE
fix(remix): ensure component-testing is exported correctly #22091

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -40,6 +40,7 @@
   },
   "exports": {
     ".": "./index.js",
-    "./plugin": "./plugin.js"
+    "./plugin": "./plugin.js",
+    "./plugins/component-testing": "./plugins/component-testing/index.js"
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `component-testing` plugin is not defined as an allowed export in the `package.json` for `remix`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure `component-testing` is defined as an allowed export

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22091
