### PR TITLE
fix(linter): ensure config.rules is spread into rules in flat config migration

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
@@ -35,12 +35,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "
@@ -85,12 +89,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "
@@ -130,12 +138,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "
@@ -174,12 +186,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   { ignores: ['ignore/me'] },
 ];
@@ -221,12 +237,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "
@@ -275,12 +295,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "
@@ -320,12 +344,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "
@@ -364,12 +392,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "
@@ -429,12 +461,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "
@@ -494,12 +530,16 @@ module.exports = [
   ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
   ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
     ...config,
     files: ['**/*.js', '**/*.jsx'],
-    rules: {},
+    rules: {
+      ...config.rules,
+    },
   })),
 ];
 "

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
@@ -102,7 +102,9 @@ describe('convertEslintJsonToFlatConfig', () => {
                   "**/*.ts",
                   "**/*.tsx"
               ],
-              rules: {}
+              rules: {
+                  ...config.rules
+              }
           })),
           ...compat.config({ env: { jest: true } }).map(config => ({
               ...config,
@@ -112,7 +114,9 @@ describe('convertEslintJsonToFlatConfig', () => {
                   "**/*.spec.js",
                   "**/*.spec.jsx"
               ],
-              rules: {}
+              rules: {
+                  ...config.rules
+              }
           })),
           { ignores: ["src/ignore/to/keep.ts"] },
           { ignores: ["something/else"] }
@@ -221,7 +225,10 @@ describe('convertEslintJsonToFlatConfig', () => {
           ...compat.config({ parser: "jsonc-eslint-parser" }).map(config => ({
               ...config,
               files: ["**/*.json"],
-              rules: { "@nx/dependency-checks": "error" }
+              rules: {
+                  ...config.rules,
+                  "@nx/dependency-checks": "error"
+              }
           })),
           { ignores: [".next/**/*"] },
           { ignores: ["something/else"] }

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -179,12 +179,16 @@ describe('convert-to-flat-config generator', () => {
         ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
           ...config,
           files: ['**/*.ts', '**/*.tsx'],
-          rules: {},
+          rules: {
+            ...config.rules,
+          },
         })),
         ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
           ...config,
           files: ['**/*.js', '**/*.jsx'],
-          rules: {},
+          rules: {
+            ...config.rules,
+          },
         })),
       ];
       "
@@ -424,12 +428,16 @@ describe('convert-to-flat-config generator', () => {
         ...compat.config({ extends: ['plugin:@nx/typescript'] }).map((config) => ({
           ...config,
           files: ['**/*.ts', '**/*.tsx'],
-          rules: {},
+          rules: {
+            ...config.rules,
+          },
         })),
         ...compat.config({ extends: ['plugin:@nx/javascript'] }).map((config) => ({
           ...config,
           files: ['**/*.js', '**/*.jsx'],
-          rules: {},
+          rules: {
+            ...config.rules,
+          },
         })),
       ];
       "

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -775,7 +775,7 @@ export function generateFlatOverride(
   addTSObjectProperty(objectLiteralElements, 'excludedFiles', excludedFiles);
 
   // Apply rules (and spread ...config.rules into it as the first assignment)
-  addTSObjectProperty(objectLiteralElements, 'rules', rules);
+  addTSObjectProperty(objectLiteralElements, 'rules', rules || {});
   const rulesObjectAST = objectLiteralElements.pop() as ts.PropertyAssignment;
   const rulesObjectInitializer =
     rulesObjectAST.initializer as ts.ObjectLiteralExpression;

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -773,7 +773,26 @@ export function generateFlatOverride(
   ];
   addTSObjectProperty(objectLiteralElements, 'files', files);
   addTSObjectProperty(objectLiteralElements, 'excludedFiles', excludedFiles);
+
+  // Apply rules (and spread ...config.rules into it as the first assignment)
   addTSObjectProperty(objectLiteralElements, 'rules', rules);
+  const rulesObjectAST = objectLiteralElements.pop() as ts.PropertyAssignment;
+  const rulesObjectInitializer =
+    rulesObjectAST.initializer as ts.ObjectLiteralExpression;
+  const spreadAssignment = ts.factory.createSpreadAssignment(
+    ts.factory.createIdentifier('config.rules')
+  );
+  const updatedRulesProperties = [
+    spreadAssignment,
+    ...rulesObjectInitializer.properties,
+  ];
+  objectLiteralElements.push(
+    ts.factory.createPropertyAssignment(
+      'rules',
+      ts.factory.createObjectLiteralExpression(updatedRulesProperties, true)
+    )
+  );
+
   if (parserOptions) {
     addTSObjectProperty(objectLiteralElements, 'languageSettings', {
       parserOptions,

--- a/packages/next/src/generators/application/lib/add-linting.spec.ts
+++ b/packages/next/src/generators/application/lib/add-linting.spec.ts
@@ -164,7 +164,10 @@ describe('updateEslint', () => {
               "**/*.spec.tsx",
               "**/*.spec.js",
               "**/*.spec.jsx"
-          ]
+          ],
+          rules: {
+              ...config.rules,
+          }
       })),
       { ignores: [".next/**/*"] }
       ];

--- a/packages/next/src/generators/application/lib/add-linting.spec.ts
+++ b/packages/next/src/generators/application/lib/add-linting.spec.ts
@@ -166,7 +166,7 @@ describe('updateEslint', () => {
               "**/*.spec.jsx"
           ],
           rules: {
-              ...config.rules,
+              ...config.rules
           }
       })),
       { ignores: [".next/**/*"] }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

As part of the eslint flat config migration, the rules from the config being applied via `FlatCompat` are negated by applying an empty object after the `...config` spread in migrated configs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The rules from the config being applied via `FlatCompat` are spread into the rules object as the first assignment to ensure that they are not negated as part of the flat config migration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23077
