### PR TITLE
fix(misc): align nx init package.json scripts handling when deselecting all plugins

### DIFF
--- a/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
@@ -10,13 +10,16 @@ import {
   addDepsToPackageJson,
   createNxJsonFile,
   initCloud,
+  markPackageJsonAsNxProject,
   printFinalMessage,
   runInstall,
   updateGitIgnore,
 } from './utils';
 import { connectExistingRepoToNxCloudPrompt } from '../../connect/connect-to-nx-cloud';
 
-type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'>;
+type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'> & {
+  legacy?: boolean;
+};
 
 export async function addNxToMonorepo(options: Options) {
   const repoRoot = process.cwd();
@@ -91,6 +94,14 @@ export async function addNxToMonorepo(options: Options) {
     cacheableOperations,
     scriptOutputs
   );
+  if (!options.legacy) {
+    packageJsonFiles.forEach((packageJsonPath) => {
+      markPackageJsonAsNxProject(
+        join(repoRoot, packageJsonPath),
+        cacheableOperations
+      );
+    });
+  }
 
   updateGitIgnore(repoRoot);
   addDepsToPackageJson(repoRoot);

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
@@ -16,7 +16,7 @@ import {
   addDepsToPackageJson,
   createNxJsonFile,
   initCloud,
-  markRootPackageJsonAsNxProject,
+  markRootPackageJsonAsNxProjectLegacy,
   printFinalMessage,
   runInstall,
   updateGitIgnore,
@@ -121,7 +121,7 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
   updateGitIgnore(repoRoot);
   addDepsToPackageJson(repoRoot);
   addNestPluginToPackageJson(repoRoot);
-  markRootPackageJsonAsNxProject(repoRoot, cacheableOperations, pmc);
+  markRootPackageJsonAsNxProjectLegacy(repoRoot, cacheableOperations, pmc);
 
   createProjectJson(repoRoot, packageJson, nestCLIConfiguration);
   removeFile(repoRoot, 'nest-cli.json');

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
@@ -1,4 +1,5 @@
 import * as enquirer from 'enquirer';
+import { join } from 'path';
 import { InitArgs } from '../init-v1';
 import { readJsonFile } from '../../../utils/fileutils';
 import { output } from '../../../utils/output';
@@ -7,14 +8,17 @@ import {
   addDepsToPackageJson,
   createNxJsonFile,
   initCloud,
-  markRootPackageJsonAsNxProject,
+  markPackageJsonAsNxProject,
+  markRootPackageJsonAsNxProjectLegacy,
   printFinalMessage,
   runInstall,
   updateGitIgnore,
 } from './utils';
 import { connectExistingRepoToNxCloudPrompt } from '../../connect/connect-to-nx-cloud';
 
-type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'>;
+type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'> & {
+  legacy?: boolean;
+};
 
 export async function addNxToNpmRepo(options: Options) {
   const repoRoot = process.cwd();
@@ -78,7 +82,14 @@ export async function addNxToNpmRepo(options: Options) {
 
   updateGitIgnore(repoRoot);
   addDepsToPackageJson(repoRoot);
-  markRootPackageJsonAsNxProject(repoRoot, cacheableOperations, pmc);
+  if (options.legacy) {
+    markRootPackageJsonAsNxProjectLegacy(repoRoot, cacheableOperations, pmc);
+  } else {
+    markPackageJsonAsNxProject(
+      join(repoRoot, 'package.json'),
+      cacheableOperations
+    );
+  }
 
   output.log({ title: '📦 Installing dependencies' });
 

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -168,7 +168,7 @@ export function addVsCodeRecommendedExtensions(
   }
 }
 
-export function markRootPackageJsonAsNxProject(
+export function markRootPackageJsonAsNxProjectLegacy(
   repoRoot: string,
   cacheableScripts: string[],
   pmc: PackageManagerCommands
@@ -192,6 +192,24 @@ export function markRootPackageJsonAsNxProject(
     }
   }
   writeJsonFile(`package.json`, json);
+}
+
+export function markPackageJsonAsNxProject(
+  packageJsonPath: string,
+  cacheableScripts: string[]
+) {
+  const json = readJsonFile<PackageJson>(packageJsonPath);
+  if (!json.scripts) {
+    return;
+  }
+
+  json.nx = { includedScripts: [] };
+  for (let script of cacheableScripts) {
+    if (json.scripts[script]) {
+      json.nx.includedScripts.push(script);
+    }
+  }
+  writeJsonFile(packageJsonPath, json);
 }
 
 export function printFinalMessage({

--- a/packages/nx/src/command-line/init/init-v1.ts
+++ b/packages/nx/src/command-line/init/init-v1.ts
@@ -45,9 +45,9 @@ export async function initHandler(options: InitArgs) {
     } else if (isNestCLI(packageJson)) {
       await addNxToNest(options, packageJson);
     } else if (isMonorepo(packageJson)) {
-      await addNxToMonorepo(options);
+      await addNxToMonorepo({ ...options, legacy: true });
     } else {
-      await addNxToNpmRepo(options);
+      await addNxToNpmRepo({ ...options, legacy: true });
     }
   } else {
     const useDotNxFolder = await prompt<{ useDotNxFolder: string }>([


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx init` and choosing to add any Nx core plugin results in `package.json#nx.includedScripts` being set, excluding all scripts.
Running `nx init` and not selecting any Nx core plugin results in `package.json#nx` being set (no `includedScripts`) and `nx exec --` prepended to the scripts selected as cacheable.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `nx init` should always set `package.json#nx.includedScripts` defaulting to `[]`. When the user doesn't select any plugin and selects some cacheable operations, these will be added to the `includedScripts` and no `nx exec --` will be prepended to any script.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
