### PR TITLE
chore(remix): e2e tests should use strings to prevent issues running commands on windows

### DIFF
--- a/e2e/remix/tests/nx-remix.test.ts
+++ b/e2e/remix/tests/nx-remix.test.ts
@@ -118,12 +118,12 @@ describe('Remix E2E Tests', () => {
       it('should check for un-escaped dollar signs in routes', async () => {
         await expect(async () =>
           runCLI(
-            `generate @nx/remix:route --project ${plugin} --path my.route.$withParams.tsx`
+            `generate @nx/remix:route --project ${plugin} --path="my.route.$withParams.tsx"`
           )
         ).rejects.toThrow();
 
         runCLI(
-          `generate @nx/remix:route --project ${plugin} --path my.route.\\$withParams.tsx`
+          `generate @nx/remix:route --project ${plugin} --path="my.route.\\$withParams.tsx"`
         );
 
         expect(() =>
@@ -133,7 +133,7 @@ describe('Remix E2E Tests', () => {
 
       it('should pass un-escaped dollar signs in routes with skipChecks flag', async () => {
         await runCommandAsync(
-          `someWeirdUseCase=route-segment && yarn nx generate @nx/remix:route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`
+          `someWeirdUseCase=route-segment && yarn nx generate @nx/remix:route --project ${plugin} --path="my.route.$someWeirdUseCase.tsx" --force`
         );
 
         expect(() =>
@@ -146,12 +146,12 @@ describe('Remix E2E Tests', () => {
       it('should check for un-escaped dollar signs in resource routes', async () => {
         await expect(async () =>
           runCLI(
-            `generate @nx/remix:resource-route --project ${plugin} --path my.route.$withParams.ts`
+            `generate @nx/remix:resource-route --project ${plugin} --path="my.route.$withParams.ts"`
           )
         ).rejects.toThrow();
 
         runCLI(
-          `generate @nx/remix:resource-route --project ${plugin} --path my.route.\\$withParams.ts`
+          `generate @nx/remix:resource-route --project ${plugin} --path="my.route.\\$withParams.ts"`
         );
 
         expect(() =>
@@ -161,7 +161,7 @@ describe('Remix E2E Tests', () => {
 
       xit('should pass un-escaped dollar signs in resource routes with skipChecks flag', async () => {
         await runCommandAsync(
-          `someWeirdUseCase=route-segment && yarn nx generate @nx/remix:resource-route --project ${plugin} --path my.route.$someWeirdUseCase.ts --force`
+          `someWeirdUseCase=route-segment && yarn nx generate @nx/remix:resource-route --project ${plugin} --path="my.route.$someWeirdUseCase.ts" --force`
         );
 
         expect(() =>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
windows is interpreting commands run in e2e tests as separate commands when encountering $ symbol


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Encapsulate paths in strings to prevent unexpected behaviour in e2e tests

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
