### PR TITLE
fix(core): ensure project with name undefined is not created

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -200,11 +200,7 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
       readJson(tree, p, { expectComments: true })
     ),
   ];
-  const projectGlobPatterns = configurationGlobs([
-    ProjectJsonProjectsPlugin,
-    { createNodes: packageJsonWorkspacesCreateNodes },
-  ]);
-  const globbedFiles = globWithWorkspaceContext(tree.root, projectGlobPatterns);
+  const globbedFiles = globWithWorkspaceContext(tree.root, patterns);
   const createdFiles = findCreatedProjectFiles(tree, patterns);
   const deletedFiles = findDeletedProjectFiles(tree, patterns);
   const projectFiles = [...globbedFiles, ...createdFiles].filter(

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -525,6 +525,9 @@ export function readProjectConfigurationsFromRootMap(
     if (!configuration.name) {
       try {
         const { name } = readJsonFile(join(root, 'package.json'));
+        if (!name) {
+          throw new Error("No name found for project at '" + root + "'.");
+        }
         configuration.name = name;
       } catch {
         projectRootsWithNoName.push(root);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- package manager workspaces plugin does some work at module load time, which has issues with those values not being updated.
- If a plugin identifies a partial project config next to a non-nx project package.json which doesn't have a name, a project named `undefined` ends up being set in the graph. This then errors when running the task.

## Expected Behavior
- workspaces config stays up to date
- no undefined

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
