### PR TITLE
docs(angular): call out @nx/angular plugin as required to run angular devkit schematics and builders

### DIFF
--- a/docs/generated/packages/angular/documents/overview.md
+++ b/docs/generated/packages/angular/documents/overview.md
@@ -4,15 +4,24 @@ description: The Nx Plugin for Angular contains executors, generators, and utili
 ---
 
 The Nx Plugin for Angular contains executors, generators, and utilities for managing Angular applications and libraries
-within an Nx workspace. It provides:
+within an Nx workspace. It also enables using Angular Devkit builders and schematics in Nx workspaces.
 
-- Integration with libraries such as Storybook, Jest and Cypress.
+Among other things, it provides:
+
+- Integration with libraries such as:
+  - Cypress
+  - ESLint
+  - Jest
+  - Playwright
+  - Storybook
 - Generators to help scaffold code quickly, including:
   - Micro Frontends
   - Libraries, both internal to your codebase and publishable to npm
-  - Single Component Application Modules (SCAMs)
-- NgRx helpers.
-- Utilities for automatic workspace refactoring.
+  - Projects with Tailwind CSS
+- Executors providing extra capabilities on top of the Angular Devkit builders:
+  - Provide ESBuild plugins
+  - Provide custom webpack configurations
+- Utilities for automatic workspace refactoring
 
 {% callout type="note" title="Currently using the Angular CLI?" %}
 You can easily and mostly **automatically migrate from an Angular CLI** project to Nx! Learn

--- a/docs/shared/guides/nx-and-angular-cli.md
+++ b/docs/shared/guides/nx-and-angular-cli.md
@@ -146,6 +146,10 @@ You can also run Angular Schematics through the Nx CLI. So something like this w
 npx nx g @schematics/angular:component my-component
 ```
 
+{% callout type="check" title="Important" %}
+Support to run Angular Devkit builders and schematics is enabled by installing the [`@nx/angular` plugin](/nx-api/angular/documents/overview). This plugin is installed by default when creating a new Angular workspace with Nx or [migrate an existing Angular CLI workspace to Nx](#migrate-from-the-angular-cli).
+{% /callout %}
+
 ### Running Commands
 
 Commands are run in the very same way as with the Angular CLI. You just switch `ng` with `nx`. For example:

--- a/docs/shared/guides/nx-devkit-angular-devkit.md
+++ b/docs/shared/guides/nx-devkit-angular-devkit.md
@@ -6,6 +6,10 @@ This document covers the difference between Nx Devkit and Angular Devkit. See th
 
 Nx comes with a devkit to write generators and executors, but you can also use Angular devkit (schematics and builders). In other words, you can use an Angular schematic to implement a generator, and you can use an Angular builder to implement an executor.
 
+{% callout type="check" title="Important" %}
+Support to run Angular Devkit builders and schematics is enabled by installing the [`@nx/angular` plugin](/nx-api/angular/documents/overview). This plugin is installed by default when creating a new Angular workspace with Nx or [migrate an existing Angular CLI workspace to Nx](/recipes/angular/migration/angular).
+{% /callout %}
+
 **What are the differences between Nx Devkit and Angular Devkit?**
 
 ## Generators

--- a/docs/shared/packages/angular/angular-plugin.md
+++ b/docs/shared/packages/angular/angular-plugin.md
@@ -4,15 +4,24 @@ description: The Nx Plugin for Angular contains executors, generators, and utili
 ---
 
 The Nx Plugin for Angular contains executors, generators, and utilities for managing Angular applications and libraries
-within an Nx workspace. It provides:
+within an Nx workspace. It also enables using Angular Devkit builders and schematics in Nx workspaces.
 
-- Integration with libraries such as Storybook, Jest and Cypress.
+Among other things, it provides:
+
+- Integration with libraries such as:
+  - Cypress
+  - ESLint
+  - Jest
+  - Playwright
+  - Storybook
 - Generators to help scaffold code quickly, including:
   - Micro Frontends
   - Libraries, both internal to your codebase and publishable to npm
-  - Single Component Application Modules (SCAMs)
-- NgRx helpers.
-- Utilities for automatic workspace refactoring.
+  - Projects with Tailwind CSS
+- Executors providing extra capabilities on top of the Angular Devkit builders:
+  - Provide ESBuild plugins
+  - Provide custom webpack configurations
+- Utilities for automatic workspace refactoring
 
 {% callout type="note" title="Currently using the Angular CLI?" %}
 You can easily and mostly **automatically migrate from an Angular CLI** project to Nx! Learn


### PR DESCRIPTION
Updated docs:

https://nx-dev-git-fork-leosvelperez-docs-call-out-angular-plugin-nrwl.vercel.app/concepts/more-concepts/nx-and-angular#executors-vs-builders-generators-vs-schematics
https://nx-dev-git-fork-leosvelperez-docs-call-out-angular-plugin-nrwl.vercel.app/concepts/more-concepts/nx-devkit-angular-devkit
https://nx-dev-git-fork-leosvelperez-docs-call-out-angular-plugin-nrwl.vercel.app/nx-api/angular/documents/overview

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22625 
