### PR TITLE
Update local-executors.md

### DIFF
--- a/docs/shared/recipes/plugins/local-executors.md
+++ b/docs/shared/recipes/plugins/local-executors.md
@@ -10,7 +10,7 @@ If you don't already have a local plugin, use Nx to generate one:
 
 ```shell {% skipRescope=true %}
 nx add @nx/plugin
-nx g @nx/plugin:plugin my-plugin
+nx g @nx/plugin:plugin libs/my-plugin
 ```
 
 Use the Nx CLI to generate the initial files needed for your executor.


### PR DESCRIPTION
Change path for generation of my-plugin to libs/my-plugin

nx g @nx/plugin:plugin libs/my-plugin

This makes it work with the plugin executor generate command.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a new plugin for the first time with the command `nx g @nx/plugin:plugin my-plugin` it generates the plugin my-plugin in the root of the project.
When executing `nx generate @nx/plugin:executor echo --directory=libs/my-plugin/src/executors/echo` it gets an error `The provided directory resolved relative to the current working directory "libs/my-plugin/src/executors/echo" does not exist under any project root. Please make sure to navigate to a location or provide a directory that exists under a project root.
`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When executing the commands in the root of a new Nx project with no plugin, it will generate a new plugin called "my-plugin" in relative directory of `libs/my-plugin` and then the generation of the executor will work with the existing documentation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
