### PR TITLE
feat(core): list crystal plugins with nx report

### DIFF
--- a/packages/nx/src/command-line/report/report.ts
+++ b/packages/nx/src/command-line/report/report.ts
@@ -57,6 +57,7 @@ export async function reportHandler() {
     pmVersion,
     localPlugins,
     communityPlugins,
+    registeredPlugins,
     packageVersionsWeCareAbout,
     outOfSyncPackageGroup,
     projectGraphError,
@@ -76,6 +77,14 @@ export async function reportHandler() {
       `${chalk.green(p.package.padEnd(padding))} : ${chalk.bold(p.version)}`
     );
   });
+
+  if (registeredPlugins.length) {
+    bodyLines.push(LINE_SEPARATOR);
+    bodyLines.push('Registered Plugins:');
+    for (const plugin of registeredPlugins) {
+      bodyLines.push(`${chalk.green(plugin)}`);
+    }
+  }
 
   if (communityPlugins.length) {
     bodyLines.push(LINE_SEPARATOR);
@@ -130,6 +139,7 @@ export interface ReportData {
   pmVersion: string;
   localPlugins: string[];
   communityPlugins: PackageJson[];
+  registeredPlugins: string[];
   packageVersionsWeCareAbout: {
     package: string;
     version: string;
@@ -149,8 +159,10 @@ export async function getReportData(): Promise<ReportData> {
   const pm = detectPackageManager();
   const pmVersion = getPackageManagerVersion(pm);
 
-  const localPlugins = await findLocalPlugins(readNxJson());
+  const nxJson = readNxJson();
+  const localPlugins = await findLocalPlugins(nxJson);
   const communityPlugins = findInstalledCommunityPlugins();
+  const registeredPlugins = findRegisteredPluginsBeingUsed(nxJson);
 
   let projectGraphError: Error | null = null;
   if (isNativeAvailable()) {
@@ -180,6 +192,7 @@ export async function getReportData(): Promise<ReportData> {
     pmVersion,
     localPlugins,
     communityPlugins,
+    registeredPlugins,
     packageVersionsWeCareAbout,
     outOfSyncPackageGroup,
     projectGraphError,
@@ -268,6 +281,17 @@ export function findInstalledCommunityPlugins(): PackageJson[] {
       )
   );
 }
+
+export function findRegisteredPluginsBeingUsed(nxJson: NxJsonConfiguration) {
+  if (!nxJson.plugins) {
+    return [];
+  }
+
+  return nxJson.plugins.map((plugin) =>
+    typeof plugin === 'object' ? plugin.plugin : plugin
+  );
+}
+
 export function findInstalledPackagesWeCareAbout() {
   const packagesWeMayCareAbout: Record<string, string> = {};
   // TODO (v19): Remove workaround for hiding @nrwl packages when matching @nx package is found.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running Nx Report we have no way to tell if users are using Crystal plugins or not. 
When dealing with GH Issues, this makes it more difficult to discern if problems are executor related or crystal plugin related.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should list the Crystal plugins that are being used in the Nx Workspace when `nx report` is run.
This will not completely alleviate the issues with knowing whether executors are being used or not, but it will help at least.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
