### PR TITLE
fix(core): align padding for output with failed tasks

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -409,7 +409,7 @@ export async function createRunManyDynamicOutputRenderer({
                 '-'
               )} ${output.formatCommand(t.toString())}`
           )
-          .join('\n ')}`,
+          .join('\n')}`,
       ];
 
       if (failedTasks.size > numFailedToPrint) {


### PR DESCRIPTION
## Current Behavior
```
NX   Ran target lint for 3 projects (3s)

   √  0/3 succeeded [0 read from cache]

   ×  3/3 targets failed, including the following:

      - nx run bar:lint
       - nx run baz:lint
       - nx run foo:lint
```
## Expected Behavior
```
 NX   Ran target lint for 3 projects (3s)                                                                                                                                                                          
                                                                                                                                                                                                                   
   √  0/3 succeeded [0 read from cache]                                                                                                                                                                            
                                                                                                                                                                                                                   
   ×  3/3 targets failed, including the following:                                                                                                                                                                 

      - nx run foo:lint
      - nx run baz:lint
      - nx run bar:lint
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23115
