### PR TITLE
fix(core): ensure daemon socket dir exists when specified in env

### DIFF
--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -21,7 +21,7 @@ export const DAEMON_OUTPUT_LOG_FILE = join(
   'daemon.log'
 );
 
-export const socketDir = process.env.NX_DAEMON_SOCKET_DIR || createSocketDir();
+export const socketDir = createSocketDir();
 
 export const DAEMON_SOCKET_PATH = join(
   socketDir,
@@ -61,7 +61,7 @@ function socketDirName() {
  */
 function createSocketDir() {
   try {
-    const dir = socketDirName();
+    const dir = process.env.NX_DAEMON_SOCKET_DIR ?? socketDirName();
     ensureDirSync(dir);
     return dir;
   } catch (e) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We clear the socket dir when running `reset`, but don't ensure its present when starting up.

## Expected Behavior
The socket dir is created if it doesn't exist.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23002
