### PR TITLE
feat(graph): show tooltips that were previously hidden due to upublished docs

### DIFF
--- a/graph/ui-project-details/src/lib/source-info/source-info.tsx
+++ b/graph/ui-project-details/src/lib/source-info/source-info.tsx
@@ -20,10 +20,7 @@ export function SourceInfo(props: {
         content={
           (
             <SourcemapInfoToolTip
-              showLink={
-                /* TODO(v18): remove this link show/hide logic once docs are published */
-                false
-              }
+              showLink={true}
               propertyKey={props.propertyKey}
               plugin={props.data?.[1]}
               file={props.data?.[0]}

--- a/graph/ui-tooltips/src/lib/property-info-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/property-info-tooltip.tsx
@@ -65,14 +65,12 @@ const PROPERTY_INFO_TOOLTIP_TYPE_OPTIONS: Record<
       'This is a list of other tasks which must be completed before running this task.',
   },
   options: {
-    // TODO(v18): re-enable link once docs are published
-    // docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
+    docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
     heading: 'Options',
     description: 'Options modify the behaviour of the task.',
   },
   configurations: {
-    // TODO(v18): re-enable link once docs are published
-    // docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
+    docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
     heading: 'Configurations',
     description:
       'Configurations are sets of Options to allow a Target to be used in different scenarios.',


### PR DESCRIPTION
This PR enables links in the project details view that we previously hid due to the docs being unpublished.

## Changes

Sourcemap now shows the link to https://nx.dev/concepts/executors-and-configurations:

<img width="989" alt="Screenshot 2024-04-30 at 2 40 39 PM" src="https://github.com/nrwl/nx/assets/53559/25d2dbec-112e-4783-a0b0-8e53657875e1">

Configuration/Options section now link to https://nx.dev/concepts/inferred-tasks:
<img width="1001" alt="Screenshot 2024-04-30 at 2 40 02 PM" src="https://github.com/nrwl/nx/assets/53559/e4de122a-b10a-4125-b4c5-687cabbe70de">
<img width="1015" alt="Screenshot 2024-04-30 at 2 38 54 PM" src="https://github.com/nrwl/nx/assets/53559/cea37d3e-e207-4d91-aed0-e0c3a4243592">
