### PR TITLE
feat(core): add ability to add metadata to projects

### DIFF
--- a/docs/generated/devkit/ProjectConfiguration.md
+++ b/docs/generated/devkit/ProjectConfiguration.md
@@ -8,6 +8,7 @@ Project configuration
 
 - [generators](../../devkit/documents/ProjectConfiguration#generators): Object
 - [implicitDependencies](../../devkit/documents/ProjectConfiguration#implicitdependencies): string[]
+- [metadata](../../devkit/documents/ProjectConfiguration#metadata): Object
 - [name](../../devkit/documents/ProjectConfiguration#name): string
 - [namedInputs](../../devkit/documents/ProjectConfiguration#namedinputs): Object
 - [projectType](../../devkit/documents/ProjectConfiguration#projecttype): ProjectType
@@ -50,6 +51,19 @@ Example:
 • `Optional` **implicitDependencies**: `string`[]
 
 List of projects which are added as a dependency
+
+---
+
+### metadata
+
+• `Optional` **metadata**: `Object`
+
+#### Type declaration
+
+| Name            | Type                             |
+| :-------------- | :------------------------------- |
+| `targetGroups?` | `Record`\<`string`, `string`[]\> |
+| `technologies?` | `string`[]                       |
 
 ---
 

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -70,6 +70,11 @@ describe('@nx/cypress/plugin', () => {
       {
         "projects": {
           ".": {
+            "metadata": {
+              "technologies": [
+                "cypress",
+              ],
+            },
             "projectType": "application",
             "targets": {
               "e2e": {
@@ -129,6 +134,11 @@ describe('@nx/cypress/plugin', () => {
       {
         "projects": {
           ".": {
+            "metadata": {
+              "technologies": [
+                "cypress",
+              ],
+            },
             "projectType": "application",
             "targets": {
               "component-test": {
@@ -187,6 +197,17 @@ describe('@nx/cypress/plugin', () => {
       {
         "projects": {
           ".": {
+            "metadata": {
+              "targetGroups": {
+                ".:e2e-ci": [
+                  "e2e-ci--src/test.cy.ts",
+                  "e2e-ci",
+                ],
+              },
+              "technologies": [
+                "cypress",
+              ],
+            },
             "projectType": "application",
             "targets": {
               "e2e": {

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -44,6 +44,7 @@ export const allowedProjectExtensions = [
   'projectType',
   'release',
   'includedScripts',
+  'metadata',
 ] as const;
 
 // If we pass props on the workspace that angular doesn't know about,

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -111,6 +111,10 @@ export interface ProjectConfiguration {
       'generator' | 'generatorOptions'
     >;
   };
+  metadata?: {
+    technologies?: string[];
+    targetGroups?: Record<string, string[]>;
+  };
 }
 
 export interface TargetDependencyConfig {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is no official API for adding metadata to Project Nodes

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

During the `createNodes` process, plugins will be able to add metadata to Project Nodes.

2 of these fields will be handled in the future by the `nx graph` app and Nx Cloud:
1. `technologies`
  a. Type: `string[]`
  b. An array of technologies which the project utilizes
  c. ex. React, Angular, Gradle, Cypress
3. `targetGroups`
  a. Type: `Record<string, string[]>`
  b. A map of target groups which will be grouped by the project details view as well as Nx Cloud
  c. ex. `e2e-ci`

The cypress plugin has been updated to update cypress nodes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
