### PR TITLE
fix(testing): fix jest ci target names

### DIFF
--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -153,12 +153,12 @@ async function buildJestTargets(
       // nx-ignore-next-line
     })) as typeof import('jest-runtime');
 
-    const context = await Runtime.createContext(config.projectConfig, {
+    const jestContext = await Runtime.createContext(config.projectConfig, {
       maxWorkers: 1,
       watchman: false,
     });
 
-    const source = new jest.SearchSource(context);
+    const source = new jest.SearchSource(jestContext);
 
     const specs = await source.getTestPaths(config.globalConfig);
 
@@ -188,7 +188,9 @@ async function buildJestTargets(
       targetGroup.push(options.ciTargetName);
 
       for (const testPath of testPaths) {
-        const relativePath = normalize(relative(projectRoot, testPath));
+        const relativePath = normalize(
+          relative(join(context.workspaceRoot, projectRoot), testPath)
+        );
         const targetName = `${options.ciTargetName}--${relativePath}`;
         dependsOn.push(targetName);
         targets[targetName] = {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The target names look like `nxls-e2e:e2e-ci--../../../../apps/nxls-e2e/src/nx-workspace/nx-workspace-16.test.ts`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The target names look like `nxls-e2e:e2e-ci--src/nx-workspace/nx-workspace-16.test.ts`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
