### PR TITLE
fix(misc): fix publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ on:
 env:
   DEBUG: napi:*
   NX_RUN_GROUP: ${{ github.run_id }}-${{ github.run_attempt }}
+  CYPRESS_INSTALL_BINARY: 0
 
 jobs:
   build:
@@ -36,11 +37,15 @@ jobs:
             build: |-
               set -e &&
               pnpm --version &&
-              pnpm nx run-many --target=build-native -- --target=x86_64-unknown-linux-gnu
+              pnpm install --frozen-lockfile &&
+              pnpm nx run-many --verbose --target=build-native -- --target=x86_64-unknown-linux-gnu
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-            build: set -e && pnpm nx run-many --target=build-native -- --target=x86_64-unknown-linux-musl
+            build: |-
+              set -e &&
+              pnpm install --frozen-lockfile &&
+              pnpm nx run-many --verbose --target=build-native -- --target=x86_64-unknown-linux-musl
           - host: macos-13
             target: aarch64-apple-darwin
             build: |
@@ -56,7 +61,8 @@ jobs:
             build: |-
               set -e &&
               pnpm --version &&
-              pnpm nx run-many --target=build-native -- --target=aarch64-unknown-linux-gnu
+              pnpm install --frozen-lockfile &&
+              pnpm nx run-many --verbose --target=build-native -- --target=aarch64-unknown-linux-gnu
           - host: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
             setup: |
@@ -79,7 +85,8 @@ jobs:
             build: |-
               set -e &&
               rustup target add aarch64-unknown-linux-musl &&
-              pnpm nx run-many --target=build-native -- --target=aarch64-unknown-linux-musl
+              pnpm install --frozen-lockfile &&
+              pnpm nx run-many --verbose --target=build-native -- --target=aarch64-unknown-linux-musl
           - host: windows-latest
             target: aarch64-pc-windows-msvc
             build: pnpm nx run-many --target=build-native -- --target=aarch64-pc-windows-msvc
@@ -129,6 +136,7 @@ jobs:
         run: yarn config set supportedArchitectures.cpu "ia32"
         shell: bash
       - name: Install dependencies
+        if: ${{ !matrix.settings.docker }}
         run: pnpm install --frozen-lockfile
         timeout-minutes: 30
       - name: Setup node x86
@@ -202,7 +210,7 @@ jobs:
             mkdir -p /Users/runner/work/_temp/_github_workflow
             echo "{}" > /Users/runner/work/_temp/_github_workflow/event.json
             pnpm install --frozen-lockfile --ignore-scripts
-            pnpm nx run-many --outputStyle stream --target=build-native -- --target=x86_64-unknown-freebsd
+            pnpm nx run-many --verbose --outputStyle stream --target=build-native -- --target=x86_64-unknown-freebsd
             pnpm nx reset
             rm -rf node_modules
             rm -rf dist

--- a/packages/nx/src/utils/logger.ts
+++ b/packages/nx/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import chalk = require('chalk');
 
 export const NX_PREFIX = chalk.inverse(chalk.bold(chalk.cyan(' NX ')));
 


### PR DESCRIPTION
Now that we have crystalized the repo, we need to ensure that native packages are installed based on the architecture of the machine. For example, `@nx/nx-linux-x64-musl` must be installed when publishing [here](https://github.com/nrwl/nx/actions/runs/8820347220/job/24213759514).
