### PR TITLE
fix(vite): add  prop to config to ensure output dir is emptied #23382

### DIFF
--- a/packages/react/src/generators/application/__snapshots__/application.legacy.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.legacy.spec.ts.snap
@@ -31,6 +31,7 @@ nxViteTsPaths()],
         
     build: {
       outDir: '../dist/my-vite-app',
+      emptyOutDir: true,
       reportCompressedSize: true,
       commonjsOptions: {
         transformMixedEsModules: true,

--- a/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -119,6 +119,7 @@ nxViteTsPaths()],
         
     build: {
       outDir: '../dist/my-app',
+      emptyOutDir: true,
       reportCompressedSize: true,
       commonjsOptions: {
         transformMixedEsModules: true,
@@ -197,6 +198,7 @@ nxViteTsPaths()],
         
     build: {
       outDir: '../dist/my-app',
+      emptyOutDir: true,
       reportCompressedSize: true,
       commonjsOptions: {
         transformMixedEsModules: true,
@@ -322,6 +324,7 @@ nxViteTsPaths()],
         
     build: {
       outDir: '../dist/my-app',
+      emptyOutDir: true,
       reportCompressedSize: true,
       commonjsOptions: {
         transformMixedEsModules: true,

--- a/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -62,6 +62,7 @@ dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') 
       // See: https://vitejs.dev/guide/build.html#library-mode
       build: {
         outDir: '../dist/my-lib',
+        emptyOutDir: true,
         reportCompressedSize: true,
         commonjsOptions: {
           transformMixedEsModules: true,

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -30,6 +30,7 @@ export default defineConfig({
   // See: https://vitejs.dev/guide/build.html#library-mode
   build: {
     outDir: '../../dist/libs/react-lib-nonb-jest',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,
@@ -82,6 +83,7 @@ export default defineConfig({
   // See: https://vitejs.dev/guide/build.html#library-mode
   build: {
     outDir: '../../dist/libs/react-lib-nonb-jest',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,
@@ -132,6 +134,7 @@ export default defineConfig({
   cacheDir: '../../node_modules/.vite/libs/react-lib-nonb-vitest',
   build: {
     outDir: '../../dist/libs/react-lib-nonb-vitest',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,
@@ -203,6 +206,7 @@ export default defineConfig({
 
   build: {
     outDir: '../../dist/apps/my-test-react-app',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,
@@ -260,6 +264,7 @@ export default defineConfig({
 
   build: {
     outDir: '../../dist/apps/my-test-web-app',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,
@@ -317,6 +322,7 @@ export default defineConfig({
 
   build: {
     outDir: '../../dist/apps/my-test-react-app',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -374,6 +374,7 @@ export function createOrEditViteConfig(
       // See: https://vitejs.dev/guide/build.html#library-mode
       build: {
         outDir: '${buildOutDir}',
+        emptyOutDir: true,
         reportCompressedSize: true,
         commonjsOptions: {
           transformMixedEsModules: true,
@@ -395,6 +396,7 @@ export function createOrEditViteConfig(
     : `
     build: {
       outDir: '${buildOutDir}',
+      emptyOutDir: true,
       reportCompressedSize: true,
       commonjsOptions: {
         transformMixedEsModules: true,

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -68,6 +68,7 @@ export default defineConfig({
 
   build: {
     outDir: '../dist/test',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -30,6 +30,7 @@ export default defineConfig({
   // See: https://vitejs.dev/guide/build.html#library-mode
   build: {
     outDir: '../dist/my-lib',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,
@@ -125,6 +126,7 @@ export default defineConfig({
   // See: https://vitejs.dev/guide/build.html#library-mode
   build: {
     outDir: '../dist/my-lib',
+    emptyOutDir: true,
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not generate `emptyOutDir` when creating vite config, which throws a warning and does not delete the output directory when it is outside the project root.
This is common in integrated workspaces


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`emptyOutDir` should be added to the config

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23382
