### PR TITLE
fix(release): ensure changelog renderers are resolvable when processing config

### DIFF
--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -3,7 +3,6 @@ import { prompt } from 'enquirer';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { valid } from 'semver';
 import { dirSync } from 'tmp';
-import type { ChangelogRenderer } from '../../../release/changelog-renderer';
 import {
   NxReleaseChangelogConfiguration,
   readNxJson,
@@ -13,7 +12,6 @@ import {
   ProjectGraphProjectNode,
 } from '../../config/project-graph';
 import { FsTree, Tree } from '../../generators/tree';
-import { registerTsProject } from '../../plugins/js/utils/register';
 import { createProjectFileMapUsingProjectGraph } from '../../project-graph/file-map-utils';
 import { createProjectGraphAsync } from '../../project-graph/project-graph';
 import { interpolate } from '../../tasks-runner/utils';
@@ -47,6 +45,7 @@ import { createOrUpdateGithubRelease, getGitHubRepoSlug } from './utils/github';
 import { launchEditor } from './utils/launch-editor';
 import { parseChangelogMarkdown } from './utils/markdown';
 import { printAndFlushChanges } from './utils/print-changes';
+import { resolveChangelogRenderer } from './utils/resolve-changelog-renderer';
 import { resolveNxJsonConfigErrorMessage } from './utils/resolve-nx-json-error-message';
 import {
   ReleaseVersion,
@@ -57,7 +56,6 @@ import {
   handleDuplicateGitTags,
   noDiffInChangelogMessage,
 } from './utils/shared';
-import { getRootTsConfigPath } from '../../plugins/js/utils/typescript';
 
 export interface NxReleaseChangelogResult {
   workspaceChangelog?: {
@@ -639,30 +637,6 @@ async function applyChangesAndExit(
   }
 
   return;
-}
-
-function resolveChangelogRenderer(
-  changelogRendererPath: string
-): ChangelogRenderer {
-  const interpolatedChangelogRendererPath = interpolate(changelogRendererPath, {
-    workspaceRoot,
-  });
-
-  // Try and load the provided (or default) changelog renderer
-  let changelogRenderer: ChangelogRenderer;
-  let cleanupTranspiler = () => {};
-  try {
-    const rootTsconfigPath = getRootTsConfigPath();
-    if (rootTsconfigPath) {
-      cleanupTranspiler = registerTsProject(rootTsconfigPath);
-    }
-    const r = require(interpolatedChangelogRendererPath);
-    changelogRenderer = r.default || r;
-  } catch {
-  } finally {
-    cleanupTranspiler();
-  }
-  return changelogRenderer;
 }
 
 async function generateChangelogForWorkspace(

--- a/packages/nx/src/command-line/release/utils/resolve-changelog-renderer.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-changelog-renderer.ts
@@ -1,0 +1,30 @@
+import type { ChangelogRenderer } from '../../../../release/changelog-renderer';
+import { registerTsProject } from '../../../plugins/js/utils/register';
+import { getRootTsConfigPath } from '../../../plugins/js/utils/typescript';
+import { interpolate } from '../../../tasks-runner/utils';
+import { workspaceRoot } from '../../../utils/workspace-root';
+
+export function resolveChangelogRenderer(
+  changelogRendererPath: string
+): ChangelogRenderer {
+  const interpolatedChangelogRendererPath = interpolate(changelogRendererPath, {
+    workspaceRoot,
+  });
+
+  // Try and load the provided (or default) changelog renderer
+  let changelogRenderer: ChangelogRenderer;
+  let cleanupTranspiler = () => {};
+  try {
+    const rootTsconfigPath = getRootTsConfigPath();
+    if (rootTsconfigPath) {
+      cleanupTranspiler = registerTsProject(rootTsconfigPath);
+    }
+    const r = require(interpolatedChangelogRendererPath);
+    changelogRenderer = r.default || r;
+  } catch (err) {
+    throw err;
+  } finally {
+    cleanupTranspiler();
+  }
+  return changelogRenderer;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

- If there is an issue rendering or processing the configured (or default) changelog renderer the underlying error gets swallowed
- You only find out about the issue as part of the changelog step, which is most likely after projects have already been versioned which could have had side-effects which are cumbersome to undo.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

- Any and all issues with resolving changelog renderers is handled upfront during config processing/validation
- If an error does occur when processing the changelog renderer(s) then that raw error will be surfaced directly to the user

E.g. with the new experience (based on a TS configuration issue in the worksapce which breaks the ts register logic within nx):

<img width="1218" alt="image" src="https://github.com/nrwl/nx/assets/900523/4ec7cae6-f327-4214-bac7-789ecdf73a0d">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
