### PR TITLE
fix(linter): add {options.outputFile} to outputs for inferred targets

### DIFF
--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -109,6 +109,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": ".",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },
@@ -178,6 +181,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": "apps/my-app",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },
@@ -216,6 +222,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": "apps/my-app",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },
@@ -326,6 +335,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": "apps/my-app",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },
@@ -348,6 +360,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": "libs/my-lib",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },
@@ -430,6 +445,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": "apps/my-app",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },
@@ -453,6 +471,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": "libs/my-lib",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },
@@ -493,6 +514,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": "apps/myapp",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },
@@ -538,6 +562,9 @@ describe('@nx/eslint/plugin', () => {
                   "options": {
                     "cwd": "apps/myapp/nested/mylib",
                   },
+                  "outputs": [
+                    "{options.outputFile}",
+                  ],
                 },
               },
             },

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -187,6 +187,7 @@ function buildEslintTargets(
       '{workspaceRoot}/tools/eslint-rules/**/*',
       { externalDependencies: ['eslint'] },
     ],
+    outputs: ['{options.outputFile}'],
   };
   if (eslintConfigs.some((config) => isFlatConfig(config))) {
     targetConfig.options.env = {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Inferred lint targets via the `@nx/eslint` plugin do not have any outputs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Inferred lint targets via the `@nx/eslint` plugin do not have outputs containing `{options.outputFile}`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
