### PR TITLE
fix(react): applications not using plugin usage should set target defaults

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -973,4 +973,32 @@ describe('app', () => {
       }
     );
   });
+
+  it('should add targetDefaults to nxJson when addPlugin=false', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    let nxJson = readNxJson(tree);
+    delete nxJson.targetDefaults;
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    await applicationGenerator(tree, {
+      name: 'myapp',
+      addPlugin: false,
+      linter: Linter.None,
+      style: 'none',
+      e2eTestRunner: 'none',
+    });
+
+    // ASSERT
+    nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults.build).toMatchInlineSnapshot(`
+      {
+        "cache": true,
+        "dependsOn": [
+          "^build",
+        ],
+      }
+    `);
+  });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generating applications when `addPlugin: false` is not setting targetDefaults that are expected to be added by inference plugins to the individual targets


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When `addPlugin: false`, specifically set `targetDefaults.build` correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
