### PR TITLE
feat(graph): remove polyfills from graph client

### DIFF
--- a/graph/client/project.json
+++ b/graph/client/project.json
@@ -37,7 +37,6 @@
         "outputPath": "build/apps/graph",
         "index": "graph/client/src/index.html",
         "main": "graph/client/src/main.tsx",
-        "polyfills": "graph/client/src/polyfills.ts",
         "tsConfig": "graph/client/tsconfig.app.json",
         "styles": ["graph/client/src/styles.css"],
         "scripts": [],

--- a/graph/client/src/polyfills.ts
+++ b/graph/client/src/polyfills.ts
@@ -1,7 +1,0 @@
-/**
- * Polyfill stable language features. These imports will be optimized by `@babel/preset-env`.
- *
- * See: https://github.com/zloirock/core-js#babel
- */
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';


### PR DESCRIPTION
This PR removes polyfills from the graph client. We do not support legacy browsers and only stick to stable TS/JS features so there is no need for them.

<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
