### PR TITLE
fix(js): copy assets handler should correctly handle assets on windows

### DIFF
--- a/packages/js/src/utils/assets/copy-assets-handler.spec.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.spec.ts
@@ -167,6 +167,13 @@ describe('AssetInputOutputHandler', () => {
         dest: path.join(rootDir, 'dist/mylib/docs/test2.md'),
       },
     ]);
+    expect(callback).not.toHaveBeenCalledWith([
+      {
+        type: 'create',
+        src: path.join(rootDir, 'mylib/docs/a/b/nested-ignore.md'),
+        dest: path.join(rootDir, 'dist/mylib/docs/a/b/nested-ignore.md'),
+      },
+    ]);
 
     dispose();
   });

--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -1,5 +1,6 @@
 import { minimatch } from 'minimatch';
-import * as path from 'node:path/posix';
+import * as pathPosix from 'node:path/posix';
+import * as path from 'node:path';
 import * as fse from 'fs-extra';
 import ignore from 'ignore';
 import * as fg from 'fast-glob';
@@ -63,8 +64,8 @@ export class CopyAssetsHandler {
 
     // TODO(jack): Should handle nested .gitignore files
     this.ignore = ignore();
-    const gitignore = path.join(opts.rootDir, '.gitignore');
-    const nxignore = path.join(opts.rootDir, '.nxignore');
+    const gitignore = pathPosix.join(opts.rootDir, '.gitignore');
+    const nxignore = pathPosix.join(opts.rootDir, '.nxignore');
     if (fse.existsSync(gitignore))
       this.ignore.add(fse.readFileSync(gitignore).toString());
     if (fse.existsSync(nxignore))
@@ -83,13 +84,14 @@ export class CopyAssetsHandler {
         output = path.relative(opts.rootDir, opts.outputDir);
       } else {
         isGlob = true;
-        pattern = path.join(f.input, f.glob);
+        pattern = pathPosix.join(f.input, f.glob);
         input = f.input;
-        output = path.join(
+        output = pathPosix.join(
           path.relative(opts.rootDir, opts.outputDir),
           f.output
         );
-        if (f.ignore) ignore = f.ignore.map((ig) => path.join(f.input, ig));
+        if (f.ignore)
+          ignore = f.ignore.map((ig) => pathPosix.join(f.input, ig));
       }
       return {
         isGlob,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
CopyAssetsHandler was not outputting the assets in the correct location due to issues with `path/posix`.
`path/posix` is required for some areas of this code, like `minimatch`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`minimatch` ignores should continue to work as expected
assets should be output to the correct location

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
