### PR TITLE
fix(js): read lockfile from the workspace root

### DIFF
--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -31,6 +31,7 @@ interface ParsedLockFile {
   externalNodes?: ProjectGraph['externalNodes'];
   dependencies?: RawProjectGraphDependency[];
 }
+
 let parsedLockFile: ParsedLockFile = {};
 
 export const createNodes: CreateNodes = [
@@ -64,7 +65,8 @@ export const createNodes: CreateNodes = [
     const externalNodes = getLockFileNodes(
       packageManager,
       lockFileContents,
-      lockFileHash
+      lockFileHash,
+      context
     );
     parsedLockFile.externalNodes = externalNodes;
     return {

--- a/packages/nx/src/plugins/js/lock-file/lock-file.ts
+++ b/packages/nx/src/plugins/js/lock-file/lock-file.ts
@@ -37,7 +37,10 @@ import {
 import { pruneProjectGraph } from './project-graph-pruning';
 import { normalizePackageJson } from './utils/package-json';
 import { readJsonFile } from '../../../utils/fileutils';
-import { CreateDependenciesContext } from '../../../utils/nx-plugin';
+import {
+  CreateDependenciesContext,
+  CreateNodesContext,
+} from '../../../utils/nx-plugin';
 
 const YARN_LOCK_FILE = 'yarn.lock';
 const NPM_LOCK_FILE = 'package-lock.json';
@@ -54,11 +57,14 @@ const PNPM_LOCK_PATH = join(workspaceRoot, PNPM_LOCK_FILE);
 export function getLockFileNodes(
   packageManager: PackageManager,
   contents: string,
-  lockFileHash: string
+  lockFileHash: string,
+  context: CreateNodesContext
 ): Record<string, ProjectGraphExternalNode> {
   try {
     if (packageManager === 'yarn') {
-      const packageJson = readJsonFile('package.json');
+      const packageJson = readJsonFile(
+        join(context.workspaceRoot, 'package.json')
+      );
       return getYarnLockfileNodes(contents, lockFileHash, packageJson);
     }
     if (packageManager === 'pnpm') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`package.json` is read from the `cwd` for `getLockfileNodes`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`package.json` is read from the workspace root for `getLockfileNodes`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
