### PR TITLE
fix(core): forward process execArgv when using the native runner

### DIFF
--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -150,12 +150,12 @@ export class ChildProcess {
 }
 export class RustPseudoTerminal {
   constructor()
-  runCommand(command: string, commandDir?: string | undefined | null, jsEnv?: Record<string, string> | undefined | null, quiet?: boolean | undefined | null, tty?: boolean | undefined | null): ChildProcess
+  runCommand(command: string, commandDir?: string | undefined | null, jsEnv?: Record<string, string> | undefined | null, execArgv?: Array<string> | undefined | null, quiet?: boolean | undefined | null, tty?: boolean | undefined | null): ChildProcess
   /**
    * This allows us to run a pseudoterminal with a fake node ipc channel
    * this makes it possible to be backwards compatible with the old implementation
    */
-  fork(id: string, forkScript: string, pseudoIpcPath: string, commandDir: string | undefined | null, jsEnv: Record<string, string> | undefined | null, quiet: boolean): ChildProcess
+  fork(id: string, forkScript: string, pseudoIpcPath: string, commandDir: string | undefined | null, jsEnv: Record<string, string> | undefined | null, execArgv: Array<string> | undefined | null, quiet: boolean): ChildProcess
 }
 export class HashPlanner {
   constructor(nxJson: NxJson, projectGraph: ExternalObject<ProjectGraph>)

--- a/packages/nx/src/native/pseudo_terminal/mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/mac.rs
@@ -24,11 +24,12 @@ impl RustPseudoTerminal {
         command: String,
         command_dir: Option<String>,
         js_env: Option<HashMap<String, String>>,
+        exec_argv: Option<Vec<String>>,
         quiet: Option<bool>,
         tty: Option<bool>,
     ) -> napi::Result<ChildProcess> {
         let pseudo_terminal = create_pseudo_terminal()?;
-        run_command(&pseudo_terminal, command, command_dir, js_env, quiet, tty)
+        run_command(&pseudo_terminal, command, command_dir, js_env, exec_argv, quiet, tty)
     }
 
     /// This allows us to run a pseudoterminal with a fake node ipc channel
@@ -41,6 +42,7 @@ impl RustPseudoTerminal {
         pseudo_ipc_path: String,
         command_dir: Option<String>,
         js_env: Option<HashMap<String, String>>,
+        exec_argv: Option<Vec<String>>,
         quiet: bool,
     ) -> napi::Result<ChildProcess> {
         let command = format!(
@@ -51,6 +53,6 @@ impl RustPseudoTerminal {
         );
 
         trace!("nx_fork command: {}", &command);
-        self.run_command(command, command_dir, js_env, Some(quiet), Some(true))
+        self.run_command(command, command_dir, js_env, exec_argv, Some(quiet), Some(true))
     }
 }

--- a/packages/nx/src/native/pseudo_terminal/non_mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/non_mac.rs
@@ -29,6 +29,7 @@ impl RustPseudoTerminal {
         command: String,
         command_dir: Option<String>,
         js_env: Option<HashMap<String, String>>,
+        exec_argv: Option<Vec<String>>,
         quiet: Option<bool>,
         tty: Option<bool>,
     ) -> napi::Result<ChildProcess> {
@@ -37,6 +38,7 @@ impl RustPseudoTerminal {
             command,
             command_dir,
             js_env,
+            exec_argv,
             quiet,
             tty,
         )
@@ -52,6 +54,7 @@ impl RustPseudoTerminal {
         pseudo_ipc_path: String,
         command_dir: Option<String>,
         js_env: Option<HashMap<String, String>>,
+        exec_argv: Option<Vec<String>>,
         quiet: bool,
     ) -> napi::Result<ChildProcess> {
         let command = format!(
@@ -62,6 +65,6 @@ impl RustPseudoTerminal {
         );
 
         trace!("nx_fork command: {}", &command);
-        self.run_command(command, command_dir, js_env, Some(quiet), Some(true))
+        self.run_command(command, command_dir, js_env, exec_argv, Some(quiet), Some(true))
     }
 }

--- a/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
+++ b/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
@@ -117,6 +117,7 @@ pub fn run_command(
     command: String,
     command_dir: Option<String>,
     js_env: Option<HashMap<String, String>>,
+    exec_argv: Option<Vec<String>>,
     quiet: Option<bool>,
     tty: Option<bool>,
 ) -> napi::Result<ChildProcess> {
@@ -136,6 +137,10 @@ pub fn run_command(
         for (key, value) in js_env {
             cmd.env(key, value);
         }
+    }
+
+    if let Some(exec_argv) = exec_argv {
+        cmd.env("NX_PSEUDO_TERMINAL_EXEC_ARGV", exec_argv.join("|"));
     }
 
     let (exit_to_process_tx, exit_to_process_rx) = bounded(1);

--- a/packages/nx/src/tasks-runner/fork.ts
+++ b/packages/nx/src/tasks-runner/fork.ts
@@ -7,8 +7,16 @@ const forkId = process.argv[3];
 
 const script = join(__dirname, '../../bin/run-executor.js');
 
+let execArgv: string[] | undefined;
+if (process.env['NX_PSEUDO_TERMINAL_EXEC_ARGV']) {
+  execArgv = process.env['NX_PSEUDO_TERMINAL_EXEC_ARGV'].split('|');
+  delete process.env['NX_PSEUDO_TERMINAL_EXEC_ARGV'];
+}
+
 const childProcess = fork(script, {
   stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+  env: process.env,
+  execArgv,
 });
 
 const pseudoIPC = new PseudoIPCClient(pseudoIPCPath);

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -220,6 +220,7 @@ export class ForkedProcessTaskRunner {
     const childId = task.id;
     const p = await this.pseudoTerminal.fork(childId, forkScript, {
       cwd: process.cwd(),
+      execArgv: process.execArgv,
       jsEnv: env,
       quiet: !streamOutput,
     });

--- a/packages/nx/src/tasks-runner/pseudo-terminal.ts
+++ b/packages/nx/src/tasks-runner/pseudo-terminal.ts
@@ -41,18 +41,27 @@ export class PseudoTerminal {
     command: string,
     {
       cwd,
+      execArgv,
       jsEnv,
       quiet,
       tty,
     }: {
       cwd?: string;
+      execArgv?: string[];
       jsEnv?: Record<string, string>;
       quiet?: boolean;
       tty?: boolean;
     } = {}
   ) {
     return new PseudoTtyProcess(
-      this.rustPseudoTerminal.runCommand(command, cwd, jsEnv, quiet, tty)
+      this.rustPseudoTerminal.runCommand(
+        command,
+        cwd,
+        jsEnv,
+        execArgv,
+        quiet,
+        tty
+      )
     );
   }
 
@@ -61,10 +70,12 @@ export class PseudoTerminal {
     script: string,
     {
       cwd,
+      execArgv,
       jsEnv,
       quiet,
     }: {
       cwd?: string;
+      execArgv?: string[];
       jsEnv?: Record<string, string>;
       quiet?: boolean;
     }
@@ -79,6 +90,7 @@ export class PseudoTerminal {
         this.pseudoIPCPath,
         cwd,
         jsEnv,
+        execArgv,
         quiet
       ),
       id,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When using the native runner, the forked process doesn't use the parent process environment variables and `execArgv`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When using the native runner, the forked process should inherit the parent process environment variables and `execArgv`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22221 
Fixes #22297 
