### PR TITLE
fix(core): handle plugin errors from isolation correctly

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -112,10 +112,11 @@ async function handleMessage(socket, data: string) {
   }
 
   if (daemonIsOutdated()) {
-    await respondWithErrorAndExit(socket, `Lock files changed`, {
-      name: '',
-      message: 'LOCK-FILES-CHANGED',
-    });
+    await respondWithErrorAndExit(
+      socket,
+      `Lock files changed`,
+      new Error('LOCK-FILES-CHANGED')
+    );
   }
 
   resetInactivityTimeout(handleInactivityTimeout);

--- a/packages/nx/src/daemon/socket-utils.ts
+++ b/packages/nx/src/daemon/socket-utils.ts
@@ -2,7 +2,7 @@ import { unlinkSync } from 'fs';
 import { platform } from 'os';
 import { join, resolve } from 'path';
 import { DAEMON_SOCKET_PATH, socketDir } from './tmp-dir';
-import { DaemonProjectGraphError } from '../project-graph/error-types';
+import { createSerializableError } from '../utils/serializable-error';
 
 export const isWindows = platform() === 'win32';
 
@@ -27,21 +27,6 @@ export function killSocketOrPath(): void {
   } catch {}
 }
 
-// Include the original stack trace within the serialized error so that the client can show it to the user.
-function serializeError(error: Error | null): string | null {
-  if (!error) {
-    return null;
-  }
-
-  if (error instanceof DaemonProjectGraphError) {
-    error.errors = error.errors.map((e) => JSON.parse(serializeError(e)));
-  }
-
-  return `{${Object.getOwnPropertyNames(error)
-    .map((k) => `"${k}": ${JSON.stringify(error[k])}`)
-    .join(',')}}`;
-}
-
 // Prepare a serialized project graph result for sending over IPC from the server to the client
 export function serializeResult(
   error: Error | null,
@@ -49,7 +34,7 @@ export function serializeResult(
   serializedSourceMaps: string | null
 ): string | null {
   // We do not want to repeat work `JSON.stringify`ing an object containing the potentially large project graph so merge as strings
-  return `{ "error": ${serializeError(
-    error
+  return `{ "error": ${JSON.stringify(
+    error ? createSerializableError(error) : error
   )}, "projectGraph": ${serializedProjectGraph}, "sourceMaps": ${serializedSourceMaps} }`;
 }

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -235,3 +235,12 @@ export class DaemonProjectGraphError extends Error {
     this.name = this.constructor.name;
   }
 }
+
+export class LoadPluginError extends Error {
+  constructor(public plugin: string, cause: Error) {
+    super(`Could not load plugin ${plugin}`, {
+      cause,
+    });
+    this.name = this.constructor.name;
+  }
+}

--- a/packages/nx/src/utils/serializable-error.ts
+++ b/packages/nx/src/utils/serializable-error.ts
@@ -1,0 +1,29 @@
+/**
+ * This function transforms an error into an object which can be properly serialized and deserialized to be sent between processes.
+ */
+export function createSerializableError<T extends Error>(error: T): T {
+  const res = {} as T;
+
+  Object.getOwnPropertyNames(error).forEach((k) => {
+    let value = error[k];
+
+    // If an error has an error as a property such as cause, it will be transformed into a serializable error
+    if (typeof value === 'object' && value instanceof Error) {
+      value = createSerializableError(value);
+    }
+
+    // If an error has an array of errors as a property, they will be transformed into serializable errors
+    if (Array.isArray(value)) {
+      value = value.map((v) => {
+        if (typeof v === 'object' && v instanceof Error) {
+          return createSerializableError(v);
+        }
+        return v;
+      });
+    }
+
+    res[k] = value;
+  });
+
+  return res;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When Errors are thrown within plugin workers, they are not serialized properly for the Nx process to deserialize.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Errors thrown within plugins are serialized properly so they can be deserialized by the main Nx process.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
