### PR TITLE
fix(testing): close cypress web server correctly on windows

### DIFF
--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -75,9 +75,13 @@ function startWebServer(webServerCommand: string) {
   });
 
   return () => {
-    // child.kill() does not work on linux
-    // process.kill will kill the whole process group on unix
-    process.kill(-serverProcess.pid, 'SIGKILL');
+    if (process.platform === 'win32') {
+      serverProcess.kill();
+    } else {
+      // child.kill() does not work on linux
+      // process.kill will kill the whole process group on unix
+      process.kill(-serverProcess.pid, 'SIGKILL');
+    }
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress fails to close the web server on Windows. It fails with `Error: kill ESRCH` (https://github.com/nrwl/nx/actions/runs/8135984708/job/22231576219#step:11:264). This happens because Node.js doesn't support killing process groups in Windows (https://nodejs.org/docs/latest-v20.x/api/process.html#processkillpid-signal) and because we're not spawning a detached process for Windows anyway.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress should close the web server on Windows.

Successful run: https://github.com/nrwl/nx/actions/runs/8139220425/job/22242149713#step:11:201. There are unrelated failures on that run, but the failures specific to not closing the web server are addressed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
