### PR TITLE
fix(testing): convert-to-inferred generator should handle legacy cypress executor

### DIFF
--- a/packages/playwright/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/playwright/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -16,16 +16,21 @@ interface Schema {
 
 export async function convertToInferred(tree: Tree, options: Schema) {
   const projectGraph = await createProjectGraphAsync();
-  await migrateExecutorToPlugin<PlaywrightPluginOptions>(
-    tree,
-    projectGraph,
-    '@nx/playwright:playwright',
-    '@nx/playwright/plugin',
-    (targetName) => ({ targetName, ciTargetName: 'e2e-ci' }),
-    postTargetTransformer,
-    createNodes,
-    options.project
-  );
+  const migratedProjects =
+    await migrateExecutorToPlugin<PlaywrightPluginOptions>(
+      tree,
+      projectGraph,
+      '@nx/playwright:playwright',
+      '@nx/playwright/plugin',
+      (targetName) => ({ targetName, ciTargetName: 'e2e-ci' }),
+      postTargetTransformer,
+      createNodes,
+      options.project
+    );
+
+  if (migratedProjects === 0) {
+    throw new Error('Could not find any targets to migrate.');
+  }
 
   if (!options.skipFormat) {
     await formatFiles(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `convert-to-inferred` generator does not handle `@nrwl/cypress:cypress`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The generator should handle the legacy executor

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
