### PR TITLE
fix(misc): don't clear node_modules require cache

### DIFF
--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -1,4 +1,4 @@
-import { dirname, extname, join } from 'path';
+import { dirname, extname, join, sep } from 'path';
 import { existsSync, readdirSync } from 'fs';
 import { requireNx } from '../../nx';
 import { pathToFileURL } from 'node:url';
@@ -54,15 +54,26 @@ export function getRootTsConfigFileName(): string | null {
   return null;
 }
 
+const packageInstallationDirectories = [
+  `${sep}node_modules${sep}`,
+  `${sep}.yarn${sep}`,
+];
+
+export function clearRequireCache(): void {
+  for (const k of Object.keys(require.cache)) {
+    if (!packageInstallationDirectories.some((dir) => k.includes(dir))) {
+      delete require.cache[k];
+    }
+  }
+}
+
 /**
  * Load the module after ensuring that the require cache is cleared.
  */
 async function load(path: string): Promise<any> {
   // Clear cache if the path is in the cache
   if (require.cache[path]) {
-    for (const k of Object.keys(require.cache)) {
-      delete require.cache[k];
-    }
+    clearRequireCache();
   }
 
   try {

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -16,6 +16,7 @@ import { existsSync, readdirSync } from 'fs';
 import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getLockFileName } from '@nx/js';
+import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 
 export interface NextPluginOptions {
   buildTargetName?: string;
@@ -194,19 +195,13 @@ async function getOutputs(projectRoot, nextConfig) {
   }
 }
 
-async function getNextConfig(
+function getNextConfig(
   configFilePath: string,
   context: CreateNodesContext
 ): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 
-  let module;
-  if (extname(configFilePath) === '.mjs') {
-    module = await loadEsmModule(resolvedPath);
-  } else {
-    module = load(resolvedPath);
-  }
-  return module.default ?? module;
+  return loadConfigFile(resolvedPath);
 }
 
 function normalizeOptions(options: NextPluginOptions): NextPluginOptions {
@@ -229,37 +224,4 @@ function getInputs(
       externalDependencies: ['next'],
     },
   ];
-}
-
-const packageInstallationDirectories = ['node_modules', '.yarn'];
-/**
- * Load the module after ensuring that the require cache is cleared.
- */
-function load(path: string): any {
-  // Clear cache if the path is in the cache
-  if (require.cache[path]) {
-    for (const key of Object.keys(require.cache)) {
-      if (!packageInstallationDirectories.some((dir) => key.includes(dir))) {
-        delete require.cache[key];
-      }
-    }
-  }
-
-  // Then require
-  return require(path);
-}
-
-/**
- * Lazily compiled dynamic import loader function.
- */
-let dynamicLoad: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
-
-export function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
-  const modulePathWithCacheBust = `${modulePath}?version=${Date.now()}`;
-  dynamicLoad ??= new Function(
-    'modulePath',
-    `return import(modulePath);`
-  ) as Exclude<typeof dynamicLoad, undefined>;
-
-  return dynamicLoad(modulePathWithCacheBust);
 }

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -15,6 +15,7 @@ import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { existsSync, readdirSync } from 'fs';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
+import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 
 export interface ReactNativePluginOptions {
   startTargetName?: string;
@@ -59,7 +60,7 @@ export const createDependencies: CreateDependencies = () => {
 
 export const createNodes: CreateNodes<ReactNativePluginOptions> = [
   '**/app.{json,config.js}',
-  (configFilePath, options, context) => {
+  async (configFilePath, options, context) => {
     options = normalizeOptions(options);
     const projectRoot = dirname(configFilePath);
 
@@ -71,7 +72,7 @@ export const createNodes: CreateNodes<ReactNativePluginOptions> = [
     ) {
       return {};
     }
-    const appConfig = getAppConfig(configFilePath, context);
+    const appConfig = await getAppConfig(configFilePath, context);
     if (appConfig.expo) {
       return {};
     }
@@ -164,11 +165,10 @@ function buildReactNativeTargets(
 function getAppConfig(
   configFilePath: string,
   context: CreateNodesContext
-): any {
+): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 
-  let module = load(resolvedPath);
-  return module.default ?? module;
+  return loadConfigFile(resolvedPath);
 }
 
 function getInputs(
@@ -190,21 +190,6 @@ function getOutputs(projectRoot: string, dir: string) {
   } else {
     return `{workspaceRoot}/${projectRoot}/${dir}`;
   }
-}
-
-/**
- * Load the module after ensuring that the require cache is cleared.
- */
-function load(path: string): any {
-  // Clear cache if the path is in the cache
-  if (require.cache[path]) {
-    for (const k of Object.keys(require.cache)) {
-      delete require.cache[k];
-    }
-  }
-
-  // Then require
-  return require(path);
 }
 
 function normalizeOptions(

--- a/packages/webpack/src/utils/webpack/resolve-user-defined-webpack-config.ts
+++ b/packages/webpack/src/utils/webpack/resolve-user-defined-webpack-config.ts
@@ -1,4 +1,5 @@
 import { registerTsProject } from '@nx/js/src/internal';
+import { clearRequireCache } from '@nx/devkit/src/utils/config-utils';
 
 export function resolveUserDefinedWebpackConfig(
   path: string,
@@ -10,9 +11,7 @@ export function resolveUserDefinedWebpackConfig(
     // Clear cache if the path is in the cache
     if (require.cache[path]) {
       // Clear all entries because config may import other modules
-      for (const k of Object.keys(require.cache)) {
-        delete require.cache[k];
-      }
+      clearRequireCache();
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When loading a config file within a `createNodes` plugin, we bust the require cache to ensure we get fresh contents. This is required otherwise project configuration isn't updated as we update the tools configuration.

However, removing node_modules from cache can cause some weird edge cases when any of those modules contained a Symbol, as once reloaded it will be considered a different symbol.

## Expected Behavior
We don't clear node modules from require cache, to avoid causing funky behavior around Symbols.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
