### PR TITLE
fix(angular): log message about unsupported ng cache command

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -107,7 +107,14 @@ function isKnownCommand(command: string) {
 
 function shouldDelegateToAngularCLI() {
   const command = process.argv[2];
-  const commands = ['analytics', 'config', 'doc', 'update', 'completion'];
+  const commands = [
+    'analytics',
+    'cache',
+    'completion',
+    'config',
+    'doc',
+    'update',
+  ];
   return commands.indexOf(command) > -1;
 }
 
@@ -139,6 +146,10 @@ function handleAngularCLIFallbacks(workspace: WorkspaceTypeAndRoot) {
   Instead, you could try an Nx Editor Plugin for a visual tool to run Nx commands. If you're using VSCode, you can use the Nx Console plugin, or if you're using WebStorm, you could use one of the available community plugins.
   For more information, see https://nx.dev/features/integrate-with-editors`);
     }
+  } else if (process.argv[2] === 'cache') {
+    console.log(`"ng cache" is not natively supported by Nx.
+To clear the cache, you can delete the ".angular/cache" directory (or the directory configured by "cli.cache.path" in the "angular.json" file).
+To update the cache configuration, you can directly update the configuration in your "angular.json" file (https://angular.io/guide/workspace-config#cache-options).`);
   } else {
     try {
       // nx-ignore-next-line


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx cache clean` throws an error stating the project "clean" does not exist. While this is correct (Nx CLI doesn't have a `cache` command and therefore tries to map it to `nx <target> <project>`), we could handle it and provide a better error message for Angular workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `nx cache clean` in an Angular workspace should tell the user that `ng cache` is not supported and provide guidance on how to achieve what they need.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22046 
