### PR TITLE
fix(esbuild): thirdparty option

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -34,6 +34,7 @@ export function buildEsbuildOptions(
           ...options.external,
         ]
       : undefined,
+    packages: options.thirdParty ? undefined : 'external',
     minify: options.minify,
     platform: options.platform,
     target: options.target,


### PR DESCRIPTION
## Current Behavior
When using "thirdParty": false third party packages from node_modules are still bundled.

## Expected Behavior
When using "thirdParty": false third party packages from node_modules should not be bundled.

It should be behave the same as I would set the option in esbuild packages=external
See documentation here: https://esbuild.github.io/api/#packages

The thirdParty property is not handled at all in the [build-esbuild-options module](https://github.com/nrwl/nx/blob/master/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts) and therefore the packages option for esbuild is never set.

## Related Issue(s)
[@nx/esbuild:esbuild thirdParty not handled](https://github.com/nrwl/nx/issues/22531)
