### PR TITLE
fix(remix): ensure default meta tags are always present for generated applications #23037

### DIFF
--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -34,9 +34,7 @@ import {
 
 export const meta: MetaFunction = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 
@@ -44,6 +42,8 @@ export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -106,9 +106,7 @@ import {
 
 export const meta: MetaFunction = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 
@@ -116,6 +114,8 @@ export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -266,15 +266,15 @@ exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provide
 } from '@remix-run/react';
 export const meta = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -475,9 +475,7 @@ import {
 
 export const meta: MetaFunction = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 
@@ -485,6 +483,8 @@ export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -547,9 +547,7 @@ import {
 
 export const meta: MetaFunction = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 
@@ -557,6 +555,8 @@ export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -619,9 +619,7 @@ import {
 
 export const meta: MetaFunction = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 
@@ -629,6 +627,8 @@ export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -779,15 +779,15 @@ exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --
 } from '@remix-run/react';
 export const meta = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -988,9 +988,7 @@ import {
 
 export const meta: MetaFunction = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 
@@ -998,6 +996,8 @@ export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -1075,15 +1075,15 @@ exports[`Remix Application Standalone Project Repo --js should create the applic
 } from '@remix-run/react';
 export const meta = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -1328,9 +1328,7 @@ import {
 
 export const meta: MetaFunction = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 
@@ -1338,6 +1336,8 @@ export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/packages/remix/src/generators/application/files/common/app/root.tsx__tmpl__
+++ b/packages/remix/src/generators/application/files/common/app/root.tsx__tmpl__
@@ -9,15 +9,15 @@ import {
 } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ([{
-  charset: "utf-8",
   title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
 }]);
 
 export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/packages/remix/src/generators/setup-tailwind/__snapshots__/setup-tailwind.impl.spec.ts.snap
+++ b/packages/remix/src/generators/setup-tailwind/__snapshots__/setup-tailwind.impl.spec.ts.snap
@@ -35,15 +35,15 @@ import twStyles from './tailwind.css';
 export const links = () => [{ rel: 'stylesheet', href: twStyles }];
 export const meta = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -122,9 +122,7 @@ export const links: LinksFunction = () => [
 
 export const meta: MetaFunction = () => [
   {
-    charset: 'utf-8',
     title: 'New Remix App',
-    viewport: 'width=device-width,initial-scale=1',
   },
 ];
 
@@ -132,6 +130,8 @@ export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Meta tags that are required and recommended for remix apps are not being rendered correctly when deployed to serverless locations such as AWS Lambda
We do not attach them in the way that Remix recommends

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Attach these meta tags in the method that remix itself recommends to ensure maximum compatibility

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23037
