### PR TITLE
fix(core): attach cli args from target options explicitly with '='

### DIFF
--- a/e2e/nx-misc/src/extras.test.ts
+++ b/e2e/nx-misc/src/extras.test.ts
@@ -165,7 +165,7 @@ describe('Extra Nx Misc Tests', () => {
       });
 
       const result = runCLI(`run ${mylib}:echo`, { silent: true });
-      expect(result).toContain('--var1 a');
+      expect(result).toContain('--var1=a');
     }, 120000);
 
     it('should interpolate provided arguments', async () => {

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -238,7 +238,7 @@ describe('Run Commands', () => {
           { unknownOptions: { hello: 123 }, parsedArgs: { hello: 123 } } as any,
           true
         )
-      ).toEqual('echo --hello 123');
+      ).toEqual('echo --hello=123');
     });
 
     it('should add all args and unparsed args when forwardAllArgs is true', () => {

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -486,7 +486,7 @@ export function interpolateArgsIntoCommand(
               typeof opts.unknownOptions[k] !== 'object' &&
               opts.parsedArgs[k] === opts.unknownOptions[k]
           )
-          .map((k) => `--${k} ${opts.unknownOptions[k]}`)
+          .map((k) => `--${k}=${opts.unknownOptions[k]}`)
           .join(' ');
     }
     if (opts.args) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When attaching options from targets for `run-commands` we attach the value with a space:

```
"build": {
   "options": {
       "sourcemap": true
   }
}
```
becomes
`--sourcemap true`

This causes some CLI tools to fail when parsing.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Attach the option with `=`

The above target becomes
`--sourcemap=true`

<img width="733" alt="image" src="https://github.com/nrwl/nx/assets/12140467/50b56bb8-19bf-4945-b8c8-4cb5350116e6">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
