### PR TITLE
docs(core): link nx release talk

### DIFF
--- a/docs/shared/features/manage-releases.md
+++ b/docs/shared/features/manage-releases.md
@@ -2,6 +2,11 @@
 
 Once you have leveraged Nx's powerful code generation and task running capabilities to build your libraries and applications, you will want to share them with your users.
 
+{% youtube
+src="https://youtu.be/KjZKFGu3_9I"
+title="Releasing Nx Release"
+width="100%" /%}
+
 Nx provides a set of tools to help you manage your releases called `nx release`.
 
 > We recommend always starting with --dry-run, because publishing is difficult to undo


### PR DESCRIPTION
Embeds the Nx Release talk in the /features/manage-releases page:
<img width="824" alt="image" src="https://github.com/nrwl/nx/assets/542458/12632d64-97b1-4c8a-9de9-40c1ecd5da11">
