### PR TITLE
fix(misc): various inference plugins caching should track changes

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -348,6 +348,7 @@ describe('@nx/cypress/plugin', () => {
   });
 
   function mockCypressConfig(cypressConfig: Cypress.ConfigOptions) {
+    tempFs.createFileSync('cypress.config.js', JSON.stringify(cypressConfig));
     jest.mock(
       join(tempFs.tempDir, 'cypress.config.js'),
       () => ({

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -348,6 +348,9 @@ describe('@nx/cypress/plugin', () => {
   });
 
   function mockCypressConfig(cypressConfig: Cypress.ConfigOptions) {
+    // This isn't JS, but all that really matters here
+    // is that the hash is different after updating the
+    // config file. The actual config read is mocked below.
     tempFs.createFileSync('cypress.config.js', JSON.stringify(cypressConfig));
     jest.mock(
       join(tempFs.tempDir, 'cypress.config.js'),

--- a/packages/gradle/src/plugin/dependencies.ts
+++ b/packages/gradle/src/plugin/dependencies.ts
@@ -13,7 +13,7 @@ import {
   getGradleReport,
   invalidateGradleReportCache,
 } from '../utils/get-gradle-report';
-import { calculatedTargets, writeTargetsToCache } from './nodes';
+import { writeTargetsToCache } from './nodes';
 
 export const createDependencies: CreateDependencies = async (
   _,
@@ -58,7 +58,7 @@ export const createDependencies: CreateDependencies = async (
     gradleDependenciesEnd.name
   );
 
-  writeTargetsToCache(calculatedTargets);
+  writeTargetsToCache();
   if (dependencies.length) {
     invalidateGradleReportCache();
   }

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -34,7 +34,7 @@ export interface GradlePluginOptions {
 }
 
 const cachePath = join(projectGraphCacheDirectory, 'gradle.hash');
-export const targetsCache = readTargetsCache();
+const targetsCache = readTargetsCache();
 type GradleTargets = Record<
   string,
   {
@@ -75,9 +75,13 @@ export const createNodes: CreateNodes<GradlePluginOptions> = [
       options,
       context
     );
+    const project = targetsCache[hash];
+    if (!project) {
+      return {};
+    }
     return {
       projects: {
-        [projectRoot]: targetsCache[hash],
+        [projectRoot]: project,
       },
     };
   },

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -33,8 +33,6 @@ describe('@nx/jest/plugin', () => {
     });
   });
 
-  test('foo', () => {});
-
   afterEach(() => {
     jest.resetModules();
     process.chdir(cwd);

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -36,16 +36,16 @@ function readTargetsCache(): Record<string, JestTargets> {
   return existsSync(cachePath) ? readJsonFile(cachePath) : {};
 }
 
-function writeTargetsToCache(targetCache: Record<string, JestTargets>) {
+function writeTargetsToCache() {
   const cache = readTargetsCache();
   writeJsonFile(cachePath, {
     ...cache,
-    ...targetCache,
+    ...targetsCache,
   });
 }
 
 export const createDependencies: CreateDependencies = () => {
-  writeTargetsToCache(targetsCache);
+  writeTargetsToCache();
   return [];
 };
 

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1064,9 +1064,6 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-
-        await new Promise((res) => setTimeout(res, 2000)); // wait for the file to be created
-
         expect(await invokeCreateNodesOnMatchingFiles(context, {}))
           .toMatchInlineSnapshot(`
           {

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -2,6 +2,7 @@ import { type CreateNodesContext } from '@nx/devkit';
 import { minimatch } from 'minimatch';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { PLUGIN_NAME, TscPluginOptions, createNodes } from './plugin';
+import { setupWorkspaceContext } from 'nx/src/utils/workspace-context';
 
 describe(`Plugin: ${PLUGIN_NAME}`, () => {
   let context: CreateNodesContext;
@@ -30,7 +31,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
   });
 
   it('should create nodes for root tsconfig.json files', async () => {
-    applyFilesToTempFsAndContext(tempFs, context, {
+    await applyFilesToTempFsAndContext(tempFs, context, {
       'package.json': `{}`,
       'project.json': `{}`,
       'tsconfig.json': `{}`,
@@ -85,7 +86,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
   });
 
   it('should not create nodes when it is not a tsconfig.json file and there is no sibling tsconfig.json file', async () => {
-    applyFilesToTempFsAndContext(tempFs, context, {
+    await applyFilesToTempFsAndContext(tempFs, context, {
       'package.json': `{}`,
       'project.json': `{}`,
       'tsconfig.base.json': `{}`,
@@ -102,7 +103,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
   describe('typecheck target', () => {
     it('should create a node with a typecheck target for a project level tsconfig.json file by default (when there is a sibling package.json or project.json)', async () => {
       // Sibling package.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/package.json': `{}`,
       });
@@ -140,7 +141,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
@@ -178,7 +179,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Other tsconfigs present
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -221,7 +222,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should not create typecheck target for a project level tsconfig.json file if set to false in plugin options', async () => {
       // Sibling package.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/package.json': `{}`,
       });
@@ -241,7 +242,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
@@ -263,7 +264,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should not invoke tsc with `--emitDeclarationOnly` when `noEmit` is set in the tsconfig.json file', async () => {
       // set directly in tsconfig.json file
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({
           compilerOptions: { noEmit: true },
         }),
@@ -303,7 +304,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // set in extended tsconfig file
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'tsconfig.base.json': JSON.stringify({
           compilerOptions: { noEmit: true },
         }),
@@ -347,7 +348,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should not invoke tsc with `--emitDeclarationOnly` when `noEmit` is set in any of the referenced tsconfig.json files', async () => {
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({
           files: [],
           references: [{ path: './tsconfig.lib.json' }],
@@ -393,7 +394,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     describe('inputs', () => {
       it('should add the config file and the `include` and `exclude` patterns', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'],
@@ -437,7 +438,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add extended config files', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             extends: '../../tsconfig.foo.json',
             include: ['src/**/*.ts'],
@@ -486,7 +487,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add files from internal project references', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['src/**/*.ts'],
             exclude: ['src/**/*.spec.ts'], // should be ignored because a referenced internal project includes this same pattern
@@ -551,7 +552,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       it('should only add exclude paths that are not part of other tsconfig files include paths', async () => {
         // exact match
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -588,7 +589,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // other file include pattern is a subset of exclude pattern
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -624,7 +625,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // exclude pattern is a subset of other file include pattern
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -660,7 +661,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // handles mismatches with leading `./`
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -696,7 +697,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // no matching pattern in the exclude list
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -737,7 +738,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should fall back to named inputs when not using include', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({ files: ['main.ts'] }),
           'libs/my-lib/package.json': `{}`,
         });
@@ -792,7 +793,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     describe('outputs', () => {
       it('should add the `outFile`', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: { outFile: '../../dist/libs/my-lib/index.js' },
             files: ['main.ts'],
@@ -840,7 +841,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the `outDir`', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: { outDir: '../../dist/libs/my-lib' },
             files: ['main.ts'],
@@ -884,7 +885,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the inline output files when `outDir` is not defined', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             files: ['main.ts'],
           }),
@@ -939,7 +940,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should collect outputs from all internal project references', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             files: [],
             references: [
@@ -1004,7 +1005,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       it('should respect the "tsBuildInfoFile" option', async () => {
         // outFile
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: {
               outFile: '../../dist/libs/my-lib/index.js',
@@ -1054,7 +1055,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // no outFile & no outDir
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: {
               tsBuildInfoFile: '../../dist/libs/my-lib/my-lib.tsbuildinfo',
@@ -1063,6 +1064,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
+
+        await new Promise((res) => setTimeout(res, 2000)); // wait for the file to be created
+
         expect(await invokeCreateNodesOnMatchingFiles(context, {}))
           .toMatchInlineSnapshot(`
           {
@@ -1116,7 +1120,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
   describe('build target', () => {
     it('should not create a node with a build target for a project level tsconfig files by default', async () => {
       // Sibling package.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -1139,7 +1143,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -1164,7 +1168,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should not create build target for a project level tsconfig.json file if set to false in plugin options', async () => {
       // Sibling package.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -1188,7 +1192,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -1214,7 +1218,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create a node with a build target when enabled, for a project level tsconfig.lib.json build file by default', async () => {
       // Sibling package.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -1259,7 +1263,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -1306,7 +1310,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create a node with a build target when enabled, using a custom configured target name', async () => {
       // Sibling package.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -1355,7 +1359,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create a node with a build target when enabled, using a custom configured tsconfig file', async () => {
       // Sibling project.json
-      applyFilesToTempFsAndContext(tempFs, context, {
+      await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -1404,7 +1408,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     describe('inputs', () => {
       it('should add the config file and the `include` and `exclude` patterns', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             include: ['src/**/*.ts'],
             exclude: ['src/**/*.spec.ts'],
@@ -1453,7 +1457,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add extended config files', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             extends: '../../tsconfig.foo.json',
@@ -1507,7 +1511,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add files from internal project references', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             include: ['src/**/*.ts'],
@@ -1571,7 +1575,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       it('should only add exclude paths that are not part of other tsconfig files include paths', async () => {
         // exact match
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             include: ['src/**/*.ts'],
@@ -1606,7 +1610,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // other file include pattern is a subset of exclude pattern
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             include: ['**/*.ts'],
@@ -1640,7 +1644,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // exclude pattern is a subset of other file include pattern
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             include: ['src/**/*.ts'],
@@ -1674,7 +1678,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // handles mismatches with leading `./`
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             include: ['src/**/*.ts'],
@@ -1708,7 +1712,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // no matching pattern in the exclude list
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             include: ['src/**/*.ts'],
@@ -1747,7 +1751,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should fall back to named inputs when not using include', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             files: ['main.ts'],
           }),
@@ -1809,7 +1813,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     describe('outputs', () => {
       it('should add the `outFile`', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outFile: '../../dist/libs/my-lib/index.js' },
             files: ['main.ts'],
@@ -1862,7 +1866,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the `outDir`', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: '../../dist/libs/my-lib' },
             files: ['main.ts'],
@@ -1911,7 +1915,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the inline output files when `outDir` is not defined', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             files: ['main.ts'],
           }),
@@ -1971,7 +1975,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should collect outputs from all internal project references', async () => {
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outFile: '../../dist/libs/my-lib/lib.js' },
@@ -2033,7 +2037,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       it('should respect the "tsBuildInfoFile" option', async () => {
         // outFile
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
@@ -2088,7 +2092,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // no outFile & no outDir
-        applyFilesToTempFsAndContext(tempFs, context, {
+        await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
@@ -2153,16 +2157,17 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
   });
 });
 
-function applyFilesToTempFsAndContext(
+async function applyFilesToTempFsAndContext(
   tempFs: TempFs,
   context: CreateNodesContext,
   fileSys: Record<string, string>
 ) {
-  tempFs.createFilesSync(fileSys);
+  await tempFs.createFiles(fileSys);
   // @ts-expect-error update otherwise readonly property for testing
   context.configFiles = Object.keys(fileSys).filter((file) =>
     minimatch(file, createNodes[0], { dot: true })
   );
+  setupWorkspaceContext(tempFs.tempDir);
 }
 
 async function invokeCreateNodesOnMatchingFiles(

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -26,28 +26,25 @@ export interface NextPluginOptions {
 }
 
 const cachePath = join(projectGraphCacheDirectory, 'next.hash');
-const targetsCache = existsSync(cachePath) ? readTargetsCache() : {};
-
-const calculatedTargets: Record<
-  string,
-  Record<string, TargetConfiguration>
-> = {};
+const targetsCache = readTargetsCache();
 
 function readTargetsCache(): Record<
   string,
   Record<string, TargetConfiguration>
 > {
-  return readJsonFile(cachePath);
+  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
 }
 
-function writeTargetsToCache(
-  targets: Record<string, Record<string, TargetConfiguration>>
-) {
-  writeJsonFile(cachePath, targets);
+function writeTargetsToCache() {
+  const oldCache = readTargetsCache();
+  writeJsonFile(cachePath, {
+    ...oldCache,
+    ...targetsCache,
+  });
 }
 
 export const createDependencies: CreateDependencies = () => {
-  writeTargetsToCache(calculatedTargets);
+  writeTargetsToCache();
   return [];
 };
 
@@ -70,17 +67,18 @@ export const createNodes: CreateNodes<NextPluginOptions> = [
       getLockFileName(detectPackageManager(context.workspaceRoot)),
     ]);
 
-    const targets =
-      targetsCache[hash] ??
-      (await buildNextTargets(configFilePath, projectRoot, options, context));
-
-    calculatedTargets[hash] = targets;
+    targetsCache[hash] ??= await buildNextTargets(
+      configFilePath,
+      projectRoot,
+      options,
+      context
+    );
 
     return {
       projects: {
         [projectRoot]: {
           root: projectRoot,
-          targets,
+          targets: targetsCache[hash],
         },
       },
     };

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -433,6 +433,10 @@ export async function createProjectConfigurations(
       }
 
       for (const node in projectNodes) {
+        // Handles `{projects: {'libs/foo': undefined}}`.
+        if (!projectNodes[node]) {
+          continue;
+        }
         const project = {
           root: node,
           ...projectNodes[node],

--- a/packages/rollup/src/plugins/plugin.spec.ts
+++ b/packages/rollup/src/plugins/plugin.spec.ts
@@ -50,6 +50,9 @@ describe('@nx/rollup/plugin', () => {
         ],
       };
 
+      // This isn't JS, but all that really matters here
+      // is that the hash is different after updating the
+      // config file. The actual config read is mocked below.
       tempFs.createFileSync(
         'rollup.config.js',
         JSON.stringify(rollupConfigOptions)
@@ -120,6 +123,9 @@ describe('@nx/rollup/plugin', () => {
           },
         ],
       };
+      // This isn't JS, but all that really matters here
+      // is that the hash is different after updating the
+      // config file. The actual config read is mocked below.
       tempFs.createFileSync(
         'mylib/rollup.config.js',
         JSON.stringify(rollupConfigOptions)

--- a/packages/rollup/src/plugins/plugin.spec.ts
+++ b/packages/rollup/src/plugins/plugin.spec.ts
@@ -38,16 +38,7 @@ describe('@nx/rollup/plugin', () => {
         workspaceRoot: tempFs.tempDir,
         configFiles: [],
       };
-
-      tempFs.createFileSync('package.json', JSON.stringify({ name: 'mylib' }));
-      tempFs.createFileSync(
-        'src/index.js',
-        `export function main() { 
-      console.log("hello world");
-      }`
-      );
-
-      loadConfigFile.mockReturnValue({
+      const rollupConfigOptions = {
         options: [
           {
             output: {
@@ -57,7 +48,21 @@ describe('@nx/rollup/plugin', () => {
             },
           },
         ],
-      });
+      };
+
+      tempFs.createFileSync(
+        'rollup.config.js',
+        JSON.stringify(rollupConfigOptions)
+      );
+      tempFs.createFileSync('package.json', JSON.stringify({ name: 'mylib' }));
+      tempFs.createFileSync(
+        'src/index.js',
+        `export function main() { 
+      console.log("hello world");
+      }`
+      );
+
+      loadConfigFile.mockReturnValue(rollupConfigOptions);
 
       process.chdir(tempFs.tempDir);
     });
@@ -97,18 +102,7 @@ describe('@nx/rollup/plugin', () => {
         workspaceRoot: tempFs.tempDir,
         configFiles: [],
       };
-
-      tempFs.createFileSync(
-        'mylib/package.json',
-        JSON.stringify({ name: 'mylib' })
-      );
-      tempFs.createFileSync(
-        'mylib/src/index.js',
-        `export function main() { 
-      console.log("hello world");
-      }`
-      );
-      loadConfigFile.mockReturnValue({
+      const rollupConfigOptions = {
         options: [
           {
             output: {
@@ -125,7 +119,22 @@ describe('@nx/rollup/plugin', () => {
             },
           },
         ],
-      });
+      };
+      tempFs.createFileSync(
+        'mylib/rollup.config.js',
+        JSON.stringify(rollupConfigOptions)
+      );
+      tempFs.createFileSync(
+        'mylib/package.json',
+        JSON.stringify({ name: 'mylib' })
+      );
+      tempFs.createFileSync(
+        'mylib/src/index.js',
+        `export function main() { 
+      console.log("hello world");
+      }`
+      );
+      loadConfigFile.mockReturnValue(rollupConfigOptions);
 
       process.chdir(tempFs.tempDir);
     });

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -26,28 +26,25 @@ export interface VitePluginOptions {
 }
 
 const cachePath = join(projectGraphCacheDirectory, 'vite.hash');
-const targetsCache = existsSync(cachePath) ? readTargetsCache() : {};
-
-const calculatedTargets: Record<
-  string,
-  Record<string, TargetConfiguration>
-> = {};
+const targetsCache = readTargetsCache();
 
 function readTargetsCache(): Record<
   string,
   Record<string, TargetConfiguration>
 > {
-  return readJsonFile(cachePath);
+  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
 }
 
-function writeTargetsToCache(
-  targets: Record<string, Record<string, TargetConfiguration>>
-) {
-  writeJsonFile(cachePath, targets);
+function writeTargetsToCache() {
+  const oldCache = readTargetsCache();
+  writeJsonFile(cachePath, {
+    ...oldCache,
+    ...targetsCache,
+  });
 }
 
 export const createDependencies: CreateDependencies = () => {
-  writeTargetsToCache(calculatedTargets);
+  writeTargetsToCache();
   return [];
 };
 
@@ -72,17 +69,19 @@ export const createNodes: CreateNodes<VitePluginOptions> = [
       calculateHashForCreateNodes(projectRoot, options, context, [
         getLockFileName(detectPackageManager(context.workspaceRoot)),
       ]) + configFilePath;
-    const targets = targetsCache[hash]
-      ? targetsCache[hash]
-      : await buildViteTargets(configFilePath, projectRoot, options, context);
 
-    calculatedTargets[hash] = targets;
+    targetsCache[hash] ??= await buildViteTargets(
+      configFilePath,
+      projectRoot,
+      options,
+      context
+    );
 
     return {
       projects: {
         [projectRoot]: {
           root: projectRoot,
-          targets,
+          targets: targetsCache[hash],
         },
       },
     };

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -27,28 +27,25 @@ export interface WebpackPluginOptions {
 }
 
 const cachePath = join(projectGraphCacheDirectory, 'webpack.hash');
-const targetsCache = existsSync(cachePath) ? readTargetsCache() : {};
-
-const calculatedTargets: Record<
-  string,
-  Record<string, TargetConfiguration>
-> = {};
+const targetsCache = readTargetsCache();
 
 function readTargetsCache(): Record<
   string,
   Record<string, TargetConfiguration>
 > {
-  return readJsonFile(cachePath);
+  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
 }
 
-function writeTargetsToCache(
-  targets: Record<string, Record<string, TargetConfiguration>>
-) {
-  writeJsonFile(cachePath, targets);
+function writeTargetsToCache() {
+  const oldCache = readTargetsCache();
+  writeJsonFile(cachePath, {
+    ...oldCache,
+    ...targetsCache,
+  });
 }
 
 export const createDependencies: CreateDependencies = () => {
-  writeTargetsToCache(calculatedTargets);
+  writeTargetsToCache();
   return [];
 };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Plugin's cache entries overwrite each other if multiple instances of the same plugin are running. They also don't remember previous cache states.

## Expected Behavior
Plugin's caches grow as changes are made, and don't overwrite previous entries.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
