### PR TITLE
docs(testing): improve cypress plugin overview page

### DIFF
--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -236,20 +236,71 @@ For adding more dynamic configurations to your Cypress configuration, you can lo
 
 ## Environment Variables
 
-If you're needing to pass a variable to Cypress that you wish to not commit to your repository, i.e. API keys, or dynamic values based on configurations, i.e. API URLs. This is where [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables) can be used.
+If you need to pass a variable to Cypress that you don't want to commit to your repository (i.e. API keys, dynamic values based on configurations, API URLs), you can use [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables).
 
-There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the `env` option in the [project configuration](/reference/project-configuration#targets) or the commandline.
+There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the `-e` Cypress arg or the `env` option from the `@nx/cypress:cypress` executor in the [project configuration](/reference/project-configuration#targets) or the command line.
 
-Create a `cypress.env.json` file in the projects root i.e. `apps/my-cool-app-e2e/cypress.env.json`. Cypress will automatically pick up this file. This method is helpful for configurations that you want to not commit. Just don't forget to add the file to the `.gitignore` and add documentation so people in your repo know what values to populate in their local copy of the `cypress.env.json` file.
+Create a `cypress.env.json` file in the projects root (i.e. `apps/my-cool-app-e2e/cypress.env.json`). Cypress will automatically pick up this file. This method is helpful for configurations that you don't want to commit. Just don't forget to add the file to the `.gitignore` and add documentation so people in your repo know what values to populate in their local copy of the `cypress.env.json` file.
 
-Set the `env` option in the project configuration is a good way to add values you want to define that you don't mind committing to the repository, such as a base API URL. You can leverage target configurations to define different values as well.
+Setting the `-e` Cypress arg or the `env` option from the `@nx/cypress:cypress` executor in the project configuration is a good way to add values you want to define that you don't mind committing to the repository, such as a base API URL.
 
-Optionally, you can pass environment variables via the commandline with the `--env` flag.
+{% tabs %}
+{% tab label="Using inferred tasks" %}
 
-{% callout type="warning" title="Executor options and --env" %}
-Providing the `--env` flag will override the `env` option set in the project configuration.
-{% /callout %}
+```json {% fileName="project.json" %}
+{
+  ...
+  "targets": {
+    "e2e": {
+      "options": {
+        "args": "--env=API_URL=https://api.my-nx-website.com"
+      }
+    }
+  }
+}
+```
+
+{% /tab %}
+
+{% tab label="Using the @nx/cypress:cypress executor" %}
+
+```json {% fileName="project.json" %}
+{
+  ...
+  "targets": {
+    "e2e": {
+      "executor": "@nx/cypress:cypress",
+      "options": {
+        "env": "API_URL=https://api.my-nx-website.com"
+      }
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+Finally, you can also pass environment variables via the command line with the `-e` Cypress arg or the `--env` option for the `@nx/cypress:cypress` executor.
+
+{% tabs %}
+{% tab label="Using inferred tasks" %}
+
+```shell
+nx e2e frontend-e2e -e=API_URL=https://api.my-nx-website.com,API_KEY=abc-123
+```
+
+{% /tab %}
+
+{% tab label="Using the @nx/cypress:cypress executor" %}
 
 ```shell
 nx e2e frontend-e2e --env.API_URL="https://api.my-nx-website.com" --env.API_KEY="abc-123"
 ```
+
+{% /tab %}
+{% /tabs %}
+
+{% callout type="warning" title="Command-line args vs configuration options" %}
+Providing a flag will override any option with the same name set in the project or workspace configuration.
+{% /callout %}

--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -76,16 +76,17 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
     {
       "plugin": "@nx/cypress/plugin",
       "options": {
-        "ciTargetName": "e2e-ci",
         "targetName": "e2e",
-        "componentTestingTargetName": "component-test"
+        "ciTargetName": "e2e-ci",
+        "componentTestingTargetName": "component-test",
+        "openTargetName": "open-cypress"
       }
     }
   ]
 }
 ```
 
-- The `targetName`, `ciTargetName` and `componentTestingTargetName` options control the namea of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci` and `component-test`.
+The `targetName`, `ciTargetName`, `componentTestingTargetName`, and `open-cypress` options control the names of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci`, `component-test`, and `open-cypress`.
 
 ### Splitting E2E tasks by file
 

--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -35,7 +35,23 @@ nx add @nx/cypress
 
 This will install the correct version of `@nx/cypress`.
 
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/cypress` package with your package manager.
+
+```shell
+npm add -D @nx/cypress
+```
+
+{% /tab %}
+{% /tabs %}
+
 ### How @nx/cypress Infers Tasks
+
+{% callout type="note" title="Inferred Tasks" %}
+Since Nx 18, Nx plugins can infer tasks for your projects based on the configuration of different tools. You can read more about it at the [Inferred Tasks concept page](/concepts/inferred-tasks).
+{% /callout %}
 
 The `@nx/cypress` plugin will create a task for any project that has a Cypress configuration file present. Any of the following files will be recognized as a Cypress configuration file:
 
@@ -101,18 +117,6 @@ export default defineConfig({
 If you use the `setupNodeEvents` function in your Cypress configuration, make sure to invoke the same function that is returned by `nxE2EPreset`. See the recipe on [using `setupNodeEvents` with Cypress preset](/recipes/cypress/cypress-setup-node-events) for more details.
 {% /callout %}
 
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/cypress` package with your package manager.
-
-```shell
-npm add -D @nx/cypress
-```
-
-{% /tab %}
-{% /tabs %}
-
 ## E2E Testing
 
 By default, when creating a new frontend application, Nx will use Cypress to create the e2e tests project.
@@ -123,7 +127,7 @@ nx g @nx/web:app frontend
 
 ### Configure Cypress for an existing project
 
-To configure Cypress for an existing project, run the following generator
+To configure Cypress for an existing project, run the following generator:
 
 ```shell
 nx g @nx/cypress:configuration --project=your-app-name
@@ -135,56 +139,89 @@ Optionally, you can use the `--baseUrl` option if you don't want the Cypress plu
 nx g @nx/cypress:configuration --project=your-app-name --baseUrl=http://localhost:4200
 ```
 
-Replace `your-app-name` with the app's name as defined in your `tsconfig.base.json` file or the `name` property of your `package.json`.
+Replace `your-app-name` with the app's name as defined in your `project.json` file or the `name` property of your `package.json`.
+
+{% callout type="note" title="E2E setup location" %}
+The `@nx/cypress:configuration` generator is not a project generator. It won't generate a separate project for the E2E tests. It will configure Cypress for the provided project.
+
+To set up a separate project, you can generate a separate project with a project generator like `@nx/js:library` first and then run the `@nx/cypress:configuration` generator.
+{% /callout %}
 
 ### Testing Applications
 
 Run `nx e2e frontend-e2e` to execute e2e tests with Cypress.
 
-You can run your e2e test against a production build by using the `production` [configuration](https://nx.dev/concepts/executors-and-configurations#use-task-configurations)
+You can run your e2e test against a production build by using the `production` [configuration](/concepts/executors-and-configurations#use-task-configurations)
 
 ```shell
 nx e2e frontend-e2e --configuration=production
 ```
 
-{% callout type="note" title="Selecting Specific Specs" %}
+You can use the `--spec` flag to glob for test files.
 
-You can use the `--spec` flag to glob for test files
-
-```bash
+```shell
 # run the tests in the smoke/ directory
-nx e2e frontend-e2e --spec=**smoke/**
+nx e2e frontend-e2e --spec="**smoke/**"
 
 # run the tests in smoke/ directory and with dashboard in the file name
-nx e2e frontend-e2e --spec=**smoke/**,**dashboard.cy**
+nx e2e frontend-e2e --spec="**smoke/**,**dashboard.cy**"
 ```
-
-{% /callout %}
 
 By default, Cypress will run in headless mode. You will have the result of all the tests and errors (if any) in your
 terminal. Screenshots and videos will be accessible in `dist/cypress/apps/frontend/screenshots` and `dist/cypress/apps/frontend/videos`.
 
 ### Watching for Changes (Headed Mode)
 
-With, `nx e2e frontend-e2e --watch` Cypress will start in headed mode where you can see your application being tested.
-
-Running Cypress with `--watch` is a great way to enhance dev workflow - you can build up test files with the application
+You can also run Cypress in headed mode and watching for changes. This is a great way to enhance the dev workflow. You can build up test files with the application
 running and Cypress will re-run those tests as you enhance and add to the suite.
+
+{% tabs %}
+{% tab label="Using inferred tasks" %}
+
+```shell
+nx open-cypress frontend-e2e
+```
+
+{% /tab %}
+
+{% tab label="Using the @nx/cypress:cypress executor" %}
 
 ```shell
 nx e2e frontend-e2e --watch
 ```
 
+{% /tab %}
+{% /tabs %}
+
 ### Specifying a Custom Url to Test
 
 The `baseUrl` property provides you the ability to test an application hosted on a specific domain.
+
+{% tabs %}
+{% tab label="Using inferred tasks" %}
+
+```shell
+nx e2e frontend-e2e --config="baseUrl=https://frontend.com"
+```
+
+{% callout type="note" title="Required options" %}
+If `baseUrl` is not provided, Cypress will expect to have the `baseUrl` property in its config file. Otherwise, it will error.
+{% /callout %}
+
+{% /tab %}
+
+{% tab label="Using the @nx/cypress:cypress executor" %}
 
 ```shell
 nx e2e frontend-e2e --baseUrl=https://frontend.com
 ```
 
-> If no `baseUrl` and no `devServerTarget` are provided, Cypress will expect to have the `baseUrl` property in
-> the cypress config file, or will error.
+{% callout type="note" title="Required options" %}
+If no `baseUrl` and no `devServerTarget` are provided, Cypress will expect to have the `baseUrl` property in its config file. Otherwise, it will error.
+{% /callout %}
+
+{% /tab %}
+{% /tabs %}
 
 ## Using cypress.config.ts
 
@@ -194,22 +231,22 @@ you can easily add your `projectId` to save all the screenshots and videos into 
 configuration is documented
 on [the official website](https://docs.cypress.io/guides/references/configuration.html#Options).
 
-For adding more dynamic configurations to your cypress configuration, you can look into using [setupNodeEvents](https://docs.cypress.io/api/plugins/browser-launch-api#Syntax) configuration option.
+For adding more dynamic configurations to your Cypress configuration, you can look into using [setupNodeEvents](https://docs.cypress.io/api/plugins/browser-launch-api#Syntax) configuration option.
 
 ## Environment Variables
 
-If you're needing to pass a variable to cypress that you wish to not commit to your repository, i.e. API keys, or dynamic values based on configurations, i.e. API Urls. This is where [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables) can be used.
+If you're needing to pass a variable to Cypress that you wish to not commit to your repository, i.e. API keys, or dynamic values based on configurations, i.e. API URLs. This is where [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables) can be used.
 
-There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the [env executor option for cypress](/nx-api/cypress/executors/cypress#env) or the commandline.
+There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the `env` option in the [project configuration](/reference/project-configuration#targets) or the commandline.
 
-Create a `cypress.env.json` file in the projects root i.e. `apps/my-cool-app-e2e/cypress.env.json`. Cypress will automatically pick up this file. This method is helpful for configurations that you want to not commit. Just don't forget to add the file to the `.gitignore` and add documentation so people in your repo know what values to popluate in their local copy of the `cypress.env.json` file.
+Create a `cypress.env.json` file in the projects root i.e. `apps/my-cool-app-e2e/cypress.env.json`. Cypress will automatically pick up this file. This method is helpful for configurations that you want to not commit. Just don't forget to add the file to the `.gitignore` and add documentation so people in your repo know what values to populate in their local copy of the `cypress.env.json` file.
 
-Using [@nx/cypress:cypress](/nx-api/cypress/executors/cypress) env executor option is a good way to add values you want to define that you don't mine commit to the repository, such as a base API url. You can leverage [target configurations](/reference/project-configuration#targets) to define different values as well.
+Set the `env` option in the project configuration is a good way to add values you want to define that you don't mind committing to the repository, such as a base API URL. You can leverage target configurations to define different values as well.
 
 Optionally, you can pass environment variables via the commandline with the `--env` flag.
 
 {% callout type="warning" title="Executor options and --env" %}
-When using the `--env` flag, this will not be merged with any values used in the `env` executor option.
+Providing the `--env` flag will override the `env` option set in the project configuration.
 {% /callout %}
 
 ```shell

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -236,20 +236,71 @@ For adding more dynamic configurations to your Cypress configuration, you can lo
 
 ## Environment Variables
 
-If you're needing to pass a variable to Cypress that you wish to not commit to your repository, i.e. API keys, or dynamic values based on configurations, i.e. API URLs. This is where [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables) can be used.
+If you need to pass a variable to Cypress that you don't want to commit to your repository (i.e. API keys, dynamic values based on configurations, API URLs), you can use [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables).
 
-There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the `env` option in the [project configuration](/reference/project-configuration#targets) or the commandline.
+There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the `-e` Cypress arg or the `env` option from the `@nx/cypress:cypress` executor in the [project configuration](/reference/project-configuration#targets) or the command line.
 
-Create a `cypress.env.json` file in the projects root i.e. `apps/my-cool-app-e2e/cypress.env.json`. Cypress will automatically pick up this file. This method is helpful for configurations that you want to not commit. Just don't forget to add the file to the `.gitignore` and add documentation so people in your repo know what values to populate in their local copy of the `cypress.env.json` file.
+Create a `cypress.env.json` file in the projects root (i.e. `apps/my-cool-app-e2e/cypress.env.json`). Cypress will automatically pick up this file. This method is helpful for configurations that you don't want to commit. Just don't forget to add the file to the `.gitignore` and add documentation so people in your repo know what values to populate in their local copy of the `cypress.env.json` file.
 
-Set the `env` option in the project configuration is a good way to add values you want to define that you don't mind committing to the repository, such as a base API URL. You can leverage target configurations to define different values as well.
+Setting the `-e` Cypress arg or the `env` option from the `@nx/cypress:cypress` executor in the project configuration is a good way to add values you want to define that you don't mind committing to the repository, such as a base API URL.
 
-Optionally, you can pass environment variables via the commandline with the `--env` flag.
+{% tabs %}
+{% tab label="Using inferred tasks" %}
 
-{% callout type="warning" title="Executor options and --env" %}
-Providing the `--env` flag will override the `env` option set in the project configuration.
-{% /callout %}
+```json {% fileName="project.json" %}
+{
+  ...
+  "targets": {
+    "e2e": {
+      "options": {
+        "args": "--env=API_URL=https://api.my-nx-website.com"
+      }
+    }
+  }
+}
+```
+
+{% /tab %}
+
+{% tab label="Using the @nx/cypress:cypress executor" %}
+
+```json {% fileName="project.json" %}
+{
+  ...
+  "targets": {
+    "e2e": {
+      "executor": "@nx/cypress:cypress",
+      "options": {
+        "env": "API_URL=https://api.my-nx-website.com"
+      }
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+Finally, you can also pass environment variables via the command line with the `-e` Cypress arg or the `--env` option for the `@nx/cypress:cypress` executor.
+
+{% tabs %}
+{% tab label="Using inferred tasks" %}
+
+```shell
+nx e2e frontend-e2e -e=API_URL=https://api.my-nx-website.com,API_KEY=abc-123
+```
+
+{% /tab %}
+
+{% tab label="Using the @nx/cypress:cypress executor" %}
 
 ```shell
 nx e2e frontend-e2e --env.API_URL="https://api.my-nx-website.com" --env.API_KEY="abc-123"
 ```
+
+{% /tab %}
+{% /tabs %}
+
+{% callout type="warning" title="Command-line args vs configuration options" %}
+Providing a flag will override any option with the same name set in the project or workspace configuration.
+{% /callout %}

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -76,16 +76,17 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
     {
       "plugin": "@nx/cypress/plugin",
       "options": {
-        "ciTargetName": "e2e-ci",
         "targetName": "e2e",
-        "componentTestingTargetName": "component-test"
+        "ciTargetName": "e2e-ci",
+        "componentTestingTargetName": "component-test",
+        "openTargetName": "open-cypress"
       }
     }
   ]
 }
 ```
 
-- The `targetName`, `ciTargetName` and `componentTestingTargetName` options control the namea of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci` and `component-test`.
+The `targetName`, `ciTargetName`, `componentTestingTargetName`, and `open-cypress` options control the names of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci`, `component-test`, and `open-cypress`.
 
 ### Splitting E2E tasks by file
 

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -35,7 +35,23 @@ nx add @nx/cypress
 
 This will install the correct version of `@nx/cypress`.
 
+{% /tab %}
+{% tab label="Nx < 18" %}
+
+Install the `@nx/cypress` package with your package manager.
+
+```shell
+npm add -D @nx/cypress
+```
+
+{% /tab %}
+{% /tabs %}
+
 ### How @nx/cypress Infers Tasks
+
+{% callout type="note" title="Inferred Tasks" %}
+Since Nx 18, Nx plugins can infer tasks for your projects based on the configuration of different tools. You can read more about it at the [Inferred Tasks concept page](/concepts/inferred-tasks).
+{% /callout %}
 
 The `@nx/cypress` plugin will create a task for any project that has a Cypress configuration file present. Any of the following files will be recognized as a Cypress configuration file:
 
@@ -101,18 +117,6 @@ export default defineConfig({
 If you use the `setupNodeEvents` function in your Cypress configuration, make sure to invoke the same function that is returned by `nxE2EPreset`. See the recipe on [using `setupNodeEvents` with Cypress preset](/recipes/cypress/cypress-setup-node-events) for more details.
 {% /callout %}
 
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/cypress` package with your package manager.
-
-```shell
-npm add -D @nx/cypress
-```
-
-{% /tab %}
-{% /tabs %}
-
 ## E2E Testing
 
 By default, when creating a new frontend application, Nx will use Cypress to create the e2e tests project.
@@ -123,7 +127,7 @@ nx g @nx/web:app frontend
 
 ### Configure Cypress for an existing project
 
-To configure Cypress for an existing project, run the following generator
+To configure Cypress for an existing project, run the following generator:
 
 ```shell
 nx g @nx/cypress:configuration --project=your-app-name
@@ -135,56 +139,89 @@ Optionally, you can use the `--baseUrl` option if you don't want the Cypress plu
 nx g @nx/cypress:configuration --project=your-app-name --baseUrl=http://localhost:4200
 ```
 
-Replace `your-app-name` with the app's name as defined in your `tsconfig.base.json` file or the `name` property of your `package.json`.
+Replace `your-app-name` with the app's name as defined in your `project.json` file or the `name` property of your `package.json`.
+
+{% callout type="note" title="E2E setup location" %}
+The `@nx/cypress:configuration` generator is not a project generator. It won't generate a separate project for the E2E tests. It will configure Cypress for the provided project.
+
+To set up a separate project, you can generate a separate project with a project generator like `@nx/js:library` first and then run the `@nx/cypress:configuration` generator.
+{% /callout %}
 
 ### Testing Applications
 
 Run `nx e2e frontend-e2e` to execute e2e tests with Cypress.
 
-You can run your e2e test against a production build by using the `production` [configuration](https://nx.dev/concepts/executors-and-configurations#use-task-configurations)
+You can run your e2e test against a production build by using the `production` [configuration](/concepts/executors-and-configurations#use-task-configurations)
 
 ```shell
 nx e2e frontend-e2e --configuration=production
 ```
 
-{% callout type="note" title="Selecting Specific Specs" %}
+You can use the `--spec` flag to glob for test files.
 
-You can use the `--spec` flag to glob for test files
-
-```bash
+```shell
 # run the tests in the smoke/ directory
-nx e2e frontend-e2e --spec=**smoke/**
+nx e2e frontend-e2e --spec="**smoke/**"
 
 # run the tests in smoke/ directory and with dashboard in the file name
-nx e2e frontend-e2e --spec=**smoke/**,**dashboard.cy**
+nx e2e frontend-e2e --spec="**smoke/**,**dashboard.cy**"
 ```
-
-{% /callout %}
 
 By default, Cypress will run in headless mode. You will have the result of all the tests and errors (if any) in your
 terminal. Screenshots and videos will be accessible in `dist/cypress/apps/frontend/screenshots` and `dist/cypress/apps/frontend/videos`.
 
 ### Watching for Changes (Headed Mode)
 
-With, `nx e2e frontend-e2e --watch` Cypress will start in headed mode where you can see your application being tested.
-
-Running Cypress with `--watch` is a great way to enhance dev workflow - you can build up test files with the application
+You can also run Cypress in headed mode and watching for changes. This is a great way to enhance the dev workflow. You can build up test files with the application
 running and Cypress will re-run those tests as you enhance and add to the suite.
+
+{% tabs %}
+{% tab label="Using inferred tasks" %}
+
+```shell
+nx open-cypress frontend-e2e
+```
+
+{% /tab %}
+
+{% tab label="Using the @nx/cypress:cypress executor" %}
 
 ```shell
 nx e2e frontend-e2e --watch
 ```
 
+{% /tab %}
+{% /tabs %}
+
 ### Specifying a Custom Url to Test
 
 The `baseUrl` property provides you the ability to test an application hosted on a specific domain.
+
+{% tabs %}
+{% tab label="Using inferred tasks" %}
+
+```shell
+nx e2e frontend-e2e --config="baseUrl=https://frontend.com"
+```
+
+{% callout type="note" title="Required options" %}
+If `baseUrl` is not provided, Cypress will expect to have the `baseUrl` property in its config file. Otherwise, it will error.
+{% /callout %}
+
+{% /tab %}
+
+{% tab label="Using the @nx/cypress:cypress executor" %}
 
 ```shell
 nx e2e frontend-e2e --baseUrl=https://frontend.com
 ```
 
-> If no `baseUrl` and no `devServerTarget` are provided, Cypress will expect to have the `baseUrl` property in
-> the cypress config file, or will error.
+{% callout type="note" title="Required options" %}
+If no `baseUrl` and no `devServerTarget` are provided, Cypress will expect to have the `baseUrl` property in its config file. Otherwise, it will error.
+{% /callout %}
+
+{% /tab %}
+{% /tabs %}
 
 ## Using cypress.config.ts
 
@@ -194,22 +231,22 @@ you can easily add your `projectId` to save all the screenshots and videos into 
 configuration is documented
 on [the official website](https://docs.cypress.io/guides/references/configuration.html#Options).
 
-For adding more dynamic configurations to your cypress configuration, you can look into using [setupNodeEvents](https://docs.cypress.io/api/plugins/browser-launch-api#Syntax) configuration option.
+For adding more dynamic configurations to your Cypress configuration, you can look into using [setupNodeEvents](https://docs.cypress.io/api/plugins/browser-launch-api#Syntax) configuration option.
 
 ## Environment Variables
 
-If you're needing to pass a variable to cypress that you wish to not commit to your repository, i.e. API keys, or dynamic values based on configurations, i.e. API Urls. This is where [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables) can be used.
+If you're needing to pass a variable to Cypress that you wish to not commit to your repository, i.e. API keys, or dynamic values based on configurations, i.e. API URLs. This is where [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables) can be used.
 
-There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the [env executor option for cypress](/nx-api/cypress/executors/cypress#env) or the commandline.
+There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the `env` option in the [project configuration](/reference/project-configuration#targets) or the commandline.
 
-Create a `cypress.env.json` file in the projects root i.e. `apps/my-cool-app-e2e/cypress.env.json`. Cypress will automatically pick up this file. This method is helpful for configurations that you want to not commit. Just don't forget to add the file to the `.gitignore` and add documentation so people in your repo know what values to popluate in their local copy of the `cypress.env.json` file.
+Create a `cypress.env.json` file in the projects root i.e. `apps/my-cool-app-e2e/cypress.env.json`. Cypress will automatically pick up this file. This method is helpful for configurations that you want to not commit. Just don't forget to add the file to the `.gitignore` and add documentation so people in your repo know what values to populate in their local copy of the `cypress.env.json` file.
 
-Using [@nx/cypress:cypress](/nx-api/cypress/executors/cypress) env executor option is a good way to add values you want to define that you don't mine commit to the repository, such as a base API url. You can leverage [target configurations](/reference/project-configuration#targets) to define different values as well.
+Set the `env` option in the project configuration is a good way to add values you want to define that you don't mind committing to the repository, such as a base API URL. You can leverage target configurations to define different values as well.
 
 Optionally, you can pass environment variables via the commandline with the `--env` flag.
 
 {% callout type="warning" title="Executor options and --env" %}
-When using the `--env` flag, this will not be merged with any values used in the `env` executor option.
+Providing the `--env` flag will override the `env` option set in the project configuration.
 {% /callout %}
 
 ```shell


### PR DESCRIPTION
Updates the Cypress plugin overview page with content relevant to Project Crystal.

Updated doc: https://nx-dev-git-fork-leosvelperez-docs-cypress-plugin-overview-nrwl.vercel.app/nx-api/cypress/documents/overview

Blocked by:
- [x] Update `@nx/cypress/plugin` to infer an `open-cypress` task: https://github.com/nrwl/nx/pull/22556
- [x] Release Nx with the above change

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
