### PR TITLE
fix(release): parse NPM output for JSON to prevent JSON.parse from throwing

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -98,12 +98,7 @@ export default async function runExecutor(
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 
-      const jsonRegex = /\{(?:[^{}])*\}/g;
-      const jsonObjectsInOutput = result.toString().match(jsonRegex);
-      const resultJson = JSON.parse(
-        jsonObjectsInOutput[jsonObjectsInOutput.length - 1]
-      );
-
+      const resultJson = JSON.parse(result.toString());
       const distTags = resultJson['dist-tags'] || {};
       if (distTags[tag] === currentVersion) {
         console.warn(

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -220,7 +220,11 @@ export default async function runExecutor(
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    const stdoutData = JSON.parse(output.toString());
+    const jsonRegex = /\{(?:[^{}])*\}/g;
+    const jsonObjectsInOutput = output.toString().match(jsonRegex);
+    const stdoutData = JSON.parse(
+      jsonObjectsInOutput[jsonObjectsInOutput.length - 1]
+    );
 
     // If npm workspaces are in use, the publish output will nest the data under the package name, so we normalize it first
     const normalizedStdoutData = stdoutData[packageName] ?? stdoutData;

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -98,7 +98,12 @@ export default async function runExecutor(
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 
-      const resultJson = JSON.parse(result.toString());
+      const jsonRegex = /\{(?:[^{}])*\}/g;
+      const jsonObjectsInOutput = result.toString().match(jsonRegex);
+      const resultJson = JSON.parse(
+        jsonObjectsInOutput[jsonObjectsInOutput.length - 1]
+      );
+
       const distTags = resultJson['dist-tags'] || {};
       if (distTags[tag] === currentVersion) {
         console.warn(


### PR DESCRIPTION
closed #22925

## Current Behavior

If the `npm publish` command is run and has any other console output than the JSON, e.g. output from a `prepublishOnly` step, the `pnpm release` command fails.

## Expected Behavior

It should be possible to have a `prepublishOnly` step without this command failing.

## Related Issue(s)

Fixes #22925
