### PR TITLE
fix(webpack): should correctly normalize paths in NxWebpackPlugin

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
@@ -2,6 +2,7 @@ import { basename, dirname, join, relative, resolve } from 'path';
 import { statSync } from 'fs';
 import {
   normalizePath,
+  parseTargetString,
   readCachedProjectGraph,
   workspaceRoot,
 } from '@nx/devkit';
@@ -18,12 +19,21 @@ export function normalizeOptions(
   const combinedPluginAndMaybeExecutorOptions: Partial<NormalizedNxWebpackPluginOptions> =
     {};
   const isProd = process.env.NODE_ENV === 'production';
-  const projectName = process.env.NX_TASK_TARGET_PROJECT;
-  const targetName = process.env.NX_TASK_TARGET_TARGET;
-  const configurationName = process.env.NX_TASK_TARGET_CONFIGURATION;
-
   // Since this is invoked by the executor, the graph has already been created and cached.
   const projectGraph = readCachedProjectGraph();
+
+  const taskDetailsFromBuildTarget = process.env.NX_BUILD_TARGET
+    ? parseTargetString(process.env.NX_BUILD_TARGET, projectGraph)
+    : undefined;
+  const projectName = taskDetailsFromBuildTarget
+    ? taskDetailsFromBuildTarget.project
+    : process.env.NX_TASK_TARGET_PROJECT;
+  const targetName = taskDetailsFromBuildTarget
+    ? taskDetailsFromBuildTarget.target
+    : process.env.NX_TASK_TARGET_TARGET;
+  const configurationName = taskDetailsFromBuildTarget
+    ? taskDetailsFromBuildTarget.configuration
+    : process.env.NX_TASK_TARGET_CONFIGURATION;
 
   const projectNode = projectGraph.nodes[projectName];
   const targetConfig = projectNode.data.targets[targetName];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Path normalizing when running e2es on a project using `NxWebpackPlugin` is relative to the e2e project, rather than the app project.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the path normalizing is relative to the app project

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
