### PR TITLE
fix(vite): Storing nxjson details too early

### DIFF
--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -40,12 +40,6 @@ export async function viteConfigurationGeneratorInternal(
 ) {
   const tasks: GeneratorCallback[] = [];
 
-  const nxJson = readNxJson(tree);
-  const addPluginDefault =
-    process.env.NX_ADD_PLUGINS !== 'false' &&
-    nxJson.useInferencePlugins !== false;
-  schema.addPlugin ??= addPluginDefault;
-
   const projectConfig = readProjectConfiguration(tree, schema.project);
   const { targets, root: projectRoot } = projectConfig;
 
@@ -76,6 +70,12 @@ export async function viteConfigurationGeneratorInternal(
   const initTask = await initGenerator(tree, { ...schema, skipFormat: true });
   tasks.push(initTask);
   tasks.push(ensureDependencies(tree, schema));
+
+  const nxJson = readNxJson(tree);
+  const addPluginDefault =
+    process.env.NX_ADD_PLUGINS !== 'false' &&
+    nxJson.useInferencePlugins !== false;
+  schema.addPlugin ??= addPluginDefault;
 
   const hasPlugin = nxJson.plugins?.some((p) =>
     typeof p === 'string'


### PR DESCRIPTION
If we store `nx.json` before the vite initGenerator updates it due to adding vite plugin to  `nx.json`. 

When we read it back to decide if we want to use inferred targets or not it will be outdated and produce the wrong result. (i.e. it will add targets to `project.json` even though we wanted to use inferred targets). 