### PR TITLE
fix(react): pass correct argument to rspack configuration generator

### DIFF
--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -200,7 +200,7 @@ export async function applicationGeneratorInternal(
       tsConfig: joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
       target: 'web',
       newProject: true,
-      uiFramework: 'react',
+      framework: 'react',
     });
     tasks.push(rspackTask);
   }
@@ -295,8 +295,8 @@ export async function applicationGeneratorInternal(
     host.write(
       joinPathFragments(options.appProjectRoot, 'rspack.config.js'),
       stripIndents`
-        const { composePlugins, withNx, withWeb } = require('@nx/rspack');
-        module.exports = composePlugins(withNx(), withWeb(), (config) => {
+        const { composePlugins, withNx, withReact } = require('@nx/rspack');
+        module.exports = composePlugins(withNx(), withReact(), (config) => {
           config.module.rules.push({
             test: /\\.[jt]sx$/i,
             use: [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Calling incorrect property `uiFramework` when setting up `rspack` for `react` appliaction

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Calling correct property `framework` when setting up `rspack` for `react` application
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
