### PR TITLE
fix(nextjs): additional experimental HTTPS options

### DIFF
--- a/docs/generated/packages/next/executors/server.json
+++ b/docs/generated/packages/next/executors/server.json
@@ -60,6 +60,18 @@
         "type": "boolean",
         "description": "Enable HTTPS support for the Next.js development server."
       },
+      "experimentalHttpsKey": {
+        "type": "string",
+        "description": "Path to a HTTPS key file."
+      },
+      "experimentalHttpsCert": {
+        "type": "string",
+        "description": "Path to a HTTPS certificate file."
+      },
+      "experimentalHttpsCa": {
+        "type": "string",
+        "description": "Path to a HTTPS certificate authority file."
+      },
       "customServerHttps:": {
         "type": "boolean",
         "description": "Enable HTTPS support for the custom server."

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -57,6 +57,18 @@
       "type": "boolean",
       "description": "Enable HTTPS support for the Next.js development server."
     },
+    "experimentalHttpsKey": {
+      "type": "string",
+      "description": "Path to a HTTPS key file."
+    },
+    "experimentalHttpsCert": {
+      "type": "string",
+      "description": "Path to a HTTPS certificate file."
+    },
+    "experimentalHttpsCa": {
+      "type": "string",
+      "description": "Path to a HTTPS certificate authority file."
+    },
     "customServerHttps:": {
       "type": "boolean",
       "description": "Enable HTTPS support for the custom server."

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -3,7 +3,7 @@ import {
   parseTargetString,
   readTargetOptions,
 } from '@nx/devkit';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 
 import {
   NextBuildBuilderOptions,
@@ -54,16 +54,18 @@ export default async function* serveExecutor(
 
   const mode = options.dev ? 'dev' : 'start';
   const turbo = options.turbo && options.dev ? '--turbo' : '';
-  const experimentalHttps =
-    options.experimentalHttps && options.dev ? '--experimental-https' : '';
   const nextBin = require.resolve('next/dist/bin/next');
 
   yield* createAsyncIterable<{ success: boolean; baseUrl: string }>(
     async ({ done, next, error }) => {
-      const server = fork(nextBin, [mode, ...args, turbo, experimentalHttps], {
-        cwd: options.dev ? projectRoot : nextDir,
-        stdio: 'inherit',
-      });
+      const server = fork(
+        nextBin,
+        [mode, ...args, turbo, ...getExperimentalHttpsFlags(options)],
+        {
+          cwd: options.dev ? projectRoot : nextDir,
+          stdio: 'inherit',
+        }
+      );
 
       server.once('exit', (code) => {
         if (code === 0) {
@@ -91,4 +93,17 @@ export default async function* serveExecutor(
       });
     }
   );
+}
+
+function getExperimentalHttpsFlags(options: NextServeBuilderOptions): string[] {
+  if (!options.dev) return [];
+  const flags: string[] = [];
+  if (options.experimentalHttps) flags.push('--experimental-https');
+  if (options.experimentalHttpsKey)
+    flags.push(`--experimental-https-key=${options.experimentalHttpsKey}`);
+  if (options.experimentalHttpsCert)
+    flags.push(`--experimental-https-cert=${options.experimentalHttpsCert}`);
+  if (options.experimentalHttpsCa)
+    flags.push(`--experimental-https-ca=${options.experimentalHttpsCa}`);
+  return flags;
 }

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -53,6 +53,9 @@ export interface NextServeBuilderOptions {
   keepAliveTimeout?: number;
   turbo?: boolean;
   experimentalHttps?: boolean;
+  experimentalHttpsKey?: string;
+  experimentalHttpsCert?: string;
+  experimentalHttpsCa?: string;
   customServerHttps?: boolean;
 }
 


### PR DESCRIPTION
There are three additional flags if user wishes to generate their own key, cert, ca files rather than the auto-generated ones by Next.js.



## Current Behavior
Cannot pass additional CLI options.

## Expected Behavior

Can  pass additional CLI options for custom files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes https://github.com/nrwl/nx/discussions/23331
