### PR TITLE
docs(core): add a page for Nx releases

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -4343,6 +4343,14 @@
             "isExternal": false,
             "children": [],
             "disableCollapsible": false
+          },
+          {
+            "name": "Releases",
+            "path": "/reference/releases",
+            "id": "releases",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
           }
         ],
         "disableCollapsible": false
@@ -4399,6 +4407,14 @@
         "name": "Glossary",
         "path": "/reference/glossary",
         "id": "glossary",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Releases",
+        "path": "/reference/releases",
+        "id": "releases",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -5946,6 +5946,17 @@
         "isExternal": false,
         "path": "/reference/glossary",
         "tags": []
+      },
+      {
+        "id": "releases",
+        "name": "Releases",
+        "description": "",
+        "mediaImage": "",
+        "file": "shared/reference/releases",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/reference/releases",
+        "tags": []
       }
     ],
     "isExternal": false,
@@ -6027,6 +6038,17 @@
     "itemList": [],
     "isExternal": false,
     "path": "/reference/glossary",
+    "tags": []
+  },
+  "/reference/releases": {
+    "id": "releases",
+    "name": "Releases",
+    "description": "",
+    "mediaImage": "",
+    "file": "shared/reference/releases",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/reference/releases",
     "tags": []
   },
   "/troubleshooting": {

--- a/docs/map.json
+++ b/docs/map.json
@@ -1237,6 +1237,12 @@
               "id": "glossary",
               "tags": [],
               "file": "shared/reference/glossary"
+            },
+            {
+              "name": "Releases",
+              "id": "releases",
+              "tags": [],
+              "file": "shared/reference/releases"
             }
           ]
         },

--- a/docs/shared/reference/releases.md
+++ b/docs/shared/reference/releases.md
@@ -1,0 +1,51 @@
+# Releases
+
+Major Nx versions are released as the _latest_ every six months, typically around April and October.
+After each major version release, the _previous_ major version moves to long-term support (LTS) for 12 months, after
+which it becomes unsupported.
+Each major version has 18 total months of support from when it is first released to when it falls out of LTS. Users
+should use `nx migrate` to ensure that they stay on a supported version.
+
+### Major, Minor, and Patch Versions
+
+- **Patch** versions include security or bug fixes, and are released as needed.
+- **Minor** versions include new features and fixes, and are released less frequently. It is a good idea to regularly
+  update to the latest minor version.
+- **Major** versions may contain [breaking changes](#breaking-changes-and-migration-path), and are released twice a
+  year.
+
+## Supported Versions
+
+The following are the currently supported major versions of Nx.
+
+| Version | Support Type | Release Date |
+| ------- | ------------ | ------------ |
+| v19     | Current      | 2024-05-06   |
+| v18\*   | LTS          | 2024-02-03   |
+| v17     | LTS          | 2023-10-19   |
+| v16     | LTS          | 2023-04-27   |
+
+**\*Note:** v18 is a special release and does not fit into the normal release cycle. Thus, v16 continues to be supported
+according to schedule.
+
+### Current vs LTS
+
+The current version of Nx will receive new features as well as any fixes to any unintentional behavior.
+When a new major version of Nx is released, previous versions will go into LTS.
+LTS versions of Nx will receive security patches as well as critical fixes.
+
+## Deprecation Policy
+
+When the Nx team intends to remove an API or feature, it will be marked as _deprecated_. Deprecation warnings can
+surface in documentation, terminal output, or in TSDoc. The deprecated API will remain
+functional for a whole major version, after which they will be removed.
+
+For example, if a feature is deprecated in v19.1.0, it will be removed in v21.0.0 (two major versions later).
+
+## Breaking Changes and Migration Path
+
+Breaking changes, including the removal of deprecated APIs, will be highlighted under _Breaking Changes_ in
+the [changelog](/changelog).
+
+Whenever possible, the Nx team will provide automatic migrations
+through [`nx migrate`](/nx-api/nx/documents/migrate#migrate).

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -194,6 +194,7 @@
     - [.nxignore](/reference/nxignore)
     - [Environment Variables](/reference/environment-variables)
     - [Glossary](/reference/glossary)
+    - [Releases](/reference/releases)
   - [Troubleshooting](/troubleshooting)
     - [Resolve Circular Dependencies](/troubleshooting/resolve-circular-dependencies)
     - [Troubleshooting Nx Install Issues](/troubleshooting/troubleshoot-nx-install-issues)

--- a/nx-dev/nx-dev/pages/changelog.tsx
+++ b/nx-dev/nx-dev/pages/changelog.tsx
@@ -239,7 +239,11 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
               Nx Changelog
             </h1>
             <p className="mt-4">
-              All the Nx goodies in one page, sorted by release.
+              All the Nx goodies in one page, sorted by release. See our{' '}
+              <Link className="underline" href="/reference/releases">
+                release page
+              </Link>{' '}
+              for information about the release cycle and LTS policy.
             </p>
           </header>
           <ul className="m-0 space-y-6 py-6">


### PR DESCRIPTION
Add a page (under References > Releases) to show current LTS versions and policies on deprecation and breaking changes. Also link to it from the Changelog.

Preview: https://nx-dev-git-docs-releases-nrwl.vercel.app/reference/releases



## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23220
