### PR TITLE
fix(core): recommend nx reset when graph errors and print error in da…

### DIFF
--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -5,6 +5,10 @@ import { serializeResult } from '../socket-utils';
 import { deleteDaemonJsonProcessCache } from '../cache';
 import type { Watcher } from '../../native';
 import { cleanupPlugins } from './plugins';
+import {
+  DaemonProjectGraphError,
+  ProjectGraphError,
+} from '../../project-graph/error-types';
 
 export const SERVER_INACTIVITY_TIMEOUT_MS = 10800000 as const; // 10800000 ms = 3 hours
 
@@ -95,13 +99,19 @@ export async function respondWithErrorAndExit(
   description: string,
   error: Error
 ) {
+  const normalizedError =
+    error instanceof DaemonProjectGraphError
+      ? ProjectGraphError.fromDaemonProjectGraphError(error)
+      : error;
+
   // print some extra stuff in the error message
   serverLogger.requestLog(
     `Responding to the client with an error.`,
     description,
-    error.message
+    normalizedError.message
   );
-  console.error(error.stack);
+  console.error(normalizedError.stack);
 
+  // Respond with the original error
   await respondToClient(socket, serializeResult(error, null, null), null);
 }

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -32,7 +32,9 @@ export class ProjectGraphError extends Error {
     partialProjectGraph: ProjectGraph,
     partialSourceMaps: ConfigurationSourceMaps
   ) {
-    super(`Failed to process project graph.`);
+    super(
+      `Failed to process project graph. Run "nx reset" to fix this. Please report the issue if you keep seeing it.`
+    );
     this.name = this.constructor.name;
     this.#errors = errors;
     this.#partialProjectGraph = partialProjectGraph;

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -6,6 +6,7 @@ import type {
 } from '../config/workspace-json-project-json';
 import { output } from './output';
 import type { ProjectGraphError } from '../project-graph/error-types';
+import { daemonClient } from '../daemon/client/client';
 
 const LIST_CHOICE_DISPLAY_LIMIT = 10;
 
@@ -125,6 +126,9 @@ export async function handleErrors(isVerbose: boolean, fn: Function) {
       if (err.stack && isVerbose) {
         logger.info(err.stack);
       }
+    }
+    if (daemonClient.enabled()) {
+      daemonClient.reset();
     }
     return 1;
   }


### PR DESCRIPTION
…emon

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Project graph errors can often be resolved by `nx reset` but the user does not know it. Also, project graph errors when the daemon are on, cause Nx not to exit.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Project graph errors will instruct users to run nx reset and then report the issue if it happens again. Nx exits when there's a project graph error from the daemon.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
