### PR TITLE
fix(core): rethrow unknown errors during incremental graph calculation

### DIFF
--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -239,6 +239,8 @@ async function processFilesAndCreateAndSerializeProjectGraph(): Promise<Serializ
       if (e instanceof ProjectConfigurationsError) {
         graphNodes = e.partialProjectConfigurationsResult;
         projectConfigurationsError = e;
+      } else {
+        throw e;
       }
     }
     await processCollectedUpdatedAndDeletedFiles(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Non `ProjectGraphErrors` are not handled but are not thrown.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Non `ProjectGraphErrors` are rethrown

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
