### PR TITLE
fix(core): properly indent command output with mixed line endings

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -490,7 +490,7 @@ function writeCompletedTaskResultLine(line: string) {
 function writeCommandOutputBlock(commandOutput: string) {
   commandOutput = commandOutput || '';
   commandOutput = commandOutput.trimStart();
-  const lines = commandOutput.split(EOL);
+  const lines = commandOutput.split(/\r?\n/);
   let totalTrailingEmptyLines = 0;
   for (let i = lines.length - 1; i >= 0; i--) {
     if (lines[i] !== '') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The command output is not indented when it has mixed line endings (`crlf` and `lf`)

![image](https://github.com/nrwl/nx/assets/1770529/5f65e9c4-ded2-4fba-a6c8-9f22297b2b35)

## Expected Behavior
![image](https://github.com/nrwl/nx/assets/1770529/c8111456-407e-47af-8129-4efa6f5792ca)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


