### PR TITLE
fix(gradle): use os specific line separator for dependency parsing

### DIFF
--- a/packages/gradle/src/plugin/dependencies.ts
+++ b/packages/gradle/src/plugin/dependencies.ts
@@ -12,6 +12,7 @@ import { basename } from 'node:path';
 import {
   getGradleReport,
   invalidateGradleReportCache,
+  newLineSeparator,
 } from '../utils/get-gradle-report';
 import { writeTargetsToCache } from './nodes';
 
@@ -89,7 +90,7 @@ function processGradleDependencies(
   context: CreateDependenciesContext
 ): Set<RawProjectGraphDependency> {
   const dependencies: Set<RawProjectGraphDependency> = new Set();
-  const lines = readFileSync(depsFile).toString().split('\n');
+  const lines = readFileSync(depsFile).toString().split(newLineSeparator);
   let inDeps = false;
   for (const line of lines) {
     if (

--- a/packages/gradle/src/utils/get-gradle-report.ts
+++ b/packages/gradle/src/utils/get-gradle-report.ts
@@ -9,7 +9,9 @@ export const fileSeparator = process.platform.startsWith('win')
   ? 'file:///'
   : 'file://';
 
-const newLineSeparator = process.platform.startsWith('win') ? '\r\n' : '\n';
+export const newLineSeparator = process.platform.startsWith('win')
+  ? '\r\n'
+  : '\n';
 
 export interface GradleReport {
   gradleFileToGradleProjectMap: Map<string, string>;


### PR DESCRIPTION
## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
