### PR TITLE
fix(web): stop the patch if idx is undefined

### DIFF
--- a/packages/web/src/migrations/update-15-5-4/update-babel-preset.ts
+++ b/packages/web/src/migrations/update-15-5-4/update-babel-preset.ts
@@ -33,7 +33,7 @@ export default async function update(tree: Tree) {
         : p[0] === '@nrwl/web/babel'
     );
 
-    if (idx === -1) return;
+    if (idx === undefined || idx === -1) return;
 
     const preset = babelrc.presets[idx];
     if (typeof preset === 'string') {


### PR DESCRIPTION
## Current Behavior
The following patch `node_modules/@nx/web/src/migrations/update-15-5-4/update-babel-preset.js` fails and causing to stop the migration plan when migrating from Nx v15 to v16 in case of there is no `presets` defined in the `.babelrc` file.
![Screenshot 2024-05-16 at 1 01 34 PM](https://github.com/nrwl/nx/assets/49886457/476a8e07-4f58-4e79-b8ca-5a9f9ed8094e)

## Expected Behavior
Should stop the patch and continue the migration plan.

Closes https://github.com/nrwl/nx/pull/23428
