### PR TITLE
fix(core): reset should cleanup temporary nx-cloud files

### DIFF
--- a/docs/generated/cli/reset.md
+++ b/docs/generated/cli/reset.md
@@ -55,6 +55,12 @@ Type: `boolean`
 
 Clears the Nx cache directory. This will remove all local cache entries for tasks, but will not affect the remote cache.
 
+### onlyCloud
+
+Type: `boolean`
+
+Resets the Nx Cloud client. NOTE: Does not clear the remote cache.
+
 ### onlyDaemon
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/reset.md
+++ b/docs/generated/packages/nx/documents/reset.md
@@ -55,6 +55,12 @@ Type: `boolean`
 
 Clears the Nx cache directory. This will remove all local cache entries for tasks, but will not affect the remote cache.
 
+### onlyCloud
+
+Type: `boolean`
+
+Resets the Nx Cloud client. NOTE: Does not clear the remote cache.
+
 ### onlyDaemon
 
 Type: `boolean`

--- a/packages/nx/src/command-line/reset/command-object.ts
+++ b/packages/nx/src/command-line/reset/command-object.ts
@@ -4,6 +4,7 @@ export type ResetCommandOptions = {
   onlyCache?: boolean;
   onlyDaemon?: boolean;
   onlyWorkspaceData?: boolean;
+  onlyCloud?: boolean;
 };
 
 export const yargsResetCommand: CommandModule<
@@ -24,6 +25,11 @@ export const yargsResetCommand: CommandModule<
       .option('onlyDaemon', {
         description:
           'Stops the Nx Daemon, it will be restarted fresh when the next Nx command is run.',
+        type: 'boolean',
+      })
+      .option('onlyCloud', {
+        description:
+          'Resets the Nx Cloud client. NOTE: Does not clear the remote cache.',
         type: 'boolean',
       })
       .option('onlyWorkspaceData', {

--- a/packages/nx/src/nx-cloud/utilities/client.ts
+++ b/packages/nx/src/nx-cloud/utilities/client.ts
@@ -1,0 +1,35 @@
+import { findAncestorNodeModules } from '../resolution-helpers';
+import { verifyOrUpdateNxCloudClient } from '../update-manager';
+import { CloudTaskRunnerOptions } from '../nx-cloud-tasks-runner-shell';
+
+export class UnknownCommandError extends Error {
+  constructor(public command: string, public availableCommands: string[]) {
+    super(`Unknown Command "${command}"`);
+  }
+}
+
+export async function getCloudClient(options: CloudTaskRunnerOptions) {
+  const { nxCloudClient } = await verifyOrUpdateNxCloudClient(options);
+
+  const paths = findAncestorNodeModules(__dirname, []);
+  nxCloudClient.configureLightClientRequire()(paths);
+
+  return {
+    invoke: (command: string) => {
+      if (command in nxCloudClient.commands) {
+        nxCloudClient.commands[command]()
+          .then(() => process.exit(0))
+          .catch((e) => {
+            console.error(e);
+            process.exit(1);
+          });
+      } else {
+        throw new UnknownCommandError(
+          command,
+          Object.keys(nxCloudClient.commands)
+        );
+      }
+    },
+    availableCommands: Object.keys(nxCloudClient.commands),
+  };
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx reset` doesn't remove marker files used by nx cloud.
## Expected Behavior
`nx reset` removes marker files from nx cloud

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #https://github.com/nrwl/nx/issues/23308
