### PR TITLE
docs(nx-cloud): fix nx-cloud validate command example path

### DIFF
--- a/docs/nx-cloud/reference/launch-templates.md
+++ b/docs/nx-cloud/reference/launch-templates.md
@@ -321,7 +321,7 @@ within the launch template and all respective inputs within each step are approp
 To do this, run the `nx-cloud validate` command, with the path to the launch template:
 
 ```shell
-nx-cloud validate --workflow-file=./nx/workflows/agents.yaml
+nx-cloud validate --workflow-file=./.nx/workflows/agents.yaml
 ```
 
 ## Pass Environment Variables to Agents


### PR DESCRIPTION
the default path for custom launch templates is under `./.nx/workflows/agents.yaml` and the path was missing a `.`