### PR TITLE
fix(core): throw a specific error for print-affected and affected graph

### DIFF
--- a/packages/nx/src/command-line/deprecated/command-objects.ts
+++ b/packages/nx/src/command-line/deprecated/command-objects.ts
@@ -1,0 +1,53 @@
+import { CommandModule } from 'yargs';
+import { handleErrors } from '../../utils/params';
+import {
+  withAffectedOptions,
+  withDepGraphOptions,
+  withTargetAndConfigurationOption,
+} from '../yargs-utils/shared-options';
+
+const affectedGraphDeprecationMessage =
+  'Use `nx graph --affected`, or `nx affected --graph` instead depending on which best suits your use case. The `affected:graph` command has been removed in Nx 19.';
+const printAffectedDeprecationMessage =
+  'Use `nx show projects --affected`, `nx affected --graph -t build` or `nx graph --affected` depending on which best suits your use case. The `print-affected` command has been removed in Nx 19.';
+
+/**
+ * @deprecated 'Use `nx graph --affected`, or` nx affected --graph` instead depending on which best suits your use case. The `affected:graph` command will be removed in Nx 19.'
+ */
+export const yargsAffectedGraphCommand: CommandModule = {
+  command: 'affected:graph',
+  describe: false,
+  aliases: ['affected:dep-graph'],
+  builder: (yargs) => withAffectedOptions(withDepGraphOptions(yargs)),
+  handler: (args) =>
+    handleErrors(false, () => {
+      throw new Error(affectedGraphDeprecationMessage);
+    }),
+  deprecated: affectedGraphDeprecationMessage,
+};
+
+/**
+ * @deprecated 'Use `nx show --affected`, `nx affected --graph` or `nx graph --affected` depending on which best suits your use case. The `print-affected` command will be removed in Nx 19.'
+ */
+export const yargsPrintAffectedCommand: CommandModule = {
+  command: 'print-affected',
+  describe: false,
+  builder: (yargs) =>
+    withAffectedOptions(withTargetAndConfigurationOption(yargs, false))
+      .option('select', {
+        type: 'string',
+        describe:
+          'Select the subset of the returned json document (e.g., --select=projects)',
+      })
+      .option('type', {
+        type: 'string',
+        choices: ['app', 'lib'],
+        describe:
+          'Select the type of projects to be returned (e.g., --type=app)',
+      }),
+  handler: (args) =>
+    handleErrors(false, () => {
+      throw new Error(printAffectedDeprecationMessage);
+    }),
+  deprecated: printAffectedDeprecationMessage,
+};

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -4,33 +4,6 @@ export interface Example {
 }
 
 export const examples: Record<string, Example[]> = {
-  'print-affected': [
-    {
-      command: 'print-affected',
-      description:
-        'Print information about affected projects and the project graph',
-    },
-    {
-      command: 'print-affected --base=main --head=HEAD',
-      description:
-        'Print information about the projects affected by the changes between main and HEAD (e.g,. PR)',
-    },
-    {
-      command: 'print-affected -t test',
-      description:
-        'Prints information about the affected projects and a list of tasks to test them',
-    },
-    {
-      command: 'print-affected -t build --select=projects',
-      description:
-        'Prints the projects property from the print-affected output',
-    },
-    {
-      command: 'print-affected -t build --select=tasks.target.project',
-      description:
-        'Prints the tasks.target.project property from the print-affected output',
-    },
-  ],
   affected: [
     {
       command: 'affected -t custom-target',
@@ -191,38 +164,6 @@ export const examples: Record<string, Example[]> = {
     {
       command: 'graph --watch',
       description: 'Watch for changes to project graph and update in-browser',
-    },
-  ],
-  'affected:graph': [
-    {
-      command: 'affected:graph --files=libs/mylib/src/index.ts',
-      description:
-        'Open the project graph of the workspace in the browser, and highlight the projects affected by changing the index.ts file',
-    },
-    {
-      command: 'affected:graph --base=main --head=HEAD',
-      description:
-        'Open the project graph of the workspace in the browser, and highlight the projects affected by the changes between main and HEAD (e.g., PR)',
-    },
-    {
-      command: 'affected:graph --base=main --head=HEAD --file=output.json',
-      description:
-        'Save the project graph of the workspace in a json file, and highlight the projects affected by the changes between main and HEAD (e.g., PR)',
-    },
-    {
-      command: 'affected:graph --base=main --head=HEAD --file=output.html',
-      description:
-        'Generate a static website with project graph data in an html file, highlighting the projects affected by the changes between main and HEAD (e.g., PR)',
-    },
-    {
-      command: 'affected:graph --base=main~1 --head=main',
-      description:
-        'Open the project graph of the workspace in the browser, and highlight the projects affected by the last commit on main',
-    },
-    {
-      command: 'affected:graph --exclude=project-one,project-two',
-      description:
-        'Open the project graph of the workspace in the browser, highlight the projects affected, but exclude project-one and project-two',
     },
   ],
   list: [

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -36,6 +36,10 @@ import { yargsWatchCommand } from './watch/command-object';
 import { yargsResetCommand } from './reset/command-object';
 import { yargsReleaseCommand } from './release/command-object';
 import { yargsAddCommand } from './add/command-object';
+import {
+  yargsPrintAffectedCommand,
+  yargsAffectedGraphCommand,
+} from './deprecated/command-objects';
 
 // Ensure that the output takes up the available width of the terminal.
 yargs.wrap(yargs.terminalWidth());
@@ -61,6 +65,7 @@ export const commandsObject = yargs
   .command(yargsAffectedE2ECommand)
   .command(yargsAffectedLintCommand)
   .command(yargsAffectedTestCommand)
+  .command(yargsAffectedGraphCommand)
   .command(yargsConnectCommand)
   .command(yargsDaemonCommand)
   .command(yargsDepGraphCommand)
@@ -73,6 +78,7 @@ export const commandsObject = yargs
   .command(yargsListCommand)
   .command(yargsMigrateCommand)
   .command(yargsNewCommand)
+  .command(yargsPrintAffectedCommand)
   .command(yargsReleaseCommand)
   .command(yargsRepairCommand)
   .command(yargsReportCommand)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A non-descriptive error is thrown when using the recently removed `print-affected` and `affected:graph` commands.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

A descriptive error is thrown when using the recently removed `print-affected` and `affected:graph` commands.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
