### PR TITLE
fix(js): handle case where tslib or @swc/helpers are missing from externalNodes

### DIFF
--- a/packages/js/src/utils/find-npm-dependencies.ts
+++ b/packages/js/src/utils/find-npm-dependencies.ts
@@ -201,8 +201,11 @@ function collectHelperDependencies(
 
   if (target.executor === '@nx/js:tsc' && target.options?.tsConfig) {
     const tsConfig = readTsConfig(join(workspaceRoot, target.options.tsConfig));
-    if (tsConfig?.options['importHelpers']) {
-      npmDeps['tslib'] = projectGraph.externalNodes['npm:tslib']?.data.version;
+    if (
+      tsConfig?.options['importHelpers'] &&
+      projectGraph.externalNodes['npm:tslib']?.type === 'npm'
+    ) {
+      npmDeps['tslib'] = projectGraph.externalNodes['npm:tslib'].data.version;
     }
   }
   if (target.executor === '@nx/js:swc') {
@@ -212,9 +215,12 @@ function collectHelperDependencies(
     const swcConfig = fileExists(swcConfigPath)
       ? readJsonFile(swcConfigPath)
       : {};
-    if (swcConfig?.jsc?.externalHelpers) {
+    if (
+      swcConfig?.jsc?.externalHelpers &&
+      projectGraph.externalNodes['npm:@swc/helpers']?.type === 'npm'
+    ) {
       npmDeps['@swc/helpers'] =
-        projectGraph.externalNodes['npm:@swc/helpers']?.data.version;
+        projectGraph.externalNodes['npm:@swc/helpers'].data.version;
     }
   }
 }


### PR DESCRIPTION
This PR makes the `findNpmDependencies` function more resilient when a helper package is missing from `externalNodes`. If the workspace does not have `tslib` or `@swc/helpers` in `externalNodes`, it will not be included in a project's expected npm dependencies.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
