### PR TITLE
feat(js): add swc cli options --strip-leading-paths

### DIFF
--- a/docs/generated/packages/js/executors/swc.json
+++ b/docs/generated/packages/js/executors/swc.json
@@ -116,7 +116,8 @@
         "oneOf": [
           { "type": "string", "enum": ["all", "none"] },
           { "type": "array", "items": { "type": "string" } }
-        ]
+        ],
+        "x-deprecated": "Make sure all dependencies are buildable by running `nx g @nx/js:setup-build`. This option will be removed in Nx 20."
       },
       "externalBuildTargets": {
         "type": "array",
@@ -130,6 +131,11 @@
         "default": false,
         "x-priority": "internal"
       }
+    },
+    "stripLeadingPaths": {
+      "type": "boolean",
+      "description": "Remove leading directory from output (e.g. src). See: https://swc.rs/docs/usage/cli#--strip-leading-paths",
+      "default": false
     },
     "required": ["main", "outputPath", "tsConfig"],
     "definitions": {

--- a/docs/generated/packages/js/executors/tsc.json
+++ b/docs/generated/packages/js/executors/tsc.json
@@ -116,7 +116,8 @@
         "oneOf": [
           { "type": "string", "enum": ["all", "none"] },
           { "type": "array", "items": { "type": "string" } }
-        ]
+        ],
+        "x-deprecated": "Make sure all dependencies are buildable by running `nx g @nx/js:setup-build`. This option will be removed in Nx 20."
       },
       "externalBuildTargets": {
         "type": "array",

--- a/e2e/js/src/js-executor-swc.test.ts
+++ b/e2e/js/src/js-executor-swc.test.ts
@@ -92,4 +92,19 @@ myLib();
     }).toString();
     expect(result).toContain('x');
   }, 240_000);
+
+  it('should support --strip-leading-paths option', () => {
+    const lib = uniq('lib');
+    runCLI(`generate @nx/js:lib ${lib} --bundler=swc --no-interactive`);
+
+    runCLI(`build ${lib} --stripLeadingPaths`);
+
+    checkFilesExist(
+      `dist/libs/${lib}/package.json`,
+      `dist/libs/${lib}/index.js`,
+      `dist/libs/${lib}/lib/${lib}.js`,
+      `dist/libs/${lib}/index.d.ts`,
+      `dist/libs/${lib}/lib/${lib}.d.ts`
+    );
+  });
 });

--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -167,6 +167,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "19.0.0": {
+      "version": "19.0.0-beta.0",
+      "packages": {
+        "@swc/cli": {
+          "version": "~0.3.12",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -97,7 +97,8 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "x-deprecated": "Make sure all dependencies are buildable by running `nx g @nx/js:setup-build`. This option will be removed in Nx 20."
     },
     "externalBuildTargets": {
       "type": "array",
@@ -113,6 +114,11 @@
       "default": false,
       "x-priority": "internal"
     }
+  },
+  "stripLeadingPaths": {
+    "type": "boolean",
+    "description": "Remove leading directory from output (e.g. src). See: https://swc.rs/docs/usage/cli#--strip-leading-paths",
+    "default": false
   },
   "required": ["main", "outputPath", "tsConfig"],
   "definitions": {

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -17,6 +17,7 @@ import {
 import { copyPackageJson } from '../../utils/package-json';
 import {
   NormalizedSwcExecutorOptions,
+  SwcCliOptions,
   SwcExecutorOptions,
 } from '../../utils/schema';
 import { compileSwc, compileSwcWatch } from '../../utils/swc/compile-swc';
@@ -59,20 +60,16 @@ function normalizeOptions(
     outputPath
   );
 
-  const projectRootParts = projectRoot.split('/');
-  // We pop the last part of the `projectRoot` to pass
-  // the last part (projectDir) and the remainder (projectRootParts) to swc
-  const projectDir = projectRootParts.pop();
-  // default to current directory if projectRootParts is [].
-  // Eg: when a project is at the root level, outside of layout dir
-  const swcCwd = projectRootParts.join('/') || '.';
+  // Always execute from root of project, same as with SWC CLI.
+  const swcCwd = join(root, projectRoot);
   const { swcrcPath, tmpSwcrcPath } = getSwcrcPath(options, root, projectRoot);
 
   const swcCliOptions = {
-    srcPath: projectDir,
-    destPath: relative(join(root, swcCwd), outputPath),
+    srcPath: projectRoot,
+    destPath: relative(swcCwd, outputPath),
     swcCwd,
     swcrcPath,
+    stripLeadingPaths: Boolean(options.stripLeadingPaths),
   };
 
   return {
@@ -127,11 +124,16 @@ export async function* swcExecutor(
   );
 
   if (!isInlineGraphEmpty(inlineProjectGraph)) {
+    if (options.stripLeadingPaths) {
+      throw new Error(`Cannot use --strip-leading-paths with inlining.`);
+    }
+
     options.projectRoot = '.'; // set to root of workspace to include other libs for type check
 
     // remap paths for SWC compilation
-    options.swcCliOptions.srcPath = options.swcCliOptions.swcCwd;
+    options.inline = true;
     options.swcCliOptions.swcCwd = '.';
+    options.swcCliOptions.srcPath = options.swcCliOptions.swcCwd;
     options.swcCliOptions.destPath = join(
       options.swcCliOptions.destPath.split(normalize('../')).at(-1),
       options.swcCliOptions.srcPath

--- a/packages/js/src/executors/tsc/schema.json
+++ b/packages/js/src/executors/tsc/schema.json
@@ -85,7 +85,8 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "x-deprecated": "Make sure all dependencies are buildable by running `nx g @nx/js:setup-build`. This option will be removed in Nx 20."
     },
     "externalBuildTargets": {
       "type": "array",

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -51,6 +51,7 @@ export interface ExecutorOptions {
   external?: 'all' | 'none' | string[];
   externalBuildTargets?: string[];
   generateLockfile?: boolean;
+  stripLeadingPaths?: boolean;
 }
 
 export interface NormalizedExecutorOptions extends ExecutorOptions {
@@ -75,6 +76,7 @@ export interface SwcCliOptions {
   destPath: string;
   swcrcPath: string;
   swcCwd: string;
+  stripLeadingPaths: boolean;
 }
 
 export interface NormalizedSwcExecutorOptions
@@ -84,4 +86,7 @@ export interface NormalizedSwcExecutorOptions
   skipTypeCheck: boolean;
   swcCliOptions: SwcCliOptions;
   tmpSwcrcPath: string;
+  sourceRoot?: string;
+  // TODO(v20): remove inline feature
+  inline?: boolean;
 }

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxVersion = require('../../package.json').version;
 
 export const esbuildVersion = '^0.19.2';
 export const prettierVersion = '^2.6.2';
-export const swcCliVersion = '~0.1.62';
+export const swcCliVersion = '~0.3.12';
 export const swcCoreVersion = '~1.3.85';
 export const swcHelpersVersion = '~0.5.2';
 export const swcNodeVersion = '~1.8.0';


### PR DESCRIPTION
This PR updates SWC CLI for Nx 19 to support `--strip-leading-paths` CLI option.

It is a revert of [this PR](https://github.com/nrwl/nx/pull/22832) but with updated migration targeting Nx 19.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
