### PR TITLE
feat(core): create structured project graph errors with all plugin er…

### DIFF
--- a/docs/generated/cli/show.md
+++ b/docs/generated/cli/show.md
@@ -165,6 +165,12 @@ Type: `boolean`
 
 Untracked changes
 
+##### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
+
 ##### version
 
 Type: `boolean`
@@ -198,6 +204,12 @@ Show help
 Type: `string`
 
 Which project should be viewed?
+
+##### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
 
 ##### version
 

--- a/docs/generated/packages/nx/documents/show.md
+++ b/docs/generated/packages/nx/documents/show.md
@@ -165,6 +165,12 @@ Type: `boolean`
 
 Untracked changes
 
+##### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
+
 ##### version
 
 Type: `boolean`
@@ -198,6 +204,12 @@ Show help
 Type: `string`
 
 Which project should be viewed?
+
+##### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
 
 ##### version
 

--- a/packages/nx/src/command-line/affected/command-object.ts
+++ b/packages/nx/src/command-line/affected/command-object.ts
@@ -1,4 +1,4 @@
-import { boolean, CommandModule, middleware } from 'yargs';
+import { CommandModule } from 'yargs';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
 import {
   withAffectedOptions,
@@ -10,6 +10,7 @@ import {
   withRunOptions,
   withTargetAndConfigurationOption,
 } from '../yargs-utils/shared-options';
+import { handleErrors } from '../../utils/params';
 
 export const yargsAffectedCommand: CommandModule = {
   command: 'affected',
@@ -36,8 +37,17 @@ export const yargsAffectedCommand: CommandModule = {
         }),
       'affected'
     ),
-  handler: async (args) =>
-    (await import('./affected')).affected('affected', withOverrides(args)),
+  handler: async (args) => {
+    return handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        return (await import('./affected')).affected(
+          'affected',
+          withOverrides(args)
+        );
+      }
+    );
+  },
 };
 
 export const yargsAffectedTestCommand: CommandModule = {
@@ -50,11 +60,17 @@ export const yargsAffectedTestCommand: CommandModule = {
       ),
       'affected'
     ),
-  handler: async (args) =>
-    (await import('./affected')).affected('affected', {
-      ...withOverrides(args),
-      target: 'test',
-    }),
+  handler: async (args) => {
+    return handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        return (await import('./affected')).affected('affected', {
+          ...withOverrides(args),
+          target: 'test',
+        });
+      }
+    );
+  },
 };
 
 export const yargsAffectedBuildCommand: CommandModule = {
@@ -67,11 +83,17 @@ export const yargsAffectedBuildCommand: CommandModule = {
       ),
       'affected'
     ),
-  handler: async (args) =>
-    (await import('./affected')).affected('affected', {
-      ...withOverrides(args),
-      target: 'build',
-    }),
+  handler: async (args) => {
+    return handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        return (await import('./affected')).affected('affected', {
+          ...withOverrides(args),
+          target: 'build',
+        });
+      }
+    );
+  },
 };
 
 export const yargsAffectedLintCommand: CommandModule = {
@@ -84,11 +106,17 @@ export const yargsAffectedLintCommand: CommandModule = {
       ),
       'affected'
     ),
-  handler: async (args) =>
-    (await import('./affected')).affected('affected', {
-      ...withOverrides(args),
-      target: 'lint',
-    }),
+  handler: async (args) => {
+    return handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        return (await import('./affected')).affected('affected', {
+          ...withOverrides(args),
+          target: 'lint',
+        });
+      }
+    );
+  },
 };
 
 export const yargsAffectedE2ECommand: CommandModule = {
@@ -101,11 +129,17 @@ export const yargsAffectedE2ECommand: CommandModule = {
       ),
       'affected'
     ),
-  handler: async (args) =>
-    (await import('./affected')).affected('affected', {
-      ...withOverrides(args),
-      target: 'e2e',
-    }),
+  handler: async (args) => {
+    return handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        return (await import('./affected')).affected('affected', {
+          ...withOverrides(args),
+          target: 'e2e',
+        });
+      }
+    );
+  },
 };
 
 export const affectedGraphDeprecationMessage =
