### PR TITLE
fix(js): migrate core-js to 3.36 for workspaces that use it

### DIFF
--- a/packages/rollup/migrations.json
+++ b/packages/rollup/migrations.json
@@ -25,5 +25,15 @@
       "factory": "./src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps"
     }
   },
-  "packageJsonUpdates": {}
+  "packageJsonUpdates": {
+    "18.2.0": {
+      "version": "18.2.0-beta.1",
+      "packages": {
+        "core-js": {
+          "version": "3.36.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    }
+  }
 }

--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -963,6 +963,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "18.2.0": {
+      "version": "18.2.0-beta.1",
+      "packages": {
+        "core-js": {
+          "version": "3.36.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
For projects that use core-js, update to latest `3.36.1` version.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
