### PR TITLE
fix(core): workspace context glob respects exclude

### DIFF
--- a/packages/nx/src/native/workspace/config_files.rs
+++ b/packages/nx/src/native/workspace/config_files.rs
@@ -25,7 +25,7 @@ pub(super) fn glob_files(
 
         exclude_glob_set
             .as_ref()
-            .map(|exclude_glob_set| exclude_glob_set.is_match(path))
+            .map(|exclude_glob_set| !exclude_glob_set.is_match(path))
             .unwrap_or(is_match)
     }))
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When passing an exclude pattern to  the WorkspaceContext.glob, it will only check for files that exist in the exclude pattern, rather than filtering them out.

<img width="649" alt="image" src="https://github.com/nrwl/nx/assets/12140467/c24f2deb-2f69-41d9-a0df-a340c31c05fb">


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Exclude pattern should filter workspace files correctly

<img width="649" alt="image" src="https://github.com/nrwl/nx/assets/12140467/5e416665-e9e7-4648-87ee-f402d1ba8da2">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
