### PR TITLE
fix(bundling): rollup watch mode yields result from async iterable

### DIFF
--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -84,7 +84,7 @@ export async function* rollupExecutor(
 
   if (options.watch) {
     // region Watch build
-    return createAsyncIterable(({ next }) => {
+    return yield* createAsyncIterable(({ next }) => {
       const watcher = rollup.watch(rollupOptions);
       watcher.on('event', (data) => {
         if (data.code === 'START') {


### PR DESCRIPTION
This PR fixes the return from `@nx/rollup:rollup` executor so that it yields results from the inner async iterable.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
