### PR TITLE
feat(core): support finding matching projects with only negative patterns

### DIFF
--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -162,6 +162,22 @@ describe('findMatchingProjects', () => {
       'nested',
     ]);
   });
+
+  it('should support "all except" style patterns', () => {
+    expect(findMatchingProjects(['!a'], projectGraph)).toEqual([
+      'test-project',
+      'b',
+      'c',
+      'nested',
+    ]);
+    expect(findMatchingProjects(['!tag:api'], projectGraph)).toEqual([
+      'b',
+      'nested',
+    ]);
+    expect(
+      findMatchingProjects(['!tag:api', 'test-project'], projectGraph)
+    ).toEqual(['b', 'nested', 'test-project']);
+  });
 });
 
 const projects = [

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -39,6 +39,16 @@ export function findMatchingProjects(
 
   const matchedProjects: Set<string> = new Set();
 
+  // If the first pattern is an exclude pattern,
+  // we add a wildcard pattern at the first to select
+  // all projects, except the ones that match the exclude pattern.
+  // e.g. ['!tag:someTag', 'project2'] will match all projects except
+  // the ones with the tag 'someTag', and also match the project 'project2',
+  // regardless of its tags.
+  if (isExcludePattern(patterns[0])) {
+    patterns.unshift('*');
+  }
+
   for (const stringPattern of patterns) {
     if (!stringPattern.length) {
       continue;
@@ -205,11 +215,15 @@ function addMatchingProjectsByTag(
   }
 }
 
+function isExcludePattern(pattern: string): boolean {
+  return pattern.startsWith('!');
+}
+
 function parseStringPattern(
   pattern: string,
   projects: Record<string, ProjectGraphProjectNode>
 ): ProjectPattern {
-  const isExclude = pattern.startsWith('!');
+  const isExclude = isExcludePattern(pattern);
 
   // Support for things like: `!{type}:value`
   if (isExclude) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Passing `--projects !tag:someTag` would select 0 projects, since the only pattern is negative

## Expected Behavior
Passing `--projects !tag:someTag` would select X projects, where X is the number of projects without someTag.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
