### PR TITLE
feat(remix): add migration to migrate from executors to crystal usage

### DIFF
--- a/packages/remix/migrations.json
+++ b/packages/remix/migrations.json
@@ -1,5 +1,12 @@
 {
-  "generators": {},
+  "generators": {
+    "migrate-executors-to-crystal": {
+      "cli": "nx",
+      "version": "19.0.0-beta.0",
+      "description": "Update projects to remove executor usage in targets defined in project.json files. Add '@nx/remix/plugin' to infer targets for these projects instead.",
+      "factory": "./src/migrations/update-19-0-0/migrate-executors-to-crystal"
+    }
+  },
   "packageJsonUpdates": {
     "17.2.1": {
       "version": "17.2.1-beta.0",

--- a/packages/remix/src/migrations/update-19-0-0/migrate-executors-to-crystal.spec.ts
+++ b/packages/remix/src/migrations/update-19-0-0/migrate-executors-to-crystal.spec.ts
@@ -1,0 +1,565 @@
+import { getRelativeProjectJsonSchemaPath } from 'nx/src/generators/utils/project-configuration';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual<any>('@nx/devkit'),
+  createProjectGraphAsync: jest.fn().mockImplementation(async () => {
+    return projectGraph;
+  }),
+  updateProjectConfiguration: jest
+    .fn()
+    .mockImplementation((tree, projectName, projectConfiguration) => {
+      function handleEmptyTargets(
+        projectName: string,
+        projectConfiguration: ProjectConfiguration
+      ): void {
+        if (
+          projectConfiguration.targets &&
+          !Object.keys(projectConfiguration.targets).length
+        ) {
+          // Re-order `targets` to appear after the `// target` comment.
+          delete projectConfiguration.targets;
+          projectConfiguration[
+            '// targets'
+          ] = `to see all targets run: nx show project ${projectName} --web`;
+          projectConfiguration.targets = {};
+        } else {
+          delete projectConfiguration['// targets'];
+        }
+      }
+
+      const projectConfigFile = joinPathFragments(
+        projectConfiguration.root,
+        'project.json'
+      );
+
+      if (!tree.exists(projectConfigFile)) {
+        throw new Error(
+          `Cannot update Project ${projectName} at ${projectConfiguration.root}. It either doesn't exist yet, or may not use project.json for configuration. Use \`addProjectConfiguration()\` instead if you want to create a new project.`
+        );
+      }
+      handleEmptyTargets(projectName, projectConfiguration);
+      writeJson(tree, projectConfigFile, {
+        name: projectConfiguration.name ?? projectName,
+        $schema: getRelativeProjectJsonSchemaPath(tree, projectConfiguration),
+        ...projectConfiguration,
+        root: undefined,
+      });
+      projectGraph.nodes[projectName].data = projectConfiguration;
+    }),
+}));
+
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migrateExecutorsToCrystal from './migrate-executors-to-crystal';
+import {
+  type ProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+  readProjectConfiguration,
+  addProjectConfiguration as _addProjectConfiguration,
+  readNxJson,
+  joinPathFragments,
+  writeJson,
+  updateNxJson,
+  getPackageManagerCommand,
+} from '@nx/devkit';
+
+function addProjectConfiguration(
+  tree: Tree,
+  name: string,
+  project: ProjectConfiguration
+) {
+  _addProjectConfiguration(tree, name, project);
+  projectGraph.nodes[name] = {
+    name: name,
+    type: project.projectType === 'application' ? 'app' : 'lib',
+    data: {
+      projectType: project.projectType,
+      root: project.root,
+      targets: project.targets,
+    },
+  };
+}
+
+describe('Remix - Migrate Executors To Crystal', () => {
+  beforeEach(() => {
+    projectGraph = {
+      nodes: {},
+      dependencies: {},
+      externalNodes: {},
+    };
+  });
+
+  it('should successfully migrate a project using Remix executors to crystal', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const project = createTestProject(tree);
+
+    // ACT
+    await migrateExecutorsToCrystal(tree);
+
+    // ASSERT
+    // project.json modifications
+    const updatedProject = readProjectConfiguration(tree, project.name);
+    const targetKeys = Object.keys(updatedProject.targets);
+    ['build', 'start', 'serve', 'dev', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+
+    // config file modifications
+    const remixConfigFile = tree.read(`myapp/remix.config.js`, 'utf-8');
+    expect(
+      remixConfigFile.includes(
+        `serverBuildPath: \`../dist/myapp/build/index.js\``
+      )
+    ).toBeTruthy();
+
+    // nx.json modifications
+    const nxJsonPlugins = readNxJson(tree).plugins;
+    const hasRemixPlugin = nxJsonPlugins.find((plugin) =>
+      typeof plugin === 'string'
+        ? plugin === '@nx/remix/plugin'
+        : plugin.plugin === '@nx/remix/plugin'
+    );
+    expect(hasRemixPlugin).toBeTruthy();
+    if (typeof hasRemixPlugin !== 'string') {
+      [
+        ['buildTargetName', 'build'],
+        ['devTargetName', 'serve'],
+        ['startTargetName', 'start'],
+        ['typecheckTargetName', 'typecheck'],
+      ].forEach(([targetOptionName, targetName]) => {
+        expect(hasRemixPlugin.options[targetOptionName]).toEqual(targetName);
+      });
+    }
+  });
+
+  it('should successfully update a commonjs config file to use output path', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const project = createTestProject(tree, { remixConfigType: 'cjs' });
+
+    // ACT
+    await migrateExecutorsToCrystal(tree);
+
+    // ASSERT
+    // config file modifications
+    const remixConfigFile = tree.read(`myapp/remix.config.js`, 'utf-8');
+    expect(
+      remixConfigFile.includes(
+        `serverBuildPath: \`../dist/myapp/build/index.js\``
+      )
+    ).toBeTruthy();
+  });
+
+  it('should setup build and serve target names for plugin to match projects', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const project = createTestProject(tree, {
+      buildTargetName: 'bundle',
+      serveTargetName: 'open',
+    });
+
+    // ACT
+    await migrateExecutorsToCrystal(tree);
+
+    // ASSERT
+    // project.json modifications
+    const updatedProject = readProjectConfiguration(tree, project.name);
+    const targetKeys = Object.keys(updatedProject.targets);
+    ['bundle', 'start', 'open', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+
+    // nx.json modifications
+    const nxJsonPlugins = readNxJson(tree).plugins;
+    const hasRemixPlugin = nxJsonPlugins.find((plugin) =>
+      typeof plugin === 'string'
+        ? plugin === '@nx/remix/plugin'
+        : plugin.plugin === '@nx/remix/plugin'
+    );
+    expect(hasRemixPlugin).toBeTruthy();
+    if (typeof hasRemixPlugin !== 'string') {
+      [
+        ['buildTargetName', 'bundle'],
+        ['devTargetName', 'open'],
+        ['startTargetName', 'start'],
+        ['typecheckTargetName', 'typecheck'],
+      ].forEach(([targetOptionName, targetName]) => {
+        expect(hasRemixPlugin.options[targetOptionName]).toEqual(targetName);
+      });
+    }
+  });
+
+  it('should migrate port for serve to an env var', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const project = createTestProject(tree, {
+      port: 4200,
+    });
+
+    // ACT
+    await migrateExecutorsToCrystal(tree);
+
+    // ASSERT
+    // project.json modifications
+    const updatedProject = readProjectConfiguration(tree, project.name);
+    const targetKeys = Object.keys(updatedProject.targets);
+    ['build', 'start', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+    expect(targetKeys).toContain('serve');
+    expect(updatedProject.targets.serve.options).toMatchInlineSnapshot(`
+      {
+        "env": {
+          "PORT": 4200,
+        },
+      }
+    `);
+  });
+
+  it('should setup build and serve target names using the most common and not migrate projects that dont use it', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const myappProject = createTestProject(tree, {
+      appName: 'myapp',
+      appRoot: 'myapp',
+      buildTargetName: 'bundle',
+      serveTargetName: 'open',
+    });
+    const dashboardProject = createTestProject(tree, {
+      appName: 'dashboard',
+      appRoot: 'dashboard',
+      buildTargetName: 'bundle',
+      serveTargetName: 'open',
+    });
+    const shopProject = createTestProject(tree, {
+      appName: 'shop',
+      appRoot: 'shop',
+      buildTargetName: 'build',
+      serveTargetName: 'serve',
+    });
+
+    // ACT
+    await migrateExecutorsToCrystal(tree);
+
+    // ASSERT
+    let updatedProject = readProjectConfiguration(tree, myappProject.name);
+    let targetKeys = Object.keys(updatedProject.targets);
+    ['bundle', 'start', 'open', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+
+    updatedProject = readProjectConfiguration(tree, dashboardProject.name);
+    targetKeys = Object.keys(updatedProject.targets);
+    ['bundle', 'start', 'open', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+
+    updatedProject = readProjectConfiguration(tree, shopProject.name);
+    targetKeys = Object.keys(updatedProject.targets);
+    ['build', 'serve'].forEach((key) => expect(targetKeys).toContain(key));
+
+    // nx.json modifications
+    const nxJsonPlugins = readNxJson(tree).plugins;
+    const hasRemixPlugin = nxJsonPlugins.find((plugin) =>
+      typeof plugin === 'string'
+        ? plugin === '@nx/remix/plugin'
+        : plugin.plugin === '@nx/remix/plugin'
+    );
+    expect(hasRemixPlugin).toBeTruthy();
+    if (typeof hasRemixPlugin !== 'string') {
+      [
+        ['buildTargetName', 'bundle'],
+        ['devTargetName', 'open'],
+        ['startTargetName', 'start'],
+        ['typecheckTargetName', 'typecheck'],
+      ].forEach(([targetOptionName, targetName]) => {
+        expect(hasRemixPlugin.options[targetOptionName]).toEqual(targetName);
+      });
+    }
+  });
+
+  it('should setup build and serve target names using the most common and migrate only targets for projects that use it', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const myappProject = createTestProject(tree, {
+      appName: 'myapp',
+      appRoot: 'myapp',
+      buildTargetName: 'bundle',
+      serveTargetName: 'open',
+    });
+    const dashboardProject = createTestProject(tree, {
+      appName: 'dashboard',
+      appRoot: 'dashboard',
+      buildTargetName: 'bundle',
+      serveTargetName: 'open',
+    });
+    const shopProject = createTestProject(tree, {
+      appName: 'shop',
+      appRoot: 'shop',
+      buildTargetName: 'build',
+      serveTargetName: 'open',
+    });
+
+    // ACT
+    await migrateExecutorsToCrystal(tree);
+
+    // ASSERT
+    let updatedProject = readProjectConfiguration(tree, myappProject.name);
+    let targetKeys = Object.keys(updatedProject.targets);
+    ['bundle', 'start', 'open', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+
+    updatedProject = readProjectConfiguration(tree, dashboardProject.name);
+    targetKeys = Object.keys(updatedProject.targets);
+    ['bundle', 'start', 'open', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+
+    updatedProject = readProjectConfiguration(tree, shopProject.name);
+    targetKeys = Object.keys(updatedProject.targets);
+    ['start', 'open', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+    expect(targetKeys).toContain('build');
+
+    // nx.json modifications
+    const nxJsonPlugins = readNxJson(tree).plugins;
+    const hasRemixPlugin = nxJsonPlugins.find((plugin) =>
+      typeof plugin === 'string'
+        ? plugin === '@nx/remix/plugin'
+        : plugin.plugin === '@nx/remix/plugin'
+    );
+    expect(hasRemixPlugin).toBeTruthy();
+    if (typeof hasRemixPlugin !== 'string') {
+      [
+        ['buildTargetName', 'bundle'],
+        ['devTargetName', 'open'],
+        ['startTargetName', 'start'],
+        ['typecheckTargetName', 'typecheck'],
+      ].forEach(([targetOptionName, targetName]) => {
+        expect(hasRemixPlugin.options[targetOptionName]).toEqual(targetName);
+      });
+    }
+  });
+
+  it.each(['build', '@nx/remix:build'])(
+    'should not migrate build target if non migratable property exists in the targetDefaults for %s',
+    async (targetDefaultName) => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults[targetDefaultName] = {
+        options: {
+          generatePackageJson: true,
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      const myappProject = createTestProject(tree, {
+        appName: 'myapp',
+        appRoot: 'myapp',
+        buildTargetName: 'build',
+        serveTargetName: 'open',
+      });
+      const dashboardProject = createTestProject(tree, {
+        appName: 'dashboard',
+        appRoot: 'dashboard',
+        buildTargetName: 'build',
+        serveTargetName: 'open',
+      });
+
+      // ACT
+      await migrateExecutorsToCrystal(tree);
+
+      // ASSERT
+      let updatedProject = readProjectConfiguration(tree, myappProject.name);
+      let targetKeys = Object.keys(updatedProject.targets);
+      ['start', 'open', 'typecheck'].forEach((key) =>
+        expect(targetKeys).not.toContain(key)
+      );
+      expect(targetKeys).toContain('build');
+
+      updatedProject = readProjectConfiguration(tree, dashboardProject.name);
+      targetKeys = Object.keys(updatedProject.targets);
+      ['start', 'open', 'typecheck'].forEach((key) =>
+        expect(targetKeys).not.toContain(key)
+      );
+      expect(targetKeys).toContain('build');
+
+      // nx.json modifications
+      const nxJsonPlugins = readNxJson(tree).plugins;
+      const hasRemixPlugin = nxJsonPlugins.find((plugin) =>
+        typeof plugin === 'string'
+          ? plugin === '@nx/remix/plugin'
+          : plugin.plugin === '@nx/remix/plugin'
+      );
+      expect(hasRemixPlugin).toBeTruthy();
+      if (typeof hasRemixPlugin !== 'string') {
+        [
+          ['buildTargetName', 'build'],
+          ['devTargetName', 'open'],
+          ['startTargetName', 'start'],
+          ['typecheckTargetName', 'typecheck'],
+        ].forEach(([targetOptionName, targetName]) => {
+          expect(hasRemixPlugin.options[targetOptionName]).toEqual(targetName);
+        });
+      }
+    }
+  );
+
+  it('should migrate build target if migratable property exists in the targetDefaults for @nx/remix:build', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults ??= {};
+    nxJson.targetDefaults['@nx/remix:build'] = {
+      options: {
+        sourcemap: true,
+      },
+    };
+    updateNxJson(tree, nxJson);
+
+    const myappProject = createTestProject(tree, {
+      appName: 'myapp',
+      appRoot: 'myapp',
+      buildTargetName: 'build',
+      serveTargetName: 'open',
+    });
+
+    // ACT
+    await migrateExecutorsToCrystal(tree);
+
+    // ASSERT
+    let updatedProject = readProjectConfiguration(tree, myappProject.name);
+    let targetKeys = Object.keys(updatedProject.targets);
+    ['start', 'open', 'typecheck'].forEach((key) =>
+      expect(targetKeys).not.toContain(key)
+    );
+    expect(targetKeys).toContain('build');
+    expect(updatedProject.targets.build).toMatchInlineSnapshot(`
+      {
+        "options": {
+          "sourcemap": true,
+        },
+      }
+    `);
+  });
+});
+
+interface CreateRemixTestProjectOptions {
+  appName: string;
+  appRoot: string;
+  buildTargetName: string;
+  serveTargetName: string;
+  outputPath: string;
+  generatePackageJson: boolean;
+  serveCommand: string;
+  port: number;
+  remixConfigType: 'esm' | 'cjs';
+  remixConfigServerBuildPath: string | 'unset';
+}
+const defaultCreateRemixTestProjectOptions: CreateRemixTestProjectOptions = {
+  appName: 'myapp',
+  appRoot: 'myapp',
+  buildTargetName: 'build',
+  serveTargetName: 'serve',
+  outputPath: 'dist/myapp',
+  generatePackageJson: false,
+  serveCommand: `${getPackageManagerCommand().exec} remix-serve build/index.js`,
+  port: 3000,
+  remixConfigType: 'esm',
+  remixConfigServerBuildPath: 'unset',
+};
+function createTestProject(
+  tree: Tree,
+  opts: Partial<CreateRemixTestProjectOptions> = defaultCreateRemixTestProjectOptions
+) {
+  let projectOpts = { ...defaultCreateRemixTestProjectOptions, ...opts };
+  const project: ProjectConfiguration = {
+    name: projectOpts.appName,
+    root: projectOpts.appRoot,
+    projectType: 'application',
+    targets: {
+      [projectOpts.buildTargetName]: {
+        executor: '@nx/remix:build',
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath: projectOpts.outputPath,
+        },
+      },
+      [projectOpts.serveTargetName]: {
+        executor: `@nx/remix:serve`,
+        options: {
+          command: projectOpts.serveCommand,
+          manual: true,
+          port: projectOpts.port,
+        },
+      },
+      start: {
+        dependsOn: ['build'],
+        command: `remix-serve build/index.js`,
+        options: {
+          cwd: projectOpts.appRoot,
+        },
+      },
+      typecheck: {
+        command: `tsc --project tsconfig.app.json`,
+        options: {
+          cwd: projectOpts.appRoot,
+        },
+      },
+    },
+  };
+  if (projectOpts.remixConfigType === 'esm') {
+    tree.write(
+      `${projectOpts.appRoot}/remix.config.js`,
+      `import {createWatchPaths} from '@nx/remix';
+import {dirname} from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+export default {
+    ignoredRouteFiles: ["**/.*"],
+    // appDirectory: "app",
+    // assetsBuildDirectory: "public/build",
+    ${
+      projectOpts.remixConfigServerBuildPath === 'unset'
+        ? `// serverBuildPath: "build/index.js"`
+        : projectOpts.remixConfigServerBuildPath
+    },
+    // publicPath: "/build/",
+    watchPaths: () => createWatchPaths(__dirname),
+};`
+    );
+  } else {
+    tree.write(
+      `${projectOpts.appRoot}/remix.config.js`,
+      `/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ["**/.*"],
+  // appDirectory: "app",
+  // assetsBuildDirectory: "public/build",
+  ${
+    projectOpts.remixConfigServerBuildPath === 'unset'
+      ? `// serverBuildPath: "build/index.js"`
+      : projectOpts.remixConfigServerBuildPath
+  },
+  // publicPath: "/build/",
+  watchPaths: () => require("@nx/remix").createWatchPaths(__dirname),
+};`
+    );
+  }
+
+  addProjectConfiguration(tree, project.name, project);
+  return project;
+}

--- a/packages/remix/src/migrations/update-19-0-0/migrate-executors-to-crystal.ts
+++ b/packages/remix/src/migrations/update-19-0-0/migrate-executors-to-crystal.ts
@@ -1,0 +1,601 @@
+import {
+  type NxJsonConfiguration,
+  type ProjectGraph,
+  type TargetConfiguration,
+  type Tree,
+  createProjectGraphAsync,
+  getPackageManagerCommand,
+  joinPathFragments,
+  offsetFromRoot,
+  readNxJson,
+  updateNxJson,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+import { type RemixPluginOptions } from '../../plugins/plugin';
+import { tsquery } from '@phenomnomnominal/tsquery';
+
+const executors = {
+  build: '@nx/remix:build',
+  serve: '@nx/remix:serve',
+};
+
+const defaultOptionsForExecutors = {
+  build: (projectRoot: string) => ({
+    cache: true,
+    dependsOn: ['^build'],
+    inputs: ['production', '^production'],
+    executor: '@nx/remix:build',
+    outputs: ['{options.outputPath}'],
+    options: {
+      outputPath: joinPathFragments('dist', projectRoot),
+    },
+  }),
+  serve: {
+    executor: `@nx/remix:serve`,
+    options: {
+      command: `${getPackageManagerCommand().exec} remix-serve build/index.js`,
+      manual: true,
+      port: 3000,
+    },
+  },
+};
+
+const defaultCrystalPluginOptions = {
+  buildTargetName: 'build',
+  devTargetName: 'dev',
+  startTargetName: 'start',
+  typecheckTargetName: 'typecheck',
+};
+
+const nonMigratableOptions = {
+  build: [
+    'includeDevDependenciesInPackageJson',
+    'generatePackageJson',
+    'generateLockfile',
+  ],
+};
+
+export default async function migrateExecutorsToCrystal(tree: Tree) {
+  const projectGraph = await createProjectGraphAsync();
+  const nxJson = readNxJson(tree);
+  let [canMigrateBuildExecutor, targetDefaultOptionsToMigrate] =
+    checkTargetDefaultsForBuildExecutorInvalidOptions(nxJson);
+
+  const remixProjectNames: Record<string, Set<string>> = {};
+
+  const targetNameCounts: Record<
+    keyof typeof executors,
+    Record<string, number>
+  > = {
+    build: {},
+    serve: {},
+  };
+  getProjectsAndTargetToMigrate(
+    tree,
+    canMigrateBuildExecutor,
+    nxJson,
+    remixProjectNames,
+    targetNameCounts
+  );
+
+  const { preferredBuildTargetName, preferredServeTargetName } =
+    getPreferredBuildServeTargetNames(targetNameCounts);
+
+  for (const [projectName, targetNames] of Object.entries(remixProjectNames)) {
+    const projectTargets = projectGraph.nodes[projectName].data.targets;
+
+    let updatedProject = false;
+
+    updatedProject = migrateBuildTarget(
+      tree,
+      projectGraph,
+      targetNames,
+      preferredBuildTargetName,
+      projectName,
+      projectTargets,
+      updatedProject,
+      targetDefaultOptionsToMigrate
+    );
+
+    updatedProject = migrateServeTarget(
+      targetNames,
+      preferredServeTargetName,
+      projectTargets,
+      updatedProject
+    );
+
+    updatedProject = removeAdditionalTargets(projectTargets, updatedProject);
+
+    if (updatedProject) {
+      updateProjectConfiguration(tree, projectName, {
+        ...projectGraph.nodes[projectName].data,
+        targets: projectTargets,
+      });
+    }
+  }
+
+  addPlugin(tree, preferredBuildTargetName, preferredServeTargetName);
+}
+
+/**
+ * Iterate through the current target and it's options comparing it to default target
+ * Delete matching properties from current target
+ * @param currentTarget The user's target from project.json
+ * @param defaultTarget A target configuration that matches what can be handled by the plugin
+ */
+function deleteMatchingProperties(
+  currentTarget: TargetConfiguration,
+  defaultTarget: TargetConfiguration
+) {
+  for (const key in currentTarget) {
+    if (key === 'outputPath') {
+      continue;
+    } else if (Array.isArray(currentTarget[key])) {
+      if (
+        currentTarget[key].every((v) => defaultTarget[key].includes(v)) &&
+        currentTarget[key].length === defaultTarget[key].length
+      ) {
+        delete currentTarget[key];
+      }
+    } else if (
+      typeof currentTarget[key] === 'object' &&
+      typeof defaultTarget[key] === 'object'
+    ) {
+      deleteMatchingProperties(currentTarget[key], defaultTarget[key]);
+    } else if (currentTarget[key] === defaultTarget[key]) {
+      delete currentTarget[key];
+    }
+    if (
+      typeof currentTarget[key] === 'object' &&
+      Object.keys(currentTarget[key]).length === 0
+    ) {
+      delete currentTarget[key];
+    }
+  }
+}
+
+/**
+ * Add the plugin to nx.json using the preferred target names
+ * @param tree Virtual Tree
+ * @param preferredBuildTargetName The most common target name using the build executor
+ * @param preferredServeTargetName The most common target name using the serve executor
+ */
+function addPlugin(
+  tree: Tree,
+  preferredBuildTargetName: string,
+  preferredServeTargetName: string
+) {
+  const nxJson = readNxJson(tree);
+  nxJson.plugins ??= [];
+
+  let addNewPluginEntry = true;
+  for (let i = 0; i < nxJson.plugins.length; i++) {
+    const plugin = nxJson.plugins[i];
+    if (
+      typeof plugin === 'string' &&
+      plugin === '@nx/remix/plugin' &&
+      preferredBuildTargetName ===
+        defaultCrystalPluginOptions.buildTargetName &&
+      preferredServeTargetName === defaultCrystalPluginOptions.devTargetName
+    ) {
+      addNewPluginEntry = false;
+    } else if (
+      typeof plugin === 'object' &&
+      plugin.plugin === '@nx/remix/plugin'
+    ) {
+      const pluginOptions: RemixPluginOptions = plugin.options;
+      if (
+        !pluginOptions &&
+        preferredBuildTargetName ===
+          defaultCrystalPluginOptions.buildTargetName &&
+        preferredServeTargetName === defaultCrystalPluginOptions.devTargetName
+      ) {
+        addNewPluginEntry = false;
+      } else if (
+        ((pluginOptions.buildTargetName &&
+          pluginOptions.buildTargetName === preferredBuildTargetName) ||
+          (!pluginOptions.buildTargetName &&
+            preferredBuildTargetName ===
+              defaultCrystalPluginOptions.buildTargetName)) &&
+        ((pluginOptions.devTargetName &&
+          pluginOptions.devTargetName === preferredServeTargetName) ||
+          (!pluginOptions.devTargetName &&
+            preferredServeTargetName ===
+              defaultCrystalPluginOptions.devTargetName))
+      ) {
+        addNewPluginEntry = false;
+      }
+    }
+  }
+
+  if (addNewPluginEntry) {
+    nxJson.plugins.push({
+      plugin: '@nx/remix/plugin',
+      options: {
+        buildTargetName: preferredBuildTargetName,
+        devTargetName: preferredServeTargetName,
+        startTargetName: defaultCrystalPluginOptions.startTargetName,
+        typecheckTargetName: defaultCrystalPluginOptions.typecheckTargetName,
+      },
+    });
+
+    updateNxJson(tree, nxJson);
+  }
+}
+
+/**
+ * Update the remix.config.{mjs|cjs|js} config file to set the correct output path
+ * @param tree Virtual Tree
+ * @param projectRoot Root path to the project
+ * @param desiredOutputPath Output path that should be used by Remix
+ */
+function updateRemixConfigFileToSetOutputDirectory(
+  tree: Tree,
+  projectRoot: string,
+  desiredOutputPath: string
+) {
+  const children = tree.children(projectRoot);
+  const remixConfigFile = children.find((file) =>
+    /remix\.config\.(m|c)*js/.test(file)
+  );
+  if (desiredOutputPath.startsWith(projectRoot)) {
+    desiredOutputPath = desiredOutputPath.replace(`${projectRoot}/`, '');
+  } else {
+    desiredOutputPath = joinPathFragments(
+      offsetFromRoot(projectRoot),
+      desiredOutputPath
+    );
+  }
+
+  const pathToRemixConfigFile = joinPathFragments(projectRoot, remixConfigFile);
+
+  const remixConfigFileContents = tree.read(pathToRemixConfigFile, 'utf-8');
+  const CONFIG_PROPERTY_ASSIGNMENT_SELECTOR = remixConfigFileContents.includes(
+    'export default'
+  )
+    ? 'ExportAssignment > ObjectLiteralExpression PropertyAssignment'
+    : 'PropertyAccessExpression:has(Identifier[name=module] ~ Identifier[name=exports]) ~ ObjectLiteralExpression PropertyAssignment';
+  const configAst = tsquery.ast(remixConfigFileContents);
+  const propertyAssignmentNodes = tsquery(
+    configAst,
+    CONFIG_PROPERTY_ASSIGNMENT_SELECTOR,
+    { visitAllChildren: true }
+  );
+  let updatedExistingOutputPath = false;
+  for (const node of propertyAssignmentNodes) {
+    if (!node.getText().startsWith('serverBuildPath')) {
+      continue;
+    }
+    const propertyValueNode = tsquery(node, 'StringLiteral', {
+      visitAllChildren: true,
+    });
+    const propertyValue = propertyValueNode[0].getText().replace(/(["'])/, '');
+    if (desiredOutputPath !== propertyValue) {
+      const fullOutputPath = joinPathFragments(
+        desiredOutputPath,
+        propertyValue
+      );
+      tree.write(
+        pathToRemixConfigFile,
+        `${remixConfigFileContents.slice(
+          0,
+          node.getStart()
+        )}serverBuildPath: \`${fullOutputPath}\`,\n${remixConfigFileContents.slice(
+          node.getEnd()
+        )}`
+      );
+      updatedExistingOutputPath = true;
+    }
+  }
+  if (!updatedExistingOutputPath) {
+    const fullOutputPath = joinPathFragments(
+      desiredOutputPath,
+      'build/index.js'
+    );
+    tree.write(
+      pathToRemixConfigFile,
+      `${remixConfigFileContents.slice(
+        0,
+        propertyAssignmentNodes[0].getStart()
+      )}serverBuildPath: \`${fullOutputPath}\`,\n${remixConfigFileContents.slice(
+        propertyAssignmentNodes[0].getStart()
+      )}`
+    );
+  }
+}
+
+/**
+ * Remove any additional remix-only targets that are not using executors
+ * @param projectTargets Targets defined in the project's project.json
+ * @param isProjectUpdatedAlready Whether the project has been updated already to prevent false negatives
+ */
+function removeAdditionalTargets(
+  projectTargets: Record<string, TargetConfiguration>,
+  isProjectUpdatedAlready: boolean = false
+) {
+  let updatedProject = isProjectUpdatedAlready;
+  if (defaultCrystalPluginOptions.startTargetName in projectTargets) {
+    delete projectTargets[defaultCrystalPluginOptions.startTargetName];
+    updatedProject = true;
+  }
+
+  if (defaultCrystalPluginOptions.typecheckTargetName in projectTargets) {
+    delete projectTargets[defaultCrystalPluginOptions.typecheckTargetName];
+    updatedProject = true;
+  }
+  return updatedProject;
+}
+
+/**
+ * Check for the build executor in targetDefaults for invalid options that cannot be migrated
+ * And creates a key-value pair of options that need to be migrated to the build target in project.json
+ * @param nxJson NxJsonConfiguration
+ */
+function checkTargetDefaultsForBuildExecutorInvalidOptions(
+  nxJson: NxJsonConfiguration
+): [boolean, Record<string, any>] {
+  let canMigrateBuildExecutor = true;
+  let targetDefaultOptions: Record<string, any> = {};
+  if (nxJson.targetDefaults) {
+    if (
+      executors.build in nxJson.targetDefaults &&
+      nxJson.targetDefaults[executors.build].options
+    ) {
+      const targetDefaultConfigKeys = Object.keys(
+        nxJson.targetDefaults[executors.build].options
+      );
+      if (
+        targetDefaultConfigKeys.some((v) =>
+          nonMigratableOptions.build.includes(v)
+        )
+      ) {
+        // non-migratable properties exist in the targetDefaults for the build executor
+        // cannot migrate build target
+        canMigrateBuildExecutor = false;
+      } else {
+        // the options are migratable, list them in key-value pair
+        // to be added to the build target on the project.json
+        targetDefaultOptions = targetDefaultConfigKeys.reduce(
+          (opts, key) => ({
+            ...opts,
+            [key]: nxJson.targetDefaults[executors.build].options[key],
+          }),
+          targetDefaultOptions
+        );
+      }
+    }
+  }
+  return [canMigrateBuildExecutor, targetDefaultOptions];
+}
+
+/**
+ * Check for the target name in targetDefaults for invalid options that cannot be migrated
+ * And also check that the project.json does not define invalid targets
+ * @param targetName Name of the target
+ * @param targetOptions The options for that target as defined by project.json
+ * @param nxJson NxJsonConfiguration
+ */
+function checkTargetAndTargetDefaultsForTargetInvalidOptions(
+  targetName: string,
+  targetOptions: any,
+  nxJson: NxJsonConfiguration
+) {
+  const hasNonMigratableProperty =
+    targetName in nonMigratableOptions &&
+    Object.keys(targetOptions).some((v) =>
+      nonMigratableOptions[targetName].includes(v)
+    );
+
+  let hasNonMigratableTargetInTargetDefaults = false;
+  if (nxJson.targetDefaults) {
+    if (
+      targetName in nxJson.targetDefaults &&
+      nxJson.targetDefaults[targetName].options
+    ) {
+      const targetDefaultConfigKeys = Object.keys(
+        nxJson.targetDefaults[targetName].options
+      );
+      if (
+        targetDefaultConfigKeys.some((v) =>
+          nonMigratableOptions.build.includes(v)
+        )
+      ) {
+        // non-migratable properties exist in the targetDefaults for the build executor
+        // cannot migrate build target
+        hasNonMigratableTargetInTargetDefaults = true;
+      }
+    }
+  }
+  return { hasNonMigratableProperty, hasNonMigratableTargetInTargetDefaults };
+}
+
+/**
+ * Get the most common target names for the build and serve targets based on executor usage
+ * @param targetNameCounts Object containing the counts of usages of target names
+ */
+function getPreferredBuildServeTargetNames(
+  targetNameCounts: Record<keyof typeof executors, Record<string, number>>
+) {
+  const buildTargetNames = Object.keys(targetNameCounts.build);
+  let preferredBuildTargetName =
+    buildTargetNames[0] ?? defaultCrystalPluginOptions.buildTargetName;
+  if (buildTargetNames.length > 1) {
+    preferredBuildTargetName = buildTargetNames.reduce(
+      (preferredName, currentName) =>
+        targetNameCounts.build[preferredName] >=
+        targetNameCounts.build[currentName]
+          ? preferredName
+          : currentName,
+      preferredBuildTargetName
+    );
+  }
+
+  const serveTargetNames = Object.keys(targetNameCounts.serve);
+  let preferredServeTargetName =
+    serveTargetNames[0] ?? defaultCrystalPluginOptions.devTargetName;
+  if (serveTargetNames.length > 1) {
+    preferredServeTargetName = serveTargetNames.reduce(
+      (preferredName, currentName) =>
+        targetNameCounts.serve[preferredName] >=
+        targetNameCounts.serve[currentName]
+          ? preferredName
+          : currentName,
+      serveTargetNames[0]
+    );
+  }
+  return { preferredBuildTargetName, preferredServeTargetName };
+}
+
+/**
+ * Iterate through the workspace checking for Remix executors,
+ * find if they can be migrated and add them to a list of projects and targets to migrate
+ * @param tree Virtual Tree
+ * @param canMigrateBuildExecutor Whether the targetDefaults contains options that cannot be migrated
+ * @param nxJson NxJsonConfiguration
+ * @param remixProjectNames Set to store the projects and targets to migrate
+ * @param targetNameCounts Count of target name occurrences for each executor
+ */
+function getProjectsAndTargetToMigrate(
+  tree: Tree,
+  canMigrateBuildExecutor: boolean,
+  nxJson: NxJsonConfiguration,
+  remixProjectNames: Record<string, Set<string>>,
+  targetNameCounts: Record<keyof typeof executors, Record<string, number>>
+) {
+  for (const targetExecutor of Object.keys(executors)) {
+    if (
+      executors[targetExecutor] === executors.build &&
+      !canMigrateBuildExecutor
+    ) {
+      continue;
+    }
+
+    forEachExecutorOptions(
+      tree,
+      executors[targetExecutor],
+      (targetOptions, projectName, targetName) => {
+        const {
+          hasNonMigratableProperty,
+          hasNonMigratableTargetInTargetDefaults,
+        } = checkTargetAndTargetDefaultsForTargetInvalidOptions(
+          targetName,
+          targetOptions,
+          nxJson
+        );
+
+        if (
+          hasNonMigratableProperty ||
+          hasNonMigratableTargetInTargetDefaults
+        ) {
+          return;
+        }
+
+        if (!(projectName in remixProjectNames)) {
+          remixProjectNames[projectName] = new Set();
+        }
+        remixProjectNames[projectName].add(targetName);
+
+        targetNameCounts[targetExecutor][targetName] =
+          targetName in targetNameCounts[targetExecutor]
+            ? targetNameCounts[targetExecutor][targetName] + 1
+            : 1;
+      }
+    );
+  }
+}
+
+/**
+ * Migrate the build target by deleting properties from the project.json that match what will be inferred
+ * @param tree Virtual Tree
+ * @param projectGraph Project Graph of the Workspace
+ * @param targetNames Project's target names
+ * @param preferredBuildTargetName Most common occurrence of the build target name to migrate
+ * @param projectName Name of the project to migrate
+ * @param projectTargets Project's targets and their configurations
+ * @param updatedProject Whether the project has been updated
+ */
+function migrateBuildTarget(
+  tree: Tree,
+  projectGraph: ProjectGraph,
+  targetNames: Set<string>,
+  preferredBuildTargetName: string,
+  projectName: string,
+  projectTargets: Record<string, TargetConfiguration>,
+  updatedProject: boolean,
+  targetDefaultOptionsToMigrate: Record<string, any>
+) {
+  if (targetNames.has(preferredBuildTargetName)) {
+    const defaultBuildOptions = defaultOptionsForExecutors.build(
+      projectGraph.nodes[projectName].data.root
+    );
+    let currentTargetOptions = projectTargets[preferredBuildTargetName];
+    if (currentTargetOptions.options?.outputPath) {
+      let desiredOutputPath = currentTargetOptions.options.outputPath;
+
+      updateRemixConfigFileToSetOutputDirectory(
+        tree,
+        projectGraph.nodes[projectName].data.root,
+        desiredOutputPath
+      );
+      delete projectTargets[preferredBuildTargetName].options.outputPath;
+      delete projectTargets[preferredBuildTargetName].outputs;
+    }
+
+    currentTargetOptions = {
+      // current target options exist in the project.json, and would override targetDefaults
+      ...currentTargetOptions,
+      options: {
+        ...targetDefaultOptionsToMigrate,
+        ...(currentTargetOptions.options ?? {}),
+      },
+    };
+
+    deleteMatchingProperties(currentTargetOptions, defaultBuildOptions);
+    delete projectTargets[preferredBuildTargetName].executor;
+
+    if (Object.values(currentTargetOptions).length === 0) {
+      delete projectTargets[preferredBuildTargetName];
+    } else {
+      projectTargets[preferredBuildTargetName] = currentTargetOptions;
+    }
+
+    updatedProject = true;
+  }
+  return updatedProject;
+}
+
+/**
+ * Migrate the serve target by deleting properties from the project.json that match what will be inferred
+ * @param targetNames Project's target names
+ * @param preferredServeTargetName Most common occurrence of the serve target name to migrate
+ * @param projectTargets Project's targets and their configurations
+ * @param updatedProject Whether the project has been updated
+ */
+function migrateServeTarget(
+  targetNames: Set<string>,
+  preferredServeTargetName: string,
+  projectTargets: Record<string, TargetConfiguration>,
+  updatedProject: boolean
+) {
+  if (targetNames.has(preferredServeTargetName)) {
+    const defaultServeOptions = defaultOptionsForExecutors.serve;
+    const currentTargetOptions = projectTargets[preferredServeTargetName];
+    deleteMatchingProperties(currentTargetOptions, defaultServeOptions);
+    delete projectTargets[preferredServeTargetName].executor;
+    if (Object.values(currentTargetOptions).length === 0) {
+      delete projectTargets[preferredServeTargetName];
+    } else {
+      if (currentTargetOptions.options.port) {
+        currentTargetOptions.options.env ??= {};
+        currentTargetOptions.options.env.PORT =
+          currentTargetOptions.options.port;
+        delete currentTargetOptions.options.port;
+      }
+      projectTargets[preferredServeTargetName] = currentTargetOptions;
+    }
+
+    updatedProject = true;
+  }
+  return updatedProject;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Remix projects that existed before Nx Crystal use targets in `project.json` as well as the `@nx/remix:build` and `@nx/remix:serve` executors.
There is currently no path to automatically migrate to use the `@nx/remix/plugin` Crystal Plugin.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
There should be an automated migration that will migrate existing Remix projects using targets and executors defined in `project.json` files to use the `@nx/remix/plugin` Crystal Plugin.

There are some known caveats with this migration. 
- If `generatePackageJson`, `includeDevDependenciesInPackageJson` or `generateLockfile` are used along with the `@nx/remix:build` executor, there is no valid migration path to the Crystal Plugin.
  - In these cases, we will not migrate the target using these options, to prevent breaking users' projects.
- If a `serve` target exists using a `port` that is not `3000`
  - In these cases, we will migrate the `port` option to an `env` option. This will result in the following:
  ```json
  "targets": {
    "serve": {
       "options": {
           "env": {
              "PORT": 4200
          }
       }
    }
  }
  ```
Only the `env` option will be left in `project.json`. Other properties will be configured by the `@nx/remix/plugin` and the `PORT` will be provided to `process.env.PORT`. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
