### PR TITLE
docs(core): rearrange intro page

### DIFF
--- a/docs/shared/getting-started/intro.md
+++ b/docs/shared/getting-started/intro.md
@@ -6,7 +6,7 @@ Nx is a powerful open-source build system that provides tools and techniques for
 
 - **Run Tasks Efficiently**: Nx [runs tasks in parallel](/features/run-tasks) and orders the tasks based on the dependencies between them.
 - **Cache Locally & Remotely**: With [local](/features/cache-task-results) and [remote caching](/ci/features/remote-cache), Nx prevents unnecessary re-runs of tasks, saving you valuable dev time.
-- **Automate Dependency Updates**: if you leverage Nx plugins you gain additional features such as [code generation](/features/generate-code) and tools to [automatically upgrade](features/automate-updating-dependencies) your codebase and dependencies.
+- **Automate Dependency Updates**: if you leverage [Nx plugins](/concepts/nx-plugins) you gain additional features such as [code generation](/features/generate-code) and tools to [automatically upgrade](features/automate-updating-dependencies) your codebase and dependencies.
 - **Make it Your Own**: Nx is highly customizable and extensible. Fine-tune it by [creating your own plugins](/extending-nx/intro/getting-started) and optionally [share them with the community](/extending-nx/tutorials/publish-plugin#publish-your-nx-plugin).
 
 <!-- - **Monorepo and Single Projects**: Nx supports both, monorepos as well as single-project (standalone) workspaces. -->
@@ -51,6 +51,28 @@ npx create-nx-workspace@latest
 
 {% /cards %}
 
+## Have an Existing Project? Add Nx to it!
+
+If you have an existing project and want to adopt Nx or migrate to Nx just run the following command which guides you through the migration process:
+
+```shell
+npx nx@latest init
+```
+
+Alternatively, here are some recipes that give you more details based on the technology stack you're using:
+
+{% cards cols="2" mdCols="4" smCols="2" moreLink="/recipes/adopting-nx" %}
+
+{% link-card title="Add to Existing Monorepo" appearance="small" url="/recipes/adopting-nx/adding-to-monorepo" icon="pnpm" /%}
+
+{% link-card title="Add to Any Project" appearance="small" url="/recipes/adopting-nx/adding-to-existing-project" icon="nx" /%}
+
+{% link-card title="Migrate from CRA" appearance="small" url="/recipes/react/migration-cra" icon="cra" /%}
+
+{% link-card title="Migrate from Angular CLI" appearance="small" url="/recipes/angular/migration/angular" icon="angular" /%}
+
+{% /cards %}
+
 ## Pick Your Stack!
 
 {% cards cols="3" lgCols="8" mdCols="6" smCols="5" moreLink="/showcase/example-repos" %}
@@ -79,28 +101,6 @@ npx create-nx-workspace@latest
 {% link-card title="Storybook" appearance="small" url="/nx-api/storybook" icon="storybook" /%}
 {% link-card title="Jest" appearance="small" url="/nx-api/jest" icon="jest" /%}
 {% link-card title="Rspack" appearance="small" url="/nx-api/rspack" icon="rspack" /%}
-
-{% /cards %}
-
-## Have an Existing Project? Add Nx to it!
-
-If you have an existing project and want to adopt Nx or migrate to Nx just run the following command which guides you through the migration process:
-
-```shell
-npx nx@latest init
-```
-
-Alternatively, here are some recipes that give you more details based on the technology stack you're using:
-
-{% cards cols="2" mdCols="4" smCols="2" moreLink="/recipes/adopting-nx" %}
-
-{% link-card title="Add to Existing Monorepo" appearance="small" url="/recipes/adopting-nx/adding-to-monorepo" icon="pnpm" /%}
-
-{% link-card title="Add to Any Project" appearance="small" url="/recipes/adopting-nx/adding-to-existing-project" icon="nx" /%}
-
-{% link-card title="Migrate from CRA" appearance="small" url="/recipes/react/migration-cra" icon="cra" /%}
-
-{% link-card title="Migrate from Angular CLI" appearance="small" url="/recipes/angular/migration/angular" icon="angular" /%}
 
 {% /cards %}
 


### PR DESCRIPTION
Move the `nx init` command closer to the `create-nx-workspace` command on the intro page