### PR TITLE
fix(misc): add --verbose support to nx graph

### DIFF
--- a/docs/generated/cli/graph.md
+++ b/docs/generated/cli/graph.md
@@ -159,6 +159,12 @@ Type: `boolean`
 
 Untracked changes
 
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
+
 ### version
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/dep-graph.md
+++ b/docs/generated/packages/nx/documents/dep-graph.md
@@ -159,6 +159,12 @@ Type: `boolean`
 
 Untracked changes
 
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
+
 ### version
 
 Type: `boolean`

--- a/packages/nx/src/command-line/graph/command-object.ts
+++ b/packages/nx/src/command-line/graph/command-object.ts
@@ -3,6 +3,7 @@ import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
 import {
   withAffectedOptions,
   withDepGraphOptions,
+  withVerbose,
 } from '../yargs-utils/shared-options';
 
 export const yargsDepGraphCommand: CommandModule = {
@@ -11,7 +12,7 @@ export const yargsDepGraphCommand: CommandModule = {
   aliases: ['dep-graph'],
   builder: (yargs) =>
     linkToNxDevAndExamples(
-      withAffectedOptions(withDepGraphOptions(yargs)),
+      withVerbose(withAffectedOptions(withDepGraphOptions(yargs))),
       'dep-graph'
     )
       .option('affected', {

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -1,6 +1,10 @@
 import type { ProjectGraphProjectNode } from '../../config/project-graph';
 import { CommandModule, showHelp } from 'yargs';
-import { parseCSV, withAffectedOptions } from '../yargs-utils/shared-options';
+import {
+  parseCSV,
+  withAffectedOptions,
+  withVerbose,
+} from '../yargs-utils/shared-options';
 import { handleErrors } from '../../utils/params';
 
 export interface NxShowArgs {
@@ -64,7 +68,7 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
   command: 'projects',
   describe: 'Show a list of projects in the workspace',
   builder: (yargs) =>
-    withAffectedOptions(yargs)
+    withVerbose(withAffectedOptions(yargs))
       .option('affected', {
         type: 'boolean',
         description: 'Show only affected projects',
@@ -85,11 +89,6 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
         type: 'string',
         description: 'Select only projects of the given type',
         choices: ['app', 'lib', 'e2e'],
-      })
-      .option('verbose', {
-        type: 'boolean',
-        description:
-          'Prints additional information about the commands (e.g., stack traces)',
       })
       .implies('untracked', 'affected')
       .implies('uncommitted', 'affected')

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -30,7 +30,7 @@ export interface RunOptions {
 }
 
 export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
-  return withExcludeOption(yargs)
+  return withVerbose(withExcludeOption(yargs))
     .option('parallel', {
       describe: 'Max number of parallel processes [default is 3]',
       type: 'string',
@@ -62,11 +62,6 @@ export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
           : value === 'false' || value === false
           ? false
           : value,
-    })
-    .option('verbose', {
-      type: 'boolean',
-      describe:
-        'Prints additional information about the commands (e.g., stack traces)',
     })
     .option('nxBail', {
       describe: 'Stop command execution after the first failed task',
@@ -121,6 +116,20 @@ export function withConfiguration(yargs: Argv) {
     type: 'string',
     alias: 'c',
   });
+}
+
+export function withVerbose(yargs: Argv) {
+  return yargs
+    .option('verbose', {
+      describe:
+        'Prints additional information about the commands (e.g., stack traces)',
+      type: 'boolean',
+    })
+    .middleware((args) => {
+      if (args.verbose) {
+        process.env.NX_VERBOSE_LOGGING = 'true';
+      }
+    });
 }
 
 export function withBatch(yargs: Argv) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`--verbose` doesn't work for `nx graph`,  despite error logs telling you to use it

## Expected Behavior
`--verbose` is an option for nx graph and has consistent wording

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
