### PR TITLE
fix(nx-dev): Remove ToC from CI releases page

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -29,7 +29,8 @@ export function DocViewer({
     router.asPath.includes('/ci/intro/ci-with-nx') ||
     router.asPath.includes('/extending-nx/intro/getting-started') ||
     router.asPath.includes('/nx-api/devkit') ||
-    router.asPath.includes('/reference/glossary');
+    router.asPath.includes('/reference/glossary') ||
+    router.asPath.includes('/ci/reference/release-notes');
   const ref = useRef<HTMLDivElement | null>(null);
 
   const { metadata, node, treeNode } = renderMarkdown(


### PR DESCRIPTION
Remove the ToC section from CI releases.

Ref: https://nx-dev-git-fix-nx-dev-release-page-scroll-nrwl.vercel.app/ci/reference/release-notes

