### PR TITLE
fix(core): different commands should not be considered compatible targets

### DIFF
--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -71,6 +71,9 @@ describe('file-server', () => {
       config.targets['build'] = {
         command: `node copy-index.js`,
         outputs: [`{workspaceRoot}/dist/foobar`],
+        options: {
+          cwd: '{projectRoot}',
+        },
       };
       config.targets['serve'] = {
         executor: '@nx/web:file-server',

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1527,6 +1527,25 @@ describe('project-configuration-utils', () => {
         )
       ).toBe(false);
     });
+
+    it('should return false if one target specifies a command, and the other specifies commands', () => {
+      expect(
+        isCompatibleTarget(
+          {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'echo',
+            },
+          },
+          {
+            executor: 'nx:run-commands',
+            options: {
+              commands: ['echo', 'other'],
+            },
+          }
+        )
+      ).toBe(false);
+    });
   });
 
   describe('createProjectConfigurations', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -554,7 +554,7 @@ export function mergeTargetConfigurations(
 
   // Target is "compatible", e.g. executor is defined only once or is the same
   // in both places. This means that it is likely safe to merge
-  const isCompatible = isCompatibleTarget(baseTargetProperties, target);
+  const isCompatible = isCompatibleTarget(baseTarget ?? {}, target);
 
   // If the targets are not compatible, we would normally overwrite the old target
   // with the new one. However, we have a special case for targets that have the


### PR DESCRIPTION
## Current Behavior
A sm typo causes isCompatibleTarget to read incorrectly

## Expected Behavior
isCompatibleTarget is false if commands vary

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
