### PR TITLE
fix(linter): only depend on eslint v8

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
-    "eslint": "^8.0.0 || ^9.0.0",
+    "eslint": "^8.0.0",
     "semver": "^7.5.3",
     "tslib": "^2.3.0",
     "typescript": "~5.4.2"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nx/eslint` is bringing in `eslint v9` prematurely.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nx/eslint` should not bring in `eslint v9` yet. Though, it does have support for having `v9` installed at the workspace level.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/25319
