### PR TITLE
feat(bundling): add convert-to-inferred generator for @nx/rollup

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -9368,6 +9368,14 @@
                 "children": [],
                 "isExternal": false,
                 "disableCollapsible": false
+              },
+              {
+                "id": "convert-to-inferred",
+                "path": "/nx-api/rollup/generators/convert-to-inferred",
+                "name": "convert-to-inferred",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -2755,6 +2755,15 @@
         "originalFilePath": "/packages/rollup/src/generators/configuration/schema.json",
         "path": "/nx-api/rollup/generators/configuration",
         "type": "generator"
+      },
+      "/nx-api/rollup/generators/convert-to-inferred": {
+        "description": "Convert existing Rollup project(s) using `@nx/rollup:*` executors to use `@nx/rollup/plugin`.",
+        "file": "generated/packages/rollup/generators/convert-to-inferred.json",
+        "hidden": false,
+        "name": "convert-to-inferred",
+        "originalFilePath": "/packages/rollup/src/generators/convert-to-inferred/schema.json",
+        "path": "/nx-api/rollup/generators/convert-to-inferred",
+        "type": "generator"
       }
     },
     "path": "/nx-api/rollup"

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -2726,6 +2726,15 @@
         "originalFilePath": "/packages/rollup/src/generators/configuration/schema.json",
         "path": "rollup/generators/configuration",
         "type": "generator"
+      },
+      {
+        "description": "Convert existing Rollup project(s) using `@nx/rollup:*` executors to use `@nx/rollup/plugin`.",
+        "file": "generated/packages/rollup/generators/convert-to-inferred.json",
+        "hidden": false,
+        "name": "convert-to-inferred",
+        "originalFilePath": "/packages/rollup/src/generators/convert-to-inferred/schema.json",
+        "path": "rollup/generators/convert-to-inferred",
+        "type": "generator"
       }
     ],
     "githubRoot": "https://github.com/nrwl/nx/blob/master",

--- a/docs/generated/packages/rollup/generators/convert-to-inferred.json
+++ b/docs/generated/packages/rollup/generators/convert-to-inferred.json
@@ -1,0 +1,30 @@
+{
+  "name": "convert-to-inferred",
+  "factory": "./src/generators/convert-to-inferred/convert-to-inferred",
+  "schema": {
+    "$schema": "https://json-schema.org/schema",
+    "$id": "NxRollupConvertToInferred",
+    "description": "Convert existing Rollup project(s) using `@nx/rollup:rollup` executor to use `@nx/rollup/plugin`. Defaults to migrating all projects. Pass '--project' to migrate only one target.",
+    "title": "Convert Rollup project from executor to plugin",
+    "type": "object",
+    "properties": {
+      "project": {
+        "type": "string",
+        "description": "The project to convert from using the `@nx/rollup:rollup` executor to use `@nx/rollup/plugin`.",
+        "x-priority": "important"
+      },
+      "skipFormat": {
+        "type": "boolean",
+        "description": "Whether to format files at the end of the migration.",
+        "default": false
+      }
+    },
+    "presets": []
+  },
+  "description": "Convert existing Rollup project(s) using `@nx/rollup:*` executors to use `@nx/rollup/plugin`.",
+  "implementation": "/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/rollup/src/generators/convert-to-inferred/schema.json",
+  "type": "generator"
+}

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -649,6 +649,7 @@
     - [generators](/nx-api/rollup/generators)
       - [init](/nx-api/rollup/generators/init)
       - [configuration](/nx-api/rollup/generators/configuration)
+      - [convert-to-inferred](/nx-api/rollup/generators/convert-to-inferred)
   - [storybook](/nx-api/storybook)
     - [documents](/nx-api/storybook/documents)
       - [Overview](/nx-api/storybook/documents/overview)

