### PR TITLE
fix(misc): dot nx setup shouldn't include target defaults

### DIFF
--- a/e2e/nx/src/nxw.test.ts
+++ b/e2e/nx/src/nxw.test.ts
@@ -18,6 +18,14 @@ describe('nx wrapper / .nx installation', () => {
 
   beforeAll(() => {
     runNxWrapper = newWrappedNxWorkspace();
+    updateJson<NxJsonConfiguration>('nx.json', (json) => {
+      json.targetDefaults ??= {};
+      json.targetDefaults.echo = { cache: true };
+      json.installation.plugins = {
+        '@nx/js': getPublishedVersion(),
+      };
+      return json;
+    });
   });
 
   afterAll(() => {
@@ -38,14 +46,6 @@ describe('nx wrapper / .nx installation', () => {
         },
       })
     );
-
-    updateJson<NxJsonConfiguration>('nx.json', (json) => {
-      json.targetDefaults.echo = { cache: true };
-      json.installation.plugins = {
-        '@nx/js': getPublishedVersion(),
-      };
-      return json;
-    });
 
     expect(runNxWrapper('echo a')).toContain('Hello from A');
 

--- a/packages/nx/src/command-line/add/add.spec.ts
+++ b/packages/nx/src/command-line/add/add.spec.ts
@@ -1,0 +1,13 @@
+import { nxVersion } from '../../utils/versions';
+import { coreNxPluginVersions } from './add';
+
+describe('nx core packages', () => {
+  it('should map nx packages to nx version', () => {
+    expect(coreNxPluginVersions.get('@nx/workspace')).toEqual(nxVersion);
+  });
+
+  it('should map nx-cloud to latest', () => {
+    expect(coreNxPluginVersions.get('@nrwl/nx-cloud')).toEqual('latest');
+    expect(coreNxPluginVersions.get('nx-cloud')).toEqual('latest');
+  });
+});

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -46,29 +46,18 @@ export function generateDotNxSetup(version?: string) {
   flushChanges(host.root, changes);
 }
 
+export function normalizeVersionForNxJson(pkg: string, version: string) {
+  if (!valid(version)) {
+    version = execSync(`npm view ${pkg}@${version} version`).toString();
+  }
+  return version.trimEnd();
+}
+
 export function writeMinimalNxJson(host: Tree, version: string) {
   if (!host.exists('nx.json')) {
-    if (!valid(version)) {
-      version = execSync(`npm view nx@${version} version`).toString();
-    }
     writeJson<NxJsonConfiguration>(host, 'nx.json', {
-      targetDefaults: {
-        build: {
-          cache: true,
-          dependsOn: ['^build'],
-        },
-        lint: {
-          cache: true,
-        },
-        test: {
-          cache: true,
-        },
-        e2e: {
-          cache: true,
-        },
-      },
       installation: {
-        version: version.trimEnd(),
+        version: normalizeVersionForNxJson('nx', version),
       },
     });
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- `nx add @nx/gradle` installs latest version
- `nx init` sets up target defaults
- `nx add package@beta` will add `beta` as the version, rather than resolving it to the tag.

## Expected Behavior
- `nx add @nx/gradle` installs version matching `nx`
- `nx init` lets plugin handle settings
- `nx add package@beta` will add the latest version matching the beta tag

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
