### PR TITLE
feat(release): updateDependents generator option for versioning

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -193,7 +193,7 @@ describe('nx release - independent projects', () => {
         {project-name} 📄 Using the provided version specifier "999.9.9-package.3".
         {project-name} ⚠️  Warning, the following packages depend on "{project-name}" but have been filtered out via --projects, and therefore will not be updated:
         - {project-name}
-        => You can adjust this behavior by setting \`version.generatorOptions.updateDependents.when\` to "always"
+        => You can adjust this behavior by setting \`version.generatorOptions.updateDependents\` to "auto"
         {project-name} ✍️  New version 999.9.9-package.3 written to {project-name}/package.json
 
 

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -191,8 +191,10 @@ describe('nx release - independent projects', () => {
         {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
         {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
         {project-name} 📄 Using the provided version specifier "999.9.9-package.3".
+        {project-name} ⚠️  Warning, the following packages depend on "{project-name}" but have been filtered out via --projects, and therefore will not be updated:
+        - {project-name}
+        => You can adjust this behavior by setting \`version.generatorOptions.updateDependents.when\` to "always"
         {project-name} ✍️  New version 999.9.9-package.3 written to {project-name}/package.json
-        {project-name} ✍️  Applying new version 999.9.9-package.3 to 1 package which depends on {project-name}
 
 
         "name": "@proj/{project-name}",
@@ -201,10 +203,6 @@ describe('nx release - independent projects', () => {
         "scripts": {
 
 
-        "dependencies": {
-        -     "@proj/{project-name}": "0.0.0"
-        +     "@proj/{project-name}": "999.9.9-package.3"
-        }
 
 
         NX   Staging changed files with git

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -203,8 +203,6 @@ describe('nx release - independent projects', () => {
         "scripts": {
 
 
-
-
         NX   Staging changed files with git
 
 

--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -444,78 +444,252 @@ To fix this you will either need to add a package.json file at that location, or
         `);
       });
 
