### PR TITLE
fix(core): Handle removing non-empty directories and non-existing paths in cache

### DIFF
--- a/packages/nx/src/native/cache/file_ops.rs
+++ b/packages/nx/src/native/cache/file_ops.rs
@@ -1,14 +1,17 @@
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use fs_extra::error::ErrorKind;
-
 #[napi]
 pub fn remove(src: String) -> anyhow::Result<()> {
-    fs_extra::remove_items(&[src]).map_err(|err| match err.kind {
-        ErrorKind::Io(err_kind) => anyhow::Error::new(err_kind),
-        _ => anyhow::Error::new(err),
-    })
+    fs::metadata(&src)
+        .and_then(|metadata| {
+            if metadata.is_dir() {
+                fs::remove_dir_all(src)
+            } else {
+                fs::remove_file(src)
+            }
+        })
+        .map_err(anyhow::Error::new)
 }
 
 #[napi]

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -1,5 +1,5 @@
 import { workspaceRoot } from '../utils/workspace-root';
-import { mkdir, mkdirSync, pathExists, readFile, writeFile, remove as fsRemove } from 'fs-extra';
+import { mkdir, mkdirSync, pathExists, readFile, writeFile } from 'fs-extra';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
@@ -203,11 +203,15 @@ export class Cache {
   }
 
   private async remove(path: string): Promise<void> {
-    try {
-      fsRemove(path);
-    } catch (e) {
-      // It's okay if this fails, the OS will clean it up eventually
-    }
+    const { remove } = require('../native');
+    return new Promise((res, rej) => {
+      try {
+        remove(path);
+        res();
+      } catch (e) {
+        rej(e);
+      }
+    });
   }
 
   private async getFromLocalDir(task: Task) {

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -1,5 +1,5 @@
 import { workspaceRoot } from '../utils/workspace-root';
-import { mkdir, mkdirSync, pathExists, readFile, writeFile } from 'fs-extra';
+import { mkdir, mkdirSync, pathExists, readFile, writeFile, remove } from 'fs-extra';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
@@ -90,8 +90,8 @@ export class Cache {
       const tdCommit = join(this.cachePath, `${task.hash}.commit`);
 
       // might be left overs from partially-completed cache invocations
-      await this.remove(tdCommit);
-      await this.remove(td);
+      await remove(tdCommit);
+      await remove(td);
 
       await mkdir(td);
       await writeFile(
@@ -145,7 +145,7 @@ export class Cache {
           const cached = join(cachedResult.outputsPath, f);
           if (await pathExists(cached)) {
             const src = join(this.root, f);
-            await this.remove(src);
+            await remove(src);
             await this.copy(cached, src);
           }
         })
@@ -195,18 +195,6 @@ export class Cache {
     return new Promise((res, rej) => {
       try {
         copy(src, destination);
-        res();
-      } catch (e) {
-        rej(e);
-      }
-    });
-  }
-
-  private async remove(path: string): Promise<void> {
-    const { remove } = require('../native');
-    return new Promise((res, rej) => {
-      try {
-        remove(path);
         res();
       } catch (e) {
         rej(e);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When running NX concurrently sometimes NX is trying to remove non-existing path (which have been already deleted by other process) or non-empty directories (which contains files created by other process but not yet removed)

To prevent race conditions, remove from fs-extra works in following way:
> Removes a file or directory. **The directory can have contents. If the path does not exist, silently does nothing.**

## Expected Behavior
Remove operations should work with non-existing paths as well as non-empty directories

## Related Issue(s)

Fixes #22140
