### PR TITLE
fix(vue): do not add verbatimImportSyntax to tsconfig

### DIFF
--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -80,7 +80,6 @@ exports[`lib nested should create a local tsconfig.json 1`] = `
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,
-    "verbatimModuleSyntax": true,
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/packages/vue/src/utils/create-ts-config.ts
+++ b/packages/vue/src/utils/create-ts-config.ts
@@ -23,7 +23,6 @@ export function createTsConfig(
       jsxImportSource: 'vue',
       moduleResolution: 'node',
       resolveJsonModule: true,
-      verbatimModuleSyntax: true,
     },
     files: [],
     include: [],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generating a vue application adds `verbatimImportSyntax` to the tsconfig which does not allow for ESM in .js files if the `type` field in package.json is omitted.
This interferes with other tooling.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Do not add `verbatimImportSyntax`


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
