### PR TITLE
docs(core): list version for runtime input

### DIFF
--- a/docs/shared/deprecated/runtime-cache-inputs.md
+++ b/docs/shared/deprecated/runtime-cache-inputs.md
@@ -18,7 +18,7 @@ The `runtimeCacheInputs` property was used as a way to add extra inputs to the N
 }
 ```
 
-Instead of specifying the runtime inputs in `tasksRunnerOptions`, you can now include them as runtime inputs in the standard [`inputs` and `namedInputs` area of your project configuration](/reference/project-configuration#inputs-&-namedinputs) or [`nx.json`](/reference/nx-json#inputs-&-namedinputs).
+Instead of specifying the runtime inputs in `tasksRunnerOptions`, in Nx 14.4 you can include them as runtime inputs in the standard [`inputs` and `namedInputs` area of your project configuration](/reference/project-configuration#inputs-&-namedinputs) or [`nx.json`](/reference/nx-json#inputs-&-namedinputs).
 
 The new style looks like this:
 


### PR DESCRIPTION
Specifies which version of Nx allows `runtime` inputs to be listed in the `inputs` property.

Fixes #17594
