### PR TITLE
feat(graph): log errors in console in graph watch mode

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -300,9 +300,6 @@ export async function generateGraph(
     sourceMaps = projectGraphAndSourceMaps.sourceMaps;
   } catch (e) {
     if (e instanceof ProjectGraphError) {
-      output.warn({
-        title: 'Failed to process project graph. Showing partial graph.',
-      });
       rawGraph = e.getPartialProjectGraph();
       sourceMaps = e.getPartialSourcemaps();
 
@@ -310,6 +307,21 @@ export async function generateGraph(
     }
     if (!rawGraph) {
       handleProjectGraphError({ exitOnError: true }, e);
+    } else {
+      const errors = e.getErrors();
+      if (errors?.length > 0) {
+        errors.forEach((e) => {
+          output.error({
+            title: e.message,
+            bodyLines: [e.stack],
+          });
+        });
+      }
+      output.warn({
+        title: `${
+          errors?.length > 1 ? `${errors.length} errors` : `An error`
+        } occured while processing the project graph. Showing partial graph.`,
+      });
     }
   }
   let prunedGraph = pruneExternalNodes(rawGraph);
@@ -708,6 +720,21 @@ function createFileWatcher() {
             currentProjectGraphClientResponse.hash &&
           sourceMapResponse
         ) {
+          if (projectGraphClientResponse.errors?.length > 0) {
+            projectGraphClientResponse.errors.forEach((e) => {
+              output.error({
+                title: e.message,
+                bodyLines: [e.stack],
+              });
+            });
+            output.warn({
+              title: `${
+                projectGraphClientResponse.errors.length > 1
+                  ? `${projectGraphClientResponse.errors.length} errors`
+                  : `An error`
+              } occured while processing the project graph. Showing partial graph.`,
+            });
+          }
           output.note({ title: 'Graph changes updated.' });
 
           currentProjectGraphClientResponse = projectGraphClientResponse;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If there are errors while calculating the project graph, you can't see them in the console. You have to check the graph app itself for them.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
You should be able to see errors in the console as they happen & be able to click through to files as well.
![image](https://github.com/nrwl/nx/assets/34165455/50454a1f-54cf-4fe3-b71b-23f188869f27)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
