### PR TITLE
fix(nextjs): Surface error codes when build is interrupted by signals SIGINT, SIGTERM etc...

### DIFF
--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -19,6 +19,7 @@ import { checkPublicDirectory } from './lib/check-project';
 import { NextBuildBuilderOptions } from '../../utils/types';
 import { ChildProcess, fork } from 'child_process';
 import { createCliOptions } from '../../utils/create-cli-options';
+import { signalToCode } from 'nx/src/utils/exit-codes';
 
 let childProcess: ChildProcess;
 
@@ -51,9 +52,17 @@ export default async function buildExecutor(
 
   try {
     await runCliBuild(workspaceRoot, projectRoot, options);
-  } catch (error) {
-    logger.error(`Error occurred while trying to run the build command`);
-    logger.error(error);
+  } catch ({ error, code, signal }) {
+    if (code || signal) {
+      logger.error(
+        `Build process exited due to ${code ? 'code ' + code : ''} ${
+          code && signal ? 'and' : ''
+        } ${signal ? 'signal ' + signal : ''}`
+      );
+    } else {
+      logger.error(`Error occurred while trying to run the build command`);
+      logger.error(error);
+    }
     return { success: false };
   } finally {
     if (childProcess) {
@@ -128,24 +137,30 @@ function runCliBuild(
       ['build', ...args],
       {
         cwd: pathResolve(workspaceRoot, projectRoot),
-        stdio: 'inherit',
+        stdio: ['pipe', 'inherit', 'ipc', 'inherit'],
         env: process.env,
       }
     );
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
-    childProcess.on('error', (err) => {
-      reject(err);
+    process.on('SIGTERM', (signal) => {
+      reject({ code: signalToCode(signal), signal });
+    });
+    process.on('SIGINT', (signal) => {
+      reject({ code: signalToCode(signal), signal });
     });
 
-    childProcess.on('exit', (code) => {
+    childProcess.on('error', (err) => {
+      reject({ error: err });
+    });
+
+    childProcess.on('exit', (code, signal) => {
       if (code === 0) {
-        resolve(code);
+        resolve({ code, signal });
       } else {
-        reject(code);
+        reject({ code, signal });
       }
     });
   });


### PR DESCRIPTION
When the `nx/next:build` executor is abruptly interrupted due to a signal such as `SIGKILL` we should surface these signals downstream so that they can be outputted to the console.

fixes: #22148
