### PR TITLE
fix(core): handle events that do not have paths

### DIFF
--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -118,10 +118,13 @@ impl Watcher {
             let events = action
                 .events
                 .par_iter()
-                .map(|ev| {
-                    let mut watch_event: WatchEventInternal = ev.into();
-                    watch_event.origin = Some(origin_path.clone());
-                    watch_event
+                .filter_map(|ev| {
+                    ev.try_into()
+                        .map(|mut watch_event: WatchEventInternal| {
+                            watch_event.origin = Some(origin_path.clone());
+                            watch_event
+                        })
+                        .ok()
                 })
                 .collect::<Vec<WatchEventInternal>>();
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In some scenarios, when we get a watch event, there are no paths associated it with it. We assumed that all file watch events would have a path associated it with so we used `expect`. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We handle cases where file watch events may not have paths associated with it, and do not crash the Nx process. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21492