-      it(`should update dependents even when filtering to a subset of projects which do not include those dependents`, async () => {
-        expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
-          '0.0.1'
-        );
-        expect(
-          readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
-        ).toMatchInlineSnapshot(`
-          {
-            "dependencies": {
-              "my-lib": "0.0.1",
-            },
-            "name": "project-with-dependency-on-my-pkg",
-            "version": "0.0.1",
-          }
-        `);
-        expect(
-          readJson(
-            tree,
-            'libs/project-with-devDependency-on-my-pkg/package.json'
-          )
-        ).toMatchInlineSnapshot(`
-          {
-            "devDependencies": {
-              "my-lib": "0.0.1",
-            },
-            "name": "project-with-devDependency-on-my-pkg",
-            "version": "0.0.1",
-          }
-        `);
+      describe('updateDependentsOptions', () => {
+        it(`should not update dependents when filtering to a subset of projects by default`, async () => {
+          expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+            '0.0.1'
+          );
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-dependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "dependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-dependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-devDependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "devDependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-devDependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
 
-        await releaseVersionGenerator(tree, {
-          projects: [projectGraph.nodes['my-lib']], // version only my-lib
-          projectGraph,
-          specifier: '9.9.9', // user CLI specifier override set, no prompting should occur
-          currentVersionResolver: 'disk',
-          specifierSource: 'prompt',
-          releaseGroup: createReleaseGroup('independent'),
+          await releaseVersionGenerator(tree, {
+            projects: [projectGraph.nodes['my-lib']], // version only my-lib
+            projectGraph,
+            specifier: '9.9.9', // user CLI specifier override set, no prompting should occur
+            currentVersionResolver: 'disk',
+            specifierSource: 'prompt',
+            releaseGroup: createReleaseGroup('independent'),
+          });
+
+          expect(readJson(tree, 'libs/my-lib/package.json'))
+            .toMatchInlineSnapshot(`
+            {
+              "name": "my-lib",
+              "version": "9.9.9",
+            }
+          `);
+
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-dependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "dependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-dependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-devDependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "devDependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-devDependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
         });
 
-        expect(readJson(tree, 'libs/my-lib/package.json'))
-          .toMatchInlineSnapshot(`
-          {
-            "name": "my-lib",
-            "version": "9.9.9",
-          }
-        `);
+        it(`should not update dependents when filtering to a subset of projects by default, if "when" is set to "auto"`, async () => {
+          expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+            '0.0.1'
+          );
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-dependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "dependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-dependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-devDependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "devDependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-devDependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
 
-        expect(
-          readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
-        ).toMatchInlineSnapshot(`
-          {
-            "dependencies": {
-              "my-lib": "9.9.9",
+          await releaseVersionGenerator(tree, {
+            projects: [projectGraph.nodes['my-lib']], // version only my-lib
+            projectGraph,
+            specifier: '9.9.9', // user CLI specifier override set, no prompting should occur
+            currentVersionResolver: 'disk',
+            specifierSource: 'prompt',
+            releaseGroup: createReleaseGroup('independent'),
+            updateDependents: {
+              when: 'auto',
             },
-            "name": "project-with-dependency-on-my-pkg",
-            "version": "0.0.1",
-          }
-        `);
-        expect(
-          readJson(
-            tree,
-            'libs/project-with-devDependency-on-my-pkg/package.json'
-          )
-        ).toMatchInlineSnapshot(`
-          {
-            "devDependencies": {
-              "my-lib": "9.9.9",
+          });
+
+          expect(readJson(tree, 'libs/my-lib/package.json'))
+            .toMatchInlineSnapshot(`
+            {
+              "name": "my-lib",
+              "version": "9.9.9",
+            }
+          `);
+
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-dependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "dependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-dependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-devDependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "devDependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-devDependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
+        });
+
+        it(`should update dependents even when filtering to a subset of projects which do not include those dependents, if "when" is "always"`, async () => {
+          expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+            '0.0.1'
+          );
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-dependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "dependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-dependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-devDependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "devDependencies": {
+                "my-lib": "0.0.1",
+              },
+              "name": "project-with-devDependency-on-my-pkg",
+              "version": "0.0.1",
+            }
+          `);
+
+          await releaseVersionGenerator(tree, {
+            projects: [projectGraph.nodes['my-lib']], // version only my-lib
+            projectGraph,
+            specifier: '9.9.9', // user CLI specifier override set, no prompting should occur
+            currentVersionResolver: 'disk',
+            specifierSource: 'prompt',
+            releaseGroup: createReleaseGroup('independent'),
+            updateDependents: {
+              when: 'always',
             },
-            "name": "project-with-devDependency-on-my-pkg",
-            "version": "0.0.1",
-          }
-        `);
+          });
+
+          expect(readJson(tree, 'libs/my-lib/package.json'))
+            .toMatchInlineSnapshot(`
+            {
+              "name": "my-lib",
+              "version": "9.9.9",
+            }
+          `);
+
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-dependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "dependencies": {
+                "my-lib": "9.9.9",
+              },
+              "name": "project-with-dependency-on-my-pkg",
+              "version": "0.0.2",
+            }
+          `);
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-devDependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "devDependencies": {
+                "my-lib": "9.9.9",
+              },
+              "name": "project-with-devDependency-on-my-pkg",
+              "version": "0.0.2",
+            }
+          `);
+        });
       });
     });
   });

--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -525,7 +525,7 @@ To fix this you will either need to add a package.json file at that location, or
           `);
         });
 
-        it(`should not update dependents when filtering to a subset of projects by default, if "when" is set to "auto"`, async () => {
+        it(`should not update dependents when filtering to a subset of projects by default, if "updateDependents" is set to "never"`, async () => {
           expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
             '0.0.1'
           );
@@ -565,9 +565,7 @@ To fix this you will either need to add a package.json file at that location, or
             currentVersionResolver: 'disk',
             specifierSource: 'prompt',
             releaseGroup: createReleaseGroup('independent'),
-            updateDependents: {
-              when: 'auto',
-            },
+            updateDependents: 'never',
           });
 
           expect(readJson(tree, 'libs/my-lib/package.json'))
@@ -608,7 +606,7 @@ To fix this you will either need to add a package.json file at that location, or
           `);
         });
 
-        it(`should update dependents even when filtering to a subset of projects which do not include those dependents, if "when" is "always"`, async () => {
+        it(`should update dependents even when filtering to a subset of projects which do not include those dependents, if "updateDependents" is "auto"`, async () => {
           expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
             '0.0.1'
           );
@@ -648,9 +646,7 @@ To fix this you will either need to add a package.json file at that location, or
             currentVersionResolver: 'disk',
             specifierSource: 'prompt',
             releaseGroup: createReleaseGroup('independent'),
-            updateDependents: {
-              when: 'always',
-            },
+            updateDependents: 'auto',
           });
 
           expect(readJson(tree, 'libs/my-lib/package.json'))
@@ -1157,7 +1153,7 @@ Valid values are: "auto", "", "~", "^", "="`,
       jest.clearAllMocks();
     });
 
