### PR TITLE
docs(nx-cloud): document arm resource classes

### DIFF
--- a/docs/nx-cloud/reference/launch-templates.md
+++ b/docs/nx-cloud/reference/launch-templates.md
@@ -50,6 +50,9 @@ The following resource classes are available:
 - `docker_linux_amd64/large+`
 - `docker_linux_amd64/extra_large`
 - `docker_linux_amd64/extra_large+`
+- `docker_linux_arm64/medium`
+- `docker_linux_arm64/large`
+- `docker_linux_arm64/extra_large`
 - `windows/medium`
 
 See their detailed description and pricing at [nx.app/pricing](https://nx.app/pricing).


### PR DESCRIPTION
## Update Nx Cloud Resource Class Documentation

Documents the docker_linux_arm resource classes in `launch-templates.md`. No changes to the images are required.
