### PR TITLE
fix(bundling): rollup does not log build errors

### DIFF
--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -138,8 +138,9 @@ export async function* rollupExecutor(
       return { success: true, outfile };
     } catch (e) {
       if (e.formatted) {
-        // Formattted message is provided by Rollup and contains codeframes for where the error occurred.
         logger.info(e.formatted);
+      } else if (e.message) {
+        logger.info(e.message);
       }
       logger.error(e);
       logger.error(`Bundle failed: ${context.projectName}`);


### PR DESCRIPTION
closed 22896

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
given using @nx/rollup:rollup executor
when an error is thrown
then no message is logged (just stacktrace)

## Expected Behavior
error message to be displayed (as it was till v18.2.0)

## Related Issue(s)

Fixes #22896 