### PR TITLE
chore(nx-dev): update hero contact us link

### DIFF
--- a/nx-dev/ui-home/src/lib/hero.tsx
+++ b/nx-dev/ui-home/src/lib/hero.tsx
@@ -147,7 +147,7 @@ export function Hero(): JSX.Element {
             </ButtonLink>
 
             <ButtonLink
-              href="https://nx.app/enterprise?utm_source=nx.dev&utm_medium=hero"
+              href="/contact"
               variant="secondary"
               size="large"
               title="Contact us"


### PR DESCRIPTION
The ButtonLink URL destination has been changed from a specific marketing link to a general Contact Us page. This modification aims to facilitate the user contact process, simplifying their navigation experience.