### PR TITLE
fix(core): fix init logging and package.json updates

### DIFF
--- a/e2e/nx-init/src/nx-init-nest.test.ts
+++ b/e2e/nx-init/src/nx-init-nest.test.ts
@@ -48,7 +48,7 @@ describe('nx init (for NestCLI - legacy)', () => {
       }
     );
 
-    expect(output).toContain('Enabled computation caching');
+    expect(output).toContain('Run it again to replay the cached computation.');
 
     // nest-cli.json is removed
     expect(exists(`${projectRoot}/nest-cli.json`)).toBeFalsy();

--- a/e2e/nx-init/src/nx-init-npm-repo.test.ts
+++ b/e2e/nx-init/src/nx-init-npm-repo.test.ts
@@ -42,8 +42,7 @@ describe('nx init (NPM repo - legacy)', () => {
         pmc.runUninstalledPackage
       } nx@${getPublishedVersion()} init --cacheable=echo --no-interactive`
     );
-    console.log(output);
-    expect(output).toContain('Enabled computation caching');
+    expect(output).toContain('Run it again to replay the cached computation.');
 
     expect(runCLI('echo')).toContain('123');
     renameFile('nx.json', 'nx.json.old');

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
@@ -5,13 +5,10 @@ import { join, relative } from 'path';
 import { InitArgs } from '../init-v1';
 import { readJsonFile } from '../../../utils/fileutils';
 import { output } from '../../../utils/output';
-import { getPackageManagerCommand } from '../../../utils/package-manager';
 import {
   addDepsToPackageJson,
   createNxJsonFile,
   initCloud,
-  markPackageJsonAsNxProject,
-  printFinalMessage,
   runInstall,
   updateGitIgnore,
 } from './utils';
@@ -94,11 +91,6 @@ export async function addNxToMonorepo(options: Options) {
     cacheableOperations,
     scriptOutputs
   );
-  if (!options.legacy) {
-    packageJsonFiles.forEach((packageJsonPath) => {
-      markPackageJsonAsNxProject(join(repoRoot, packageJsonPath));
-    });
-  }
 
   updateGitIgnore(repoRoot);
   addDepsToPackageJson(repoRoot);
@@ -110,16 +102,6 @@ export async function addNxToMonorepo(options: Options) {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     initCloud(repoRoot, 'nx-init-monorepo');
   }
-
-  const pmc = getPackageManagerCommand();
-  printFinalMessage({
-    learnMoreLink: 'https://nx.dev/recipes/adopting-nx/adding-to-monorepo',
-    bodyLines: [
-      `- Run "${pmc.exec} nx run-many --target=build" to run the build script for every project in the monorepo.`,
-      '- Run it again to replay the cached computation.',
-      `- Run "${pmc.exec} nx graph" to see the structure of the monorepo.`,
-    ],
-  });
 }
 
 // scanning package.json files

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
@@ -17,7 +17,6 @@ import {
   createNxJsonFile,
   initCloud,
   markRootPackageJsonAsNxProjectLegacy,
-  printFinalMessage,
   runInstall,
   updateGitIgnore,
 } from './utils';
@@ -139,10 +138,6 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     initCloud(repoRoot, 'nx-init-nest');
   }
-
-  printFinalMessage({
-    learnMoreLink: 'https://nx.dev/recipes/adopting-nx/adding-to-monorepo',
-  });
 }
 
 function addNestPluginToPackageJson(repoRoot: string) {
@@ -177,8 +172,6 @@ function createProjectJson(
         buildTarget: `${packageName}:build`,
       },
     };
-
-    console.log(nestCLIOptions);
 
     if (nestCLIOptions.webpackOptions) {
       json.targets['build'] = {

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
@@ -10,7 +10,6 @@ import {
   initCloud,
   markPackageJsonAsNxProject,
   markRootPackageJsonAsNxProjectLegacy,
-  printFinalMessage,
   runInstall,
   updateGitIgnore,
 } from './utils';
@@ -96,9 +95,4 @@ export async function addNxToNpmRepo(options: Options) {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     initCloud(repoRoot, 'nx-init-npm-repo');
   }
-
-  printFinalMessage({
-    learnMoreLink:
-      'https://nx.dev/recipes/adopting-nx/adding-to-existing-project',
-  });
 }

--- a/packages/nx/src/command-line/init/implementation/angular/index.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/index.ts
@@ -8,7 +8,6 @@ import type { PackageJson } from '../../../../utils/package-json';
 import {
   addDepsToPackageJson,
   initCloud,
-  printFinalMessage,
   runInstall,
   updateGitIgnore,
 } from '../utils';
@@ -65,13 +64,6 @@ export async function addNxToAngularCliRepo(options: Options) {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     initCloud(repoRoot, 'nx-init-angular');
   }
-
-  printFinalMessage({
-    learnMoreLink: 'https://nx.dev/recipes/angular/migration/angular',
-    bodyLines: [
-      '- Execute "npx nx build" twice to see the computation caching in action.',
-    ],
-  });
 }
 
 async function collectCacheableOperations(options: Options): Promise<string[]> {

--- a/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
@@ -11,7 +11,7 @@ import {
   resolvePackageVersionUsingInstallation,
   resolvePackageVersionUsingRegistry,
 } from '../../../../utils/package-manager';
-import { initCloud, printFinalMessage } from '../utils';
+import { initCloud } from '../utils';
 import type { Options } from './types';
 import { connectExistingRepoToNxCloudPrompt } from '../../../connect/connect-to-nx-cloud';
 
@@ -111,13 +111,6 @@ export async function getLegacyMigrationFunctionIfApplicable(
       output.log({ title: '🛠️ Setting up Nx Cloud' });
       initCloud(repoRoot, 'nx-init-angular');
     }
-
-    printFinalMessage({
-      learnMoreLink: 'https://nx.dev/recipes/angular/migration/angular',
-      bodyLines: [
-        '- Execute "npx nx build" twice to see the computation caching in action.',
-      ],
-    });
   };
 }
 

--- a/packages/nx/src/command-line/init/implementation/react/index.ts
+++ b/packages/nx/src/command-line/init/implementation/react/index.ts
@@ -14,7 +14,6 @@ import {
   PackageManagerCommands,
 } from '../../../../utils/package-manager';
 import { PackageJson } from '../../../../utils/package-json';
-import { printFinalMessage } from '../utils';
 import { checkForCustomWebpackSetup } from './check-for-custom-webpack-setup';
 import { checkForUncommittedChanges } from './check-for-uncommitted-changes';
 import { cleanUpFiles } from './clean-up-files';
@@ -140,27 +139,6 @@ async function reorgnizeWorkspaceStructure(options: NormalizedOptions) {
 
   output.log({ title: '📦 Installing dependencies' });
   installDependencies(options);
-
-  const buildCommand = options.integrated
-    ? `npx nx build ${options.reactAppName}`
-    : 'npm run build';
-  printFinalMessage({
-    learnMoreLink:
-      'https://nx.dev/recipes/adopting-nx/adding-to-existing-project',
-    bodyLines: [
-      `- Execute "${buildCommand}" twice to see the computation caching in action.`,
-    ],
-  });
-
-  output.note({
-    title: 'First time using Nx? Check out this interactive Nx tutorial.',
-    bodyLines: [
-      `https://nx.dev/react-tutorial/1-code-generation`,
-      ` `,
-      `Prefer watching videos? Check out this free Nx course on Egghead.io.`,
-      `https://egghead.io/playlists/scale-react-development-with-nx-4038`,
-    ],
-  });
 
   if (options.isVite) {
     const indexPath = options.isStandalone

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -206,20 +206,16 @@ export function markPackageJsonAsNxProject(packageJsonPath: string) {
 
 export function printFinalMessage({
   learnMoreLink,
-  bodyLines,
 }: {
   learnMoreLink?: string;
-  bodyLines?: string[];
 }): void {
-  const normalizedBodyLines = (bodyLines ?? []).map((l) =>
-    l.startsWith('- ') ? l : `- ${l}`
-  );
+  const pmc = getPackageManagerCommand();
 
   output.success({
     title: '🎉 Done!',
     bodyLines: [
-      '- Enabled computation caching!',
-      ...normalizedBodyLines,
+      `- Run "${pmc.exec} nx run-many -t build" to run the build target for every project in the workspace. Run it again to replay the cached computation. https://nx.dev/features/cache-task-results`,
+      `- Run "${pmc.exec} nx graph" to see the graph of projects and tasks in your workspace. https://nx.dev/core-features/explore-graph`,
       learnMoreLink ? `- Learn more at ${learnMoreLink}.` : undefined,
     ].filter(Boolean),
   });

--- a/packages/nx/src/command-line/init/init-v1.ts
+++ b/packages/nx/src/command-line/init/init-v1.ts
@@ -12,7 +12,7 @@ import { runNxSync } from '../../utils/child-process';
 import { directoryExists, readJsonFile } from '../../utils/fileutils';
 import { PackageJson } from '../../utils/package-json';
 import { nxVersion } from '../../utils/versions';
-import { isMonorepo } from './implementation/utils';
+import { isMonorepo, printFinalMessage } from './implementation/utils';
 
 export interface InitArgs {
   addE2e: boolean;
@@ -40,14 +40,37 @@ export async function initHandler(options: InitArgs) {
     const packageJson: PackageJson = readJsonFile('package.json');
     if (existsSync('angular.json')) {
       await addNxToAngularCliRepo(options);
+
+      printFinalMessage({
+        learnMoreLink: 'https://nx.dev/recipes/angular/migration/angular',
+      });
+      return;
     } else if (isCRA(packageJson)) {
       await addNxToCraRepo(options);
+
+      printFinalMessage({
+        learnMoreLink: options.integrated
+          ? 'https://nx.dev/getting-started/tutorials/react-monorepo-tutorial'
+          : 'https://nx.dev/getting-started/tutorials/react-standalone-tutorial',
+      });
+      return;
     } else if (isNestCLI(packageJson)) {
       await addNxToNest(options, packageJson);
+      printFinalMessage({
+        learnMoreLink: 'https://nx.dev/recipes/adopting-nx/adding-to-monorepo',
+      });
+      return;
     } else if (isMonorepo(packageJson)) {
       await addNxToMonorepo({ ...options, legacy: true });
+      printFinalMessage({
+        learnMoreLink: 'https://nx.dev/recipes/adopting-nx/adding-to-monorepo',
+      });
     } else {
       await addNxToNpmRepo({ ...options, legacy: true });
+      printFinalMessage({
+        learnMoreLink:
+          'https://nx.dev/recipes/adopting-nx/adding-to-existing-project',
+      });
     }
   } else {
     const useDotNxFolder = await prompt<{ useDotNxFolder: string }>([

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -11,6 +11,7 @@ import {
   addDepsToPackageJson,
   createNxJsonFile,
   isMonorepo,
+  printFinalMessage,
   runInstall,
   updateGitIgnore,
 } from './implementation/utils';
@@ -67,6 +68,10 @@ export async function initHandler(options: InitArgs): Promise<void> {
       ...options,
       integrated: !!options.integrated,
     });
+
+    printFinalMessage({
+      learnMoreLink: 'https://nx.dev/recipes/angular/migration/angular',
+    });
     return;
   }
 
@@ -86,6 +91,9 @@ export async function initHandler(options: InitArgs): Promise<void> {
       nxCloud: false,
     });
   }
+  const learnMoreLink = isMonorepo(packageJson)
+    ? 'https://nx.dev/getting-started/tutorials/npm-workspaces-tutorial'
+    : 'https://nx.dev/recipes/adopting-nx/adding-to-existing-project';
   const useNxCloud =
     options.nxCloud ??
     (options.interactive ? await connectExistingRepoToNxCloudPrompt() : false);
@@ -128,12 +136,8 @@ export async function initHandler(options: InitArgs): Promise<void> {
     );
   }
 
-  output.log({
-    title: '👀 Explore Your Workspace',
-    bodyLines: [
-      `Run "nx graph" to show the graph of the workspace. It will show tasks that you can run with Nx.`,
-      `Read this guide on exploring your workspace: https://nx.dev/core-features/explore-graph`,
-    ],
+  printFinalMessage({
+    learnMoreLink,
   });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The "final" message for the init flow is not always at the bottom of the logs. For the new init flow, it gets covered up by all the init logs. Also, for npm monorepos, all `package.json` files have `nx: {}` added which should not be the case for any `package.json` files in the case of a monorepo.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The final message for the init flow appears at the bottom of the logs. All the `package.json` files are also not touched for a npm workspace case.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
