### PR TITLE
fix(angular): libraries should not contain tslib by default #21023

### DIFF
--- a/packages/angular/src/generators/library/files/base/package.json__tpl__
+++ b/packages/angular/src/generators/library/files/base/package.json__tpl__
@@ -5,8 +5,5 @@
     "@angular/common": "<%= angularPeerDepVersion %>",
     "@angular/core": "<%= angularPeerDepVersion %>"
   },
-  "dependencies": {
-    "tslib": "^2.3.0"
-  },
   "sideEffects": false
 }

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -178,6 +178,9 @@ describe('lib', () => {
       expect(packageJson.devDependencies['postcss']).toBeDefined();
       expect(packageJson.devDependencies['autoprefixer']).toBeDefined();
       expect(packageJson.devDependencies['postcss-url']).toBeDefined();
+
+      const libPackageJson = readJson(tree, 'my-lib/package.json');
+      expect(libPackageJson.dependencies?.['tslib']).toBeFalsy();
     });
 
     it('should create project configuration', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating buildable and publishable angular libraries, we always add `tslib` to the `package.json#dependencies`.
These libaries may not actually use this dependency and therefore it is redundant.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Do not add `tslib` by default.
If users need it, they can add it when they do.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21023
