### PR TITLE
fix(devkit): executor-to-plugin-migrator should add // targets hint

### DIFF
--- a/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
+++ b/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
@@ -147,6 +147,13 @@ class ExecutorToPluginMigrator<T> {
     } else {
       delete projectConfig.targets[targetName];
     }
+
+    if (!projectConfig['// targets']) {
+      projectConfig[
+        '// targets'
+      ] = `to see all targets run: nx show project ${projectName} --web`;
+    }
+
     updateProjectConfiguration(this.tree, projectName, projectConfig);
 
     return `${projectFromGraph.data.root}/**/*`;

--- a/packages/eslint/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/eslint/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -10,6 +10,7 @@ import {
   joinPathFragments,
   type ProjectConfiguration,
   type ProjectGraph,
+  readJson,
   readNxJson,
   readProjectConfiguration,
   type Tree,
@@ -413,8 +414,14 @@ describe('Eslint - Convert Executors To Plugin', () => {
       // project.json modifications
       const updatedProject = readProjectConfiguration(tree, project.name);
       const targetKeys = Object.keys(updatedProject.targets);
-      ['lint'].forEach((key) => expect(targetKeys).not.toContain(key));
-
+      expect(targetKeys).not.toContain('lint');
+      const projectJsonForProject = readJson(
+        tree,
+        `${project.root}/project.json`
+      );
+      expect(projectJsonForProject['// targets']).toEqual(
+        'to see all targets run: nx show project myapp --web'
+      );
       // nx.json modifications
       const nxJsonPlugins = readNxJson(tree).plugins;
       const addedTestEslintPlugin = nxJsonPlugins.find((plugin) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When `convert-to-inferred` generators are run, they leave no hints as to what happened to the targets.
This is usually fine as the person running the generator should know what it is doing.
However, other team members who may not have been privy to the migration may be confused when they see an empty project.json


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add the same `// targets` hint that we generate for plugin-first projects to help guide users to the PDV to see the targets.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