-    it('should not update transitive dependents when updateDependents.when is set to "auto" and the transitive dependents are not in the same batch', async () => {
+    it('should not update transitive dependents when updateDependents is set to "never" and the transitive dependents are not in the same batch', async () => {
       expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
         '0.0.1'
       );
@@ -1187,7 +1183,7 @@ Valid values are: "auto", "", "~", "^", "="`,
         }
       `);
 
-      // It should not include transitive dependents in the versionData because we are filtering to only my-lib and updateDependents.when is set to "auto"
+      // It should not include transitive dependents in the versionData because we are filtering to only my-lib and updateDependents is set to "never"
       expect(
         await releaseVersionGenerator(tree, {
           projects: [projectGraph.nodes['my-lib']], // version only my-lib
@@ -1196,9 +1192,7 @@ Valid values are: "auto", "", "~", "^", "="`,
           currentVersionResolver: 'disk',
           specifierSource: 'prompt',
           releaseGroup: createReleaseGroup('independent'),
-          updateDependents: {
-            when: 'auto',
-          },
+          updateDependents: 'never',
         })
       ).toMatchInlineSnapshot(`
         {
@@ -1220,7 +1214,7 @@ Valid values are: "auto", "", "~", "^", "="`,
         }
       `);
 
-      // The version of project-with-dependency-on-my-lib is untouched because it is not in the same batch as my-lib and updateDependents.when is set to "auto"
+      // The version of project-with-dependency-on-my-lib is untouched because it is not in the same batch as my-lib and updateDependents is set to "never"
       expect(
         readJson(tree, 'libs/project-with-dependency-on-my-lib/package.json')
       ).toMatchInlineSnapshot(`
@@ -1233,7 +1227,7 @@ Valid values are: "auto", "", "~", "^", "="`,
         }
       `);
 
-      // The version of project-with-transitive-dependency-on-my-lib is untouched because it is not in the same batch as my-lib and updateDependents.when is set to "auto"
+      // The version of project-with-transitive-dependency-on-my-lib is untouched because it is not in the same batch as my-lib and updateDependents is set to "never"
       expect(
         readJson(
           tree,
@@ -1250,7 +1244,7 @@ Valid values are: "auto", "", "~", "^", "="`,
       `);
     });
 
-    it('should always update transitive dependents when updateDependents.when is set to "always"', async () => {
+    it('should always update transitive dependents when updateDependents is set to "auto"', async () => {
       expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
         '0.0.1'
       );
@@ -1289,9 +1283,7 @@ Valid values are: "auto", "", "~", "^", "="`,
           currentVersionResolver: 'disk',
           specifierSource: 'prompt',
           releaseGroup: createReleaseGroup('independent'),
-          updateDependents: {
-            when: 'always',
-          },
+          updateDependents: 'auto',
         })
       ).toMatchInlineSnapshot(`
         {

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -519,7 +519,10 @@ To fix this you will either need to add a package.json file at that location, or
       versionData[projectName] = {
         currentVersion,
         newVersion: null, // will stay as null in the final result in the case that no changes are detected
-        dependentProjects: allDependentProjects,
+        dependentProjects:
+          updateDependentsOptions.when === 'always'
+            ? allDependentProjects
+            : dependentProjectsInCurrentBatch,
       };
 
       if (!specifier) {

--- a/packages/js/src/generators/release-version/utils/resolve-local-package-dependencies.ts
+++ b/packages/js/src/generators/release-version/utils/resolve-local-package-dependencies.ts
@@ -12,7 +12,7 @@ import { satisfies } from 'semver';
 import { Package } from './package';
 import { resolveVersionSpec } from './resolve-version-spec';
 
-interface LocalPackageDependency extends ProjectGraphDependency {
+export interface LocalPackageDependency extends ProjectGraphDependency {
   /**
    * The rawVersionSpec contains the value of the version spec as it was defined in the package.json
    * of the dependent project. This can be useful in cases where the version spec is a range, path or

--- a/packages/js/src/generators/release-version/utils/update-lock-file.ts
+++ b/packages/js/src/generators/release-version/utils/update-lock-file.ts
@@ -125,8 +125,10 @@ function execLockFileUpdate(
   env: object = {}
 ): void {
   try {
+    const LARGE_BUFFER = 1024 * 1000000;
     execSync(command, {
       cwd,
+      maxBuffer: LARGE_BUFFER,
       env: {
         ...process.env,
         ...env,

--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -671,4 +671,82 @@ describe('defaultChangelogRenderer()', () => {
       `);
     });
   });
