### PR TITLE
fix(vite): handle both vite.config.ts and vitest.config.ts

### DIFF
--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -123,8 +123,8 @@ async function buildViteTargets(
 
   const targets: Record<string, TargetConfiguration> = {};
 
-  // If file is not vitest.config and buildable, create targets for build, serve, preview and serve-static
-  if (!configFilePath.includes('vitest.config') && isBuildable) {
+  // If file is vite.config and buildable, create targets for build, serve, preview and serve-static
+  if (configFilePath.includes('vite.config') && isBuildable) {
     targets[options.buildTargetName] = await buildTarget(
       options.buildTargetName,
       namedInputs,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When a package has both `vite.config.ts` and `vitest.config.ts`, plugin fails to infer targets correctly (in my case, I had some packages with `test` targets, some with `build` targets). 

## Expected Behavior
Having both files should not bother nx plugin. 

## Related Issue(s)
Might fix #22244