### PR TITLE
fix(webpack): fix default compiler option

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -41,7 +41,7 @@ export function applyBaseConfig(
   } = {}
 ): void {
   // Defaults that was applied from executor schema previously.
-  options.compiler ??= options.tsConfig ? 'babel' : undefined;
+  options.compiler ??= 'babel';
   options.deleteOutputPath ??= true;
   options.externalDependencies ??= 'all';
   options.fileReplacements ??= [];

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -41,7 +41,7 @@ export function applyBaseConfig(
   } = {}
 ): void {
   // Defaults that was applied from executor schema previously.
-  options.compiler ??= 'babel';
+  options.compiler ??= options.tsConfig ? 'babel' : undefined;
   options.deleteOutputPath ??= true;
   options.externalDependencies ??= 'all';
   options.fileReplacements ??= [];

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
@@ -54,7 +54,9 @@ export function createLoaderFromCompiler(
         },
       };
     case 'babel':
-      const tsConfig = readTsConfig(path.join(options.root, options.tsConfig));
+      const tsConfig = options.tsConfig
+        ? readTsConfig(path.join(options.root, options.tsConfig))
+        : undefined;
 
       const babelConfig = {
         test: /\.([jt])sx?$/,
@@ -62,7 +64,9 @@ export function createLoaderFromCompiler(
         exclude: /node_modules/,
         options: {
           cwd: path.join(options.root, options.sourceRoot),
-          emitDecoratorMetadata: tsConfig.options.emitDecoratorMetadata,
+          emitDecoratorMetadata: tsConfig
+            ? tsConfig.options.emitDecoratorMetadata
+            : false,
           isModern: true,
           isTest: process.env.NX_CYPRESS_COMPONENT_TEST === 'true',
           envName: process.env.BABEL_ENV ?? process.env.NODE_ENV,


### PR DESCRIPTION
Given a configuration without `options.tsConfig` the `babel` compiler breaks in `createLoaderFromCompiler` where the babel case uses `path.join(options.root, options.tsConfig)` and throws an exception if it's undefined. 

## Current Behavior


In my case, the root `package.json` generates a dependency in the tree with "empty" options:
```
{
  root: '/root/of/my/monorepo/monorepo',
  projectRoot: '',
  sourceRoot: '',
  outputFileName: undefined,
  outputPath: undefined,
  assets: [],
  target: 'web',
  projectName: undefined,
  targetName: undefined,
  configurationName: undefined,
  projectGraph: undefined
}
``` 
which breaks the project graph with this exception:
```
Unable to read angular.json
[Failed to process project graph.
  The "@nx/webpack/plugin" plugin threw an error while creating nodes from src/backend/server/webpack.config.js:
    TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
        at new NodeError (node:internal/errors:405:5)
        at validateString (node:internal/validators:162:11)
        at Object.join (node:path:1171:7)
        at createLoaderFromCompiler (/monorepo/node_modules/.pnpm/@nx+webpack@18.2.2_@swc-node+register@1.9.0_@swc+core@1.3.107_@types+node@18.16.9_nx@18.2.2_t_auhl3zn4afi4laot7gdsrcezcy/node_modules/@nx/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.js:50:58)
        at applyNxDependentConfig (/monorepo/node_modules/.pnpm/@nx+webpack@18.2.2_@swc-node+register@1.9.0_@swc+core@1.3.107_@types+node@18.16.9_nx@18.2.2_t_auhl3zn4afi4laot7gdsrcezcy/node_modules/@nx/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.js:314:61)
        at applyBaseConfig (/monorepo/node_modules/.pnpm/@nx+webpack@18.2.2_@swc-node+register@1.9.0_@swc+core@1.3.107_@types+node@18.16.9_nx@18.2.2_t_auhl3zn4afi4laot7gdsrcezcy/node_modules/@nx/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.js:36:5)
        at configure (/monorepo/node_modules/.pnpm/@nx+webpack@18.2.2_@swc-node+register@1.9.0_@swc+core@1.3.107_@types+node@18.16.9_nx@18.2.2_t_auhl3zn4afi4laot7gdsrcezcy/node_modules/@nx/webpack/src/utils/with-nx.js:15:49)
        at combined (/monorepo/node_modules/.pnpm/@nx+webpack@18.2.2_@swc-node+register@1.9.0_@swc+core@1.3.107_@types+node@18.16.9_nx@18.2.2_t_auhl3zn4afi4laot7gdsrcezcy/node_modules/@nx/webpack/src/utils/config.js:23:28)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async readWebpackOptions (/monorepo/node_modules/.pnpm/@nx+webpack@18.2.2_@swc-node+register@1.9.0_@swc+core@1.3.107_@types+node@18.16.9_nx@18.2.2_t_auhl3zn4afi4laot7gdsrcezcy/node_modules/@nx/webpack/src/utils/webpack/read-webpack-options.js:17:18)] {
  name: 'ProjectGraphError'
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The default values should fallback properly without throwing an exception for this case.