### PR TITLE
fix(repo): should ensure that unit tests are run correctly across package managers

### DIFF
--- a/packages/nx/src/generators/testing-utils/create-tree-with-empty-workspace.ts
+++ b/packages/nx/src/generators/testing-utils/create-tree-with-empty-workspace.ts
@@ -1,5 +1,6 @@
 import { FsTree } from '../tree';
 import type { Tree } from '../tree';
+import { workspaceRoot } from '../../utils/workspace-root';
 
 /**
  * Creates a host for testing.
@@ -8,6 +9,12 @@ export function createTreeWithEmptyWorkspace(
   opts = {} as { layout?: 'apps-libs' }
 ): Tree {
   const tree = new FsTree('/virtual', false);
+  // Our unit tests are all written as though they are at the root of a workspace
+  // However, when they are run in a subdirectory of the workspaceRoot,
+  // the relative path between workspaceRoot and the directory the tests are run
+  // is prepended to the paths created in the virtual tree.
+  // Setting this envVar to workspaceRoot prevents this behaviour
+  process.env.INIT_CWD = workspaceRoot;
   return addCommonFiles(tree, opts.layout === 'apps-libs');
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
NPM sets an INIT_CWD env var which is used when calculating the path to generate files for project generators.
When running via plugin usage, the CWD of the sub process is set to our projects directory containing the config file.
But with NPM, the INIT_CWD is still workspaceRoot if run at root of the repo
Therefore, our unit tests that were written as though running at root, were now running in a subdirectory, causing incorrect paths on all package managers except NPM.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Unit tests should continue to function, regardless of package manager

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
