### PR TITLE
fix(angular): @angular/core should always be provided as a shared package #19121

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -39,6 +39,7 @@ export const DEFAULT_NPM_PACKAGES_TO_AVOID = [
   '@nrwl/angular/mf',
 ];
 export const DEFAULT_ANGULAR_PACKAGES_TO_SHARE = [
+  '@angular/core',
   '@angular/animations',
   '@angular/common',
 ];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In our Module Federation utils for Angular, we set some packages that should always be shared.
This array was missing `@angular/core` which should be shared at all times for DI to function as expected


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure `@angular/core` is shared

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19121