+
+  describe('dependency bumps', () => {
+    it('should render the dependency bumps in addition to the commits', async () => {
+      expect(
+        await defaultChangelogRenderer({
+          projectGraph,
+          commits,
+          releaseVersion: 'v1.1.0',
+          entryWhenNoChanges: false as const,
+          changelogRenderOptions: {
+            authors: true,
+          },
+          conventionalCommitsConfig: DEFAULT_CONVENTIONAL_COMMITS_CONFIG,
+          project: 'pkg-a',
+          dependencyBumps: [
+            {
+              dependencyName: 'pkg-b',
+              newVersion: '2.0.0',
+            },
+          ],
+        })
+      ).toMatchInlineSnapshot(`
+        "## v1.1.0
+
+
+        ### 🚀 Features
+
+        - **pkg-a:** new hotness
+
+
+        ### 🩹 Fixes
+
+        - all packages fixed
+
+        - **pkg-a:** squashing bugs
+
+
+        ### 🧱 Updated Dependencies
+
+        - Updated pkg-b to 2.0.0
+
+
+        ### ❤️  Thank You
+
+        - James Henry"
+      `);
+    });
+
+    it('should render the dependency bumps and release version title even when there are no commits', async () => {
+      expect(
+        await defaultChangelogRenderer({
+          projectGraph,
+          commits: [],
+          releaseVersion: 'v3.1.0',
+          entryWhenNoChanges:
+            'should not be printed because we have dependency bumps',
+          changelogRenderOptions: {
+            authors: true,
+          },
+          conventionalCommitsConfig: DEFAULT_CONVENTIONAL_COMMITS_CONFIG,
+          project: 'pkg-a',
+          dependencyBumps: [
+            {
+              dependencyName: 'pkg-b',
+              newVersion: '4.0.0',
+            },
+          ],
+        })
+      ).toMatchInlineSnapshot(`
+        "## v3.1.0
+
+
+        ### 🧱 Updated Dependencies
+
+        - Updated pkg-b to 4.0.0"
+      `);
+    });
+  });
 });

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -939,12 +939,15 @@ async function generateChangelogForProjects(
         : undefined;
 
     const dependencyBumps = projectToDependencyProjectNames.has(project)
-      ? projectToDependencyProjectNames.get(project).map((dep) => {
-          return {
-            dependencyName: dep,
-            newVersion: projectsVersionData[dep].newVersion,
-          };
-        })
+      ? projectToDependencyProjectNames
+          .get(project)
+          .map((dep) => {
+            return {
+              dependencyName: dep,
+              newVersion: projectsVersionData[dep].newVersion,
+            };
+          })
+          .filter((b) => b.newVersion !== null)
       : undefined;
 
     let contents = await changelogRenderer({

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -33,7 +33,11 @@ export type VersionData = Record<
      */
     newVersion: string | null;
     currentVersion: string;
-    dependentProjects: any[]; // TODO: investigate generic type for this once more ecosystems are explored
+    /**
+     * The list of projects which depend upon the current project.
+     * TODO: investigate generic type for this once more ecosystems are explored
+     */
+    dependentProjects: any[];
   }
 >;
 

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -73,12 +73,11 @@ export interface ReleaseVersionGeneratorSchema {
   installArgs?: string;
   installIgnoreScripts?: boolean;
   conventionalCommitsConfig?: NxReleaseConfig['conventionalCommits'];
-  updateDependents?: {
-    // "auto" means "only when the dependents are already included in the current batch", and is the default
-    when?: 'auto' | 'always';
-    // in the case "when" is set to "always", what semver bump should be applied to the dependents which are not included in the current batch
-    bump?: 'patch' | 'minor' | 'major';
-  };
+  /**
+   * 'auto' allows users to opt into dependents being updated (a patch version bump) when a dependency is versioned.
+   * This is only applicable to independently released projects.
+   */
+  updateDependents?: 'never' | 'auto';
 }
 
 export interface NxReleaseVersionResult {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When releasing projects independently, if a dependent project is untouched directly by the changes, it will not have its version updated and there is no way to opt into this behavior.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When releasing projects independently, if a dependent project is untouched directly by the changes, **BY DEFAULT** it will not have its version updated, **BUT** you can opt into it always being updated via a generator option (`release.version.generatorOptions.updateDependents.when = always` and you can control what kind of semver bump should be applied to the otherwise unchanged dependent project. Transitive local dependents (`A -> B -> C`) will also be updated in this scenario.

Additionally, when opted into, such version only changes will appear in the changelog under a new `Updated Dependencies` section.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22268
