### PR TITLE
fix(vite): pass cli arguments as options to vitest

### DIFF
--- a/packages/vite/src/executors/test/lib/utils.ts
+++ b/packages/vite/src/executors/test/lib/utils.ts
@@ -63,12 +63,14 @@ export async function getOptions(
 
   const { parseCLI } = await loadVitestDynamicImport();
 
-  const normalizedExtraArgs = parseCLI([
-    'vitest',
-    ...getOptionsAsArgv(options),
-  ]);
+  const {
+    options: { watch, ...normalizedExtraArgs },
+  } = parseCLI(['vitest', ...getOptionsAsArgv(options)]);
 
   const settings = {
+    // Explicitly set watch mode to false if not provided otherwise vitest
+    // will enable watch mode by default for non CI environments
+    watch: watch ?? false,
     ...normalizedExtraArgs,
     // This should not be needed as it's going to be set in vite.config.ts
     // but leaving it here in case someone did not migrate correctly

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -22,7 +22,9 @@ export async function* vitestExecutor(
   const resolvedOptions =
     (await getOptions(options, context, projectRoot)) ?? {};
 
-  const nxReporter = new NxReporter(resolvedOptions['watch']);
+  const watch = resolvedOptions['watch'] === true;
+
+  const nxReporter = new NxReporter(watch);
   if (resolvedOptions['reporters'] === undefined) {
     resolvedOptions['reporters'] = [];
   } else if (typeof resolvedOptions['reporters'] === 'string') {
@@ -49,7 +51,7 @@ export async function* vitestExecutor(
     }
   };
 
-  if (resolvedOptions['watch'] === true) {
+  if (watch) {
     process.on('SIGINT', processExit);
     process.on('SIGTERM', processExit);
     process.on('exit', processExit);


### PR DESCRIPTION
# Context

Issue: #22354

I noticed the cli arguments were no longer working when the vite test executor was used.

# Problem / solution

A recent change (00dae6a811ae3afb6b30245a228b5f8f3dcdeb86) introduced the use of `vitest.parseCli`. However, its return type (no longer?) is a valid options object.
The `parseCli` function ([docs](https://vitest.dev/advanced/api.html#parsecli)) from `vitest` returns an object which should first be destructured to get the proper options object:

```ts
const {
   filter,
   options,
} = parseCli(['vitest', ...argv])
```


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Cli args such as `--watch` or `--coverage` of `--ui` are not used when using `@nx/vite` test executor.

```sh
# setup
npx create-nx-workspace@latest --preset ts --ci skip nx-react-vite
cd nx-react-vite
npm i -D @nx/react
NX_ADD_PLUGINS=false npx nx g @nx/react:app my-app --bundler=vite --unitTestRunner vitest
```

```sh
# exits after first run, doesn't wait for new changes
npx nx test my-app --watch 
# doesn't create a coverage report
npx nx test my-app --coverage
# doesn't open the ui
npx nx test my-app --ui
```

## Expected Behavior

```sh
# should watch for changes and rerun test when changes occur
npx nx test my-app --watch
# should create a coverage report
npx nx test my-app --coverage
# should open a ui page showing all tests
npx nx test my-app --ui
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22354, Fixes #22392

Issue relates to #21890
