### PR TITLE
fix(devkit): run callback for forEachProjectConfig when target.options is undefined

### DIFF
--- a/packages/angular/src/migrations/update-16-1-0/update-server-executor-config.ts
+++ b/packages/angular/src/migrations/update-16-1-0/update-server-executor-config.ts
@@ -30,8 +30,8 @@ export default async function (tree: Tree) {
           : projectConfiguration.targets[targetName].options;
 
         if (
-          configToUpdate.buildOptimizer === undefined &&
-          configToUpdate.optimization !== undefined
+          configToUpdate?.buildOptimizer === undefined &&
+          configToUpdate?.optimization !== undefined
         ) {
           configToUpdate.buildOptimizer = !!configToUpdate.optimization;
         }

--- a/packages/devkit/src/generators/executor-options-utils.ts
+++ b/packages/devkit/src/generators/executor-options-utils.ts
@@ -55,9 +55,7 @@ function forEachProjectConfig<Options>(
         continue;
       }
 
-      if (target.options) {
-        callback(target.options, projectName, targetName);
-      }
+      callback(target.options ?? {}, projectName, targetName);
 
       if (!target.configurations) {
         continue;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`forEachExecutorOptions` will not run the callback if `target.options` is undefined.
This means that even if a target exists with an executor, the target is not being processed if it does not have `options`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Run the callback anyway even if `target.options` is undefined

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
