### PR TITLE
fix(nx-plugin): fix eslint 9 errors

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -96,10 +96,10 @@ export default ESLintUtils.RuleCreator(
       },
     ]
   ) {
-    if (!(context.parserServices as any).isJSON) {
+    if (!(context.sourceCode.parserServices as any).isJSON) {
       return {};
     }
-    const fileName = normalizePath(context.getFilename());
+    const fileName = normalizePath(context.filename ?? context.getFilename());
     // support only package.json
     if (!fileName.endsWith('/package.json')) {
       return {};


### PR DESCRIPTION
## Current Behavior

With Eslint 9 we get two errors

![image](https://github.com/nrwl/nx/assets/12986906/63f20c49-c58f-402f-aa22-44f90b227f8f)
![image](https://github.com/nrwl/nx/assets/12986906/11cea1a3-7e70-4f8c-86d9-79b47c2d0a6b)

## Expected Behavior
No unexpected errors

## Related Issue(s)
https://github.com/nrwl/nx/issues/22769

## Fixes
- fix `Cannot read properties of undefined (reading 'isJSON')` error 
- fix filename context in eslint 9

## Other
I confirmed that this would fix the issues in our monorepo by manually modifying the `dependency-checks` and confirming ti solves the error