### PR TITLE
fix(core): local plugins should be able to use {projectRoot} in options block

### DIFF
--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -59,6 +59,7 @@ describe('Workspaces', () => {
         projectType: 'library',
         targets: {
           'nx-release-publish': {
+            configurations: {},
             dependsOn: ['^nx-release-publish'],
             executor: '@nx/js:release-publish',
             options: {},

--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.spec.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.spec.ts
@@ -78,28 +78,4 @@ describe('workspace-projects', () => {
       ).toEqual(['b', 'b-1', 'b-2']);
     });
   });
-
-  describe('normalizeTargets', () => {
-    it('should support {projectRoot}, {workspaceRoot}, and {projectName} tokens', () => {
-      expect(
-        normalizeProjectTargets(
-          {
-            name: 'project',
-            root: 'my/project',
-            targets: {
-              build: {
-                executor: 'target',
-                options: {
-                  a: '{projectRoot}',
-                  b: '{workspaceRoot}',
-                  c: '{projectName}',
-                },
-              },
-            },
-          },
-          'build'
-        ).build.options
-      ).toEqual({ a: 'my/project', b: '', c: 'project' });
-    });
-  });
 });

--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
@@ -99,21 +99,6 @@ export function normalizeProjectTargets(
       delete targets[target];
       continue;
     }
-
-    targets[target].options = resolveNxTokensInOptions(
-      targets[target].options,
-      project,
-      `${projectName}:${target}`
-    );
-
-    targets[target].configurations ??= {};
-    for (const configuration in targets[target].configurations) {
-      targets[target].configurations[configuration] = resolveNxTokensInOptions(
-        targets[target].configurations[configuration],
-        project,
-        `${projectName}:${target}:${configuration}`
-      );
-    }
   }
   return targets;
 }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -9,6 +9,7 @@ import {
   isCompatibleTarget,
   mergeProjectConfigurationIntoRootMap,
   mergeTargetConfigurations,
+  normalizeTarget,
   readProjectConfigurationsFromRootMap,
   readTargetDefaultsForTarget,
 } from './project-configuration-utils';
@@ -572,6 +573,7 @@ describe('project-configuration-utils', () => {
           "root": "libs/lib-a",
           "targets": {
             "build": {
+              "configurations": {},
               "executor": "nx:run-commands",
               "options": {
                 "command": "tsc",
@@ -725,8 +727,9 @@ describe('project-configuration-utils', () => {
       expect(targets.echo).toMatchInlineSnapshot(`
         {
           "command": "echo lib-a",
+          "configurations": {},
           "options": {
-            "cwd": "{projectRoot}",
+            "cwd": "libs/lib-a",
           },
         }
       `);
@@ -1545,6 +1548,28 @@ describe('project-configuration-utils', () => {
           }
         )
       ).toBe(false);
+    });
+  });
+
+  describe('normalizeTarget', () => {
+    it('should support {projectRoot}, {workspaceRoot}, and {projectName} tokens', () => {
+      const config = {
+        name: 'project',
+        root: 'libs/project',
+        targets: {
+          foo: { command: 'echo {projectRoot}' },
+        },
+      };
+      expect(normalizeTarget(config.targets.foo, config))
+        .toMatchInlineSnapshot(`
+        {
+          "configurations": {},
+          "executor": "nx:run-commands",
+          "options": {
+            "command": "echo libs/project",
+          },
+        }
+      `);
     });
   });
 


### PR DESCRIPTION
…ns block

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Local nx plugins registered in `nx.json` are looked up by their build target's `main` option. This is read from a partial projects configuration without any of the custom plugin inference.

Because of how this partial graph was constructed, `{projectRoot}` and similar tokens were not properly inlined, resulting in plugin failing to load.

## Expected Behavior
Tokens are inlined at the time of project configuration construction

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22940
Fixes #23083
