### PR TITLE
fix(core): fix exclude for empty array

### DIFF
--- a/packages/nx/src/native/tests/workspace_files.spec.ts
+++ b/packages/nx/src/native/tests/workspace_files.spec.ts
@@ -187,6 +187,52 @@ describe('workspace files', () => {
     `);
   });
 
+  describe('globbing', () => {
+    let context: WorkspaceContext;
+    let fs: TempFs;
+
+    beforeEach(async () => {
+      fs = new TempFs('workspace-files');
+
+      await fs.createFiles({
+        'file.txt': '',
+        'file.css': '',
+        'file.js': '',
+      });
+
+      context = new WorkspaceContext(
+        fs.tempDir,
+        cacheDirectoryForWorkspace(fs.tempDir)
+      );
+    });
+
+    afterEach(() => {
+      context = null;
+      fs.reset();
+    });
+
+    it('should glob', () => {
+      const results = context.glob(['**/*.txt']);
+      expect(results).toContain('file.txt');
+      expect(results).not.toContain('file.css');
+      expect(results).not.toContain('file.js');
+    });
+
+    it('should glob and exclude patterns', () => {
+      const results = context.glob(['**/*'], ['**/*.txt']);
+      expect(results).not.toContain('file.txt');
+      expect(results).toContain('file.css');
+      expect(results).toContain('file.js');
+    });
+
+    it('should glob and not exclude if exclude is empty', () => {
+      const results = context.glob(['**/*'], []);
+      expect(results).toContain('file.txt');
+      expect(results).toContain('file.css');
+      expect(results).toContain('file.js');
+    });
+  });
+
   // describe('errors', () => {
   //   it('it should infer names of configuration files without a name', async () => {
   //     const fs = new TempFs('workspace-files');

--- a/packages/nx/src/native/workspace/config_files.rs
+++ b/packages/nx/src/native/workspace/config_files.rs
@@ -11,9 +11,16 @@ pub(super) fn glob_files(
 ) -> napi::Result<impl ParallelIterator<Item = &FileData>> {
     let globs = build_glob_set(&globs)?;
 
-    let exclude_glob_set = exclude
-        .map(|exclude| build_glob_set(&exclude))
-        .transpose()?;
+    let exclude_glob_set = match exclude {
+        Some(exclude) => {
+            if exclude.is_empty() {
+                None
+            } else {
+                Some(build_glob_set(&exclude)?)
+            }
+        }
+        None => None,
+    };
 
     Ok(files.par_iter().filter(move |file_data| {
         let path = &file_data.file;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Globbing with an excludes array which is empty yields every file being excluded.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Globbing with an excludes array which is empty yields no file being excluded.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
