### PR TITLE
docs(core): correct Type(S|s)cript typo in ESLint guide

### DIFF
--- a/docs/shared/eslint.md
+++ b/docs/shared/eslint.md
@@ -1,4 +1,4 @@
-# Configuring ESLint with Typescript
+# Configuring ESLint with TypeScript
 
 ESLint is powerful linter by itself, able to work on the syntax of your source files and assert things about based on the rules you configure. It gets even more powerful, however, when TypeScript type-checker is layered on top of it when analyzing TypeScript files, which is something that `@typescript-eslint` allows us to do.
 


### PR DESCRIPTION
🙂 