### PR TITLE
fix(core): nxComponentTestingPreset should not expose bundler option

### DIFF
--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -1,6 +1,6 @@
 import {
   nxBaseCypressPreset,
-  NxComponentTestingOptions,
+  NxComponentTestingPresetOptions,
 } from '@nx/cypress/plugins/cypress-preset';
 import {
   createExecutorContext,
@@ -45,7 +45,7 @@ import { gte } from 'semver';
  */
 export function nxComponentTestingPreset(
   pathToConfig: string,
-  options?: NxComponentTestingOptions
+  options?: NxComponentTestingPresetOptions
 ) {
   if (global.NX_GRAPH_CREATION) {
     // this is only used by plugins, so we don't need the component testing

--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -34,6 +34,11 @@ export interface NxComponentTestingOptions {
   compiler?: 'swc' | 'babel';
 }
 
+// The bundler is only used while generating the component testing configuration
+// It cannot be changed after the configuration is generated
+export interface NxComponentTestingPresetOptions
+  extends Omit<NxComponentTestingOptions, 'bundler'> {}
+
 export function nxBaseCypressPreset(
   pathToConfig: string,
   options?: { testingType: 'component' | 'e2e' }


### PR DESCRIPTION
When using `nxComponentTestingPreset` after the configuration has been created for your e2e project, you should not be able to use the `bundler` option to change to a new bundler. 

The project will need to be reconfigured for the new bundler.

fixes: #23008