### PR TITLE
fix(core): prefer project specific external deps

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/build-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/build-dependencies.ts
@@ -3,6 +3,19 @@ import { buildExplicitPackageJsonDependencies } from './explicit-package-json-de
 import { CreateDependenciesContext } from '../../../../project-graph/plugins';
 import { RawProjectGraphDependency } from '../../../../project-graph/project-graph-builder';
 
+/**
+ * When processing external dependencies, we need to keep track of which version of that dependency
+ * is most appropriate for each source project. A workspace may contain multiple copies of a dependency
+ * but we should base the graph on the version that is most relevant to the source project, otherwise
+ * things like the dependency-check lint rule will not work as expected.
+ *
+ * We need to track this in this separate cache because the project file map that lives on the ctx will
+ * only be updated at the very end.
+ *
+ * sourceProject => resolved external node name (e.g. 'npm:lodash@4.0.0')
+ */
+export type ExternalDependenciesCache = Map<string, string>;
+
 export function buildExplicitDependencies(
   jsPluginConfig: {
     analyzeSourceFiles?: boolean;
@@ -12,7 +25,22 @@ export function buildExplicitDependencies(
 ): RawProjectGraphDependency[] {
   if (totalNumberOfFilesToProcess(ctx) === 0) return [];
 
+  const externalDependenciesCache: ExternalDependenciesCache = new Map();
   let dependencies: RawProjectGraphDependency[] = [];
+
+  /**
+   * NOTE: It is important that we process package.json files first so that accurate versions for
+   * external dependencies are captured in the ExternalDependenciesCache before converting
+   * imports within TS files.
+   */
+  if (
+    jsPluginConfig.analyzePackageJson === undefined ||
+    jsPluginConfig.analyzePackageJson === true
+  ) {
+    dependencies = dependencies.concat(
+      buildExplicitPackageJsonDependencies(ctx, externalDependenciesCache)
+    );
+  }
 
   if (
     jsPluginConfig.analyzeSourceFiles === undefined ||
@@ -25,17 +53,9 @@ export function buildExplicitDependencies(
     } catch {}
     if (tsExists) {
       dependencies = dependencies.concat(
-        buildExplicitTypeScriptDependencies(ctx)
+        buildExplicitTypeScriptDependencies(ctx, externalDependenciesCache)
       );
     }
-  }
-  if (
-    jsPluginConfig.analyzePackageJson === undefined ||
-    jsPluginConfig.analyzePackageJson === true
-  ) {
-    dependencies = dependencies.concat(
-      buildExplicitPackageJsonDependencies(ctx)
-    );
   }
 
   return dependencies;

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/build-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/build-dependencies.ts
@@ -12,9 +12,9 @@ import { RawProjectGraphDependency } from '../../../../project-graph/project-gra
  * We need to track this in this separate cache because the project file map that lives on the ctx will
  * only be updated at the very end.
  *
- * sourceProject => resolved external node name (e.g. 'npm:lodash@4.0.0')
+ * sourceProject => resolved external node names (e.g. 'npm:lodash@4.0.0')
  */
-export type ExternalDependenciesCache = Map<string, string>;
+export type ExternalDependenciesCache = Map<string, Set<string>>;
 
 export function buildExplicitDependencies(
   jsPluginConfig: {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
@@ -101,10 +101,16 @@ describe('explicit package json dependencies', () => {
     tempFs.cleanup();
   });
 
-  it(`should add dependencies for projects based on deps in package.json`, () => {
-    const res = buildExplicitPackageJsonDependencies(ctx);
-
+  it(`should add dependencies for projects based on deps in package.json and populate the cache`, () => {
+    const cache = new Map();
+    const res = buildExplicitPackageJsonDependencies(ctx, cache);
     expect(res).toEqual([
+      {
+        source: 'proj',
+        target: 'proj3',
+        sourceFile: 'libs/proj/package.json',
+        type: 'static',
+      },
       {
         source: 'proj',
         target: 'proj2',
@@ -117,12 +123,11 @@ describe('explicit package json dependencies', () => {
         target: 'npm:external',
         type: 'static',
       },
-      {
-        source: 'proj',
-        target: 'proj3',
-        sourceFile: 'libs/proj/package.json',
-        type: 'static',
-      },
     ]);
+    expect(cache).toMatchInlineSnapshot(`
+      Map {
+        "proj" => "npm:external",
+      }
+    `);
   });
 });

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
@@ -126,7 +126,9 @@ describe('explicit package json dependencies', () => {
     ]);
     expect(cache).toMatchInlineSnapshot(`
       Map {
-        "proj" => "npm:external",
+        "proj" => Set {
+          "npm:external",
+        },
       }
     `);
   });

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -108,7 +108,10 @@ function processPackageJson(
         };
         validateDependency(dependency, ctx);
         collectedDeps.push(dependency);
-        externalDependenciesCache.set(sourceProject, dependency.target);
+        const depsForSource =
+          externalDependenciesCache.get(sourceProject) || new Set();
+        depsForSource.add(dependency.target);
+        externalDependenciesCache.set(sourceProject, depsForSource);
       }
     });
   } catch (e) {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -125,7 +125,7 @@ function readDeps(packageJson: PackageJson) {
   const deps = {};
 
   /**
-   * We process dependencies in a rough order or increasing importance such that if a dependency is listed in multiple
+   * We process dependencies in a rough order of increasing importance such that if a dependency is listed in multiple
    * sections, the version listed under the "most important" one wins, with production dependencies being the most important.
    */
   const depType = [

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -45,7 +45,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(ctx);
+      const res = buildExplicitTypeScriptDependencies(ctx, new Map());
 
       expect(res).toEqual([
         {
@@ -75,6 +75,53 @@ describe('explicit project dependencies', () => {
       ]);
     });
 
+    it('should build prefer external dependencies found in the externalDependenciesCache', async () => {
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
+        sourceProjectFiles: [
+          {
+            path: 'libs/proj/index.ts',
+            content: `
+              import * as npmPackage from 'npm-package';
+            `,
+          },
+        ],
+      });
+
+      // Set the cache to include a project specific version of the external dependency
+      const externalDependenciesCache = new Map();
+      externalDependenciesCache.set(source, 'npm:npm-package@0.5.0');
+
+      const resWithEmptyCache = buildExplicitTypeScriptDependencies(
+        ctx,
+        new Map()
+      );
+      const resWithCache = buildExplicitTypeScriptDependencies(
+        ctx,
+        externalDependenciesCache
+      );
+
+      expect(resWithEmptyCache).toEqual([
+        {
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'npm:npm-package',
+          type: 'static',
+        },
+      ]);
+
+      expect(resWithCache).toEqual([
+        {
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          // The project specific version is preferred over the root version (which would be 'npm:npm-package')
+          target: 'npm:npm-package@0.5.0',
+          type: 'static',
+        },
+      ]);
+    });
+
     it('should build explicit dependencies for static exports', async () => {
       const source = 'proj';
       const ctx = await createContext({
@@ -91,7 +138,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(ctx);
+      const res = buildExplicitTypeScriptDependencies(ctx, new Map());
 
       expect(res).toEqual([
         {
@@ -131,7 +178,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(ctx);
+      const res = buildExplicitTypeScriptDependencies(ctx, new Map());
       expect(res).toEqual([
         {
           source,
@@ -170,7 +217,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(ctx);
+      const res = buildExplicitTypeScriptDependencies(ctx, new Map());
 
       expect(res).toEqual([
         {
@@ -231,7 +278,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(ctx);
+      const res = buildExplicitTypeScriptDependencies(ctx, new Map());
 
       expect(res).toEqual([
         {
@@ -275,7 +322,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(ctx);
+      const res = buildExplicitTypeScriptDependencies(ctx, new Map());
 
       expect(res).toEqual([
         {
@@ -390,7 +437,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(ctx);
+      const res = buildExplicitTypeScriptDependencies(ctx, new Map());
 
       expect(res).toEqual([]);
     });
@@ -462,7 +509,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(ctx);
+      const res = buildExplicitTypeScriptDependencies(ctx, new Map());
 
       expect(res).toEqual([]);
     });

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -91,7 +91,9 @@ describe('explicit project dependencies', () => {
 
       // Set the cache to include a project specific version of the external dependency
       const externalDependenciesCache = new Map();
-      externalDependenciesCache.set(source, 'npm:npm-package@0.5.0');
+      const cachedDeps = new Set();
+      cachedDeps.add('npm:npm-package@0.5.0');
+      externalDependenciesCache.set(source, cachedDeps);
 
       const resWithEmptyCache = buildExplicitTypeScriptDependencies(
         ctx,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

We only ever discover one version of an external dependency for the file-map.json. This means the `@nx/dependency-checks` lint rule can produce incorrect failures when multiple copies of a dependency exist within a workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

In the file-map.json the project specific version of a package (if multiple exist) is preferred and therefore the lint rule produces accurate results.

---

For example, in a repo where the root package.json has lodash@4.0.0 (which becomes `npm:lodash` on graph) and the foo project has lodash@3.0.0:

**Before**

![image](https://github.com/nrwl/nx/assets/900523/fa0b3711-5004-4abc-9904-0433a37bc3cf)

**After**

![image](https://github.com/nrwl/nx/assets/900523/d0527368-44b4-486f-aa7a-79d996a20ef4)