### PR TITLE
fix(js): print warning when --generateLockfile is used with Bun rather than erroring out

### DIFF
--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -11,6 +11,7 @@ import {
   ExecutorContext,
   getOutputsForTargetAndConfiguration,
   joinPathFragments,
+  logger,
   ProjectFileMap,
   ProjectGraph,
   ProjectGraphExternalNode,
@@ -103,18 +104,24 @@ export function updatePackageJson(
 
   if (options.generateLockfile) {
     const packageManager = detectPackageManager(context.root);
-    const lockFile = createLockFile(
-      packageJson,
-      context.projectGraph,
-      packageManager
-    );
-    writeFileSync(
-      `${options.outputPath}/${getLockFileName(packageManager)}`,
-      lockFile,
-      {
-        encoding: 'utf-8',
-      }
-    );
+    if (packageManager === 'bun') {
+      logger.warn(
+        `Bun lockfile generation is unsupported. Remove "generateLockfile" option or set it to false.`
+      );
+    } else {
+      const lockFile = createLockFile(
+        packageJson,
+        context.projectGraph,
+        packageManager
+      );
+      writeFileSync(
+        `${options.outputPath}/${getLockFileName(packageManager)}`,
+        lockFile,
+        {
+          encoding: 'utf-8',
+        }
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Currently if you pass `--generateLockfile` and use Bun, it'll error out because the lockfile content is returned as `null`. There is no API to prune `bun.lockb` files so it's better to skip it with a warning to the user. We can discuss generating `yarn.lock` file instead as a follow-up.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
