### PR TITLE
fix(testing): remove root from the cypress ci-e2e group

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -199,7 +199,7 @@ describe('@nx/cypress/plugin', () => {
           ".": {
             "metadata": {
               "targetGroups": {
-                ".:e2e-ci": [
+                "e2e-ci": [
                   "e2e-ci--src/test.cy.ts",
                   "e2e-ci",
                 ],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress defines a group named `{projectRoot}:{ciE2eTarget}`. The project root part is useless information because the information is on the project itself.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress plugin defines a group named `{ciE2eTarget}`. So like..

```
{ 'e2e-ci': ['e2e-ci', 'e2e-ci--file.spec.ts'], }
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
