### PR TITLE
fix(core): properly cleanup when the project-graph creation fails

### DIFF
--- a/packages/nx/bin/post-install.ts
+++ b/packages/nx/bin/post-install.ts
@@ -11,10 +11,10 @@ import { readNxJson } from '../src/config/nx-json';
 import { setupWorkspaceContext } from '../src/utils/workspace-context';
 
 (async () => {
+  const start = new Date();
   try {
     setupWorkspaceContext(workspaceRoot);
     if (isMainNxPackage() && fileExists(join(workspaceRoot, 'nx.json'))) {
-      const b = new Date();
       assertSupportedPlatform();
 
       try {
@@ -35,14 +35,17 @@ import { setupWorkspaceContext } from '../src/utils/workspace-context';
           });
         })
       );
-      if (process.env.NX_VERBOSE_LOGGING === 'true') {
-        const a = new Date();
-        console.log(`Nx postinstall steps took ${a.getTime() - b.getTime()}ms`);
-      }
     }
   } catch (e) {
     if (process.env.NX_VERBOSE_LOGGING === 'true') {
       console.log(e);
+    }
+  } finally {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
+      const end = new Date();
+      console.log(
+        `Nx postinstall steps took ${end.getTime() - start.getTime()}ms`
+      );
     }
   }
 })();

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -82,35 +82,37 @@ export async function buildProjectGraphAndSourceMapsWithoutDaemon() {
   const nxJson = readNxJson();
 
   const [plugins, cleanup] = await loadNxPluginsInIsolation(nxJson.plugins);
+  try {
+    performance.mark('retrieve-project-configurations:start');
+    const { projects, externalNodes, sourceMaps, projectRootMap } =
+      await retrieveProjectConfigurations(plugins, workspaceRoot, nxJson);
+    performance.mark('retrieve-project-configurations:end');
 
-  performance.mark('retrieve-project-configurations:start');
-  const { projects, externalNodes, sourceMaps, projectRootMap } =
-    await retrieveProjectConfigurations(plugins, workspaceRoot, nxJson);
-  performance.mark('retrieve-project-configurations:end');
+    performance.mark('retrieve-workspace-files:start');
+    const { allWorkspaceFiles, fileMap, rustReferences } =
+      await retrieveWorkspaceFiles(workspaceRoot, projectRootMap);
+    performance.mark('retrieve-workspace-files:end');
 
-  performance.mark('retrieve-workspace-files:start');
-  const { allWorkspaceFiles, fileMap, rustReferences } =
-    await retrieveWorkspaceFiles(workspaceRoot, projectRootMap);
-  performance.mark('retrieve-workspace-files:end');
-
-  const cacheEnabled = process.env.NX_CACHE_PROJECT_GRAPH !== 'false';
-  performance.mark('build-project-graph-using-project-file-map:start');
-  const projectGraph = (
-    await buildProjectGraphUsingProjectFileMap(
-      projects,
-      externalNodes,
-      fileMap,
-      allWorkspaceFiles,
-      rustReferences,
-      cacheEnabled ? readFileMapCache() : null,
-      cacheEnabled,
-      plugins
-    )
-  ).projectGraph;
-  performance.mark('build-project-graph-using-project-file-map:end');
-  delete global.NX_GRAPH_CREATION;
-  cleanup();
-  return { projectGraph, sourceMaps };
+    const cacheEnabled = process.env.NX_CACHE_PROJECT_GRAPH !== 'false';
+    performance.mark('build-project-graph-using-project-file-map:start');
+    const projectGraph = (
+      await buildProjectGraphUsingProjectFileMap(
+        projects,
+        externalNodes,
+        fileMap,
+        allWorkspaceFiles,
+        rustReferences,
+        cacheEnabled ? readFileMapCache() : null,
+        cacheEnabled,
+        plugins
+      )
+    ).projectGraph;
+    performance.mark('build-project-graph-using-project-file-map:end');
+    delete global.NX_GRAPH_CREATION;
+    return { projectGraph, sourceMaps };
+  } finally {
+    cleanup();
+  }
 }
 
 function handleProjectGraphError(opts: { exitOnError: boolean }, e) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When the project graph fails during postinstall, the postinstall hangs because the workers are not cleaned up.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When the project graph fails during postinstall or anywhere, the workers will be cleaned up allowing the process to exit.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
