### PR TITLE
fix(vite): fix ignored vitest cli options (#22006)

### DIFF
--- a/packages/vite/src/executors/test/lib/utils.ts
+++ b/packages/vite/src/executors/test/lib/utils.ts
@@ -69,7 +69,7 @@ export async function getOptions(
   ]);
 
   const settings = {
-    ...normalizedExtraArgs,
+    ...normalizedExtraArgs.options,
     // This should not be needed as it's going to be set in vite.config.ts
     // but leaving it here in case someone did not migrate correctly
     root: resolved.config.root ?? root,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Passing CLI parameters to vitest doesn't work - vitest does not get the params and they are ignored.

`nx run my-app:test --update` does not update the snapshots.

It looks like this started happening after the switch to use `parseCLI` in https://github.com/nrwl/nx/pull/21890/

`parseCLI` returns CLI parameters in an `options` object (see https://vitest.dev/advanced/api.html#parsecli), and the merged vitest config looks like this:
```typescript
{
    ...,
    options: {
        update: true
    }
}
```

Before the switch to `parseCLI`, options were included directly in the merged config, so it looked like this:
```typescript
{
    ...,
    update: true
}
```

`options` isn't a valid field for a vitest config, and the `update` flag gets ignored.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx run my-app:test --update` should update the snapshots.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
I'm linking to https://github.com/nrwl/nx/issues/22006 because this issue was noted in this comment - https://github.com/nrwl/nx/issues/22006#issuecomment-1965539423

But this isn't about the hanging test runner, so please let me know if it is better to file a new issue rather than use the existing one.


Related to #22006 
