### PR TITLE
docs(misc): remove some wrong references to the deprecated cacheableOperations option

### DIFF
--- a/docs/shared/angular-tutorial/angular-monorepo.md
+++ b/docs/shared/angular-tutorial/angular-monorepo.md
@@ -891,7 +891,7 @@ NX   Successfully ran targets test, lint, e2e for 5 projects (54ms)
 Nx read the output from the cache instead of running the command for 10 out of 10 tasks.
 ```
 
-Not all tasks might be cacheable though. You can configure `cacheableOperations` in the `nx.json` file. You can also [learn more about how caching works](/features/cache-task-results).
+Not all tasks might be cacheable though. You can [configure which tasks are cacheable](/features/cache-task-results) in [the project configuration](/reference/project-configuration#cache) or in [the global Nx configuration](/reference/nx-json#cache). You can also [learn more about how caching works](/concepts/how-caching-works).
 
 ### Testing Affected Projects
 

--- a/docs/shared/migration/from-turborepo.md
+++ b/docs/shared/migration/from-turborepo.md
@@ -107,18 +107,18 @@ For each `turbo.json` configuration property, the equivalent Nx property is list
 | `globalPassThroughEnv`    | N/A. See [Defining Environment Variables](/recipes/tips-n-tricks/define-environment-variables)                                                         |
 | `globalDotEnv`            | add to the [`sharedGlobals` `namedInput`](/recipes/running-tasks/configure-inputs)                                                                     |
 
-| **Task Configuration:**         |                                                                                                   |
-| ------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `extends`                       | N/A. The project configurations will always extend the `targetDefaults` defined in `nx.json`.     |
-| `pipeline[task].dependsOn`      | [Same syntax](/reference/project-configuration#dependson).                                        |
-| `pipeline[task].dotEnv`         | Define [file `inputs`](/reference/project-configuration#filesets)                                 |
-| `pipeline[task].env`            | Define [env `inputs`](/reference/project-configuration#env-variables)                             |
-| `pipeline[task].passThroughEnv` | N/A. See [Defining Environment Variables](/recipes/tips-n-tricks/define-environment-variables)    |
-| `pipeline[task].outputs`        | [Same syntax](/reference/project-configuration#outputs).                                          |
-| `pipeline[task].cache`          | Define in the [`nx.json` `cacheableOperations` property](/reference/nx-json#tasks-runner-options) |
-| `pipeline[task].inputs`         | [Same syntax](/reference/project-configuration#filesets).                                         |
-| `pipeline[task].outputMode`     | Use the [`--output-style` command line flag](/nx-api/nx/documents/run-many#output-style)          |
-| `pipeline[task].persistent`     | N/A.                                                                                              |
+| **Task Configuration:**         |                                                                                                |
+| ------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `extends`                       | N/A. The project configurations will always extend the `targetDefaults` defined in `nx.json`.  |
+| `pipeline[task].dependsOn`      | [Same syntax](/reference/project-configuration#dependson).                                     |
+| `pipeline[task].dotEnv`         | Define [file `inputs`](/reference/project-configuration#filesets)                              |
+| `pipeline[task].env`            | Define [env `inputs`](/reference/project-configuration#env-variables)                          |
+| `pipeline[task].passThroughEnv` | N/A. See [Defining Environment Variables](/recipes/tips-n-tricks/define-environment-variables) |
+| `pipeline[task].outputs`        | [Same syntax](/reference/project-configuration#outputs).                                       |
+| `pipeline[task].cache`          | [Same syntax](/reference/project-configuration#cache)                                          |
+| `pipeline[task].inputs`         | [Same syntax](/reference/project-configuration#filesets).                                      |
+| `pipeline[task].outputMode`     | Use the [`--output-style` command line flag](/nx-api/nx/documents/run-many#output-style)       |
+| `pipeline[task].persistent`     | N/A.                                                                                           |
 
 ## Command Equivalents
 

--- a/docs/shared/recipes/add-stack/add-astro.md
+++ b/docs/shared/recipes/add-stack/add-astro.md
@@ -48,7 +48,7 @@ NX   🎉 Done!
 - Learn more at https://nx.dev/recipes/adopting-nx/adding-to-existing-project.
 ```
 
