### PR TITLE
fix(nx-cloud): ensure root .env files are loaded during dte

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -4,8 +4,7 @@ import {
   WorkspaceTypeAndRoot,
 } from '../src/utils/find-workspace-root';
 import * as chalk from 'chalk';
-import { config as loadDotEnvFile } from 'dotenv';
-import { expand } from 'dotenv-expand';
+import { loadRootEnvFiles } from '../src/utils/dotenv';
 import { initLocal } from './init-local';
 import { output } from '../src/utils/output';
 import {
@@ -33,8 +32,12 @@ function main() {
 
   require('nx/src/utils/perf-logging');
 
+  const workspace = findWorkspaceRoot(process.cwd());
+
   performance.mark('loading dotenv files:start');
-  loadDotEnvFiles();
+  if (workspace) {
+    loadRootEnvFiles(workspace.dir);
+  }
   performance.mark('loading dotenv files:end');
   performance.measure(
     'loading dotenv files',
@@ -42,7 +45,6 @@ function main() {
     'loading dotenv files:end'
   );
 
-  const workspace = findWorkspaceRoot(process.cwd());
   // new is a special case because there is no local workspace to load
   if (
     process.argv[2] === 'new' ||
@@ -102,21 +104,6 @@ function main() {
         require(localNx);
       }
     }
-  }
-}
-
-/**
- * This loads dotenv files from:
- * - .env
- * - .local.env
- * - .env.local
- */
-function loadDotEnvFiles() {
-  for (const file of ['.local.env', '.env.local', '.env']) {
-    const myEnv = loadDotEnvFile({
-      path: file,
-    });
-    expand(myEnv);
   }
 }
 

--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -7,9 +7,11 @@ import { invokeTasksRunner } from './run-command';
 import { InvokeRunnerTerminalOutputLifeCycle } from './life-cycles/invoke-runner-terminal-output-life-cycle';
 import { performance } from 'perf_hooks';
 import { getOutputs } from './utils';
+import { loadRootEnvFiles } from '../utils/dotenv';
 
 export async function initTasksRunner(nxArgs: NxArgs) {
   performance.mark('init-local');
+  loadRootEnvFiles();
   workspaceConfigurationCheck();
   const nxJson = readNxJson();
   if (nxArgs.verbose) {

--- a/packages/nx/src/utils/dotenv.ts
+++ b/packages/nx/src/utils/dotenv.ts
@@ -1,0 +1,19 @@
+import { config as loadDotEnvFile } from 'dotenv';
+import { expand } from 'dotenv-expand';
+import { workspaceRoot } from './workspace-root';
+import { join } from 'path';
+
+/**
+ * This loads dotenv files from:
+ * - .env
+ * - .local.env
+ * - .env.local
+ */
+export function loadRootEnvFiles(root = workspaceRoot) {
+  for (const file of ['.local.env', '.env.local', '.env']) {
+    const myEnv = loadDotEnvFile({
+      path: join(root, file),
+    });
+    expand(myEnv);
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When tasks are ran via `initTasksRunner`, the root .env may not be loaded

## Expected Behavior
When creating the tasks runner, we load .env files

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
