### PR TITLE
fix(release): update regex for remote URL

### DIFF
--- a/packages/nx/src/command-line/release/utils/github.ts
+++ b/packages/nx/src/command-line/release/utils/github.ts
@@ -43,7 +43,7 @@ export function getGitHubRepoSlug(remoteName = 'origin'): RepoSlug {
     }).trim();
 
     // Extract the 'user/repo' part from the URL
-    const regex = /github\.com[/:]([\w-]+\/[\w-]+)/;
+    const regex = /(?:github(?:\.|(?:(?:\.\w{2,}){1,})(?!\w))(?:[/:])|git@[\w.-]+:)([\w-]+\/[\w-]+)/;
     const match = remoteUrl.match(regex);
 
     if (match && match[1]) {


### PR DESCRIPTION
Updates remote URL regex to match on GitHub, GitHub Enterprise, and local git repositories.

## Current Behavior
Currently the regular expression will only match URLs beginning with `github.com`

## Expected Behavior
It should also match GitHub Enterprise as well as local git repositories

## Related Issue(s)

Fixes #23178
Closes #21906
