### PR TITLE
feat(react): finish static build on exit

### DIFF
--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -217,10 +217,6 @@ async function buildStaticRemotes(
       stdoutStream.write(stdoutString);
       if (stdoutString.includes('Successfully ran target build')) {
         staticProcess.stdout.removeAllListeners('data');
-        logger.info(
-          `NX Built ${staticRemotesConfig.remotes.length} static remotes`
-        );
-        res();
       }
     });
     staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
@@ -231,6 +227,11 @@ async function buildStaticRemotes(
           `Remote failed to start. A complete log can be found in: ${remoteBuildLogFile}`
         );
       }
+
+      logger.info(
+        `NX Built ${staticRemotesConfig.remotes.length} static remotes`
+      );
+      res();
     });
     process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
     process.on('exit', () => staticProcess.kill('SIGTERM'));


### PR DESCRIPTION
feat(react): finish static build on exit

fork does not ensure returning all logs from the process

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when there is many remotes and logs, the process does not return all the message and just exit the process of static build, this causes to run the host that looks like it hanged up

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
run static build properly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
