### PR TITLE
feat(remix): use Remix CLI directly with Remix Crystal Plugin

### DIFF
--- a/packages/remix/src/generators/init/init.spec.ts
+++ b/packages/remix/src/generators/init/init.spec.ts
@@ -36,7 +36,7 @@ describe('Remix Init Generator', () => {
           {
             "options": {
               "buildTargetName": "build",
-              "serveTargetName": "serve",
+              "devTargetName": "dev",
               "startTargetName": "start",
               "typecheckTargetName": "typecheck",
             },

--- a/packages/remix/src/generators/init/init.ts
+++ b/packages/remix/src/generators/init/init.ts
@@ -30,7 +30,7 @@ function addPlugin(tree) {
     plugin: '@nx/remix/plugin',
     options: {
       buildTargetName: 'build',
-      serveTargetName: 'serve',
+      devTargetName: 'dev',
       startTargetName: 'start',
       typecheckTargetName: 'typecheck',
     },

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -8,30 +8,30 @@ exports[`@nx/remix/plugin non-root project should create nodes 1`] = `
       "targets": {
         "build": {
           "cache": true,
+          "command": "remix build",
           "dependsOn": [
             "^build",
           ],
-          "executor": "@nx/remix:build",
           "inputs": [
             "production",
             "^production",
           ],
           "options": {
-            "outputPath": "my-app",
+            "cwd": "my-app",
           },
           "outputs": [
             "{workspaceRoot}/my-app/build",
             "{workspaceRoot}/my-app/public/build",
           ],
         },
-        "serve": {
-          "executor": "@nx/remix:serve",
+        "dev": {
+          "command": "remix dev --manual",
           "options": {
-            "command": "npx remix-serve build/index.js",
+            "cwd": "my-app",
           },
         },
         "start": {
-          "command": "npx remix-serve build/index.js",
+          "command": "remix-serve build/index.js",
           "dependsOn": [
             "build",
           ],
@@ -64,30 +64,30 @@ exports[`@nx/remix/plugin root project should create nodes 1`] = `
       "targets": {
         "build": {
           "cache": true,
+          "command": "remix build",
           "dependsOn": [
             "^build",
           ],
-          "executor": "@nx/remix:build",
           "inputs": [
             "production",
             "^production",
           ],
           "options": {
-            "outputPath": ".",
+            "cwd": ".",
           },
           "outputs": [
             "{workspaceRoot}/build",
             "{workspaceRoot}/public/build",
           ],
         },
-        "serve": {
-          "executor": "@nx/remix:serve",
+        "dev": {
+          "command": "remix dev --manual",
           "options": {
-            "command": "npx remix-serve build/index.js",
+            "cwd": ".",
           },
         },
         "start": {
-          "command": "npx remix-serve build/index.js",
+          "command": "remix-serve build/index.js",
           "dependsOn": [
             "build",
           ],

--- a/packages/remix/src/plugins/plugin.spec.ts
+++ b/packages/remix/src/plugins/plugin.spec.ts
@@ -18,8 +18,8 @@ describe('@nx/remix/plugin', () => {
               cache: false,
               inputs: ['foo', '^foo'],
             },
-            serve: {
-              command: 'npm run serve',
+            dev: {
+              command: 'npm run dev',
             },
             start: {
               command: 'npm run start',
@@ -65,7 +65,7 @@ module.exports = {
         'remix.config.cjs',
         {
           buildTargetName: 'build',
-          serveTargetName: 'serve',
+          devTargetName: 'dev',
           startTargetName: 'start',
           typecheckTargetName: 'typecheck',
         },
@@ -123,7 +123,7 @@ module.exports = {
         'my-app/remix.config.cjs',
         {
           buildTargetName: 'build',
-          serveTargetName: 'serve',
+          devTargetName: 'dev',
           startTargetName: 'start',
           typecheckTargetName: 'tsc',
         },

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -44,7 +44,7 @@ export const createDependencies: CreateDependencies = () => {
 
 export interface RemixPluginOptions {
   buildTargetName?: string;
-  serveTargetName?: string;
+  devTargetName?: string;
   startTargetName?: string;
   typecheckTargetName?: string;
 }
@@ -58,7 +58,9 @@ export const createNodes: CreateNodes<RemixPluginOptions> = [
     const siblingFiles = readdirSync(fullyQualifiedProjectRoot);
     if (
       !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
+      !siblingFiles.includes('project.json') &&
+      !siblingFiles.includes('vite.config.ts') &&
+      !siblingFiles.includes('vite.config.js')
     ) {
       return {};
     }
@@ -110,7 +112,7 @@ async function buildRemixTargets(
     assetsBuildDirectory,
     namedInputs
   );
-  targets[options.serveTargetName] = serveTarget(serverBuildPath);
+  targets[options.devTargetName] = devTarget(serverBuildPath, projectRoot);
   targets[options.startTargetName] = startTarget(
     projectRoot,
     serverBuildPath,
@@ -151,19 +153,18 @@ function buildTarget(
         : ['default', '^default']),
     ],
     outputs: [serverBuildOutputPath, assetsBuildOutputPath],
-    executor: '@nx/remix:build',
-    options: {
-      outputPath: projectRoot,
-    },
+    command: 'remix build',
+    options: { cwd: projectRoot },
   };
 }
 
-function serveTarget(serverBuildPath: string): TargetConfiguration {
+function devTarget(
+  serverBuildPath: string,
+  projectRoot: string
+): TargetConfiguration {
   return {
-    executor: '@nx/remix:serve',
-    options: {
-      command: `npx remix-serve ${serverBuildPath}`,
-    },
+    command: 'remix dev --manual',
+    options: { cwd: projectRoot },
   };
 }
 
@@ -174,7 +175,7 @@ function startTarget(
 ): TargetConfiguration {
   return {
     dependsOn: [buildTargetName],
-    command: `npx remix-serve ${serverBuildPath}`,
+    command: `remix-serve ${serverBuildPath}`,
     options: {
       cwd: projectRoot,
     },
@@ -224,7 +225,7 @@ async function getBuildPaths(
 function normalizeOptions(options: RemixPluginOptions) {
   options ??= {};
   options.buildTargetName ??= 'build';
-  options.serveTargetName ??= 'serve';
+  options.devTargetName ??= 'dev';
   options.startTargetName ??= 'start';
   options.typecheckTargetName ??= 'typecheck';
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Due to a, now resolved, issue, invoking Remix CLI via `run-commands` was not possible therefore the Remix Crystal Plugin was using the `@nx/remix` executors under the hood for `build` and `serve`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Invoke the Remix CLI directly and align with the npm commands created and used by remix applications (`build` and `dev`).

