### PR TITLE
chore(devkit): fix failing devkit test for convertNxExecutor

### DIFF
--- a/packages/devkit/src/utils/convert-nx-executor.spec.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.spec.ts
@@ -1,3 +1,9 @@
+// When plugins from root nx.json load through ts-jest, they can cause transpile errors such as `@nx/playwright/plugin.d.ts` containing an unexpected "export" keyword.
+// Mock `loadNxPlugins` function to prevent them from loading.
+jest.mock('nx/src/utils/nx-plugin', () => ({
+  loadNxPlugins: () => Promise.resolve([]),
+}));
+
 import { convertNxExecutor } from './convert-nx-executor';
 
 describe('Convert Nx Executor', () => {


### PR DESCRIPTION
This PR fixes a failing unit test in `devkit` for `convertNxExecutor`. The failure is caused by loading plugins from root `nx.json` (which are not needed for the test), which lead to unexpected `export` keyword from being run by Jest.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Unit test is failing: https://staging.nx.app/runs/AhXfo7gza6/task/devkit%3Atest

## Expected Behavior
Unit test passes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
