### PR TITLE
fix(core): Handle Next.js returning 0 for SIGINT and SIGTERM error codes

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -163,7 +163,10 @@ function normalizeOptions(
 ): NormalizedRunCommandsOptions {
   if (options.command) {
     options.commands = [{ command: options.command }];
-    options.parallel = !!options.readyWhen;
+    //(@nicholas) revert options.parallel after: https://github.com/vercel/next.js/pull/62907 has been promoted and we update to the new next version
+    // For now, this is the only way to handle next.js passing exit code 0 for processes that end with SIGINT or SIGTERM
+    // As it will force the process to run as a Node.js process instead of a Rust process and we can handle the exit codes properly
+    options.parallel = options.parallel ?? !!options.readyWhen;
   } else {
     options.commands = options.commands.map((c) =>
       typeof c === 'string' ? { command: c } : c


### PR DESCRIPTION
Currently, if a process was ran using the `run-commands` executor ends due to `SIGTERM` or `SIGINT` while the process code is `0`. Nx, will continue to cache that output.

To handle this type of behaviour we can force the process to be node instead of rust. 

This will be a temporary stand-in until: https://github.com/vercel/next.js/pull/62907 is merged and promoted.