### PR TITLE
fix(repo): hash proper projects when nx

### DIFF
--- a/project.json
+++ b/project.json
@@ -12,6 +12,17 @@
     },
     "populate-local-registry-storage": {
       "cache": true,
+      "inputs": [
+        {
+          "input": "production",
+          "projects": [
+            "*",
+            "!nx-dev",
+            "!typedoc-theme",
+            "!tools-documentation-create-embeddings"
+          ]
+        }
+      ],
       "command": "node ./scripts/local-registry/run-populate-storage.mjs",
       "outputs": ["{workspaceRoot}/build/local-registry/storage"]
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `prepopulate-local-registry` task was not being hashed according to the packages properly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `prepopulate-local-registry` task is hashing the packages we build for publishing.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
