### PR TITLE
feat(core): load root .env files on daemon

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -29,7 +29,6 @@ import { DaemonProjectGraphError } from '../daemon-project-graph-error';
 import { ProjectGraphError } from '../../project-graph/project-graph';
 
 const DAEMON_ENV_SETTINGS = {
-  ...process.env,
   NX_PROJECT_GLOB_CACHE: 'false',
   NX_CACHE_PROJECTS_CONFIG: 'false',
 };
@@ -402,7 +401,7 @@ export class DaemonClient {
         detached: true,
         windowsHide: true,
         shell: false,
-        env: DAEMON_ENV_SETTINGS,
+        env: { ...process.env, ...DAEMON_ENV_SETTINGS },
       }
     );
     backgroundProcess.unref();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We use environment variables for experimental feature flags, which sometimes need to be used on the daemon. Its common to list these variables in a .env file, which is loaded when the CLI is initialized.

The daemon is started with an environment that consists of some custom settings, combined with the process.env. This environment is set as a constant at the module level, so the value is captured the first time the daemon client is required in. 

This appears to occur _**before**_ the dotenv config function has been used, so feature flags specified in `.env` are not propogated to the daemon correctly.

## Expected Behavior
Feature flags specified in `.env` propogate to the daemon.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
