### PR TITLE
fix(core): expand env variables on load and unload

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "czg": "^1.4.0",
     "detect-port": "^1.5.1",
     "dotenv": "~16.3.1",
-    "dotenv-expand": "^10.0.0",
+    "dotenv-expand": "~11.0.0",
     "ejs": "^3.1.7",
     "enhanced-resolve": "^5.8.3",
     "esbuild": "0.19.5",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -42,7 +42,7 @@
     "cli-spinners": "2.6.1",
     "cliui": "^8.0.1",
     "dotenv": "~16.3.1",
-    "dotenv-expand": "~10.0.0",
+    "dotenv-expand": "~11.0.0",
     "enquirer": "~2.3.6",
     "figures": "3.2.0",
     "flat": "^5.0.2",

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -165,19 +165,15 @@ function loadDotEnvFilesForTask(
   ];
 
   for (const file of dotEnvFiles) {
-    const myEnv = loadDotEnvFile({
-      path: file,
+    expand({
+      ...loadDotEnvFile({
+        path: file,
+        processEnv: environmentVariables,
+        // Do not override existing env variables as we load
+        override: false,
+      }),
       processEnv: environmentVariables,
-      // Do not override existing env variables as we load
-      override: false,
     });
-    environmentVariables = {
-      ...expand({
-        ...myEnv,
-        ignoreProcessEnv: true, // Do not override existing env variables as we load
-      }).parsed,
-      ...environmentVariables,
-    };
   }
 
   return environmentVariables;
@@ -186,7 +182,14 @@ function loadDotEnvFilesForTask(
 function unloadDotEnvFiles(environmentVariables: NodeJS.ProcessEnv) {
   const unloadDotEnvFile = (filename: string) => {
     let parsedDotEnvFile: NodeJS.ProcessEnv = {};
-    loadDotEnvFile({ path: filename, processEnv: parsedDotEnvFile });
+    expand({
+      ...loadDotEnvFile({
+        path: filename,
+        processEnv: parsedDotEnvFile,
+        override: false,
+      }),
+      processEnv: parsedDotEnvFile,
+    });
     Object.keys(parsedDotEnvFile).forEach((envVarKey) => {
       if (environmentVariables[envVarKey] === parsedDotEnvFile[envVarKey]) {
         delete environmentVariables[envVarKey];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,10 +565,10 @@ devDependencies:
     version: 1.5.1
   dotenv:
     specifier: ~16.3.1
-    version: 16.3.1
+    version: 16.3.2
   dotenv-expand:
-    specifier: ^10.0.0
-    version: 10.0.0
+    specifier: ~11.0.0
+    version: 11.0.6
   ejs:
     specifier: ^3.1.7
     version: 3.1.8
@@ -8487,7 +8487,7 @@ packages:
       create-require: 1.1.1
       defu: 6.1.4
       destr: 2.0.2
-      dotenv: 16.3.1
+      dotenv: 16.3.2
       git-url-parse: 13.1.1
       is-docker: 3.0.0
       jiti: 1.21.0
@@ -10588,7 +10588,7 @@ packages:
       chalk: 4.1.2
       chokidar: 3.5.3
       cross-spawn: 7.0.3
-      dotenv: 16.3.1
+      dotenv: 16.3.2
       es-module-lexer: 1.4.1
       esbuild: 0.17.6
       esbuild-plugins-node-modules-polyfill: 1.6.1(esbuild@0.17.6)
@@ -16353,7 +16353,7 @@ packages:
     dependencies:
       chokidar: 3.5.3
       defu: 6.1.4
-      dotenv: 16.3.1
+      dotenv: 16.3.2
       giget: 1.2.1
       jiti: 1.21.0
       mlly: 1.5.0
@@ -18615,8 +18615,20 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /dotenv@16.3.1:
-    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+  /dotenv-expand@11.0.6:
+    resolution: {integrity: sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==}
+    engines: {node: '>=12'}
+    dependencies:
+      dotenv: 16.4.5
+    dev: true
+
+  /dotenv@16.3.2:
+    resolution: {integrity: sha512-HTlk5nmhkm8F6JcdXvHIzaorzCoziNQT9mGxLPVXW8wJF1TiGSL60ZGB4gHWabHOaMmWmhvk2/lPHfnBiT78AQ==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
     dev: true
 
@@ -23716,7 +23728,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       app-root-dir: 1.0.2
-      dotenv: 16.3.1
+      dotenv: 16.3.2
       dotenv-expand: 10.0.0
     dev: true
 
@@ -26206,8 +26218,8 @@ packages:
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
       cliui: 8.0.1
-      dotenv: 16.3.1
-      dotenv-expand: 10.0.0
+      dotenv: 16.3.2
+      dotenv-expand: 11.0.6
       enquirer: 2.3.6
       figures: 3.2.0
       flat: 5.0.2
@@ -26271,7 +26283,7 @@ packages:
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
       cliui: 8.0.1
-      dotenv: 16.3.1
+      dotenv: 16.3.2
       dotenv-expand: 10.0.0
       enquirer: 2.3.6
       figures: 3.2.0


### PR DESCRIPTION
Env variables using other variables were not unloaded from the environment and further customizations were impossible in more specific env files.

## Current Behavior
The unloading and re-loading of env variables in [task-runner/task-env](https://github.com/nrwl/nx/blob/ef81455b6492fee266c0d6ddfc41a79dc2041f8b/packages/nx/src/tasks-runner/task-env.ts#L189) is faulty because composed variables are not unloaded because they are not expanded, just parsed and checked to be equal to the process.env value.

I'm using the `@nx-tools/nx-container` plugin to build Docker images and I'm passing some input parameters via env var like:
```
INPUT_BUILD_ARGS="API_HOST=${API_HOST}\nAPI_PORT=${API_PORT}"
```
Nx loads `.env`, `.local.env` and `.env.local` by default and I have the localhost configuration in one of them.

But when I want to build for `production` I want to get the values of `.env.production` and  debugging the issue deeply I found that my var was not unloaded because it was comparing the evaluated value in process.env (`INPUT_BUILD_ARGS="API_HOST=localhost\nAPI_PORT=3000"`) with the non-expanded value (`INPUT_BUILD_ARGS="API_HOST=${API_HOST}\nAPI_PORT=${API_PORT}"`) so it was not unloaded.

After this adjustment and the upgrade of `dotenv-expand` to not affect process.env it works successfully :)

## Expected Behavior
To have my composed variables expanded so they are correctly unloaded and overridden by a specific `.env*` file.