### PR TITLE
fix(core): only start plugin workers once

### DIFF
--- a/packages/devkit/src/utils/convert-nx-executor.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.ts
@@ -8,7 +8,6 @@ const {
   Workspaces,
   readNxJsonFromDisk,
   retrieveProjectConfigurationsWithAngularProjects,
-  shutdownPluginWorkers,
 } = requireNx();
 
 /**
@@ -39,7 +38,6 @@ export function convertNxExecutor(executor: Executor) {
             (workspaces as any).readProjectsConfigurations({
               _includeProjectsFromAngularJson: true,
             });
-      shutdownPluginWorkers?.();
 
       const context: ExecutorContext = {
         root: builderContext.workspaceRoot,

--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -3,7 +3,7 @@ import { TempFs } from '../internal-testing-utils/temp-fs';
 import { withEnvironmentVariables } from '../internal-testing-utils/with-environment';
 import { retrieveProjectConfigurations } from '../project-graph/utils/retrieve-workspace-files';
 import { readNxJson } from './configuration';
-import { loadNxPluginsRemotely } from '../project-graph/plugins/internal-api';
+import { loadNxPluginsInIsolation } from '../project-graph/plugins/internal-api';
 
 describe('Workspaces', () => {
   let fs: TempFs;
@@ -38,7 +38,7 @@ describe('Workspaces', () => {
           NX_WORKSPACE_ROOT_PATH: fs.tempDir,
         },
         async () => {
-          const [plugins, cleanup] = await loadNxPluginsRemotely(
+          const [plugins, cleanup] = await loadNxPluginsInIsolation(
             readNxJson(fs.tempDir).plugins,
             fs.tempDir
           );

--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -3,7 +3,7 @@ import { TempFs } from '../internal-testing-utils/temp-fs';
 import { withEnvironmentVariables } from '../internal-testing-utils/with-environment';
 import { retrieveProjectConfigurations } from '../project-graph/utils/retrieve-workspace-files';
 import { readNxJson } from './configuration';
-import { shutdownPluginWorkers } from '../project-graph/plugins/plugin-pool';
+import { loadNxPluginsRemotely } from '../project-graph/plugins/internal-api';
 
 describe('Workspaces', () => {
   let fs: TempFs;
@@ -37,7 +37,19 @@ describe('Workspaces', () => {
         {
           NX_WORKSPACE_ROOT_PATH: fs.tempDir,
         },
-        () => retrieveProjectConfigurations(fs.tempDir, readNxJson(fs.tempDir))
+        async () => {
+          const [plugins, cleanup] = await loadNxPluginsRemotely(
+            readNxJson(fs.tempDir).plugins,
+            fs.tempDir
+          );
+          const res = retrieveProjectConfigurations(
+            plugins,
+            fs.tempDir,
+            readNxJson(fs.tempDir)
+          );
+          cleanup();
+          return res;
+        }
       );
       expect(projects['my-package']).toEqual({
         name: 'my-package',

--- a/packages/nx/src/daemon/server/handle-request-project-graph.ts
+++ b/packages/nx/src/daemon/server/handle-request-project-graph.ts
@@ -3,6 +3,8 @@ import { serializeResult } from '../socket-utils';
 import { serverLogger } from './logger';
 import { getCachedSerializedProjectGraphPromise } from './project-graph-incremental-recomputation';
 import { HandlerResult } from './server';
+import { getPlugins } from './plugins';
+import { readNxJson } from '../../config/nx-json';
 
 export async function handleRequestProjectGraph(): Promise<HandlerResult> {
   try {

--- a/packages/nx/src/daemon/server/plugins.ts
+++ b/packages/nx/src/daemon/server/plugins.ts
@@ -1,7 +1,7 @@
 import { readNxJson } from '../../config/nx-json';
 import {
   RemotePlugin,
-  loadNxPluginsRemotely,
+  loadNxPluginsInIsolation,
 } from '../../project-graph/plugins/internal-api';
 import { workspaceRoot } from '../../utils/workspace-root';
 
@@ -13,7 +13,7 @@ export async function getPlugins() {
     return loadedPlugins;
   }
   const pluginsConfiguration = readNxJson().plugins ?? [];
-  const [result, cleanupFn] = await loadNxPluginsRemotely(
+  const [result, cleanupFn] = await loadNxPluginsInIsolation(
     pluginsConfiguration,
     workspaceRoot
   );

--- a/packages/nx/src/daemon/server/plugins.ts
+++ b/packages/nx/src/daemon/server/plugins.ts
@@ -1,0 +1,26 @@
+import { readNxJson } from '../../config/nx-json';
+import {
+  RemotePlugin,
+  loadNxPluginsRemotely,
+} from '../../project-graph/plugins/internal-api';
+import { workspaceRoot } from '../../utils/workspace-root';
+
+let loadedPlugins: Promise<RemotePlugin[]>;
+let cleanup: () => void;
+
+export async function getPlugins() {
+  if (loadedPlugins) {
+    return loadedPlugins;
+  }
+  const pluginsConfiguration = readNxJson().plugins ?? [];
+  const [result, cleanupFn] = await loadNxPluginsRemotely(
+    pluginsConfiguration,
+    workspaceRoot
+  );
+  cleanup = cleanupFn;
+  return result;
+}
+
+export function cleanupPlugins() {
+  cleanup();
+}

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -4,21 +4,26 @@ import { serverLogger } from './logger';
 import { serializeResult } from '../socket-utils';
 import { deleteDaemonJsonProcessCache } from '../cache';
 import type { Watcher } from '../../native';
+import { cleanupPlugins } from './plugins';
 
 export const SERVER_INACTIVITY_TIMEOUT_MS = 10800000 as const; // 10800000 ms = 3 hours
 
 let watcherInstance: Watcher | undefined;
+
 export function storeWatcherInstance(instance: Watcher) {
   watcherInstance = instance;
 }
+
 export function getWatcherInstance() {
   return watcherInstance;
 }
 
 let outputWatcherInstance: Watcher | undefined;
+
 export function storeOutputWatcherInstance(instance: Watcher) {
   outputWatcherInstance = instance;
 }
+
 export function getOutputWatcherInstance() {
   return outputWatcherInstance;
 }
@@ -35,6 +40,7 @@ export async function handleServerProcessTermination({
   try {
     server.close();
     deleteDaemonJsonProcessCache();
+    cleanupPlugins();
 
     if (watcherInstance) {
       await watcherInstance.stop();

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -21,4 +21,3 @@ export {
   findProjectForPath,
 } from './project-graph/utils/find-project-for-path';
 export { registerTsProject } from './plugins/js/utils/register';
-export { shutdownPluginWorkers } from './project-graph/plugins/plugin-pool';

--- a/packages/nx/src/executors/utils/convert-nx-executor.ts
+++ b/packages/nx/src/executors/utils/convert-nx-executor.ts
@@ -7,7 +7,7 @@ import { readNxJson } from '../../config/nx-json';
 import { Executor, ExecutorContext } from '../../config/misc-interfaces';
 import { retrieveProjectConfigurations } from '../../project-graph/utils/retrieve-workspace-files';
 import { ProjectsConfigurations } from '../../config/workspace-json-project-json';
-import { loadNxPluginsRemotely } from '../../project-graph/plugins/internal-api';
+import { loadNxPluginsInIsolation } from '../../project-graph/plugins/internal-api';
 
 /**
  * Convert an Nx Executor into an Angular Devkit Builder
@@ -19,7 +19,7 @@ export function convertNxExecutor(executor: Executor) {
     const promise = async () => {
       const nxJsonConfiguration = readNxJson(builderContext.workspaceRoot);
 
-      const [plugins, cleanup] = await loadNxPluginsRemotely(
+      const [plugins, cleanup] = await loadNxPluginsInIsolation(
         nxJsonConfiguration.plugins,
         builderContext.workspaceRoot
       );

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -28,6 +28,7 @@ import { readJson, writeJson } from './json';
 import { readNxJson } from './nx-json';
 
 import type { Tree } from '../tree';
+import { NxPlugin } from '../../project-graph/plugins';
 
 export { readNxJson, updateNxJson } from './nx-json';
 
@@ -201,7 +202,7 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
   ];
   const projectGlobPatterns = configurationGlobs([
     ProjectJsonProjectsPlugin,
-    { createNodes: packageJsonWorkspacesCreateNodes },
+    { createNodes: packageJsonWorkspacesCreateNodes } as NxPlugin,
   ]);
   const globbedFiles = globWithWorkspaceContext(tree.root, projectGlobPatterns);
   const createdFiles = findCreatedProjectFiles(tree, patterns);

--- a/packages/nx/src/migrations/update-15-1-0/set-project-names.ts
+++ b/packages/nx/src/migrations/update-15-1-0/set-project-names.ts
@@ -4,16 +4,14 @@ import { dirname } from 'path';
 import { readJson, writeJson } from '../../generators/utils/json';
 import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 import { retrieveProjectConfigurationPaths } from '../../project-graph/utils/retrieve-workspace-files';
-import { loadNxPlugins } from '../../project-graph/plugins/internal-api';
-import { shutdownPluginWorkers } from '../../project-graph/plugins/plugin-pool';
+import { loadPlugins } from '../../project-graph/plugins/internal-api';
 
 export default async function (tree: Tree) {
   const nxJson = readNxJson(tree);
-  const projectFiles = await retrieveProjectConfigurationPaths(
+  const projectFiles = retrieveProjectConfigurationPaths(
     tree.root,
-    await loadNxPlugins(nxJson?.plugins)
+    (await loadPlugins(nxJson?.plugins ?? [], tree.root)).map((p) => p.plugin)
   );
-  await shutdownPluginWorkers();
   const projectJsons = projectFiles.filter((f) => f.endsWith('project.json'));
 
   for (let f of projectJsons) {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -1,4 +1,5 @@
 import { TempFs } from '../../../../internal-testing-utils/temp-fs';
+
 const tempFs = new TempFs('explicit-project-deps');
 
 import { ProjectGraphBuilder } from '../../../../project-graph/project-graph-builder';
@@ -9,7 +10,8 @@ import {
 } from '../../../../project-graph/utils/retrieve-workspace-files';
 import { CreateDependenciesContext } from '../../../../project-graph/plugins';
 import { setupWorkspaceContext } from '../../../../utils/workspace-context';
-import { shutdownPluginWorkers } from '../../../../project-graph/plugins/plugin-pool';
+import ProjectJsonProjectsPlugin from '../../../project-json/build-nodes/project-json';
+import { loadNxPluginsRemotely } from '../../../../project-graph/plugins/internal-api';
 
 // projectName => tsconfig import path
 const dependencyProjectNamesToImportPaths = {
@@ -21,10 +23,6 @@ const dependencyProjectNamesToImportPaths = {
 describe('explicit project dependencies', () => {
   beforeEach(() => {
     tempFs.reset();
-  });
-
-  afterEach(async () => {
-    await shutdownPluginWorkers();
   });
 
   describe('static imports, dynamic imports, and commonjs requires', () => {
@@ -568,10 +566,13 @@ async function createContext(
 
   setupWorkspaceContext(tempFs.tempDir);
 
+  const [plugins, cleanup] = await loadNxPluginsRemotely([], tempFs.tempDir);
   const { projects, projectRootMap } = await retrieveProjectConfigurations(
+    plugins,
     tempFs.tempDir,
     nxJson
   );
+  cleanup();
 
   const { fileMap } = await retrieveWorkspaceFiles(
     tempFs.tempDir,

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -11,7 +11,7 @@ import {
 import { CreateDependenciesContext } from '../../../../project-graph/plugins';
 import { setupWorkspaceContext } from '../../../../utils/workspace-context';
 import ProjectJsonProjectsPlugin from '../../../project-json/build-nodes/project-json';
-import { loadNxPluginsRemotely } from '../../../../project-graph/plugins/internal-api';
+import { loadNxPluginsInIsolation } from '../../../../project-graph/plugins/internal-api';
 
 // projectName => tsconfig import path
 const dependencyProjectNamesToImportPaths = {
@@ -566,7 +566,7 @@ async function createContext(
 
   setupWorkspaceContext(tempFs.tempDir);
 
-  const [plugins, cleanup] = await loadNxPluginsRemotely([], tempFs.tempDir);
+  const [plugins, cleanup] = await loadNxPluginsInIsolation([], tempFs.tempDir);
   const { projects, projectRootMap } = await retrieveProjectConfigurations(
     plugins,
     tempFs.tempDir,

--- a/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
+++ b/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
@@ -4,13 +4,14 @@ import { workspaceRoot } from '../../../utils/workspace-root';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { configurationGlobs } from '../../utils/retrieve-workspace-files';
-import { loadNxPlugins } from '../../plugins/internal-api';
+import { loadPlugins } from '../../plugins/internal-api';
 import { combineGlobPatterns } from '../../../utils/globs';
 
 export const getTouchedProjectsFromProjectGlobChanges: TouchedProjectLocator =
   async (touchedFiles, projectGraphNodes, nxJson): Promise<string[]> => {
+    const plugins = await loadPlugins(nxJson?.plugins ?? [], workspaceRoot);
     const globPattern = combineGlobPatterns(
-      configurationGlobs(await loadNxPlugins(nxJson?.plugins, workspaceRoot))
+      configurationGlobs(plugins.map((p) => p.plugin))
     );
 
     const touchedProjects = new Set<string>();

--- a/packages/nx/src/project-graph/plugins/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/plugin-pool.ts
@@ -9,19 +9,15 @@ import { PluginConfiguration } from '../../config/nx-json';
 import { RemotePlugin, nxPluginCache } from './internal-api';
 import { PluginWorkerResult, consumeMessage, createMessage } from './messaging';
 
-const pool: Set<ChildProcess> = new Set();
+const cleanupFunctions = new Set<() => void>();
 
-const pidMap = new Map<number, { name: string; pending: Set<string> }>();
+const pluginNames = new Map<ChildProcess, string>();
 
-interface PromiseBankEntry {
+interface PendingPromise {
   promise: Promise<unknown>;
   resolver: (result: any) => void;
   rejector: (err: any) => void;
 }
-
-// transaction id (tx) -> Promise, Resolver, Rejecter
-// Makes sure that we can resolve the correct promise when the worker sends back the result
-const promiseBank = new Map<string, PromiseBankEntry>();
 
 export function loadRemoteNxPlugin(plugin: PluginConfiguration, root: string) {
   // this should only really be true when running unit tests within
@@ -47,54 +43,64 @@ export function loadRemoteNxPlugin(plugin: PluginConfiguration, root: string) {
     ],
   });
   worker.send(createMessage({ type: 'load', payload: { plugin, root } }));
-  pool.add(worker);
 
   // logger.verbose(`[plugin-worker] started worker: ${worker.pid}`);
 
+  const pendingPromises = new Map<string, PendingPromise>();
+
+  const exitHandler = createWorkerExitHandler(worker, pendingPromises);
+
+  const cleanupFunction = () => {
+    worker.off('exit', exitHandler);
+    shutdownPluginWorker(worker, pendingPromises);
+  };
+
+  cleanupFunctions.add(cleanupFunction);
+
   return [
     new Promise<RemotePlugin>((res, rej) => {
-      worker.on('message', createWorkerHandler(worker, res, rej));
-      worker.on('exit', createWorkerExitHandler(worker));
+      worker.on(
+        'message',
+        createWorkerHandler(worker, pendingPromises, res, rej)
+      );
+      worker.on('exit', exitHandler);
     }),
     () => {
-      shutdownPluginWorkers();
+      cleanupFunction();
+      cleanupFunctions.delete(cleanupFunction);
     },
   ] as const;
 }
 
-let pluginWorkersShutdown = false;
-
-async function shutdownPluginWorkers() {
+async function shutdownPluginWorker(
+  worker: ChildProcess,
+  pendingPromises: Map<string, PendingPromise>
+) {
   // Clears the plugin cache so no refs to the workers are held
   nxPluginCache.clear();
 
-  // Marks the workers as shutdown so that we don't report unexpected exits
-  pluginWorkersShutdown = true;
-
   // logger.verbose(`[plugin-pool] starting worker shutdown`);
 
-  const pending = getPendingPromises(pool, pidMap);
+  // Other things may be interacting with the worker.
+  // Wait for all pending promises to be done before killing the worker
+  await Promise.all(
+    Array.from(pendingPromises.values()).map(({ promise }) => promise)
+  );
 
-  await Promise.all(pending.map((p) => p.promise));
-
-  // logger.verbose(`[plugin-pool] all pending operations completed`);
-
-  for (const childProcess of pool) {
-    childProcess.kill('SIGINT');
-  }
-
-  // logger.verbose(`[plugin-pool] all workers killed`);
+  worker.kill('SIGINT');
 }
 
 /**
  * Creates a message handler for the given worker.
  * @param worker Instance of plugin-worker
+ * @param pending Set of pending promises
  * @param onload Resolver for RemotePlugin promise
  * @param onloadError Rejecter for RemotePlugin promise
  * @returns Function to handle messages from the worker
  */
 function createWorkerHandler(
   worker: ChildProcess,
+  pending: Map<string, PendingPromise>,
   onload: (plugin: RemotePlugin) => void,
   onloadError: (err?: unknown) => void
 ) {
@@ -112,8 +118,7 @@ function createWorkerHandler(
         if (result.success) {
           const { name, createNodesPattern } = result;
           pluginName = name;
-          const pending = new Set<string>();
-          pidMap.set(worker.pid, { name, pending });
+          pluginNames.set(worker, pluginName);
           onload({
             name,
             createNodes: createNodesPattern
@@ -166,80 +171,59 @@ function createWorkerHandler(
         }
       },
       createDependenciesResult: ({ tx, ...result }) => {
-        const { resolver, rejector } = promiseBank.get(tx);
+        const { resolver, rejector } = pending.get(tx);
         if (result.success) {
           resolver(result.dependencies);
         } else if (result.success === false) {
           rejector(result.error);
         }
-        pidMap.get(worker.pid)?.pending.delete(tx);
-        promiseBank.delete(tx);
       },
       createNodesResult: ({ tx, ...result }) => {
-        const { resolver, rejector } = promiseBank.get(tx);
+        const { resolver, rejector } = pending.get(tx);
         if (result.success) {
           resolver(result.result);
         } else if (result.success === false) {
           rejector(result.error);
         }
-        pidMap.get(worker.pid)?.pending.delete(tx);
-        promiseBank.delete(tx);
       },
       processProjectGraphResult: ({ tx, ...result }) => {
-        const { resolver, rejector } = promiseBank.get(tx);
+        const { resolver, rejector } = pending.get(tx);
         if (result.success) {
           resolver(result.graph);
         } else if (result.success === false) {
           rejector(result.error);
         }
-        pidMap.get(worker.pid)?.pending.delete(tx);
-        promiseBank.delete(tx);
       },
     });
   };
 }
 
