### PR TITLE
docs(nx-cloud): Change exec to dlx for GHA Nx cloud agent command.

### DIFF
--- a/docs/nx-cloud/tutorial/github-actions.md
+++ b/docs/nx-cloud/tutorial/github-actions.md
@@ -403,7 +403,7 @@ The Nx Agents feature
 Let's enable Nx Agents
 
 ```shell
-pnpm exec nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 ```
 
 We recommend you add this line right after you check out the repo, before installing node modules.
@@ -442,7 +442,7 @@ jobs:
         with:
           version: 8
       - run: |
-          pnpm exec nx-cloud start-ci-run \
+          pnpm dlx nx-cloud start-ci-run \
             --distribute-on="3 linux-medium-js" \
             --stop-agents-after="e2e-ci"
       - name: Restore cached npm dependencies


### PR DESCRIPTION
Node modules are installed yet so exec causes `Command "nx-cloud" not found. ` error.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The suggested command in recommended position causes an error.

## Expected Behavior
The suggested command in recommended position would not cause an error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
