### PR TITLE
fix(webpack): apply-base-config should initialize options it will set #23296

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -197,6 +197,20 @@ function applyNxIndependentConfig(
     moduleTrace: !!options.verbose,
     usedExports: !!options.verbose,
   };
+
+  /**
+   * Initialize properties that get set when webpack is used during task execution.
+   * These properties may be used by consumers who expect them to not be undefined.
+   *
+   * When @nx/webpack/plugin resolves the config, it is not during a task, and therefore
+   * these values are not set, which can lead to errors being thrown when reading
+   * the webpack options from the resolved file.
+   */
+  config.entry ??= {};
+  config.resolve ??= {};
+  config.module ??= {};
+  config.plugins ??= [];
+  config.externals ??= [];
 }
 
 function applyNxDependentConfig(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/webpack/plugin` will resolve and read webpack options from user defined config files.
However, it does not set the env vars indicating that a task is being run, because tasks are not being run at this stage.

This means that certain config properties are not being set by `applyBaseConfig`.

Users' webpack configs may rely on these properties being set so they can modify them.
When not set, this throws, meaning the graph cannot be constructed.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Initialize the properties that we usually set when `applyBaseConfig` is used.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23296
