### PR TITLE
fix(js): update babel preset to specify minor version of core-js for better optimization

### DIFF
--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -26,7 +26,8 @@ describe('Jest', () => {
       `generate @nx/js:lib ${name} --unitTestRunner=jest --no-interactive`
     );
 
-    const results = await runCLIAsync(`test ${name}`, {
+    const results = await runCLIAsync(`test ${name} --skip-nx-cache`, {
+      silenceError: true,
       env: {
         ...process.env, // need to set this for some reason, or else get "env: node: No such file or directory"
         NODE_ENV: 'foobar',

--- a/packages/js/babel.ts
+++ b/packages/js/babel.ts
@@ -57,7 +57,11 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
           : {
               // Allow importing core-js in entrypoint and use browserslist to select polyfills.
               useBuiltIns: options.useBuiltIns ?? 'entry',
-              corejs: options.useBuiltIns !== false ? 3 : null,
+              corejs:
+                options.useBuiltIns !== false
+                  ? // Setting the minor version as well for better optimization (See: https://github.com/zloirock/core-js#babelpreset-env)
+                    '3.36'
+                  : null,
               // Do not transform modules to CJS
               modules: false,
               targets: isModern ? { esmodules: 'intersect' } : undefined,

--- a/packages/rollup/src/utils/ensure-dependencies.ts
+++ b/packages/rollup/src/utils/ensure-dependencies.ts
@@ -4,7 +4,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { swcCoreVersion, swcHelpersVersion } from '@nx/js/src/utils/versions';
-import { swcLoaderVersion, tsLibVersion } from './versions';
+import { coreJsVersion, swcLoaderVersion, tsLibVersion } from './versions';
 
 export type EnsureDependenciesOptions = {
   compiler?: 'babel' | 'swc' | 'tsc';
@@ -14,17 +14,27 @@ export function ensureDependencies(
   tree: Tree,
   options: EnsureDependenciesOptions
 ): GeneratorCallback {
-  if (options.compiler === 'swc') {
-    return addDependenciesToPackageJson(
-      tree,
-      {},
-      {
-        '@swc/helpers': swcHelpersVersion,
-        '@swc/core': swcCoreVersion,
-        'swc-loader': swcLoaderVersion,
-      }
-    );
+  switch (options.compiler) {
+    case 'swc':
+      return addDependenciesToPackageJson(
+        tree,
+        {},
+        {
+          '@swc/helpers': swcHelpersVersion,
+          '@swc/core': swcCoreVersion,
+          'swc-loader': swcLoaderVersion,
+        }
+      );
+    case 'babel':
+      return addDependenciesToPackageJson(
+        tree,
+        {},
+        {
+          'core-js': coreJsVersion, // needed for preset-env to work
+          tslib: tsLibVersion,
+        }
+      );
+    default:
+      return addDependenciesToPackageJson(tree, {}, { tslib: tsLibVersion });
   }
-
-  return addDependenciesToPackageJson(tree, {}, { tslib: tsLibVersion });
 }

--- a/packages/rollup/src/utils/versions.ts
+++ b/packages/rollup/src/utils/versions.ts
@@ -1,3 +1,5 @@
 export const nxVersion = require('../../package.json').version;
 export const swcLoaderVersion = '0.1.15';
 export const tsLibVersion = '^2.3.0';
+
+export const coreJsVersion = '^3.36.1';

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -10,4 +10,4 @@ export const storybookVersion = '^7.5.3';
 export const reactVersion = '^18.2.0';
 export const viteVersion = '~5.0.0';
 
-export const coreJsVersion = '^3.6.5';
+export const coreJsVersion = '^3.36.1';


### PR DESCRIPTION
This PR adds the minor version when passing `corejs` option to `@babel/preset-env`. When it is passed as just major version `3`, there are some optimizations that may be skipped.

- Also fix `@nx/rollup:configuration` generator to add `core-js` as needed (apps don't need it anymore, but libs still do if they target `cjs`)
- Update `core-js` to `^3.36.1`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21354