@@ -122,12 +156,18 @@ export const yargsAffectedGraphCommand: CommandModule = {
       withAffectedOptions(withDepGraphOptions(yargs)),
       'affected:graph'
     ),
-  handler: async (args) =>
-    await (
-      await import('./affected')
-    ).affected('graph', {
-      ...args,
-    }),
+  handler: async (args) => {
+    return handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        return await (
+          await import('./affected')
+        ).affected('graph', {
+          ...args,
+        });
+      }
+    );
+  },
   deprecated: affectedGraphDeprecationMessage,
 };
 
@@ -157,10 +197,15 @@ export const yargsPrintAffectedCommand: CommandModule = {
           'Select the type of projects to be returned (e.g., --type=app)',
       }),
   handler: async (args) => {
-    await (
-      await import('./affected')
-    ).affected('print-affected', withOverrides(args));
-    process.exit(0);
+    return handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        await (
+          await import('./affected')
+        ).affected('print-affected', withOverrides(args));
+        process.exit(0);
+      }
+    );
   },
   deprecated: printAffectedDeprecationMessage,
 };

--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -279,6 +279,7 @@ function throwInvalidInvocation(availableGenerators: string[]) {
     )})`
   );
 }
+
 export function printGenHelp(
   opts: GenerateOptions,
   schema: Schema,
@@ -306,12 +307,11 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
   }
   const verbose = process.env.NX_VERBOSE_LOGGING === 'true';
 
-  const nxJsonConfiguration = readNxJson();
-  const projectGraph = await createProjectGraphAsync({ exitOnError: true });
-  const projectsConfigurations =
-    readProjectsConfigurationFromProjectGraph(projectGraph);
-
   return handleErrors(verbose, async () => {
+    const nxJsonConfiguration = readNxJson();
+    const projectGraph = await createProjectGraphAsync();
+    const projectsConfigurations =
+      readProjectsConfigurationFromProjectGraph(projectGraph);
     const opts = await convertToGenerateOptions(
       args,
       'generate',

--- a/packages/nx/src/command-line/run-many/command-object.ts
+++ b/packages/nx/src/command-line/run-many/command-object.ts
@@ -7,6 +7,7 @@ import {
   withOverrides,
   withBatch,
 } from '../yargs-utils/shared-options';
+import { handleErrors } from '../../utils/params';
 
 export const yargsRunManyCommand: CommandModule = {
   command: 'run-many',
@@ -21,5 +22,10 @@ export const yargsRunManyCommand: CommandModule = {
       'run-many'
     ),
   handler: async (args) =>
-    (await import('./run-many')).runMany(withOverrides(args)),
+    await handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        (await import('./run-many')).runMany(withOverrides(args));
+      }
+    ),
 };

--- a/packages/nx/src/command-line/run/command-object.ts
+++ b/packages/nx/src/command-line/run/command-object.ts
@@ -4,6 +4,7 @@ import {
   withOverrides,
   withRunOneOptions,
 } from '../yargs-utils/shared-options';
+import { handleErrors } from '../../utils/params';
 
 export const yargsRunCommand: CommandModule = {
   command: 'run [project][:target][:configuration] [_..]',
@@ -16,7 +17,12 @@ export const yargsRunCommand: CommandModule = {
     You can skip the use of Nx cache by using the --skip-nx-cache option.`,
   builder: (yargs) => withRunOneOptions(withBatch(yargs)),
   handler: async (args) =>
