### PR TITLE
chore(misc): remove perf timings from individual createNodes files

### DIFF
--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -65,7 +65,6 @@ export async function runCreateNodesInParallel(
   const results: CreateNodesResultWithContext[] = [];
 
   const promises: Array<Promise<void>> = configFiles.map(async (file) => {
-    performance.mark(`${plugin.name}:createNodes:${file} - start`);
     try {
       const value = await plugin.createNodes[1](file, options, context);
       if (value) {
@@ -82,13 +81,6 @@ export async function runCreateNodesInParallel(
           pluginName: plugin.name,
           file,
         })
-      );
-    } finally {
-      performance.mark(`${plugin.name}:createNodes:${file} - end`);
-      performance.measure(
-        `${plugin.name}:createNodes:${file}`,
-        `${plugin.name}:createNodes:${file} - start`,
-        `${plugin.name}:createNodes:${file} - end`
       );
     }
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We measure perf timings for every file ran via createNodes

## Expected Behavior
We only measure the plugin-wide timing for createNodes. The per-file timings were inaccurate anyways and a bit on the noisy side.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
