### PR TITLE
feat(core): improve checks for process.env.CI

### DIFF
--- a/packages/create-nx-workspace/src/utils/ci/is-ci.ts
+++ b/packages/create-nx-workspace/src/utils/ci/is-ci.ts
@@ -1,6 +1,6 @@
 export function isCI() {
   return (
-    process.env.CI === 'true' ||
+    (process.env.CI && process.env.CI !== 'false') ||
     process.env.TF_BUILD === 'true' ||
     process.env.GITHUB_ACTIONS === 'true' ||
     process.env.BUILDKITE === 'true' ||

--- a/packages/nx/src/utils/is-ci.ts
+++ b/packages/nx/src/utils/is-ci.ts
@@ -1,6 +1,6 @@
 export function isCI() {
   return (
-    process.env.CI === 'true' ||
+    (process.env.CI && process.env.CI !== 'false') ||
     process.env.TF_BUILD === 'true' ||
     process.env.GITHUB_ACTIONS === 'true' ||
     process.env.BUILDKITE === 'true' ||


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Today, nx does not disable the output styling and [WoodpeckerCI](https://woodpecker-ci.org/) doesn't go well with it, This requires us to manually add "output-style=stream" to every nx command, which solves the issue but I understand that we could have a woodpecker check to isCI function as well

reference:
https://woodpecker-ci.org/docs/usage/environment#built-in-environment-variables

## Expected Behavior
Disable styling in nx command outputs when running in WoodpeckerCI

## Related Issue(s)
I haven't found a related issue, but this PR came as a suggestion in this discord thread: https://discord.com/channels/1143497901675401286/1225808236104646706


@ edit

the title is "feat(core): add WoodpeckerCI to isCI check" but the check also applies to other CI vendors that set process.env.CI to a non-empty string

@ edit2

I've improved the PR title with feat(core): improve checks for process.env.CI since it now covers all CI players that dont'set process.env.CI directly to "true" but to other values instead