### PR TITLE
feat(core): expand meaning of plugins array to allow installing non-runtime plugins and inter-opt with installations property

### DIFF
--- a/docs/generated/devkit/ExpandedPluginConfiguration.md
+++ b/docs/generated/devkit/ExpandedPluginConfiguration.md
@@ -10,9 +10,10 @@
 
 #### Type declaration
 
-| Name       | Type       |
-| :--------- | :--------- |
-| `exclude?` | `string`[] |
-| `include?` | `string`[] |
-| `options?` | `T`        |
-| `plugin`   | `string`   |
+| Name       | Type       | Description                                                                                                      |
+| :--------- | :--------- | :--------------------------------------------------------------------------------------------------------------- |
+| `exclude?` | `string`[] | Glob patterns to exclude paths from the plugin's createNodes function.                                           |
+| `include?` | `string`[] | Glob patterns to limit which paths the plugin's createNodes function will run on.                                |
+| `options?` | `T`        | Configuration options for the loaded plugin                                                                      |
+| `plugin`   | `string`   | The plugin module that should be loaded by Nx                                                                    |
+| `version?` | `string`   | The version of the plugin to be installed by the Nx wrapper. If Nx is invoked from node_modules, this is unused. |

--- a/docs/shared/recipes/installation/install-non-javascript.md
+++ b/docs/shared/recipes/installation/install-non-javascript.md
@@ -41,3 +41,20 @@ nx graph
 
 {% /tab %}
 {% /tabs %}