-You can add a task as cacheable after the fact by updating the `cacheableOperations` in the `nx.json` file. Learn more about [caching task results](/recipes/adopting-nx/adding-to-existing-project#installing-nx-on-a-non-monorepo-project) or [how caching works](/features/cache-task-results).
+You can [configure a task as cacheable](/features/cache-task-results) after the fact by updating [the project configuration](/reference/project-configuration#cache) or [the global Nx configuration](/reference/nx-json#cache). Learn more about [caching task results](/features/cache-task-results) or [how caching works](/concepts/how-caching-works).
 
 ## Running Tasks
 

--- a/docs/shared/recipes/running-tasks/root-level-scripts.md
+++ b/docs/shared/recipes/running-tasks/root-level-scripts.md
@@ -80,7 +80,7 @@ Our fully configured example would look like this:
 }
 ```
 
-To cache the `docs` target, you can add `docs` to the `cacheableOperations` in `nx.json` and then your output would look like this:
+To cache the `docs` target, you can set `cache: true` to the `docs` target shown in the `package.json` above and then your output would look like this:
 
 ```{% command="nx docs" path="~/myorg" %}
 > nx run myorg:docs  [existing outputs match the cache, left as is]
@@ -96,7 +96,7 @@ NX   Successfully ran target docs for project myorg (31ms)
 Nx read the output from the cache instead of running the command for 1 out of 1 tasks.
 ```
 
-Read more about [cacheableOperations](/features/cache-task-results) and fine-tuning caching with [task inputs](/recipes/running-tasks/configure-inputs).
+Read more about [caching task results](/features/cache-task-results) and fine-tuning caching with [task inputs](/recipes/running-tasks/configure-inputs).
 
 ## Keep using NPM to run scripts rather than Nx
 

--- a/docs/shared/recipes/running-tasks/root-level-scripts.md
+++ b/docs/shared/recipes/running-tasks/root-level-scripts.md
@@ -80,7 +80,7 @@ Our fully configured example would look like this:
 }
 ```
 
-To cache the `docs` target, you can set `cache: true` to the `docs` target shown in the `package.json` above and then your output would look like this:
+To cache the `docs` target, you can set `cache: true` on the `docs` target shown in the `package.json` above. Your output would then look as follows:
 
 ```{% command="nx docs" path="~/myorg" %}
 > nx run myorg:docs  [existing outputs match the cache, left as is]

--- a/docs/shared/recipes/troubleshoot-cache-misses.md
+++ b/docs/shared/recipes/troubleshoot-cache-misses.md
@@ -2,7 +2,13 @@
 
 Problem: A task is being executed when you expect it to be replayed from the cache.
 
-1. Check if your task is either marked with `"cache": true` in `nx.json#targetDefaults` or listed in `cacheableOperations` defined in `nx.json#tasksRunnerOptions`
+1. Check if your task is marked as cacheable:
+
+   - Check the task has a "Cacheable" label in the Project Details View. You can do so by running `nx show project <project-name> --web` or by checking the [Project Details View in Nx Console](/recipes/nx-console/console-project-details).
+   - If you're using a version lower than Nx 17.2.0, check:
+     - the target configuration in the project's `project.json` file has `"cache": true` set, or
+     - the target configuration in `nx.json#targetDefaults` has `"cache": true` set, or
+     - the task is listed in `cacheableOperations` defined in `nx.json#tasksRunnerOptions`
 
 1. Check if the output of your task is changing the inputs of your task
 

--- a/docs/shared/recipes/troubleshoot-cache-misses.md
+++ b/docs/shared/recipes/troubleshoot-cache-misses.md
@@ -4,7 +4,7 @@ Problem: A task is being executed when you expect it to be replayed from the cac
 
 1. Check if your task is marked as cacheable:
 
-   - Check the task has a "Cacheable" label in the Project Details View. You can do so by running `nx show project <project-name> --web` or by checking the [Project Details View in Nx Console](/recipes/nx-console/console-project-details).
+   - Check the task has a "Cacheable" label in the Project Details View. You can do so by running `nx show project <project-name> --web` or by checking it in [Nx Console](/recipes/nx-console/console-project-details).
    - If you're using a version lower than Nx 17.2.0, check:
      - the target configuration in the project's `project.json` file has `"cache": true` set, or
      - the target configuration in `nx.json#targetDefaults` has `"cache": true` set, or


### PR DESCRIPTION
Updated docs:

- https://nx-dev-git-fork-leosvelperez-docs-remove-wrong-cach-3dd86f-nrwl.vercel.app/getting-started/tutorials/angular-monorepo-tutorial#caching
- https://nx-dev-git-fork-leosvelperez-docs-remove-wrong-cach-3dd86f-nrwl.vercel.app/recipes/adopting-nx/from-turborepo#specific-configuration-property-conversions
- https://nx-dev-git-fork-leosvelperez-docs-remove-wrong-cach-3dd86f-nrwl.vercel.app/showcase/example-repos/add-astro#add-nx
- https://nx-dev-git-fork-leosvelperez-docs-remove-wrong-cach-3dd86f-nrwl.vercel.app/recipes/running-tasks/root-level-scripts#configuring-a-rootlevel-target
- https://nx-dev-git-fork-leosvelperez-docs-remove-wrong-cach-3dd86f-nrwl.vercel.app/recipes/troubleshooting/troubleshoot-cache-misses

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
