### PR TITLE
docs(core): angular monorepo redirect

### DIFF
--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -782,6 +782,8 @@ const nested5minuteTutorialUrls = {
   '/angular-tutorial': '/getting-started/tutorials/angular-monorepo-tutorial',
   '/angular-tutorial/1-code-generation':
     '/getting-started/tutorials/angular-monorepo-tutorial',
+  '/getting-started/angular-monorepo-tutorial':
+    '/getting-started/tutorials/angular-monorepo-tutorial',
   '/angular-tutorial/2-project-graph':
     '/getting-started/tutorials/angular-monorepo-tutorial',
   '/angular-tutorial/3-task-running':


### PR DESCRIPTION
Adds a redirect for a bad link to the angular monorepo tutorial