### PR TITLE
docs(misc): update typedoc

### DIFF
--- a/docs/generated/devkit/CreateDependencies.md
+++ b/docs/generated/devkit/CreateDependencies.md
@@ -2,6 +2,9 @@
 
 Ƭ **CreateDependencies**\<`T`\>: (`options`: `T` \| `undefined`, `context`: [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext)) => [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`\<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
 
+A function which parses files in the workspace to create dependencies in the [ProjectGraph](../../devkit/documents/ProjectGraph)
+Use [validateDependency](../../devkit/documents/validateDependency) to validate dependencies
+
 #### Type parameters
 
 | Name | Type      |
@@ -11,9 +14,6 @@
 #### Type declaration
 
 ▸ (`options`, `context`): [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`\<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
-
-A function which parses files in the workspace to create dependencies in the [ProjectGraph](../../devkit/documents/ProjectGraph)
-Use [validateDependency](../../devkit/documents/validateDependency) to validate dependencies
 
 ##### Parameters
 

--- a/docs/generated/devkit/CreateNodesFunction.md
+++ b/docs/generated/devkit/CreateNodesFunction.md
@@ -2,6 +2,9 @@
 
 Ƭ **CreateNodesFunction**\<`T`\>: (`projectConfigurationFile`: `string`, `options`: `T` \| `undefined`, `context`: [`CreateNodesContext`](../../devkit/documents/CreateNodesContext)) => [`CreateNodesResult`](../../devkit/documents/CreateNodesResult) \| `Promise`\<[`CreateNodesResult`](../../devkit/documents/CreateNodesResult)\>
 
+A function which parses a configuration file into a set of nodes.
+Used for creating nodes for the [ProjectGraph](../../devkit/documents/ProjectGraph)
+
 #### Type parameters
 
 | Name | Type      |
@@ -11,9 +14,6 @@
 #### Type declaration
 
 ▸ (`projectConfigurationFile`, `options`, `context`): [`CreateNodesResult`](../../devkit/documents/CreateNodesResult) \| `Promise`\<[`CreateNodesResult`](../../devkit/documents/CreateNodesResult)\>
-
-A function which parses a configuration file into a set of nodes.
-Used for creating nodes for the [ProjectGraph](../../devkit/documents/ProjectGraph)
 
 ##### Parameters
 

--- a/docs/generated/devkit/Executor.md
+++ b/docs/generated/devkit/Executor.md
@@ -2,6 +2,8 @@
 
 Ƭ **Executor**\<`T`\>: (`options`: `T`, `context`: [`ExecutorContext`](../../devkit/documents/ExecutorContext)) => `Promise`\<\{ `success`: `boolean` }\> \| `AsyncIterableIterator`\<\{ `success`: `boolean` }\>
 
+Implementation of a target of a project
+
 #### Type parameters
 
 | Name | Type  |
@@ -11,8 +13,6 @@
 #### Type declaration
 
 ▸ (`options`, `context`): `Promise`\<\{ `success`: `boolean` }\> \| `AsyncIterableIterator`\<\{ `success`: `boolean` }\>
-
-Implementation of a target of a project
 
 ##### Parameters
 

--- a/docs/generated/devkit/Generator.md
+++ b/docs/generated/devkit/Generator.md
@@ -2,6 +2,8 @@
 
 Ƭ **Generator**\<`T`\>: (`tree`: `any`, `schema`: `T`) => `void` \| [`GeneratorCallback`](../../devkit/documents/GeneratorCallback) \| `Promise`\<`void` \| [`GeneratorCallback`](../../devkit/documents/GeneratorCallback)\>
 
+A function that schedules updates to the filesystem to be done atomically
+
 #### Type parameters
 
 | Name | Type      |
@@ -11,8 +13,6 @@
 #### Type declaration
 
 ▸ (`tree`, `schema`): `void` \| [`GeneratorCallback`](../../devkit/documents/GeneratorCallback) \| `Promise`\<`void` \| [`GeneratorCallback`](../../devkit/documents/GeneratorCallback)\>
-
-A function that schedules updates to the filesystem to be done atomically
 
 ##### Parameters
 

--- a/docs/generated/devkit/GeneratorCallback.md
+++ b/docs/generated/devkit/GeneratorCallback.md
@@ -2,11 +2,11 @@
 
 Ƭ **GeneratorCallback**: () => `void` \| `Promise`\<`void`\>
 
+A callback function that is executed after changes are made to the file system
+
 #### Type declaration
 
 ▸ (): `void` \| `Promise`\<`void`\>
-
-A callback function that is executed after changes are made to the file system
 
 ##### Returns
 

--- a/docs/generated/devkit/ProjectTargetConfigurator.md
+++ b/docs/generated/devkit/ProjectTargetConfigurator.md
@@ -2,6 +2,10 @@
 
 Ƭ **ProjectTargetConfigurator**: (`file`: `string`) => `Record`\<`string`, [`TargetConfiguration`](../../devkit/documents/TargetConfiguration)\>
 
+**`Deprecated`**
+
+Add targets to the projects in a [CreateNodes](../../devkit/documents/CreateNodes) function instead. This will be removed in Nx 19
+
 #### Type declaration
 
 ▸ (`file`): `Record`\<`string`, [`TargetConfiguration`](../../devkit/documents/TargetConfiguration)\>
@@ -15,7 +19,3 @@
 ##### Returns
 
 `Record`\<`string`, [`TargetConfiguration`](../../devkit/documents/TargetConfiguration)\>
-
-**`Deprecated`**
-
-Add targets to the projects in a [CreateNodes](../../devkit/documents/CreateNodes) function instead. This will be removed in Nx 19

--- a/docs/generated/devkit/TaskGraphExecutor.md
+++ b/docs/generated/devkit/TaskGraphExecutor.md
@@ -2,6 +2,8 @@
 
 Ƭ **TaskGraphExecutor**\<`T`\>: (`taskGraph`: [`TaskGraph`](../../devkit/documents/TaskGraph), `options`: `Record`\<`string`, `T`\>, `overrides`: `T`, `context`: [`ExecutorContext`](../../devkit/documents/ExecutorContext)) => `Promise`\<`BatchExecutorResult` \| `AsyncIterableIterator`\<`BatchExecutorTaskResult`\>\>
 
+Implementation of a target of a project that handles multiple projects to be batched
+
 #### Type parameters
 
 | Name | Type  |
@@ -11,8 +13,6 @@
 #### Type declaration
 
 ▸ (`taskGraph`, `options`, `overrides`, `context`): `Promise`\<`BatchExecutorResult` \| `AsyncIterableIterator`\<`BatchExecutorTaskResult`\>\>
-
-Implementation of a target of a project that handles multiple projects to be batched
 
 ##### Parameters
 

--- a/docs/generated/devkit/defaultTasksRunner.md
+++ b/docs/generated/devkit/defaultTasksRunner.md
@@ -2,9 +2,6 @@
 
 ▸ **defaultTasksRunner**(`tasks`, `options`, `context?`): `any`
 
-`any | Promise<{ [id: string]: TaskStatus }>`
-will change to Promise<{ [id: string]: TaskStatus }> after Nx 15 is released.
-
 #### Parameters
 
 | Name                         | Type                                                                                       |

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "ts-node": "10.9.1",
     "tsconfig-paths": "^4.1.2",
     "tsconfig-paths-webpack-plugin": "4.0.0",
-    "typedoc": "0.25.4",
+    "typedoc": "0.25.12",
     "typedoc-plugin-markdown": "3.17.1",
     "typescript": "~5.3.2",
     "unist-builder": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,11 +918,11 @@ devDependencies:
     specifier: 4.0.0
     version: 4.0.0
   typedoc:
-    specifier: 0.25.4
-    version: 0.25.4(typescript@5.3.3)
+    specifier: 0.25.12
+    version: 0.25.12(typescript@5.3.3)
   typedoc-plugin-markdown:
     specifier: 3.17.1
-    version: 3.17.1(typedoc@0.25.4)
+    version: 3.17.1(typedoc@0.25.12)
   typescript:
     specifier: ~5.3.2
     version: 5.3.3
@@ -22920,6 +22920,8 @@ packages:
     peerDependenciesMeta:
       webpack:
         optional: true
+      webpack-sources:
+        optional: true
     dependencies:
       webpack: 5.88.0(@swc/core@1.3.86)(esbuild@0.19.5)
       webpack-sources: 3.2.3
@@ -22931,6 +22933,8 @@ packages:
       webpack: '*'
     peerDependenciesMeta:
       webpack:
+        optional: true
+      webpack-sources:
         optional: true
     dependencies:
       webpack: 5.90.1(@swc/core@1.3.86)(esbuild@0.20.0)
@@ -29690,8 +29694,8 @@ packages:
       rechoir: 0.6.2
     dev: true
 
-  /shiki@0.14.1:
-    resolution: {integrity: sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==}
+  /shiki@0.14.7:
+    resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
     dependencies:
       ansi-sequence-parser: 1.1.0
       jsonc-parser: 3.2.0
@@ -31532,26 +31536,26 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typedoc-plugin-markdown@3.17.1(typedoc@0.25.4):
+  /typedoc-plugin-markdown@3.17.1(typedoc@0.25.12):
     resolution: {integrity: sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==}
     peerDependencies:
       typedoc: '>=0.24.0'
     dependencies:
       handlebars: 4.7.7
-      typedoc: 0.25.4(typescript@5.3.3)
+      typedoc: 0.25.12(typescript@5.3.3)
     dev: true
 
-  /typedoc@0.25.4(typescript@5.3.3):
-    resolution: {integrity: sha512-Du9ImmpBCw54bX275yJrxPVnjdIyJO/84co0/L9mwe0R3G4FSR6rQ09AlXVRvZEGMUg09+z/usc8mgygQ1aidA==}
+  /typedoc@0.25.12(typescript@5.3.3):
+    resolution: {integrity: sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==}
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
       minimatch: 9.0.3
-      shiki: 0.14.1
+      shiki: 0.14.7
       typescript: 5.3.3
     dev: true
 


### PR DESCRIPTION
Updates `typedoc` to a version that supports TypeScript 5.4, which will soon be supported as part of [the Angular 17.3 support](https://github.com/nrwl/nx/pull/22202).

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
