### PR TITLE
fix(core): keep plugin workers until main process shutdown

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -22,7 +22,7 @@ interface PendingPromise {
 export function loadRemoteNxPlugin(
   plugin: PluginConfiguration,
   root: string
-): [Promise<LoadedNxPlugin>, () => void] {
+): Promise<LoadedNxPlugin> {
   // this should only really be true when running unit tests within
   // the Nx repo. We still need to start the worker in this case,
   // but its typescript.
@@ -60,19 +60,13 @@ export function loadRemoteNxPlugin(
 
   cleanupFunctions.add(cleanupFunction);
 
-  return [
-    new Promise<LoadedNxPlugin>((res, rej) => {
-      worker.on(
-        'message',
-        createWorkerHandler(worker, pendingPromises, res, rej)
-      );
-      worker.on('exit', exitHandler);
-    }),
-    () => {
-      cleanupFunction();
-      cleanupFunctions.delete(cleanupFunction);
-    },
-  ] as const;
+  return new Promise<LoadedNxPlugin>((res, rej) => {
+    worker.on(
+      'message',
+      createWorkerHandler(worker, pendingPromises, res, rej)
+    );
+    worker.on('exit', exitHandler);
+  });
 }
 
 async function shutdownPluginWorker(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Plugin workers are shutdown after graph creation

## Expected Behavior
Workers are kept alive until process end, to avoid needing to restart the workers if createProjectGraphAsync is used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
