### PR TITLE
fix(core): update pty version to add windows specific flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 [[package]]
 name = "filedescriptor"
 version = "0.8.3"
-source = "git+https://github.com/cammisuli/wezterm#3db3f2d05f7188af9c7527214605f18332fac06d"
+source = "git+https://github.com/cammisuli/wezterm?rev=b538ee29e1e89eeb4832fb35ae095564dce34c29#b538ee29e1e89eeb4832fb35ae095564dce34c29"
 dependencies = [
  "libc",
  "thiserror",
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "portable-pty"
 version = "0.8.1"
-source = "git+https://github.com/cammisuli/wezterm#3db3f2d05f7188af9c7527214605f18332fac06d"
+source = "git+https://github.com/cammisuli/wezterm?rev=b538ee29e1e89eeb4832fb35ae095564dce34c29#b538ee29e1e89eeb4832fb35ae095564dce34c29"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -4,7 +4,7 @@ version = '0.1.0'
 edition = '2021'
 
 [dependencies]
-portable-pty = { git = "https://github.com/cammisuli/wezterm" }
+portable-pty = { git = "https://github.com/cammisuli/wezterm", rev = "b538ee29e1e89eeb4832fb35ae095564dce34c29" }
 anyhow = "1.0.71"
 colored = "2"
 crossbeam-channel = '0.5'


### PR DESCRIPTION
In https://github.com/nrwl/nx/pull/21683, we swapped the version of `portable_pty` to a forked version containing a bug fix for windows users. Unfortunately, the cargo installation pulled down a revision from GitHub that was 1 commit behind head, and missed part of the fix.

We hope that including the full fix will resolve some issues users on windows are facing with a hanging terminal + outputted ansi codes. Unfortunately, we have been unable to reliably reproduce the reported issue  before the fix so we haven't been able to confidently validate the fix either.