### PR TITLE
docs(core): add docs for registering new targets + merge logic

### DIFF
--- a/docs/shared/deprecated/v1-nx-plugin-api.md
+++ b/docs/shared/deprecated/v1-nx-plugin-api.md
@@ -96,6 +96,8 @@ export function registerProjectTargets(
 }
 ```
 
+For guidance on implementing a similar function in the v2 API, see the documentation on [createNodes](/extending-nx/recipes/project-graph-plugins#example-extending-projects-adding-targets).
+
 ### Multiple Matches
 
 It is possible that the registerProjectTargets function may be called multiple times for one project. This could occur in a few cases, one of which is demonstrated above.

--- a/docs/shared/recipes/plugins/project-graph-plugins.md
+++ b/docs/shared/recipes/plugins/project-graph-plugins.md
@@ -82,7 +82,9 @@ If you create targets for a project within a plugin's code, the Nx migration gen
 
 #### Example (extending projects / adding targets)
 
-A plugin can also be written to modify existing projects. Most of Nx's first party plugins are written to add a target to a given project based on the configuration files present for that project. The below example shows how a plugin could add a target to a project based on the presence of a `tsconfig.json` file.
+When writing a plugin to add support for some tooling, it may need to add a target to an existing project. For example, our @nx/jest plugin adds a target to the project for running Jest tests. This is done by checking for the presence of a jest configuration file, and if it is present, adding a target to the project.
+
+Most of Nx's first party plugins are written to add a target to a given project based on the configuration files present for that project. The below example shows how a plugin could add a target to a project based on the presence of a `tsconfig.json` file.
 
 ```typescript {% fileName="/my-plugin/index.ts" %}
 export const createNodes: CreateNodes = [
@@ -90,7 +92,9 @@ export const createNodes: CreateNodes = [
   (fileName: string, opts, context: CreateNodesContext) => {
     const root = dirname(fileName);
 
-    const isProject = existsSync(join(root, 'project.json'));
+    const isProject =
+      existsSync(join(root, 'project.json')) ||
+      existsSync(join(root, 'package.json'));
     if (!isProject) {
       return {};
     }
@@ -110,7 +114,7 @@ export const createNodes: CreateNodes = [
 ];
 ```
 
-By checking for the presence of a `project.json` file, the plugin can ensure that the project it is modifying is an existing Nx project.
+By checking for the presence of a `project.json` or 'package.json' file, the plugin can be more confident that the project it is modifying is an existing Nx project.
 
 When extending an existing project, its important to consider how Nx will merge the returned project configurations. In general, plugins are run in the order they are listed in `nx.json`, abd then Nx's built-in plugins are run last. Plugins overwrite information that was identified by plugins that run before them if a merge is not possible.
 

--- a/docs/shared/recipes/plugins/project-graph-plugins.md
+++ b/docs/shared/recipes/plugins/project-graph-plugins.md
@@ -114,7 +114,7 @@ export const createNodes: CreateNodes = [
 ];
 ```
 
-By checking for the presence of a `project.json` or 'package.json' file, the plugin can be more confident that the project it is modifying is an existing Nx project.
+By checking for the presence of a `project.json` or `package.json` file, the plugin can be more confident that the project it is modifying is an existing Nx project.
 
 When extending an existing project, its important to consider how Nx will merge the returned project configurations. In general, plugins are run in the order they are listed in `nx.json`, abd then Nx's built-in plugins are run last. Plugins overwrite information that was identified by plugins that run before them if a merge is not possible.
 

--- a/docs/shared/recipes/plugins/project-graph-plugins.md
+++ b/docs/shared/recipes/plugins/project-graph-plugins.md
@@ -51,7 +51,7 @@ Project nodes in the graph are considered to be the same if the project has the 
 
 Note: This is a shallow merge, so if you have a target with the same name in both plugins, the target from the second plugin will overwrite the target from the first plugin. Options, configurations, or any other properties within the target will be overwritten **_not_** merged.
 
-#### Example
+#### Example (adding projects)
 
 A simplified version of Nx's built-in `project.json` plugin is shown below, which adds a new project to the project graph for each `project.json` file it finds. This should be exported from the entry point of your plugin, which is listed in `nx.json`
 
@@ -79,6 +79,57 @@ If you create targets for a project within a plugin's code, the Nx migration gen
 2. If you create a dynamic target for an executor you don't own, only define the `executor` property and instruct your users to define their options in the `targetDefaults` property of `nx.json`.
 
 {% /callout %}
+
+#### Example (extending projects / adding targets)
+
+A plugin can also be written to modify existing projects. Most of Nx's first party are written to add a target to a given project based on the configuration files present for that project. The below example shows how a plugin could add a target to a project based on the presence of a `tsconfig.json` file.
+
+```typescript {% fileName="/my-plugin/index.ts" %}
+export const createNodes: CreateNodes = [
+  '**/tsconfig.json',
+  (fileName: string, opts, context: CreateNodesContext) => {
+    const root = dirname(fileName);
+
+    const isProject = existsSync(join(root, 'project.json'));
+    if (!isProject) {
+      return {};
+    }
+
+    return {
+      projects: {
+        [root]: {
+          targets: {
+            build: {
+              command: `tsc -p ${fileName}`,
+            },
+          },
+        },
+      },
+    };
+  },
+];
+```
+
+By checking for the presence of a `project.json` file, the plugin can ensure that the project it is modifying is an existing Nx project.
+
+When extending an existing project, its important to consider how Nx will merge the returned project configurations. In general, plugins are ran in the order they are listed in `nx.json`, with Nx's built-in plugins being ran last. Plugins overwrite information that was identified by plugins that ran before them if a merge is not possible.
+
+Nx considers two identified projects to be the same if and only if they have the same root. If two projects are identified with the same name, but different roots, there will be an error.
+
+The logic for merging project declarations is as follows:
+
+- `name`, `sourceRoot`, `projectType`, and any other top level properties which are a literal (e.g. not an array or object) are overwritten.
+- `tags` are merged and deduplicated.
+- `implicitDependencies` are merged, with dependencies from later plugins being appended to the end
+- `targets` are merged, with special logic for the targets inside of them:
+  - If the targets are deemed compatible (They use the same executor / command, or one of the two declarations does not specify an executor / command):
+    - The `executor` or `command` remains the same
+    - The `options` object is merged with the later plugin's options overwriting the earlier plugin's options. This is a shallow merge, so if a property is an object, the later plugin's object will overwrite the earlier plugin's object rather than merging the two.
+    - The `configurations` object is merged, with the later plugin's configurations overwriting the earlier plugin's configurations. The options for each configuration are merged in the same way as the top level options.
+    - `inputs` and `outputs` overwrite the earlier plugin's inputs and outputs.
+  - If the targets are not deemed compatible, the later plugin's target will overwrite the earlier plugin's target.
+- `generators` are merged. If both project configurations specify the same generator, those generators are merged.
+- `namedInputs` are merged. If both project configurations specify the same named input, the later plugin's named input will overwrite the earlier plugin's named input. This is what allows overriding a named input from a plugin that ran earlier (e.g. in project.json).
 
 ### Adding External Nodes
 

--- a/docs/shared/recipes/plugins/project-graph-plugins.md
+++ b/docs/shared/recipes/plugins/project-graph-plugins.md
@@ -82,7 +82,7 @@ If you create targets for a project within a plugin's code, the Nx migration gen
 
 #### Example (extending projects / adding targets)
 
-A plugin can also be written to modify existing projects. Most of Nx's first party are written to add a target to a given project based on the configuration files present for that project. The below example shows how a plugin could add a target to a project based on the presence of a `tsconfig.json` file.
+A plugin can also be written to modify existing projects. Most of Nx's first party plugins are written to add a target to a given project based on the configuration files present for that project. The below example shows how a plugin could add a target to a project based on the presence of a `tsconfig.json` file.
 
 ```typescript {% fileName="/my-plugin/index.ts" %}
 export const createNodes: CreateNodes = [
@@ -112,7 +112,7 @@ export const createNodes: CreateNodes = [
 
 By checking for the presence of a `project.json` file, the plugin can ensure that the project it is modifying is an existing Nx project.
 
-When extending an existing project, its important to consider how Nx will merge the returned project configurations. In general, plugins are ran in the order they are listed in `nx.json`, with Nx's built-in plugins being ran last. Plugins overwrite information that was identified by plugins that ran before them if a merge is not possible.
+When extending an existing project, its important to consider how Nx will merge the returned project configurations. In general, plugins are run in the order they are listed in `nx.json`, abd then Nx's built-in plugins are run last. Plugins overwrite information that was identified by plugins that run before them if a merge is not possible.
 
 Nx considers two identified projects to be the same if and only if they have the same root. If two projects are identified with the same name, but different roots, there will be an error.
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There are no docs for how projects are merged if they are identified by multiple projects, but we also are missing docs for how inference plugins can extend existing projects rather than identifiying new projects.

## Expected Behavior
These 2 situations are documented. Knowledge of these are necessary to write "crystal" plugins, and help community plugin authors.

New section: https://nx-dev-git-fork-agentender-docs-merge-logic-add-targets-nrwl.vercel.app/extending-nx/recipes/project-graph-plugins#example-adding-projects

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
