### PR TITLE
docs(misc): remove incorrect and not needed targetDefaults option from snippet

### DIFF
--- a/docs/shared/reference/inputs.md
+++ b/docs/shared/reference/inputs.md
@@ -188,15 +188,12 @@ Naming a set of inputs with the same name as a set of inputs defined for the wor
 
 By default, Nx Workspaces are generated with the following named inputs:
 
-```jsonc {% fileName="nx.json" highlightLines=["2-6"] %}
+```jsonc {% fileName="nx.json" %}
 {
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"], // Default Inputs
     "production": ["default", "!{projectRoot}/jest.config.ts"], // Production Inputs
     "sharedGlobals": [] // Shared Global Inputs
-  },
-  "targetDefaults": {
-    "inputs": ["default", "^default"]
   }
 }
 ```


### PR DESCRIPTION
Updated doc: https://nx-dev-git-fork-leosvelperez-docs-fix-wrong-example-nrwl.vercel.app/reference/inputs#named-input-conventions

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
