### PR TITLE
fix(core): ensure create nodes functions are properly parallelized

### DIFF
--- a/docs/generated/devkit/CreateNodesContext.md
+++ b/docs/generated/devkit/CreateNodesContext.md
@@ -6,7 +6,7 @@ Context for [CreateNodesFunction](../../devkit/documents/CreateNodesFunction)
 
 ### Properties
 
-- [configFiles](../../devkit/documents/CreateNodesContext#configfiles): string[]
+- [configFiles](../../devkit/documents/CreateNodesContext#configfiles): readonly string[]
 - [nxJsonConfiguration](../../devkit/documents/CreateNodesContext#nxjsonconfiguration): NxJsonConfiguration<string[] | "\*">
 - [workspaceRoot](../../devkit/documents/CreateNodesContext#workspaceroot): string
 
@@ -14,7 +14,7 @@ Context for [CreateNodesFunction](../../devkit/documents/CreateNodesFunction)
 
 ### configFiles
 
-• `Readonly` **configFiles**: `string`[]
+• `Readonly` **configFiles**: readonly `string`[]
 
 The subset of configuration files which match the createNodes pattern
 

--- a/packages/nx/src/project-graph/plugins/public-api.ts
+++ b/packages/nx/src/project-graph/plugins/public-api.ts
@@ -22,7 +22,7 @@ export interface CreateNodesContext {
   /**
    * The subset of configuration files which match the createNodes pattern
    */
-  readonly configFiles: string[];
+  readonly configFiles: readonly string[];
 }
 
 /**

--- a/packages/nx/src/project-graph/plugins/utils.spec.ts
+++ b/packages/nx/src/project-graph/plugins/utils.spec.ts
@@ -1,0 +1,123 @@
+import { runCreateNodesInParallel } from './utils';
+
+const configFiles = ['file1', 'file2'] as const;
+
+const context = {
+  file: 'file1',
+  nxJsonConfiguration: {},
+  workspaceRoot: '',
+  configFiles,
+} as const;
+
+describe('createNodesInParallel', () => {
+  it('should return results with context', async () => {
+    const plugin = {
+      name: 'test',
+      createNodes: [
+        '*/**/*',
+        async (file: string) => {
+          return {
+            projects: {
+              [file]: {
+                root: file,
+              },
+            },
+          };
+        },
+      ],
+    } as const;
+    const options = {};
+
+    const results = await runCreateNodesInParallel(
+      configFiles,
+      plugin,
+      options,
+      context
+    );
+
+    expect(results).toMatchInlineSnapshot(`
+      [
+        {
+          "file": "file1",
+          "pluginName": "test",
+          "projects": {
+            "file1": {
+              "root": "file1",
+            },
+          },
+        },
+        {
+          "file": "file2",
+          "pluginName": "test",
+          "projects": {
+            "file2": {
+              "root": "file2",
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should handle async errors', async () => {
+    const plugin = {
+      name: 'test',
+      createNodes: [
+        '*/**/*',
+        async () => {
+          throw new Error('Async Error');
+        },
+      ],
+    } as const;
+    const options = {};
+
+    const error = await runCreateNodesInParallel(
+      configFiles,
+      plugin,
+      options,
+      context
+    ).catch((e) => e);
+
+    expect(error).toMatchInlineSnapshot(
+      `[AggregateCreateNodesError: Failed to create nodes]`
+    );
+
+    expect(error.errors).toMatchInlineSnapshot(`
+      [
+        [CreateNodesError: The "test" plugin threw an error while creating nodes from file1:],
+        [CreateNodesError: The "test" plugin threw an error while creating nodes from file2:],
+      ]
+    `);
+  });
+
+  it('should handle sync errors', async () => {
+    const plugin = {
+      name: 'test',
+      createNodes: [
+        '*/**/*',
+        () => {
+          throw new Error('Sync Error');
+        },
+      ],
+    } as const;
+    const options = {};
+
+    const error = await runCreateNodesInParallel(
+      configFiles,
+      plugin,
+      options,
+      context
+    ).catch((e) => e);
+
+    expect(error).toMatchInlineSnapshot(
+      `[AggregateCreateNodesError: Failed to create nodes]`
+    );
+
+    expect(error.errors).toMatchInlineSnapshot(`
+      [
+        [CreateNodesError: The "test" plugin threw an error while creating nodes from file1:],
+        [CreateNodesError: The "test" plugin threw an error while creating nodes from file2:],
+      ]
+    `);
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The logic for parallelizing create nodes runs is slightly flawed, and a bit hard to follow. If the function is synchronous, promise.resolve(fn()) blocks while fn() is executed.

## Expected Behavior
The updated logic ensures things are in a promise from the get-go and should be properly parallelized.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
