### PR TITLE
feat(core): validate that outputs is an array of strings

### DIFF
--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -489,4 +489,24 @@ describe('utils', () => {
       });
     });
   });
+
+  describe('validateOutputs', () => {
+    it('returns undefined if there are no errors', () => {
+      expect(validateOutputs(['{projectRoot}/dist'])).toBeUndefined();
+    });
+
+    it('throws an error if the output is not an array', () => {
+      expect(() => validateOutputs('output' as unknown as string[])).toThrow(
+        "The 'outputs' field must be an array"
+      );
+    });
+
+    it("throws an error if the output has entries that aren't strings", () => {
+      expect(() =>
+        validateOutputs(['foo', 1, null, true, {}, []] as unknown as string[])
+      ).toThrow(
+        "The 'outputs' field must contain only strings, but received types: [string, number, object, boolean, object, object]"
+      );
+    });
+  });
 });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -107,7 +107,32 @@ class InvalidOutputsError extends Error {
   }
 }
 
+function assertOutputsAreValidType(outputs: unknown) {
+  if (!Array.isArray(outputs)) {
+    throw new Error("The 'outputs' field must be an array");
+  }
+
+  const typesArray = [];
+  let hasInvalidType = false;
+  for (const output of outputs) {
+    if (typeof output !== 'string') {
+      hasInvalidType = true;
+    }
+    typesArray.push(typeof output);
+  }
+
+  if (hasInvalidType) {
+    throw new Error(
+      `The 'outputs' field must contain only strings, but received types: [${typesArray.join(
+        ', '
+      )}]`
+    );
+  }
+}
+
 export function validateOutputs(outputs: string[]) {
+  assertOutputsAreValidType(outputs);
+
   const invalidOutputs = new Set<string>();
 
   for (const output of outputs) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

I accidentally configured my target outputs as
```
outputs: "{projectRoot}/dist"
```

And was confused by the error message

```
The following outputs are invalid:
- {
- p
- r
- o
- j
...
Please run "nx repair" to repair your configuration
```

## Expected Behavior

A slightly nicer error message

```
The 'outputs' field must be an array
```

I also made it so that if you enter non-string values in the array it flags them

```
The 'outputs' field must contain only strings, but received types: [string, number, object, boolean, object, object]
```
