### PR TITLE
chore(repo): add package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,6 +370,6 @@
       "check-codeowners",
       "documentation"
     ]
-  }
+  },
+  "packageManager": "pnpm@8.15.7"
 }
-


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Corepack 0.26.0 which comes with Node 22 keeps adding `packageManager` to the `package.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The change above is committed with the latest version of pnpm 8 so we can develop freely on Node 22.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
