### PR TITLE
fix(linter): rename languageSettings to languageOptions for flat config migration

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -547,7 +547,7 @@ describe('convert-to-flat-config generator', () => {
         {
           files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
           rules: {},
-          languageSettings: {
+          languageOptions: {
             parserOptions: { project: ['apps/dx-assets-ui/tsconfig.*?.json'] },
           },
         },

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -762,7 +762,7 @@ export function generateFlatOverride(
   ) {
     if (override.parserOptions) {
       const { parserOptions, ...rest } = override;
-      return generateAst({ ...rest, languageSettings: { parserOptions } });
+      return generateAst({ ...rest, languageOptions: { parserOptions } });
     }
     return generateAst(override);
   }
@@ -775,7 +775,7 @@ export function generateFlatOverride(
   addTSObjectProperty(objectLiteralElements, 'excludedFiles', excludedFiles);
   addTSObjectProperty(objectLiteralElements, 'rules', rules);
   if (parserOptions) {
-    addTSObjectProperty(objectLiteralElements, 'languageSettings', {
+    addTSObjectProperty(objectLiteralElements, 'languageOptions', {
       parserOptions,
     });
   }


### PR DESCRIPTION
partially fixes #22782

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
after run migration eslint to flat config it migrate parserOptions to `languageSettings`, while eslint does not have that, and have `languageOptions`
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
migrate to `languageOptions`
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
