### PR TITLE
fix(react): remote generator should update host's app routes

### DIFF
--- a/packages/react/src/generators/remote/lib/update-host-with-remote.ts
+++ b/packages/react/src/generators/remote/lib/update-host-with-remote.ts
@@ -7,7 +7,6 @@ import {
   Tree,
 } from '@nx/devkit';
 import {
-  addRemoteDefinition,
   addRemoteRoute,
   addRemoteToConfig,
 } from '../../../module-federation/ast-utils';
@@ -38,10 +37,6 @@ export function updateHostWithRemote(
     );
   }
 
-  const remoteDefsPath = joinPathFragments(
-    hostConfig.sourceRoot,
-    'remotes.d.ts'
-  );
   const appComponentPath = findAppComponentPath(host, hostConfig.sourceRoot);
 
   if (host.exists(moduleFederationConfigPath)) {
@@ -65,31 +60,14 @@ export function updateHostWithRemote(
     );
   }
 
-  if (host.exists(remoteDefsPath)) {
-    let sourceCode = host.read(remoteDefsPath).toString();
-    const source = tsModule.createSourceFile(
-      moduleFederationConfigPath,
-      sourceCode,
-      tsModule.ScriptTarget.Latest,
-      true
-    );
-    host.write(
-      remoteDefsPath,
-      applyChangesToString(sourceCode, addRemoteDefinition(source, remoteName))
-    );
-  } else {
-    logger.warn(
-      `Could not find remote definitions at ${remoteDefsPath}. Did you generate this project with "@nx/react:host"?`
-    );
-  }
-
   if (host.exists(appComponentPath)) {
     let sourceCode = host.read(appComponentPath).toString();
     const source = tsModule.createSourceFile(
       moduleFederationConfigPath,
       sourceCode,
       tsModule.ScriptTarget.Latest,
-      true
+      true,
+      tsModule.ScriptKind.TSX
     );
     host.write(
       appComponentPath,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When parsing the source file for updating the host's app.tsx file, typescript was not parsing the file as a TSX file.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The file should be parsed as TSX

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