-function createWorkerExitHandler(worker: ChildProcess) {
+function createWorkerExitHandler(
+  worker: ChildProcess,
+  pendingPromises: Map<string, PendingPromise>
+) {
   return () => {
-    if (!pluginWorkersShutdown) {
-      pidMap.get(worker.pid)?.pending.forEach((tx) => {
-        const { rejector } = promiseBank.get(tx);
-        rejector(
-          new Error(
-            `Plugin worker ${
-              pidMap.get(worker.pid).name ?? worker.pid
-            } exited unexpectedly with code ${worker.exitCode}`
-          )
-        );
-      });
-      shutdownPluginWorkers();
+    for (const [_, pendingPromise] of pendingPromises) {
+      pendingPromise.rejector(
+        new Error(
+          `Plugin worker ${
+            pluginNames.get(worker) ?? worker.pid
+          } exited unexpectedly with code ${worker.exitCode}`
+        )
+      );
     }
   };
 }
 
 process.on('exit', () => {
-  if (pool.size) {
-    shutdownPluginWorkers();
+  for (const fn of cleanupFunctions) {
+    fn();
   }
 });
 
-function getPendingPromises(
-  pool: Set<ChildProcess>,
-  pidMap: Map<number, { name: string; pending: Set<string> }>
-) {
-  const pendingTxs: Array<PromiseBankEntry> = [];
-  for (const p of pool) {
-    const { pending } = pidMap.get(p.pid) ?? { pending: new Set() };
-    for (const tx of pending) {
-      pendingTxs.push(promiseBank.get(tx));
-    }
-  }
-  return pendingTxs;
-}
-
 function registerPendingPromise(
   tx: string,
-  pending: Set<string>,
+  pending: Map<string, PendingPromise>,
   callback: () => void
 ): Promise<any> {
   let resolver, rejector;
@@ -249,18 +233,15 @@ function registerPendingPromise(
     rejector = rej;
 
     callback();
-  }).then((val) => {
-    // Remove the promise from the pending set
+  }).finally(() => {
     pending.delete(tx);
-    // Return the original value
-    return val;
   });
 
-  pending.add(tx);
-  promiseBank.set(tx, {
+  pending.set(tx, {
     promise,
     resolver,
     rejector,
   });
+
   return promise;
 }

--- a/packages/nx/src/project-graph/plugins/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/plugin-worker.ts
@@ -1,11 +1,8 @@
 import { consumeMessage, PluginWorkerMessage } from './messaging';
-import {
-  CreateNodesResultWithContext,
-  loadPlugin,
-  NormalizedPlugin,
-} from './internal-api';
+import { CreateNodesResultWithContext, NormalizedPlugin } from './internal-api';
 import { CreateNodesContext } from './public-api';
 import { CreateNodesError } from './utils';
+import { loadPlugin } from './worker-api';
 
 global.NX_GRAPH_CREATION = true;
 

--- a/packages/nx/src/project-graph/plugins/worker-api.ts
+++ b/packages/nx/src/project-graph/plugins/worker-api.ts
@@ -1,7 +1,6 @@
 // This file contains methods and utilities that should **only** be used by the plugin worker.
 
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
-import { PluginConfiguration } from '../../config/nx-json';
 
 import { join } from 'node:path/posix';
 import { getNxRequirePaths } from '../../utils/installation-directory';
@@ -10,7 +9,6 @@ import {
   readModulePackageJsonWithoutFallbacks,
 } from '../../utils/package-json';
 import { readJsonFile } from '../../utils/fileutils';
-import path = require('node:path/posix');
 import { workspaceRoot } from '../../utils/workspace-root';
 import { existsSync } from 'node:fs';
 import { readTsConfig } from '../../utils/typescript';
@@ -27,42 +25,8 @@ import { logger } from '../../utils/logger';
 
 import type * as ts from 'typescript';
 import { extname } from 'node:path';
-import { normalizeNxPlugin } from './utils';
 import { NxPlugin } from './public-api';
-
-export type LoadedNxPlugin = {
-  plugin: NxPlugin;
-  options?: unknown;
-};
-
-export async function loadNxPluginAsync(
-  pluginConfiguration: PluginConfiguration,
-  paths: string[],
-  projects: Record<string, ProjectConfiguration>,
-  root: string
-): Promise<LoadedNxPlugin> {
-  const { plugin: moduleName, options } =
-    typeof pluginConfiguration === 'object'
-      ? pluginConfiguration
-      : { plugin: pluginConfiguration, options: undefined };
-
-  performance.mark(`Load Nx Plugin: ${moduleName} - start`);
-  let { pluginPath, name } = await getPluginPathAndName(
-    moduleName,
-    paths,
-    projects,
-    root
-  );
-  const plugin = normalizeNxPlugin(await importPluginModule(pluginPath));
-  plugin.name ??= name;
-  performance.mark(`Load Nx Plugin: ${moduleName} - end`);
-  performance.measure(
-    `Load Nx Plugin: ${moduleName}`,
-    `Load Nx Plugin: ${moduleName} - start`,
-    `Load Nx Plugin: ${moduleName} - end`
-  );
-  return { plugin, options };
-}
+import path = require('node:path/posix');
 
 export function readPluginPackageJson(
   pluginName: string,
@@ -250,15 +214,4 @@ export function getPluginPathAndName(
       ? readJsonFile(packageJsonPath) // read name from package.json
       : { name: moduleName };
   return { pluginPath, name };
-}
-
-async function importPluginModule(pluginPath: string): Promise<NxPlugin> {
-  const m = await import(pluginPath);
-  if (
-    m.default &&
-    ('createNodes' in m.default || 'createDependencies' in m.default)
-  ) {
-    return m.default;
-  }
-  return m;
 }

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -17,6 +17,7 @@ import {
   retrieveWorkspaceFiles,
 } from './utils/retrieve-workspace-files';
 import { readNxJson } from '../config/nx-json';
+import { loadNxPluginsRemotely, RemotePlugin } from './plugins/internal-api';
 
 /**
  * Synchronously reads the latest cached copy of the workspace's ProjectGraph.
@@ -80,9 +81,11 @@ export async function buildProjectGraphAndSourceMapsWithoutDaemon() {
   global.NX_GRAPH_CREATION = true;
   const nxJson = readNxJson();
 
+  const [plugins, cleanup] = await loadNxPluginsRemotely(nxJson.plugins);
+
   performance.mark('retrieve-project-configurations:start');
   const { projects, externalNodes, sourceMaps, projectRootMap } =
-    await retrieveProjectConfigurations(workspaceRoot, nxJson);
+    await retrieveProjectConfigurations(plugins, workspaceRoot, nxJson);
   performance.mark('retrieve-project-configurations:end');
 
   performance.mark('retrieve-workspace-files:start');
@@ -100,11 +103,13 @@ export async function buildProjectGraphAndSourceMapsWithoutDaemon() {
       allWorkspaceFiles,
       rustReferences,
       cacheEnabled ? readFileMapCache() : null,
-      cacheEnabled
+      cacheEnabled,
+      plugins
     )
   ).projectGraph;
   performance.mark('build-project-graph-using-project-file-map:end');
   delete global.NX_GRAPH_CREATION;
+  cleanup();
   return { projectGraph, sourceMaps };
 }
 

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -17,7 +17,7 @@ import {
   retrieveWorkspaceFiles,
 } from './utils/retrieve-workspace-files';
 import { readNxJson } from '../config/nx-json';
-import { loadNxPluginsRemotely, RemotePlugin } from './plugins/internal-api';
+import { loadNxPluginsInIsolation, RemotePlugin } from './plugins/internal-api';
 
 /**
  * Synchronously reads the latest cached copy of the workspace's ProjectGraph.
@@ -81,7 +81,7 @@ export async function buildProjectGraphAndSourceMapsWithoutDaemon() {
   global.NX_GRAPH_CREATION = true;
   const nxJson = readNxJson();
 
-  const [plugins, cleanup] = await loadNxPluginsRemotely(nxJson.plugins);
+  const [plugins, cleanup] = await loadNxPluginsInIsolation(nxJson.plugins);
 
   performance.mark('retrieve-project-configurations:start');
   const { projects, externalNodes, sourceMaps, projectRootMap } =

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -19,7 +19,6 @@ import {
   CreateNodesResultWithContext,
   RemotePlugin,
 } from '../plugins/internal-api';
-import { shutdownPluginWorkers } from '../plugins/plugin-pool';
 
 export type SourceInformation = [file: string, plugin: string];
 export type ConfigurationSourceMaps = Record<
@@ -230,11 +229,7 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
     let r = createNodes(matchedFiles, {
       nxJsonConfiguration: nxJson,
       workspaceRoot: root,
-    }).catch((e) =>
-      shutdownPluginWorkers().then(() => {
-        throw e;
-      })
-    );
+    });
 
     results.push(r);
   }

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -25,9 +25,17 @@ describe('retrieveProjectConfigurationPaths', () => {
       })
     );
 
-    const configPaths = await retrieveProjectConfigurationPaths(fs.tempDir, [
+    const configPaths = retrieveProjectConfigurationPaths(fs.tempDir, [
       {
-        createNodes: ['{project.json,**/project.json}', () => {}],
+        name: 'test',
+        createNodes: [
+          '{project.json,**/project.json}',
+          () => {
+            return {
+              projects: {},
+            };
+          },
+        ],
       },
     ]);
 

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -10,7 +10,10 @@ import {
   buildProjectsConfigurationsFromProjectPathsAndPlugins,
   ConfigurationSourceMaps,
 } from './project-configuration-utils';
-import { RemotePlugin, loadNxPluginsRemotely } from '../plugins/internal-api';
+import {
+  RemotePlugin,
+  loadNxPluginsInIsolation,
+} from '../plugins/internal-api';
 import {
   getNxWorkspaceFilesFromContext,
   globWithWorkspaceContext,
@@ -91,7 +94,7 @@ export async function retrieveProjectConfigurationsWithAngularProjects(
     pluginsToLoad.push(join(__dirname, '../../adapter/angular-json'));
   }
 
-  const [plugins, cleanup] = await loadNxPluginsRemotely(
+  const [plugins, cleanup] = await loadNxPluginsInIsolation(
     nxJson?.plugins ?? [],
     workspaceRoot
   );
@@ -146,7 +149,7 @@ export async function retrieveProjectConfigurationsWithoutPluginInference(
   root: string
 ): Promise<Record<string, ProjectConfiguration>> {
   const nxJson = readNxJson(root);
-  const [plugins, cleanup] = await loadNxPluginsRemotely([]); // only load default plugins
+  const [plugins, cleanup] = await loadNxPluginsInIsolation([]); // only load default plugins
   const projectGlobPatterns = retrieveProjectConfigurationPaths(root, plugins);
   const cacheKey = root + ',' + projectGlobPatterns.join(',');
 

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -10,14 +10,14 @@ import {
   buildProjectsConfigurationsFromProjectPathsAndPlugins,
   ConfigurationSourceMaps,
 } from './project-configuration-utils';
-import { RemotePlugin, loadNxPlugins } from '../plugins/internal-api';
+import { RemotePlugin, loadNxPluginsRemotely } from '../plugins/internal-api';
 import {
   getNxWorkspaceFilesFromContext,
   globWithWorkspaceContext,
 } from '../../utils/workspace-context';
 import { buildAllWorkspaceFiles } from './build-all-workspace-files';
 import { join } from 'path';
-import { shutdownPluginWorkers } from '../plugins/plugin-pool';
+import { NxPlugin } from '../plugins';
 
 /**
  * Walks the workspace directory to create the `projectFileMap`, `ProjectConfigurations` and `allWorkspaceFiles`
@@ -60,23 +60,17 @@ export async function retrieveWorkspaceFiles(
 
 /**
  * Walk through the workspace and return `ProjectConfigurations`. Only use this if the projectFileMap is not needed.
- *
- * @param workspaceRoot
- * @param nxJson
  */
 export async function retrieveProjectConfigurations(
+  plugins: RemotePlugin[],
   workspaceRoot: string,
   nxJson: NxJsonConfiguration
 ): Promise<RetrievedGraphNodes> {
-  const plugins = await loadNxPlugins(nxJson?.plugins ?? [], workspaceRoot);
   const projects = await _retrieveProjectConfigurations(
     workspaceRoot,
     nxJson,
     plugins
   );
-  if (!global.NX_GRAPH_CREATION) {
-    await shutdownPluginWorkers();
-  }
   return projects;
 }
 
@@ -97,9 +91,18 @@ export async function retrieveProjectConfigurationsWithAngularProjects(
     pluginsToLoad.push(join(__dirname, '../../adapter/angular-json'));
   }
 
-  const plugins = await loadNxPlugins(nxJson?.plugins ?? [], workspaceRoot);
+  const [plugins, cleanup] = await loadNxPluginsRemotely(
+    nxJson?.plugins ?? [],
+    workspaceRoot
+  );
 
-  return _retrieveProjectConfigurations(workspaceRoot, nxJson, plugins);
+  const res = _retrieveProjectConfigurations(
+    workspaceRoot,
+    nxJson,
+    await plugins
+  );
+  cleanup();
+  return res;
 }
 
 export type RetrievedGraphNodes = {
@@ -127,7 +130,7 @@ function _retrieveProjectConfigurations(
 
 export function retrieveProjectConfigurationPaths(
   root: string,
-  plugins: PluginGlobsOnly
+  plugins: NxPlugin[]
 ): string[] {
   const projectGlobPatterns = configurationGlobs(plugins);
   return globWithWorkspaceContext(root, projectGlobPatterns);
@@ -143,7 +146,7 @@ export async function retrieveProjectConfigurationsWithoutPluginInference(
   root: string
 ): Promise<Record<string, ProjectConfiguration>> {
   const nxJson = readNxJson(root);
-  const plugins = await loadNxPlugins([]); // only load default plugins
+  const [plugins, cleanup] = await loadNxPluginsRemotely([]); // only load default plugins
   const projectGlobPatterns = retrieveProjectConfigurationPaths(root, plugins);
   const cacheKey = root + ',' + projectGlobPatterns.join(',');
 
@@ -160,6 +163,8 @@ export async function retrieveProjectConfigurationsWithoutPluginInference(
   );
 
   projectsWithoutPluginCache.set(cacheKey, projects);
+
+  cleanup();
 
   return projects;
 }
@@ -195,12 +200,10 @@ export async function createProjectConfigurations(
   };
 }
 
-type PluginGlobsOnly = Array<{ createNodes?: readonly [string, ...unknown[]] }>;
-
-export function configurationGlobs(plugins: PluginGlobsOnly): string[] {
+export function configurationGlobs(plugins: Array<NxPlugin>): string[] {
   const globPatterns = [];
   for (const plugin of plugins) {
-    if (plugin.createNodes) {
+    if ('createNodes' in plugin && plugin.createNodes) {
       globPatterns.push(plugin.createNodes[0]);
     }
   }

--- a/packages/nx/src/utils/plugins/plugin-capabilities.ts
+++ b/packages/nx/src/utils/plugins/plugin-capabilities.ts
@@ -2,9 +2,8 @@ import * as chalk from 'chalk';
 import { dirname, join } from 'path';
 
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
-import { readPluginPackageJson } from '../../project-graph/plugins';
-import { RemotePlugin } from '../../project-graph/plugins/internal-api';
-import { loadRemoteNxPlugin } from '../../project-graph/plugins/plugin-pool';
+import { NxPlugin, readPluginPackageJson } from '../../project-graph/plugins';
+import { loadPlugin } from '../../project-graph/plugins/internal-api';
 import { readJsonFile } from '../fileutils';
 import { getNxRequirePaths } from '../installation-directory';
 import { output } from '../output';
@@ -46,7 +45,7 @@ export async function getPluginCapabilities(
         getNxRequirePaths(workspaceRoot)
       );
     const pluginModule = includeRuntimeCapabilities
-      ? await tryGetModule(packageJson, workspaceRoot, projects)
+      ? await tryGetModule(packageJson, workspaceRoot)
       : ({} as Record<string, unknown>);
     return {
       name: pluginName,
@@ -99,19 +98,18 @@ export async function getPluginCapabilities(
 
 async function tryGetModule(
   packageJson: PackageJson,
-  workspaceRoot: string,
-  projects: Record<string, ProjectConfiguration>
-): Promise<RemotePlugin | null> {
+  workspaceRoot: string
+): Promise<NxPlugin | null> {
   try {
     return packageJson.generators ??
       packageJson.executors ??
       packageJson['nx-migrations'] ??
       packageJson['schematics'] ??
       packageJson['builders']
-      ? await loadRemoteNxPlugin(packageJson.name, workspaceRoot)
+      ? (await loadPlugin(packageJson.name, workspaceRoot)).plugin
       : ({
           name: packageJson.name,
-        } as RemotePlugin);
+        } as NxPlugin);
   } catch {
     return null;
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In the daemon, plugin workers will be loaded and shutdown concurrently by different processes. This causes requests to be unanswered and for the main process to hang.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The main Nx process does not hang and the requests are fulfilled. The daemon starts the plugin workers once and uses them until it shuts down.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
