### PR TITLE
feat(vue): setup-unocss generator

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -9639,6 +9639,14 @@
                 "disableCollapsible": false
               },
               {
+                "id": "setup-unocss",
+                "path": "/nx-api/vue/generators/setup-unocss",
+                "name": "setup-unocss",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
+              },
+              {
                 "id": "storybook-configuration",
                 "path": "/nx-api/vue/generators/storybook-configuration",
                 "name": "storybook-configuration",

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -3052,6 +3052,15 @@
         "path": "/nx-api/vue/generators/setup-tailwind",
         "type": "generator"
       },
+      "/nx-api/vue/generators/setup-unocss": {
+        "description": "Set up UnoCSS configuration for a project.",
+        "file": "generated/packages/vue/generators/setup-unocss.json",
+        "hidden": false,
+        "name": "setup-unocss",
+        "originalFilePath": "/packages/vue/src/generators/setup-unocss/schema.json",
+        "path": "/nx-api/vue/generators/setup-unocss",
+        "type": "generator"
+      },
       "/nx-api/vue/generators/storybook-configuration": {
         "description": "Set up storybook for a Vue app or library.",
         "file": "generated/packages/vue/generators/storybook-configuration.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -3020,6 +3020,15 @@
         "type": "generator"
       },
       {
+        "description": "Set up UnoCSS configuration for a project.",
+        "file": "generated/packages/vue/generators/setup-unocss.json",
+        "hidden": false,
+        "name": "setup-unocss",
+        "originalFilePath": "/packages/vue/src/generators/setup-unocss/schema.json",
+        "path": "vue/generators/setup-unocss",
+        "type": "generator"
+      },
+      {
         "description": "Set up storybook for a Vue app or library.",
         "file": "generated/packages/vue/generators/storybook-configuration.json",
         "hidden": false,

--- a/docs/generated/packages/vue/generators/setup-unocss.json
+++ b/docs/generated/packages/vue/generators/setup-unocss.json
@@ -1,0 +1,53 @@
+{
+  "name": "setup-unocss",
+  "factory": "./src/generators/setup-unocss/setup-unocss",
+  "schema": {
+    "$schema": "https://json-schema.org/schema",
+    "cli": "nx",
+    "$id": "NxVueUnoCSSSetupGenerator",
+    "title": "Configures UnoCSS for an application or a library.",
+    "description": "Adds the UnoCSS configuration files for a given Vue project and installs, if needed, the packages required for UnoCSS to work.",
+    "type": "object",
+    "examples": [
+      {
+        "command": "nx g setup-unocss --project=my-app",
+        "description": "Initialize UnoCSS configuration for the `my-app` project."
+      }
+    ],
+    "properties": {
+      "project": {
+        "type": "string",
+        "description": "The name of the project to add the UnoCSS setup for.",
+        "alias": "p",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-dropdown": "projects",
+        "x-prompt": "What project would you like to add the UnoCSS setup?",
+        "x-priority": "important"
+      },
+      "skipFormat": {
+        "type": "boolean",
+        "description": "Skips formatting the workspace after the generator completes.",
+        "x-priority": "internal"
+      },
+      "skipPackageJson": {
+        "type": "boolean",
+        "default": false,
+        "description": "Do not add dependencies to `package.json`.",
+        "x-priority": "internal"
+      },
+      "entrypoint": {
+        "type": "string",
+        "description": "Path to the project entry point relative to the workspace root. This option is only needed if the entrypoint location cannot be found automatically."
+      }
+    },
+    "additionalProperties": false,
+    "required": ["project"],
+    "presets": []
+  },
+  "description": "Set up UnoCSS configuration for a project.",
+  "implementation": "/packages/vue/src/generators/setup-unocss/setup-unocss.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/vue/src/generators/setup-unocss/schema.json",
+  "type": "generator"
+}

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -685,6 +685,7 @@
       - [library](/nx-api/vue/generators/library)
       - [component](/nx-api/vue/generators/component)
       - [setup-tailwind](/nx-api/vue/generators/setup-tailwind)
+      - [setup-unocss](/nx-api/vue/generators/setup-unocss)
       - [storybook-configuration](/nx-api/vue/generators/storybook-configuration)
       - [stories](/nx-api/vue/generators/stories)
   - [web](/nx-api/web)

--- a/packages/vue/generators.json
+++ b/packages/vue/generators.json
@@ -34,6 +34,11 @@
       "schema": "./src/generators/setup-tailwind/schema.json",
       "description": "Set up Tailwind configuration for a project."
     },
