### PR TITLE
fix(angular):  module federation -  devRemotes is made optional for static remotes

### DIFF
--- a/packages/angular/src/executors/module-federation-dev-server/lib/start-dev-remotes.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/lib/start-dev-remotes.ts
@@ -28,7 +28,7 @@ export async function startRemotes(
       'module-federation-dev-server'
     );
 
-    const configurationOverride = options.devRemotes.find(
+    const configurationOverride = options.devRemotes?.find(
       (
         r
       ): r is {


### PR DESCRIPTION
The new feature `module-federation: add remote configuration override (https://github.com/nrwl/nx/pull/19694)` causes issues for developers that are using static remotes...

## Current Behavior
After upgrading and migrating Nx to 19.1.0, when I try to start my module federated host application using nx serve, I get a TypeError as shown in the failure logs.

If I use the command nx serve and specify --devRemotes, it works without any problems.

## Expected Behavior
runs without --devRemotes

## Related Issue(s)
https://github.com/nrwl/nx/issues/26169
https://github.com/nrwl/nx/issues/20973

## Fixes 

Not everyone is starting up MFE with --devRemotes but uses static remotes.
this feature causes issues.
