### PR TITLE
fix(core): combine executor properties with name `env` before passing to run commands

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -407,10 +407,18 @@ export class TaskOrchestrator {
           const args = getPrintableCommandArgsForTask(task);
           output.logCommand(args.join(' '));
         }
+
+        // The `nx:run-commands` executor schema has a property called `env` that we want to combine
+        // with the values we loaded, if it exists.
+        const combinedEnv =
+          combinedOptions.env !== undefined
+            ? { ...env, ...combinedOptions.env }
+            : env;
+
         const { success, terminalOutput } = await runCommandsImpl(
           {
             ...combinedOptions,
-            env,
+            env: combinedEnv,
             usePty: isRunOne && !this.tasksSchedule.hasTasks(),
             streamOutput,
           },


### PR DESCRIPTION
## Current Behavior
Nx's environment variable loading is also called `env`, which would overwrite the nx:run-commands executor `env` property value. Combine the two if an `env` property from the executor exists.

## Expected Behavior
`env` executor property is propagated properly
