### PR TITLE
docs(angular): update min nx version for angular 17.2.0 compat

### DIFF
--- a/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
+++ b/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
@@ -14,7 +14,7 @@ We provide a recommended version, and it is usually the latest minor version of 
 
 | Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                   |
 | --------------- | ------------------------------ | -------------------------------------- |
-| ~17.2.0         | **latest**                     | 18.1.0 <= latest                       |
+| ~17.2.0         | **latest**                     | 18.1.1 <= latest                       |
 | ~17.1.0         | **latest**                     | 17.3.0 <= latest                       |
 | ~17.0.0         | **latest**                     | 17.1.0 <= latest                       |
 | ~16.2.0         | **latest**                     | 16.7.0 <= latest                       |

--- a/docs/shared/packages/angular/angular-nx-version-matrix.md
+++ b/docs/shared/packages/angular/angular-nx-version-matrix.md
@@ -14,7 +14,7 @@ We provide a recommended version, and it is usually the latest minor version of 
 
 | Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                   |
 | --------------- | ------------------------------ | -------------------------------------- |
-| ~17.2.0         | **latest**                     | 18.1.0 <= latest                       |
+| ~17.2.0         | **latest**                     | 18.1.1 <= latest                       |
 | ~17.1.0         | **latest**                     | 17.3.0 <= latest                       |
 | ~17.0.0         | **latest**                     | 17.1.0 <= latest                       |
 | ~16.2.0         | **latest**                     | 16.7.0 <= latest                       |


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Nx & Angular version matrix docs has Nx 18.1.0 as the min version that supports Angular 17.2.0. That Nx version was released by mistake and was deprecated afterwards, so it can't be used.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Nx & Angular version matrix docs has Nx 18.1.1 as the min version that supports Angular 17.2.0.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
