### PR TITLE
feat(core): add metadata to targets

### DIFF
--- a/docs/generated/devkit/ProjectConfiguration.md
+++ b/docs/generated/devkit/ProjectConfiguration.md
@@ -8,7 +8,7 @@ Project configuration
 
 - [generators](../../devkit/documents/ProjectConfiguration#generators): Object
 - [implicitDependencies](../../devkit/documents/ProjectConfiguration#implicitdependencies): string[]
-- [metadata](../../devkit/documents/ProjectConfiguration#metadata): Object
+- [metadata](../../devkit/documents/ProjectConfiguration#metadata): ProjectMetadata
 - [name](../../devkit/documents/ProjectConfiguration#name): string
 - [namedInputs](../../devkit/documents/ProjectConfiguration#namedinputs): Object
 - [projectType](../../devkit/documents/ProjectConfiguration#projecttype): ProjectType
@@ -56,14 +56,9 @@ List of projects which are added as a dependency
 
 ### metadata
 
-• `Optional` **metadata**: `Object`
+• `Optional` **metadata**: `ProjectMetadata`
 
-#### Type declaration
-
-| Name            | Type                             |
-| :-------------- | :------------------------------- |
-| `targetGroups?` | `Record`\<`string`, `string`[]\> |
-| `technologies?` | `string`[]                       |
+Metadata about the project
 
 ---
 

--- a/docs/generated/devkit/TargetConfiguration.md
+++ b/docs/generated/devkit/TargetConfiguration.md
@@ -19,6 +19,7 @@ Target's configuration
 - [dependsOn](../../devkit/documents/TargetConfiguration#dependson): (string | TargetDependencyConfig)[]
 - [executor](../../devkit/documents/TargetConfiguration#executor): string
 - [inputs](../../devkit/documents/TargetConfiguration#inputs): (string | InputDefinition)[]
+- [metadata](../../devkit/documents/TargetConfiguration#metadata): TargetMetadata
 - [options](../../devkit/documents/TargetConfiguration#options): T
 - [outputs](../../devkit/documents/TargetConfiguration#outputs): string[]
 
@@ -83,6 +84,14 @@ Example: '@nx/rollup:rollup'
 • `Optional` **inputs**: (`string` \| `InputDefinition`)[]
 
 This describes filesets, runtime dependencies and other inputs that a target depends on.
+
+---
+
+### metadata
+
+• `Optional` **metadata**: `TargetMetadata`
+
+Metadata about the target
 
 ---
 

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'cypress';
 
 import { createNodes } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { resetWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { join } from 'path';
 import { nxE2EPreset } from '../../plugins/cypress-preset';
 
@@ -16,9 +17,9 @@ describe('@nx/cypress/plugin', () => {
 
     await tempFs.createFiles({
       'package.json': '{}',
+      'cypress.config.js': '',
       'src/test.cy.ts': '',
     });
-    process.chdir(tempFs.tempDir);
     context = {
       nxJsonConfiguration: {
         // These defaults should be overridden by plugin
@@ -41,6 +42,11 @@ describe('@nx/cypress/plugin', () => {
   afterEach(() => {
     jest.resetModules();
     tempFs.cleanup();
+    tempFs = null;
+  });
+
+  afterAll(() => {
+    resetWorkspaceContext();
   });
 
   it('should add a target for e2e', async () => {
@@ -70,11 +76,7 @@ describe('@nx/cypress/plugin', () => {
       {
         "projects": {
           ".": {
-            "metadata": {
-              "technologies": [
-                "cypress",
-              ],
-            },
+            "metadata": undefined,
             "projectType": "application",
             "targets": {
               "e2e": {
@@ -94,6 +96,12 @@ describe('@nx/cypress/plugin', () => {
                     ],
                   },
                 ],
+                "metadata": {
+                  "description": "Runs Cypress Tests",
+                  "technologies": [
+                    "cypress",
+                  ],
+                },
                 "options": {
                   "cwd": ".",
                 },
@@ -104,6 +112,12 @@ describe('@nx/cypress/plugin', () => {
               },
               "open-cypress": {
                 "command": "cypress open",
+                "metadata": {
+                  "description": "Opens Cypress",
+                  "technologies": [
+                    "cypress",
+                  ],
+                },
                 "options": {
                   "cwd": ".",
                 },
@@ -140,11 +154,7 @@ describe('@nx/cypress/plugin', () => {
       {
         "projects": {
           ".": {
-            "metadata": {
-              "technologies": [
-                "cypress",
-              ],
-            },
+            "metadata": undefined,
             "projectType": "application",
             "targets": {
               "component-test": {
@@ -159,6 +169,12 @@ describe('@nx/cypress/plugin', () => {
                     ],
                   },
                 ],
+                "metadata": {
+                  "description": "Runs Cypress Component Tests",
+                  "technologies": [
+                    "cypress",
+                  ],
+                },
                 "options": {
                   "cwd": ".",
                 },
@@ -169,6 +185,12 @@ describe('@nx/cypress/plugin', () => {
               },
               "open-cypress": {
                 "command": "cypress open",
+                "metadata": {
+                  "description": "Opens Cypress",
+                  "technologies": [
+                    "cypress",
+                  ],
+                },
                 "options": {
                   "cwd": ".",
                 },
@@ -184,16 +206,16 @@ describe('@nx/cypress/plugin', () => {
     mockCypressConfig(
       defineConfig({
         e2e: {
-          specPattern: '**/*.cy.ts',
-          videosFolder: './dist/videos',
-          screenshotsFolder: './dist/screenshots',
-          ...nxE2EPreset('.', {
+          ...nxE2EPreset(join(tempFs.tempDir, 'cypress.config.js'), {
             webServerCommands: {
               default: 'my-app:serve',
               production: 'my-app:serve:production',
             },
             ciWebServerCommand: 'my-app:serve-static',
           }),
+          specPattern: '**/*.cy.ts',
+          videosFolder: './dist/videos',
+          screenshotsFolder: './dist/screenshots',
         },
       })
     );
@@ -216,9 +238,6 @@ describe('@nx/cypress/plugin', () => {
                   "e2e-ci",
                 ],
               },
-              "technologies": [
-                "cypress",
-              ],
             },
             "projectType": "application",
             "targets": {
@@ -239,12 +258,18 @@ describe('@nx/cypress/plugin', () => {
                     ],
                   },
                 ],
+                "metadata": {
+                  "description": "Runs Cypress Tests",
+                  "technologies": [
+                    "cypress",
+                  ],
+                },
                 "options": {
                   "cwd": ".",
                 },
                 "outputs": [
-                  "{projectRoot}/dist/cypress/videos",
-                  "{projectRoot}/dist/cypress/screenshots",
+                  "{projectRoot}/dist/videos",
+                  "{projectRoot}/dist/screenshots",
                 ],
               },
               "e2e-ci": {
@@ -266,9 +291,15 @@ describe('@nx/cypress/plugin', () => {
                     ],
                   },
                 ],
+                "metadata": {
+                  "description": "Runs Cypress Tests in CI",
+                  "technologies": [
+                    "cypress",
+                  ],
+                },
                 "outputs": [
-                  "{projectRoot}/dist/cypress/videos",
-                  "{projectRoot}/dist/cypress/screenshots",
+                  "{projectRoot}/dist/videos",
+                  "{projectRoot}/dist/screenshots",
                 ],
               },
               "e2e-ci--src/test.cy.ts": {
@@ -283,16 +314,28 @@ describe('@nx/cypress/plugin', () => {
                     ],
                   },
                 ],
+                "metadata": {
+                  "description": "Runs Cypress Tests in src/test.cy.ts in CI",
+                  "technologies": [
+                    "cypress",
+                  ],
+                },
                 "options": {
                   "cwd": ".",
                 },
                 "outputs": [
-                  "{projectRoot}/dist/cypress/videos",
-                  "{projectRoot}/dist/cypress/screenshots",
+                  "{projectRoot}/dist/videos",
+                  "{projectRoot}/dist/screenshots",
                 ],
               },
               "open-cypress": {
                 "command": "cypress open",
+                "metadata": {
+                  "description": "Opens Cypress",
+                  "technologies": [
+                    "cypress",
+                  ],
+                },
                 "options": {
                   "cwd": ".",
                 },

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -111,10 +111,21 @@ export interface ProjectConfiguration {
       'generator' | 'generatorOptions'
     >;
   };
-  metadata?: {
-    technologies?: string[];
-    targetGroups?: Record<string, string[]>;
-  };
+
+  /**
+   * Metadata about the project
+   */
+  metadata?: ProjectMetadata;
+}
+
+export interface ProjectMetadata {
+  technologies?: string[];
+  targetGroups?: Record<string, string[]>;
+}
+
+export interface TargetMetadata {
+  description?: string;
+  technologies?: string[];
 }
 
 export interface TargetDependencyConfig {
@@ -203,4 +214,9 @@ export interface TargetConfiguration<T = any> {
    * Determines if Nx is able to cache a given target.
    */
   cache?: boolean;
+
+  /**
+   * Metadata about the target
+   */
+  metadata?: TargetMetadata;
 }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -444,6 +444,101 @@ describe('project-configuration-utils', () => {
         expect(result.cache).not.toBeDefined();
       });
     });
+
+    describe('metadata', () => {
+      it('should be added', () => {
+        const rootMap = new RootMapBuilder()
+          .addProject({
+            root: 'libs/lib-a',
+            name: 'lib-a',
+          })
+          .getRootMap();
+        const sourceMap: ConfigurationSourceMaps = {
+          'libs/lib-a': {},
+        };
+        mergeProjectConfigurationIntoRootMap(
+          rootMap,
+          {
+            root: 'libs/lib-a',
+            name: 'lib-a',
+            targets: {
+              build: {
+                metadata: {
+                  description: 'do stuff',
+                  technologies: ['tech'],
+                },
+              },
+            },
+          },
+          sourceMap,
+          ['dummy', 'dummy.ts']
+        );
+
+        expect(rootMap.get('libs/lib-a').targets.build.metadata).toEqual({
+          description: 'do stuff',
+          technologies: ['tech'],
+        });
+        expect(sourceMap['libs/lib-a']).toMatchObject({
+          'targets.build.metadata.description': ['dummy', 'dummy.ts'],
+          'targets.build.metadata.technologies': ['dummy', 'dummy.ts'],
+          'targets.build.metadata.technologies.0': ['dummy', 'dummy.ts'],
+        });
+      });
+
+      it('should be merged', () => {
+        const rootMap = new RootMapBuilder()
+          .addProject({
+            root: 'libs/lib-a',
+            name: 'lib-a',
+            targets: {
+              build: {
+                metadata: {
+                  description: 'do stuff',
+                  technologies: ['tech'],
+                },
+              },
+            },
+          })
+          .getRootMap();
+        const sourceMap: ConfigurationSourceMaps = {
+          'libs/lib-a': {
+            'targets.build.metadata.technologies': ['existing', 'existing.ts'],
+            'targets.build.metadata.technologies.0': [
+              'existing',
+              'existing.ts',
+            ],
+          },
+        };
+        mergeProjectConfigurationIntoRootMap(
+          rootMap,
+          {
+            root: 'libs/lib-a',
+            name: 'lib-a',
+            targets: {
+              build: {
+                metadata: {
+                  description: 'do cool stuff',
+                  technologies: ['tech2'],
+                },
+              },
+            },
+          },
+          sourceMap,
+          ['dummy', 'dummy.ts']
+        );
+
+        expect(rootMap.get('libs/lib-a').targets.build.metadata).toEqual({
+          description: 'do cool stuff',
+          technologies: ['tech', 'tech2'],
+        });
+        expect(sourceMap['libs/lib-a']).toMatchObject({
+          'targets.build.metadata.description': ['dummy', 'dummy.ts'],
+          'targets.build.metadata.technologies': ['existing', 'existing.ts'],
+          'targets.build.metadata.technologies.0': ['existing', 'existing.ts'],
+          'targets.build.metadata.technologies.1': ['dummy', 'dummy.ts'],
+        });
+      });
+    });
   });
 
   describe('mergeProjectConfigurationIntoRootMap', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Projects can have technologies assigned to them but people would assume that every target has the same metadata. This results in cypress projects having the e2e target which uses cypress.. but also lint tasks which also use cypress.. which doesn't make much sense.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Targets can have technologies assigned to them just like projects. This also means targets have metadata which... allows for adding a description field.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
