### PR TITLE
chore(misc): revert e2e task splitting to unblock building on freebsd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
             pids+=($!)
 
             (pnpm nx affected --targets=lint,test,build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &&
-            pnpm nx affected --targets=e2e,e2e-ci --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
+            pnpm nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
             pids+=($!)
 
             for pid in "${pids[@]}"; do

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -19,7 +19,6 @@ launch-templates:
           PATHS: |
             node_modules
             ~/.cache/Cypress
-            ~/.cache/ms-playwright
             ~/.pnpm-store
             ~/.sdkman
             ~/.sdkman/candidates/gradle
@@ -36,10 +35,8 @@ launch-templates:
         script: |
           pnpm install --frozen-lockfile
 
-      - name: Install Browsers
-        script: |
-          pnpm exec cypress install
-          pnpm exec playwright install
+      - name: Install Cypress
+        script: pnpm exec cypress install
 
       - name: Install Rust
         script: |

--- a/nx-dev/nx-dev-e2e/playwright.config.ts
+++ b/nx-dev/nx-dev-e2e/playwright.config.ts
@@ -1,46 +1,27 @@
 import { defineConfig, devices } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
 
-/*
- * NOTE: We're not using the `nxE2EPreset` from `@nx/playwright` because there is an issue with `nx-ignore` + nx repo + crystal.
- *
- * The problem is specific to Nx repo, because of the following incompatible combination:
- * 1. `nx-ignore` only installs nx + necessary plugins (as defined in nx.json).
- * 2. `@nx/playwright/plugin` registers tsconfig-paths, thus `@nx/devkit` and `nx` packages are read from source
- *    e.g. packages/devkit rather than node_modules/@nx/devkit
- * 3. When `@nx/playwright/plugin` reads this config file (playwright.config.ts), it eventually loads `packages/devkit` instead of `node_modules/@nx/devkit`.
- *
- * Then, you will see an error like this:
- * Unable to create nodes for nx-dev/nx-dev-e2e/playwright.config.ts using plugin @nx/playwright/plugin.
- * 	 Inner Error: Error: Cannot find module 'fs-extra'
- * Require stack:
- * - /vercel/path0/packages/nx/src/project-graph/nx-deps-cache.ts
- * - /vercel/path0/packages/nx/src/project-graph/project-graph.ts
- * - /vercel/path0/packages/nx/src/config/workspaces.ts
- * - /vercel/path0/packages/nx/src/devkit-exports.ts
- * - /vercel/path0/packages/devkit/index.ts
- *
- * Again, this is specific to Nx repo only, because we both install nx + plugins to node_modules, but they are also mapped to source in tsconfig paths.
- */
+// nx-ignore-next-line
+import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+
+const preset = nxE2EPreset(__filename, { testDir: './src' });
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './src',
-  outputDir: '../../dist/.playwright/nx-dev-e2e/test-output',
-  /* Run tests in files in parallel */
-  fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  ...preset,
+  // CI default is 'dot', which doesn't show error output in CI.
+  // use list so errors are visible in CI logs
+  reporter: process.env.CI ? 'list' : preset.reporter,
   // how long the entire suite can run, prevent CI from timing out
   globalTimeout: process.env.CI ? 1_800_000 : undefined,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -53,7 +34,7 @@ export default defineConfig({
   },
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm exec nx run nx-dev:start',
+    command: 'pnpm exec nx run nx-dev:serve:production',
     url: 'http://localhost:4200',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
@@ -62,6 +43,16 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
     },
   ],
 });

--- a/nx-dev/nx-dev-e2e/project.json
+++ b/nx-dev/nx-dev-e2e/project.json
@@ -4,7 +4,21 @@
   "sourceRoot": "nx-dev/nx-dev-e2e/src",
   "projectType": "application",
   "targets": {
-    "lint": {}
+    "lint": {},
+    "e2e": {
+      "dependsOn": [
+        {
+          "target": "build-base",
+          "dependencies": true
+        }
+      ],
+      "executor": "@nx/playwright:playwright",
+      "outputs": ["{workspaceRoot}/dist/.playwright/nx-dev/nx-dev-e2e"],
+      "options": {
+        "config": "nx-dev/nx-dev-e2e/playwright.config.ts",
+        "project": ["chromium"]
+      }
+    }
   },
   "tags": ["scope:nx-dev", "type:e2e"],
   "implicitDependencies": ["nx-dev"]

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -80,10 +80,6 @@
         "parallel": true
       }
     },
-    "start": {
-      "dependsOn": ["build-base"],
-      "command": "nx run nx-dev:serve:production"
-    },
     "serve": {
       "executor": "@nx/next:server",
       "dependsOn": ["copy-docs"],

--- a/nx.json
+++ b/nx.json
@@ -207,16 +207,7 @@
       }
     }
   },
-  "plugins": [
-    "@monodon/rust",
-    {
-      "plugin": "@nx/playwright/plugin",
-      "options": {
-        "targetName": "pw-e2e",
-        "ciTargetName": "e2e-ci"
-      }
-    }
-  ],
+  "plugins": ["@monodon/rust"],
   "nxCloudAccessToken": "YmZiOWQyNzctOThiZC00MjYwLWI3YTAtZDA3MDg4YWY1YTExfHJlYWQ=",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,


### PR DESCRIPTION
Reverts: https://github.com/nrwl/nx/pull/22181

We need to look at workarounds when using `@nx/playwright/plugin` on freebsd, then we can do the split again.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
