### PR TITLE
fix(vite): ensure cache is created correctly for separate vite and vitest config files #22244

### DIFF
--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -66,9 +66,12 @@ export const createNodes: CreateNodes<VitePluginOptions> = [
 
     options = normalizeOptions(options);
 
-    const hash = calculateHashForCreateNodes(projectRoot, options, context, [
-      getLockFileName(detectPackageManager(context.workspaceRoot)),
-    ]);
+    // We do not want to alter how the hash is calculated, so appending the config file path to the hash
+    // to prevent vite/vitest files overwriting the target cache created by the other
+    const hash =
+      calculateHashForCreateNodes(projectRoot, options, context, [
+        getLockFileName(detectPackageManager(context.workspaceRoot)),
+      ]) + configFilePath;
     const targets = targetsCache[hash]
       ? targetsCache[hash]
       : await buildViteTargets(configFilePath, projectRoot, options, context);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When both a Vite config file and Vitest config file exist for a single project, the hash that is calculated when creating the targets is the same, and therefore one operation overwrites the other.
This leads to invalid store of targets available for the project.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Both sets of targets should produce a different hash allowing for a separate cache for each which gets merged correctly when targets are inferred.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22244
