### PR TITLE
fix(misc): move e2e-ci to a separate parallel 1 command

### DIFF
--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -54,7 +54,8 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - script: npx nx-cloud record -- echo Hello World
-      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build e2e-ci
+      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) lint test build
+      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --parallel 1 e2e-ci
 "
 `;
 
@@ -79,7 +80,8 @@ pipelines:
             - npm ci
 
             - npx nx-cloud record -- nx format:check
-            - npx nx affected -t lint test build e2e-ci --base=origin/main
+            - npx nx affected --base=origin/main -t lint test build
+            - npx nx affected --base=origin/main --parallel 1 -t e2e-ci
 
   branches:
     main:
@@ -122,7 +124,8 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World
-      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build e2e-ci
+      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build
+      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --parallel 1 -t e2e-ci
 
 workflows:
   version: 2
@@ -168,7 +171,8 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World
-      - run: npx nx affected -t lint test build e2e-ci
+      - run: npx nx affected -t lint test build
+      - run: npx nx affected --parallel 1 -t e2e-ci
 "
 `;
 
@@ -207,7 +211,8 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World
-      - run: npx nx affected -t lint test build e2e-ci
+      - run: npx nx affected -t lint test build
+      - run: npx nx affected --parallel 1 -t e2e-ci
 "
 `;
 
@@ -265,7 +270,7 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - script: npx nx-cloud record -- echo Hello World
-      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) lint test build
 "
 `;
 
@@ -290,7 +295,7 @@ pipelines:
             - npm ci
 
             - npx nx-cloud record -- nx format:check
-            - npx nx affected -t lint test build --base=origin/main
+            - npx nx affected --base=origin/main -t lint test build
 
   branches:
     main:
@@ -505,7 +510,7 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - script: pnpm exec nx-cloud record -- echo Hello World
-      - script: pnpm exec nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+      - script: pnpm exec nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) lint test build
 "
 `;
 
@@ -532,7 +537,7 @@ pipelines:
             - pnpm install --frozen-lockfile
 
             - pnpm exec nx-cloud record -- nx format:check
-            - pnpm exec nx affected -t lint test build --base=origin/main
+            - pnpm exec nx affected --base=origin/main -t lint test build
 
   branches:
     main:
@@ -760,7 +765,7 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - script: yarn nx-cloud record -- echo Hello World
-      - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+      - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) lint test build
 "
 `;
 
@@ -785,7 +790,7 @@ pipelines:
             - yarn install --frozen-lockfile
 
             - yarn nx-cloud record -- nx format:check
-            - yarn nx affected -t lint test build --base=origin/main
+            - yarn nx affected --base=origin/main -t lint test build
 
   branches:
     main:

--- a/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
@@ -56,4 +56,5 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - script: <%= packageManagerPrefix %> nx-cloud record -- echo Hello World
-      - script: <%= packageManagerPrefix %> nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build<% if(hasE2E){ %> e2e-ci<% } %>
+      - script: <%= packageManagerPrefix %> nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) lint test build<% if(hasE2E){ %>
+      - script: <%= packageManagerPrefix %> nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --parallel 1 e2e-ci<% } %>

--- a/packages/workspace/src/generators/ci-workflow/files/bitbucket-pipelines/bitbucket-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/bitbucket-pipelines/bitbucket-pipelines.yml__tmpl__
@@ -22,7 +22,8 @@ pipelines:
             - <%= packageManagerInstall %>
 
             - <%= packageManagerPrefix %> nx-cloud record -- nx format:check
-            - <%= packageManagerPrefix %> nx affected -t lint test build<% if(hasE2E){ %> e2e-ci<% } %> --base=origin/<%= mainBranch %>
+            - <%= packageManagerPrefix %> nx affected --base=origin/<%= mainBranch %> -t lint test build<% if(hasE2E){ %>
+            - <%= packageManagerPrefix %> nx affected --base=origin/<%= mainBranch %> --parallel 1 -t e2e-ci<% } %>
 
   branches:
     main:

--- a/packages/workspace/src/generators/ci-workflow/files/circleci/.circleci/config.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/circleci/.circleci/config.yml__tmpl__
@@ -25,7 +25,8 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: <%= packageManagerPrefix %> nx-cloud record -- echo Hello World
-      - run: <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build<% if(hasE2E){ %> e2e-ci<% } %>
+      - run: <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build<% if(hasE2E){ %>
+      - run: <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD --parallel 1 -t e2e-ci<% } %>
 
 workflows:
   version: 2

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -37,4 +37,5 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: <%= packageManagerPrefix %> nx-cloud record -- echo Hello World
-      - run: <%= packageManagerPrefix %> nx affected -t lint test build<% if(hasE2E){ %> e2e-ci<% } %>
+      - run: <%= packageManagerPrefix %> nx affected -t lint test build<% if(hasE2E){ %>
+      - run: <%= packageManagerPrefix %> nx affected --parallel 1 -t e2e-ci<% } %>

--- a/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
@@ -22,4 +22,5 @@ variables:
 
     # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
     # - <%= packageManagerPrefix %> nx-cloud record -- echo Hello World
-    - <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build<% if(hasE2E){ %> e2e-ci<% } %>
+    - <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build<% if(hasE2E){ %>
+    - <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD --parallel 1 -t e2e-ci<% } %>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The generated `ci-workflow` runs `e2e-ci` with `parallel: 3` by default.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The generated `ci-workflow` runs `e2e-ci` in a separate step with `parallel: 1`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
