### PR TITLE
fix(storybook): handle inherited config correctly when identifying the framework used for inferred tasks

### DIFF
--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -15,7 +15,8 @@ import { existsSync, readFileSync, readdirSync } from 'fs';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
 import { getLockFileName } from '@nx/js';
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
+import type { StorybookConfig } from '@storybook/types';
 
 export interface StorybookPluginOptions {
   buildStorybookTargetName?: string;
@@ -52,7 +53,7 @@ export const createDependencies: CreateDependencies = () => {
 
 export const createNodes: CreateNodes<StorybookPluginOptions> = [
   '**/.storybook/main.{js,ts,mjs,mts,cjs,cts}',
-  (configFilePath, options, context) => {
+  async (configFilePath, options, context) => {
     let projectRoot = '';
     if (configFilePath.includes('/.storybook')) {
       projectRoot = dirname(configFilePath).replace('/.storybook', '');
@@ -82,7 +83,7 @@ export const createNodes: CreateNodes<StorybookPluginOptions> = [
 
     const targets = targetsCache[hash]
       ? targetsCache[hash]
-      : buildStorybookTargets(
+      : await buildStorybookTargets(
           configFilePath,
           projectRoot,
           options,
@@ -105,7 +106,7 @@ export const createNodes: CreateNodes<StorybookPluginOptions> = [
   },
 ];
 
-function buildStorybookTargets(
+async function buildStorybookTargets(
   configFilePath: string,
   projectRoot: string,
   options: StorybookPluginOptions,
@@ -116,9 +117,12 @@ function buildStorybookTargets(
 
   const namedInputs = getNamedInputs(projectRoot, context);
 
-  const storybookFramework = getStorybookFramework(configFilePath, context);
+  const storybookFramework = await getStorybookFramework(
+    configFilePath,
+    context
+  );
 
-  const frameworkIsAngular = storybookFramework === "'@storybook/angular'";
+  const frameworkIsAngular = storybookFramework === '@storybook/angular';
 
   if (frameworkIsAngular && !projectName) {
     throw new Error(
@@ -262,61 +266,14 @@ function serveStaticTarget(
   return targetConfig;
 }
 
-function getStorybookFramework(
+async function getStorybookFramework(
   configFilePath: string,
   context: CreateNodesContext
-): string {
+): Promise<string> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
-  const mainTsJs = readFileSync(resolvedPath, 'utf-8');
-  const importDeclarations = tsquery.query(
-    mainTsJs,
-    'ImportDeclaration:has(ImportSpecifier:has([text="StorybookConfig"]))'
-  )?.[0];
+  const { framework } = await loadConfigFile<StorybookConfig>(resolvedPath);
 
-  if (!importDeclarations) {
-    return parseFrameworkName(mainTsJs);
-  }
-
-  const storybookConfigImportPackage = tsquery.query(
-    importDeclarations,
-    'StringLiteral'
-  )?.[0];
-
-  if (storybookConfigImportPackage?.getText() === `'@storybook/core-common'`) {
-    return parseFrameworkName(mainTsJs);
-  }
-
-  return storybookConfigImportPackage?.getText();
-}
-
-function parseFrameworkName(mainTsJs: string) {
-  const frameworkPropertyAssignment = tsquery.query(
-    mainTsJs,
-    `PropertyAssignment:has(Identifier:has([text="framework"]))`
-  )?.[0];
-
-  if (!frameworkPropertyAssignment) {
-    return undefined;
-  }
-
-  const propertyAssignments = tsquery.query(
-    frameworkPropertyAssignment,
-    `PropertyAssignment:has(Identifier:has([text="name"]))`
-  );
-
-  const namePropertyAssignment = propertyAssignments?.find((expression) => {
-    return expression.getText().startsWith('name');
-  });
-
-  if (!namePropertyAssignment) {
-    const storybookConfigImportPackage = tsquery.query(
-      frameworkPropertyAssignment,
-      'StringLiteral'
-    )?.[0];
-    return storybookConfigImportPackage?.getText();
-  }
-
-  return tsquery.query(namePropertyAssignment, `StringLiteral`)?.[0]?.getText();
+  return typeof framework === 'string' ? framework : framework.name;
 }
 
 function getOutputs(projectRoot: string): string[] {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When inferring Storybook tasks and identifying the framework used in the Storybook configuration, the project `.storybook/main.{js|ts}` file is scanned using AST to get the `framework` property. This doesn't account for the framework to have been defined in a base/parent configuration file that's merged into the project Storybook configuration. Therefore, the framework is not correctly identified in such cases.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When inferring Storybook tasks, the framework should be correctly identified regardless of where it was defined (project config or base/parent config).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
