### PR TITLE
fix(webpack): support standard webpack config with @nx/webpack:dev-server

### DIFF
--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -100,6 +100,10 @@ export async function* devServerExecutor(
           configuration: serveOptions.buildTarget.split(':')[2],
         }
       );
+    } else if (userDefinedWebpackConfig) {
+      // New behavior, we want the webpack config to export object
+      config = userDefinedWebpackConfig;
+      config.devServer ??= devServer;
     }
   }
 


### PR DESCRIPTION
This PR brings the standard webpack config behavior from `@nx/webpack:webpack` to `@nx/webpack:dev-server`. Previously, the `dev-server` executor only worked with our own `withNx` and other composable plugin functions. With the change from this PR, users can export a standard webpack configuration as shown in the new e2e test.
## Current Behavior
Dev-server results in an error like:
```NX   Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.

 - configuration should be an object:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, extends?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
   -> Options object as provided by the user.

ValidationError: Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration should be an object:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, extends?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
   -> Options object as provided by the user.
```

## Expected Behavior
Dev-server should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22288

