### PR TITLE
fix(core): handle relative paths after {projectRoot} in outputs

### DIFF
--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -1,6 +1,7 @@
 import {
   expandDependencyConfigSyntaxSugar,
   getOutputsForTargetAndConfiguration,
+  interpolate,
   transformLegacyOutputs,
   validateOutputs,
 } from './utils';
@@ -19,6 +20,14 @@ describe('utils', () => {
       },
     };
   }
+
+  describe('interpolate', () => {
+    it('should not mangle URLs', () => {
+      expect(interpolate('https://npm-registry.example.com/', {})).toEqual(
+        'https://npm-registry.example.com/'
+      );
+    });
+  });
 
   describe('getOutputsForTargetAndConfiguration', () => {
     const task = {
@@ -56,6 +65,18 @@ describe('utils', () => {
           })
         )
       ).toEqual(['one', 'myapp/two', 'myapp/three']);
+    });
+
+    it('should handle relative paths after {projectRoot}', () => {
+      expect(
+        getOutputsForTargetAndConfiguration(
+          task.target,
+          task.overrides,
+          getNode({
+            outputs: ['{projectRoot}/../relative/path'],
+          })
+        )
+      ).toEqual(['relative/path']);
     });
 
     it('should interpolate {projectRoot} when it is not at the beginning', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Outputs such as `{projectRoot}/../relative/path` do not get interpolated correctly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Outputs such as `{projectRoot}/../relative/path` get interpolated correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
