### PR TITLE
docs(core): fix broken link in NPM Workspace Tutorial

### DIFF
--- a/docs/shared/tutorials/npm-workspaces.md
+++ b/docs/shared/tutorials/npm-workspaces.md
@@ -20,7 +20,7 @@ Here's the source code of the final result for this tutorial.
 
 ## Starting Repository
 
-To get started, check out [the sample repository](https://github.com/nrwl/tuskydesigns) on your local machine:
+To get started, check out [the sample repository](https://github.com/nrwl/tuskydesign) on your local machine:
 
 ```shell
 git clone https://github.com/nrwl/tuskydesign.git


### PR DESCRIPTION
## Current Behavior
In the documentation [NPM Workspaces Tutorial](https://nx.dev/getting-started/tutorials/npm-workspaces-tutorial) there is a link which refers to a non-existent GitHub repository.

## Expected Behavior
In the documentation [NPM Workspaces Tutorial](https://nx.dev/getting-started/tutorials/npm-workspaces-tutorial) there is a link which refers to the correct GitHub repository.

## Related Issue(s)

Fixes #22489
