### PR TITLE
fix(linter): Should work if extends is a string

### DIFF
--- a/packages/eslint/src/generators/init/init-migration.ts
+++ b/packages/eslint/src/generators/init/init-migration.ts
@@ -159,6 +159,12 @@ function migrateEslintFile(projectEslintPath: string, tree: Tree) {
         }
         // add extends
         json.extends = json.extends || [];
+
+        // ensure extends is an array
+        if (typeof json.extends === 'string') {
+          json.extends = [json.extends];
+        }
+
         const pathToRootConfig = `${offsetFromRoot(
           dirname(projectEslintPath)
         )}${baseFile}`;


### PR DESCRIPTION
Ensure that `extends` is an array before trying to `.push` or `.indexOf`