### PR TITLE
docs(core): nx migrate search results

### DIFF
--- a/docs/shared/features/automate-updating-dependencies.md
+++ b/docs/shared/features/automate-updating-dependencies.md
@@ -2,13 +2,15 @@
 
 Keeping a codebase updated with the latest changes in your framework of choice can be challenging. Not to mention that "tooling maintenance work" is usually hard to squeeze into your feature sprint.
 
+## nx migrate Makes Updating Simple
+
 The `nx migrate` command helps by automating the process of updating:
 
 - package versions in your `package.json`
 - configuration files (e.g. your Jest, ESLint or Nx config)
 - your source code (e.g. fixing breaking changes or migrating to new best practices)
 
-## How does it work?
+## How Does It Work?
 
 {% youtube
 src="https://www.youtube.com/embed/Ss6MfcXi0jE"
@@ -25,7 +27,7 @@ Updating happens in three steps:
 - The source code in the repo is updated to match the new versions of packages according to the set of instructions specified in `migrations.json` file.
 - Optionally remove the `migrations.json` file or keep it to re-run the migration in different Git branches
 
-### Step 1: Updating dependencies and generating migrations
+### Step 1: Update Dependencies and Generating Migrations
 
 First, run the `migrate` command:
 
@@ -52,7 +54,7 @@ Now, you can inspect `package.json` to see if the changes make sense. Sometimes 
 At this stage, after inspecting the `package.json`, you may wish to manually run the appropriate install command for your workspace (e.g. `npm install`, `yarn`, or `pnpm install`) but in the next step `nx migrate --run-migrations` will also run this automatically for you.
 {% /callout %}
 
-### Step 2: Running migrations
+### Step 2: Run Migrations
 
 You can now run the actual code migrations that were generated in the `migrations.json` in the previous step.
 
@@ -64,7 +66,7 @@ This will update your source code in your workspace in accordance with the imple
 
 Note that each Nx plugin is able to provide a set of migrations which are relevant to particular versions of the package. Hence `migrations.json` will only contain migrations which are appropriate for the update you are currently applying.
 
-### Step 3: Cleaning up
+### Step 3: Clean Up
 
 After you run all the migrations, you can remove `migrations.json` and commit any outstanding changes.
 
@@ -92,6 +94,6 @@ For a list of all the plugins you currently have installed, run:
 nx report
 ```
 
-## Need to opt-out of some migrations?
+## Need to Opt-out of Some Migrations?
 
 Sometimes you need to temporarily opt-out from some migrations because your workspace is not ready yet. You can manually adjust the `migrations.json` or run the update with the `--interactive` flag to choose which migrations you accept. Find more details in our [Advanced Update Process](/recipes/tips-n-tricks/advanced-update) guide.


### PR DESCRIPTION
Adds "nx migrate" in a header for the Automate updating dependencies page so that it shows up more prominently in search results.