### PR TITLE
fix(js): update jest snapshot after vite-plugin-dts bump

### DIFF
--- a/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -15,8 +15,7 @@ export default defineConfig({
     nxViteTsPaths(),
     dts({
       entryRoot: 'src',
-      tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),
-      skipDiagnostics: true,
+      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
     }),
   ],
 


### PR DESCRIPTION
## Current Behavior
Broken snapshot on `master`

## Expected Behavior
Fixed snapshot on `master`
