### PR TITLE
fix(js): copy assets handler should handle ignore globs on windows

### DIFF
--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -1,5 +1,5 @@
 import { minimatch } from 'minimatch';
-import * as path from 'path';
+import * as path from 'node:path/posix';
 import * as fse from 'fs-extra';
 import ignore from 'ignore';
 import * as fg from 'fast-glob';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We use `node:path` for path operations in copy-assets-handler

## Expected Behavior
We use `node:path/posix` to ensure paths are in the proper format for minimatch

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23050
