### PR TITLE
fix(nextjs): Adding styles to nextjs cypress should not fail.

### DIFF
--- a/packages/cypress/src/generators/component-configuration/component-configuration.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.ts
@@ -97,6 +97,7 @@ function normalizeOptions(
   return {
     addPlugin,
     ...options,
+    framework: options.framework ?? null,
     directory: options.directory ?? 'cypress',
   };
 }

--- a/packages/cypress/src/generators/component-configuration/files/__directory__/support/component-index.html
+++ b/packages/cypress/src/generators/component-configuration/files/__directory__/support/component-index.html
@@ -5,7 +5,10 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title><%= project %> Components App</title>
-
+  <% if(framework === 'next') { %>
+  <!-- Used by Next.js to inject CSS. -->
+  <div id="__next_css__DO_NOT_USE__"></div>
+  <% } %>
 </head>
 <body>
   <div data-cy-root></div>

--- a/packages/cypress/src/generators/component-configuration/schema.d.ts
+++ b/packages/cypress/src/generators/component-configuration/schema.d.ts
@@ -10,4 +10,5 @@ export interface CypressComponentConfigurationSchema {
    * @internal
    */
   addExplicitTargets?: boolean;
+  framework?: 'next';
 }

--- a/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -39,6 +39,7 @@ export async function cypressComponentConfigurationInternal(
     await baseCyCtConfig(tree, {
       project: options.project,
       skipFormat: true,
+      framework: 'next',
       jsx: true,
       addPlugin: options.addPlugin,
     })


### PR DESCRIPTION
When testing nextjs components with cypress we need to update the html to include styles added by Next.js

RE: https://github.com/cypress-io/cypress-component-testing-apps/blob/main/react-next13-ts/cypress/support/component-index.html

```component.ts
import { mount } from 'cypress/react18';
import './styles.ct.css'; // <--------- Here

import './commands';

// add component testing only related command here, such as mount
declare global {
  // eslint-disable-next-line @typescript-eslint/no-namespace
  namespace Cypress {
    // eslint-disable-next-line @typescript-eslint/no-unused-vars
    interface Chainable<Subject> {
      mount: typeof mount;
    }
  }
}

Cypress.Commands.add('mount', mount);
```
Also added a test case for `Router` from `next/router` to show that server component testing works.

`async` server component testing is not yet defined from RSC see: https://github.com/testing-library/react-testing-library/issues/1209
Hence, these test cases are not generated.

closes: #21768

