### PR TITLE
docs(misc): add missing initial package.json content to monorepo migration recipe

### DIFF
--- a/docs/shared/migration/adding-to-monorepo.md
+++ b/docs/shared/migration/adding-to-monorepo.md
@@ -50,7 +50,22 @@ This will set up Nx for you - updating the `package.json` file and creating a ne
 }
 ```
 
-When Nx updates your `package.json` scripts, it looks for scripts that can be replaced with an Nx command that has caching automatically enabled. The `package.json` defined above would be updated to look like this:
+When Nx updates your `package.json` scripts, it looks for scripts that can be replaced with an Nx command that has caching automatically enabled. Assuming you initially had a `package.json` file looking like the following:
+
+```json {% fileName="package.json" %}
+{
+  "name": "my-workspace",
+  ...
+  "scripts": {
+    "build": "next build",
+    "lint": "eslint ./src",
+    "test": "node ./run-tests.js"
+  },
+  ...
+}
+```
+
+After setting up Nx, the `package.json` file would be updated to look like this:
 
 ```json {% fileName="package.json" %}
 {


### PR DESCRIPTION
Updated doc: https://nx-dev-git-fork-leosvelperez-docs-fix-adding-to-mon-5dfc8c-nrwl.vercel.app/recipes/adopting-nx/adding-to-monorepo

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
