### PR TITLE
fix(core): load config util supports absolute paths on windows

### DIFF
--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -1,6 +1,7 @@
 import { dirname, extname, join } from 'path';
 import { existsSync, readdirSync } from 'fs';
 import { requireNx } from '../../nx';
+import { pathToFileURL } from 'node:url';
 
 const { workspaceRoot, registerTsProject } = requireNx();
 
@@ -70,8 +71,9 @@ async function load(path: string): Promise<any> {
     return require(path);
   } catch (e: any) {
     if (e.code === 'ERR_REQUIRE_ESM') {
-      // If `require` fails to load ESM, try dynamic `import()`.
-      return await dynamicImport(`${path}?t=${Date.now()}`);
+      // If `require` fails to load ESM, try dynamic `import()`. ESM requires file url protocol for handling absolute paths.
+      const pathAsFileUrl = pathToFileURL(path).pathname;
+      return await dynamicImport(`${pathAsFileUrl}?t=${Date.now()}`);
     }
 
     // Re-throw all other errors


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when a plugin attempts to load an ESM config file during graph creation with an absolute path on windows, it falls over as the protocol is unsupported.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use pathToFileURl to correctly form the path needed for ESM config files to be imported.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21936
