### PR TITLE
fix(bundling): show codeframes for Rollup build errors

### DIFF
--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -138,6 +138,10 @@ export async function* rollupExecutor(
       logger.info(`⚡ Done in ${duration}`);
       return { success: true, outfile };
     } catch (e) {
+      if (e.formatted) {
+        // Formattted message is provided by Rollup and contains codeframes for where the error occurred.
+        logger.info(e.formatted);
+      }
       logger.error(e);
       logger.error(`Bundle failed: ${context.projectName}`);
       return { success: false };


### PR DESCRIPTION
This PR prints out more useful information for when Rollup builds fail. Currently, only the error message is printed, which is just a stacktrace such as:

```
    at Object.wrapException (/Users/jack/projects/acme5/node_modules/sass/sass.dart.js:2184:43)
    at SpanScanner.error$3$length$position (/Users/jack/projects/acme5/node_modules/sass/sass.dart.js:79737:15)
    at SpanScanner._fail$1 (/Users/jack/projects/acme5/node_modules/sass/sass.dart.js:79862:12)
    at SpanScanner.expectChar$2$name (/Users/jack/projects/acme5/node_modules/sass/sass.dart.js:79818:12)
    at SpanScanner.expectChar$1 (/Users/jack/projects/acme5/node_modules/sass/sass.dart.js:79821:19)
    at ScssParser0.children$1 (/Users/jack/projects/acme5/node_modules/sass/sass.dart.js:107462:10)
```

We also need to print  the formatted message from Rollup, which would point to the actual source of the error. For example, for SASS errors it will show:

```
Error: expected "{".
  ╷
9 │ >container }
  │            ^
  ╵
  ui/src/lib/ui.module.scss 9:12  root stylesheet
```

## Current Behavior
Errors are not as useful.

## Expected Behavior
Show more useful errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
