### PR TITLE
fix(core): copy native files to tmp file location instead of .nx/cache

### DIFF
--- a/packages/nx/src/command-line/reset/reset.ts
+++ b/packages/nx/src/command-line/reset/reset.ts
@@ -5,6 +5,7 @@ import {
   projectGraphCacheDirectory,
 } from '../../utils/cache-directory';
 import { output } from '../../utils/output';
+import { nativeFileCacheLocation } from '../../native/native-file-cache-location';
 
 export async function resetHandler() {
   output.note({
@@ -13,6 +14,11 @@ export async function resetHandler() {
   });
   await daemonClient.stop();
   output.log({ title: 'Daemon Server - Stopped' });
+  try {
+    rmSync(nativeFileCacheLocation, { recursive: true, force: true });
+  } catch (e) {
+    // ignore, deleting the native file cache is not critical and can fail if another process is locking the file
+  }
   rmSync(cacheDir, { recursive: true, force: true });
   if (projectGraphCacheDirectory !== cacheDir) {
     rmSync(projectGraphCacheDirectory, { recursive: true, force: true });

--- a/packages/nx/src/native/index.js
+++ b/packages/nx/src/native/index.js
@@ -2,7 +2,7 @@ const { join, basename } = require('path');
 const { copyFileSync, existsSync, mkdirSync } = require('fs');
 const Module = require('module');
 const { nxVersion } = require('../utils/versions');
-const { cacheDir } = require('../utils/cache-directory');
+const { nativeFileCacheLocation } = require('./native-file-cache-location');
 
 const nxPackages = new Set([
   '@nx/nx-android-arm64',
@@ -52,13 +52,14 @@ Module._load = function (request, parent, isMain) {
   ) {
     const nativeLocation = require.resolve(modulePath);
     const fileName = basename(nativeLocation);
-    // we copy the file to the cache directory (.nx/cache by default) and prefix with nxVersion to avoid stale files being loaded
-    const tmpFile = join(cacheDir, nxVersion + '-' + fileName);
+
+    // we copy the file to a workspace-scoped tmp directory and prefix with nxVersion to avoid stale files being loaded
+    const tmpFile = join(nativeFileCacheLocation, nxVersion + '-' + fileName);
     if (existsSync(tmpFile)) {
       return originalLoad.apply(this, [tmpFile, parent, isMain]);
     }
-    if (!existsSync(cacheDir)) {
-      mkdirSync(cacheDir, { recursive: true });
+    if (!existsSync(nativeFileCacheLocation)) {
+      mkdirSync(nativeFileCacheLocation, { recursive: true });
     }
     copyFileSync(nativeLocation, tmpFile);
     return originalLoad.apply(this, [tmpFile, parent, isMain]);

--- a/packages/nx/src/native/native-file-cache-location.ts
+++ b/packages/nx/src/native/native-file-cache-location.ts
@@ -1,0 +1,10 @@
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createHash } from 'crypto';
+import { workspaceRoot } from '../utils/workspace-root';
+
+export const nativeFileCacheLocation = join(
+  tmpdir(),
+  'nx-native-file-cache',
+  createHash('sha256').update(workspaceRoot).digest('hex')
+);


### PR DESCRIPTION
## Current Behavior
Currently, the `.node` files required to load native code are saved in `.nx/cache`. This can cause different issues:
- users on windows sometimes experience errors during `nx reset` because it's trying to delete the entire folder and some process is still locking the file
- `@angular-eslint` users are seeing the `.nx/cache` folder in their workspace since it uses `@nx/devkit` 

## Expected Behavior
We want no errors and for noone to be bothered by the `.node` file. This is why we move the `.node` file to a tmp location outside the workspace instead of `.nx/cache`.  We still make sure to delete it during `nx reset` but throw no errors if that fails. It will simply be deleted by the next invocation of `nx reset`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/23224
