### PR TITLE
fix(storybook): do not infer a test-storybook task if @storybook/test-runner is not installed

### DIFF
--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -21,6 +21,7 @@ describe('@nx/storybook/plugin', () => {
       workspaceRoot: tempFs.tempDir,
       configFiles: [],
     };
+    tempFs.createFileSync('package.json', JSON.stringify({ name: 'repo' }));
     tempFs.createFileSync(
       'my-app/project.json',
       JSON.stringify({ name: 'my-app' })
@@ -89,11 +90,6 @@ describe('@nx/storybook/plugin', () => {
     ).toMatchObject({
       command: 'storybook dev',
     });
-    expect(
-      nodes?.['projects']?.['my-app']?.targets?.['test-storybook']
-    ).toMatchObject({
-      command: 'test-storybook',
-    });
   });
 
   it('should create angular nodes', async () => {
@@ -158,11 +154,6 @@ describe('@nx/storybook/plugin', () => {
         compodoc: false,
       },
     });
-    expect(
-      nodes?.['projects']?.['my-ng-app']?.targets?.['test-storybook']
-    ).toMatchObject({
-      command: 'test-storybook',
-    });
   });
 
   it('should support main.js', async () => {
@@ -216,11 +207,6 @@ describe('@nx/storybook/plugin', () => {
       nodes?.['projects']?.['my-react-lib']?.targets?.['storybook']
     ).toMatchObject({
       command: 'storybook dev',
-    });
-    expect(
-      nodes?.['projects']?.['my-react-lib']?.targets?.['test-storybook']
-    ).toMatchObject({
-      command: 'test-storybook',
     });
   });
 

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -148,7 +148,9 @@ async function buildStorybookTargets(
     configFilePath
   );
 
-  targets[options.testStorybookTargetName] = testTarget(projectRoot);
+  if (isStorybookTestRunnerInstalled()) {
+    targets[options.testStorybookTargetName] = testTarget(projectRoot);
+  }
 
   targets[options.staticStorybookTargetName] = serveStaticTarget(
     options,
@@ -323,4 +325,13 @@ function buildProjectName(
     name = packageJson.name;
   }
   return name;
+}
+
+function isStorybookTestRunnerInstalled(): boolean {
+  try {
+    require.resolve('@storybook/test-runner');
+    return true;
+  } catch (e) {
+    return false;
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nx/storybook/plugin` always infers a `test-storybook` task with the `@storybook/test-runner` included in the `externalDependencies`. It doesn't check whether the package is actually installed, which causes the hasher to fail with `The externalDependency '@storybook/test-runner' for '<project>:test-storybook' could not be found`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nx/storybook/plugin` should only infer a `test-storybook` task when the `@storybook/test-runner` package is installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
