### PR TITLE
feat(graph): add expandedTargets to project details on nx dev

### DIFF
--- a/docs/shared/tutorials/gradle.md
+++ b/docs/shared/tutorials/gradle.md
@@ -119,7 +119,7 @@ that we've installed reflects Gradle's tasks to Nx, which allows it to run any o
 ./nx show project application --web
 ```
 
-{% project-details title="Project Details View" jsonFile="shared/tutorials/gradle-pdv.json" %}
+{% project-details title="Project Details View" jsonFile="shared/tutorials/gradle-pdv.json" expandedTargets=["build"] %}
 {% /project-details %}
 
 The Nx command to run the `build` task for the `application` project is:

--- a/graph/shared/src/lib/expanded-targets-provider.tsx
+++ b/graph/shared/src/lib/expanded-targets-provider.tsx
@@ -7,8 +7,16 @@ export const ExpandedTargetsContext = createContext<{
   collapseAllTargets?: () => void;
 }>({});
 
-export const ExpandedTargetsProvider = ({ children }) => {
-  const [expandedTargets, setExpandedTargets] = useState<string[]>([]);
+export const ExpandedTargetsProvider = ({
+  children,
+  initialExpanededTargets = [],
+}: {
+  children: React.ReactNode;
+  initialExpanededTargets?: string[];
+}) => {
+  const [expandedTargets, setExpandedTargets] = useState<string[]>(
+    initialExpanededTargets
+  );
 
   const toggleTarget = (targetName: string) => {
     setExpandedTargets((prevExpandedTargets) => {

--- a/nx-dev/ui-markdoc/src/lib/tags/project-details.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/project-details.component.tsx
@@ -19,11 +19,13 @@ export function ProjectDetails({
   height,
   title,
   jsonFile,
+  expandedTargets = [],
   children,
 }: {
   height: string;
   title: string;
   jsonFile?: string;
+  expandedTargets?: string[];
   children: ReactElement;
 }): JSX.Element {
   const [parsedProps, setParsedProps] = useState<any>();
@@ -81,7 +83,7 @@ export function ProjectDetails({
           height ? `p-4 h-[${height}] overflow-y-auto` : 'p-4'
         }`}
       >
-        <ExpandedTargetsProvider>
+        <ExpandedTargetsProvider initialExpanededTargets={expandedTargets}>
           <ProjectDetailsUi
             project={parsedProps.project}
             sourceMap={parsedProps.sourceMap}

--- a/nx-dev/ui-markdoc/src/lib/tags/project-details.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/tags/project-details.schema.ts
@@ -14,5 +14,8 @@ export const projectDetails: Schema = {
     height: {
       type: 'String',
     },
+    expandedTargets: {
+      type: 'Array',
+    },
   },
 };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
now in nx.dev, we can set which targets are opened in project details in markdown:
```
{% project-details title="Project Details View" height="100px" expandedTargets=["test"] %}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
