### PR TITLE
fix(bundling): prevent sensitive keys from being bundled

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -230,4 +230,32 @@ describe('EsBuild Plugin', () => {
     const output = runCLI(`build ${myPkg}`);
     expect(output).toContain('custom config loaded');
   }, 120_000);
+
+  it('should bundle in non-sensitive NX_ environment variables', () => {
+    const myPkg = uniq('my-pkg');
+    runCLI(`generate @nx/js:lib ${myPkg} --bundler=esbuild`, {});
+
+    updateFile(
+      `libs/${myPkg}/src/index.ts`,
+      `
+      console.log(process.env['NX_CLOUD_ENCRYPTION_KEY']);
+      console.log(process.env['NX_CLOUD_ACCESS_TOKEN']);
+      console.log(process.env['NX_PUBLIC_TEST']);
+      `
+    );
+
+    runCLI(`build ${myPkg} --platform=browser`, {
+      env: {
+        NX_CLOUD_ENCRYPTION_KEY: 'secret',
+        NX_CLOUD_ACCESS_TOKEN: 'secret',
+        NX_PUBLIC_TEST: 'foobar',
+      },
+    });
+
+    const output = runCommand(`node dist/libs/${myPkg}/index.cjs`, {
+      failOnError: true,
+    });
+    expect(output).not.toMatch(/secret/);
+    expect(output).toMatch(/foobar/);
+  });
 });

--- a/packages/esbuild/src/utils/environment-variables.ts
+++ b/packages/esbuild/src/utils/environment-variables.ts
@@ -1,8 +1,15 @@
+// Prevent sensitive keys from being bundled when source code uses entire `process.env` object rather than individual keys (e.g. `process.env.NX_FOO`).
+// TODO(v19): Only env vars prefixed with NX_PUBLIC should be bundled. This is a breaking change so we won't do it in v18.
+const excludedKeys = ['NX_CLOUD_ACCESS_TOKEN', 'NX_CLOUD_ENCRYPTION_KEY'];
+
 export function getClientEnvironment(): Record<string, string> {
   const NX_APP = /^NX_/i;
 
   return Object.keys(process.env)
-    .filter((key) => NX_APP.test(key) || key === 'NODE_ENV')
+    .filter(
+      (key) =>
+        !excludedKeys.includes(key) && (NX_APP.test(key) || key === 'NODE_ENV')
+    )
     .reduce((env, key) => {
       env[`process.env.${key}`] = JSON.stringify(process.env[key]);
       return env;

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -360,9 +360,13 @@ export function getNextConfig(
   };
 }
 
+// Prevent sensitive keys from being bundled when source code uses entire `process.env` object rather than individual keys (e.g. `process.env.NX_FOO`).
+// TODO(v19): BREAKING: Only support NEXT_PUBLIC_ env vars and ignore NX_ vars since this is a standard Next.js feature.
+const excludedKeys = ['NX_CLOUD_ACCESS_TOKEN', 'NX_CLOUD_ENCRYPTION_KEY'];
+
 function getNxEnvironmentVariables() {
   return Object.keys(process.env)
-    .filter((env) => /^NX_/i.test(env))
+    .filter((env) => !excludedKeys.includes(env) && /^NX_/i.test(env))
     .reduce((env, key) => {
       env[key] = process.env[key];
       return env;

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -18,6 +18,10 @@ import { mergePlugins } from './merge-plugins';
 import { withReact } from '../with-react';
 import { existsSync } from 'fs';
 
+// Prevent sensitive keys from being bundled when source code uses entire `process.env` object rather than individual keys (e.g. `process.env.NX_FOO`).
+// TODO(v19): BREAKING: Only env vars prefixed with NX_PUBLIC should be bundled. This is a breaking change so we won't do it in v18.
+const excludedKeys = ['NX_CLOUD_ACCESS_TOKEN', 'NX_CLOUD_ENCRYPTION_KEY'];
+
 // This is shamelessly taken from CRA and modified for NX use
 // https://github.com/facebook/create-react-app/blob/4784997f0682e75eb32a897b4ffe34d735912e6c/packages/react-scripts/config/env.js#L71
 function getClientEnvironment(mode) {
@@ -27,7 +31,11 @@ function getClientEnvironment(mode) {
   const STORYBOOK_PREFIX = /^STORYBOOK_/i;
 
   const raw = Object.keys(process.env)
-    .filter((key) => NX_PREFIX.test(key) || STORYBOOK_PREFIX.test(key))
+    .filter(
+      (key) =>
+        !excludedKeys.includes(key) &&
+        (NX_PREFIX.test(key) || STORYBOOK_PREFIX.test(key))
+    )
     .reduce(
       (env, key) => {
         env[key] = process.env[key];

--- a/packages/webpack/src/utils/get-client-environment.ts
+++ b/packages/webpack/src/utils/get-client-environment.ts
@@ -1,10 +1,14 @@
+// Prevent sensitive keys from being bundled when source code uses entire `process.env` object rather than individual keys (e.g. `process.env.NX_FOO`).
+// TODO(v19): Only env vars prefixed with NX_PUBLIC should be bundled. This is a breaking change so we won't do it in v18.
+const excludedKeys = ['NX_CLOUD_ACCESS_TOKEN', 'NX_CLOUD_ENCRYPTION_KEY'];
+
 export function getClientEnvironment(mode?: string) {
   // Grab NODE_ENV and NX_* environment variables and prepare them to be
   // injected into the application via DefinePlugin in webpack configuration.
   const NX_APP = /^NX_/i;
 
   const raw = Object.keys(process.env)
-    .filter((key) => NX_APP.test(key))
+    .filter((key) => !excludedKeys.includes(key) && NX_APP.test(key))
     .reduce(
       (env, key) => {
         env[key] = process.env[key];

--- a/packages/webpack/src/utils/webpack/interpolate-env-variables-to-index.ts
+++ b/packages/webpack/src/utils/webpack/interpolate-env-variables-to-index.ts
@@ -8,8 +8,12 @@ export function interpolateEnvironmentVariablesToIndex(
 
 const NX_PREFIX = /^NX_/i;
 
+// Prevent sensitive keys from being bundled when source code uses entire `process.env` object rather than individual keys (e.g. `process.env.NX_FOO`).
+// TODO(v19): Only env vars prefixed with NX_PUBLIC should be bundled. This is a breaking change so we won't do it in v18.
+const excludedKeys = ['NX_CLOUD_ACCESS_TOKEN', 'NX_CLOUD_ENCRYPTION_KEY'];
+
 function isNxEnvironmentKey(x: string): boolean {
-  return NX_PREFIX.test(x);
+  return !excludedKeys.includes(x) && NX_PREFIX.test(x);
 }
 
 function getClientEnvironment(deployUrl: string) {


### PR DESCRIPTION
This PR removes `NX_CLOUD_ENCRYPTION_KEY` and `NX_CLOUD_ACCESS_TOKEN` from bundled in application code. This could happen if `process.env` object is used, such as:

```js
const { NX_FOO } = process.env;
```

The build process swaps out `process.env` with the object containing all `NX_` environment variables, including the secrets. This problem was noted by Payfit and Hasura.

In Nx 19, we will introduce a breaking change to only bundle in vars prefixed with `NX_PUBLIC`.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
