### PR TITLE
docs(cypress): fix code snippet in cypress-setup-node-events.md

### DIFF
--- a/docs/shared/packages/cypress/cypress-setup-node-events.md
+++ b/docs/shared/packages/cypress/cypress-setup-node-events.md
@@ -20,7 +20,7 @@ The Cypress preset that Nx provides (`@nx/cypress/plugins/cypress-preset`) uses 
 import { defineConfig } from 'cypress';
 import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 
-const config = nxE2EPreset(__filename, {
+const preset = nxE2EPreset(__filename, {
   cypressDir: 'src',
   bundler: 'vite',
   webServerCommands: {
@@ -32,10 +32,10 @@ const config = nxE2EPreset(__filename, {
 
 export default defineConfig({
   e2e: {
-    ...config,
+    ...preset,
     async setupNodeEvents(on, config) {
       // This line sets up the web server as provided via `webServerCommands` and `ciWebServerCommand`
-      await config.setupNodeEvents(on, config);
+      await preset.setupNodeEvents(on, config);
 
       // Register your listeners here
     },


### PR DESCRIPTION
This fixes an example. The outer config variable was shadowed, so this example would fail. By changing the outer variable name, this works



## Current Behavior
The provided example fails, due to variable shadowing. The tests cannot run

## Expected Behavior
The cypress tests should be able to run

