### PR TITLE
fix(angular): Module federation with Crystal enabled.

### DIFF
--- a/packages/angular/src/utils/mf/with-module-federation-ssr.ts
+++ b/packages/angular/src/utils/mf/with-module-federation-ssr.ts
@@ -4,6 +4,9 @@ import { getModuleFederationConfig } from './utils';
 export async function withModuleFederationForSSR(
   options: ModuleFederationConfig
 ) {
+  if (global.NX_GRAPH_CREATION) {
+    return (config) => config;
+  }
   const { sharedLibraries, sharedDependencies, mappedRemotes } =
     await getModuleFederationConfig(options, {
       isServer: true,

--- a/packages/angular/src/utils/mf/with-module-federation.ts
+++ b/packages/angular/src/utils/mf/with-module-federation.ts
@@ -3,6 +3,9 @@ import { getModuleFederationConfig } from './utils';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
 export async function withModuleFederation(options: ModuleFederationConfig) {
+  if (global.NX_GRAPH_CREATION) {
+    return (config) => config;
+  }
   const { sharedLibraries, sharedDependencies, mappedRemotes } =
     await getModuleFederationConfig(options);
 


### PR DESCRIPTION
Ensures that `withModuleFederation` and `withModuleFederationSSR` does not try to read from the project graph while it's being created.

