### PR TITLE
fix(core): workspace remove generator should handle no root jest config

### DIFF
--- a/packages/workspace/src/generators/remove/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/update-jest-config.spec.ts
@@ -91,4 +91,24 @@ describe('updateRootJestConfig', () => {
 
     expect(rootJestConfig).toMatchSnapshot();
   });
+
+  it('should handle not having a root jest config file', async () => {
+    // ARRANGE
+    tree.delete('jest.config.ts');
+
+    await libraryGenerator(tree, {
+      name: 'test',
+      bundler: 'vite',
+      unitTestRunner: 'vitest',
+    });
+
+    // ACT
+    expect(() =>
+      updateJestConfig(
+        tree,
+        { projectName: 'test', skipFormat: false, forceRemove: false },
+        readProjectConfiguration(tree, 'test')
+      )
+    ).not.toThrow();
+  });
 });

--- a/packages/workspace/src/generators/remove/lib/update-jest-config.ts
+++ b/packages/workspace/src/generators/remove/lib/update-jest-config.ts
@@ -69,6 +69,7 @@ export function updateJestConfig(
   const rootConfigPath = findRootJestConfig(tree);
 
   if (
+    !rootConfigPath ||
     !tree.exists(rootConfigPath) ||
     !tree.exists(join(projectConfig.root, 'jest.config.ts')) ||
     isUsingUtilityFunction(tree) ||


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/workspace:remove` generator will throw if there is not a `jest.config.ts` at the root of the workspace.
However, when using vitest for projects, there may not be a root jest.config file.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Handle no root jest.config file

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
