### PR TITLE
fix(linter): only set flat config env for eslint v9+

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -36,6 +36,7 @@
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
     "eslint": "^8.0.0 || ^9.0.0",
+    "semver": "^7.5.3",
     "tslib": "^2.3.0",
     "typescript": "~5.4.2"
   },

--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -108,9 +108,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": ".",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",
@@ -183,9 +180,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": "apps/my-app",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",
@@ -227,9 +221,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": "apps/my-app",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",
@@ -343,9 +334,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": "apps/my-app",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",
@@ -371,9 +359,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": "libs/my-lib",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",
@@ -459,9 +444,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": "apps/my-app",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",
@@ -488,9 +470,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": "libs/my-lib",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",
@@ -534,9 +513,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": "apps/myapp",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",
@@ -585,9 +561,6 @@ describe('@nx/eslint/plugin', () => {
                   ],
                   "options": {
                     "cwd": "apps/myapp/nested/mylib",
-                    "env": {
-                      "ESLINT_USE_FLAT_CONFIG": "false",
-                    },
                   },
                   "outputs": [
                     "{options.outputFile}",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `ESLINT_USE_FLAT_CONFIG` env flag was set unnecessarily  even if the installed version of ESLint is < 9.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `ESLINT_USE_FLAT_CONFIG` env flag is only set if the value is different than the default in the installed version of ESLint.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
