### PR TITLE
feat(core): allow executor definition to point to another executor

### DIFF
--- a/packages/nx/src/command-line/run/executor-utils.ts
+++ b/packages/nx/src/command-line/run/executor-utils.ts
@@ -129,16 +129,17 @@ function readExecutorJson(
     join(dirname(packageJsonPath), executorsFile)
   );
   const executorsJson = readJsonFile<ExecutorsJson>(executorsFilePath);
-  const executorConfig: {
-    implementation: string;
-    batchImplementation?: string;
-    schema: string;
-    hasher?: string;
-  } = executorsJson.executors?.[executor] || executorsJson.builders?.[executor];
+  const executorConfig =
+    executorsJson.executors?.[executor] || executorsJson.builders?.[executor];
   if (!executorConfig) {
     throw new Error(
       `Cannot find executor '${executor}' in ${executorsFilePath}.`
     );
+  }
+  if (typeof executorConfig === 'string') {
+    // Angular CLI can have a builder pointing to another package:builder
+    const [packageName, executorName] = executorConfig.split(':');
+    return readExecutorJson(packageName, executorName, root, projects);
   }
   const isNgCompat = !executorsJson.executors?.[executor];
   return { executorsFilePath, executorConfig, isNgCompat };

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -37,13 +37,14 @@ export interface GeneratorsJsonEntry {
 
 export type OutputCaptureMethod = 'direct-nodejs' | 'pipe';
 
-export interface ExecutorsJsonEntry {
+export interface ExecutorJsonEntryConfig {
   schema: string;
   implementation: string;
   batchImplementation?: string;
   description?: string;
   hasher?: string;
 }
+export type ExecutorsJsonEntry = string | ExecutorJsonEntryConfig;
 
 export type Dependencies = 'dependencies' | 'devDependencies';
 

--- a/packages/plugin/src/migrations/update-16-0-0/cli-in-schema-json.ts
+++ b/packages/plugin/src/migrations/update-16-0-0/cli-in-schema-json.ts
@@ -160,7 +160,7 @@ function deleteCliPropFromSchemaFile(
   entry: ExecutorsJsonEntry | GeneratorsJsonEntry,
   tree: Tree
 ) {
-  if (!entry.schema) {
+  if (typeof entry === 'string' || !entry.schema) {
     return;
   }
   const schemaPath = joinPathFragments(dirname(collectionPath), entry.schema);


### PR DESCRIPTION
Add support for executor definitions that point to another executor. The upcoming Angular 18 uses this feature: https://github.com/angular/angular-cli/blob/main/packages/angular_devkit/build_angular/builders.json#L4, so we need to be able to resolve the builders correctly using such a configuration.

Note: the change is also in [the Angular 18 PR](https://github.com/nrwl/nx/pull/22509), where it's tested with the Angular version that requires it. I'm extracting the change to this PR to facilitate reviews and reduce the size of the Angular 18 PR.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
