### PR TITLE
fix(nextjs): Boolean flags do not need a value

### DIFF
--- a/packages/next/src/utils/create-cli-options.ts
+++ b/packages/next/src/utils/create-cli-options.ts
@@ -4,7 +4,12 @@ export function createCliOptions(
   return Object.entries(obj).reduce((arr, [key, value]) => {
     if (value !== undefined) {
       const kebabCase = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
-      arr.push(`--${kebabCase}=${value}`);
+      if (value === true || typeof value !== 'boolean') {
+        // Boolean flags don't need a value (e.g. --debug)
+        arr.push(
+          `--${kebabCase}` + (typeof value !== 'boolean' ? `=${value}` : '')
+        );
+      }
     }
     return arr;
   }, []);


### PR DESCRIPTION
Boolean options passed to the `next-cli` as arguments should not require a value.

So `--profile=true` will not work with Next.js `v14.2.0`+. However `--profile` works on both the current and future versions. 

closes: #23062