### PR TITLE
docs(nx-dev): update define-environment-variables.md changed `NX_` to…

### DIFF
--- a/docs/shared/guides/define-environment-variables.md
+++ b/docs/shared/guides/define-environment-variables.md
@@ -40,10 +40,10 @@ it will ignore it. It does this for two reasons:
 
 For example:
 
-1. `apps/my-app/.env.local` contains `NX_API_URL=http://localhost:3333`
-2. `apps/my-app/.env` contains `NX_API_URL=https://api.example.com`
+1. `apps/my-app/.env.local` contains `NX_PUBLIC_API_URL=http://localhost:3333`
+2. `apps/my-app/.env` contains `NX_PUBLIC_API_URL=https://api.example.com`
 3. Nx will first load the variables from `apps/my-app/.env.local` into the process. When it tries to load the variables
-   from `apps/my-app/.env`, it will notice that `NX_API_URL` already exists, so it will ignore it.
+   from `apps/my-app/.env`, it will notice that `NX_PUBLIC_API_URL` already exists, so it will ignore it.
 
 We recommend nesting your **app** specific `env` files in `apps/your-app`, and creating workspace/root level `env` files
 for workspace-specific settings (like the [Nx Cloud token](/ci/recipes/security/access-tokens)).
@@ -68,17 +68,17 @@ In Unix systems, we need to set the environment variables before calling a comma
 Let's say that we want to define an API URL for the application to use:
 
 ```shell
-NX_API_URL=http://localhost:3333 nx build myapp
+NX_PUBLIC_API_URL=http://localhost:3333 nx build myapp
 ```
 
 **Windows (cmd.exe)**
 
 ```shell
-set "NX_API_URL=http://localhost:3333" && nx build myapp
+set "NX_PUBLIC_API_URL=http://localhost:3333" && nx build myapp
 ```
 
 **Windows (Powershell)**
 
 ```shell
-($env:NX_API_URL = "http://localhost:3333") -and (nx build myapp)
+($env:NX_PUBLIC_API_URL = "http://localhost:3333") -and (nx build myapp)
 ```


### PR DESCRIPTION
## Current Behavior
Incorrect environment variable prefix `NX_` in docs.

## Expected Behavior
Correct environment variable prefix `NX_PUBLIC_` in docs.

## Related Issue(s)
https://github.com/nrwl/nx/issues/23362
