### PR TITLE
chore(gradle): use -version when logging java version in e2es

### DIFF
--- a/e2e/gradle/src/gradle.test.ts
+++ b/e2e/gradle/src/gradle.test.ts
@@ -97,7 +97,7 @@ function createGradleProject(
   projectName: string,
   type: 'kotlin' | 'groovy' = 'kotlin'
 ) {
-  e2eConsoleLogger(`Using java version: ${execSync('java --version')}`);
+  e2eConsoleLogger(`Using java version: ${execSync('java -version')}`);
   const gradleCommand = isWindows()
     ? resolve(`${__dirname}/../gradlew.bat`)
     : resolve(`${__dirname}/../gradlew`);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Java 9 has changed the version flag to single `-`
Our e2es are trying to use `--`


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use `-version`


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
