### PR TITLE
fix(js): typescript plugin target hashing

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -104,18 +104,20 @@ export const createNodes: CreateNodes<TscPluginOptions> = [
       return {};
     }
 
-    const hash = calculateHashForCreateNodes(
+    const nodeHash = calculateHashForCreateNodes(
       projectRoot,
       pluginOptions,
       context,
       [getLockFileName(detectPackageManager(context.workspaceRoot))]
     );
+    // The hash is calculated at the node/project level, so we add the config file path to avoid conflicts when caching
+    const cacheKey = `${nodeHash}_${configFilePath}`;
 
-    const targets = targetsCache[hash]
-      ? targetsCache[hash]
+    const targets = targetsCache[cacheKey]
+      ? targetsCache[cacheKey]
       : buildTscTargets(fullConfigPath, projectRoot, pluginOptions, context);
 
-    calculatedTargets[hash] = targets;
+    calculatedTargets[cacheKey] = targets;
 
     return {
       projects: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Different targets (typecheck vs build) can clobber each other within the cache, leading to missing targets

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Targets are cached based on a combination of node hash _and_ config file path

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
