### PR TITLE
fix(webpack): remove url-loader from dependencies since it is replaced by asset modules

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -43,7 +43,6 @@
     "fs-extra": "^11.1.0",
     "ignore": "^5.0.4",
     "semver": "^7.5.3",
-    "url-loader": "^4.1.1",
     "tslib": "^2.3.0",
     "webpack-merge": "^5.8.0",
     "@nx/js": "file:../js",

--- a/packages/webpack/src/utils/ensure-dependencies.ts
+++ b/packages/webpack/src/utils/ensure-dependencies.ts
@@ -11,7 +11,6 @@ import {
   svgrWebpackVersion,
   swcLoaderVersion,
   tsLibVersion,
-  urlLoaderVersion,
 } from './versions';
 
 export type EnsureDependenciesOptions = {
@@ -41,7 +40,6 @@ export function ensureDependencies(
       reactRefreshWebpackPluginVersion;
     devDependencies['@svgr/webpack'] = svgrWebpackVersion;
     devDependencies['react-refresh'] = reactRefreshVersion;
-    devDependencies['url-loader'] = urlLoaderVersion;
   }
 
   tasks.push(addDependenciesToPackageJson(tree, {}, devDependencies));

--- a/packages/webpack/src/utils/versions.ts
+++ b/packages/webpack/src/utils/versions.ts
@@ -9,4 +9,3 @@ export const webpackCliVersion = '^5.1.4';
 export const reactRefreshWebpackPluginVersion = '^0.5.7';
 export const svgrWebpackVersion = '^8.0.1';
 export const reactRefreshVersion = '^0.10.0';
-export const urlLoaderVersion = '^4.1.1';


### PR DESCRIPTION
We have already replaced `url-loader` with Webpack 5's asset modules, this clean-up was previously missed. We'll remove `file-loader` in Nx 20, since removing it now results in a breaking change for SVGR users.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
