### PR TITLE
docs(core): collapse concepts and recipes

### DIFF
--- a/nx-dev/data-access-menu/src/lib/menu.utils.ts
+++ b/nx-dev/data-access-menu/src/lib/menu.utils.ts
@@ -1,5 +1,7 @@
 import { MenuItem, MenuSection } from '@nx/nx-dev/models-menu';
 
+const COLLAPSIBLE_SECTIONS = ['concepts', 'recipes'];
+
 export function getBasicNxSection(items: MenuItem[]): MenuSection {
   return {
     id: 'basic',
@@ -19,7 +21,9 @@ export function getBasicNxSection(items: MenuItem[]): MenuSection {
       .map((m) => {
         return {
           ...m,
-          disableCollapsible: !m.id.endsWith('tutorial'),
+          disableCollapsible: !COLLAPSIBLE_SECTIONS.some((collapsibleSection) =>
+            m.id.endsWith(collapsibleSection)
+          ),
         };
       }),
   };


### PR DESCRIPTION
Collapse the concepts and recipes sections by default

![Screenshot 2024-05-07 at 11 34 05 AM](https://github.com/nrwl/nx/assets/861504/1428c5e9-9c46-4001-b9dc-d06e2efa086d)
