### PR TITLE
fix(core): handle created directories when watching on linux

### DIFF
--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -1,7 +1,11 @@
 use napi::bindgen_prelude::*;
+use std::fs::read_dir;
 
-use std::path::PathBuf;
+use crate::native::utils::Normalize;
+use crate::native::walker::nx_walker_sync;
+use std::path::{Path, PathBuf};
 use tracing::trace;
+use watchexec_events::filekind::CreateKind;
 use watchexec_events::{Event, Tag};
 
 use crate::native::watch::utils::transform_event;
@@ -28,7 +32,7 @@ impl From<&WatchEventInternal> for WatchEvent {
     fn from(value: &WatchEventInternal) -> Self {
         let path = value
             .path
-            .strip_prefix(value.origin.as_ref().expect("origin is available"))
+            .strip_prefix(&value.origin)
             .unwrap_or(&value.path)
             .display()
             .to_string();
@@ -47,86 +51,135 @@ impl From<&WatchEventInternal> for WatchEvent {
 pub(super) struct WatchEventInternal {
     pub path: PathBuf,
     pub r#type: EventType,
-    pub origin: Option<String>,
+    pub origin: String,
 }
 
+pub fn transform_event_to_watch_events(
+    value: &Event,
+    origin: &str,
+) -> anyhow::Result<Vec<WatchEventInternal>> {
+    let transformed = transform_event(value);
+    let value = transformed.as_ref().unwrap_or(value);
 
+    let Some(path) = value.paths().next() else {
+        let error_msg = "unable to get path from the event";
+        trace!(?value, error_msg);
+        anyhow::bail!(error_msg)
+    };
 
-impl TryFrom<&Event> for WatchEventInternal {
-    type Error = anyhow::Error;
+    let Some(event_kind) = value.tags.iter().find_map(|t| match t {
+        Tag::FileEventKind(event_kind) => Some(event_kind),
+        _ => None,
+    }) else {
+        let error_msg = "unable to get the file event kind";
+        trace!(?value, error_msg);
+        anyhow::bail!(error_msg)
+    };
 
-    fn try_from(value: &Event) -> std::result::Result<Self, Self::Error> {
-        let transformed = transform_event(value);
-        let value = transformed.as_ref().unwrap_or(value);
+    let path_ref = path.0;
+    if path.1.is_none() && !path_ref.exists() {
+        Ok(vec![WatchEventInternal {
+            path: path_ref.into(),
+            r#type: EventType::delete,
+            origin: origin.to_owned(),
+        }])
+    } else {
+        #[cfg(target_os = "macos")]
+        {
+            use std::fs;
+            use std::os::macos::fs::MetadataExt;
 
-        let Some(path) =  value.paths().next() else {
-             let error_msg = "unable to get path from the event";
-             trace!(?value, error_msg);
-             anyhow::bail!(error_msg)
-        };
+            let origin = origin.to_owned();
+            let t = fs::metadata(path_ref);
+            match t {
+                Err(_) => Ok(vec![WatchEventInternal {
+                    path: path_ref.into(),
+                    r#type: EventType::delete,
+                    origin,
+                }]),
+                Ok(t) => {
+                    let modified_time = t.st_mtime();
+                    let birth_time = t.st_birthtime();
 
-        let Some( event_kind ) = value
-            .tags
-            .iter()
-            .find_map(|t| match t {
-                Tag::FileEventKind(event_kind) => Some(event_kind),
-                _ => None,
-            }) else {
-            let error_msg = "unable to get the file event kind";
-            trace!(?value, error_msg);
-            anyhow::bail!(error_msg)
-        };
-
-        let path_ref = path.0;
-        let event_type = if path.1.is_none() && !path_ref.exists() {
-            EventType::delete
-        } else {
-            #[cfg(target_os = "macos")]
-            {
-                use std::fs;
-                use std::os::macos::fs::MetadataExt;
-
-                let t = fs::metadata(path_ref);
-                match t {
-                    Err(_) => EventType::delete,
-                    Ok(t) => {
-                        let modified_time = t.st_mtime();
-                        let birth_time = t.st_birthtime();
-
-                        // if a file is created and updated near the same time, we always get a create event
-                        // so we need to check the timestamps to see if it was created or updated
-                        // if the modified time is the same as birth_time then it was created
-                        if modified_time == birth_time {
-                            EventType::create
-                        } else {
-                            EventType::update
-                        }
+                    // if a file is created and updated near the same time, we always get a create event
+                    // so we need to check the timestamps to see if it was created or updated
+                    // if the modified time is the same as birth_time then it was created
+                    if modified_time == birth_time {
+                        Ok(vec![WatchEventInternal {
+                            path: path_ref.into(),
+                            r#type: EventType::create,
+                            origin,
+                        }])
+                    } else {
+                        Ok(vec![WatchEventInternal {
+                            path: path_ref.into(),
+                            r#type: EventType::update,
+                            origin,
+                        }])
                     }
                 }
             }
+        }
 
-            #[cfg(not(target_os = "macos"))]
-            {
-                use watchexec_events::filekind::FileEventKind;
-                use watchexec_events::filekind::ModifyKind::Name;
-                use watchexec_events::filekind::RenameMode;
+        #[cfg(target_os = "windows")]
+        {
+            use watchexec_events::filekind::FileEventKind;
+            use watchexec_events::filekind::ModifyKind::Name;
+            use watchexec_events::filekind::RenameMode;
 
-                match event_kind {
-                    FileEventKind::Create(_) => EventType::create,
+            let event_kind = match event_kind {
+                FileEventKind::Create(CreateKind::File) => EventType::create,
+                FileEventKind::Modify(Name(RenameMode::To)) => EventType::create,
+                FileEventKind::Modify(Name(RenameMode::From)) => EventType::delete,
+                FileEventKind::Modify(_) => EventType::update,
+                _ => EventType::update,
+            };
+
+            Ok(vec![WatchEventInternal {
+                path: path_ref.into(),
+                r#type: event_kind,
+                origin: origin.to_owned(),
+            }])
+        }
+
+        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+        {
+            use watchexec_events::filekind::FileEventKind;
+            use watchexec_events::filekind::ModifyKind::Name;
+            use watchexec_events::filekind::RenameMode;
+
+            if matches!(event_kind, FileEventKind::Create(CreateKind::Folder)) {
+                let mut result = vec![];
+
+                for path in nx_walker_sync(path_ref, None) {
+                    let path = path_ref.join(path);
+                    if !path.is_dir() {
+                        result.push(WatchEventInternal {
+                            path,
+                            r#type: EventType::create,
+                            origin: origin.to_owned(),
+                        });
+                    }
+                }
+
+                Ok(result)
+            } else {
+                let event_kind = match event_kind {
+                    FileEventKind::Create(CreateKind::File) => EventType::create,
                     FileEventKind::Modify(Name(RenameMode::To)) => EventType::create,
                     FileEventKind::Modify(Name(RenameMode::From)) => EventType::delete,
                     FileEventKind::Modify(_) => EventType::update,
                     _ => EventType::update,
-                }
+                };
+
+                Ok(vec![WatchEventInternal {
+                    path: path_ref.into(),
+                    r#type: event_kind,
+                    origin: origin.to_owned(),
+                }])
             }
-        };
-
-        trace!(?path, ?event_kind, ?event_type, "event kind -> event type");
-
-        Ok(WatchEventInternal {
-            path: path.0.into(),
-            r#type: event_type,
-            origin: None,
-        })
+        }
     }
+
+    // trace!(?path, ?event_kind, ?event_type, "event kind -> event type");
 }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -78,6 +78,9 @@ impl Filterer for WatchFilterer {
                     FileEventKind::Create(CreateKind::File) => continue,
                     FileEventKind::Remove(RemoveKind::File) => continue,
 
+                    #[cfg(target_os = "linux")]
+                    FileEventKind::Create(CreateKind::Folder) => continue,
+
                     #[cfg(windows)]
                     FileEventKind::Modify(ModifyKind::Any) => continue,
                     #[cfg(windows)]
@@ -92,6 +95,13 @@ impl Filterer for WatchFilterer {
                     path,
                     file_type: Some(FileType::File) | None,
                 } if !path.display().to_string().ends_with('~') => continue,
+
+                #[cfg(target_os = "linux")]
+                Tag::Path {
+                    path: _,
+                    file_type: Some(FileType::Dir),
+                } => continue,
+
                 Tag::Source(Source::Filesystem) => continue,
                 _ => return Ok(false),
             }

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use std::path::MAIN_SEPARATOR;
 use std::sync::Arc;
 
-use crate::native::watch::types::{EventType, WatchEvent, WatchEventInternal};
+use crate::native::watch::types::{
+    transform_event_to_watch_events, EventType, WatchEvent, WatchEventInternal,
+};
 use crate::native::watch::watch_filterer;
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{
@@ -118,14 +120,8 @@ impl Watcher {
             let events = action
                 .events
                 .par_iter()
-                .filter_map(|ev| {
-                    ev.try_into()
-                        .map(|mut watch_event: WatchEventInternal| {
-                            watch_event.origin = Some(origin_path.clone());
-                            watch_event
-                        })
-                        .ok()
-                })
+                .filter_map(|ev| transform_event_to_watch_events(ev, &origin_path).ok())
+                .flatten()
                 .collect::<Vec<WatchEventInternal>>();
 
             let mut group_events: HashMap<String, WatchEventInternal> = HashMap::new();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The nx file watcher does not pick up some files created in new directories on linux. This may result in the project graph not being built correctly because important files such as `project.json` or `cypress.config.js`, etc. are not recorded to the workspace context that they are updated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The nx file watcher does pick up files created in new directories on linux and things work properly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
