### PR TITLE
fix(core): catch workspace validity check errors

### DIFF
--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -15,6 +15,7 @@ export class ProjectGraphError extends Error {
     | ProjectsWithConflictingNamesError
     | ProcessDependenciesError
     | ProcessProjectGraphError
+    | WorkspaceValidityError
   >;
   readonly #partialProjectGraph: ProjectGraph;
   readonly #partialSourceMaps: ConfigurationSourceMaps;
@@ -28,6 +29,7 @@ export class ProjectGraphError extends Error {
       | ProcessDependenciesError
       | ProcessProjectGraphError
       | CreateMetadataError
+      | WorkspaceValidityError
     >,
     partialProjectGraph: ProjectGraph,
     partialSourceMaps: ConfigurationSourceMaps
@@ -219,6 +221,23 @@ export class ProcessDependenciesError extends Error {
     this.stack = `${this.message}\n  ${cause.stack.split('\n').join('\n  ')}`;
   }
 }
+export class WorkspaceValidityError extends Error {
+  constructor(public readonly cause: string) {
+    super(cause);
+    this.name = this.constructor.name;
+  }
+}
+
+export function isWorkspaceValidityError(
+  e: unknown
+): e is WorkspaceValidityError {
+  return (
+    e instanceof WorkspaceValidityError ||
+    (typeof e === 'object' &&
+      'name' in e &&
+      e?.name === WorkspaceValidityError.name)
+  );
+}
 
 export class ProcessProjectGraphError extends Error {
   constructor(public readonly pluginName: string, { cause }) {
@@ -236,7 +255,10 @@ export class ProcessProjectGraphError extends Error {
 export class AggregateProjectGraphError extends Error {
   constructor(
     public readonly errors: Array<
-      CreateMetadataError | ProcessDependenciesError | ProcessProjectGraphError
+      | CreateMetadataError
+      | ProcessDependenciesError
+      | ProcessProjectGraphError
+      | WorkspaceValidityError
     >,
     public readonly partialProjectGraph: ProjectGraph
   ) {

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -222,8 +222,9 @@ export class ProcessDependenciesError extends Error {
   }
 }
 export class WorkspaceValidityError extends Error {
-  constructor(public readonly cause: string) {
-    super(cause);
+  constructor(public message: string) {
+    message = `Configuration Error\n${message}`;
+    super(message);
     this.name = this.constructor.name;
   }
 }

--- a/packages/nx/src/utils/assert-workspace-validity.spec.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.spec.ts
@@ -32,7 +32,8 @@ describe('assertWorkspaceValidity', () => {
 
     expect(() => assertWorkspaceValidity(mockProjects, {}))
       .toThrowErrorMatchingInlineSnapshot(`
-      "The following implicitDependencies should be an array of strings:
+      "Configuration Error
+      The following implicitDependencies should be an array of strings:
         lib1.implicitDependencies: "*"
 
       The following implicitDependencies point to non-existent project(s):

--- a/packages/nx/src/utils/assert-workspace-validity.spec.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.spec.ts
@@ -32,8 +32,7 @@ describe('assertWorkspaceValidity', () => {
 
     expect(() => assertWorkspaceValidity(mockProjects, {}))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Configuration Error
-      The following implicitDependencies should be an array of strings:
+      "The following implicitDependencies should be an array of strings:
         lib1.implicitDependencies: "*"
 
       The following implicitDependencies point to non-existent project(s):

--- a/packages/nx/src/utils/assert-workspace-validity.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.ts
@@ -3,6 +3,7 @@ import { NxJsonConfiguration } from '../config/nx-json';
 import { findMatchingProjects } from './find-matching-projects';
 import { output } from './output';
 import { ProjectGraphProjectNode } from '../config/project-graph';
+import { WorkspaceValidityError } from '../devkit-internals';
 
 export function assertWorkspaceValidity(
   projects: Record<string, ProjectConfiguration>,
@@ -99,7 +100,7 @@ export function assertWorkspaceValidity(
       .join('\n\n');
   }
 
-  throw new Error(`Configuration Error\n${message}`);
+  throw new WorkspaceValidityError(message);
 }
 
 function detectAndSetInvalidProjectGlobValues(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Errors thrown by `assertWorkspaceValidity` aren't handled and lead to the nx process' exit

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Errors are properly caught and handled with the ability to recover a partial project graph like other errors.
