### PR TITLE
docs(express): add library import to express project example

### DIFF
--- a/docs/shared/recipes/add-stack/add-express.md
+++ b/docs/shared/recipes/add-stack/add-express.md
@@ -73,13 +73,14 @@ export function someFunction(): string {
 
 import express from 'express';
 import * as path from 'path';
+import { someFunction } from '@my-express-app/my-lib';
 
 const app = express();
 
 app.use('/assets', express.static(path.join(__dirname, 'assets')));
 
 app.get('/api', (req, res) => {
-  res.send({ message: 'Welcome to my-express-app!' });
+  res.send({ message: `Welcome to my-express-app! ${someFunction()}` });
 });
 
 const port = process.env.PORT || 3333;


### PR DESCRIPTION
The provided example of creating an express project with a custom library is missing the import of the custom library.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

https://nx.dev/showcase/example-repos/add-express

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22292
