### PR TITLE
Revert "chore(repo): enable plugin isolation for nx repo (#22785)"

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-NX_ISOLATE_PLUGINS=true

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ out
 .angular
 
 # Local dev files
+.env
 .bashrc
 .nx
 


### PR DESCRIPTION
This reverts commit 063a5d464fbf5f1c395bc621b122a0e3f603ecf2.

- Plugin ISO is "working", but not with multiple instances of same plugin (e.g. jest)
	- When running in isolation, plugins can **_truly_** run in parallel. 
	- When actually runnning in parallel, the jest plugin (and potentially others) write to the same file in parallel.
	- If these writes happen close enough together, the JSON is malformed.
	- This results in an error when trying to load the plugin for future runs.

