### PR TITLE
docs(release): adjust description for preid to be more clear

### DIFF
--- a/docs/generated/cli/release.md
+++ b/docs/generated/cli/release.md
@@ -159,7 +159,7 @@ Show help
 
 Type: `string`
 
-The optional prerelease identifier to apply to the version, in the case that specifier has been set to prerelease.
+The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to `prerelease`.
 
 ##### specifier
 

--- a/docs/generated/packages/js/generators/release-version.json
+++ b/docs/generated/packages/js/generators/release-version.json
@@ -34,7 +34,7 @@
       },
       "preid": {
         "type": "string",
-        "description": "The optional prerelease identifier to apply to the version, in the case that specifier has been set to prerelease."
+        "description": "The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to prerelease."
       },
       "packageRoot": {
         "type": "string",

--- a/docs/generated/packages/nx/documents/release.md
+++ b/docs/generated/packages/nx/documents/release.md
@@ -159,7 +159,7 @@ Show help
 
 Type: `string`
 
-The optional prerelease identifier to apply to the version, in the case that specifier has been set to prerelease.
+The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to `prerelease`.
 
 ##### specifier
 

--- a/packages/js/src/generators/release-version/schema.json
+++ b/packages/js/src/generators/release-version/schema.json
@@ -33,7 +33,7 @@
     },
     "preid": {
       "type": "string",
-      "description": "The optional prerelease identifier to apply to the version, in the case that specifier has been set to prerelease."
+      "description": "The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to prerelease."
     },
     "packageRoot": {
       "type": "string",

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -192,7 +192,7 @@ const versionCommand: CommandModule<NxReleaseArgs, VersionOptions> = {
         .option('preid', {
           type: 'string',
           describe:
-            'The optional prerelease identifier to apply to the version, in the case that specifier has been set to prerelease.',
+            'The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to `prerelease`.',
           default: '',
         })
         .option('stage-changes', {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
It is not clear that --preid must be used with --specifier=prelease.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It is clear that --preid is only used when --specifier=prerelease
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
