### PR TITLE
chore(testing): increase windows e2e test timeout

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -281,7 +281,7 @@ jobs:
         id: e2e-run
         run: pnpm nx run ${{ matrix.project }}:e2e
         shell: bash
-        timeout-minutes: 120
+        timeout-minutes: 180
         env:
           GIT_AUTHOR_EMAIL: test@test.com
           GIT_AUTHOR_NAME: Test


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Some tests on the Windows E2E Matrix are timing out. 


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Increase the timeout to investigate further if they are passing or failing but just reaching the timeout.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