+    "setup-unocss": {
+      "factory": "./src/generators/setup-unocss/setup-unocss",
+      "schema": "./src/generators/setup-unocss/schema.json",
+      "description": "Set up UnoCSS configuration for a project."
+    },
     "storybook-configuration": {
       "factory": "./src/generators/storybook-configuration/configuration#storybookConfigurationGeneratorInternal",
       "schema": "./src/generators/storybook-configuration/schema.json",

--- a/packages/vue/index.ts
+++ b/packages/vue/index.ts
@@ -10,6 +10,8 @@ export {
 } from './src/generators/stories/stories';
 export { setupTailwindGenerator } from './src/generators/setup-tailwind/setup-tailwind';
 export { SetupTailwindOptions } from './src/generators/setup-tailwind/schema';
+export { setupUnoCSSGenerator } from './src/generators/setup-unocss/setup-unocss';
+export { SetupUnoCSSOptions } from './src/generators/setup-unocss/schema';
 export { type InitSchema } from './src/generators/init/schema';
 export { vueInitGenerator } from './src/generators/init/init';
 export * from './src/utils/versions';

--- a/packages/vue/src/generators/setup-unocss/files/uno.config.js.template
+++ b/packages/vue/src/generators/setup-unocss/files/uno.config.js.template
@@ -1,0 +1,6 @@
+// uno.config.ts
+import { defineConfig } from 'unocss'
+
+export default defineConfig({
+  // ...UnoCSS options
+})

--- a/packages/vue/src/generators/setup-unocss/lib/add-unocss-style-imports.ts
+++ b/packages/vue/src/generators/setup-unocss/lib/add-unocss-style-imports.ts
@@ -1,0 +1,36 @@
+import { joinPathFragments, ProjectConfiguration, Tree } from '@nx/devkit';
+
+import { SetupUnoCSSOptions } from '../schema';
+
+const knownEntrypointLocations = [
+  // What we generate by default
+  'src/main.ts',
+  'src/main.js',
+]
+
+export function addUnoCSSStyleImports(
+  tree: Tree,
+  project: ProjectConfiguration,
+  _options: SetupUnoCSSOptions
+) {
+  if (_options.entrypoint) {
+    knownEntrypointLocations.push(_options.entrypoint);
+  }
+
+  const entrypointPath = knownEntrypointLocations
+  .map((file) => joinPathFragments(project.root, file))
+  .find((file) => tree.exists(file));
+
+  if (!entrypointPath) {
+    throw new Error(
+      `Could not find the entrypoint to update. Use --entrypoint to specify this path (relative to the workspace root).`
+    );
+  }
+
+  const content = tree.read(entrypointPath).toString();
+  tree.write(
+    entrypointPath,
+    `import 'virtual:uno.css';\n${content}`
+  );
+
+}

--- a/packages/vue/src/generators/setup-unocss/schema.d.ts
+++ b/packages/vue/src/generators/setup-unocss/schema.d.ts
@@ -1,0 +1,6 @@
+export interface SetupUnoCSSOptions {
+  project: string;
+  skipFormat?: boolean;
+  skipPackageJson?: boolean;
+  entrypoint?: string;
+}

--- a/packages/vue/src/generators/setup-unocss/schema.json
+++ b/packages/vue/src/generators/setup-unocss/schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "NxVueUnoCSSSetupGenerator",
+  "title": "Configures UnoCSS for an application or a library.",
+  "description": "Adds the UnoCSS configuration files for a given Vue project and installs, if needed, the packages required for UnoCSS to work.",
+  "type": "object",
+  "examples": [
+    {
+      "command": "nx g setup-unocss --project=my-app",
+      "description": "Initialize UnoCSS configuration for the `my-app` project."
+    }
+  ],
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project to add the UnoCSS setup for.",
+      "alias": "p",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-dropdown": "projects",
+      "x-prompt": "What project would you like to add the UnoCSS setup?",
+      "x-priority": "important"
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skips formatting the workspace after the generator completes.",
+      "x-priority": "internal"
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`.",
+      "x-priority": "internal"
+    },
+    "entrypoint": {
+      "type": "string",
+      "description": "Path to the project entry point relative to the workspace root. This option is only needed if the entrypoint location cannot be found automatically."
+    }
+  },
+  "additionalProperties": false,
+  "required": ["project"]
+}

--- a/packages/vue/src/generators/setup-unocss/setup-unocss.spec.ts
+++ b/packages/vue/src/generators/setup-unocss/setup-unocss.spec.ts
@@ -1,0 +1,62 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  writeJson,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import update from './setup-unocss';
+
+describe('vue setup-unocss generator', () => {
+
+  it('should install packages', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'example', {
+      root: 'example',
+      sourceRoot: 'example/src',
+      targets: {},
+    });
+    writeJson(tree, 'package.json', {
+      dependencies: {
+        vue: '999.9.9',
+      },
+    });
+
+    await update(tree, {
+      project: 'example',
+    });
+
+    expect(readJson(tree, 'package.json')).toEqual({
+      dependencies: {
+        vue: '999.9.9',
+      },
+      devDependencies: {
+        unocss: expect.any(String),
+      },
+    });
+  });
+
+  it('should support skipping package install', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'example', {
+      root: 'example',
+      sourceRoot: 'example/src',
+      targets: {},
+    });
+    writeJson(tree, 'package.json', {
+      dependencies: {
+        vue: '999.9.9',
+      },
+    });
+
+    await update(tree, {
+      project: 'example',
+      skipPackageJson: true,
+    });
+
+    expect(readJson(tree, 'package.json')).toEqual({
+      dependencies: {
+        vue: '999.9.9',
+      },
+    });
+  });
+});

--- a/packages/vue/src/generators/setup-unocss/setup-unocss.ts
+++ b/packages/vue/src/generators/setup-unocss/setup-unocss.ts
@@ -1,0 +1,44 @@
+import { join } from 'path';
+
+import type { GeneratorCallback, Tree } from '@nx/devkit';
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  generateFiles,
+  readProjectConfiguration,
+} from '@nx/devkit';
+
+import {
+  unocssVersion,
+} from '../../utils/versions';
+
+import type { SetupUnoCSSOptions } from './schema';
+import {addUnoCSSStyleImports} from './lib/add-unocss-style-imports'
+
+export async function setupUnoCSSGenerator(
+  tree: Tree,
+  options: SetupUnoCSSOptions
+): Promise<void | GeneratorCallback> {
+  let installTask: GeneratorCallback | undefined = undefined;
+  const project = readProjectConfiguration(tree, options.project);
+
+  generateFiles(tree, join(__dirname, './files'), project.root, {});
+
+  addUnoCSSStyleImports(tree, project, options);
+
+  if (!options.skipPackageJson) {
+    installTask = addDependenciesToPackageJson(
+      tree,
+      {},
+      {
+        unocss: unocssVersion,
+      }
+    );
+  }
+
+  if (!options.skipFormat) await formatFiles(tree);
+
+  return installTask;
+}
+
+export default setupUnoCSSGenerator;

--- a/packages/vue/src/utils/versions.ts
+++ b/packages/vue/src/utils/versions.ts
@@ -19,6 +19,9 @@ export const postcssVersion = '8.4.21';
 export const tailwindcssVersion = '3.2.7';
 export const autoprefixerVersion = '10.4.13';
 
+// unocss
+export const unocssVersion = "0.59.4"
+
 // other deps
 export const sassVersion = '1.62.1';
 export const lessVersion = '3.12.2';


### PR DESCRIPTION
## Description
NX has made my developer life easier. I like UnoCSS more than TailwindCSS, but setting up UnoCSS every time is a hassle. I'm attempting to craft a plugin to automate UnoCSS setup, hoping to ease the hassle of doing it manually each time.

## Expected Behavior
Should work exactly the same as `nx g @nx/vue:setup-tailwind` but setup UnoCSS instead.

## Hardware Specifications
- Machine: MacBook Pro M1
- OS: Sonoma 14.4

## TODOs
- [x] Setup environment to work on the plugin locally
- [x] Develop the vue setup-tailwind generator
- [x] Test it locally in a new repository
- [ ] Test it locally within the fork (Error: Cannot find configuration for task @nx/nx-source:test)
- [ ] Community review 

Fixes #
#23114 (duplicate of #19888) 
#19888