-    (await import('./run-one')).runOne(process.cwd(), withOverrides(args)),
+    await handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        (await import('./run-one')).runOne(process.cwd(), withOverrides(args));
+      }
+    ),
 };
 
 /**
@@ -26,6 +32,15 @@ export const yargsNxInfixCommand: CommandModule = {
   ...yargsRunCommand,
   command: '$0 <target> [project] [_..]',
   describe: 'Run a target for a project',
-  handler: async (args) =>
-    (await import('./run-one')).runOne(process.cwd(), withOverrides(args, 0)),
+  handler: async (args) => {
+    await handleErrors(
+      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+      async () => {
+        return (await import('./run-one')).runOne(
+          process.cwd(),
+          withOverrides(args, 0)
+        );
+      }
+    );
+  },
 };

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -37,7 +37,7 @@ export async function runOne(
   workspaceConfigurationCheck();
 
   const nxJson = readNxJson();
-  const projectGraph = await createProjectGraphAsync({ exitOnError: true });
+  const projectGraph = await createProjectGraphAsync();
 
   const opts = parseRunOneOptions(cwd, args, projectGraph, nxJson);
 

--- a/packages/nx/src/daemon/daemon-project-graph-error.ts
+++ b/packages/nx/src/daemon/daemon-project-graph-error.ts
@@ -1,0 +1,15 @@
+import { ProjectGraph } from '../config/project-graph';
+import { ConfigurationSourceMaps } from '../project-graph/utils/project-configuration-utils';
+
+export class DaemonProjectGraphError extends Error {
+  constructor(
+    public errors: any[],
+    readonly projectGraph: ProjectGraph,
+    readonly sourceMaps: ConfigurationSourceMaps
+  ) {
+    super(
+      `The Daemon Process threw an error while calculating the project graph. Convert this error to a ProjectGraphError to get more information.`
+    );
+    this.name = this.constructor.name;
+  }
+}

--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -2,6 +2,7 @@ import { Task, TaskGraph } from '../../config/task-graph';
 import { getCachedSerializedProjectGraphPromise } from './project-graph-incremental-recomputation';
 import { InProcessTaskHasher } from '../../hasher/task-hasher';
 import { readNxJson } from '../../config/configuration';
+import { DaemonProjectGraphError } from '../daemon-project-graph-error';
 
 /**
  * We use this not to recreated hasher for every hash operation
@@ -16,8 +17,23 @@ export async function handleHashTasks(payload: {
   tasks: Task[];
   taskGraph: TaskGraph;
 }) {
-  const { projectGraph, allWorkspaceFiles, fileMap, rustReferences } =
-    await getCachedSerializedProjectGraphPromise();
+  const {
+    error,
+    projectGraph: _graph,
+    allWorkspaceFiles,
+    fileMap,
+    rustReferences,
+  } = await getCachedSerializedProjectGraphPromise();
+
+  let projectGraph = _graph;
+  if (error) {
+    if (error instanceof DaemonProjectGraphError) {
+      projectGraph = error.projectGraph;
+    } else {
+      throw error;
+    }
+  }
+
   const nxJson = readNxJson();
 
   if (projectGraph !== storedProjectGraph) {

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -8,15 +8,18 @@ import {
 } from '../../config/project-graph';
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
 import { hashArray } from '../../hasher/file-hasher';
-import { buildProjectGraphUsingProjectFileMap as buildProjectGraphUsingFileMap } from '../../project-graph/build-project-graph';
+import {
+  buildProjectGraphUsingProjectFileMap as buildProjectGraphUsingFileMap,
+  CreateDependenciesError,
+} from '../../project-graph/build-project-graph';
 import { updateFileMap } from '../../project-graph/file-map-utils';
 import {
   FileMapCache,
   nxProjectGraph,
   readFileMapCache,
+  writeCache,
 } from '../../project-graph/nx-deps-cache';
 import {
-  RetrievedGraphNodes,
   retrieveProjectConfigurations,
   retrieveWorkspaceFiles,
 } from '../../project-graph/utils/retrieve-workspace-files';
@@ -29,10 +32,16 @@ import { workspaceRoot } from '../../utils/workspace-root';
 import { notifyFileWatcherSockets } from './file-watching/file-watcher-sockets';
 import { serverLogger } from './logger';
 import { NxWorkspaceFilesExternals } from '../../native';
+import {
+  ConfigurationResult,
+  ProjectConfigurationsError,
+} from '../../project-graph/utils/project-configuration-utils';
+import { DaemonProjectGraphError } from '../daemon-project-graph-error';
 
 interface SerializedProjectGraph {
   error: Error | null;
   projectGraph: ProjectGraph | null;
+  projectFileMapCache: FileMapCache | null;
   fileMap: FileMap | null;
   allWorkspaceFiles: FileData[] | null;
   serializedProjectGraph: string | null;
@@ -85,6 +94,7 @@ export async function getCachedSerializedProjectGraphPromise(): Promise<Serializ
       serializedProjectGraph: null,
       serializedSourceMaps: null,
       projectGraph: null,
+      projectFileMapCache: null,
       fileMap: null,
       allWorkspaceFiles: null,
       rustReferences: null,
@@ -148,7 +158,7 @@ function computeWorkspaceConfigHash(
 }
 
 async function processCollectedUpdatedAndDeletedFiles(
-  { projects, externalNodes, projectRootMap }: RetrievedGraphNodes,
+  { projects, externalNodes, projectRootMap }: ConfigurationResult,
   updatedFileHashes: Record<string, string>,
   deletedFiles: string[]
 ) {
@@ -219,29 +229,76 @@ async function processFilesAndCreateAndSerializeProjectGraph(): Promise<Serializ
     const nxJson = readNxJson(workspaceRoot);
     // Set this globally to allow plugins to know if they are being called from the project graph creation
     global.NX_GRAPH_CREATION = true;
-    const graphNodes = await retrieveProjectConfigurations(
-      workspaceRoot,
-      nxJson
-    );
+
+    let graphNodes: ConfigurationResult;
+    let projectConfigurationsError;
+
+    try {
+      graphNodes = await retrieveProjectConfigurations(workspaceRoot, nxJson);
+    } catch (e) {
+      if (e instanceof ProjectConfigurationsError) {
+        graphNodes = e.partialProjectConfigurationsResult;
+        projectConfigurationsError = e;
+      }
+    }
     await processCollectedUpdatedAndDeletedFiles(
       graphNodes,
       updatedFileHashes,
       deletedFiles
     );
-    const g = createAndSerializeProjectGraph(graphNodes);
+    const g = await createAndSerializeProjectGraph(graphNodes);
 
     delete global.NX_GRAPH_CREATION;
-    return g;
+
+    const errors = [...(projectConfigurationsError?.errors ?? [])];
+
+    if (g.error) {
+      if (g.error instanceof CreateDependenciesError) {
+        errors.concat(g.error.errors);
+      } else {
+        return {
+          error: g.error,
+          projectGraph: null,
+          projectFileMapCache: null,
+          fileMap: null,
+          rustReferences: null,
+          allWorkspaceFiles: null,
+          serializedProjectGraph: null,
+          serializedSourceMaps: null,
+        };
+      }
+    }
+
+    if (errors.length > 0) {
+      return {
+        error: new DaemonProjectGraphError(
+          errors,
+          g.projectGraph,
+          graphNodes.sourceMaps
+        ),
+        projectGraph: null,
+        projectFileMapCache: null,
+        fileMap: null,
+        rustReferences: null,
+        allWorkspaceFiles: null,
+        serializedProjectGraph: null,
+        serializedSourceMaps: null,
+      };
+    } else {
+      writeCache(g.projectFileMapCache, g.projectGraph);
+      return g;
+    }
   } catch (err) {
-    return Promise.resolve({
+    return {
       error: err,
       projectGraph: null,
+      projectFileMapCache: null,
       fileMap: null,
       rustReferences: null,
       allWorkspaceFiles: null,
       serializedProjectGraph: null,
       serializedSourceMaps: null,
-    });
+    };
   }
 }
 
@@ -263,7 +320,7 @@ function copyFileMap(m: FileMap) {
 async function createAndSerializeProjectGraph({
   projects,
   sourceMaps,
-}: RetrievedGraphNodes): Promise<SerializedProjectGraph> {
+}: ConfigurationResult): Promise<SerializedProjectGraph> {
   try {
     performance.mark('create-project-graph-start');
     const fileMap = copyFileMap(fileMapWithFiles.fileMap);
@@ -276,9 +333,9 @@ async function createAndSerializeProjectGraph({
         fileMap,
         allWorkspaceFiles,
         rustReferences,
-        currentProjectFileMapCache || readFileMapCache(),
-        true
+        currentProjectFileMapCache || readFileMapCache()
       );
+
     currentProjectFileMapCache = projectFileMapCache;
     currentProjectGraph = projectGraph;
 
@@ -302,6 +359,7 @@ async function createAndSerializeProjectGraph({
     return {
       error: null,
       projectGraph,
+      projectFileMapCache,
       fileMap,
       allWorkspaceFiles,
       serializedProjectGraph,
@@ -315,6 +373,7 @@ async function createAndSerializeProjectGraph({
     return {
       error: e,
       projectGraph: null,
+      projectFileMapCache: null,
       fileMap: null,
       allWorkspaceFiles: null,
       serializedProjectGraph: null,

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -8,17 +8,21 @@ import type { Watcher } from '../../native';
 export const SERVER_INACTIVITY_TIMEOUT_MS = 10800000 as const; // 10800000 ms = 3 hours
 
 let watcherInstance: Watcher | undefined;
+
 export function storeWatcherInstance(instance: Watcher) {
   watcherInstance = instance;
 }
+
 export function getWatcherInstance() {
   return watcherInstance;
 }
 
 let outputWatcherInstance: Watcher | undefined;
+
 export function storeOutputWatcherInstance(instance: Watcher) {
   outputWatcherInstance = instance;
 }
+
 export function getOutputWatcherInstance() {
   return outputWatcherInstance;
 }
@@ -95,10 +99,7 @@ export async function respondWithErrorAndExit(
     description,
     error.message
   );
-  console.error(error);
-
-  error.message = `${error.message}\n\nBecause of the error the Nx daemon process has exited. The next Nx command is going to restart the daemon process.\nIf the error persists, please run "nx reset".`;
+  console.error(error.stack);
 
   await respondToClient(socket, serializeResult(error, null, null), null);
-  process.exit(1);
 }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -15,6 +15,7 @@ import {
 
 import { minimatch } from 'minimatch';
 import { join } from 'path';
+import { performance } from 'perf_hooks';
 
 export type SourceInformation = [file: string, plugin: string];
 export type ConfigurationSourceMaps = Record<
@@ -278,30 +279,32 @@ export function mergeProjectConfigurationIntoRootMap(
 export type ConfigurationResult = {
   projects: Record<string, ProjectConfiguration>;
   externalNodes: Record<string, ProjectGraphExternalNode>;
-  rootMap: Record<string, string>;
+  projectRootMap: Record<string, string>;
   sourceMaps: ConfigurationSourceMaps;
+};
+type CreateNodesResultWithContext = CreateNodesResult & {
+  file: string;
+  pluginName: string;
 };
 
 /**
  * Transforms a list of project paths into a map of project configurations.
  *
+ * @param root The workspace root
  * @param nxJson The NxJson configuration
  * @param workspaceFiles A list of non-ignored workspace files
  * @param plugins The plugins that should be used to infer project configuration
- * @param root The workspace root
  */
