### PR TITLE
docs(misc): add section to ignore .nx/cache dir in manual migration docs

### DIFF
--- a/docs/shared/migration/manual.md
+++ b/docs/shared/migration/manual.md
@@ -44,6 +44,15 @@ Next, we'll create a blank `nx.json` configuration file for Nx:
 {}
 ```
 
+## Add `.nx/cache` to `.gitignore`
+
+Next, we'll add [the Nx default cache directory](/features/cache-task-results#where-is-the-cache-stored) to the list of files to be ignored by Git. Update the `.gitignore` file adding the `.nx/cache` entry:
+
+```text {% fileName=".gitignore" %}
+...
+.nx/cache
+```
+
 ## Set Up Caching For a Task
 
 Now, let's set up caching for a script in your `package.json` file. Let's say you have a `build` script that looks like this:


### PR DESCRIPTION
Updated docs:

- https://nx-dev-git-fork-leosvelperez-docs-manual-migration-4430f9-nrwl.vercel.app/recipes/adopting-nx/manual#add-to

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
