### PR TITLE
fix(core): do not use pseudo terminal if platform is unsuported and f…

### DIFF
--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -2,7 +2,10 @@ import * as path from 'path';
 import type { ExecutorContext } from '../../config/misc-interfaces';
 import { getPackageManagerCommand } from '../../utils/package-manager';
 import { execSync } from 'child_process';
-import { getPseudoTerminal } from '../../tasks-runner/pseudo-terminal';
+import {
+  getPseudoTerminal,
+  PseudoTerminal,
+} from '../../tasks-runner/pseudo-terminal';
 
 export interface RunScriptOptions {
   script: string;
@@ -31,7 +34,7 @@ export default async function (
         .join(path.delimiter) ?? '';
     env.PATH = filteredPath;
 
-    if (process.stdout.isTTY) {
+    if (PseudoTerminal.isSupported()) {
       await ptyProcess(command, cwd, env);
     } else {
       nodeProcess(command, cwd, env);

--- a/packages/nx/src/tasks-runner/pseudo-terminal.spec.ts
+++ b/packages/nx/src/tasks-runner/pseudo-terminal.spec.ts
@@ -3,7 +3,7 @@ import { getPseudoTerminal, PseudoTerminal } from './pseudo-terminal';
 describe('PseudoTerminal', () => {
   let terminal: PseudoTerminal;
   beforeAll(() => {
-    terminal = getPseudoTerminal();
+    terminal = getPseudoTerminal(true);
   });
 
   afterAll(() => {


### PR DESCRIPTION
…or run-many

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Users will get an error if the pseudo terminal is used on an unsupported platform.

Also, `nx run-many --parallel 3` will not work.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is a fallback for unsupported platforms

`nx run-many --parallel 3` will work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/22235
