### PR TITLE
fix(release): propagate release for dependent packages

### DIFF
--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -28,7 +28,8 @@ export async function resolveSemverSpecifierFromConventionalCommits(
   const relevantCommits = await getCommitsRelevantToProjects(
     projectGraph,
     parsedCommits,
-    projectNames
+    projectNames,
+    true
   );
   return determineSemverChange(relevantCommits, CONVENTIONAL_COMMITS_CONFIG);
 }


### PR DESCRIPTION
Propagate release for all dependant packages that need updating when projectRelationship is "independent" . 

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Right now when monorepo has `projectRelationship: "independent"`, `nx release` is tagging and releasing only projects with changes and not projects that depend on those. For example, lets say that we have 2 projects in our monorepo: `is-even` and `is-odd` (which depends on `is-even`). If we make changes to `is-even`, `nx release` will only tag and release that project and not `is-odd` too, even though it's `package.json` is updated to reflect the dependency on the latest version of `is-even`.
`nx release` config that we are using in the example:
```json
  "release": {
    "version": {
      "conventionalCommits": true
    },
    "changelog": {
      "projectChangelogs": true
    },
    "projectsRelationship": "independent",
    "releaseTagPattern": "{projectName}-{version}"
  },
```

![image](https://github.com/nrwl/nx/assets/21104002/828363d1-8163-4bf8-a33a-db9ec1119426)
![image](https://github.com/nrwl/nx/assets/21104002/bad3a019-b059-46cc-9cd3-df4343a8ecf6)

## Expected Behavior
`nx release` will tag and release projects that depend on projects with changes too. In the example above, both packages will be released.

<img width="984" alt="image" src="https://github.com/nrwl/nx/assets/21104002/3a62218b-9afb-4b84-acd4-d6b2c3e8478b">
<img width="984" alt="image" src="https://github.com/nrwl/nx/assets/21104002/39c9330c-eb86-4083-89fd-a52dc5ae1a71">


## Related Issue(s)

Fixes #22268
