### PR TITLE
fix(nuxt): use loadConfigFile from devkit rather than @nuxt/kit

### DIFF
--- a/e2e/nuxt/src/nuxt.test.ts
+++ b/e2e/nuxt/src/nuxt.test.ts
@@ -17,7 +17,7 @@ describe('Nuxt Plugin', () => {
       unsetProjectNameAndRootFormat: false,
     });
     runCLI(
-      `generate @nx/nuxt:app ${app} --unitTestRunner=vitest --projectNameAndRootFormat=as-provided e2eTestRunner=cypress`
+      `generate @nx/nuxt:app ${app} --unitTestRunner=vitest --projectNameAndRootFormat=as-provided --e2eTestRunner=cypress`
     );
     runCLI(
       `generate @nx/nuxt:component --directory=${app}/src/components/one --name=one --nameAndDirectoryFormat=as-provided --unitTestRunner=vitest`

--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
             "cwd": "my-app",
           },
           "outputs": [
-            "{workspaceRoot}/dist/my-app/",
+            "{workspaceRoot}/dist/my-app/.nuxt",
           ],
         },
         "acme-serve-static": {
@@ -56,7 +56,7 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
             "cwd": "my-app",
           },
           "outputs": [
-            "{workspaceRoot}/dist/my-app/",
+            "{workspaceRoot}/dist/my-app/.nuxt",
           ],
         },
         "my-serve": {
@@ -96,7 +96,7 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
             "cwd": ".",
           },
           "outputs": [
-            "dist/my-app/",
+            "dist/my-app/.nuxt",
           ],
         },
         "build-static": {
@@ -118,7 +118,7 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
             "cwd": ".",
           },
           "outputs": [
-            "dist/my-app/",
+            "dist/my-app/.nuxt",
           ],
         },
         "serve": {

--- a/packages/nuxt/src/plugins/plugin.spec.ts
+++ b/packages/nuxt/src/plugins/plugin.spec.ts
@@ -2,8 +2,8 @@ import { CreateNodesContext } from '@nx/devkit';
 import { createNodes } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
-jest.mock('@nuxt/kit', () => ({
-  loadNuxtConfig: jest.fn().mockImplementation(() => {
+jest.mock('@nx/devkit/src/utils/config-utils', () => ({
+  loadConfigFile: jest.fn().mockImplementation(() => {
     return Promise.resolve({
       buildDir: '../dist/my-app/.nuxt',
     });

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -13,9 +13,9 @@ import { basename, dirname, isAbsolute, join, relative } from 'path';
 import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { existsSync, readdirSync } from 'fs';
-import { loadNuxtKitDynamicImport } from '../utils/executor-utils';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getLockFileName } from '@nx/js';
+import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 
 const cachePath = join(projectGraphCacheDirectory, 'nuxt.hash');
 const targetsCache = existsSync(cachePath) ? readTargetsCache() : {};
@@ -208,15 +208,16 @@ async function getInfoFromNuxtConfig(
 ): Promise<{
   buildDir: string;
 }> {
-  const { loadNuxtConfig } = await loadNuxtKitDynamicImport();
-
-  const config = await loadNuxtConfig({
-    cwd: joinPathFragments(context.workspaceRoot, projectRoot),
-    configFile: basename(configFilePath),
-  });
-
+  // TODO(Colum): Once plugins are isolated we can go back to @nuxt/kit since each plugin will be run in its own worker.
+  const config = await loadConfigFile(
+    join(context.workspaceRoot, configFilePath)
+  );
   return {
-    buildDir: config?.buildDir,
+    buildDir:
+      config?.buildDir ??
+      // Match .nuxt default build dir from '@nuxt/schema'
+      // See: https://github.com/nuxt/nuxt/blob/871404ae5673425aeedde82f123ea58aa7c6facf/packages/schema/src/config/common.ts#L117-L119
+      '.nuxt',
   };
 }
 
@@ -226,16 +227,10 @@ function getOutputs(
 ): {
   buildOutputs: string[];
 } {
-  let nuxtBuildDir = nuxtConfig?.buildDir;
-  if (nuxtConfig?.buildDir && basename(nuxtConfig?.buildDir) === '.nuxt') {
-    // if buildDir exists, it will be `something/something/.nuxt`
-    // we want the "general" outputPath to be `something/something`
-    nuxtBuildDir = nuxtConfig.buildDir.replace(
-      basename(nuxtConfig.buildDir),
-      ''
-    );
-  }
-  const buildOutputPath = normalizeOutputPath(nuxtBuildDir, projectRoot);
+  const buildOutputPath = normalizeOutputPath(
+    nuxtConfig?.buildDir,
+    projectRoot
+  );
 
   return {
     buildOutputs: [buildOutputPath],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
When using `@nuxt/kit` to load `nuxt.config.ts` files, it can result in errors when used in conjunction with `@nx/vite/plugin` (and the `loadConfigFile` function from `vite`).

This PR switches to our own function from` @nx/devkit`, which we can guarantee plays nicely with `@nx/cypress`, `@nx/playwright`, and anything else that uses the same plugin.

Note: When we isolate each crystal plugin into their own worker, this issue should be resolved as well. However, this is a quicker fix with smaller impact.

## Current Behavior
Errors can occur during graph construction when combining nuxt + vitest + playwright/cypress.

## Expected Behavior
Errors should not occur during graph construction.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