+
+## Installing Plugins
+
+When Nx is managing its own installation, you can install plugins with `nx add {pluginName}`. This will install the plugin in the `.nx` folder and add it to the `nx.json` file. To manually install a plugin, you can add the plugin to `nx.json` as shown below:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "{pluginName}",
+      "version": "1.0.0"
+    }
+  ]
+}
+```
+
+The next time you run Nx, the plugin will be installed and available for use.

--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -460,6 +460,12 @@ describe('migrate', () => {
           'migrate-child-package': '1.0.0',
         },
       };
+      j.plugins = [
+        {
+          plugin: 'migrate-parent-package',
+          version: '1.0.0',
+        },
+      ];
       return j;
     });
     runCLI(
@@ -491,6 +497,12 @@ describe('migrate', () => {
     expect(nxJson.installation.plugins['migrate-child-package']).toEqual(
       '9.0.0'
     );
+    const updatedPlugin = nxJson.plugins.find(
+      (p) => typeof p === 'object' && p.plugin === 'migrate-parent-package'
+    );
+    expect(
+      typeof updatedPlugin === 'object' && updatedPlugin.version === '2.0.0'
+    ).toBeTruthy();
     // should keep new line on package
     const packageContent = readFile('package.json');
     expect(packageContent.charCodeAt(packageContent.length - 1)).toEqual(10);

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.spec.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.spec.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from 'fs';
 import { sanitizeWrapperScript } from './add-nx-scripts';
+import { join } from 'path';
 
 describe('sanitizeWrapperScript', () => {
   it('should remove any comments starting with //#', () => {
@@ -20,5 +22,186 @@ const variable = 3;`);
   it('should remove empty comments', () => {
     const stripped = sanitizeWrapperScript(`test; //`);
     expect(stripped.length).toEqual(5);
+  });
+
+  // This test serves as a final sanity check to ensure that the contents of the
+  // nxw.ts file are as expected. It will need to be updated if the contents of
+  // nxw.ts change.
+  //
+  // NOTE: this doesn't match the written nxw in consumer repos as its still
+  // typescript, but its close enough for a sanity check.
+  it('should match expected contents', () => {
+    const contents = readFileSync(join(__dirname, 'nxw.ts'), 'utf-8');
+    const stripped = sanitizeWrapperScript(contents);
+    expect(stripped).toMatchInlineSnapshot(`
+      "// This file should be committed to your repository! It wraps Nx and ensures
+      // that your local installation matches nx.json.
+      //
+      // You should not edit this file, as future updates to Nx may require changes to it.
+      // See: https://nx.dev/recipes/installation/install-non-javascript for more info.
+
+      const fs: typeof import('fs') = require('fs');
+      const path: typeof import('path') = require('path');
+      const cp: typeof import('child_process') = require('child_process');
+
+      import type { NxJsonConfiguration } from '../../../../config/nx-json';
+      import type { PackageJson } from '../../../../utils/package-json';
+
+      const installationPath = path.join(__dirname, 'installation', 'package.json');
+
+      function matchesCurrentNxInstall(
+        currentInstallation: PackageJson,
+        nxJson: NxJsonConfiguration
+      ) {
+        if (
+          !currentInstallation.devDependencies ||
+          !Object.keys(currentInstallation.devDependencies).length
+        ) {
+          return false;
+        }
+
+        try {
+          if (
+            currentInstallation.devDependencies['nx'] !==
+              nxJson.installation.version ||
+            require(path.join(
+              path.dirname(installationPath),
+              'node_modules',
+              'nx',
+              'package.json'
+            )).version !== nxJson.installation.version
+          ) {
+            return false;
+          }
+          for (const [plugin, desiredVersion] of getDesiredPluginVersions(nxJson)) {
+            if (currentInstallation.devDependencies[plugin] !== desiredVersion) {
+              return false;
+            }
+          }
+          return true;
+        } catch {
+          return false;
+        }
+      }
+
+      function ensureDir(p: string) {
+        if (!fs.existsSync(p)) {
+          fs.mkdirSync(p, { recursive: true });
+        }
+      }
+
+      function getCurrentInstallation(): PackageJson {
+        try {
+          return require(installationPath);
+        } catch {
+          return {
+            name: 'nx-installation',
+            version: '0.0.0',
+            devDependencies: {},
+          };
+        }
+      }
+
+      function performInstallation(
+        currentInstallation: PackageJson,
+        nxJson: NxJsonConfiguration
+      ) {
+        fs.writeFileSync(
+          installationPath,
+          JSON.stringify({
+            name: 'nx-installation',
+            devDependencies: {
+              nx: nxJson.installation.version,
+              ...getDesiredPluginVersions(nxJson),
+            },
+          })
+        );
+
+        try {
+          cp.execSync('npm i', {
+            cwd: path.dirname(installationPath),
+            stdio: 'inherit',
+          });
+        } catch (e) {
+          // revert possible changes to the current installation
+          fs.writeFileSync(installationPath, JSON.stringify(currentInstallation));
+          // rethrow
+          throw e;
+        }
+      }
+
+      function getDesiredPluginVersions(nxJson: NxJsonConfiguration) {
+        const packages: Record<string, string> = {};
+
+        for (const [plugin, version] of Object.entries(
+          nxJson?.installation?.plugins ?? {}
+        )) {
+          packages[plugin] = version;
+        }
+
+        for (const plugin of nxJson.plugins ?? []) {
+          if (typeof plugin === 'object' && plugin.version) {
+            packages[getPackageName(plugin.plugin)] = plugin.version;
+          }
+        }
+
+        return Object.entries(packages);
+      }
+
+      function getPackageName(name: string) {
+        if (name.startsWith('@')) {
+          return name.split('/').slice(0, 2).join('/');
+        }
+        return name.split('/')[0];
+      }
+
+      function ensureUpToDateInstallation() {
+        const nxJsonPath = path.join(__dirname, '..', 'nx.json');
+        let nxJson: NxJsonConfiguration;
+
+        try {
+          nxJson = require(nxJsonPath);
+          if (!nxJson.installation) {
+            console.error(
+              '[NX]: The "installation" entry in the "nx.json" file is required when running the nx wrapper. See https://nx.dev/recipes/installation/install-non-javascript'
+            );
+            process.exit(1);
+          }
+        } catch {
+          console.error(
+            '[NX]: The "nx.json" file is required when running the nx wrapper. See https://nx.dev/recipes/installation/install-non-javascript'
+          );
+          process.exit(1);
+        }
+
+        try {
+          ensureDir(path.join(__dirname, 'installation'));
+          const currentInstallation = getCurrentInstallation();
+          if (!matchesCurrentNxInstall(currentInstallation, nxJson)) {
+            performInstallation(currentInstallation, nxJson);
+          }
+        } catch (e: unknown) {
+          const messageLines = [
+            '[NX]: Nx wrapper failed to synchronize installation.',
+          ];
+          if (e instanceof Error) {
+            messageLines.push('');
+            messageLines.push(e.message);
+            messageLines.push(e.stack);
+          } else {
+            messageLines.push(e.toString());
+          }
+          console.error(messageLines.join('\\n'));
+          process.exit(1);
+        }
+      }
+
+      if (!process.env.NX_WRAPPER_SKIP_INSTALL) {
+        ensureUpToDateInstallation();
+      }
+
+      require('./installation/node_modules/nx/bin/nx');
+      "
+    `);
   });
 });

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -104,17 +104,17 @@ export function getNxWrapperContents() {
 // Remove any empty comments or comments that start with `//#: ` or eslint-disable comments.
 // This removes the sourceMapUrl since it is invalid, as well as any internal comments.
 export function sanitizeWrapperScript(input: string) {
-  const linesToRemove = [
+  const removals = [
     // Comments that start with //#
-    '\\s*\\/\\/# .*',
+    '\\s+\\/\\/# .*',
     // Comments that are empty (often used for newlines between internal comments)
-    '\\s*\\/\\/\\s*',
+    '\\s+\\/\\/\\s*$',
     // Comments that disable an eslint rule.
-    '\\s*\\/\\/ eslint-disable-next-line.*',
+    '(^|\\s?)\\/\\/ ?eslint-disable.*$',
   ];
 
   const replacements = [
-    [linesToRemove.map((line) => `^${line}$`).join('|'), ''],
+    ...removals.map((r) => [r, '']),
     // Remove the sourceMapUrl comment
     ['^\\/\\/# sourceMappingURL.*$', ''],
     // Keep empty comments if ! is present

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -42,7 +42,7 @@ function matchesCurrentNxInstall(
     ) {
       return false;
     }
-    for (const [plugin, desiredVersion] of getDesiredPluginVersions(nxJson)) {
+    for (const [plugin, desiredVersion] of getDesiredPackageVersions(nxJson)) {
       if (currentInstallation.devDependencies[plugin] !== desiredVersion) {
         return false;
       }
@@ -79,10 +79,7 @@ function performInstallation(
     installationPath,
     JSON.stringify({
       name: 'nx-installation',
-      devDependencies: {
-        nx: nxJson.installation.version,
-        ...getDesiredPluginVersions(nxJson),
-      },
+      devDependencies: Object.fromEntries(getDesiredPackageVersions(nxJson)),
     })
   );
 
@@ -100,19 +97,35 @@ function performInstallation(
   }
 }
 
-function getDesiredPluginVersions(nxJson: NxJsonConfiguration) {
-  const packages: Record<string, string> = {};
+let WARNED_DEPRECATED_INSTALLATIONS_PLUGIN_PROPERTY = false;
+function getDesiredPackageVersions(nxJson: NxJsonConfiguration) {
+  const packages: Record<string, string> = {
+    nx: nxJson.installation.version,
+  };
 
   //# adds support for "legacy" installation of plugins
   for (const [plugin, version] of Object.entries(
     nxJson?.installation?.plugins ?? {}
   )) {
     packages[plugin] = version;
+    if (!WARNED_DEPRECATED_INSTALLATIONS_PLUGIN_PROPERTY) {
+      console.warn(
+        '[Nx]: The "installation.plugins" entry in the "nx.json" file is deprecated. Use "plugins" instead. See https://nx.dev/recipes/installation/install-non-javascript'
+      );
+      WARNED_DEPRECATED_INSTALLATIONS_PLUGIN_PROPERTY = true;
+    }
   }
 
   for (const plugin of nxJson.plugins ?? []) {
-    if (typeof plugin === 'object' && plugin.version) {
-      packages[getPackageName(plugin.plugin)] = plugin.version;
+    if (typeof plugin === 'object') {
+      if (plugin.version) {
+        packages[getPackageName(plugin.plugin)] = plugin.version;
+      }
+      //# } else if (!nxJson.installation?.plugins?.[pluginName]) {
+      //# // Ideally we'd like to warn here, but we don't know that
+      //# // the plugin isn't a local plugin at this point. As such,
+      //# // the warning may not be relevant, and I'd like to avoid that.
+      //# }
     }
   }
 
@@ -124,6 +137,8 @@ function getDesiredPluginVersions(nxJson: NxJsonConfiguration) {
 //#      - `@nx/workspace/plugin` -> `@nx/workspace`
 //#      - `@nx/workspace/other`  -> `@nx/workspace`
 //#      - `nx/plugin`            -> `nx`
+//# This is a copy of a function in 'nx/src/utils/nx-installation'.
+//# It's tested there, but can't be imported since Nx isn't installed yet.
 function getPackageName(name: string) {
   if (name.startsWith('@')) {
     return name.split('/').slice(0, 2).join('/');

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -1,9 +1,11 @@
 // This file should be committed to your repository! It wraps Nx and ensures
 // that your local installation matches nx.json.
+//!
+// You should not edit this file, as future updates to Nx may require changes to it.
 // See: https://nx.dev/recipes/installation/install-non-javascript for more info.
 //
 //# The contents of this file are executed before packages are installed.
-//# As such, we should not import anything from nx, other @nrwl packages,
+//# As such, we should not import anything from nx, other @nx packages,
 //# or any other npm packages. Only import node builtins. Type Imports are
 //# fine, since they are removed by the typescript compiler.
 
@@ -18,7 +20,7 @@ const installationPath = path.join(__dirname, 'installation', 'package.json');
 
 function matchesCurrentNxInstall(
   currentInstallation: PackageJson,
-  nxJsonInstallation: NxJsonConfiguration['installation']
+  nxJson: NxJsonConfiguration
 ) {
   if (
     !currentInstallation.devDependencies ||
@@ -30,19 +32,17 @@ function matchesCurrentNxInstall(
   try {
     if (
       currentInstallation.devDependencies['nx'] !==
-        nxJsonInstallation.version ||
+        nxJson.installation.version ||
       require(path.join(
         path.dirname(installationPath),
         'node_modules',
         'nx',
         'package.json'
-      )).version !== nxJsonInstallation.version
+      )).version !== nxJson.installation.version
     ) {
       return false;
     }
-    for (const [plugin, desiredVersion] of Object.entries(
-      nxJsonInstallation.plugins || {}
-    )) {
+    for (const [plugin, desiredVersion] of getDesiredPluginVersions(nxJson)) {
       if (currentInstallation.devDependencies[plugin] !== desiredVersion) {
         return false;
       }
@@ -81,7 +81,7 @@ function performInstallation(
       name: 'nx-installation',
       devDependencies: {
         nx: nxJson.installation.version,
-        ...nxJson.installation.plugins,
+        ...getDesiredPluginVersions(nxJson),
       },
     })
   );
@@ -98,6 +98,37 @@ function performInstallation(
     // rethrow
     throw e;
   }
+}
+
+function getDesiredPluginVersions(nxJson: NxJsonConfiguration) {
+  const packages: Record<string, string> = {};
+
+  //# adds support for "legacy" installation of plugins
+  for (const [plugin, version] of Object.entries(
+    nxJson?.installation?.plugins ?? {}
+  )) {
+    packages[plugin] = version;
+  }
+
+  for (const plugin of nxJson.plugins ?? []) {
+    if (typeof plugin === 'object' && plugin.version) {
+      packages[getPackageName(plugin.plugin)] = plugin.version;
+    }
+  }
+
+  return Object.entries(packages);
+}
+
+//# Converts import paths to package names.
+//# e.g. - `@nx/workspace`        -> `@nx/workspace`
+//#      - `@nx/workspace/plugin` -> `@nx/workspace`
+//#      - `@nx/workspace/other`  -> `@nx/workspace`
+//#      - `nx/plugin`            -> `nx`
+function getPackageName(name: string) {
+  if (name.startsWith('@')) {
+    return name.split('/').slice(0, 2).join('/');
+  }
+  return name.split('/')[0];
 }
 
 function ensureUpToDateInstallation() {
@@ -122,7 +153,7 @@ function ensureUpToDateInstallation() {
   try {
     ensureDir(path.join(__dirname, 'installation'));
     const currentInstallation = getCurrentInstallation();
-    if (!matchesCurrentNxInstall(currentInstallation, nxJson.installation)) {
+    if (!matchesCurrentNxInstall(currentInstallation, nxJson)) {
       performInstallation(currentInstallation, nxJson);
     }
   } catch (e: unknown) {

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -529,9 +529,30 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
 export type PluginConfiguration = string | ExpandedPluginConfiguration;
 
 export type ExpandedPluginConfiguration<T = unknown> = {
+  /**
+   * The plugin module that should be loaded by Nx
+   */
   plugin: string;
+
+  /**
+   * The version of the plugin to be installed by the Nx wrapper.
+   * If Nx is invoked from node_modules, this is unused.
+   */
+  version?: string;
+
+  /**
+   * Configuration options for the loaded plugin
+   */
   options?: T;
+
+  /**
+   * Glob patterns to limit which paths the plugin's createNodes function will run on.
+   */
   include?: string[];
+
+  /**
+   * Glob patterns to exclude paths from the plugin's createNodes function.
+   */
   exclude?: string[];
 };
 

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -1,6 +1,7 @@
 import { consumeMessage, isPluginWorkerMessage } from './messaging';
 import { createSerializableError } from '../../../utils/serializable-error';
 import { consumeMessagesFromSocket } from '../../../utils/consume-messages-from-socket';
+import { isRuntimePlugin } from '../utils';
 
 import { createServer } from 'net';
 import { unlinkSync } from 'fs';
@@ -76,6 +77,11 @@ const server = createServer((socket) => {
                 hasCreateMetadata:
                   'createMetadata' in plugin && !!plugin.createMetadata,
                 success: true,
+                callback: isRuntimePlugin(plugin)
+                  ? undefined
+                  : () => {
+                      process.exit(0);
+                    },
               },
             };
           } catch (e) {

--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -4,6 +4,8 @@ import {
   CreateNodesResult,
 } from './public-api';
 import { AggregateCreateNodesError } from '../error-types';
+import type { LoadedNxPlugin } from './loaded-nx-plugin';
+
 export async function createNodesFromFiles<T = unknown>(
   createNodes: CreateNodesFunction<T>,
   configFiles: readonly string[],
@@ -36,9 +38,5 @@ export async function createNodesFromFiles<T = unknown>(
 }
 
 export function isRuntimePlugin(plugin: LoadedNxPlugin): boolean {
-  return !!(
-    plugin.createNodes ||
-    plugin.createDependencies ||
-    plugin.processProjectGraph
-  );
+  return !!(plugin.createNodes || plugin.createDependencies);
 }

--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -34,3 +34,11 @@ export async function createNodesFromFiles<T = unknown>(
   }
   return results;
 }
+
+export function isRuntimePlugin(plugin: LoadedNxPlugin): boolean {
+  return !!(
+    plugin.createNodes ||
+    plugin.createDependencies ||
+    plugin.processProjectGraph
+  );
+}

--- a/packages/nx/src/utils/nx-installation.spec.ts
+++ b/packages/nx/src/utils/nx-installation.spec.ts
@@ -1,0 +1,90 @@
+import { getPackageName, updateDependenciesInNxJson } from './nx-installation';
+
+describe('nx managed installation utils', () => {
+  describe('get package name', () => {
+    it.each([
+      ['plugin', 'plugin'],
+      ['plugin/other', 'plugin'],
+      ['@scope/plugin', '@scope/plugin'],
+      ['@scope/plugin/other', '@scope/plugin'],
+    ])('should read package name for %s: %s', (input, expected) => {
+      expect(getPackageName(input)).toEqual(expected);
+    });
+  });
+
+  describe('updateDependenciesInNxJson', () => {
+    it('should handle legacy nx json dependencies', async () => {
+      const updated = await updateDependenciesInNxJson(
+        {
+          installation: {
+            version: '1.0.0',
+            plugins: {
+              plugin: '1.0.0',
+            },
+          },
+        },
+        {
+          plugin: { version: '2.0.0' },
+        }
+      );
+
+      expect(updated).toEqual({
+        installation: {
+          version: '1.0.0',
+          plugins: {
+            plugin: '2.0.0',
+          },
+        },
+      });
+    });
+
+    it('should update plugin versions in plugins array', async () => {
+      const updated = await updateDependenciesInNxJson(
+        {
+          installation: {
+            version: '1.0.0',
+          },
+          plugins: [{ plugin: 'plugin', version: '1.0.0' }],
+        },
+        {
+          plugin: { version: '2.0.0' },
+        }
+      );
+
+      expect(updated).toEqual({
+        installation: {
+          version: '1.0.0',
+        },
+        plugins: [{ plugin: 'plugin', version: '2.0.0' }],
+      });
+    });
+
+    it('should update plugin versions in plugins array and installation.plugins', async () => {
+      const updated = await updateDependenciesInNxJson(
+        {
+          installation: {
+            version: '1.0.0',
+            plugins: {
+              plugin: '1.0.0',
+            },
+          },
+          plugins: [{ plugin: 'other', version: '1.0.0' }],
+        },
+        {
+          plugin: { version: '2.0.0' },
+          other: { version: '2.0.1' },
+        }
+      );
+
+      expect(updated).toEqual({
+        installation: {
+          version: '1.0.0',
+          plugins: {
+            plugin: '2.0.0',
+          },
+        },
+        plugins: [{ plugin: 'other', version: '2.0.1' }],
+      });
+    });
+  });
+});

--- a/packages/nx/src/utils/nx-installation.ts
+++ b/packages/nx/src/utils/nx-installation.ts
@@ -1,0 +1,75 @@
+import { valid } from 'semver';
+import { NxJsonConfiguration } from '../config/nx-json';
+import { PackageJsonUpdateForPackage } from '../config/misc-interfaces';
+import { resolvePackageVersionUsingRegistry } from './package-manager';
+
+export async function updateDependenciesInNxJson(
+  nxJson: NxJsonConfiguration,
+  updates: Record<string, PackageJsonUpdateForPackage>
+) {
+  const nxVersion = updates.nx?.version;
+  if (nxVersion) {
+    nxJson.installation.version = nxVersion;
+  }
+
+  for (const plugin of nxJson.plugins ?? []) {
+    if (typeof plugin === 'object' && plugin.version) {
+      const packageName = getPackageName(plugin.plugin);
+      const update = updates[packageName];
+      if (update) {
+        plugin.version = await normalizeVersionForNxJson(
+          plugin.plugin,
+          update.version
+        );
+      }
+    }
+  }
+
+  if (nxJson.installation.plugins) {
+    for (const dep in nxJson.installation.plugins) {
+      const update = updates[dep];
+      if (update) {
+        nxJson.installation.plugins[dep] = await normalizeVersionForNxJson(
+          dep,
+          update.version
+        );
+      }
+    }
+  }
+
+  return nxJson;
+}
+
+export function getPackageName(name: string) {
+  if (name.startsWith('@')) {
+    return name.split('/').slice(0, 2).join('/');
+  }
+  return name.split('/')[0];
+}
+
+export function readDependenciesFromNxJson(
+  nxJson: NxJsonConfiguration
+): Record<string, string> {
+  const deps = {};
+  if (nxJson?.installation?.version) {
+    deps['nx'] = nxJson.installation.version;
+    for (const dep in nxJson.installation.plugins ?? {}) {
+      deps[dep] = nxJson.installation.plugins[dep];
+    }
+    for (const plugin of nxJson.plugins ?? []) {
+      if (typeof plugin === 'object' && plugin.version) {
+        deps[plugin.plugin] = plugin.version;
+      }
+    }
+  }
+  return deps;
+}
+
+async function normalizeVersionForNxJson(
+  dep: string,
+  version: string
+): Promise<string> {
+  return valid(version)
+    ? version
+    : await resolvePackageVersionUsingRegistry(dep, version);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Folks using the nx wrapper (nxw.js in .nx) install plugins in nx.json[installation][plugins].

This is a bit weird since there is also nx.json[plugins]

## Expected Behavior
You can specify plugins in the top level plugins array.

This PR also adds a field called "runtime" that can be set to false to tell Nx that a plugin worker doesn't need to be spawned for a listed plugin.

This PR fixes up:
- `nx migrate` support for plugins array contained versions
- `nx add`, to add plugins to the plugins array by default
- Plugin workers shutdown automatically if a plugin has no runtime functions

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
