### PR TITLE
fix(devkit): update peer dependency on nx to include Nx 19

### DIFF
--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -37,7 +37,7 @@
     "yargs-parser": "21.1.1"
   },
   "peerDependencies": {
-    "nx": ">= 16 <= 18"
+    "nx": ">= 16 <= 19"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx Devkit 18.x will be compatible with Nx 19.x but is not labeled as such in `peerDependencies`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx Devkit `18.3.0+` will be labeled as compatible with Nx `19.x` versions.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
