### PR TITLE
docs(nx-dev): Add deprecation message for aws-lambda

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -1384,7 +1384,7 @@
                 "disableCollapsible": false
               },
               {
-                "name": "Deploying AWS lambda in Node.js",
+                "name": "Deploying AWS lambda in Node.js (deprecated)",
                 "path": "/recipes/node/node-aws-lambda",
                 "id": "node-aws-lambda",
                 "isExternal": false,
@@ -2615,7 +2615,7 @@
             "disableCollapsible": false
           },
           {
-            "name": "Deploying AWS lambda in Node.js",
+            "name": "Deploying AWS lambda in Node.js (deprecated)",
             "path": "/recipes/node/node-aws-lambda",
             "id": "node-aws-lambda",
             "isExternal": false,
@@ -2658,7 +2658,7 @@
         "disableCollapsible": false
       },
       {
-        "name": "Deploying AWS lambda in Node.js",
+        "name": "Deploying AWS lambda in Node.js (deprecated)",
         "path": "/recipes/node/node-aws-lambda",
         "id": "node-aws-lambda",
         "isExternal": false,

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -1891,7 +1891,7 @@
           },
           {
             "id": "node-aws-lambda",
-            "name": "Deploying AWS lambda in Node.js",
+            "name": "Deploying AWS lambda in Node.js (deprecated)",
             "description": "",
             "mediaImage": "",
             "file": "shared/recipes/deployment/node-aws-lambda",
@@ -3577,7 +3577,7 @@
       },
       {
         "id": "node-aws-lambda",
-        "name": "Deploying AWS lambda in Node.js",
+        "name": "Deploying AWS lambda in Node.js (deprecated)",
         "description": "",
         "mediaImage": "",
         "file": "shared/recipes/deployment/node-aws-lambda",
@@ -3637,7 +3637,7 @@
   },
   "/recipes/node/node-aws-lambda": {
     "id": "node-aws-lambda",
-    "name": "Deploying AWS lambda in Node.js",
+    "name": "Deploying AWS lambda in Node.js (deprecated)",
     "description": "",
     "mediaImage": "",
     "file": "shared/recipes/deployment/node-aws-lambda",

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -838,7 +838,7 @@
       "description": "",
       "file": "shared/recipes/deployment/node-aws-lambda",
       "id": "node-aws-lambda",
-      "name": "Deploying AWS lambda in Node.js",
+      "name": "Deploying AWS lambda in Node.js (deprecated)",
       "path": "/recipes/node/node-aws-lambda"
     }
   ],
@@ -861,7 +861,7 @@
       "description": "",
       "file": "shared/recipes/deployment/node-aws-lambda",
       "id": "node-aws-lambda",
-      "name": "Deploying AWS lambda in Node.js",
+      "name": "Deploying AWS lambda in Node.js (deprecated)",
       "path": "/recipes/node/node-aws-lambda"
     },
     {

--- a/docs/map.json
+++ b/docs/map.json
@@ -576,7 +576,7 @@
                   "file": "shared/recipes/deployment/node-serverless-functions-netlify"
                 },
                 {
-                  "name": "Deploying AWS lambda in Node.js",
+                  "name": "Deploying AWS lambda in Node.js (deprecated)",
                   "id": "node-aws-lambda",
                   "tags": ["deployment", "node"],
                   "file": "shared/recipes/deployment/node-aws-lambda"

--- a/docs/shared/recipes/deployment/node-aws-lambda.md
+++ b/docs/shared/recipes/deployment/node-aws-lambda.md
@@ -1,5 +1,10 @@
 # Deploying AWS Lambda Functions in Node.js
 
+{% callout type="warning"  title="deprecated" %}
+The @nx/aws-lambda plugin is deprecated and unmaintained.
+We are committed to providing high-quality tooling to community, and we no longer have the capacity to keep this plugin updated.
+{% /callout %}
+
 This recipe guides you through setting up AWS Lambda functions with Nx.
 
 ## Getting set up

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -88,7 +88,7 @@
     - [Node](/recipes/node)
       - [Deploying a Node App to Fly.io](/recipes/node/node-server-fly-io)
       - [Add and Deploy Netlify Edge Functions with Node](/recipes/node/node-serverless-functions-netlify)
-      - [Deploying AWS lambda in Node.js](/recipes/node/node-aws-lambda)
+      - [Deploying AWS lambda in Node.js (deprecated)](/recipes/node/node-aws-lambda)
       - [Set Up Application Proxies](/recipes/node/application-proxies)
       - [Wait for Tasks to Finish](/recipes/node/wait-for-tasks)
     - [Storybook](/recipes/storybook)


### PR DESCRIPTION
Adds deprecation message for `@nx/aws-lambda` since the module is deprecated and unmaintained.

Ref: https://www.npmjs.com/package/@nx/aws-lambda

closes: #23520
