### PR TITLE
fix(core): projectName should not be interpolated as undefined

### DIFF
--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -12,7 +12,7 @@ export class ProjectGraphError extends Error {
     | MergeNodesError
     | CreateMetadataError
     | ProjectsWithNoNameError
-    | ProjectsWithConflictingNamesError
+    | MultipleProjectsWithSameNameError
     | ProcessDependenciesError
     | ProcessProjectGraphError
   >;
@@ -24,7 +24,7 @@ export class ProjectGraphError extends Error {
       | CreateNodesError
       | MergeNodesError
       | ProjectsWithNoNameError
-      | ProjectsWithConflictingNamesError
+      | MultipleProjectsWithSameNameError
       | ProcessDependenciesError
       | ProcessProjectGraphError
       | CreateMetadataError
@@ -71,9 +71,9 @@ export class ProjectGraphError extends Error {
   }
 }
 
-export class ProjectsWithConflictingNamesError extends Error {
+export class MultipleProjectsWithSameNameError extends Error {
   constructor(
-    conflicts: Map<string, string[]>,
+    public conflicts: Map<string, string[]>,
     public projects: Record<string, ProjectConfiguration>
   ) {
     super(
@@ -90,20 +90,38 @@ export class ProjectsWithConflictingNamesError extends Error {
   }
 }
 
-export function isProjectsWithConflictingNamesError(
+export class ProjectWithExistingNameError extends Error {
+  constructor(public projectName: string, public projectRoot: string) {
+    super(`The project "${projectName}" is defined in multiple locations.`);
+    this.name = this.constructor.name;
+  }
+}
+
+export function isProjectWithExistingNameError(
   e: unknown
-): e is ProjectsWithConflictingNamesError {
+): e is ProjectWithExistingNameError {
   return (
-    e instanceof ProjectsWithConflictingNamesError ||
+    e instanceof ProjectWithExistingNameError ||
     (typeof e === 'object' &&
       'name' in e &&
-      e?.name === ProjectsWithConflictingNamesError.prototype.name)
+      e?.name === ProjectWithExistingNameError.name)
+  );
+}
+
+export function isMultipleProjectsWithSameNameError(
+  e: unknown
+): e is MultipleProjectsWithSameNameError {
+  return (
+    e instanceof MultipleProjectsWithSameNameError ||
+    (typeof e === 'object' &&
+      'name' in e &&
+      e?.name === MultipleProjectsWithSameNameError.name)
   );
 }
 
 export class ProjectsWithNoNameError extends Error {
   constructor(
-    projectRoots: string[],
+    public projectRoots: string[],
     public projects: Record<string, ProjectConfiguration>
   ) {
     super(
@@ -122,7 +140,25 @@ export function isProjectsWithNoNameError(
     e instanceof ProjectsWithNoNameError ||
     (typeof e === 'object' &&
       'name' in e &&
-      e?.name === ProjectsWithNoNameError.prototype.name)
+      e?.name === ProjectsWithNoNameError.name)
+  );
+}
+
+export class ProjectWithNoNameError extends Error {
+  constructor(public projectRoot: string) {
+    super(`The project in ${projectRoot} has no name provided.`);
+    this.name = this.constructor.name;
+  }
+}
+
+export function isProjectWithNoNameError(
+  e: unknown
+): e is ProjectWithNoNameError {
+  return (
+    e instanceof ProjectWithNoNameError ||
+    (typeof e === 'object' &&
+      'name' in e &&
+      e?.name === ProjectWithNoNameError.name)
   );
 }
 
@@ -132,13 +168,24 @@ export class ProjectConfigurationsError extends Error {
       | MergeNodesError
       | CreateNodesError
       | ProjectsWithNoNameError
-      | ProjectsWithConflictingNamesError
+      | MultipleProjectsWithSameNameError
     >,
     public readonly partialProjectConfigurationsResult: ConfigurationResult
   ) {
     super('Failed to create project configurations');
     this.name = this.constructor.name;
   }
+}
+
+export function isProjectConfigurationsError(
+  e: unknown
+): e is ProjectConfigurationsError {
+  return (
+    e instanceof ProjectConfigurationsError ||
+    (typeof e === 'object' &&
+      'name' in e &&
+      e?.name === ProjectConfigurationsError.name)
+  );
 }
 
 export class CreateNodesError extends Error {
@@ -252,7 +299,7 @@ export function isAggregateProjectGraphError(
     e instanceof AggregateProjectGraphError ||
     (typeof e === 'object' &&
       'name' in e &&
-      e?.name === AggregateProjectGraphError.prototype.name)
+      e?.name === AggregateProjectGraphError.name)
   );
 }
 
@@ -261,7 +308,7 @@ export function isCreateMetadataError(e: unknown): e is CreateMetadataError {
     e instanceof CreateMetadataError ||
     (typeof e === 'object' &&
       'name' in e &&
-      e?.name === CreateMetadataError.prototype.name)
+      e?.name === CreateMetadataError.name)
   );
 }
 

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -27,9 +27,13 @@ import {
   ProjectConfigurationsError,
   isAggregateCreateNodesError,
   ProjectsWithNoNameError,
-  ProjectsWithConflictingNamesError,
-  isProjectsWithConflictingNamesError,
+  MultipleProjectsWithSameNameError,
+  isMultipleProjectsWithSameNameError,
   isProjectsWithNoNameError,
+  ProjectWithNoNameError,
+  ProjectWithExistingNameError,
+  isProjectWithExistingNameError,
+  isProjectWithNoNameError,
 } from '../error-types';
 
 export type SourceInformation = [file: string | null, plugin: string];
@@ -204,7 +208,7 @@ export function mergeProjectConfigurationIntoRootMap(
 
       const normalizedTarget = skipTargetNormalization
         ? target
-        : normalizeTarget(target, project);
+        : resolveCommandSyntacticSugar(target, project.root);
 
       const mergedTarget = mergeTargetConfigurations(
         normalizedTarget,
@@ -348,7 +352,7 @@ export async function createProjectConfigurations(
     | CreateNodesError
     | MergeNodesError
     | ProjectsWithNoNameError
-    | ProjectsWithConflictingNamesError
+    | MultipleProjectsWithSameNameError
   > = [];
 
   // We iterate over plugins first - this ensures that plugins specified first take precedence.
@@ -454,16 +458,11 @@ export async function createProjectConfigurations(
     }
 
     try {
-      // We still call this just to assert that the root map
-      // only contains valid project names. This is a safety check.
-      //
-      // The signature itself can't be changed as we need it to return
-      // project configurations for use in devkit.
-      readProjectConfigurationsFromRootMap(projectRootMap);
+      validateAndNormalizeProjectRootMap(projectRootMap);
     } catch (e) {
       if (
         isProjectsWithNoNameError(e) ||
-        isProjectsWithConflictingNamesError(e)
+        isMultipleProjectsWithSameNameError(e)
       ) {
         errors.push(e);
       } else {
@@ -518,40 +517,117 @@ export function readProjectConfigurationsFromRootMap(
   const projectRootsWithNoName: string[] = [];
 
   for (const root in projectRootMap) {
-    const configuration = projectRootMap[root];
+    const project = projectRootMap[root];
     // We're setting `// targets` as a comment `targets` is empty due to Project Crystal.
     // Strip it before returning configuration for usage.
-    if (configuration['// targets']) delete configuration['// targets'];
-    if (!configuration.name) {
-      try {
-        const { name } = readJsonFile(join(root, 'package.json'));
-        if (!name) {
-          throw new Error("No name found for project at '" + root + "'.");
-        }
-        configuration.name = name;
-      } catch {
-        projectRootsWithNoName.push(root);
+    if (project['// targets']) delete project['// targets'];
+
+    try {
+      validateProject(project, projects);
+      projects[project.name] = project;
+    } catch (e) {
+      if (isProjectWithNoNameError(e)) {
+        projectRootsWithNoName.push(e.projectRoot);
+      } else if (isProjectWithExistingNameError(e)) {
+        const rootErrors = conflicts.get(e.projectName) ?? [
+          projects[e.projectName].root,
+        ];
+        rootErrors.push(e.projectRoot);
+        conflicts.set(e.projectName, rootErrors);
+      } else {
+        throw e;
       }
-    }
-    if (configuration.name in projects) {
-      let rootErrors = conflicts.get(configuration.name) ?? [
-        projects[configuration.name].root,
-      ];
-      rootErrors.push(root);
-      conflicts.set(configuration.name, rootErrors);
-      projects[configuration.name] = configuration;
-    } else {
-      projects[configuration.name] = configuration;
     }
   }
 
   if (conflicts.size > 0) {
-    throw new ProjectsWithConflictingNamesError(conflicts, projects);
+    throw new MultipleProjectsWithSameNameError(conflicts, projects);
   }
   if (projectRootsWithNoName.length > 0) {
     throw new ProjectsWithNoNameError(projectRootsWithNoName, projects);
   }
   return projects;
+}
+
+function validateAndNormalizeProjectRootMap(
+  projectRootMap: Record<string, ProjectConfiguration>
+) {
+  // Name -> Project, used to validate that all projects have unique names
+  const projects: Record<string, ProjectConfiguration> = {};
+  // If there are projects that have the same name, that is an error.
+  // This object tracks name -> (all roots of projects with that name)
+  // to provide better error messaging.
+  const conflicts = new Map<string, string[]>();
+  const projectRootsWithNoName: string[] = [];
+
+  for (const root in projectRootMap) {
+    const project = projectRootMap[root];
+    // We're setting `// targets` as a comment `targets` is empty due to Project Crystal.
+    // Strip it before returning configuration for usage.
+    if (project['// targets']) delete project['// targets'];
+
+    try {
+      validateProject(project, projects);
+      projects[project.name] = project;
+    } catch (e) {
+      if (isProjectWithNoNameError(e)) {
+        projectRootsWithNoName.push(e.projectRoot);
+      } else if (isProjectWithExistingNameError(e)) {
+        const rootErrors = conflicts.get(e.projectName) ?? [
+          projects[e.projectName].root,
+        ];
+        rootErrors.push(e.projectRoot);
+        conflicts.set(e.projectName, rootErrors);
+      } else {
+        throw e;
+      }
+    }
+
+    for (const targetName in project.targets) {
+      project.targets[targetName] = normalizeTarget(
+        project.targets[targetName],
+        project
+      );
+
+      if (
+        !project.targets[targetName].executor &&
+        !project.targets[targetName].command
+      ) {
+        delete project.targets[targetName];
+      }
+    }
+  }
+
+  if (conflicts.size > 0) {
+    throw new MultipleProjectsWithSameNameError(conflicts, projects);
+  }
+  if (projectRootsWithNoName.length > 0) {
+    throw new ProjectsWithNoNameError(projectRootsWithNoName, projects);
+  }
+  return projectRootMap;
+}
+
+export function validateProject(
+  project: ProjectConfiguration,
+  // name -> project
+  knownProjects: Record<string, ProjectConfiguration>
+) {
+  if (!project.name) {
+    try {
+      const { name } = readJsonFile(join(project.root, 'package.json'));
+      if (!name) {
+        throw new Error(`Project at ${project.root} has no name provided.`);
+      }
+      project.name = name;
+    } catch {
+      throw new ProjectWithNoNameError(project.root);
+    }
+  } else if (
+    knownProjects[project.name] &&
+    knownProjects[project.name].root !== project.root
+  ) {
+    throw new ProjectWithExistingNameError(project.name, project.root);
+  }
 }
 
 /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Tokens are interpolated into arguments while merging things into the root map. Unfortunately, this means `{projectName}` is sometimes interpolated as `undefined` because the project's name isn't known yet.

## Expected Behavior
Tokens are interpolated after the root map has been constructed, but still during `createProjectConfigurations` s.t. we can know that we have final project configurations afterwards.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
