### PR TITLE
fix(core): recursive resolve deps on create command graph

### DIFF
--- a/packages/nx/src/commands-runner/create-command-graph.spec.ts
+++ b/packages/nx/src/commands-runner/create-command-graph.spec.ts
@@ -1,0 +1,97 @@
+import { source } from '@angular-devkit/schematics';
+import { createCommandGraph } from './create-command-graph';
+import { CommandGraph } from './command-graph';
+
+export { createCommandGraph } from './create-command-graph';
+
+describe('createCommandGraph', () => {
+  it('should create command graph with empty dependencies', () => {
+    const projectGraph = {
+      dependencies: {},
+      nodes: {},
+    };
+    const projectNames = [];
+    const nxArgs = {};
+    const result = createCommandGraph(projectGraph, projectNames, nxArgs);
+    expect(result).toEqual({ dependencies: {}, roots: [] });
+  });
+
+  it('should create command graph with dependencies', () => {
+    const projectGraph = {
+      dependencies: {
+        dep1: [{ target: 'dep2', type: 'static', source: 'dep1' }],
+        dep2: [],
+      },
+      nodes: {
+        dep1: {
+          type: 'lib' as 'lib',
+          name: 'dep1',
+          data: {
+            files: [],
+            root: 'dep1',
+          },
+        },
+        dep2: {
+          type: 'lib' as 'lib',
+          name: 'dep2',
+          data: {
+            files: [],
+            root: 'dep2',
+          },
+        },
+      },
+    };
+    const projectNames = ['dep1'];
+    const nxArgs = {};
+    const result = createCommandGraph(projectGraph, projectNames, nxArgs);
+    expect(result).toEqual({
+      dependencies: { dep1: ['dep2'], dep2: [] },
+      roots: ['dep2'],
+    });
+  });
+
+  it('should create command graph with nested dependencies', () => {
+    const projectGraph = {
+      dependencies: {
+        dep1: [{ target: 'dep2', type: 'static', source: 'dep1' }],
+        dep2: [],
+        dep3: [{ target: 'dep1', type: 'static', source: 'dep3' }],
+      },
+      nodes: {
+        dep1: {
+          type: 'lib' as 'lib',
+          name: 'dep1',
+          data: {
+            files: [],
+            root: 'dep1',
+          },
+        },
+        dep2: {
+          type: 'lib' as 'lib',
+          name: 'dep2',
+          data: {
+            files: [],
+            root: 'dep2',
+          },
+        },
+        dep3: {
+          type: 'lib' as 'lib',
+          name: 'dep3',
+          data: {
+            files: [],
+            root: 'dep3',
+          },
+        },
+      },
+    };
+    const result = createCommandGraph(
+      projectGraph,
+      ['dep1', 'dep2', 'dep3'],
+      {}
+    );
+    expect(result).toEqual({
+      dependencies: { dep1: ['dep2'], dep2: [], dep3: ['dep1'] },
+      roots: ['dep2'],
+    });
+  });
+});

--- a/packages/nx/src/tasks-runner/task-graph-utils.ts
+++ b/packages/nx/src/tasks-runner/task-graph-utils.ts
@@ -15,16 +15,16 @@ function _findCycle(
   return null;
 }
 
-export function findCycle(taskGraph: {
+export function findCycle(graph: {
   dependencies: Record<string, string[]>;
 }): string[] | null {
   const visited = {};
-  for (const t of Object.keys(taskGraph.dependencies)) {
+  for (const t of Object.keys(graph.dependencies)) {
     visited[t] = false;
   }
 
-  for (const t of Object.keys(taskGraph.dependencies)) {
-    const cycle = _findCycle(taskGraph, t, visited, [t]);
+  for (const t of Object.keys(graph.dependencies)) {
+    const cycle = _findCycle(graph, t, visited, [t]);
     if (cycle) return cycle;
   }
 


### PR DESCRIPTION
## introductory
<img width="620" alt="image" src="https://github.com/nrwl/nx/assets/21343944/1ef5e2a2-0f65-4fde-aa7d-b52152af59a7">


## Current Behavior

```shell
nx exec --projects=my-node-app -- pwd
TypeError: graph.dependencies[id] is not iterable
    at _findCycle (/Users/anatolijfedorov/prjcts/tmp/nx-nest-workspace/node_modules/nx/src/tasks-runner/task-graph-utils.js:8:39)
    at _findCycle (/Users/anatolijfedorov/prjcts/tmp/nx-nest-workspace/node_modules/nx/src/tasks-runner/task-graph-utils.js:11:23)
    at findCycle (/Users/anatolijfedorov/prjcts/tmp/nx-nest-workspace/node_modules/nx/src/tasks-runner/task-graph-utils.js:23:23)
    at createCommandGraph (/Users/anatolijfedorov/prjcts/tmp/nx-nest-workspace/node_modules/nx/src/commands-runner/create-command-graph.js:25:52)
    at getCommandProjects (/Users/anatolijfedorov/prjcts/tmp/nx-nest-workspace/node_modules/nx/src/commands-runner/get-command-projects.js:7:72)
    at runScriptAsNxTarget (/Users/anatolijfedorov/prjcts/tmp/nx-nest-workspace/node_modules/nx/src/command-line/exec/exec.js:60:73)
    at Object.nxExecCommand (/Users/anatolijfedorov/prjcts/tmp/nx-nest-workspace/node_modules/nx/src/command-line/exec/exec.js:44:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.handler (/Users/anatolijfedorov/prjcts/tmp/nx-nest-workspace/node_modules/nx/src/command-line/exec/command-object.js:11:13)

```


## Expected Behavior

```shell
nx exec --projects=my-node-app -- pwd
/tmp/nx-nest-workspace/my-node-lib-2
/tmp/nx-nest-workspace/my-node-lib
/tmp/nx-nest-workspace/apps/my-node-app
```

Fixes https://github.com/nrwl/nx/issues/22994
Added function that resolves dependencies recursively