### PR TITLE
fix(release): improve error handling for npm publish

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -286,16 +286,20 @@ export default async function runExecutor(
       const stdoutData = JSON.parse(err.stdout?.toString() || '{}');
 
       console.error('npm publish error:');
-      if (stdoutData.error.summary) {
+      if (stdoutData.error?.summary) {
         console.error(stdoutData.error.summary);
       }
-      if (stdoutData.error.detail) {
+      if (stdoutData.error?.detail) {
         console.error(stdoutData.error.detail);
       }
 
       if (context.isVerbose) {
         console.error('npm publish stdout:');
         console.error(JSON.stringify(stdoutData, null, 2));
+      }
+
+      if (!stdoutData.error) {
+        throw err;
       }
       return {
         success: false,


### PR DESCRIPTION
This change improves error handling for npm publish function. When there is any error that is not handled by the catch clause, it is throwing an "cannot read summary of undefined", because the stdoutData.error is undefined. With this change, it is going to correctly throw the root error that was the cause of the problem.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When an unexpected error occurs on npm publish, it is trowing "cannot read summary of undefined" error.

## Expected Behavior
Throws the exact error that was the root cause of the problem

## Related Issue(s)

Fixes #
