### PR TITLE
fix(misc): improve package.json scripts handling when running "nx init" and "nx add"

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -31,6 +31,7 @@ export interface InitArgs {
 }
 
 export async function initHandler(options: InitArgs): Promise<void> {
+  process.env.NX_RUNNING_NX_INIT = 'true';
   const version =
     process.env.NX_VERSION ?? (prerelease(nxVersion) ? 'next' : 'latest');
   if (process.env.NX_VERSION) {
@@ -112,7 +113,7 @@ export async function initHandler(options: InitArgs): Promise<void> {
     if (!detectPluginsResponse.updatePackageScripts) {
       const rootPackageJsonPath = join(repoRoot, 'package.json');
       const json = readJsonFile<PackageJson>(rootPackageJsonPath);
-      json.nx = {};
+      json.nx = { includedScripts: [] };
       writeJsonFile(rootPackageJsonPath, json);
     }
 


### PR DESCRIPTION
Updates the `package.json` scripts handling to:

- `nx init`:
    - not replacing scripts => set `includedScripts` to `[]`
    - replacing scripts => set `includedScripts` to `[]`
- nx add:
    - not replacing scripts (`--updatePackageScripts=false`) => don't set/touch `includedScripts`
    - replacing scripts (default) =>
        - if `includedScripts` is not set => set `includedScripts` with all scripts except the ones that match an inferred target that was used to replace a script
        - if `includedScripts` is already set => exclude scripts that match inferred targets that were used to replace a script

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
