### PR TITLE
chore(repo): e2e matrix

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -55,6 +55,11 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ github.run_id }}
 
+      - name: Ensure Python setuptools Installed on Macos
+        if: ${{ matrix.os == 'macos-latest' }}
+        id: brew-install-python-setuptools
+        run: brew install python-setuptools
+
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
@@ -403,7 +408,7 @@ jobs:
         timeout-minutes: 15
 
   process-result:
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'nrwl' }}
     runs-on: ubuntu-latest
     needs: e2e
     outputs:


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
E2E Matrix is not running because python 3 on macos does not come with required modules pre-installed

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Install the required python modules before running `pnpm install`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
