### PR TITLE
fix(core): do not re-read from nx.json for dependsOn

### DIFF
--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -1,7 +1,6 @@
 import {
   joinPathFragments,
   normalizePath,
-  parseTargetString,
   ProjectGraph,
   readCachedProjectGraph,
   targetToTargetString,
@@ -9,7 +8,6 @@ import {
 import type { DependentBuildableProjectNode } from '@nx/js/src/utils/buildable-libs-utils';
 import { WebpackNxBuildCoordinationPlugin } from '@nx/webpack/src/plugins/webpack-nx-build-coordination-plugin';
 import { existsSync } from 'fs';
-import { readNxJson } from 'nx/src/config/configuration';
 import { isNpmProject } from 'nx/src/project-graph/operators';
 import { getDependencyConfigs } from 'nx/src/tasks-runner/utils';
 import { relative } from 'path';
@@ -27,16 +25,9 @@ function shouldSkipInitialTargetRun(
   project: string,
   target: string
 ): boolean {
-  const nxJson = readNxJson();
-  const defaultDependencyConfigs = Object.entries(
-    nxJson.targetDefaults ?? {}
-  ).reduce((acc, [targetName, dependencyConfig]) => {
-    acc[targetName] = dependencyConfig.dependsOn;
-    return acc;
-  }, {});
   const projectDependencyConfigs = getDependencyConfigs(
     { project, target },
-    defaultDependencyConfigs,
+    {},
     projectGraph
   );
 

--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -16,7 +16,7 @@ export class ProcessTasks {
   readonly dependencies: { [k: string]: string[] } = {};
 
   constructor(
-    private readonly defaultDependencyConfigs: TargetDependencies,
+    private readonly extraTargetDependencies: TargetDependencies,
     private readonly projectGraph: ProjectGraph
   ) {}
 
@@ -99,7 +99,7 @@ export class ProcessTasks {
 
     const dependencyConfigs = getDependencyConfigs(
       { project: task.target.project, target: task.target.target },
-      this.defaultDependencyConfigs,
+      this.extraTargetDependencies,
       this.projectGraph
     );
     for (const dependencyConfig of dependencyConfigs) {
@@ -377,14 +377,14 @@ export class ProcessTasks {
 
 export function createTaskGraph(
   projectGraph: ProjectGraph,
-  defaultDependencyConfigs: TargetDependencies,
+  extraTargetDependencies: TargetDependencies,
   projectNames: string[],
   targets: string[],
   configuration: string | undefined,
   overrides: Object,
   excludeTaskDependencies: boolean = false
 ): TaskGraph {
-  const p = new ProcessTasks(defaultDependencyConfigs, projectGraph);
+  const p = new ProcessTasks(extraTargetDependencies, projectGraph);
   const roots = p.processTasks(
     projectNames,
     targets,

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -90,7 +90,7 @@ async function getTerminalOutputLifeCycle(
 
 function createTaskGraphAndValidateCycles(
   projectGraph: ProjectGraph,
-  defaultDependencyConfigs: TargetDependencies,
+  extraTargetDependencies: TargetDependencies,
   projectNames: string[],
   nxArgs: NxArgs,
   overrides: any,
@@ -101,7 +101,7 @@ function createTaskGraphAndValidateCycles(
 ) {
   const taskGraph = createTaskGraph(
     projectGraph,
-    defaultDependencyConfigs,
+    extraTargetDependencies,
     projectNames,
     nxArgs.targets,
     nxArgs.configuration,
@@ -142,15 +142,11 @@ export async function runCommand(
   const status = await handleErrors(
     process.env.NX_VERBOSE_LOGGING === 'true',
     async () => {
-      const defaultDependencyConfigs = mergeTargetDependencies(
-        nxJson.targetDefaults,
-        extraTargetDependencies
-      );
       const projectNames = projectsToRun.map((t) => t.name);
 
       const taskGraph = createTaskGraphAndValidateCycles(
         projectGraph,
-        defaultDependencyConfigs,
+        extraTargetDependencies ?? {},
         projectNames,
         nxArgs,
         overrides,

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -14,20 +14,15 @@ import { splitByColons } from '../utils/split-target';
 import { getExecutorInformation } from '../command-line/run/executor-utils';
 import { CustomHasher, ExecutorConfig } from '../config/misc-interfaces';
 import { readProjectsConfigurationFromProjectGraph } from '../project-graph/project-graph';
-
-export function getCommandAsString(execCommand: string, task: Task) {
-  const args = getPrintableCommandArgsForTask(task);
-  return [execCommand, 'nx', ...args].join(' ').trim();
-}
-
 export function getDependencyConfigs(
   { project, target }: { project: string; target: string },
-  defaultDependencyConfigs: Record<string, (TargetDependencyConfig | string)[]>,
+  extraTargetDependencies: Record<string, (TargetDependencyConfig | string)[]>,
   projectGraph: ProjectGraph
 ): TargetDependencyConfig[] | undefined {
   const dependencyConfigs = (
     projectGraph.nodes[project].data?.targets[target]?.dependsOn ??
-    defaultDependencyConfigs[target] ??
+    // This is passed into `run-command` from programmatic invocations
+    extraTargetDependencies[target] ??
     []
   ).map((config) =>
     typeof config === 'string'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx.json` `dependsOn` for targets already get merged into the project configuration. When `nx.json` defines a dependsOn for a target but a plugin overwrites it, the task graph still considers the dependsOn from `nx.json`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The task graph is created based on the project configurations.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
