### PR TITLE
feat(testing): use createNodesV2 for jest

### DIFF
--- a/docs/generated/devkit/createNodesFromFiles.md
+++ b/docs/generated/devkit/createNodesFromFiles.md
@@ -10,12 +10,12 @@
 
 #### Parameters
 
-| Name          | Type                                                                  |
-| :------------ | :-------------------------------------------------------------------- |
-| `createNodes` | [`CreateNodesFunction`](../../devkit/documents/CreateNodesFunction)   |
-| `configFiles` | readonly `string`[]                                                   |
-| `options`     | `T`                                                                   |
-| `context`     | [`CreateNodesContextV2`](../../devkit/documents/CreateNodesContextV2) |
+| Name          | Type                                                                       |
+| :------------ | :------------------------------------------------------------------------- |
+| `createNodes` | [`CreateNodesFunction`](../../devkit/documents/CreateNodesFunction)\<`T`\> |
+| `configFiles` | readonly `string`[]                                                        |
+| `options`     | `T`                                                                        |
+| `context`     | [`CreateNodesContextV2`](../../devkit/documents/CreateNodesContextV2)      |
 
 #### Returns
 

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -123,13 +123,14 @@ export const makeCreateNodes =
   };
 
 /**
- * @deprecated `{@link createNodesV2} is replacing this. Update your plugin to export its own `createNodesV2` function that wraps this one instead.`
+ @deprecated This is replaced with {@link createNodesV2}. Update your plugin to export its own `createNodesV2` function that wraps this one instead.
+  This function will change to the v2 function in Nx 20.
  */
 export const createNodes: CreateNodes<GradlePluginOptions> = [
   gradleConfigGlob,
   (configFile, options, context) => {
     logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will error.'
+      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
     );
     populateGradleReport(context.workspaceRoot);
     const gradleReport = getCurrentGradleReport();

--- a/packages/jest/plugin.ts
+++ b/packages/jest/plugin.ts
@@ -1,5 +1,5 @@
 export {
   createNodes,
-  createDependencies,
+  createNodesV2,
   JestPluginOptions,
 } from './src/plugins/plugin';

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -9,8 +9,8 @@ import {
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
-import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
-import { createNodes } from '../../plugins/plugin';
+import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
+import { createNodesV2 } from '../../plugins/plugin';
 import {
   getPresetExt,
   type JestPresetExtension,
@@ -104,11 +104,11 @@ export async function jestInitGeneratorInternal(
   if (!tree.exists(`jest.preset.${presetExt}`)) {
     updateProductionFileSet(tree);
     if (options.addPlugin) {
-      await addPluginV1(
+      await addPlugin(
         tree,
         await createProjectGraphAsync(),
         '@nx/jest/plugin',
-        createNodes,
+        createNodesV2,
         {
           targetName: ['test', 'jest:test', 'jest-test'],
         },

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -1,11 +1,11 @@
 import { CreateNodesContext } from '@nx/devkit';
 import { join } from 'path';
 
-import { createNodes } from './plugin';
+import { createNodesV2 } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
 describe('@nx/jest/plugin', () => {
-  let createNodesFunction = createNodes[1];
+  let createNodesFunction = createNodesV2[1];
   let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd: string;
@@ -45,46 +45,55 @@ describe('@nx/jest/plugin', () => {
       },
       context
     );
-    const nodes = await createNodesFunction(
-      'proj/jest.config.js',
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
       {
         targetName: 'test',
       },
       context
     );
 
-    expect(nodes.projects.proj).toMatchInlineSnapshot(`
-      {
-        "metadata": undefined,
-        "root": "proj",
-        "targets": {
-          "test": {
-            "cache": true,
-            "command": "jest",
-            "inputs": [
-              "default",
-              "^production",
-              {
-                "externalDependencies": [
-                  "jest",
-                ],
+    expect(results).toMatchInlineSnapshot(`
+      [
+        [
+          "proj/jest.config.js",
+          {
+            "projects": {
+              "proj": {
+                "metadata": undefined,
+                "root": "proj",
+                "targets": {
+                  "test": {
+                    "cache": true,
+                    "command": "jest",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "jest",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Run Jest Tests",
+                      "technologies": [
+                        "jest",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "proj",
+                    },
+                    "outputs": [
+                      "{workspaceRoot}/coverage",
+                    ],
+                  },
+                },
               },
-            ],
-            "metadata": {
-              "description": "Run Jest Tests",
-              "technologies": [
-                "jest",
-              ],
             },
-            "options": {
-              "cwd": "proj",
-            },
-            "outputs": [
-              "{workspaceRoot}/coverage",
-            ],
           },
-        },
-      }
+        ],
+      ]
     `);
   });
 
@@ -97,8 +106,8 @@ describe('@nx/jest/plugin', () => {
       },
       context
     );
-    const nodes = await createNodesFunction(
-      'proj/jest.config.js',
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
       {
         targetName: 'test',
         ciTargetName: 'test-ci',
@@ -106,95 +115,104 @@ describe('@nx/jest/plugin', () => {
       context
     );
 
-    expect(nodes.projects.proj).toMatchInlineSnapshot(`
-      {
-        "metadata": {
-          "targetGroups": {
-            "E2E (CI)": [
-              "test-ci",
-              "test-ci--src/unit.spec.ts",
-            ],
-          },
-        },
-        "root": "proj",
-        "targets": {
-          "test": {
-            "cache": true,
-            "command": "jest",
-            "inputs": [
-              "default",
-              "^production",
-              {
-                "externalDependencies": [
-                  "jest",
-                ],
+    expect(results).toMatchInlineSnapshot(`
+      [
+        [
+          "proj/jest.config.js",
+          {
+            "projects": {
+              "proj": {
+                "metadata": {
+                  "targetGroups": {
+                    "E2E (CI)": [
+                      "test-ci",
+                      "test-ci--src/unit.spec.ts",
+                    ],
+                  },
+                },
+                "root": "proj",
+                "targets": {
+                  "test": {
+                    "cache": true,
+                    "command": "jest",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "jest",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Run Jest Tests",
+                      "technologies": [
+                        "jest",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "proj",
+                    },
+                    "outputs": [
+                      "{workspaceRoot}/coverage",
+                    ],
+                  },
+                  "test-ci": {
+                    "cache": true,
+                    "dependsOn": [
+                      "test-ci--src/unit.spec.ts",
+                    ],
+                    "executor": "nx:noop",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "jest",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Run Jest Tests in CI",
+                      "technologies": [
+                        "jest",
+                      ],
+                    },
+                    "outputs": [
+                      "{workspaceRoot}/coverage",
+                    ],
+                  },
+                  "test-ci--src/unit.spec.ts": {
+                    "cache": true,
+                    "command": "jest src/unit.spec.ts",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "jest",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Run Jest Tests in src/unit.spec.ts",
+                      "technologies": [
+                        "jest",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "proj",
+                    },
+                    "outputs": [
+                      "{workspaceRoot}/coverage",
+                    ],
+                  },
+                },
               },
-            ],
-            "metadata": {
-              "description": "Run Jest Tests",
-              "technologies": [
-                "jest",
-              ],
             },
-            "options": {
-              "cwd": "proj",
-            },
-            "outputs": [
-              "{workspaceRoot}/coverage",
-            ],
           },
-          "test-ci": {
-            "cache": true,
-            "dependsOn": [
-              "test-ci--src/unit.spec.ts",
-            ],
-            "executor": "nx:noop",
-            "inputs": [
-              "default",
-              "^production",
-              {
-                "externalDependencies": [
-                  "jest",
-                ],
-              },
-            ],
-            "metadata": {
-              "description": "Run Jest Tests in CI",
-              "technologies": [
-                "jest",
-              ],
-            },
-            "outputs": [
-              "{workspaceRoot}/coverage",
-            ],
-          },
-          "test-ci--src/unit.spec.ts": {
-            "cache": true,
-            "command": "jest src/unit.spec.ts",
-            "inputs": [
-              "default",
-              "^production",
-              {
-                "externalDependencies": [
-                  "jest",
-                ],
-              },
-            ],
-            "metadata": {
-              "description": "Run Jest Tests in src/unit.spec.ts",
-              "technologies": [
-                "jest",
-              ],
-            },
-            "options": {
-              "cwd": "proj",
-            },
-            "outputs": [
-              "{workspaceRoot}/coverage",
-            ],
-          },
-        },
-      }
+        ],
+      ]
     `);
   });
 });

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -1,8 +1,10 @@
 import {
-  CreateDependencies,
   CreateNodes,
   CreateNodesContext,
+  createNodesFromFiles,
+  CreateNodesV2,
   joinPathFragments,
+  logger,
   normalizePath,
   NxJsonConfiguration,
   ProjectConfiguration,
@@ -10,7 +12,7 @@ import {
   TargetConfiguration,
   writeJsonFile,
 } from '@nx/devkit';
-import { dirname, join, normalize, relative, resolve } from 'path';
+import { dirname, join, relative, resolve } from 'path';
 
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { existsSync, readdirSync, readFileSync } from 'fs';
@@ -21,100 +23,130 @@ import { clearRequireCache } from '@nx/devkit/src/utils/config-utils';
 import { getGlobPatternsFromPackageManagerWorkspaces } from 'nx/src/plugins/package-json-workspaces';
 import { combineGlobPatterns } from 'nx/src/utils/globs';
 import { minimatch } from 'minimatch';
+import { hashObject } from 'nx/src/devkit-internals';
 
 export interface JestPluginOptions {
   targetName?: string;
   ciTargetName?: string;
 }
 
-const cachePath = join(projectGraphCacheDirectory, 'jest.hash');
-const targetsCache = readTargetsCache();
-
 type JestTargets = Awaited<ReturnType<typeof buildJestTargets>>;
 
-function readTargetsCache(): Record<string, JestTargets> {
+function readTargetsCache(cachePath: string): Record<string, JestTargets> {
   return existsSync(cachePath) ? readJsonFile(cachePath) : {};
 }
 
-function writeTargetsToCache() {
-  const cache = readTargetsCache();
-  writeJsonFile(cachePath, {
-    ...cache,
-    ...targetsCache,
-  });
+function writeTargetsToCache(
+  cachePath: string,
+  results: Record<string, JestTargets>
+) {
+  writeJsonFile(cachePath, results);
 }
 
-export const createDependencies: CreateDependencies = () => {
-  writeTargetsToCache();
-  return [];
-};
+const jestConfigGlob = '**/jest.config.{cjs,mjs,js,cts,mts,ts}';
 
-export const createNodes: CreateNodes<JestPluginOptions> = [
-  '**/jest.config.{cjs,mjs,js,cts,mts,ts}',
-  async (configFilePath, options, context) => {
-    const projectRoot = dirname(configFilePath);
-
-    const packageManagerWorkspacesGlob = combineGlobPatterns(
-      getGlobPatternsFromPackageManagerWorkspaces(context.workspaceRoot)
+export const createNodesV2: CreateNodesV2<JestPluginOptions> = [
+  jestConfigGlob,
+  async (configFiles, options, context) => {
+    const optionsHash = hashObject(options);
+    const cachePath = join(
+      projectGraphCacheDirectory,
+      `jest-${optionsHash}.hash`
     );
-
-    // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
-    ) {
-      return {};
-    } else if (
-      !siblingFiles.includes('project.json') &&
-      siblingFiles.includes('package.json')
-    ) {
-      const path = joinPathFragments(projectRoot, 'package.json');
-
-      const isPackageJsonProject = minimatch(
-        path,
-        packageManagerWorkspacesGlob
+    const targetsCache = readTargetsCache(cachePath);
+    try {
+      return await createNodesFromFiles(
+        (configFile, options, context) =>
+          createNodesInternal(configFile, options, context, targetsCache),
+        configFiles,
+        options,
+        context
       );
-
-      if (!isPackageJsonProject) {
-        return {};
-      }
+    } finally {
+      writeTargetsToCache(cachePath, targetsCache);
     }
-
-    const jestConfigContent = readFileSync(
-      resolve(context.workspaceRoot, configFilePath),
-      'utf-8'
-    );
-    if (jestConfigContent.includes('getJestProjectsAsync()')) {
-      // The `getJestProjectsAsync` function uses the project graph, which leads to a
-      // circular dependency. We can skip this since it's no intended to be used for
-      // an Nx project.
-      return {};
-    }
-
-    options = normalizeOptions(options);
-
-    const hash = calculateHashForCreateNodes(projectRoot, options, context);
-    targetsCache[hash] ??= await buildJestTargets(
-      configFilePath,
-      projectRoot,
-      options,
-      context
-    );
-
-    const { targets, metadata } = targetsCache[hash];
-
-    return {
-      projects: {
-        [projectRoot]: {
-          root: projectRoot,
-          targets,
-          metadata,
-        },
-      },
-    };
   },
 ];
+
+/**
+ * @deprecated This is replaced with {@link createNodesV2}. Update your plugin to export its own `createNodesV2` function that wraps this one instead.
+ * This function will change to the v2 function in Nx 20.
+ */
+export const createNodes: CreateNodes<JestPluginOptions> = [
+  jestConfigGlob,
+  (...args) => {
+    logger.warn(
+      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
+    );
+    return createNodesInternal(...args, {});
+  },
+];
+
+async function createNodesInternal(
+  configFilePath,
+  options,
+  context,
+  targetsCache: Record<string, JestTargets>
+) {
+  const projectRoot = dirname(configFilePath);
+
+  const packageManagerWorkspacesGlob = combineGlobPatterns(
+    getGlobPatternsFromPackageManagerWorkspaces(context.workspaceRoot)
+  );
+
+  // Do not create a project if package.json and project.json isn't there.
+  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
+  if (
+    !siblingFiles.includes('package.json') &&
+    !siblingFiles.includes('project.json')
+  ) {
+    return {};
+  } else if (
+    !siblingFiles.includes('project.json') &&
+    siblingFiles.includes('package.json')
+  ) {
+    const path = joinPathFragments(projectRoot, 'package.json');
+
+    const isPackageJsonProject = minimatch(path, packageManagerWorkspacesGlob);
+
+    if (!isPackageJsonProject) {
+      return {};
+    }
+  }
+
+  const jestConfigContent = readFileSync(
+    resolve(context.workspaceRoot, configFilePath),
+    'utf-8'
+  );
+  if (jestConfigContent.includes('getJestProjectsAsync()')) {
+    // The `getJestProjectsAsync` function uses the project graph, which leads to a
+    // circular dependency. We can skip this since it's no intended to be used for
+    // an Nx project.
+    return {};
+  }
+
+  options = normalizeOptions(options);
+
+  const hash = calculateHashForCreateNodes(projectRoot, options, context);
+  targetsCache[hash] ??= await buildJestTargets(
+    configFilePath,
+    projectRoot,
+    options,
+    context
+  );
+
+  const { targets, metadata } = targetsCache[hash];
+
+  return {
+    projects: {
+      [projectRoot]: {
+        root: projectRoot,
+        targets,
+        metadata,
+      },
+    },
+  };
+}
 
 async function buildJestTargets(
   configFilePath: string,

--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -58,7 +58,7 @@ export type AsyncFn<T extends Function> = T extends (
   : never;
 
 export async function createNodesFromFiles<T = unknown>(
-  createNodes: CreateNodesFunction,
+  createNodes: CreateNodesFunction<T>,
   configFiles: readonly string[],
   options: T,
   context: CreateNodesContextV2


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nx/jest/plugin` uses CreateNodesV1. Multiple Jest plugins are not able to be run in parallel and in isolation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nx/jest/plugin` uses CreateNodesV2. Multiple jest plugins are able to run in parallel and in isolation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
