### PR TITLE
docs(expo): fix the instructions for rejecting local cache

### DIFF
--- a/docs/shared/guides/unknown-local-cache.md
+++ b/docs/shared/guides/unknown-local-cache.md
@@ -37,7 +37,7 @@ error.
 ## You Share Cache with Another Machine Using a Network Drive
 
 You can prefix any Nx command with `NX_REJECT_UNKNOWN_LOCAL_CACHE=0` to ignore the error (
-e.g., `NX REJECT_UNKNOWN_LOCAL_CACHE=0 nx run-many -t build test`). This is similar to
+e.g., `NX_REJECT_UNKNOWN_LOCAL_CACHE=0 nx run-many -t build test`). This is similar to
 setting `NODE_TLS_REJECT_UNAUTHORIZED=0` to ignore any errors stemming form self-signed certificates. Even though it
 will make it work, this approach is discouraged.
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

The current instructions are misleading, for example, NX REJECT_UNKNOWN_LOCAL_CACHE=0, which won't function if we implement it; it should be NX_REJECT_UNKNOWN_LOCAL_CACHE=0.


## Expected Behavior

The instructions should be consistent with the code implementation.

https://github.com/search?q=repo%3Anrwl%2Fnx%20REJECT_UNKNOWN_LOCAL_CACHE&type=code

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
