### PR TITLE
chore(repo): bump agents docker image

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -1,7 +1,7 @@
 launch-templates:
   linux-medium:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.9-v3'
+    image: 'ubuntu22.04-node20.11-v3'
     env:
       GIT_AUTHOR_EMAIL: test@test.com
       GIT_AUTHOR_NAME: Test
@@ -30,7 +30,7 @@ launch-templates:
           sudo apt-get install -y ca-certificates lsof
       - name: Install Pnpm
         script: |
-          npm install -g @pnpm/exe@8.7.4
+          npm install -g pnpm@8.15.5
 
       - name: Pnpm Install
         script: |


### PR DESCRIPTION
Updates the Nx Agents Docker image to a newer one that supports Node 20.11.1, which is a requirement of the upcoming Angular v18.

The new image changed the PNPM installation from `@pnpm/exe` to `pnpm`, so this PR also updates the PNPM installation to match that. Without that change, the step fails, as can be seen in the following CIPE: https://staging.nx.app/cipes/6602f2ab7216aa25ee6d7123?step=c39656c5-7e40-4921-9fe0-84cb4580beeb#step-list-pane.

The following are runs with the old image and the new image with the Angular v18 upcoming changes:

- Old image: https://staging.nx.app/runs/NalwptI048
  - the projects `e2e-angular-core` and `e2e-nx-init` fail due to an invalid node engine
- New image: https://staging.nx.app/runs/l6PYvgnKY6
  - the projects `e2e-angular-core` and `e2e-nx-init` no longer fail

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
