### PR TITLE
fix(js): match core-js version with babel options

### DIFF
--- a/e2e/webpack/src/webpack.test.ts
+++ b/e2e/webpack/src/webpack.test.ts
@@ -2,6 +2,7 @@ import {
   cleanupProject,
   listFiles,
   newProject,
+  packageInstall,
   readFile,
   rmDist,
   runCLI,
@@ -188,4 +189,38 @@ describe('Webpack Plugin', () => {
     expect(content).not.toMatch(/secret/);
     expect(content).toMatch(/foobar/);
   });
+
+  it('should support babel + core-js to polyfill JS features', async () => {
+    const appName = uniq('app');
+    runCLI(
+      `generate @nx/web:app ${appName} --bundler webpack --compiler=babel`
+    );
+    packageInstall('core-js', undefined, '3.26.1', 'prod');
+    updateFile(
+      `apps/${appName}/src/main.ts`,
+      `
+      import 'core-js/stable';
+      async function main() {
+        const result = await Promise.resolve('foobar')
+        console.log(result);
+      }
+      main();
+    `
+    );
+
+    // Modern browser
+    updateFile(`apps/${appName}/.browserslistrc`, `last 1 Chrome version\n`);
+    runCLI(`build ${appName}`);
+    expect(readMainFile(`dist/apps/${appName}`)).toMatch(`await Promise`);
+
+    // Legacy browser
+    updateFile(`apps/${appName}/.browserslistrc`, `IE 11\n`);
+    runCLI(`build ${appName}`);
+    expect(readMainFile(`dist/apps/${appName}`)).not.toMatch(`await Promise`);
+  });
 });
+
+function readMainFile(dir: string): string {
+  const main = listFiles(dir).find((f) => f.startsWith('main.'));
+  return readFile(`${dir}/${main}`);
+}

--- a/packages/js/babel.ts
+++ b/packages/js/babel.ts
@@ -1,4 +1,5 @@
 import { dirname } from 'path';
+import { parse } from 'semver';
 import { logger } from '@nx/devkit';
 
 /*
@@ -54,23 +55,7 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
         // such as import syntax.
         isTest || process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID
           ? { targets: { node: 'current' }, loose: true }
-          : {
-              // Allow importing core-js in entrypoint and use browserslist to select polyfills.
-              useBuiltIns: options.useBuiltIns ?? 'entry',
-              corejs:
-                options.useBuiltIns !== false
-                  ? // Setting the minor version as well for better optimization (See: https://github.com/zloirock/core-js#babelpreset-env)
-                    '3.36'
-                  : null,
-              // Do not transform modules to CJS
-              modules: false,
-              targets: isModern ? { esmodules: 'intersect' } : undefined,
-              bugfixes: true,
-              // Exclude transforms that make all code slower
-              exclude: ['transform-typeof-symbol'],
-              // This must match the setting for `@babel/plugin-proposal-class-properties`
-              loose,
-            },
+          : createBabelPresetEnvOptions(options.useBuiltIns, isModern, loose),
       ],
       [
         require.resolve('@babel/preset-typescript'),
@@ -122,3 +107,41 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
     ],
   };
 };
+
+function createBabelPresetEnvOptions(
+  useBuiltIns: string | boolean,
+  isModern: boolean,
+  loose: boolean
+) {
+  const presetOptions: any = {
+    // Do not transform modules to CJS
+    modules: false,
+    targets: isModern ? { esmodules: 'intersect' } : undefined,
+    bugfixes: true,
+    // Exclude transforms that make all code slower
+    exclude: ['transform-typeof-symbol'],
+    // This must match the setting for `@babel/plugin-proposal-class-properties`
+    loose,
+  };
+
+  // If core-js is installed then set corresponding options, otherwise don't use core-js.
+  // Previously, core-js was required for all projects, but it is not longer required when using only stable JS features that does not need to be transpiled.
+  const coreJsVersion = findCoreJsVersion();
+  if (coreJsVersion) {
+    presetOptions.useBuiltIns = useBuiltIns ?? 'entry';
+    presetOptions.corejs = useBuiltIns !== false ? coreJsVersion : null;
+  }
+
+  return presetOptions;
+}
+
+function findCoreJsVersion(): string | null {
+  try {
+    // nx-ignore-next-line
+    const v = require('core-js/package.json').version;
+    const { major, minor } = parse(v);
+    return `${major}.${minor}`;
+  } catch (e) {
+    return null;
+  }
+}


### PR DESCRIPTION
The [previous PR](https://github.com/nrwl/nx/pull/22433) to set minor version of `corejs` when transpiling using babel may break projects if the version in workspace isn't matching the compat data.

We should read the installed version from the workspace and use that.

## Current Behavior
If compat and the `core-js` versions have a mismatch, then the build may break.

## Expected Behavior
Build should work no matter which `corejs` version is used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
