### PR TITLE
feat(nextjs): Add https option for custom server

### DIFF
--- a/docs/generated/packages/next/executors/server.json
+++ b/docs/generated/packages/next/executors/server.json
@@ -59,6 +59,10 @@
       "experimentalHttps": {
         "type": "boolean",
         "description": "Enable HTTPS support for the Next.js development server."
+      },
+      "customServerHttps:": {
+        "type": "boolean",
+        "description": "Enable HTTPS support for the custom server."
       }
     },
     "required": ["buildTarget"],

--- a/packages/next/src/executors/server/custom-server.impl.ts
+++ b/packages/next/src/executors/server/custom-server.impl.ts
@@ -30,8 +30,11 @@ async function* runCustomServer(
 ) {
   process.env.NX_NEXT_DIR ??= root;
   process.env.NX_NEXT_PUBLIC_DIR = join(root, 'public');
+  const httpProtocol = options.customServerHttps ? 'https' : 'http';
 
-  const baseUrl = `http://${options.hostname || 'localhost'}:${options.port}`;
+  const baseUrl = `${httpProtocol}://${options.hostname || 'localhost'}:${
+    options.port
+  }`;
 
   const customServerBuild = await runExecutor(
     parseTargetString(options.customServerTarget, context),

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -56,6 +56,10 @@
     "experimentalHttps": {
       "type": "boolean",
       "description": "Enable HTTPS support for the Next.js development server."
+    },
+    "customServerHttps:": {
+      "type": "boolean",
+      "description": "Enable HTTPS support for the custom server."
     }
   },
   "required": ["buildTarget"],

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -53,6 +53,7 @@ export interface NextServeBuilderOptions {
   keepAliveTimeout?: number;
   turbo?: boolean;
   experimentalHttps?: boolean;
+  customServerHttps?: boolean;
 }
 
 export interface NextExportBuilderOptions {


### PR DESCRIPTION
This PR adds the ability to pass `customServerHttps` to `@nx/next:server` executor so that the http protocol can be both `http` and `https`. 

fixes: #22051 
