### PR TITLE
fix(graph): properly remove <base> tag when generating static graph file

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -444,7 +444,7 @@ export async function generateGraph(
       );
       html = html.replace(/src="/g, 'src="static/');
       html = html.replace(/href="styles/g, 'href="static/styles');
-      html = html.replace('<base href="/" />', '');
+      html = html.replace(/<base href="\/".*>/g, '');
       html = html.replace(/type="module"/g, '');
 
       writeFileSync(fullFilePath, html);


### PR DESCRIPTION
the `<base href="/" />` tag was changed to `<base href="/">` recently. Probably a third-party update?
Either way, the replacement logic for building a local `.html` file is updated to handle both cases and be resilient to future changes.