### PR TITLE
fix(js): do not default to commonjs type field in package.json

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -44,7 +44,6 @@ describe('lib', () => {
         name: '@proj/my-lib',
         private: true,
         version: '0.0.1',
-        type: 'commonjs',
         scripts: {
           build: "echo 'implement build'",
           test: "echo 'implement test'",
@@ -977,6 +976,9 @@ describe('lib', () => {
         expect(config.targets.build.options.project).toEqual(
           `my-lib/package.json`
         );
+
+        const pkgJson = readJson(tree, 'my-lib/package.json');
+        expect(pkgJson.type).not.toBeDefined();
       });
 
       it('should always set compiler to swc if bundler is rollup', async () => {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -869,10 +869,10 @@ function determineEntryFields(
       };
     case 'rollup':
       return {
-        type: 'commonjs',
+        // Since we're publishing both formats, skip the type field.
+        // Bundlers or Node will determine the entry point to use.
         main: './index.cjs',
         module: './index.js',
-        // typings is missing for rollup currently
       };
     case 'vite':
       return {
@@ -891,9 +891,9 @@ function determineEntryFields(
       };
     default: {
       return {
-        // CJS is the safest optional for now due to lack of support from some packages
-        // also setting `type: module` results in different resolution behavior (e.g. import 'foo' no longer resolves to 'foo/index.js')
-        type: 'commonjs',
+        // Safest option is to not set a type field.
+        // Allow the user to decide which module format their library is using
+        type: undefined,
       };
     }
   }

--- a/packages/rollup/src/executors/rollup/lib/update-package-json.ts
+++ b/packages/rollup/src/executors/rollup/lib/update-package-json.ts
@@ -52,7 +52,7 @@ export function updatePackageJson(
 
     packageJson.main = cjsExports['.'];
 
-    if (!hasEsmFormat) {
+    if (!hasEsmFormat && !options.skipTypeField) {
       packageJson.type = 'commonjs';
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/js:library` generator will default the `packageJson.type` field to `commonjs` in the following scenarios:

 - Rollup Bundler is used
 - No bundler is used

#### Rollup Behaviour

Rollup supports generating both ESM and CJS output files. The `build` target that is created even specifies that both formats should be used.
However, the `@nx/rollup:rollup` executor will restrict the output format based on the `packageJson.type` field.

Therefore, we're always forcing CJS. This can lead to further issues when the package is built and distributed to other repos.

The `skipTypeField` option is also not respected in `commonjs` output formats.

#### No Bundler Behaviour

When no bundler is specified for the library, we still add `packageJson.type = commonjs`.
This is unnecessarily restrictive and can lead to further behavioural issues.

It is safer to not set a `type` field and allow the user to specify this themselves based on their needs.
 
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Do not default to `commonjs` for no bundler or with rollup.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19384
