### PR TITLE
docs(core): add missing option for dep-checks lint rule

### DIFF
--- a/docs/generated/packages/eslint-plugin/documents/dependency-checks.md
+++ b/docs/generated/packages/eslint-plugin/documents/dependency-checks.md
@@ -61,12 +61,13 @@ Sometimes we intentionally want to add or remove a dependency from our `package.
     "error",
     {
       "buildTargets": ["build", "custom-build"], // add non standard build target names
-      "ignoredDependencies": ["lodash"], // these libs will be omitted from checks
-      "includeTransitiveDependencies": true, // collect dependencies transitively from children
-      "ignoredFiles": ["webpack.config.js", "eslint.config.js"], // list of files that should be skipped for check
       "checkMissingDependencies": true, // toggle to disable
       "checkObsoleteDependencies": true, // toggle to disable
-      "checkVersionMismatches": true // toggle to disable
+      "checkVersionMismatches": true, // toggle to disable
+      "ignoredDependencies": ["lodash"], // these libs will be omitted from checks
+      "ignoredFiles": ["webpack.config.js", "eslint.config.js"], // list of files that should be skipped for check
+      "includeTransitiveDependencies": true, // collect dependencies transitively from children
+      "useLocalPathsForWorkspaceDependencies": true // toggle to disable
     }
   ]
 }
@@ -74,12 +75,13 @@ Sometimes we intentionally want to add or remove a dependency from our `package.
 
 ## Options
 
-| Property                      | Type            | Default     | Description                                                                                                                               |
-| ----------------------------- | --------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| buildTargets                  | _Array<string>_ | _["build"]_ | List of build target names                                                                                                                |
-| ignoredDependencies           | _Array<string>_ | _[]_        | List of dependencies to ignore for checks                                                                                                 |
-| includeTransitiveDependencies | _boolean_       | _false_     | Enable to collect dependencies of children projects                                                                                       |
-| ignoredFiles                  | _Array<string>_ | N/A         | List of files to ignore when collecting dependencies. The default value will be set based on the selected executor during the generation. |
-| checkMissingDependencies      | _boolean_       | _true_      | Disable to skip checking for missing dependencies                                                                                         |
-| checkObsoleteDependencies     | _boolean_       | _true_      | Disable to skip checking for unused dependencies                                                                                          |
-| checkVersionMismatches        | _boolean_       | _true_      | Disable to skip checking if version specifier matches installed version                                                                   |
+| Property                              | Type            | Default     | Description                                                                                                                               |
+| ------------------------------------- | --------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| buildTargets                          | _Array<string>_ | _["build"]_ | List of build target names                                                                                                                |
+| checkMissingDependencies              | _boolean_       | _true_      | Disable to skip checking for missing dependencies                                                                                         |
+| checkObsoleteDependencies             | _boolean_       | _true_      | Disable to skip checking for unused dependencies                                                                                          |
+| checkVersionMismatches                | _boolean_       | _true_      | Disable to skip checking if version specifier matches installed version                                                                   |
+| ignoredDependencies                   | _Array<string>_ | _[]_        | List of dependencies to ignore for checks                                                                                                 |
+| ignoredFiles                          | _Array<string>_ | N/A         | List of files to ignore when collecting dependencies. The default value will be set based on the selected executor during the generation. |
+| includeTransitiveDependencies         | _boolean_       | _false_     | Enable to collect dependencies of children projects                                                                                       |
+| useLocalPathsForWorkspaceDependencies | _boolean_       | _false_     | Set workspace dependencies as relative file:// paths. Useful for monorepos that link via file:// in package.json files.                   |

--- a/docs/shared/packages/eslint/dependency-checks.md
+++ b/docs/shared/packages/eslint/dependency-checks.md
@@ -61,12 +61,13 @@ Sometimes we intentionally want to add or remove a dependency from our `package.
     "error",
     {
       "buildTargets": ["build", "custom-build"], // add non standard build target names
-      "ignoredDependencies": ["lodash"], // these libs will be omitted from checks
-      "includeTransitiveDependencies": true, // collect dependencies transitively from children
-      "ignoredFiles": ["webpack.config.js", "eslint.config.js"], // list of files that should be skipped for check
       "checkMissingDependencies": true, // toggle to disable
       "checkObsoleteDependencies": true, // toggle to disable
-      "checkVersionMismatches": true // toggle to disable
+      "checkVersionMismatches": true, // toggle to disable
+      "ignoredDependencies": ["lodash"], // these libs will be omitted from checks
+      "ignoredFiles": ["webpack.config.js", "eslint.config.js"], // list of files that should be skipped for check
+      "includeTransitiveDependencies": true, // collect dependencies transitively from children
+      "useLocalPathsForWorkspaceDependencies": true // toggle to disable
     }
   ]
 }
@@ -74,12 +75,13 @@ Sometimes we intentionally want to add or remove a dependency from our `package.
 
 ## Options
 
-| Property                      | Type            | Default     | Description                                                                                                                               |
-| ----------------------------- | --------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| buildTargets                  | _Array<string>_ | _["build"]_ | List of build target names                                                                                                                |
-| ignoredDependencies           | _Array<string>_ | _[]_        | List of dependencies to ignore for checks                                                                                                 |
-| includeTransitiveDependencies | _boolean_       | _false_     | Enable to collect dependencies of children projects                                                                                       |
-| ignoredFiles                  | _Array<string>_ | N/A         | List of files to ignore when collecting dependencies. The default value will be set based on the selected executor during the generation. |
-| checkMissingDependencies      | _boolean_       | _true_      | Disable to skip checking for missing dependencies                                                                                         |
-| checkObsoleteDependencies     | _boolean_       | _true_      | Disable to skip checking for unused dependencies                                                                                          |
-| checkVersionMismatches        | _boolean_       | _true_      | Disable to skip checking if version specifier matches installed version                                                                   |
+| Property                              | Type            | Default     | Description                                                                                                                               |
+| ------------------------------------- | --------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| buildTargets                          | _Array<string>_ | _["build"]_ | List of build target names                                                                                                                |
+| checkMissingDependencies              | _boolean_       | _true_      | Disable to skip checking for missing dependencies                                                                                         |
+| checkObsoleteDependencies             | _boolean_       | _true_      | Disable to skip checking for unused dependencies                                                                                          |
+| checkVersionMismatches                | _boolean_       | _true_      | Disable to skip checking if version specifier matches installed version                                                                   |
+| ignoredDependencies                   | _Array<string>_ | _[]_        | List of dependencies to ignore for checks                                                                                                 |
+| ignoredFiles                          | _Array<string>_ | N/A         | List of files to ignore when collecting dependencies. The default value will be set based on the selected executor during the generation. |
+| includeTransitiveDependencies         | _boolean_       | _false_     | Enable to collect dependencies of children projects                                                                                       |
+| useLocalPathsForWorkspaceDependencies | _boolean_       | _false_     | Set workspace dependencies as relative file:// paths. Useful for monorepos that link via file:// in package.json files.                   |


### PR DESCRIPTION
This option was added in https://github.com/nrwl/nx/pull/20157 but never made it into docs.

<img width="951" alt="Screenshot 2024-05-08 at 9 34 00 AM" src="https://github.com/nrwl/nx/assets/53559/b43fc774-2a68-49b2-8709-b43a685a520b">
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
