### PR TITLE
fix(rollup): remove exports field from @nx/rollup/package.json since is a breaking change

### DIFF
--- a/packages/rollup/project.json
+++ b/packages/rollup/project.json
@@ -8,11 +8,6 @@
     "build-base": {
       "executor": "@nx/js:tsc",
       "options": {
-        "generateExportsField": true,
-        "additionalEntryPoints": [
-          "{projectRoot}/{executors,generators,migrations}.json",
-          "{projectRoot}/plugin.ts"
-        ],
         "assets": [
           {
             "input": "packages/rollup",


### PR DESCRIPTION
We cannot add `exports` field outside of a major version release, and not without extensive testing.

## Current Behavior
Deep imports of Rollup is breaking.

## Expected Behavior
Rollup imports should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/22508
