### PR TITLE
fix(testing): convert-to-inferred generators should add includes only when needed

### DIFF
--- a/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -121,6 +121,11 @@ function createTestProject(
           testingType: `e2e`,
           devServerTarget: 'myapp:serve',
         },
+        configurations: {
+          ci: {
+            devServerTarget: 'myapp:static-serve',
+          },
+        },
       },
     },
   };
@@ -273,6 +278,21 @@ describe('Cypress - Convert Executors To Plugin', () => {
           );
         });
       }
+
+      // cypress.config.ts modifications
+      expect(tree.read(`${project.root}/cypress.config.ts`, 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+
+        import { defineConfig } from 'cypress';
+
+        export default defineConfig({
+          e2e: {
+            ...nxE2EPreset(__filename, {ciWebServerCommand: "npx nx run myapp:static-serve",webServerCommands: {"default":"npx nx run myapp:serve","ci":"npx nx run myapp:static-serve"}, cypressDir: 'src' }),
+            baseUrl: 'http://localhost:4200',
+          },
+        });"
+      `);
     });
 
     it('should setup Cypress plugin to match projects', async () => {
@@ -430,12 +450,12 @@ describe('Cypress - Convert Executors To Plugin', () => {
       // project.json modifications
       const updatedProject = readProjectConfiguration(tree, project.name);
       expect(updatedProject.targets.e2e).toMatchInlineSnapshot(`
-      {
-        "options": {
-          "runner-ui": true,
-        },
-      }
-    `);
+              {
+                "options": {
+                  "runner-ui": true,
+                },
+              }
+          `);
 
       // nx.json modifications
       const nxJsonPlugins = readNxJson(tree).plugins;
@@ -476,12 +496,12 @@ describe('Cypress - Convert Executors To Plugin', () => {
       // project.json modifications
       const updatedProject = readProjectConfiguration(tree, project.name);
       expect(updatedProject.targets.e2e).toMatchInlineSnapshot(`
-      {
-        "options": {
-          "no-exit": true,
-        },
-      }
-    `);
+              {
+                "options": {
+                  "no-exit": true,
+                },
+              }
+          `);
 
       // nx.json modifications
       const nxJsonPlugins = readNxJson(tree).plugins;

--- a/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -263,6 +263,7 @@ describe('Cypress - Convert Executors To Plugin', () => {
       );
       expect(hasCypressPlugin).toBeTruthy();
       if (typeof hasCypressPlugin !== 'string') {
+        expect(hasCypressPlugin.include).not.toBeDefined();
         [
           ['targetName', 'e2e'],
           ['ciTargetName', 'e2e-ci'],

--- a/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -117,7 +117,7 @@ function postTargetTransformer(
         tree,
         configFilePath,
         webServerCommands,
-        target.configurations?.ci?.devServerTarget
+        webServerCommands?.['ci']
       );
     }
 

--- a/packages/cypress/src/generators/convert-to-inferred/lib/add-dev-server-target-to-config.spec.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/lib/add-dev-server-target-to-config.spec.ts
@@ -115,7 +115,7 @@ export default defineConfig({
         tree,
         configFilePath,
         { default: 'npx nx run myorg:serve' },
-        'myorg:static-serve'
+        'npx nx run myorg:static-serve'
       );
 
       // ASSERT
@@ -151,7 +151,7 @@ export default defineConfig({
         tree,
         configFilePath,
         { default: 'npx nx run myorg:serve' },
-        'myorg:static-serve'
+        'npx nx run myorg:static-serve'
       );
 
       // ASSERT
@@ -191,7 +191,7 @@ export default defineConfig({
           production: 'npx nx run myorg:serve:production',
           ci: 'npx nx run myorg-static-serve',
         },
-        'myorg:static-serve'
+        'npx nx run myorg:static-serve'
       );
 
       // ASSERT

--- a/packages/cypress/src/generators/convert-to-inferred/lib/add-dev-server-target-to-config.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/lib/add-dev-server-target-to-config.ts
@@ -85,7 +85,7 @@ export function addDevServerTargetToConfig(
             `${configFileContents.slice(
               0,
               ciWebServerCommandNode.getStart()
-            )}"npx nx run ${ciDevServerTarget}"${configFileContents.slice(
+            )}"${ciDevServerTarget}"${configFileContents.slice(
               ciWebServerCommandNode.getEnd()
             )}`
           );
@@ -96,7 +96,7 @@ export function addDevServerTargetToConfig(
           `${configFileContents.slice(
             0,
             nxE2ePresetOptionsNode.getStart() + 1
-          )}ciWebServerCommand: "npx nx run ${ciDevServerTarget}",${configFileContents.slice(
+          )}ciWebServerCommand: "${ciDevServerTarget}",${configFileContents.slice(
             nxE2ePresetOptionsNode.getStart() + 1
           )}`
         );

--- a/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
+++ b/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
@@ -197,6 +197,19 @@ class ExecutorToPluginMigrator<T> {
       }
 
       if (!existingPlugin) {
+        const allConfigFilesAreIncluded = this.#configFiles.every(
+          (configFile) => {
+            for (const includePattern of plugin.include) {
+              if (minimatch(configFile, includePattern, { dot: true })) {
+                return true;
+              }
+            }
+            return false;
+          }
+        );
+        if (allConfigFilesAreIncluded) {
+          plugin.include = undefined;
+        }
         this.#nxJson.plugins.push(plugin);
       }
     }


### PR DESCRIPTION
- fix(devkit): executor-to-plugin-migrator should remove includes when all config files are handled
- fix(testing): cypress convert-to-inferred should add ciWebServerCommand correctly

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`includes` are being added to all new plugins that are being added to nx.json.
It should only be added when not all config files are addressed by the plugin to be added.

Cypress Convert To Inferred is not creating a `ciWebServerCommand` when it is possible to do so.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure `includes` is added only when required.
Ensure `cypress:convert-to-inferred` is adding a ciWebServerCommand correctly


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
