### PR TITLE
fix(node): Docker generator should work

### DIFF
--- a/packages/node/src/generators/application/application.legacy.spec.ts
+++ b/packages/node/src/generators/application/application.legacy.spec.ts
@@ -1,3 +1,5 @@
+import 'nx/src/internal-testing-utils/mock-project-graph';
+
 import {
   readNxJson,
   readProjectConfiguration,

--- a/packages/node/src/generators/e2e-project/e2e-project.spec.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.spec.ts
@@ -1,3 +1,5 @@
+import 'nx/src/internal-testing-utils/mock-project-graph';
+
 import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { applicationGenerator } from '../application/application';

--- a/packages/node/src/generators/setup-docker/files/Dockerfile__tmpl__
+++ b/packages/node/src/generators/setup-docker/files/Dockerfile__tmpl__
@@ -14,7 +14,7 @@ WORKDIR /app
 RUN addgroup --system <%= project %> && \
           adduser --system -G <%= project %> <%= project %>
 
-COPY <%= buildLocation %> <%= project %>
+COPY <%= buildLocation %> <%= project %>/
 RUN chown -R <%= project %>:<%= project %> .
 
 # You can remove this install step if you build with `--bundle` option.

--- a/packages/node/src/generators/setup-docker/setup-docker.spec.ts
+++ b/packages/node/src/generators/setup-docker/setup-docker.spec.ts
@@ -1,16 +1,35 @@
-import { readProjectConfiguration, Tree } from '@nx/devkit';
+import 'nx/src/internal-testing-utils/mock-project-graph';
+
+import {
+  ProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { applicationGenerator } from '../application/application';
+
 describe('setupDockerGenerator', () => {
   let tree: Tree;
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace();
+
+    jest.resetModules();
   });
 
   describe('integrated', () => {
     it('should create docker assets when --docker is passed', async () => {
+      const projectName = 'integreated-api';
+      // Since we mock the project graph, we need to mock the project configuration as well
+      mockReadCachedProjectConfiguration({
+        name: projectName,
+        root: projectName,
+      });
+
+      const { applicationGenerator } = await import(
+        '../application/application'
+      );
+
       await applicationGenerator(tree, {
-        name: 'api',
+        name: projectName,
         framework: 'express',
         e2eTestRunner: 'none',
         docker: true,
@@ -18,14 +37,16 @@ describe('setupDockerGenerator', () => {
         addPlugin: true,
       });
 
-      const project = readProjectConfiguration(tree, 'api');
+      const project = readProjectConfiguration(tree, projectName);
 
-      expect(tree.exists('api/Dockerfile')).toBeTruthy();
+      const dockerFile = tree.read(`${projectName}/Dockerfile`, 'utf8');
+      expect(tree.exists(`${projectName}/Dockerfile`)).toBeTruthy();
+      expect(dockerFile).toContain(`COPY dist/${projectName} ${projectName}/`);
       expect(project.targets).toEqual(
         expect.objectContaining({
           'docker-build': {
             dependsOn: ['build'],
-            command: 'docker build -f api/Dockerfile . -t api',
+            command: `docker build -f ${projectName}/Dockerfile . -t ${projectName}`,
           },
         })
       );
@@ -34,8 +55,14 @@ describe('setupDockerGenerator', () => {
 
   describe('standalone', () => {
     it('should create docker assets when --docker is passed', async () => {
+      const projectName = 'standalone-api';
+      mockReadCachedProjectConfiguration({ name: projectName, root: '' });
+
+      const { applicationGenerator } = await import(
+        '../application/application'
+      );
       await applicationGenerator(tree, {
-        name: 'api',
+        name: projectName,
         framework: 'fastify',
         rootProject: true,
         docker: true,
@@ -43,16 +70,39 @@ describe('setupDockerGenerator', () => {
         addPlugin: true,
       });
 
-      const project = readProjectConfiguration(tree, 'api');
-      expect(tree.exists('Dockerfile')).toBeTruthy();
+      const project = readProjectConfiguration(tree, projectName);
+      const dockerFile = tree.read(`Dockerfile`, 'utf8');
+
+      expect(tree.exists(`Dockerfile`)).toBeTruthy();
+      expect(dockerFile).toContain(`COPY dist/${projectName} ${projectName}/`);
       expect(project.targets).toEqual(
         expect.objectContaining({
           'docker-build': {
             dependsOn: ['build'],
-            command: 'docker build -f Dockerfile . -t api',
+            command: `docker build -f Dockerfile . -t ${projectName}`,
           },
         })
       );
     });
   });
 });
+
+const mockReadCachedProjectConfiguration = (
+  projectConfig: ProjectConfiguration
+) => {
+  jest.mock('nx/src/project-graph/project-graph', () => {
+    return {
+      ...jest.requireActual('nx/src/project-graph/project-graph'),
+      readCachedProjectConfiguration: jest.fn(() => {
+        return {
+          root: projectConfig.root,
+          targets: {
+            build: {
+              outputs: [`dist/${projectConfig.name}`],
+            },
+          },
+        };
+      }),
+    };
+  });
+};


### PR DESCRIPTION
Also fixes the unit tests for node package

## Currently

When you generate a docker file using either the node generator or the node:setup-docker generator using inferred targets would create the DockerFile but the COPY command would be incorrect.

It would resemble something similar to
```
//...

COPY   acme 

//etc...

```

## Expected

Now it generates the correct command.

```
//...

COPY dist/acme  acme/

//etc...

```

closes: #23365
