### PR TITLE
fix(js): do not write cached lockfile parsed results when an error is…

### DIFF
--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -88,7 +88,7 @@ export const createDependencies: CreateDependencies = (
   if (
     pluginConfig.analyzeLockfile &&
     lockFileExists(packageManager) &&
-    parsedLockFile
+    parsedLockFile.externalNodes
   ) {
     const lockFilePath = join(workspaceRoot, getLockFileName(packageManager));
     const lockFileContents = readFileSync(lockFilePath).toString();


### PR DESCRIPTION
… thrown

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When project graph fails to construct during `postinstall`, the js plugin still writes a cached parsed lockfile and the graph is incorrectly successful.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When project graph fails to construct during `postinstall`, the js plugin does not write a cached parsed lockfile. The graph is recalculated after the `postinstall` and it is correct.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
