### PR TITLE
fix(core): use current user when hashing native file & enable setting its directory via env

### DIFF
--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -30,6 +30,7 @@ The following environment variables are ones that you can set to change the beha
 | NX_SKIP_LOG_GROUPING             | boolean | If set to `true`, Nx will not group command's logs on CI.                                                                                                                                                                      |
 | NX_MIGRATE_CLI_VERSION           | string  | The version of Nx to use for running the `nx migrate` command. If not set, it defaults to `latest`.                                                                                                                            |
 | NX_LOAD_DOT_ENV_FILES            | boolean | If set to 'false', Nx will not load any environment files (e.g. `.local.env`, `.env.local`)                                                                                                                                    |
+| NX_NATIVE_FILE_CACHE_DIRECTORY   | string  | The cache for native `.node` files is stored under a global temp directory by default. Set this variable to use a different directory. This is interpreted as an absolute path.                                                |
 
 Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators.
 

--- a/packages/nx/src/command-line/reset/reset.ts
+++ b/packages/nx/src/command-line/reset/reset.ts
@@ -5,7 +5,7 @@ import {
   projectGraphCacheDirectory,
 } from '../../utils/cache-directory';
 import { output } from '../../utils/output';
-import { nativeFileCacheLocation } from '../../native/native-file-cache-location';
+import { getNativeFileCacheLocation } from '../../native/native-file-cache-location';
 
 export async function resetHandler() {
   output.note({
@@ -15,7 +15,7 @@ export async function resetHandler() {
   await daemonClient.stop();
   output.log({ title: 'Daemon Server - Stopped' });
   try {
-    rmSync(nativeFileCacheLocation, { recursive: true, force: true });
+    rmSync(getNativeFileCacheLocation(), { recursive: true, force: true });
   } catch (e) {
     // ignore, deleting the native file cache is not critical and can fail if another process is locking the file
   }

--- a/packages/nx/src/native/index.js
+++ b/packages/nx/src/native/index.js
@@ -2,7 +2,7 @@ const { join, basename } = require('path');
 const { copyFileSync, existsSync, mkdirSync } = require('fs');
 const Module = require('module');
 const { nxVersion } = require('../utils/versions');
-const { nativeFileCacheLocation } = require('./native-file-cache-location');
+const { getNativeFileCacheLocation } = require('./native-file-cache-location');
 
 const nxPackages = new Set([
   '@nx/nx-android-arm64',
@@ -54,6 +54,7 @@ Module._load = function (request, parent, isMain) {
     const fileName = basename(nativeLocation);
 
     // we copy the file to a workspace-scoped tmp directory and prefix with nxVersion to avoid stale files being loaded
+    const nativeFileCacheLocation = getNativeFileCacheLocation();
     const tmpFile = join(nativeFileCacheLocation, nxVersion + '-' + fileName);
     if (existsSync(tmpFile)) {
       return originalLoad.apply(this, [tmpFile, parent, isMain]);

--- a/packages/nx/src/native/native-file-cache-location.ts
+++ b/packages/nx/src/native/native-file-cache-location.ts
@@ -15,6 +15,10 @@ function getNativeFileCacheBaseFolder() {
   if (process.env.NX_NATIVE_FILE_CACHE_DIRECTORY) {
     return process.env.NX_NATIVE_FILE_CACHE_DIRECTORY;
   } else {
-    return join(tmpdir(), 'nx-native-file-cache');
+    const shortUserHash = createHash('sha256')
+      .update(userInfo().username)
+      .digest('hex')
+      .substring(0, 7);
+    return join(tmpdir(), `nx-native-file-cache-${shortUserHash}`);
   }
 }

--- a/packages/nx/src/native/native-file-cache-location.ts
+++ b/packages/nx/src/native/native-file-cache-location.ts
@@ -3,22 +3,15 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 import { workspaceRoot } from '../utils/workspace-root';
 
-export const nativeFileCacheLocation = join(
-  getNativeFileCacheBaseFolder(),
-  createHash('sha256')
-    .update(workspaceRoot)
-    .update(userInfo().username)
-    .digest('hex')
-);
-
-function getNativeFileCacheBaseFolder() {
+export function getNativeFileCacheLocation() {
   if (process.env.NX_NATIVE_FILE_CACHE_DIRECTORY) {
     return process.env.NX_NATIVE_FILE_CACHE_DIRECTORY;
   } else {
-    const shortUserHash = createHash('sha256')
+    const shortHash = createHash('sha256')
       .update(userInfo().username)
+      .update(workspaceRoot)
       .digest('hex')
       .substring(0, 7);
-    return join(tmpdir(), `nx-native-file-cache-${shortUserHash}`);
+    return join(tmpdir(), `nx-native-file-cache-${shortHash}`);
   }
 }

--- a/packages/nx/src/native/native-file-cache-location.ts
+++ b/packages/nx/src/native/native-file-cache-location.ts
@@ -1,10 +1,20 @@
-import { tmpdir } from 'os';
+import { tmpdir, userInfo } from 'os';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { workspaceRoot } from '../utils/workspace-root';
 
 export const nativeFileCacheLocation = join(
-  tmpdir(),
-  'nx-native-file-cache',
-  createHash('sha256').update(workspaceRoot).digest('hex')
+  getNativeFileCacheBaseFolder(),
+  createHash('sha256')
+    .update(workspaceRoot)
+    .update(userInfo().username)
+    .digest('hex')
 );
+
+function getNativeFileCacheBaseFolder() {
+  if (process.env.NX_NATIVE_FILE_CACHE_DIRECTORY) {
+    return process.env.NX_NATIVE_FILE_CACHE_DIRECTORY;
+  } else {
+    return join(tmpdir(), 'nx-native-file-cache');
+  }
+}


### PR DESCRIPTION
## Current Behavior
The native file hashing takes only the nx version & workspace path into account. 
There is also no way to control the storage location of native `.node` files used by nx.

## Expected Behavior
The native file hashing takes the nx version, workspace path & current username into account, making sure the cache isn't shared between multiple users on the same device.
It's also possible to control the exact location of the native file cache by setting the `NX_NATIVE_FILE_CACHE_DIRECTORY` environment variable if you need to move it somewhere else.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
