### PR TITLE
fix(react): disable tty for next build

### DIFF
--- a/docs/generated/packages/nx/executors/run-commands.json
+++ b/docs/generated/packages/nx/executors/run-commands.json
@@ -126,6 +126,11 @@
         "type": "boolean",
         "description": "Whether arguments should be forwarded when interpolation is not present.",
         "default": true
+      },
+      "tty": {
+        "type": "boolean",
+        "description": "Whether commands should be run with a tty terminal",
+        "hidden": true
       }
     },
     "additionalProperties": true,

--- a/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -23,6 +23,7 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
           ],
           "options": {
             "cwd": "my-app",
+            "tty": false,
           },
           "outputs": [
             "{workspaceRoot}/my-app/.next",
@@ -82,6 +83,7 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
           ],
           "options": {
             "cwd": ".",
+            "tty": false,
           },
           "outputs": [
             "{projectRoot}/.next",

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -130,6 +130,11 @@ async function getBuildTargetConfig(
     inputs: getInputs(namedInputs),
     outputs: [nextOutputPath, `${nextOutputPath}/!(cache)`],
   };
+
+  // TODO(ndcunningham): Update this to be consider different versions of next.js which is running
+  // This doesn't actually need to be tty, but next.js has a bug, https://github.com/vercel/next.js/issues/62906, where it exits 0 when SIGINT is sent.
+  targetConfig.options.tty = false;
+
   return targetConfig;
 }
 

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -60,6 +60,7 @@ export interface RunCommandsOptions extends Json {
   __unparsed__: string[];
   usePty?: boolean;
   streamOutput?: boolean;
+  tty?: boolean;
 }
 
 const propKeys = [
@@ -77,6 +78,7 @@ const propKeys = [
   'streamOutput',
   'verbose',
   'forwardAllArgs',
+  'tty',
 ];
 
 export interface NormalizedRunCommandsOptions extends RunCommandsOptions {
@@ -151,7 +153,8 @@ async function runInParallel(
       options.env ?? {},
       true,
       options.usePty,
-      options.streamOutput
+      options.streamOutput,
+      options.tty
     ).then((result: { success: boolean; terminalOutput: string }) => ({
       result,
       command: c.command,
@@ -269,7 +272,8 @@ async function runSerially(
         options.env ?? {},
         false,
         options.usePty,
-        options.streamOutput
+        options.streamOutput,
+        options.tty
       );
     terminalOutput += result.terminalOutput;
     if (!result.success) {
@@ -298,7 +302,8 @@ async function createProcess(
   env: Record<string, string>,
   isParallel: boolean,
   usePty: boolean = true,
-  streamOutput: boolean = true
+  streamOutput: boolean = true,
+  tty: boolean
 ): Promise<{ success: boolean; terminalOutput: string }> {
   env = processEnv(color, cwd, env);
   // The rust runCommand is always a tty, so it will not look nice in parallel and if we need prefixes
@@ -319,6 +324,7 @@ async function createProcess(
       cwd,
       jsEnv: env,
       quiet: !streamOutput,
+      tty,
     });
 
     childProcesses.add(cp);

--- a/packages/nx/src/executors/run-commands/schema.json
+++ b/packages/nx/src/executors/run-commands/schema.json
@@ -100,8 +100,15 @@
     },
     "args": {
       "oneOf": [
-        { "type": "array", "items": { "type": "string" } },
-        { "type": "string" }
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
       ],
       "description": "Extra arguments. You can pass them as follows: nx run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)"
     },
@@ -140,6 +147,11 @@
       "type": "boolean",
       "description": "Whether arguments should be forwarded when interpolation is not present.",
       "default": true
+    },
+    "tty": {
+      "type": "boolean",
+      "description": "Whether commands should be run with a tty terminal",
+      "hidden": true
     }
   },
   "additionalProperties": true,

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -150,7 +150,7 @@ export class ChildProcess {
 }
 export class RustPseudoTerminal {
   constructor()
-  runCommand(command: string, commandDir?: string | undefined | null, jsEnv?: Record<string, string> | undefined | null, quiet?: boolean | undefined | null): ChildProcess
+  runCommand(command: string, commandDir?: string | undefined | null, jsEnv?: Record<string, string> | undefined | null, quiet?: boolean | undefined | null, tty?: boolean | undefined | null): ChildProcess
   /**
    * This allows us to run a pseudoterminal with a fake node ipc channel
    * this makes it possible to be backwards compatible with the old implementation

--- a/packages/nx/src/native/pseudo_terminal/mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/mac.rs
@@ -25,9 +25,10 @@ impl RustPseudoTerminal {
         command_dir: Option<String>,
         js_env: Option<HashMap<String, String>>,
         quiet: Option<bool>,
+        tty: Option<bool>,
     ) -> napi::Result<ChildProcess> {
         let pseudo_terminal = create_pseudo_terminal()?;
-        run_command(&pseudo_terminal, command, command_dir, js_env, quiet)
+        run_command(&pseudo_terminal, command, command_dir, js_env, quiet, tty)
     }
 
     /// This allows us to run a pseudoterminal with a fake node ipc channel
@@ -50,6 +51,6 @@ impl RustPseudoTerminal {
         );
 
         trace!("nx_fork command: {}", &command);
-        self.run_command(command, command_dir, js_env, Some(quiet))
+        self.run_command(command, command_dir, js_env, Some(quiet), Some(true))
     }
 }

--- a/packages/nx/src/native/pseudo_terminal/non_mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/non_mac.rs
@@ -30,8 +30,16 @@ impl RustPseudoTerminal {
         command_dir: Option<String>,
         js_env: Option<HashMap<String, String>>,
         quiet: Option<bool>,
+        tty: Option<bool>,
     ) -> napi::Result<ChildProcess> {
-        run_command(&self.pseudo_terminal, command, command_dir, js_env, quiet)
+        run_command(
+            &self.pseudo_terminal,
+            command,
+            command_dir,
+            js_env,
+            quiet,
+            tty,
+        )
     }
 
     /// This allows us to run a pseudoterminal with a fake node ipc channel
@@ -54,6 +62,6 @@ impl RustPseudoTerminal {
         );
 
         trace!("nx_fork command: {}", &command);
-        self.run_command(command, command_dir, js_env, Some(quiet))
+        self.run_command(command, command_dir, js_env, Some(quiet), Some(true))
     }
 }

--- a/packages/nx/src/tasks-runner/pseudo-terminal.ts
+++ b/packages/nx/src/tasks-runner/pseudo-terminal.ts
@@ -43,14 +43,16 @@ export class PseudoTerminal {
       cwd,
       jsEnv,
       quiet,
+      tty,
     }: {
       cwd?: string;
       jsEnv?: Record<string, string>;
       quiet?: boolean;
+      tty?: boolean;
     } = {}
   ) {
     return new PseudoTtyProcess(
-      this.rustPseudoTerminal.runCommand(command, cwd, jsEnv, quiet)
+      this.rustPseudoTerminal.runCommand(command, cwd, jsEnv, quiet, tty)
     );
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

https://github.com/vercel/next.js/issues/62906 is causing Nx to improperly cache interrupted Next.js builds.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Being in tty takes away Nx's ability to control the exit code. This adds a flag to `run-command` to disable tty and thus returns Nx's ability to control the exit code. This flag shouldn't really be necessary but it is a workaround for the Next.js issue above, so I've made it hidden.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
