### PR TITLE
docs(core): Fix the '>' position when rendering multiline commands

### DIFF
--- a/nx-dev/ui-fence/src/lib/fences/terminal-output.tsx
+++ b/nx-dev/ui-fence/src/lib/fences/terminal-output.tsx
@@ -17,7 +17,7 @@ export function TerminalOutput({
         <div className="items-left flex flex-col">
           {commandLines.map((line, index) => {
             return (
-              <div key={index} className="flex items-center">
+              <div key={index} className="flex">
                 <p className="mt-0.5">
                   {path && (
                     <span className="text-purple-600 dark:text-fuchsia-500">


### PR DESCRIPTION
This PR fixes the formatting for multiline commands
before the '>' would appear at a position like this:
![image](https://github.com/nrwl/nx/assets/338948/a0cfdf69-d104-4d5e-af83-302ebb23d098)

after should be something similar to:
<img width="679" alt="Screenshot 2024-04-26 at 3 37 15 PM" src="https://github.com/nrwl/nx/assets/338948/5f3988c8-a092-443f-8801-955b97f9f5eb">
