### PR TITLE
feat(testing): remove --watch=false from inferred vitest targets to keep things inlined with vitest recommendations

### DIFF
--- a/e2e/vite/src/vite-crystal.test.ts
+++ b/e2e/vite/src/vite-crystal.test.ts
@@ -49,7 +49,7 @@ describe('@nx/vite/plugin', () => {
       }, 200_000);
 
       it('should test application', () => {
-        const result = runCLI(`test ${myApp}`);
+        const result = runCLI(`test ${myApp} --watch=false`);
         expect(result).toContain('Successfully ran target test');
       }, 200_000);
     });
@@ -60,7 +60,7 @@ describe('@nx/vite/plugin', () => {
       }, 200_000);
 
       it('should test application', () => {
-        const result = runCLI(`test ${myVueApp}`);
+        const result = runCLI(`test ${myVueApp} --watch=false`);
         expect(result).toContain('Successfully ran target test');
       }, 200_000);
     });

--- a/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -17,10 +17,12 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
                 "vitest",
               ],
             },
+            {
+              "env": "CI",
+            },
           ],
           "options": {
             "cwd": ".",
-            "watch": false,
           },
           "outputs": [
             "{projectRoot}/coverage",

--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -17,10 +17,12 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
                 "vitest",
               ],
             },
+            {
+              "env": "CI",
+            },
           ],
           "options": {
             "cwd": ".",
-            "watch": false,
           },
           "outputs": [
             "{projectRoot}/coverage",

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -216,7 +216,7 @@ async function testTarget(
 ) {
   return {
     command: `vitest`,
-    options: { cwd: joinPathFragments(projectRoot), watch: false },
+    options: { cwd: joinPathFragments(projectRoot) },
     cache: true,
     inputs: [
       ...('production' in namedInputs
@@ -225,6 +225,7 @@ async function testTarget(
       {
         externalDependencies: ['vitest'],
       },
+      { env: 'CI' },
     ],
     outputs,
   };


### PR DESCRIPTION
Users should use `vitest`, which will run with watch mode for local dev, and non-watch mode in CI.

If users need to run `affected` or `run-many` locally they can always pass `--watch=false` manually. This is the same as running through npm workspaces or other monorepo tools. IMO, users should be running tests from their IDEs anyway.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
