### PR TITLE
fix(core): ensure setting up nx cloud in nx migrate using the generator from the installed latest version

### DIFF
--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -1,5 +1,7 @@
 import { output } from '../../utils/output';
 import { readNxJson } from '../../config/configuration';
+import { FsTree, flushChanges } from '../../generators/tree';
+import { connectToNxCloud } from '../../nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud';
 import { getNxCloudUrl, isNxCloudUsed } from '../../utils/nx-cloud-utils';
 import { runNxSync } from '../../utils/child-process';
 import { NxJsonConfiguration } from '../../config/nx-json';
@@ -11,6 +13,7 @@ import {
   messages,
 } from '../../utils/ab-testing';
 import { nxVersion } from '../../utils/versions';
+import { workspaceRoot } from '../../utils/workspace-root';
 import chalk = require('chalk');
 
 export function onlyDefaultRunnerIsUsed(nxJson: NxJsonConfiguration) {
@@ -59,9 +62,12 @@ export async function connectToNxCloudCommand(): Promise<boolean> {
     return false;
   }
 
-  runNxSync(`g nx:connect-to-nx-cloud --quiet --no-interactive`, {
-    stdio: [0, 1, 2],
-  });
+  const tree = new FsTree(workspaceRoot, false, 'connect-to-nx-cloud');
+  const callback = await connectToNxCloud(tree, {});
+  tree.lock();
+  flushChanges(workspaceRoot, tree.listChanges());
+  callback();
+
   return true;
 }
 

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -89,8 +89,8 @@ function printSuccessMessage(url: string) {
 }
 
 interface ConnectToNxCloudOptions {
-  analytics: boolean;
-  installationSource: string;
+  analytics?: boolean;
+  installationSource?: string;
   hideFormatLogs?: boolean;
 }
 
@@ -114,6 +114,8 @@ export async function connectToNxCloud(
   tree: Tree,
   schema: ConnectToNxCloudOptions
 ) {
+  schema.installationSource ??= 'user';
+
   const nxJson = readNxJson(tree) as
     | null
     | (NxJsonConfiguration & { neverConnectToCloud: boolean });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Choosing to set up Nx Cloud during `nx migrate` executes the generator from the locally installed packages. This leads to the user getting an outdated flow and messaging.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Choosing to set up Nx Cloud during `nx migrate` should execute the generator from the installed latest version to ensure the user gets the up-to-date flow and messaging.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
