### PR TITLE
fix(core): only check for `err` in `handleWorkspaceChanges`

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -298,7 +298,7 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
       return;
     }
 
-    if (err || !changeEvents || !changeEvents.length) {
+    if (err) {
       let error = typeof err === 'string' ? new Error(err) : err;
       serverLogger.watcherLog(
         'Unexpected workspace watcher error',


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When there are watch event changes, and we filter them all out, we get an empty `changedEvents` array. There were previous checks that had a `!changedEvents.length` condition that resolved to true when the length was 0. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We now check to see if `err` is set before triggering the error branch

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23031
