### PR TITLE
fix(core): fix gh group success icon

### DIFF
--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -266,7 +266,7 @@ class CLIOutput {
   private getStatusIcon(taskStatus: TaskStatus) {
     switch (taskStatus) {
       case 'success':
-        return '✔️';
+        return '✅';
       case 'failure':
         return '❌';
       case 'skipped':


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Success icon is smaller than other icons
<img width="754" alt="image" src="https://github.com/nrwl/nx/assets/881612/16a32c61-e942-4669-86ce-d666b2a1a988">

## Expected Behavior
Success icon size should match the other icons
![image](https://github.com/nrwl/nx/assets/881612/f2016fe8-734c-4bec-9335-54754434daba)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
