### PR TITLE
fix(core): prevent device status report from being printed during pty execution

### DIFF
--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -39,7 +39,7 @@ export interface NxArgs {
 }
 
 export function createOverrides(__overrides_unparsed__: string[] = []) {
-  let overrides =
+  let overrides: Record<string, any> =
     yargsParser(__overrides_unparsed__, {
       configuration: {
         'camel-case-expansion': false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
On windows the terminal frequent outputs the device status report escape code (`\x1B[6n`) to the terminal. This results in another escape code being emitted onto stdin, in the form of `\x1B[[ ?; ? R` which has been seen in reported issues. When this is put into stdin as a response to the device status report, Nx hangs.

## Expected Behavior
We don't playback the DSR from the pseudoterminal. The hope is that this is enough to prevent the hanging, but the underlying issue is flaky and not super easily reproduced.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
