### PR TITLE
cleanup(devkit): ensure externalDependencies input from inferred task is merged into target inputs when migrating

### DIFF
--- a/packages/eslint/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/eslint/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -59,7 +59,7 @@ function postTargetTransformer(
   projectDetails: { projectName: string; root: string }
 ): TargetConfiguration {
   if (target.inputs) {
-    target.inputs = target.inputs.filter(
+    const inputs = target.inputs.filter(
       (input) =>
         typeof input === 'string' &&
         ![
@@ -69,7 +69,7 @@ function postTargetTransformer(
           '{workspaceRoot}/eslint.config.js',
         ].includes(input)
     );
-    if (target.inputs.length === 0) {
+    if (inputs.length === 0) {
       delete target.inputs;
     }
   }

--- a/packages/playwright/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/playwright/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -378,6 +378,54 @@ describe('Playwright - Convert Executors To Plugin', () => {
         (addedTestPlaywrightPlugin as ExpandedPluginConfiguration).include
       ).not.toBeDefined();
     });
+
+    it('should remove inputs when they are inferred', async () => {
+      const project = createTestProject(tree);
+      project.targets.e2e.options.runnerUi = true;
+      updateProjectConfiguration(tree, project.name, project);
+      createTestProject(tree, { appRoot: 'second', appName: 'second' });
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults['@nx/playwright:playwright'] = {
+        inputs: ['default', '^default'],
+      };
+      updateNxJson(tree, nxJson);
+
+      await convertToInferred(tree, {
+        project: project.name,
+        skipFormat: true,
+      });
+
+      // project.json modifications
+      const updatedProject = readProjectConfiguration(tree, project.name);
+      expect(updatedProject.targets.e2e.inputs).toBeUndefined();
+    });
+
+    it('should keep inputs when any of them are not inferred', async () => {
+      const project = createTestProject(tree);
+      project.targets.e2e.options.runnerUi = true;
+      updateProjectConfiguration(tree, project.name, project);
+      createTestProject(tree, { appRoot: 'second', appName: 'second' });
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults['@nx/playwright:playwright'] = {
+        inputs: ['default', '^default', '{workspaceRoot}/some-file.ts'],
+      };
+      updateNxJson(tree, nxJson);
+
+      await convertToInferred(tree, {
+        project: project.name,
+        skipFormat: true,
+      });
+
+      // project.json modifications
+      const updatedProject = readProjectConfiguration(tree, project.name);
+      expect(updatedProject.targets.e2e.inputs).toStrictEqual([
+        'default',
+        '^default',
+        '{workspaceRoot}/some-file.ts',
+      ]);
+    });
   });
 
   describe('--all', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
