### PR TITLE
fix(misc): mark migration for escaping env vars as skipped in nx repair

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -58,7 +58,8 @@
       "cli": "nx",
       "version": "16.8.0-beta.3",
       "description": "Escape $ in env variables",
-      "implementation": "./src/migrations/update-16-8-0/escape-dollar-sign-env-variables"
+      "implementation": "./src/migrations/update-16-8-0/escape-dollar-sign-env-variables",
+      "x-repair-skip": true
     },
     "17.0.0-move-cache-directory": {
       "cli": "nx",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The migration to escape env vars is ran any time someone runs nx repair

## Expected Behavior
New workspaces may have env vars that were written with expansion in mind, so running nx repair shouldn't escape them

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