--- a/e2e/webpack/src/webpack.legacy.test.ts
+++ b/e2e/webpack/src/webpack.legacy.test.ts
@@ -118,21 +118,21 @@ describe('Webpack Plugin (legacy)', () => {
     updateFile(
       `${appName}/webpack.config.js`,
       `
-        const { join } = require('path');
-        const {NxWebpackPlugin} = require('@nx/webpack');
-        module.exports = {
-          output: {
-            path: join(__dirname, '../dist/app9524918'),
-          },
-          plugins: [
-            new NxAppWebpackPlugin({
-              main: './src/main.ts',
-              compiler: 'tsc',
-              index: './src/index.html',
-              tsConfig: './tsconfig.app.json',
-            })
-          ]
-        };
+const { join } = require('path');
+const {NxWebpackPlugin} = require('@nx/webpack');
+module.exports = {
+  output: {
+    path: join(__dirname, '../dist/app9524918'),
+  },
+  plugins: [
+    new NxAppWebpackPlugin({
+      main: './src/main.ts',
+      compiler: 'tsc',
+      index: './src/index.html',
+      tsConfig: './tsconfig.app.json',
+    })
+  ]
+};
       `
     );
 

--- a/packages/react/plugins/bundle-rollup.ts
+++ b/packages/react/plugins/bundle-rollup.ts
@@ -1,5 +1,6 @@
 import * as rollup from 'rollup';
 
+// TODO(v20): This should be deprecated and removed in v22.
 function getRollupOptions(options: rollup.RollupOptions) {
   const extraGlobals = {
     react: 'React',

--- a/packages/rollup/generators.json
+++ b/packages/rollup/generators.json
@@ -14,6 +14,11 @@
       "factory": "./src/generators/configuration/configuration",
       "schema": "./src/generators/configuration/schema.json",
       "description": "Add rollup configuration to a project."
+    },
+    "convert-to-inferred": {
+      "factory": "./src/generators/convert-to-inferred/convert-to-inferred",
+      "schema": "./src/generators/convert-to-inferred/schema.json",
+      "description": "Convert existing Rollup project(s) using `@nx/rollup:*` executors to use `@nx/rollup/plugin`."
     }
   }
 }

--- a/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -1,0 +1,586 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import {
+  addProjectConfiguration,
+  type ProjectConfiguration,
+  readNxJson,
+  readProjectConfiguration,
+  type Tree,
+  updateNxJson,
+} from '@nx/devkit';
+import convertToInferred from './convert-to-inferred';
+
+interface CreateProjectOptions {
+  name: string;
+  root: string;
+  targetName: string;
+  targetOptions: Record<string, unknown>;
+  targetOutputs: string[];
+  targetInputs?: unknown[];
+  additionalTargetProperties?: Record<string, unknown>;
+}
+
+const defaultCreateProjectOptions: CreateProjectOptions = {
+  name: 'mypkg',
+  root: 'mypkg',
+  targetName: 'build',
+  targetOptions: {},
+  targetOutputs: ['{options.outputPath}'],
+};
+
+function createProject(tree: Tree, opts: Partial<CreateProjectOptions> = {}) {
+  const projectOpts = {
+    ...defaultCreateProjectOptions,
+    ...opts,
+    targetOptions:
+      opts.targetOptions === null ? undefined : { ...opts.targetOptions },
+  };
+
+  if (projectOpts.targetOptions) {
+    projectOpts.targetOptions.main ??= `${projectOpts.root}/src/index.ts`;
+    projectOpts.targetOptions.outputPath ??= `dist/${projectOpts.root}`;
+    projectOpts.targetOptions.tsConfig ??= `${projectOpts.root}/tsconfig.lib.json`;
+    projectOpts.targetOptions.compiler ??= 'babel';
+    projectOpts.targetOptions.format ??= ['esm'];
+    projectOpts.targetOptions.external ??= [];
+    projectOpts.targetOptions.assets ??= [];
+  }
+
+  const project: ProjectConfiguration = {
+    name: projectOpts.name,
+    root: projectOpts.root,
+    projectType: 'library',
+    targets: {
+      [projectOpts.targetName]: {
+        executor: '@nx/rollup:rollup',
+        outputs: projectOpts.targetOutputs ?? ['{options.outputPath}'],
+        options: projectOpts.targetOptions,
+        ...projectOpts.additionalTargetProperties,
+      },
+    },
+  };
+
+  addProjectConfiguration(tree, project.name, project);
+
+  return project;
+}
+
+describe('Rollup - Convert Executors To Plugin', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('--project', () => {
+    it('should setup a new Rollup plugin and only migrate one specific project', async () => {
+      const project = createProject(tree, {
+        name: 'mypkg',
+        root: 'mypkg',
+      });
+      createProject(tree, {
+        name: 'otherpkg1',
+        root: 'otherpkg1',
+      });
+      createProject(tree, {
+        name: 'otherpkg2',
+        root: 'otherpkg2',
+      });
+
+      await convertToInferred(tree, { project: project.name });
+
+      expect(readNxJson(tree).plugins).toEqual([
+        {
+          options: {
+            targetName: 'build',
+          },
+          plugin: '@nx/rollup/plugin',
+        },
+      ]);
+      expect(tree.read('mypkg/rollup.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withNx } = require('@nx/rollup/with-nx');
+
+        // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+        const options = {
+          main: './src/index.ts',
+          outputPath: '../dist/mypkg',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'babel',
+          format: ['esm'],
+          external: [],
+          assets: [],
+        };
+
+        const config = withNx(options, {
+          // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+          // e.g.
+          // output: { sourcemap: true },
+        });
+
+        module.exports = config;
+        "
+      `);
+      expect(tree.exists('otherpkg1/rollup.config.js')).toBe(false);
+      expect(tree.exists('otherpkg2/rollup.config.js')).toBe(false);
+      expect(readProjectConfiguration(tree, project.name).targets).toEqual({});
+    });
+
+    it('should support existing rollupConfig files', async () => {
+      const projectWithSingleConfig = createProject(tree, {
+        name: 'mypkg1',
+        root: 'mypkg1',
+        targetOptions: {
+          rollupConfig: '@nx/react/plugins/bundle-rollup',
+        },
+      });
+      const projectWithMultipleConfigsAndEntries = createProject(tree, {
+        name: 'mypkg2',
+        root: 'mypkg2',
+        targetOptions: {
+          additionalEntryPoints: ['mypkg2/src/foo.ts', 'mypkg2/src/bar.ts'],
+          rollupConfig: [
+            '@nx/react/plugins/bundle-rollup',
+            'mypkg2/rollup.config.other.js',
+            'shared/rollup.config.base.js',
+          ],
+        },
+      });
+
+      await convertToInferred(tree, { project: projectWithSingleConfig.name });
+      await convertToInferred(tree, {
+        project: projectWithMultipleConfigsAndEntries.name,
+      });
+
+      expect(tree.read('mypkg1/rollup.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withNx } = require('@nx/rollup/with-nx');
+
+        // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+        const options = {
+          main: './src/index.ts',
+          outputPath: '../dist/mypkg1',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'babel',
+          format: ['esm'],
+          external: [],
+          assets: [],
+        };
+
+        let config = withNx(options, {
+          // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+          // e.g.
+          // output: { sourcemap: true },
+        });
+
+        config = require('@nx/react/plugins/bundle-rollup')(config, options);
+
+        module.exports = config;
+        "
+      `);
+      expect(tree.read('mypkg2/rollup.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withNx } = require('@nx/rollup/with-nx');
+
+        // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+        const options = {
+          additionalEntryPoints: ['./src/foo.ts', './src/bar.ts'],
+          main: './src/index.ts',
+          outputPath: '../dist/mypkg2',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'babel',
+          format: ['esm'],
+          external: [],
+          assets: [],
+        };
+
+        let config = withNx(options, {
+          // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+          // e.g.
+          // output: { sourcemap: true },
+        });
+
+        config = require('@nx/react/plugins/bundle-rollup')(config, options);
+        config = require('./rollup.config.other.js')(config, options);
+        config = require('../shared/rollup.config.base.js')(config, options);
+
+        module.exports = config;
+        "
+      `);
+
+      expect(
+        readProjectConfiguration(tree, projectWithSingleConfig.name).targets
+      ).toEqual({});
+      expect(
+        readProjectConfiguration(
+          tree,
+          projectWithMultipleConfigsAndEntries.name
+        ).targets
+      ).toEqual({});
+    });
+
+    it('should handle conflicts with existing rollup.config.js file', async () => {
+      const project = createProject(tree, {
+        name: 'mypkg1',
+        root: 'mypkg1',
+        targetOptions: {
+          rollupConfig: [
+            'mypkg1/rollup.config.js',
+            'mypkg1/rollup.other.config.js',
+          ],
+        },
+      });
+      tree.write(
+        'mypkg1/rollup.config.js',
+        '// existing config\nmodule.exports = {};'
+      );
+
+      await convertToInferred(tree, { project: project.name });
+
+      expect(tree.read('mypkg1/rollup.migrated.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "// existing config
+        module.exports = {};
+        "
+      `);
+      expect(tree.read('mypkg1/rollup.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withNx } = require('@nx/rollup/with-nx');
+
+        // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+        const options = {
+          main: './src/index.ts',
+          outputPath: '../dist/mypkg1',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'babel',
+          format: ['esm'],
+          external: [],
+          assets: [],
+        };
+
+        let config = withNx(options, {
+          // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+          // e.g.
+          // output: { sourcemap: true },
+        });
+
+        config = require('./rollup.migrated.config.js')(config, options);
+        config = require('./rollup.other.config.js')(config, options);
+
+        module.exports = config;
+        "
+      `);
+    });
+
+    it('should migrate existing outputs to include output from rollup config', async () => {
+      const project = createProject(tree, {
+        name: 'mypkg',
+        root: 'mypkg',
+        targetOutputs: [
+          '{options.outputPath}',
+          '{projectRoot}/other-artifacts',
+        ],
+      });
+
+      await convertToInferred(tree, { project: project.name });
+
+      expect(readProjectConfiguration(tree, project.name).targets).toEqual({
+        build: {
+          outputs: [
+            '{projectRoot}/../dist/mypkg',
+            '{projectRoot}/other-artifacts',
+          ],
+        },
+      });
+    });
+
+    it('should leave custom inputs, dependsOn, etc. intact', async () => {
+      const project = createProject(tree, {
+        name: 'mypkg',
+        root: 'mypkg',
+        additionalTargetProperties: {
+          inputs: [
+            'production',
+            { env: 'CI' },
+            { externalDependencies: ['rollup'] },
+          ],
+          dependsOn: ['^build', 'build-base'],
+        },
+      });
+
+      await convertToInferred(tree, { project: project.name });
+
+      expect(readProjectConfiguration(tree, project.name).targets).toEqual({
+        build: {
+          inputs: [
+            'production',
+            { env: 'CI' },
+            { externalDependencies: ['rollup'] },
+          ],
+          dependsOn: ['^build', 'build-base'],
+        },
+      });
+    });
+
+    it('should add Rollup CLI as external dependency in inputs if not already present', async () => {
+      const project1 = createProject(tree, {
+        name: 'mypkg1',
+        root: 'mypkg1',
+        additionalTargetProperties: {
+          inputs: ['production', { env: 'CI' }],
+        },
+      });
+
+      const project2 = createProject(tree, {
+        name: 'mypkg2',
+        root: 'mypkg2',
+        additionalTargetProperties: {
+          inputs: [
+            'production',
+            { env: 'CI' },
+            { externalDependencies: ['foo'] },
+          ],
+        },
+      });
+
+      await convertToInferred(tree, { project: project1.name });
+      await convertToInferred(tree, { project: project2.name });
+
+      expect(readProjectConfiguration(tree, project1.name).targets).toEqual({
+        build: {
+          inputs: [
+            'production',
+            { env: 'CI' },
+            { externalDependencies: ['rollup'] },
+          ],
+        },
+      });
+      expect(readProjectConfiguration(tree, project2.name).targets).toEqual({
+        build: {
+          inputs: [
+            'production',
+            { env: 'CI' },
+            { externalDependencies: ['foo', 'rollup'] },
+          ],
+        },
+      });
+    });
+
+    it('should inline options from configurations into the config file', async () => {
+      const project = createProject(tree, {
+        name: 'mypkg',
+        root: 'mypkg',
+        additionalTargetProperties: {
+          defaultConfiguration: 'foo',
+          configurations: {
+            foo: {
+              watch: true,
+              main: 'mypkg/src/foo.ts',
+            },
+            bar: {
+              watch: false,
+              main: 'mypkg/src/bar.ts',
+            },
+          },
+        },
+      });
+
+      await convertToInferred(tree, { project: project.name });
+
+      expect(tree.read('mypkg/rollup.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withNx } = require('@nx/rollup/with-nx');
+
+        // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+        const configValues = {
+          default: {
+            main: './src/index.ts',
+            outputPath: '../dist/mypkg',
+            tsConfig: './tsconfig.lib.json',
+            compiler: 'babel',
+            format: ['esm'],
+            external: [],
+            assets: [],
+          },
+          foo: {
+            main: 'mypkg/src/foo.ts',
+          },
+          bar: {
+            main: 'mypkg/src/bar.ts',
+          },
+        };
+
+        // Determine the correct configValue to use based on the configuration
+        const nxConfiguration = process.env.NX_TASK_TARGET_CONFIGURATION ?? 'default';
+
+        const options = {
+          ...configValues.default,
+          ...configValues[nxConfiguration],
+        };
+
+        const config = withNx(options, {
+          // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+          // e.g.
+          // output: { sourcemap: true },
+        });
+
+        module.exports = config;
+        "
+      `);
+      expect(readProjectConfiguration(tree, project.name).targets).toEqual({
+        build: {
+          configurations: {
+            bar: {
+              watch: false,
+            },
+            foo: {
+              watch: true,
+            },
+          },
+          defaultConfiguration: 'foo',
+        },
+      });
+    });
+
+    it('should merge targetDefaults for @nx/rollup:rollup into target options and generated config', async () => {
+      const project = createProject(tree, {
+        name: 'mypkg1',
+        root: 'mypkg1',
+        targetInputs: ['production', '^production', { env: 'CI' }],
+        targetOptions: null,
+      });
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        '@nx/rollup:rollup': {
+          cache: true,
+          dependsOn: ['build-base', '^build'],
+          inputs: ['production', '^production'],
+          options: {
+            main: './src/main.ts',
+            outputPath: '../dist/mypkg1',
+            tsConfig: './tsconfig.lib.json',
+            compiler: 'swc',
+            format: ['esm', 'cjs'],
+            external: ['react', 'react-dom'],
+            assets: [{ glob: 'mypkg/README.md', input: '.', output: '.' }],
+          },
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      await convertToInferred(tree, { project: project.name });
+
+      // Doesn't override what's already in project.json
+      expect(
+        readProjectConfiguration(tree, project.name).targets.build.inputs
+      ).toEqual([
+        'production',
+        '^production',
+        { externalDependencies: ['rollup'] },
+      ]);
+      // These properties are set since they were undefined in project.json
+      expect(
+        readProjectConfiguration(tree, project.name).targets.build.dependsOn
+      ).toEqual(['build-base', '^build']);
+      expect(
+        readProjectConfiguration(tree, project.name).targets.build.cache
+      ).toBe(true);
+      // Plugin options are read from targetDefaults since they were missing in project.json
+      expect(tree.read('mypkg1/rollup.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withNx } = require('@nx/rollup/with-nx');
+
+        // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+        const options = {
+          main: '../src/main.ts',
+          outputPath: '../../dist/mypkg1',
+          tsConfig: '../tsconfig.lib.json',
+          compiler: 'swc',
+          format: ['esm', 'cjs'],
+          external: ['react', 'react-dom'],
+          assets: [
+            {
+              glob: 'mypkg/README.md',
+              input: '.',
+              output: '.',
+            },
+          ],
+        };
+
+        const config = withNx(options, {
+          // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+          // e.g.
+          // output: { sourcemap: true },
+        });
+
+        module.exports = config;
+        "
+      `);
+    });
+  });
+
+  describe('all projects', () => {
+    it('should successfully migrate projects using Rollup executors to plugin', async () => {
+      createProject(tree, {
+        name: 'pkg1',
+        root: 'pkg1',
+      });
+      createProject(tree, {
+        name: 'pkg2',
+        root: 'pkg2',
+      });
+
+      await convertToInferred(tree, {});
+
+      expect(tree.read('pkg1/rollup.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withNx } = require('@nx/rollup/with-nx');
+
+        // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+        const options = {
+          main: './src/index.ts',
+          outputPath: '../dist/pkg1',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'babel',
+          format: ['esm'],
+          external: [],
+          assets: [],
+        };
+
+        const config = withNx(options, {
+          // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+          // e.g.
+          // output: { sourcemap: true },
+        });
+
+        module.exports = config;
+        "
+      `);
+      expect(tree.read('pkg2/rollup.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withNx } = require('@nx/rollup/with-nx');
+
+        // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+        const options = {
+          main: './src/index.ts',
+          outputPath: '../dist/pkg2',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'babel',
+          format: ['esm'],
+          external: [],
+          assets: [],
+        };
+
+        const config = withNx(options, {
+          // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+          // e.g.
+          // output: { sourcemap: true },
+        });
+
+        module.exports = config;
+        "
+      `);
+      expect(readProjectConfiguration(tree, 'pkg1').targets).toEqual({});
+      expect(readProjectConfiguration(tree, 'pkg2').targets).toEqual({});
+    });
+  });
+});

--- a/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -1,0 +1,129 @@
+import {
+  formatFiles,
+  getProjects,
+  readNxJson,
+  type Tree,
+  updateNxJson,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+
+import { extractRollupConfigFromExecutorOptions } from './lib/extract-rollup-config-from-executor-options';
+import { RollupExecutorOptions } from '../../executors/rollup/schema';
+
+interface Schema {
+  project?: string;
+  skipFormat?: boolean;
+}
+
+export async function convertToInferred(tree: Tree, options: Schema) {
+  let migrated = 0;
+
+  const projects = getProjects(tree);
+
+  forEachExecutorOptions<RollupExecutorOptions>(
+    tree,
+    '@nx/rollup:rollup',
+    (_, projectName, targetName, configurationName) => {
+      if (options.project && projectName !== options.project) return;
+
+      const project = projects.get(projectName);
+      const target = project.targets[targetName];
+
+      // We'll handle configurations when dealing with default options.
+      if (configurationName) return;
+
+      // Since targetDefaults for '@nx/rollup:rollup' will no longer apply, we want to copy them to the target options.
+      const nxJson = readNxJson(tree);
+      const defaults = nxJson.targetDefaults['@nx/rollup:rollup'];
+      if (defaults) {
+        for (const [key, value] of Object.entries(defaults)) {
+          target[key] ??= value;
+        }
+      }
+
+      const extractedPluginOptions = extractRollupConfigFromExecutorOptions(
+        tree,
+        target.options,
+        target.configurations,
+        project.root
+      );
+
+      // If rollup is not an external dependency, add it
+      if (
+        target.inputs &&
+        !target.inputs.some(
+          (i) =>
+            Array.isArray(i['externalDependencies']) &&
+            i['externalDependencies'].includes('rollup')
+        )
+      ) {
+        const idx = target.inputs.findIndex((i) =>
+          Array.isArray(i['externalDependencies'])
+        );
+        if (idx === -1) {
+          target.inputs.push({ externalDependencies: ['rollup'] });
+        } else {
+          target.inputs[idx]['externalDependencies'].push('rollup');
+        }
+      }
+
+      // Clean up the target now that it is inferred
+      delete target.executor;
+      if (
+        target.outputs &&
+        target.outputs.length === 1 &&
+        // "{projectRoot}/{options.outputPath}" is an invalid output for Rollup since
+        // there would be a mismatch between where the executor outputs to and where Nx caches.
+        // If users have this set erroneously, then it will continue to not work.
+        (target.outputs[0] === '{options.outputPath}' ||
+          target.outputs[0] === '{workspaceRoot}/{options.outputPath}')
+      ) {
+        // If only the default `options.outputPath` is set as output, remove it and use path inferred from `rollup.config.js`.
+        delete target.outputs;
+      } else {
+        // Otherwise, replace `options.outputPath` with what is inferred from `rollup.config.js`.
+        target.outputs = target.outputs.map((output) =>
+          // Again, "{projectRoot}/{options.outputPath}" is an invalid output for Rollup.
+          output === '{options.outputPath}' ||
+          output === '{workspaceRoot}/{options.outputPath}'
+            ? `{projectRoot}/${extractedPluginOptions.outputPath}`
+            : output
+        );
+      }
+      if (Object.keys(target.options).length === 0) delete target.options;
+      if (Object.keys(target).length === 0) delete project.targets[targetName];
+
+      updateProjectConfiguration(tree, projectName, project);
+
+      nxJson.plugins ??= [];
+      if (
+        !nxJson.plugins.some((p) =>
+          typeof p === 'string'
+            ? p === '@nx/rollup/plugin'
+            : p.plugin === '@nx/rollup/plugin'
+        )
+      ) {
+        nxJson.plugins.push({
+          plugin: '@nx/rollup/plugin',
+          options: {
+            targetName: 'build',
+          },
+        });
+      }
+      updateNxJson(tree, nxJson);
+
+      migrated++;
+    }
+  );
+
+  if (migrated === 0) {
+    throw new Error('Could not find any targets to migrate.');
+  }
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+}
+
+export default convertToInferred;

--- a/packages/rollup/src/generators/convert-to-inferred/lib/extract-rollup-config-from-executor-options.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/lib/extract-rollup-config-from-executor-options.ts
@@ -1,0 +1,116 @@
+import { joinPathFragments, stripIndents, Tree } from '@nx/devkit';
+import { RollupExecutorOptions } from '../../../executors/rollup/schema';
+import { normalizePathOptions } from './normalize-path-options';
+
+export function extractRollupConfigFromExecutorOptions(
+  tree: Tree,
+  options: RollupExecutorOptions,
+  configurations: Record<string, Partial<RollupExecutorOptions>>,
+  projectRoot: string
+) {
+  normalizePathOptions(projectRoot, options);
+
+  let newRollupConfigContent: string;
+
+  const hasConfigurations =
+    !!configurations && Object.keys(configurations).length > 0;
+
+  const oldRollupConfig = Array.isArray(options.rollupConfig)
+    ? options.rollupConfig
+    : options.rollupConfig
+    ? [options.rollupConfig]
+    : [];
+  delete options.rollupConfig;
+
+  // Resolve conflict with rollup.config.js if it exists.
+  for (let i = 0; i < oldRollupConfig.length; i++) {
+    const file = oldRollupConfig[i];
+    if (file === './rollup.config.js') {
+      tree.rename(
+        joinPathFragments(projectRoot, 'rollup.config.js'),
+        joinPathFragments(projectRoot, `rollup.migrated.config.js`)
+      );
+      oldRollupConfig.splice(i, 1, './rollup.migrated.config.js');
+    }
+  }
+
+  const defaultOptions: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(options)) {
+    if (key === 'watch') continue;
+    delete options[key];
+    defaultOptions[key] = value;
+  }
+  if (hasConfigurations) {
+    const configurationOptions: Record<string, Record<string, unknown>> = {};
+    for (const [key, value] of Object.entries(configurations)) {
+      for (const [optionKey, optionValue] of Object.entries(value)) {
+        if (optionKey === 'watch') continue;
+        delete value[optionKey];
+        configurationOptions[key] ??= {};
+        configurationOptions[key][optionKey] = optionValue;
+      }
+    }
+
+    newRollupConfigContent = stripIndents`
+      const { withNx } = require('@nx/rollup/with-nx');
+      
+      // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+      const configValues =  ${JSON.stringify(
+        {
+          default: defaultOptions,
+          ...configurationOptions,
+        },
+        null,
+        2
+      )}; 
+        
+      // Determine the correct configValue to use based on the configuration
+      const nxConfiguration = process.env.NX_TASK_TARGET_CONFIGURATION ?? 'default';
+      
+      const options = {
+        ...configValues.default,
+        ...configValues[nxConfiguration],
+      };
+      
+      ${oldRollupConfig.length > 0 ? 'let' : 'const'} config = withNx(options, {
+        // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+        // e.g. 
+        // output: { sourcemap: true },
+      });
+      
+      ${oldRollupConfig
+        // Normalize path
+        .map((s) => `config = require('${s}')(config, options);`)
+        .join('\n')}
+      
+      module.exports = config;
+    `;
+  } else {
+    newRollupConfigContent = stripIndents`
+      const { withNx } = require('@nx/rollup/with-nx');
+      
+      // These options were migrated by @nx/rollup:convert-to-inferred from project.json
+      const options = ${JSON.stringify(defaultOptions, null, 2)};
+      
+      ${oldRollupConfig.length > 0 ? 'let' : 'const'} config = withNx(options, {
+        // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+        // e.g. 
+        // output: { sourcemap: true },
+      });
+      
+      ${oldRollupConfig
+        // Normalize path
+        .map((s) => `config = require('${s}')(config, options);`)
+        .join('\n')}
+      
+      module.exports = config;
+    `;
+  }
+
+  tree.write(
+    joinPathFragments(projectRoot, `rollup.config.js`),
+    newRollupConfigContent
+  );
+
+  return defaultOptions;
+}

--- a/packages/rollup/src/generators/convert-to-inferred/lib/normalize-path-options.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/lib/normalize-path-options.ts
@@ -1,0 +1,61 @@
+import { joinPathFragments, offsetFromRoot } from '@nx/devkit';
+import { RollupExecutorOptions } from '../../../executors/rollup/schema';
+
+const executorPathFieldsToMigrate: Array<keyof RollupExecutorOptions> = [
+  'tsConfig',
+  'project',
+  'main',
+  'outputPath',
+  'rollupConfig',
+  'additionalEntryPoints',
+];
+
+export function normalizePathOptions(
+  projectRoot: string,
+  options: RollupExecutorOptions
+): void {
+  for (const [key, value] of Object.entries(options)) {
+    if (
+      !executorPathFieldsToMigrate.includes(key as keyof RollupExecutorOptions)
+    )
+      continue;
+
+    if (Array.isArray(value)) {
+      options[key] = value.map((v) =>
+        normalizeValue(projectRoot, key as keyof RollupExecutorOptions, v)
+      );
+    } else {
+      options[key] = normalizeValue(
+        projectRoot,
+        key as keyof RollupExecutorOptions,
+        value
+      );
+    }
+  }
+}
+
+function normalizeValue(
+  projectRoot: string,
+  key: keyof RollupExecutorOptions,
+  value: string
+): string {
+  // Logic matches `@nx/rollup:rollup` in `normalizePluginPath` function.
+
+  if (!value) return value;
+
+  if (key === 'rollupConfig') {
+    try {
+      // If this can load as npm module, keep as is.
+      require.resolve(value);
+      return value;
+    } catch {
+      // Otherwise continue below convert to relative path from project.
+    }
+  }
+
+  if (value.startsWith(`${projectRoot}/`)) {
+    return value.replace(new RegExp(`^${projectRoot}/`), './');
+  } else {
+    return joinPathFragments(offsetFromRoot(projectRoot), value);
+  }
+}

--- a/packages/rollup/src/generators/convert-to-inferred/schema.json
+++ b/packages/rollup/src/generators/convert-to-inferred/schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "NxRollupConvertToInferred",
+  "description": "Convert existing Rollup project(s) using `@nx/rollup:rollup` executor to use `@nx/rollup/plugin`. Defaults to migrating all projects. Pass '--project' to migrate only one target.",
+  "title": "Convert Rollup project from executor to plugin",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The project to convert from using the `@nx/rollup:rollup` executor to use `@nx/rollup/plugin`.",
+      "x-priority": "important"
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Whether to format files at the end of the migration.",
+      "default": false
+    }
+  }
+}

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -268,6 +268,9 @@ export function withNx(
 function createInput(
   options: RollupWithNxPluginOptions
 ): Record<string, string> {
+  // During graph creation, these input entries don't affect target configuration, so we can skip them.
+  // If convert-to-inferred generator is used, and project uses configurations, some options like main might be missing from default options.
+  if (global.NX_GRAPH_CREATION) return {};
   const mainEntryFileName = options.outputFileName || options.main;
   const input: Record<string, string> = {};
   input[parse(mainEntryFileName).name] = join(workspaceRoot, options.main);


### PR DESCRIPTION
This PR adds `@nx/rollup:convert-to-inferred` generator.


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
