### PR TITLE
docs(nx-cloud): add info about start-ci-run and --stop-agents-after u…

### DIFF
--- a/docs/nx-cloud/reference/nx-cloud-cli.md
+++ b/docs/nx-cloud/reference/nx-cloud-cli.md
@@ -5,6 +5,12 @@
 At the beginning of your main job, invoke `npx nx-cloud start-ci-run`. This tells Nx Cloud that the following series of
 command correspond to the same CI run.
 
+{% callout type="warning" title="Do not run start-ci-run locally" %}
+`nx-cloud start-ci-run` is designed to run in CI. If you run the command locally, it can cause your local Nx repo think it's apart of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
+
+If you ran the command locally, you can remove your systems temp files to reset your local system. Typically restarting your system is enough to fix this issue.
+{% /callout %}
+
 You can configure your CI run by passing the following flags:
 
 ### --distribute-on
@@ -57,6 +63,22 @@ run.
 
 You can fix it by telling Nx Cloud that it can terminate agents after it sees a certain
 target: `npx nx-cloud start-ci-run --stop-agents-after=e2e`.
+
+The target name for `--stop-agents-after` should be the last target ran within your pipeline. If not Nx Cloud will complete the CI pipeline execution, preventing the subsequent commands from running.
+
+For example:
+
+```yaml
+- run: npx nx-cloud start-ci-run --stop-agents-after=build
+- run: nx affected -t build,lint,test
+```
+
+If build tasks are all cached, then all build tasks will complete immediately causing lint and test tasks to fail with an error saying the CI pipeline execution has already been completed. Instead you should re-order your targets to make sure the build target is last
+
+```yaml
+- run: npx nx-cloud start-ci-run --stop-agents-after=build
+- run: nx affected -t lint,test,build
+```
 
 ### --require-explicit-completion
 

--- a/docs/nx-cloud/reference/nx-cloud-cli.md
+++ b/docs/nx-cloud/reference/nx-cloud-cli.md
@@ -6,9 +6,9 @@ At the beginning of your main job, invoke `npx nx-cloud start-ci-run`. This tell
 command correspond to the same CI run.
 
 {% callout type="warning" title="Do not run start-ci-run locally" %}
-`nx-cloud start-ci-run` is designed to run in CI. If you run the command locally, it can cause your local Nx repo think it's apart of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
+`nx-cloud start-ci-run` is designed to run in CI. If you run the command locally, it can cause your local Nx repo to think it's a part of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
 
-If you ran the command locally, you can remove your systems temp files to reset your local system. Typically restarting your system is enough to fix this issue.
+If you accidentally run the command locally, you can remove your system's temp files to reset your local system. Typically restarting your system is enough to fix this issue.
 {% /callout %}
 
 You can configure your CI run by passing the following flags:
@@ -64,9 +64,9 @@ run.
 You can fix it by telling Nx Cloud that it can terminate agents after it sees a certain
 target: `npx nx-cloud start-ci-run --stop-agents-after=e2e`.
 
-The target name for `--stop-agents-after` should be the last target ran within your pipeline. If not Nx Cloud will complete the CI pipeline execution, preventing the subsequent commands from running.
+The target name for `--stop-agents-after` should be the last target run within your pipeline. If not, Nx Cloud will end the CI pipeline execution, preventing the subsequent commands from running.
 
-For example:
+Incorrect example:
 
 ```yaml
 - run: npx nx-cloud start-ci-run --stop-agents-after=build
@@ -75,7 +75,9 @@ For example:
 - run: nx affected -t test
 ```
 
-If build tasks are all cached, then all build tasks will complete immediately causing lint and test tasks to fail with an error saying the CI pipeline execution has already been completed. Instead you should re-order your targets to make sure the build target is last
+If build tasks are all cached, then all build tasks will complete immediately causing lint and test tasks to fail with an error saying the CI pipeline execution has already been completed. Instead you should re-order your targets to make sure the build target is last.
+
+Corrected example:
 
 ```yaml
 - run: npx nx-cloud start-ci-run --stop-agents-after=build

--- a/docs/nx-cloud/reference/nx-cloud-cli.md
+++ b/docs/nx-cloud/reference/nx-cloud-cli.md
@@ -70,14 +70,18 @@ For example:
 
 ```yaml
 - run: npx nx-cloud start-ci-run --stop-agents-after=build
-- run: nx affected -t build,lint,test
+- run: nx affected -t build
+- run: nx affected -t lint
+- run: nx affected -t test
 ```
 
 If build tasks are all cached, then all build tasks will complete immediately causing lint and test tasks to fail with an error saying the CI pipeline execution has already been completed. Instead you should re-order your targets to make sure the build target is last
 
 ```yaml
 - run: npx nx-cloud start-ci-run --stop-agents-after=build
-- run: nx affected -t lint,test,build
+- run: nx affected -t lint
+- run: nx affected -t test
+- run: nx affected -t build
 ```
 
 ### --require-explicit-completion


### PR DESCRIPTION
…sage

Make it more clear about the usage of `--stop-agents-after` and potential issues where your pipline might not behave as you'd expect

Explain `start-ci-run` is for CI environments, and how to get around the issue if you do run it locally

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
