### PR TITLE
chore(nx-dev): increase webServer timeout for e2e tests

### DIFF
--- a/nx-dev/nx-dev-e2e/playwright.config.ts
+++ b/nx-dev/nx-dev-e2e/playwright.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
     command: 'pnpm exec nx run nx-dev:start',
     url: 'http://localhost:4200',
     reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
   },
   projects: [
     {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

E2E tests for nx-dev are failing on CI with a timeout when waiting for the web server to start.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

E2E tests for nx-dev should wait longer for the web server to start.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
