### PR TITLE
docs(core): various references to Nx Cloud

### DIFF
--- a/docs/shared/features/cache-task-results.md
+++ b/docs/shared/features/cache-task-results.md
@@ -123,7 +123,7 @@ The cache is stored in `.nx/cache` by default. You can also [change where the ca
 
 ## Enable Remote Caching
 
-You can enable remote caching by connecting to [Nx Cloud](/ci/features/remote-cache). To connect Nx to Nx Cloud run the following command:
+You can enable remote caching (Nx Replay) by connecting to [Nx Cloud](/ci/features/remote-cache). To connect Nx to Nx Cloud run the following command:
 
 ```shell
 npx nx connect

--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -40,4 +40,4 @@ Nx will set the following environment variables so they can be accessible within
 | NX_DRY_RUN                   | boolean | Set to `true` during dry runs of generators. Use this to avoid side effects during generators.                        |
 | NX_INTERACTIVE               | boolean | Set to `false` when running generators with `--interactive=false`. Use this to prevent prompting during generators    |
 
-When using remote caching, [Nx Cloud Environment Variables](/ci/reference/env-vars) are also available.
+[Nx Cloud Environment Variables](/ci/reference/env-vars) are listed on a dedicated page.

--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -461,3 +461,15 @@ pass `--buildable=true` when creating new libraries with the `@nx/js` plugin.
 ## Extends
 
 Some presets use the `extends` property to hide some default options in a separate json file. The json file specified in the `extends` property is located in your `node_modules` folder. The Nx preset files are specified in [the `nx` package](https://github.com/nrwl/nx/tree/master/packages/nx/presets).
+
+## Nx Cloud
+
+There are also options for [Nx Cloud](https://nx.app) that are set in the `nx.json` file. For instance, you authenticate with the Nx Cloud service using an `nxCloudAccessToken` like this:
+
+```json {% fileName="nx.json" %}
+{
+  "nxCloudAccessToken": "SOMETOKEN"
+}
+```
+
+For more details on configuring Nx Cloud, see the [Nx Cloud Configuration Options page](/ci/reference/config).


### PR DESCRIPTION
Adds references to the CI docs in:
- Cache task results
- Environment variables reference
- Nx.json reference