-export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
+export function createProjectConfigurations(
+  root: string = workspaceRoot,
   nxJson: NxJsonConfiguration,
   workspaceFiles: string[], // making this parameter allows devkit to pick up newly created projects
-  plugins: LoadedNxPlugin[],
-  root: string = workspaceRoot
+  plugins: LoadedNxPlugin[]
 ): Promise<ConfigurationResult> {
-  type CreateNodesResultWithContext = CreateNodesResult & {
-    file: string;
-    pluginName: string;
-  };
+  performance.mark('build-project-configs:start');
 
   const results: Array<Promise<Array<CreateNodesResultWithContext>>> = [];
+  const errors: Array<CreateNodesError | MergeNodesError> = [];
 
   // We iterate over plugins first - this ensures that plugins specified first take precedence.
   for (const { plugin, options } of plugins) {
@@ -331,12 +334,18 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
         if (r instanceof Promise) {
           pluginResults.push(
             r
-              .catch((e) => {
+              .catch((error) => {
                 performance.mark(`${plugin.name}:createNodes:${file} - end`);
-                throw new CreateNodesError(
-                  `Unable to create nodes for ${file} using plugin ${plugin.name}.`,
-                  e
+                errors.push(
+                  new CreateNodesError({
+                    file,
+                    pluginName: plugin.name,
+                    error,
+                  })
                 );
+                return {
+                  projects: {},
+                };
               })
               .then((r) => {
                 performance.mark(`${plugin.name}:createNodes:${file} - end`);
@@ -361,14 +370,17 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
             pluginName: plugin.name,
           });
         }
-      } catch (e) {
-        throw new CreateNodesError(
-          `Unable to create nodes for ${file} using plugin ${plugin.name}.`,
-          e
+      } catch (error) {
+        errors.push(
+          new CreateNodesError({
+            file,
+            pluginName: plugin.name,
+            error,
+          })
         );
       }
     }
-    // If there are no promises (counter undefined) or all promises have resolved (counter === 0)
+
     results.push(
       Promise.all(pluginResults).then((results) => {
         performance.mark(`${plugin.name}:createNodes - end`);
@@ -417,10 +429,13 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
             configurationSourceMaps,
             sourceInfo
           );
-        } catch (e) {
-          throw new CreateNodesError(
-            `Unable to merge project information for "${project.root}" from ${result.file} using plugin ${result.pluginName}.`,
-            e
+        } catch (error) {
+          errors.push(
+            new MergeNodesError({
+              file,
+              pluginName,
+              error,
+            })
           );
         }
       }
@@ -437,12 +452,28 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
       'createNodes:merge - end'
     );
 
-    return {
-      projects,
-      externalNodes,
-      rootMap,
-      sourceMaps: configurationSourceMaps,
-    };
+    performance.mark('build-project-configs:end');
+    performance.measure(
+      'build-project-configs',
+      'build-project-configs:start',
+      'build-project-configs:end'
+    );
+
+    if (errors.length === 0) {
+      return {
+        projects,
+        externalNodes,
+        projectRootMap: rootMap,
+        sourceMaps: configurationSourceMaps,
+      };
+    } else {
+      throw new ProjectConfigurationsError(errors, {
+        projects,
+        externalNodes,
+        projectRootMap: rootMap,
+        sourceMaps: configurationSourceMaps,
+      });
+    }
   });
 }
 
@@ -493,20 +524,59 @@ export function readProjectConfigurationsFromRootMap(
   return projects;
 }
 
-class CreateNodesError extends Error {
-  constructor(msg, cause: Error | unknown) {
-    const message = `${msg} ${
-      !cause
-        ? ''
-        : cause instanceof Error
-        ? `\n\n\t Inner Error: ${cause.stack}`
-        : cause
-    }`;
-    // These errors are thrown during a JS callback which is invoked via rust.
-    // The errors messaging gets lost in the rust -> js -> rust transition, but
-    // logging the error here will ensure that it is visible in the console.
-    console.error(message);
-    super(message, { cause });
+export class ProjectConfigurationsError extends Error {
+  constructor(
+    public readonly errors: Array<MergeNodesError | CreateNodesError>,
+    public readonly partialProjectConfigurationsResult: ConfigurationResult
+  ) {
+    super('Failed to create project configurations');
+    this.name = this.constructor.name;
+  }
+}
+
+export class CreateNodesError extends Error {
+  file: string;
+  pluginName: string;
+
+  constructor({
+    file,
+    pluginName,
+    error,
+  }: {
+    file: string;
+    pluginName: string;
+    error: Error;
+  }) {
+    const msg = `The "${pluginName}" plugin threw an error while creating nodes from ${file}:`;
+
+    super(msg, { cause: error });
+    this.name = this.constructor.name;
+    this.file = file;
+    this.pluginName = pluginName;
+    this.stack = `${this.message}\n  ${error.stack.split('\n').join('\n  ')}`;
+  }
+}
+
+export class MergeNodesError extends Error {
+  file: string;
+  pluginName: string;
+
+  constructor({
+    file,
+    pluginName,
+    error,
+  }: {
+    file: string;
+    pluginName: string;
+    error: Error;
+  }) {
+    const msg = `The nodes created from ${file} by the "${pluginName}" could not be merged into the project graph:`;
+
+    super(msg, { cause: error });
+    this.name = this.constructor.name;
+    this.file = file;
+    this.pluginName = pluginName;
+    this.stack = `${this.message}\n  ${error.stack.split('\n').join('\n  ')}`;
   }
 }
 

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -2,7 +2,7 @@ import * as chalk from 'chalk';
 import { EOL } from 'os';
 import * as readline from 'readline';
 import { isCI } from './is-ci';
-import { TaskStatus } from '../tasks-runner/tasks-runner';
+import type { TaskStatus } from '../tasks-runner/tasks-runner';
 
 const GH_GROUP_PREFIX = '::group::';
 const GH_GROUP_SUFFIX = '::endgroup::';

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -1,10 +1,11 @@
 import { logger } from './logger';
-import { NxJsonConfiguration } from '../config/nx-json';
-import {
+import type { NxJsonConfiguration } from '../config/nx-json';
+import type {
   TargetConfiguration,
   ProjectsConfigurations,
 } from '../config/workspace-json-project-json';
 import { output } from './output';
+import type { ProjectGraphError } from '../project-graph/project-graph';
 
 const LIST_CHOICE_DISPLAY_LIMIT = 10;
 
@@ -96,6 +97,21 @@ export async function handleErrors(isVerbose: boolean, fn: Function) {
     err ||= new Error('Unknown error caught');
     if (err.constructor.name === 'UnsuccessfulWorkflowExecution') {
       logger.error('The generator workflow failed. See above.');
+    } else if (err.name === 'ProjectGraphError') {
+      const projectGraphError = err as ProjectGraphError;
+      let title = projectGraphError.message;
+      if (isVerbose) {
+        title += ' See errors below.';
+      }
+
+      const bodyLines = isVerbose
+        ? [projectGraphError.stack]
+        : ['Pass --verbose to see the stacktraces.'];
+
+      output.error({
+        title,
+        bodyLines: bodyLines,
+      });
     } else {
       const lines = (err.message ? err.message : err.toString()).split('\n');
       const bodyLines = lines.slice(1);


### PR DESCRIPTION
…rors

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When an error is thrown while creating a part of the project graph, the rest of the project graph is not created. The underlying error is thrown immediately.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When an error is thrown when creating a part of the project graph, the error is stored and thrown later. These errors are all exposed via the `ProjectGraphError` class which will contain a few things:

1. A partial project graph
2. The partial source maps
3. The underlying errors

This error is still a legitimate error but in some cases it could be handled.

Most processes likely need the full project graph so the error will be printed out. The full stacktraces are hidden unless `--verbose` is passed.

For example, in the graph app such as the graph or the project details view, we can still show the partial graph or the partial project.

```
~/p/nx-examples (master↑1|●1✚3) $ nx lint cart

 NX   Failed to process project graph.

Pass --verbose to see the stacktraces.

~/p/nx-examples (master↑1|●1✚3) $ nx lint cart --verbose

 NX   Failed to process project graph. See errors below.

Failed to process project graph.
  The "@nx/jest/plugin" plugin threw an error while creating nodes from apps/cart/jest.config.ts:
    Error: Jest: Failed to parse the TypeScript config file /home/jason/projects/nx-examples/apps/cart/jest.config.ts
      TSError: ⨯ Unable to compile TypeScript:
    apps/cart/jest.config.ts(9,12): error TS1109: Expression expected.
    
        at readConfigFileAndSetRootDir (/home/jason/projects/nx-examples/node_modules/jest-config/build/readConfigFileAndSetRootDir.js:116:13)
        at async readInitialOptions (/home/jason/projects/nx-examples/node_modules/jest-config/build/index.js:403:13)
        at async readConfig (/home/jason/projects/nx-examples/node_modules/jest-config/build/index.js:147:48)
        at async buildJestTargets (/home/jason/projects/nx-examples/node_modules/@nx/jest/src/plugins/plugin.js:71:20)
        at async exports.createNodes (/home/jason/projects/nx-examples/node_modules/@nx/jest/src/plugins/plugin.js:58:14)
        at async Promise.all (index 0)
        at async Promise.all (index 3)
        at async processFilesAndCreateAndSerializeProjectGraph (/home/jason/projects/nx-examples/node_modules/nx/src/daemon/server/project-graph-incremental-recomputation.js:148:26)
        at async handleRequestProjectGraph (/home/jason/projects/nx-examples/node_modules/nx/src/daemon/server/handle-request-project-graph.js:12:24)
        at async handleResult (/home/jason/projects/nx-examples/node_modules/nx/src/daemon/server/server.js:110:16)

```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
