### PR TITLE
fix(testing): name group of e2e ci tasks distinctly from target name

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -199,7 +199,7 @@ describe('@nx/cypress/plugin', () => {
           ".": {
             "metadata": {
               "targetGroups": {
-                "e2e-ci": [
+                "E2E (CI)": [
                   "e2e-ci--src/test.cy.ts",
                   "e2e-ci",
                 ],

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -220,8 +220,9 @@ async function buildCypressTargets(
       const outputs = getOutputs(projectRoot, cypressConfig, 'e2e');
       const inputs = getInputs(namedInputs);
 
-      targetGroups = { [options.ciTargetName]: [] };
-      const ciTargetGroup = targetGroups[options.ciTargetName];
+      const groupName = 'E2E (CI)';
+      targetGroups = { [groupName]: [] };
+      const ciTargetGroup = targetGroups[groupName];
       for (const file of specFiles) {
         const relativeSpecFilePath = normalizePath(relative(projectRoot, file));
         const targetName = options.ciTargetName + '--' + relativeSpecFilePath;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress e2e targets are grouped under the name of the `ciTargetName`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress e2e targets are grouped under `E2E (CI)` which is descriptive of when those targets should be used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
