### PR TITLE
feat(vite): set watch:false in test config by default

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -104,6 +104,7 @@ export default defineConfig({
   // },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../node_modules/.vitest/my-app',

--- a/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -23,7 +23,8 @@ nxViteTsPaths(),
         
         
         test: {
-          'globals': true,
+          'watch': false,
+'globals': true,
 'cache': {"dir":"../node_modules/.vitest/my-lib"},
 'environment': "jsdom",
 'include': ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
@@ -83,6 +84,7 @@ dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') 
       },
         
         test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../node_modules/.vitest/my-lib'

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -384,6 +384,7 @@ export default defineConfig({
 
   test: {
     setupFiles: ['test-setup.ts'],
+    watch: false,
     globals: true,
     cache: {
       dir: '../node_modules/.vitest/test',
@@ -897,6 +898,7 @@ export default defineConfig({
 
   test: {
     setupFiles: ['test-setup.ts'],
+    watch: false,
     globals: true,
     cache: {
       dir: '../../node_modules/.vitest/apps/test',
@@ -1217,6 +1219,7 @@ export default defineConfig({
 
   test: {
     setupFiles: ['test-setup.ts'],
+    watch: false,
     globals: true,
     cache: {
       dir: './node_modules/.vitest/test',

--- a/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
+++ b/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
@@ -41,6 +41,7 @@ export default defineConfig({
 
   test: {
     setupFiles: ['./src/test-setup.ts'],
+    watch: false,
     globals: true,
     cache: { dir: '../node_modules/.vitest/test' },
     environment: 'jsdom',
@@ -119,6 +120,7 @@ export default defineConfig({
 
   test: {
     setupFiles: ['./src/test-setup.ts'],
+    watch: false,
     globals: true,
     cache: { dir: '../../node_modules/.vitest/libs/test' },
     environment: 'jsdom',

--- a/packages/remix/src/generators/storybook-configuration/__snapshots__/storybook-configuration.impl.spec.ts.snap
+++ b/packages/remix/src/generators/storybook-configuration/__snapshots__/storybook-configuration.impl.spec.ts.snap
@@ -104,6 +104,7 @@ export default defineConfig({
 
   test: {
     setupFiles: ['./src/test-setup.ts'],
+    watch: false,
     globals: true,
     cache: { dir: '../../node_modules/.vitest/libs/storybook-test' },
     environment: 'jsdom',

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -49,6 +49,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../node_modules/.vitest/my-lib',
@@ -267,6 +268,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../../node_modules/.vitest/libs/react-lib-nonb-jest',
@@ -493,6 +495,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../../node_modules/.vitest/apps/my-test-react-app',

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -21,6 +21,7 @@ export default defineConfig({
     'import.meta.vitest': undefined,
   },
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../../node_modules/.vitest/apps/my-test-react-app',
@@ -61,6 +62,7 @@ export default defineConfig({
   // },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../../node_modules/.vitest/apps/my-test-react-app',
@@ -96,6 +98,7 @@ export default defineConfig({
   // },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../../node_modules/.vitest/libs/react-lib-nonb-jest',

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -432,6 +432,7 @@ export function createOrEditViteConfig(
 
   const testOption = options.includeVitest
     ? `test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '${normalizedJoinPaths(

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -76,6 +76,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../node_modules/.vitest/test',

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -51,6 +51,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../node_modules/.vitest/my-lib',
@@ -147,6 +148,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../node_modules/.vitest/my-lib',

--- a/packages/workspace/src/generators/preset/__snapshots__/preset.spec.ts.snap
+++ b/packages/workspace/src/generators/preset/__snapshots__/preset.spec.ts.snap
@@ -106,6 +106,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: './node_modules/.vitest/proj',
@@ -194,6 +195,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: '../../node_modules/.vitest/apps/proj',
@@ -248,6 +250,7 @@ export default defineConfig({
   },
 
   test: {
+    watch: false,
     globals: true,
     cache: {
       dir: './node_modules/.vitest/proj',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, running vitest with inference will result in a process that waits for the user to end it as vitest defaults to running in watch mode.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should set watch:false to allow users to specifically choose watch mode by passing `--watch`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
