### PR TITLE
docs(core): fix dependsOn snippet in project configuration reference

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -348,7 +348,7 @@ You can also express task dependencies with an object syntax:
 ```json
 {
   "targets": {
-    "build": {
+    "test": {
       "dependsOn": [
         {
           "target": "build", // target name


### PR DESCRIPTION
I'm not totally sure, but by reading the docs, the intent of the first example is to say that the test target depends of the build target. Otherwise, it would mean that the build target depends of the build target, which does not make sense. Or did I misunderstood something in the doc ?

