### PR TITLE
feat(core): add ability to scope plugins

### DIFF
--- a/docs/generated/devkit/PluginConfiguration.md
+++ b/docs/generated/devkit/PluginConfiguration.md
@@ -1,3 +1,3 @@
 # Type alias: PluginConfiguration
 
-Ƭ **PluginConfiguration**: `string` \| \{ `options?`: `unknown` ; `plugin`: `string` }
+Ƭ **PluginConfiguration**: `string` \| \{ `exclude?`: `string`[] ; `include?`: `string`[] ; `options?`: `unknown` ; `plugin`: `string` }

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -270,7 +270,9 @@
                   {
                     "type": "array",
                     "description": "The projects that the targets belong to.",
-                    "items": { "type": "string" }
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 ]
               },
@@ -294,8 +296,12 @@
                 "required": ["input"],
                 "not": {
                   "anyOf": [
-                    { "required": ["projects"] },
-                    { "required": ["dependencies"] }
+                    {
+                      "required": ["projects"]
+                    },
+                    {
+                      "required": ["dependencies"]
+                    }
                   ]
                 }
               }
@@ -327,7 +333,9 @@
             "properties": {
               "externalDependencies": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "The list of external dependencies that our target depends on for `nx:run-commands` and community plugins."
               }
             },
@@ -495,8 +503,12 @@
                     "required": ["target"],
                     "not": {
                       "anyOf": [
-                        { "required": ["projects"] },
-                        { "required": ["dependencies"] }
+                        {
+                          "required": ["projects"]
+                        },
+                        {
+                          "required": ["dependencies"]
+                        }
                       ]
                     }
                   }
@@ -529,6 +541,20 @@
             "options": {
               "type": "object",
               "description": "The options passed to the plugin when creating nodes and dependencies"
+            },
+            "include": {
+              "type": "array",
+              "description": "File patterns which are included by the plugin",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclude": {
+              "type": "array",
+              "description": "File patterns which are excluded by the plugin",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -438,7 +438,12 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
 
 export type PluginConfiguration =
   | string
-  | { plugin: string; options?: unknown };
+  | {
+      plugin: string;
+      options?: unknown;
+      include?: string[];
+      exclude?: string[];
+    };
 
 export function readNxJson(root: string = workspaceRoot): NxJsonConfiguration {
   const nxJson = join(root, 'nx.json');

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -156,6 +156,8 @@ export type NxPlugin = NxPluginV1 | NxPluginV2;
 export type LoadedNxPlugin = {
   plugin: NxPluginV2 & Pick<NxPluginV1, 'processProjectGraph'>;
   options?: unknown;
+  include?: string[];
+  exclude?: string[];
 };
 
 // Short lived cache (cleared between cmd runs)
@@ -225,8 +227,22 @@ export async function loadNxPluginAsync(
       ? pluginConfiguration
       : { plugin: pluginConfiguration, options: undefined };
   let pluginModule = nxPluginCache.get(moduleName);
+
+  const include =
+    typeof pluginConfiguration === 'object'
+      ? pluginConfiguration.include
+      : undefined;
+  const exclude =
+    typeof pluginConfiguration === 'object'
+      ? pluginConfiguration.exclude
+      : undefined;
   if (pluginModule) {
-    return { plugin: pluginModule, options };
+    return {
+      plugin: pluginModule,
+      options,
+      include,
+      exclude,
+    };
   }
   performance.mark(`Load Nx Plugin: ${moduleName} - start`);
   let { pluginPath, name } = await getPluginPathAndName(
@@ -246,7 +262,12 @@ export async function loadNxPluginAsync(
     `Load Nx Plugin: ${moduleName} - start`,
     `Load Nx Plugin: ${moduleName} - end`
   );
-  return { plugin, options };
+  return {
+    plugin,
+    options,
+    include,
+    exclude,
+  };
 }
 
 export async function loadNxPlugins(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is no way to users to filter where plugins are applied. Only by the plugin author.

This means that errors thrown make the plugin unusable and more modifications to the project graph are made than desired.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Plugins can be scoped via `include` and `exclude` which are both lists of file patterns.

```json
{
  plugins: [
    {
      plugin: '@nx/jest/plugin',
      include: ['packages/**/*'],
      exclude: ['e2e/**/*']
    }
  ]
}
```

This will scope running the plugin to processing only those config files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
