### PR TITLE
fix(misc): guard against failure to decode file in migration

### DIFF
--- a/packages/nx/src/migrations/update-16-8-0/escape-dollar-sign-env-variables.ts
+++ b/packages/nx/src/migrations/update-16-8-0/escape-dollar-sign-env-variables.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../utils/logger';
 import { Tree } from '../../generators/tree';
 import { getProjects } from '../../generators/utils/project-configuration';
 
@@ -59,13 +60,23 @@ function parseEnvFile(tree: Tree, envFilePath: string) {
   if (!tree.exists(envFilePath)) {
     return;
   }
+
   let envFileContent = tree.read(envFilePath, 'utf-8');
+  if (!envFileContent) {
+    // envFileContent is null if we fail to read the file for any reason
+    // e.g. the file is not utf-8 encoded
+    logger.info(
+      `Unable to update ${envFilePath}. Nx interpolates environment variables in the form of $VAR_NAME. To escape the dollar sign, use \\$VAR_NAME.`
+    );
+    return;
+  }
+
   envFileContent = envFileContent
     .split('\n')
     .map((line) => {
       line = line.trim();
 
-      if (!line.includes('$')) {
+      if (!line || !line.includes('$')) {
         return line;
       }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
A migration in `nx` (escape-dollar-sing-env-variables) does not guard against non utf-8 files, and can result in a crash during the migration run.

## Expected Behavior
If it fails to parse a file, we'll log a message and keep going.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22956
