### PR TITLE
fix(core): regression register ts transpiler for local plugin

### DIFF
--- a/packages/nx/src/project-graph/plugins/loader.ts
+++ b/packages/nx/src/project-graph/plugins/loader.ts
@@ -56,6 +56,9 @@ export function readPluginPackageJson(
           localPluginPath.path,
           'package.json'
         );
+        if (!unregisterPluginTSTranspiler) {
+          registerPluginTSTranspiler();
+        }
         return {
           path: localPluginPackageJson,
           json: readJsonFile(localPluginPackageJson),
@@ -115,10 +118,6 @@ function lookupLocalPlugin(
   const projectConfig = findNxProjectForImportPath(importPath, projects, root);
   if (!projectConfig) {
     return null;
-  }
-
-  if (!unregisterPluginTSTranspiler) {
-    registerPluginTSTranspiler();
   }
 
   return { path: path.join(root, projectConfig.root), projectConfig };

--- a/packages/nx/src/project-graph/plugins/loader.ts
+++ b/packages/nx/src/project-graph/plugins/loader.ts
@@ -116,6 +116,10 @@ function lookupLocalPlugin(
     return null;
   }
 
+  if (!unregisterPluginTSTranspiler) {
+    registerPluginTSTranspiler();
+  }
+
   const projectConfig: ProjectConfiguration = projects[plugin];
   return { path: path.join(root, projectConfig.root), projectConfig };
 }


### PR DESCRIPTION
This change solves a regression after https://github.com/nrwl/nx/pull/22527 in NX 18.3.x with registering the ts transpiler for local plugins. 

In the deleted file packages/nx/src/utils/nx-plugin.ts the method registerPluginTSTranspiler was called on line 461 https://github.com/nrwl/nx/pull/22527/commits/1f04cde9a382cfdc38aabbe5f4d3338f30ac4dcc#diff-4cb86fce6ea77ce0e318878f99d35ca09197cd67f2b4024a996d41bba47d3ea2L460-L462

This part was missing in the replacement file packages/nx/src/project-graph/plugins/loader.ts around line 120
https://github.com/nrwl/nx/pull/22527/files#diff-42e02f59c2df8000df3ad944ae8a5d21b25c9593087666c8e6577cce2b17faecR120

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
ts transpiler is not registered for local plugin generators that use a directory structure with index.ts

<img width="938" alt="Screenshot 2024-04-23 at 16 37 06" src="https://github.com/nrwl/nx/assets/4587734/6a14339c-67ed-40d8-b182-233a6df4add5">

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The ts transpiler is registered for local plugins

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes  #22958
