### PR TITLE
fix(webpack): resolve assets from executor options as relative to workspace root

### DIFF
--- a/packages/webpack/src/executors/webpack/lib/normalize-options.ts
+++ b/packages/webpack/src/executors/webpack/lib/normalize-options.ts
@@ -37,7 +37,8 @@ export function normalizeOptions(
       options.assets,
       root,
       sourceRoot,
-      projectRoot
+      projectRoot,
+      false // executor assets are relative to workspace root for consistency
     );
   }
   return normalizedOptions as NormalizedWebpackExecutorOptions;

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
@@ -51,14 +51,16 @@ export function normalizeOptions(
     }
     Object.assign(
       combinedPluginAndMaybeExecutorOptions,
-      buildTargetOptions,
-      options // plugin options take precedence
+      options,
+      // executor options take precedence (especially for overriding with CLI args)
+      buildTargetOptions
     );
   } else {
     Object.assign(
       combinedPluginAndMaybeExecutorOptions,
-      originalTargetOptions,
-      options // plugin options take precedence
+      options,
+      // executor options take precedence (especially for overriding with CLI args)
+      originalTargetOptions
     );
   }
 
@@ -121,7 +123,8 @@ export function normalizeAssets(
   assets: any[],
   root: string,
   sourceRoot: string,
-  projectRoot: string
+  projectRoot: string,
+  resolveRelativePathsToProjectRoot = true
 ): AssetGlobPattern[] {
   return assets.map((asset) => {
     if (typeof asset === 'string') {
@@ -155,7 +158,7 @@ export function normalizeAssets(
 
       const assetPath = normalizePath(asset.input);
       let resolvedAssetPath = resolve(root, assetPath);
-      if (asset.input.startsWith('.')) {
+      if (resolveRelativePathsToProjectRoot && asset.input.startsWith('.')) {
         const resolvedProjectRoot = resolve(root, projectRoot);
         resolvedAssetPath = resolve(resolvedProjectRoot, assetPath);
       }


### PR DESCRIPTION
The [previous fix to relative asset paths](https://github.com/nrwl/nx/commit/4be897ac3f40d4b4d4001584d9dbd8d6ab85db96) introduced a regression when using `@nx/webpack:webpack` executor.

When options are passed from the executor, the paths are relative to the workspace root _not_ project root. Thus, we need special handling when normalizing executor options.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Executor is resolving assets relative to project root.

## Expected Behavior
Executor options should always be relative to workspace root for consistency.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
