### PR TITLE
feat(webpack): create build log for remotes to help debug errors

### DIFF
--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -18,9 +18,10 @@ import {
   createAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
-import { fork } from 'child_process';
-import { basename, dirname, join } from 'path';
-import { cpSync } from 'fs';
+import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
+import { fork } from 'node:child_process';
+import { basename, dirname, join } from 'node:path';
+import { createWriteStream, cpSync } from 'node:fs';
 
 type ModuleFederationDevServerOptions = WebDevServerOptions & {
   devRemotes?: string[];
@@ -178,10 +179,19 @@ async function buildStaticRemotes(
         stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
       }
     );
+
+    // File to debug build failures e.g. 2024-01-01T00_00_0_0Z-build.log'
+    const remoteBuildLogFile = join(
+      projectGraphCacheDirectory,
+      `${new Date().toISOString().replace(/[:\.]/g, '_')}-build.log`
+    );
+    const stdoutStream = createWriteStream(remoteBuildLogFile);
+
     staticProcess.stdout.on('data', (data) => {
       const ANSII_CODE_REGEX =
         /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
       const stdoutString = data.toString().replace(ANSII_CODE_REGEX, '');
+      stdoutStream.write(stdoutString);
       if (stdoutString.includes('Successfully ran target build')) {
         staticProcess.stdout.removeAllListeners('data');
         logger.info(
@@ -192,8 +202,11 @@ async function buildStaticRemotes(
     });
     staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
     staticProcess.on('exit', (code) => {
+      stdoutStream.end();
       if (code !== 0) {
-        throw new Error(`Remote failed to start. See above for errors.`);
+        throw new Error(
+          `Remote failed to start. A complete log can be found in: ${remoteBuildLogFile}`
+        );
       }
     });
     process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));


### PR DESCRIPTION
This PR adds a log file for users to inspect whenever the remotes fail to build. 

Users will see an error like this when serving host fails at the build step:

```
> nx run shell:serve:development


 NX  Starting module federation dev-server for shell with 2 remotes


 NX  Building 2 static remotes...

/private/tmp/acme3/node_modules/@nx/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.js:121
                throw new Error(`Remote failed to start. A complete log can be found in: ${remoteBuildLogFile}`);
                ^

Error: Remote failed to start. A complete log can be found in: /private/tmp/acme3/.nx/cache/2024-03-27T15_48_01_673Z-build.log
    at ChildProcess.<anonymous> (/private/tmp/acme3/node_modules/@nx/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.js:121:23)
    at ChildProcess.emit (node:events:518:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:294:12)

Node.js v20.11.1
```

## Current Behavior
Errors are swallowed since `run-many` is logging to stdout.

## Expected Behavior
Errors should be surfaced, in this case, via a build log file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
