### PR TITLE
fix(angular): execute wrapped schematics post tasks and log messages

### DIFF
--- a/docs/generated/devkit/ngcli_adapter/wrapAngularDevkitSchematic.md
+++ b/docs/generated/devkit/ngcli_adapter/wrapAngularDevkitSchematic.md
@@ -1,6 +1,6 @@
 # Function: wrapAngularDevkitSchematic
 
-▸ **wrapAngularDevkitSchematic**(`collectionName`, `generatorName`): (`host`: `Tree`, `generatorOptions`: \{ `[k: string]`: `any`; }) => `Promise`\<`any`\>
+▸ **wrapAngularDevkitSchematic**(`collectionName`, `generatorName`): (`host`: `Tree`, `generatorOptions`: \{ `[k: string]`: `any`; }) => `Promise`\<`GeneratorCallback`\>
 
 #### Parameters
 
@@ -13,7 +13,7 @@
 
 `fn`
 
-▸ (`host`, `generatorOptions`): `Promise`\<`any`\>
+▸ (`host`, `generatorOptions`): `Promise`\<`GeneratorCallback`\>
 
 ##### Parameters
 
@@ -24,4 +24,4 @@
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<`GeneratorCallback`\>

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -23,7 +23,14 @@ import { Stats } from 'fs';
 import { dirname, extname, join, resolve } from 'path';
 
 import { concat, from, Observable, of, zip } from 'rxjs';
-import { catchError, concatMap, map, tap } from 'rxjs/operators';
+import {
+  catchError,
+  concatMap,
+  defaultIfEmpty,
+  last,
+  map,
+  tap,
+} from 'rxjs/operators';
 
 import type { GenerateOptions } from '../command-line/generate/generate';
 import { NxJsonConfiguration } from '../config/nx-json';
@@ -57,6 +64,7 @@ import {
   ExecutorConfig,
   ExecutorContext,
   ExecutorsJson,
+  GeneratorCallback,
   TaskGraphExecutor,
 } from '../config/misc-interfaces';
 import { readPluginPackageJson } from '../project-graph/plugins';
@@ -967,7 +975,10 @@ export function wrapAngularDevkitSchematic(
   // were written with Nx in mind, and may care about tags.
   require('./compat');
 
-  return async (host: Tree, generatorOptions: { [k: string]: any }) => {
+  return async (
+    host: Tree,
+    generatorOptions: { [k: string]: any }
+  ): Promise<GeneratorCallback> => {
     const graph = await createProjectGraphAsync();
     const { projects } = readProjectsConfigurationFromProjectGraph(graph);
 
@@ -980,16 +991,6 @@ export function wrapAngularDevkitSchematic(
         generatorOptions
       );
     }
-
-    const emptyLogger = {
-      log: (e) => {},
-      info: (e) => {},
-      warn: (e) => {},
-      debug: () => {},
-      error: (e) => {},
-      fatal: (e) => {},
-    } as any;
-    emptyLogger.createChild = () => emptyLogger;
 
     const recorder = (
       event: import('@angular-devkit/schematics').DryRunEvent
@@ -1020,6 +1021,7 @@ export function wrapAngularDevkitSchematic(
 
     const fsHost = new NxScopeHostUsedForWrappedSchematics(host.root, host);
 
+    const logger = getLogger(generatorOptions.verbose);
     const options = {
       generatorOptions,
       dryRun: true,
@@ -1052,7 +1054,7 @@ export function wrapAngularDevkitSchematic(
       fsHost,
       host.root,
       workflow,
-      emptyLogger,
+      logger,
       options,
       schematic,
       false,
@@ -1062,6 +1064,19 @@ export function wrapAngularDevkitSchematic(
     if (res.status !== 0) {
       throw new Error(res.loggingQueue.join('\n'));
     }
+
+    const { lastValueFrom } = require('rxjs');
+    const toPromise = (obs: Observable<any>) =>
+      lastValueFrom ? lastValueFrom(obs) : obs.toPromise();
+
+    return async () => {
+      // https://github.com/angular/angular-cli/blob/344193f79d880177e421cff85dd3e94338d07420/packages/angular_devkit/schematics/src/workflow/base.ts#L194-L200
+      await toPromise(
+        workflow.engine
+          .executePostTasks()
+          .pipe(defaultIfEmpty(undefined), last())
+      );
+    };
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running wrapped Angular CLI schematics:

- tasks scheduled to run after the generation are not executed
- the `context.logger` methods are no-op

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running wrapped Angular CLI schematics:

- tasks scheduled to run after the generation should be executed
- the `context.logger` methods should correctly log messages

The `wrapAngularDevkitSchematic` will now return a function (the generator) that returns a `GeneratorCallback`, which will run the wrapped schematic post tasks. Consuming generators will need to return the value returned by the wrapped schematic invocation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22390
