### PR TITLE
fix(core): ensure include and excluded return from plugin worker

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -24,6 +24,8 @@ export interface PluginWorkerLoadResult {
   payload:
     | {
         name: string;
+        include?: string[];
+        exclude?: string[];
         createNodesPattern: string;
         hasCreateDependencies: boolean;
         hasProcessProjectGraph: boolean;

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -110,11 +110,13 @@ function createWorkerHandler(
     return consumeMessage(message, {
       'load-result': (result) => {
         if (result.success) {
-          const { name, createNodesPattern } = result;
+          const { name, createNodesPattern, include, exclude } = result;
           pluginName = name;
           pluginNames.set(worker, pluginName);
           onload({
             name,
+            include,
+            exclude,
             createNodes: createNodesPattern
               ? [
                   createNodesPattern,

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -26,6 +26,8 @@ process.on('message', async (message: Serializable) => {
           type: 'load-result',
           payload: {
             name: plugin.name,
+            include: plugin.include,
+            exclude: plugin.exclude,
             createNodesPattern: plugin.createNodes?.[0],
             hasCreateDependencies:
               'createDependencies' in plugin && !!plugin.createDependencies,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
Plugin Pool Worker is not returning `include` and `exclude` from `PluginConfiguration`

## Current Behavior
<!-- This is the behavior we have today -->
Ensure `include` and `exclude` are returned

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
