### PR TITLE
fix(js): Correct file path for cjs.js

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -412,7 +412,7 @@ function getFileToRun(
 function fileToRunCorrectPath(fileToRun: string): string {
   if (fileExists(fileToRun)) return fileToRun;
 
-  const extensionsToTry = ['.cjs', '.mjs', 'cjs.js', '.esm.js'];
+  const extensionsToTry = ['.cjs', '.mjs', '.cjs.js', '.esm.js'];
 
   for (const ext of extensionsToTry) {
     const file = fileToRun.replace(/\.js$/, ext);


### PR DESCRIPTION
The file path for CommonJS files should be with extension `.cjs.js`.

closes: #23029