### PR TITLE
fix(js): propagate error from child process to @nx/js:node executor

### DIFF
--- a/e2e/js/src/js-executor-node.test.ts
+++ b/e2e/js/src/js-executor-node.test.ts
@@ -44,6 +44,7 @@ describe('js:node executor', () => {
 
     const output = runCLI(`run ${esbuildLib}:run-node`, {
       redirectStderr: true,
+      silenceError: true,
     });
     expect(output).toContain('Hello from my library!');
     expect(output).toContain('This is an error');

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -175,7 +175,13 @@ export async function* nodeExecutor(
                   `NX Process exited with code ${code}, waiting for changes to restart...`
                 );
               }
-              if (!options.watch) done();
+              if (!options.watch) {
+                if (code !== 0) {
+                  error(new Error(`Process exited with code ${code}`));
+                } else {
+                  done();
+                }
+              }
               resolve();
             });
 


### PR DESCRIPTION
This PR allows `@nx/js:node` executor to exit with an error code rather than marking the run as successful. This change will mark the task as a failure rather than success.

**Notes:**
- If `watch: true`, then we already log out the exit code, and users can update code to restart the process.
- If `watch: false`, then the exit code will be `1` and we log out the error code from the child process as well.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
