### PR TITLE
docs(misc): remove nx:run-commands section from @nx/workspace plugin overview

### DIFF
--- a/docs/generated/packages/workspace/documents/overview.md
+++ b/docs/generated/packages/workspace/documents/overview.md
@@ -38,11 +38,3 @@ Like when moving projects, some steps are often missed when removing projects. T
 4. The path mapping in `tsconfig.base.json` will be removed.
 
 > See more about [`@nx/workspace:remove`](/nx-api/workspace/generators/remove)
-
-## Running custom commands
-
-Executors provide an optimized way of running targets but unfortunately, not every target has an executor written for it. The [`nx:run-commands`](/nx-api/nx/executors/run-commands) executor is an executor that runs any command or multiple commands in the shell. This can be useful when integrating with other tools which do not have an executor provided. There is also a generator to help configure this executor.
-
-Running `nx g @nx/workspace:run-commands printhello --project my-feature-lib --command 'echo hello'` will create a `my-feature-lib:printhello` target that executes `echo hello` in the shell.
-
-> See more about [`nx:run-commands`](/nx-api/nx/executors/run-commands)

--- a/docs/shared/packages/workspace/workspace-plugin.md
+++ b/docs/shared/packages/workspace/workspace-plugin.md
@@ -38,11 +38,3 @@ Like when moving projects, some steps are often missed when removing projects. T
 4. The path mapping in `tsconfig.base.json` will be removed.
 
 > See more about [`@nx/workspace:remove`](/nx-api/workspace/generators/remove)
-
-## Running custom commands
-
-Executors provide an optimized way of running targets but unfortunately, not every target has an executor written for it. The [`nx:run-commands`](/nx-api/nx/executors/run-commands) executor is an executor that runs any command or multiple commands in the shell. This can be useful when integrating with other tools which do not have an executor provided. There is also a generator to help configure this executor.
-
-Running `nx g @nx/workspace:run-commands printhello --project my-feature-lib --command 'echo hello'` will create a `my-feature-lib:printhello` target that executes `echo hello` in the shell.
-
-> See more about [`nx:run-commands`](/nx-api/nx/executors/run-commands)


### PR DESCRIPTION
Updated docs:

- https://nx-dev-git-fork-leosvelperez-docs-remove-run-comman-530943-nrwl.vercel.app/nx-api/workspace/documents/overview

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
