### PR TITLE
fix(testing): convert-to-inferred for cypress should handle nxE2EPreset with no options object

### DIFF
--- a/packages/cypress/src/generators/convert-to-inferred/lib/add-dev-server-target-to-config.spec.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/lib/add-dev-server-target-to-config.spec.ts
@@ -74,6 +74,44 @@ export default defineConfig({
       `);
     });
 
+    it('should add options object if it does not exist', () => {
+      // ARRANGE
+      tree.write(
+        configFilePath,
+        `import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    ...nxE2EPreset(__filename),
+    baseUrl: "http://localhost:4200",
+  },
+});`
+      );
+      // ACT
+      addDevServerTargetToConfig(
+        tree,
+        configFilePath,
+        {
+          default: 'npx nx run myorg:serve',
+        },
+        'npx nx run myorg:serve-static'
+      );
+
+      // ASSERT
+      expect(tree.read(configFilePath, 'utf-8')).toMatchInlineSnapshot(`
+        "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+        import { defineConfig } from 'cypress';
+
+        export default defineConfig({
+          e2e: {
+            ...nxE2EPreset(__filename,{ciWebServerCommand: "npx nx run myorg:serve-static", webServerCommands: {"default":"npx nx run myorg:serve"},}),
+            baseUrl: "http://localhost:4200",
+          },
+        });"
+      `);
+    });
+
     it('should update the webServerCommands if it does not match', () => {
       // ARRANGE
       tree.write(

--- a/packages/cypress/src/generators/convert-to-inferred/lib/add-dev-server-target-to-config.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/lib/add-dev-server-target-to-config.ts
@@ -21,12 +21,19 @@ export function addDevServerTargetToConfig(
 
   let ast = tsquery.ast(configFileContents);
 
-  const NX_E2E_PRESET_OPTIONS_SELECTOR =
-    'PropertyAssignment:has(Identifier[name=e2e]) CallExpression:has(Identifier[name=nxE2EPreset]) > ObjectLiteralExpression';
-  const nxE2ePresetOptionsNodes = tsquery(ast, NX_E2E_PRESET_OPTIONS_SELECTOR, {
+  const NX_E2E_PRESET_SELECTOR =
+    'PropertyAssignment:has(Identifier[name=e2e]) CallExpression:has(Identifier[name=nxE2EPreset])';
+  const nxE2ePresetOptionsNodes = tsquery(ast, NX_E2E_PRESET_SELECTOR, {
     visitAllChildren: true,
   });
   if (nxE2ePresetOptionsNodes.length !== 0) {
+    const NX_E2E_PRESET_OPTIONS_SELECTOR =
+      'PropertyAssignment:has(Identifier[name=e2e]) CallExpression:has(Identifier[name=nxE2EPreset]) > ObjectLiteralExpression';
+    const optionsObjectNodes = tsquery(ast, NX_E2E_PRESET_OPTIONS_SELECTOR, {
+      visitAllChildren: true,
+    });
+    const hasObjectDefinition = optionsObjectNodes?.length > 0;
+
     let nxE2ePresetOptionsNode = nxE2ePresetOptionsNodes[0];
     const WEB_SERVER_COMMANDS_SELECTOR =
       'PropertyAssignment:has(Identifier[name=webServerCommands])';
@@ -47,23 +54,42 @@ export function addDevServerTargetToConfig(
         )}${configFileContents.slice(webServerCommandsNodes[0].getEnd())}`
       );
     } else {
-      tree.write(
-        configFilePath,
-        `${configFileContents.slice(
-          0,
-          nxE2ePresetOptionsNode.getStart() + 1
-        )}webServerCommands: ${JSON.stringify(
-          webServerCommands
-        )},${configFileContents.slice(nxE2ePresetOptionsNode.getStart() + 1)}`
-      );
+      if (hasObjectDefinition) {
+        tree.write(
+          configFilePath,
+          `${configFileContents.slice(
+            0,
+            optionsObjectNodes[0].getStart() + 1
+          )}webServerCommands: ${JSON.stringify(
+            webServerCommands
+          )},${configFileContents.slice(optionsObjectNodes[0].getStart() + 1)}`
+        );
+      } else {
+        tree.write(
+          configFilePath,
+          `${configFileContents.slice(
+            0,
+            nxE2ePresetOptionsNode.getEnd() - 1
+          )},{ webServerCommands: ${JSON.stringify(
+            webServerCommands
+          )},}${configFileContents.slice(nxE2ePresetOptionsNode.getEnd() - 1)}`
+        );
+      }
     }
 
     if (ciDevServerTarget) {
       configFileContents = tree.read(configFilePath, 'utf-8');
       ast = tsquery.ast(configFileContents);
-      nxE2ePresetOptionsNode = tsquery(ast, NX_E2E_PRESET_OPTIONS_SELECTOR, {
+      nxE2ePresetOptionsNode = tsquery(ast, NX_E2E_PRESET_SELECTOR, {
         visitAllChildren: true,
       })[0];
+
+      const NX_E2E_PRESET_OPTIONS_SELECTOR =
+        'PropertyAssignment:has(Identifier[name=e2e]) CallExpression:has(Identifier[name=nxE2EPreset]) > ObjectLiteralExpression';
+      const optionsObjectNodes = tsquery(ast, NX_E2E_PRESET_OPTIONS_SELECTOR, {
+        visitAllChildren: true,
+      });
+      const hasObjectDefinition = optionsObjectNodes?.length > 0;
 
       const CI_WEB_SERVER_COMMANDS_SELECTOR =
         'PropertyAssignment:has(Identifier[name=ciWebServerCommand])';
@@ -91,15 +117,27 @@ export function addDevServerTargetToConfig(
           );
         }
       } else {
-        tree.write(
-          configFilePath,
-          `${configFileContents.slice(
-            0,
-            nxE2ePresetOptionsNode.getStart() + 1
-          )}ciWebServerCommand: "${ciDevServerTarget}",${configFileContents.slice(
-            nxE2ePresetOptionsNode.getStart() + 1
-          )}`
-        );
+        if (hasObjectDefinition) {
+          tree.write(
+            configFilePath,
+            `${configFileContents.slice(
+              0,
+              optionsObjectNodes[0].getStart() + 1
+            )}ciWebServerCommand: "${ciDevServerTarget}",${configFileContents.slice(
+              optionsObjectNodes[0].getStart() + 1
+            )}`
+          );
+        } else {
+          tree.write(
+            configFilePath,
+            `${configFileContents.slice(
+              0,
+              nxE2ePresetOptionsNode.getEnd() - 1
+            )},{ ciWebServerCommand: "${ciDevServerTarget}",}${configFileContents.slice(
+              nxE2ePresetOptionsNode.getEnd() - 1
+            )}`
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
