### PR TITLE
chore(core): fix formatting in default base migration

### DIFF
--- a/packages/nx/src/migrations/update-17-2-0/move-default-base.spec.ts
+++ b/packages/nx/src/migrations/update-17-2-0/move-default-base.spec.ts
@@ -11,20 +11,20 @@ describe('update-17.1.0 migration', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
   });
 
-  it("shouldn't do anything if affected.defaultBase is not set", () => {
+  it("shouldn't do anything if affected.defaultBase is not set", async () => {
     tree.write('nx.json', JSON.stringify({}));
-    update(tree);
+    await update(tree);
     expect(readNxJson(tree)).toEqual({});
   });
 
-  it("shouldn't remove affected if other keys present", () => {
+  it("shouldn't remove affected if other keys present", async () => {
     updateNxJson(tree, {
       affected: {
         defaultBase: 'master',
         otherKey: 'otherValue',
       } as any,
     });
-    update(tree);
+    await update(tree);
     expect(readNxJson(tree)).toEqual({
       affected: {
         otherKey: 'otherValue',
@@ -33,13 +33,13 @@ describe('update-17.1.0 migration', () => {
     });
   });
 
-  it('should remove affected if no other keys present', () => {
+  it('should remove affected if no other keys present', async () => {
     updateNxJson(tree, {
       affected: {
         defaultBase: 'master',
       } as any,
     });
-    update(tree);
+    await update(tree);
     expect(readNxJson(tree)).toEqual({
       defaultBase: 'master',
     });

--- a/packages/nx/src/migrations/update-17-2-0/move-default-base.ts
+++ b/packages/nx/src/migrations/update-17-2-0/move-default-base.ts
@@ -7,7 +7,7 @@ import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/inte
 /**
  * Updates existing workspaces to move nx.json's affected.defaultBase to nx.json's base.
  */
-export default function update(host: Tree) {
+export default async function update(host: Tree) {
   const nxJson = readNxJson(host) as NxJsonConfiguration & {
     affected: { defaultBase?: string };
   };
@@ -19,5 +19,5 @@ export default function update(host: Tree) {
     }
     updateNxJson(host, nxJson);
   }
-  formatChangedFilesWithPrettierIfAvailable(host);
+  await formatChangedFilesWithPrettierIfAvailable(host);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx.json` was unformatted after this migration

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx.json` is formatted in this migration

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
