### PR TITLE
fix(bundling): print errors from rollup build

### DIFF
--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -137,7 +137,8 @@ export async function* rollupExecutor(
       updatePackageJson(options, packageJson);
       logger.info(`⚡ Done in ${duration}`);
       return { success: true, outfile };
-    } catch {
+    } catch (e) {
+      logger.error(e);
       logger.error(`Bundle failed: ${context.projectName}`);
       return { success: false };
     }


### PR DESCRIPTION
The errors from Rollup build is being swallowed. This PR prints errors so users can debug.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
