### PR TITLE
Fix/nx dev header enterprise

### DIFF
--- a/nx-dev/ui-common/src/lib/headers/header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/header.tsx
@@ -46,7 +46,7 @@ export function Header(): JSX.Element {
   }, []);
 
   return (
-    <div className="z-5 relative inset-x-0 top-0 flex print:hidden">
+    <div className="relative inset-x-0 top-0 z-[5] flex print:hidden">
       {/*DESKTOP*/}
       <div className="mx-auto hidden w-full max-w-7xl items-center justify-between space-x-10 p-4 px-8 lg:flex">
         {/*PRIMARY NAVIGATION*/}


### PR DESCRIPTION
## Current
On nx-dev `z-5` does not exists as a tailwind class so the style fails to apply.
So when you are on nx.dev/enterprise and try the use the menu in the header nothing works.

This was probably a typo from the previous PR: https://github.com/nrwl/nx/pull/23250

## Expected:
You should be able to interact with the menu on the enterprise page.
Using `z-[5]`
