### PR TITLE
chore(repo): prefer ts node on freebsd publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 3 * * 2-6" # Tuesdays - Saturdays, at 3am UTC
   workflow_dispatch:
   release:
-    types: [published]
+    types: [ published ]
 
 env:
   DEBUG: napi:*
@@ -158,62 +158,63 @@ jobs:
           if-no-files-found: error
 
   build-freebsd:
-     if: ${{ github.repository_owner == 'nrwl' }}
-     runs-on: macos-13-large
-     name: Build FreeBSD
-     timeout-minutes: 45
-     steps:
-       - uses: actions/checkout@v4
-         if: ${{ github.event_name != 'schedule' }}
-       - name: Build
-         id: build
-         if: ${{ github.event_name != 'schedule' }}
-         uses: cross-platform-actions/action@v0.22.0
-         env:
-           DEBUG: napi:*
-           RUSTUP_IO_THREADS: 1
-         with:
-           operating_system: freebsd
-           version: '13.2'
-           architecture: x86-64
-           environment_variables: DEBUG RUSTUP_IO_THREADS CI
-           shell: bash
-           run: |
-             env
-             whoami
-             sudo pkg install -y -f node libnghttp2 npm git
-             sudo npm install --location=global --ignore-scripts pnpm
-             curl https://sh.rustup.rs -sSf --output rustup.sh
-             sh rustup.sh -y --profile minimal --default-toolchain stable
-             source "$HOME/.cargo/env"
-             echo "~~~~ rustc --version ~~~~"
-             rustc --version
-             echo "~~~~ node -v ~~~~"
-             node -v
-             echo "~~~~ pnpm --version ~~~~"
-             pnpm --version
-             pwd
-             ls -lah
-             whoami
-             env
-             freebsd-version
-             mkdir -p /Users/runner/work/_temp/_github_workflow
-             echo "{}" > /Users/runner/work/_temp/_github_workflow/event.json
-             pnpm install --frozen-lockfile --ignore-scripts
-             pnpm nx run-many --outputStyle stream --target=build-native -- --target=x86_64-unknown-freebsd
-             pnpm nx reset
-             rm -rf node_modules
-             rm -rf dist
-             echo "KILL ALL NODE PROCESSES"
-             killall node || true
-             echo "COMPLETE"
-       - name: Upload artifact
-         if: ${{ github.event_name != 'schedule' }}
-         uses: actions/upload-artifact@v3
-         with:
-           name: bindings-freebsd
-           path: packages/**/*.node
-           if-no-files-found: error
+    if: ${{ github.repository_owner == 'nrwl' }}
+    runs-on: macos-13-large
+    name: Build FreeBSD
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'schedule' }}
+      - name: Build
+        id: build
+        if: ${{ github.event_name != 'schedule' }}
+        uses: cross-platform-actions/action@v0.22.0
+        env:
+          DEBUG: napi:*
+          RUSTUP_IO_THREADS: 1
+          NX_PREFER_TS_NODE: true
+        with:
+          operating_system: freebsd
+          version: '13.2'
+          architecture: x86-64
+          environment_variables: DEBUG RUSTUP_IO_THREADS CI NX_PREFER_TS_NODE
+          shell: bash
+          run: |
+            env
+            whoami
+            sudo pkg install -y -f node libnghttp2 npm git
+            sudo npm install --location=global --ignore-scripts pnpm
+            curl https://sh.rustup.rs -sSf --output rustup.sh
+            sh rustup.sh -y --profile minimal --default-toolchain stable
+            source "$HOME/.cargo/env"
+            echo "~~~~ rustc --version ~~~~"
+            rustc --version
+            echo "~~~~ node -v ~~~~"
+            node -v
+            echo "~~~~ pnpm --version ~~~~"
+            pnpm --version
+            pwd
+            ls -lah
+            whoami
+            env
+            freebsd-version
+            mkdir -p /Users/runner/work/_temp/_github_workflow
+            echo "{}" > /Users/runner/work/_temp/_github_workflow/event.json
+            pnpm install --frozen-lockfile --ignore-scripts
+            pnpm nx run-many --outputStyle stream --target=build-native -- --target=x86_64-unknown-freebsd
+            pnpm nx reset
+            rm -rf node_modules
+            rm -rf dist
+            echo "KILL ALL NODE PROCESSES"
+            killall node || true
+            echo "COMPLETE"
+      - name: Upload artifact
+        if: ${{ github.event_name != 'schedule' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: bindings-freebsd
+          path: packages/**/*.node
+          if-no-files-found: error
 
   publish:
     if: ${{ github.repository_owner == 'nrwl' }}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Swc does not support freebsd so using swc in the playwright plugin fails when trying to publish for FreeBSD

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

TS Node is used on FreeBSD instead and we're able to publish to FreeBSD

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
