### PR TITLE
fix(module-federation): ensure targetDefaults for module federation executors are setup correctly

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -371,6 +371,12 @@
       },
       "description": "Update the @angular/cli package version to ~17.2.0.",
       "factory": "./src/migrations/update-18-1-0/update-angular-cli"
+    },
+    "fix-target-defaults-for-webpack-browser": {
+      "cli": "nx",
+      "version": "18.1.1-beta.0",
+      "description": "Ensure targetDefaults inputs for task hashing when '@nx/angular:webpack-browser' is used are correct for Module Federation.",
+      "factory": "./src/migrations/update-18-1-1/fix-target-defaults-inputs"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
+++ b/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
@@ -7,7 +7,10 @@ export function addMfEnvToTargetDefaultInputs(tree: Tree) {
 
   nxJson.targetDefaults ??= {};
   nxJson.targetDefaults[webpackExecutor] ??= {};
-  nxJson.targetDefaults[webpackExecutor].inputs ??= [];
+  nxJson.targetDefaults[webpackExecutor].inputs ??= [
+    'production',
+    '^production',
+  ];
 
   let mfEnvVarExists = false;
   for (const input of nxJson.targetDefaults[webpackExecutor].inputs) {

--- a/packages/angular/src/migrations/update-18-1-1/fix-target-defaults-inputs.spec.ts
+++ b/packages/angular/src/migrations/update-18-1-1/fix-target-defaults-inputs.spec.ts
@@ -1,8 +1,8 @@
-import addMfEnvVarToTargetDefaults from './add-mf-env-var-to-target-defaults';
+import fixTargetDefaultInputs from './fix-target-defaults-inputs';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { addProjectConfiguration, readNxJson, updateNxJson } from '@nx/devkit';
 
-describe('addMfEnvVarToTargetDefaults', () => {
+describe('fixTargetDefaultsInputs', () => {
   it('should add the executor and input when it does not exist', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace();
@@ -18,7 +18,7 @@ describe('addMfEnvVarToTargetDefaults', () => {
     tree.write('module-federation.config.ts', '');
 
     // ACT
-    await addMfEnvVarToTargetDefaults(tree);
+    await fixTargetDefaultInputs(tree);
 
     // ASSERT
     const nxJson = readNxJson(tree);
@@ -56,7 +56,7 @@ describe('addMfEnvVarToTargetDefaults', () => {
     });
 
     // ACT
-    await addMfEnvVarToTargetDefaults(tree);
+    await fixTargetDefaultInputs(tree);
 
     // ASSERT
     const nxJson = readNxJson(tree);
@@ -99,7 +99,7 @@ describe('addMfEnvVarToTargetDefaults', () => {
     updateNxJson(tree, nxJson);
 
     // ACT
-    await addMfEnvVarToTargetDefaults(tree);
+    await fixTargetDefaultInputs(tree);
 
     // ASSERT
     nxJson = readNxJson(tree);
@@ -108,6 +108,8 @@ describe('addMfEnvVarToTargetDefaults', () => {
         "@nx/angular:webpack-browser": {
           "inputs": [
             "^build",
+            "production",
+            "^production",
             {
               "env": "NX_MF_DEV_SERVER_STATIC_REMOTES",
             },

--- a/packages/angular/src/migrations/update-18-1-1/fix-target-defaults-inputs.ts
+++ b/packages/angular/src/migrations/update-18-1-1/fix-target-defaults-inputs.ts
@@ -1,0 +1,75 @@
+import {
+  getProjects,
+  type Tree,
+  type ProjectConfiguration,
+  joinPathFragments,
+  formatFiles,
+  readNxJson,
+  updateNxJson,
+} from '@nx/devkit';
+
+export default async function (tree: Tree) {
+  if (!isWebpackBrowserUsed(tree)) {
+    return;
+  }
+  ensureTargetDefaultsContainProductionInputs(tree);
+
+  await formatFiles(tree);
+}
+
+function ensureTargetDefaultsContainProductionInputs(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  const webpackExecutor = '@nx/angular:webpack-browser';
+  const mfEnvVar = 'NX_MF_DEV_SERVER_STATIC_REMOTES';
+
+  nxJson.targetDefaults[webpackExecutor] ??= {};
+
+  nxJson.targetDefaults[webpackExecutor].inputs ??= [
+    'production',
+    '^production',
+    { env: mfEnvVar },
+  ];
+
+  if (!nxJson.targetDefaults[webpackExecutor].inputs.includes('production')) {
+    nxJson.targetDefaults[webpackExecutor].inputs.push('production');
+  }
+
+  if (!nxJson.targetDefaults[webpackExecutor].inputs.includes('^production')) {
+    nxJson.targetDefaults[webpackExecutor].inputs.push('^production');
+  }
+
+  let mfEnvVarExists = false;
+  for (const input of nxJson.targetDefaults[webpackExecutor].inputs) {
+    if (typeof input === 'object' && input['env'] === mfEnvVar) {
+      mfEnvVarExists = true;
+      break;
+    }
+  }
+
+  if (!mfEnvVarExists) {
+    nxJson.targetDefaults[webpackExecutor].inputs.push({ env: mfEnvVar });
+  }
+
+  updateNxJson(tree, nxJson);
+}
+
+function isWebpackBrowserUsed(tree: Tree) {
+  const projects = getProjects(tree);
+  for (const project of projects.values()) {
+    const targets = project.targets || {};
+    for (const [_, target] of Object.entries(targets)) {
+      if (
+        target.executor === '@nx/angular:webpack-browser' &&
+        (tree.exists(
+          joinPathFragments(project.root, 'module-federation.config.ts')
+        ) ||
+          tree.exists(
+            joinPathFragments(project.root, 'module-federation.config.js')
+          ))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -53,6 +53,12 @@
       "version": "18.0.0-beta.0",
       "description": "Add NX_MF_DEV_SERVER_STATIC_REMOTES to inputs for task hashing when '@nx/webpack:webpack' is used for Module Federation.",
       "factory": "./src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults"
+    },
+    "fix-target-defaults-for-webpack": {
+      "cli": "nx",
+      "version": "18.1.1-beta.0",
+      "description": "Ensure targetDefaults inputs for task hashing when '@nx/webpack:webpack' is used are correct for Module Federation.",
+      "factory": "./src/migrations/update-18-1-1/fix-target-defaults-inputs"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
+++ b/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
@@ -25,6 +25,8 @@ describe('addMfEnvVarToTargetDefaults', () => {
       {
         "@nx/webpack:webpack": {
           "inputs": [
+            "production",
+            "^production",
             {
               "env": "NX_MF_DEV_SERVER_STATIC_REMOTES",
             },

--- a/packages/react/src/migrations/update-18-1-1/fix-target-defaults-inputs.spec.ts
+++ b/packages/react/src/migrations/update-18-1-1/fix-target-defaults-inputs.spec.ts
@@ -1,8 +1,8 @@
-import addMfEnvVarToTargetDefaults from './add-mf-env-var-to-target-defaults';
+import fixTargetDefaultsInputs from './fix-target-defaults-inputs';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { addProjectConfiguration, readNxJson, updateNxJson } from '@nx/devkit';
 
-describe('addMfEnvVarToTargetDefaults', () => {
+describe('fixTargetDefaultsInputs', () => {
   it('should add the executor and input when it does not exist', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace();
@@ -10,21 +10,20 @@ describe('addMfEnvVarToTargetDefaults', () => {
       root: '',
       targets: {
         build: {
-          executor: '@nx/angular:webpack-browser',
+          executor: '@nx/webpack:webpack',
         },
       },
     });
-
     tree.write('module-federation.config.ts', '');
 
     // ACT
-    await addMfEnvVarToTargetDefaults(tree);
+    await fixTargetDefaultsInputs(tree);
 
     // ASSERT
     const nxJson = readNxJson(tree);
     expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
       {
-        "@nx/angular:webpack-browser": {
+        "@nx/webpack:webpack": {
           "inputs": [
             "production",
             "^production",
@@ -56,7 +55,7 @@ describe('addMfEnvVarToTargetDefaults', () => {
     });
 
     // ACT
-    await addMfEnvVarToTargetDefaults(tree);
+    await fixTargetDefaultsInputs(tree);
 
     // ASSERT
     const nxJson = readNxJson(tree);
@@ -79,10 +78,11 @@ describe('addMfEnvVarToTargetDefaults', () => {
       root: '',
       targets: {
         build: {
-          executor: '@nx/angular:webpack-browser',
+          executor: '@nx/webpack:webpack',
         },
       },
     });
+
     tree.write('module-federation.config.ts', '');
 
     let nxJson = readNxJson(tree);
@@ -90,7 +90,7 @@ describe('addMfEnvVarToTargetDefaults', () => {
       ...nxJson,
       targetDefaults: {
         ...nxJson.targetDefaults,
-        ['@nx/angular:webpack-browser']: {
+        ['@nx/webpack:webpack']: {
           inputs: ['^build'],
         },
       },
@@ -99,15 +99,17 @@ describe('addMfEnvVarToTargetDefaults', () => {
     updateNxJson(tree, nxJson);
 
     // ACT
-    await addMfEnvVarToTargetDefaults(tree);
+    await fixTargetDefaultsInputs(tree);
 
     // ASSERT
     nxJson = readNxJson(tree);
     expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
       {
-        "@nx/angular:webpack-browser": {
+        "@nx/webpack:webpack": {
           "inputs": [
             "^build",
+            "production",
+            "^production",
             {
               "env": "NX_MF_DEV_SERVER_STATIC_REMOTES",
             },

--- a/packages/react/src/migrations/update-18-1-1/fix-target-defaults-inputs.ts
+++ b/packages/react/src/migrations/update-18-1-1/fix-target-defaults-inputs.ts
@@ -1,0 +1,75 @@
+import {
+  getProjects,
+  type Tree,
+  type ProjectConfiguration,
+  joinPathFragments,
+  formatFiles,
+  readNxJson,
+  updateNxJson,
+} from '@nx/devkit';
+
+export default async function (tree: Tree) {
+  if (!hasModuleFederationProject(tree)) {
+    return;
+  }
+  ensureTargetDefaultsContainProductionInputs(tree);
+
+  await formatFiles(tree);
+}
+
+function ensureTargetDefaultsContainProductionInputs(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  const webpackExecutor = '@nx/webpack:webpack';
+  const mfEnvVar = 'NX_MF_DEV_SERVER_STATIC_REMOTES';
+
+  nxJson.targetDefaults[webpackExecutor] ??= {};
+
+  nxJson.targetDefaults[webpackExecutor].inputs ??= [
+    'production',
+    '^production',
+    { env: mfEnvVar },
+  ];
+
+  if (!nxJson.targetDefaults[webpackExecutor].inputs.includes('production')) {
+    nxJson.targetDefaults[webpackExecutor].inputs.push('production');
+  }
+
+  if (!nxJson.targetDefaults[webpackExecutor].inputs.includes('^production')) {
+    nxJson.targetDefaults[webpackExecutor].inputs.push('^production');
+  }
+
+  let mfEnvVarExists = false;
+  for (const input of nxJson.targetDefaults[webpackExecutor].inputs) {
+    if (typeof input === 'object' && input['env'] === mfEnvVar) {
+      mfEnvVarExists = true;
+      break;
+    }
+  }
+
+  if (!mfEnvVarExists) {
+    nxJson.targetDefaults[webpackExecutor].inputs.push({ env: mfEnvVar });
+  }
+
+  updateNxJson(tree, nxJson);
+}
+
+function hasModuleFederationProject(tree: Tree) {
+  const projects = getProjects(tree);
+  for (const project of projects.values()) {
+    const targets = project.targets || {};
+    for (const [_, target] of Object.entries(targets)) {
+      if (
+        target.executor === '@nx/webpack:webpack' &&
+        (tree.exists(
+          joinPathFragments(project.root, 'module-federation.config.ts')
+        ) ||
+          tree.exists(
+            joinPathFragments(project.root, 'module-federation.config.js')
+          ))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/packages/react/src/utils/add-mf-env-to-inputs.ts
+++ b/packages/react/src/utils/add-mf-env-to-inputs.ts
@@ -7,7 +7,10 @@ export function addMfEnvToTargetDefaultInputs(tree: Tree) {
 
   nxJson.targetDefaults ??= {};
   nxJson.targetDefaults[webpackExecutor] ??= {};
-  nxJson.targetDefaults[webpackExecutor].inputs ??= [];
+  nxJson.targetDefaults[webpackExecutor].inputs ??= [
+    'production',
+    '^production',
+  ];
 
   let mfEnvVarExists = false;
   for (const input of nxJson.targetDefaults[webpackExecutor].inputs) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `targetDefaults` for `@nx/angular:webpack-browser` and `@nx/webpack:webpack` were missing inputs required for task hashing to correctly invalidate cache.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the `targetDefaults` correctly include `production` and `^production` and add these inputs if they are currently missing.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22265
