### PR TITLE
docs(nx-cloud): update start-ci-run docs with --force flag and cleanup command

### DIFF
--- a/docs/nx-cloud/reference/nx-cloud-cli.md
+++ b/docs/nx-cloud/reference/nx-cloud-cli.md
@@ -6,10 +6,10 @@ At the beginning of your main job, invoke `npx nx-cloud start-ci-run`. This tell
 command correspond to the same CI run.
 
 {% callout type="warning" title="Do not run start-ci-run locally" %}
-`nx-cloud start-ci-run` is designed to run in CI. It will check to see if it is running in a CI environment and if not, it will exit. Bypass this check with `nx-cloud start-ci-run --force`.
-It generates a temporary marker file that can cause a local Nx repo to think it's a part of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
+`nx-cloud start-ci-run` generates a temporary marker file that can cause a local Nx repo to behave as if it is a part of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
+To discourage this from happening, this command will run a check to see if it is running in a CI environment. You can bypass this check with `nx-cloud start-ci-run --force`.
 
-You can remove all generated files with `nx-cloud cleanup` to reset your workspace if you accidentally run this command locally.
+If you accidentally run this command locally, remove all generated marker files with `nx-cloud cleanup`.
 {% /callout %}
 
 You can configure your CI run by passing the following flags:

--- a/docs/nx-cloud/reference/nx-cloud-cli.md
+++ b/docs/nx-cloud/reference/nx-cloud-cli.md
@@ -6,9 +6,10 @@ At the beginning of your main job, invoke `npx nx-cloud start-ci-run`. This tell
 command correspond to the same CI run.
 
 {% callout type="warning" title="Do not run start-ci-run locally" %}
-`nx-cloud start-ci-run` is designed to run in CI. If you run the command locally, it can cause your local Nx repo to think it's a part of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
+`nx-cloud start-ci-run` is designed to run in CI. It will check to see if it is running in a CI environment and if not, it will exit. Bypass this check with `nx-cloud start-ci-run --force`.
+It generates a temporary marker file that can cause a local Nx repo to think it's a part of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
 
-If you accidentally run the command locally, you can remove your system's temp files to reset your local system. Typically restarting your system is enough to fix this issue.
+You can remove all generated files with `nx-cloud cleanup` to reset your workspace if you accidentally run this command locally.
 {% /callout %}
 
 You can configure your CI run by passing the following flags:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Updates docs to include `nx-cloud cleanup` command as an alternative to resetting your system after running `nx-cloud start-ci-run`. 

Also provides more context about `nx-cloud start-ci-run`'s check for local environments and how to bypass this check with the `--force` flag. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
