### PR TITLE
fix(bundling): use watch mode for rollup plugin

### DIFF
--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -94,7 +94,9 @@ async function buildRollupTarget(
   const namedInputs = getNamedInputs(projectRoot, context);
   const rollupConfig = (
     (await loadConfigFile(
-      joinPathFragments(context.workspaceRoot, configFilePath)
+      joinPathFragments(context.workspaceRoot, configFilePath),
+      {},
+      true // Enable watch mode so that rollup properly reloads config files without reusing a cached version
     )) as { options: RollupOptions[] }
   ).options;
   const outputs = getOutputs(rollupConfig, projectRoot);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nx/rollup/plugin` will not properly reload `rollup.config.js` files when they are updated as they are cached.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nx/rollup/plugin` loads rollup configs with `watchMode` enabled so that rollup utilizes the proper cache busting mechanism so that `rollup.config.js` is properly reloaded.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
