### PR TITLE
feat(core): default show to web view when in interactive terminal

### DIFF
--- a/docs/generated/cli/show.md
+++ b/docs/generated/cli/show.md
@@ -53,10 +53,16 @@ Show affected projects in the workspace, excluding end-to-end projects:
  nx show projects --affected --exclude=*-e2e
 ```
 
-Show detailed information about "my-app" in a json format.:
+If in an interactive terminal, opens the project detail view. If not in an interactive terminal, defaults to JSON.:
 
 ```shell
  nx show project my-app
+```
+
+Show detailed information about "my-app" in a json format.:
+
+```shell
+ nx show project my-app --json
 ```
 
 Show information about "my-app" in a human readable format.:
@@ -233,4 +239,4 @@ Show version number
 
 Type: `boolean`
 
-Show project details in the browser
+Show project details in the browser. (default when interactive)

--- a/docs/generated/packages/nx/documents/show.md
+++ b/docs/generated/packages/nx/documents/show.md
@@ -53,10 +53,16 @@ Show affected projects in the workspace, excluding end-to-end projects:
  nx show projects --affected --exclude=*-e2e
 ```
 
-Show detailed information about "my-app" in a json format.:
+If in an interactive terminal, opens the project detail view. If not in an interactive terminal, defaults to JSON.:
 
 ```shell
  nx show project my-app
+```
+
+Show detailed information about "my-app" in a json format.:
+
+```shell
+ nx show project my-app --json
 ```
 
 Show information about "my-app" in a human readable format.:
@@ -233,4 +239,4 @@ Show version number
 
 Type: `boolean`
 
-Show project details in the browser
+Show project details in the browser. (default when interactive)

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -302,6 +302,12 @@ export const examples: Record<string, Example[]> = {
 
     {
       command: 'show project my-app',
+      description:
+        'If in an interactive terminal, opens the project detail view. If not in an interactive terminal, defaults to JSON.',
+    },
+
+    {
+      command: 'show project my-app --json',
       description: 'Show detailed information about "my-app" in a json format.',
     },
 

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -145,10 +145,10 @@ const showProjectCommand: CommandModule<NxShowArgs, ShowProjectOptions> = {
         alias: 'p',
         description: 'Which project should be viewed?',
       })
-      .default('json', true)
       .option('web', {
         type: 'boolean',
-        description: 'Show project details in the browser',
+        description:
+          'Show project details in the browser. (default when interactive)',
       })
       .option('open', {
         type: 'boolean',
@@ -157,8 +157,15 @@ const showProjectCommand: CommandModule<NxShowArgs, ShowProjectOptions> = {
         implies: 'web',
       })
       .check((argv) => {
-        if (argv.web) {
-          argv.json = false;
+        // If TTY is enabled, default to web. Otherwise, default to JSON.
+        const alreadySpecified =
+          argv.web !== undefined || argv.json !== undefined;
+        if (!alreadySpecified) {
+          if (process.stdout.isTTY) {
+            argv.web = true;
+          } else {
+            argv.json = true;
+          }
         }
         return true;
       })


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx show projects` shows unformatted json by default

## Expected Behavior
In a TTY we open web view by default

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20650
