### PR TITLE
fix(js): append target when generating tmp tsconfig to prevent conflicts #21396

### DIFF
--- a/e2e/vite/src/vite-legacy.test.ts
+++ b/e2e/vite/src/vite-legacy.test.ts
@@ -213,7 +213,7 @@ export default App;
       const results = runCLI(`build ${app} --buildLibsFromSource=false`);
       expect(results).toContain('Successfully ran target build for project');
       // this should be less modules than building from source
-      expect(results).toContain('38 modules transformed');
+      expect(results).toContain('40 modules transformed');
     });
 
     it('should build app from libs without package.json in lib', () => {

--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -434,6 +434,7 @@ export function createTmpTsConfig(
     workspaceRoot,
     'tmp',
     projectRoot,
+    process.env.NX_TASK_TARGET_TARGET ?? 'build',
     'tsconfig.generated.json'
   );
   const parsedTSConfig = readTsConfigWithRemappedPaths(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running multiple tasks for a project concurrently, if they generate a tmp tsconfig file, they generate them to the same locaction which can create conflicts.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure that the location of the generated tsconfig file is differentiated based on the task that needs it

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21396
