### PR TITLE
feat(testing): infer open-cypress task

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -553,7 +553,9 @@ describe('app', () => {
           [
             {
               "options": {
+                "ciTargetName": "e2e-ci",
                 "componentTestingTargetName": "component-test",
+                "openTargetName": "open-cypress",
                 "targetName": "e2e",
               },
               "plugin": "@nx/cypress/plugin",

--- a/packages/cypress/src/generators/init/init.spec.ts
+++ b/packages/cypress/src/generators/init/init.spec.ts
@@ -80,7 +80,9 @@ describe('init', () => {
         "plugins": [
           {
             "options": {
+              "ciTargetName": "e2e-ci",
               "componentTestingTargetName": "component-test",
+              "openTargetName": "open-cypress",
               "targetName": "e2e",
             },
             "plugin": "@nx/cypress/plugin",

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -74,6 +74,8 @@ export function addPlugin(tree: Tree) {
     options: {
       targetName: 'e2e',
       componentTestingTargetName: 'component-test',
+      ciTargetName: 'e2e-ci',
+      openTargetName: 'open-cypress',
     } as CypressPluginOptions,
   });
   updateNxJson(tree, nxJson);

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -102,6 +102,12 @@ describe('@nx/cypress/plugin', () => {
                   "{projectRoot}/dist/screenshots",
                 ],
               },
+              "open-cypress": {
+                "command": "cypress open",
+                "options": {
+                  "cwd": ".",
+                },
+              },
             },
           },
         },
@@ -160,6 +166,12 @@ describe('@nx/cypress/plugin', () => {
                   "{projectRoot}/dist/videos",
                   "{projectRoot}/dist/screenshots",
                 ],
+              },
+              "open-cypress": {
+                "command": "cypress open",
+                "options": {
+                  "cwd": ".",
+                },
               },
             },
           },
@@ -278,6 +290,12 @@ describe('@nx/cypress/plugin', () => {
                   "{projectRoot}/dist/cypress/videos",
                   "{projectRoot}/dist/cypress/screenshots",
                 ],
+              },
+              "open-cypress": {
+                "command": "cypress open",
+                "options": {
+                  "cwd": ".",
+                },
               },
             },
           },

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -26,6 +26,7 @@ import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 export interface CypressPluginOptions {
   ciTargetName?: string;
   targetName?: string;
+  openTargetName?: string;
   componentTestingTargetName?: string;
 }
 
@@ -268,12 +269,18 @@ async function buildCypressTargets(
     };
   }
 
+  targets[options.openTargetName] = {
+    command: `cypress open`,
+    options: { cwd: projectRoot },
+  };
+
   return { targets, targetGroups };
 }
 
 function normalizeOptions(options: CypressPluginOptions): CypressPluginOptions {
   options ??= {};
   options.targetName ??= 'e2e';
+  options.openTargetName ??= 'open-cypress';
   options.componentTestingTargetName ??= 'component-test';
   options.ciTargetName ??= 'e2e-ci';
   return options;


### PR DESCRIPTION
Infer a new task named `open-cypress`, which runs the command `cypress open` from the project root.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22389 
