### PR TITLE
fix(testing): fix test files pattern for jest inferred split tasks

### DIFF
--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -3,6 +3,7 @@ import {
   CreateNodes,
   CreateNodesContext,
   joinPathFragments,
+  normalizePath,
   NxJsonConfiguration,
   ProjectConfiguration,
   readJsonFile,
@@ -195,7 +196,7 @@ async function buildJestTargets(
       targetGroup.push(options.ciTargetName);
 
       for (const testPath of testPaths) {
-        const relativePath = normalize(
+        const relativePath = normalizePath(
           relative(join(context.workspaceRoot, projectRoot), testPath)
         );
         const targetName = `${options.ciTargetName}--${relativePath}`;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/jest/plugin` inferred split tasks are defined with a file pattern that doesn't match any file on Windows.

Run on Nx Console repo where the issue can be seen: https://cloud.nx.app/runs/DXf1XT18tA

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/jest/plugin` inferred split tasks are defined with [a file pattern](https://jestjs.io/docs/cli#jest-regexfortestfiles) that should work in any OS.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
