### PR TITLE
fix(core): fix caching outputs which have symlinks

### DIFF
--- a/packages/nx/src/native/cache/file_ops.rs
+++ b/packages/nx/src/native/cache/file_ops.rs
@@ -1,5 +1,5 @@
-use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
 
 use fs_extra::error::ErrorKind;
 
@@ -13,22 +13,52 @@ pub fn remove(src: String) -> anyhow::Result<()> {
 
 #[napi]
 pub fn copy(src: String, dest: String) -> anyhow::Result<()> {
-    let copy_options = fs_extra::dir::CopyOptions::new()
-        .overwrite(true)
-        .skip_exist(false);
-
     let dest: PathBuf = dest.into();
     let dest_parent = dest.parent().unwrap_or(&dest);
+
+    let src: PathBuf = src.into();
 
     if !dest_parent.exists() {
         fs::create_dir_all(dest_parent)?;
     }
 
-    fs_extra::copy_items(&[src], dest_parent, &copy_options).map_err(|err| match err.kind {
-        ErrorKind::Io(err_kind) => anyhow::Error::new(err_kind),
-        _ => anyhow::Error::new(err),
-    })?;
+    if src.is_dir() {
+        copy_dir_all(&src, dest).map_err(anyhow::Error::new)?;
+    } else if src.is_symlink() {
+        symlink(fs::read_link(src)?, dest)?;
+    } else {
+        fs::copy(src, dest)?;
+    }
 
+    Ok(())
+}
+
+#[cfg(windows)]
+fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
+    std::os::windows::fs::symlink_file(original, link)
+}
+
+#[cfg(unix)]
+fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
+    std::os::unix::fs::symlink(original, link)
+}
+
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else if ty.is_symlink() {
+            symlink(
+                fs::read_link(entry.path())?,
+                dst.as_ref().join(entry.file_name()),
+            )?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
     Ok(())
 }
 
@@ -70,5 +100,45 @@ mod test {
         copy(src.to_string_lossy().into(), dest.to_string_lossy().into()).unwrap();
 
         assert!(temp.child("new-parent/file.txt").exists());
+    }
+
+    #[test]
+    fn should_copy_symlinks() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.child("parent").child("target.txt");
+        target.touch().unwrap();
+        let link = temp.child("parent").child("file.txt");
+
+        link.symlink_to_file(&target).unwrap();
+
+        let src = temp.join("parent/file.txt");
+        let dest = temp.join("new-parent/file.txt");
+        copy(src.to_string_lossy().into(), dest.to_string_lossy().into()).unwrap();
+
+        assert!(temp.child("new-parent/file.txt").exists());
+        assert_eq!(
+            temp.child("new-parent/file.txt").read_link().unwrap(),
+            target.path()
+        );
+    }
+
+    #[test]
+    fn should_copy_directories_with_symlinks() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.child("parent").child("target.txt");
+        target.touch().unwrap();
+        let link = temp.child("parent").child("file.txt");
+
+        link.symlink_to_file(&target).unwrap();
+
+        let src = temp.join("parent");
+        let dest = temp.join("new-parent");
+        copy(src.to_string_lossy().into(), dest.to_string_lossy().into()).unwrap();
+
+        assert!(temp.child("new-parent/file.txt").exists());
+        assert_eq!(
+            temp.child("new-parent/file.txt").read_link().unwrap(),
+            target.path()
+        );
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Outputs (build artifacts) which contain symlinks within them fail to be copied to the cache and fail. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Symlinks within build outputs are successfully copied into the cache and point to the same place when they are restored.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/19502
Fixes https://github.com/nrwl/nx/issues/18830
