### PR TITLE
cleanup(release): update outdated snapshots in e2e tests

### DIFF
--- a/e2e/release/src/multiple-release-branches.test.ts
+++ b/e2e/release/src/multiple-release-branches.test.ts
@@ -164,9 +164,6 @@ describe('nx release multiple release branches', () => {
       "scripts": {
 
 
-      NX   Updating {package-manager} lock file
-
-
       NX   Committing changes with git
 
 
@@ -219,9 +216,6 @@ describe('nx release multiple release branches', () => {
       "scripts": {
 
 
-      NX   Updating {package-manager} lock file
-
-
       NX   Committing changes with git
 
 
@@ -269,9 +263,6 @@ describe('nx release multiple release branches', () => {
       -   "version": "0.0.7",
       +   "version": "0.0.8",
       "scripts": {
-
-
-      NX   Updating {package-manager} lock file
 
 
       NX   Committing changes with git
@@ -372,9 +363,6 @@ describe('nx release multiple release branches', () => {
       "scripts": {
 
 
-      NX   Updating {package-manager} lock file
-
-
       NX   Committing changes with git
 
 
@@ -425,9 +413,6 @@ describe('nx release multiple release branches', () => {
       -   "version": "0.0.0",
       +   "version": "1.0.0",
       "scripts": {
-
-
-      NX   Updating {package-manager} lock file
 
 
       NX   Committing changes with git


### PR DESCRIPTION
Updates some outdated snapshots in e2e tests for `nx release`. It looks like https://github.com/nrwl/nx/pull/22055 could have been merged while being out of date with the master branch (specifically missing the changes in https://github.com/nrwl/nx/pull/22082).

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
