### PR TITLE
fix(bundling): support exported array of options for rollup

### DIFF
--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -210,4 +210,30 @@ export default config;
     checkFilesExist(`libs/test/dist/bundle.js`);
     checkFilesExist(`libs/test/dist/bundle.es.js`);
   });
+
+  it('should support array config from rollup.config.js', () => {
+    const jsLib = uniq('jslib');
+    runCLI(`generate @nx/js:lib ${jsLib} --bundler rollup`);
+    updateFile(
+      `libs/${jsLib}/rollup.config.js`,
+      `module.exports = (config) => [{
+        ...config,
+        output: {
+          format: "esm",
+          dir: "dist/test",
+          name: "Mylib",
+          entryFileNames: "[name].js",
+          chunkFileNames: "[name].js"
+        }
+      }]`
+    );
+    updateJson(join('libs', jsLib, 'project.json'), (config) => {
+      config.targets.build.options.rollupConfig = `libs/${jsLib}/rollup.config.js`;
+      return config;
+    });
+
+    expect(() => runCLI(`build ${jsLib} --format=esm`)).not.toThrow();
+
+    checkFilesExist(`dist/test/index.js`);
+  });
 });


### PR DESCRIPTION
This PR allows users to export an array of rollup options in `rollup.config.js`.

The e2e test shows an example:

```js
module.exports = (config) => [{
...config,
output: {
  format: "esm",
  dir: "dist/test",
  name: "Mylib",
  entryFileNames: "[name].js",
  chunkFileNames: "[name].js"
}
}];
```

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16567
