### PR TITLE
fix(misc): propogate NX_PERF_LOGGING to plugin workers

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -4,6 +4,10 @@ import { loadNxPlugin } from '../loader';
 import { Serializable } from 'child_process';
 import { createSerializableError } from '../../../utils/serializable-error';
 
+if (process.env.NX_PERF_LOGGING === 'true') {
+  require('../../../utils/perf-logging');
+}
+
 global.NX_GRAPH_CREATION = true;
 
 let plugin: LoadedNxPlugin;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When plugin isolation is enabled, logs from createNodes perf are not visible

## Expected Behavior
plugin isolation and perf logging are compatible

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
