### PR TITLE
fix(js): handle tsconfig file with no compilerOptions

### DIFF
--- a/packages/js/src/utils/typescript/create-ts-config.ts
+++ b/packages/js/src/utils/typescript/create-ts-config.ts
@@ -24,10 +24,12 @@ export function extractTsConfigBase(host: Tree) {
   const tsconfig = readJson(host, 'tsconfig.json');
   const baseCompilerOptions = {} as any;
 
-  for (let compilerOption of Object.keys(tsConfigBaseOptions)) {
-    baseCompilerOptions[compilerOption] =
-      tsconfig.compilerOptions[compilerOption];
-    delete tsconfig.compilerOptions[compilerOption];
+  if (tsconfig.compilerOptions) {
+    for (let compilerOption of Object.keys(tsConfigBaseOptions)) {
+      baseCompilerOptions[compilerOption] =
+        tsconfig.compilerOptions[compilerOption];
+      delete tsconfig.compilerOptions[compilerOption];
+    }
   }
   writeJson(host, 'tsconfig.base.json', {
     compileOnSave: false,


### PR DESCRIPTION
Handles adding a root `tsconfig.base.json` when there is a root `tsconfig.json` with no `compilerOptions` property.

Prerequisites:
Have a repository has a root `tsconfig.json` with no `compilerOptions` property and there is no root `tsconfig.base.json`.

Steps to reproduce:
1. Generate a js library (`nx g @nx/js:lib my-lib`)

Expected results:
Library is created.

Actual results:
There is an error.

```
 NX   Cannot read properties of undefined (reading 'rootDir')
```

This PR fixes the error.