### PR TITLE
fix(vite): support passing --watch to inferred vitest commands

### DIFF
--- a/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
       "targets": {
         "test": {
           "cache": true,
-          "command": "vitest run",
+          "command": "vitest",
           "inputs": [
             "default",
             "^production",
@@ -20,6 +20,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
           ],
           "options": {
             "cwd": ".",
+            "watch": false,
           },
           "outputs": [
             "{projectRoot}/coverage",

--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
       "targets": {
         "test": {
           "cache": true,
-          "command": "vitest run",
+          "command": "vitest",
           "inputs": [
             "default",
             "^production",
@@ -20,6 +20,7 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
           ],
           "options": {
             "cwd": ".",
+            "watch": false,
           },
           "outputs": [
             "{projectRoot}/coverage",

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -215,8 +215,8 @@ async function testTarget(
   projectRoot: string
 ) {
   return {
-    command: `vitest run`,
-    options: { cwd: joinPathFragments(projectRoot) },
+    command: `vitest`,
+    options: { cwd: joinPathFragments(projectRoot), watch: false },
     cache: true,
     inputs: [
       ...('production' in namedInputs


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We currently do not handle passing `--watch` when running inferred `vitest` commands

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should support handling `--watch`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23185
