### PR TITLE
feat(graph): enable watch mode by default

### DIFF
--- a/docs/generated/cli/affected-graph.md
+++ b/docs/generated/cli/affected-graph.md
@@ -163,6 +163,6 @@ Choose whether to view the projects or task graph
 
 Type: `boolean`
 
-Default: `false`
+Default: `true`
 
 Watch for changes to project graph and update in-browser

--- a/docs/generated/cli/graph.md
+++ b/docs/generated/cli/graph.md
@@ -185,6 +185,6 @@ Choose whether to view the projects or task graph
 
 Type: `boolean`
 
-Default: `false`
+Default: `true`
 
 Watch for changes to project graph and update in-browser

--- a/docs/generated/packages/nx/documents/affected-dep-graph.md
+++ b/docs/generated/packages/nx/documents/affected-dep-graph.md
@@ -163,6 +163,6 @@ Choose whether to view the projects or task graph
 
 Type: `boolean`
 
-Default: `false`
+Default: `true`
 
 Watch for changes to project graph and update in-browser

--- a/docs/generated/packages/nx/documents/dep-graph.md
+++ b/docs/generated/packages/nx/documents/dep-graph.md
@@ -185,6 +185,6 @@ Choose whether to view the projects or task graph
 
 Type: `boolean`
 
-Default: `false`
+Default: `true`
 
 Watch for changes to project graph and update in-browser

--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -94,7 +94,7 @@ export async function affected(
 
           return await generateGraph(
             {
-              watch: false,
+              watch: true,
               open: true,
               view: 'tasks',
               targets: nxArgs.targets,

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -504,7 +504,7 @@ async function startServer(
   environmentJs: string,
   host: string,
   port = 4211,
-  watchForchanges = false,
+  watchForchanges = true,
   affected: string[] = [],
   focus: string = null,
   groupByFolder: boolean = false,

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -173,9 +173,10 @@ async function runPublishOnProjects(
       .filter((projectName) =>
         projectHasTarget(projectGraph.nodes[projectName], requiredTargetName)
       );
+
     await generateGraph(
       {
-        watch: false,
+        watch: true,
         all: false,
         open: true,
         view: 'tasks',

--- a/packages/nx/src/command-line/run-many/run-many.ts
+++ b/packages/nx/src/command-line/run-many/run-many.ts
@@ -54,7 +54,7 @@ export async function runMany(
     const projectNames = projects.map((t) => t.name);
     return await generateGraph(
       {
-        watch: false,
+        watch: true,
         open: true,
         view: 'tasks',
         all: nxArgs.all,

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -70,7 +70,7 @@ export async function runOne(
 
     return await generateGraph(
       {
-        watch: false,
+        watch: true,
         open: true,
         view: 'tasks',
         targets: nxArgs.targets,

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -310,7 +310,7 @@ export function withDepGraphOptions(yargs: Argv) {
     .option('watch', {
       describe: 'Watch for changes to project graph and update in-browser',
       type: 'boolean',
-      default: false,
+      default: true,
     })
     .option('open', {
       describe: 'Open the project graph in the browser.',


### PR DESCRIPTION
`nx graph` will now run in watch mode by default. Before you would often have to cancel the process and run it again with `nx graph --watch`

## Breaking Changes

* `nx graph` now starts with watch mode by default. Disable it by passing `--watch false`