### PR TITLE
fix(webpack): only add entrypoints if they are intentionally injected #20049

### DIFF
--- a/packages/webpack/src/utils/webpack/package-chunk-sort.ts
+++ b/packages/webpack/src/utils/webpack/package-chunk-sort.ts
@@ -19,12 +19,18 @@ export function generateEntryPoints(appConfig: {
     return [...new Set(entryPoints)];
   };
 
+  const styleEntryPoints = appConfig.styles.filter(
+    (style) => !(typeof style !== 'string' && !style.inject)
+  );
+  const scriptEntryPoints = appConfig.scripts.filter(
+    (script) => !(typeof script !== 'string' && !script.inject)
+  );
   const entryPoints = [
     'runtime',
     'polyfills',
     'sw-register',
-    ...extraEntryPoints(appConfig.styles, 'styles'),
-    ...extraEntryPoints(appConfig.scripts, 'scripts'),
+    ...extraEntryPoints(styleEntryPoints, 'styles'),
+    ...extraEntryPoints(scriptEntryPoints, 'scripts'),
     'vendor',
     'main',
   ];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We are still injecting `styles` and `scripts` even if `inject=false` in `project.json`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Do not inject styles and scripts if `inject=false`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20049
