### PR TITLE
chore(repo): remove @side/jest-runtime as Node v20.10 patched the memory leak

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -8,8 +8,6 @@ module.exports = {
     '^.+\\.(ts|js|html)$': 'ts-jest',
   },
   resolver: '../../scripts/patched-jest-resolver.js',
-  // Fixes https://github.com/jestjs/jest/issues/11956
-  runtime: '@side/jest-runtime',
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageReporters: ['html'],
   maxWorkers: 1,

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@rollup/plugin-url": "^7.0.0",
     "@schematics/angular": "~17.3.0",
-    "@side/jest-runtime": "^1.1.0",
     "@storybook/addon-essentials": "7.5.3",
     "@storybook/core-server": "7.5.3",
     "@storybook/react": "7.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,9 +359,6 @@ devDependencies:
   '@schematics/angular':
     specifier: ~17.3.0
     version: 17.3.0
-  '@side/jest-runtime':
-    specifier: ^1.1.0
-    version: 1.1.0(@jest/transform@29.7.0)(jest-runtime@29.7.0)(jest@29.4.3)
   '@storybook/addon-essentials':
     specifier: 7.5.3
     version: 7.5.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
@@ -10981,19 +10978,6 @@ packages:
       jsonc-parser: 3.2.1
     transitivePeerDependencies:
       - chokidar
-    dev: true
-
-  /@side/jest-runtime@1.1.0(@jest/transform@29.7.0)(jest-runtime@29.7.0)(jest@29.4.3):
-    resolution: {integrity: sha512-KikALXowNWyOxn/zdy4AUgkYq/1hASkOEEP0+bcCDv5L3KJNwDw8kmzBcx7sljnwV8yi2cLGzt9QH9EjwA9TKg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    peerDependencies:
-      '@jest/transform': '>=28'
-      jest: '>=28'
-      jest-runtime: '>=28'
-    dependencies:
-      '@jest/transform': 29.7.0
-      jest: 29.4.3(@types/node@18.19.8)(ts-node@10.9.1)
-      jest-runtime: 29.7.0
     dev: true
 
   /@sigstore/bundle@2.1.1:

--- a/tools/documentation/create-embeddings/jest.preset.js
+++ b/tools/documentation/create-embeddings/jest.preset.js
@@ -8,8 +8,6 @@ module.exports = {
     '^.+\\.(ts|tsx|js|jsx|mts|mjs)$': 'ts-jest',
   },
   resolver: '../../../scripts/patched-jest-resolver.js',
-  // Fixes https://github.com/jestjs/jest/issues/11956
-  runtime: '@side/jest-runtime',
   moduleFileExtensions: ['ts', 'js', 'mts', 'html'],
   coverageReporters: ['html'],
   maxWorkers: 1,


### PR DESCRIPTION
We no longer need `@side/jest-runtime` as the issues in Node have been resolved, and using it blocks Rollup v4 and Prettier v3 upgrade.

Original Jest issue: https://github.com/jestjs/jest/issues/11956
Node release for 20.10: https://github.com/nodejs/node/releases/tag/v20.10.0

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
