### PR TITLE
fix(linter): convert parser options to flat config even is parser is missing

### DIFF
--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -760,9 +760,13 @@ export function generateFlatOverride(
     !override.plugins &&
     !override.parser
   ) {
+    if (override.parserOptions) {
+      const { parserOptions, ...rest } = override;
+      return generateAst({ ...rest, languageSettings: { parserOptions } });
+    }
     return generateAst(override);
   }
-  const { files, excludedFiles, rules, ...rest } = override;
+  const { files, excludedFiles, rules, parserOptions, ...rest } = override;
 
   const objectLiteralElements: ts.ObjectLiteralElementLike[] = [
     ts.factory.createSpreadAssignment(ts.factory.createIdentifier('config')),
@@ -770,6 +774,11 @@ export function generateFlatOverride(
   addTSObjectProperty(objectLiteralElements, 'files', files);
   addTSObjectProperty(objectLiteralElements, 'excludedFiles', excludedFiles);
   addTSObjectProperty(objectLiteralElements, 'rules', rules);
+  if (parserOptions) {
+    addTSObjectProperty(objectLiteralElements, 'languageSettings', {
+      parserOptions,
+    });
+  }
 
   return ts.factory.createSpreadElement(
     ts.factory.createCallExpression(


### PR DESCRIPTION
When converting to flat config and parser is missing, the parserOptions would be left unparsed which then lead to a runtime error. This PR ensures parserOptions are properly handled on their own.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
