### PR TITLE
fix(react): HMR for withModuleFederation #22300

### DIFF
--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -32,6 +32,14 @@ export async function withModuleFederation(
       runtimeChunk: false,
     };
 
+    if (
+      config.mode === 'development' &&
+      Object.keys(mappedRemotes).length > 1 &&
+      !options.exposes
+    ) {
+      config.optimization.runtimeChunk = 'single';
+    }
+
     config.experiments = {
       ...config.experiments,
       outputModule: !isGlobal,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
HMR for React Module Federation is not currently functioning as expected

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
HMR for React Module Federation should work as expected.
Only set `runtimeChunk: single` for initial host application, and only when mode === development

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22300
