### PR TITLE
fix(core): override Path env variable on Windows platform

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -436,7 +436,9 @@ function processEnv(color: boolean, cwd: string, env: Record<string, string>) {
     ...localEnv,
     ...env,
   };
-  res.PATH = localEnv.PATH; // need to override PATH to make sure we are using the local node_modules
+  // need to override PATH to make sure we are using the local node_modules
+  if (localEnv.PATH) res.PATH = localEnv.PATH; // UNIX-like
+  if (localEnv.Path) res.Path = localEnv.Path; // Windows
 
   if (color) {
     res.FORCE_COLOR = `${color}`;


### PR DESCRIPTION
closed #22359

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Execute tasks than run commands like vite or webpack-cli on Windows terminates in error

## Expected Behavior
Execute tasks successfully

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22359
