### PR TITLE
docs(remix): replace serve target with dev

### DIFF
--- a/docs/shared/guides/remix.md
+++ b/docs/shared/guides/remix.md
@@ -81,8 +81,8 @@ NX   Successfully ran target build for project myapp (3s)
 
 2. To serve your application for use during development run:
 
-```{% command="nx serve myapp" path="~/acme" %}
-> nx run myapp:serve
+```{% command="nx dev myapp" path="~/acme" %}
+> nx run myapp:dev
 
 💿 Building...
 💿 Rebuilt in 377ms


### PR DESCRIPTION
Introduced in https://github.com/nrwl/nx/commit/9b81821e67ffea6d49920624f6ff0001eeb42ed1#diff-e825adecd2e970948d64453d80fd7526f0ec4f5d1ef1ce3b371405f56a911889
https://github.com/nrwl/nx/blob/4a4c2b9e8e1a22d35f4e4433221ee3a3bc3fc064/packages/remix/src/plugins/plugin.ts#L228

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
```
~/d/remix-nx (main)> nx serve app

 NX   Cannot find configuration for task app:serve

Pass --verbose to see the stacktrace.
```

## Expected Behavior
```
~/d/remix-nx (main) [1]> nx dev app

> nx run app:dev


 💿  remix dev

 info  building...
 info  built (477ms)
 ```

## Related Issue(s)
None