### PR TITLE
feat(nx-dev): add engineering team contact page

### DIFF
--- a/nx-dev/nx-dev/pages/contact/engineering.tsx
+++ b/nx-dev/nx-dev/pages/contact/engineering.tsx
@@ -1,0 +1,46 @@
+import { useRouter } from 'next/router';
+import { NextSeo } from 'next-seo';
+import { Footer, Header } from '@nx/nx-dev/ui-common';
+import {
+  TalkToOurEngineeringTeam,
+  TalkToOurSalesTeam,
+} from '@nx/nx-dev/ui-contact';
+
+export function EngineeringTeam(): JSX.Element {
+  const router = useRouter();
+
+  return (
+    <>
+      <NextSeo
+        title="Talk to our Developer Productivity Engineers"
+        description="Contact our Developer Productivity Engineers for demos, onboarding assistance, and technical support. Share your requirements and challenges with us, and we will help you utilize Nx Enterprise to enhance your organization's product development."
+        openGraph={{
+          url: 'https://nx.dev' + router.asPath,
+          title: 'Talk to our Developer Productivity Engineers',
+          description:
+            "Contact our Developer Productivity Engineers for demos, onboarding assistance, and technical support. Share your requirements and challenges with us, and we will help you utilize Nx Enterprise to enhance your organization's product development.",
+          images: [
+            {
+              url: 'https://nx.dev/socials/nx-media.png',
+              width: 800,
+              height: 421,
+              alt: 'Nx: Smart Monorepos · Fast CI',
+              type: 'image/jpeg',
+            },
+          ],
+          siteName: 'NxDev',
+          type: 'website',
+        }}
+      />
+      <Header />
+      <main id="main" role="main" className="py-24 lg:py-32">
+        <div>
+          <TalkToOurEngineeringTeam />
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+export default EngineeringTeam;

--- a/nx-dev/nx-dev/pages/contact/sales.tsx
+++ b/nx-dev/nx-dev/pages/contact/sales.tsx
@@ -10,12 +10,12 @@ export function ContactSales(): JSX.Element {
     <>
       <NextSeo
         title="Talk to our Sales team"
-        description="We’re here to help you find the right plan and pricing for your requirements. We can talk about how Nx Cloud Enterprise helps you drive better business outcomes."
+        description="We’re here to help you find the right plan and pricing for your needs and discuss how Nx Cloud Enterprise can drive better business outcomes for your organization."
         openGraph={{
           url: 'https://nx.dev' + router.asPath,
           title: 'Talk to our Sales team',
           description:
-            'We’re here to help you find the right plan and pricing for your requirements. We can talk about how Nx Cloud Enterprise helps you drive better business outcomes.',
+            'We’re here to help you find the right plan and pricing for your needs and discuss how Nx Cloud Enterprise can drive better business outcomes for your organization.',
           images: [
             {
               url: 'https://nx.dev/socials/nx-media.png',

--- a/nx-dev/ui-contact/src/index.ts
+++ b/nx-dev/ui-contact/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/contact-links';
 export * from './lib/how-can-we-help';
 export * from './lib/talk-to-our-sales-team';
+export * from './lib/talk-to-our-engineering-team';

--- a/nx-dev/ui-contact/src/lib/how-can-we-help.tsx
+++ b/nx-dev/ui-contact/src/lib/how-can-we-help.tsx
@@ -2,7 +2,7 @@ import { ButtonLink, SectionHeading } from '@nx/nx-dev/ui-common';
 import {
   ArrowUpRightIcon,
   ChatBubbleLeftRightIcon,
-  UsersIcon,
+  ChevronRightIcon,
 } from '@heroicons/react/24/outline';
 
 export function HowCanWeHelp(): JSX.Element {
@@ -14,8 +14,57 @@ export function HowCanWeHelp(): JSX.Element {
             How can we help?
           </SectionHeading>
         </div>
-        <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-2 lg:gap-8">
+        <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-4 md:grid-cols-2">
           <section className="rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
+            <div className="flex items-center gap-2">
+              <ChevronRightIcon
+                aria-hidden="true"
+                className="h-5 w-5 shrink-0"
+              />
+              <h3 className="text-xl font-medium text-slate-700 dark:text-slate-300">
+                Sales
+              </h3>
+            </div>
+            <p className="mt-4">
+              Contact our sales team to discuss plans, expected usage,
+              certifications, organization constraints, and get the best pricing
+              for your team.
+            </p>
+            <ButtonLink
+              href="/contact/sales"
+              variant="primary"
+              size="default"
+              title="Talk to our sales team"
+              className="mt-6"
+            >
+              Reach out to sales
+            </ButtonLink>
+          </section>
+          <section className="rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
+            <div className="flex items-center gap-2">
+              <ChevronRightIcon
+                aria-hidden="true"
+                className="h-5 w-5 shrink-0"
+              />
+              <h3 className="text-xl font-medium text-slate-700 dark:text-slate-300">
+                Engineers
+              </h3>
+            </div>
+            <p className="mt-4">
+              Contact our developer productivity engineers team for demos,
+              onboarding assistance, and technical product questions.
+            </p>
+            <ButtonLink
+              href="/contact/engineering"
+              variant="primary"
+              size="default"
+              title="Talk to our engineering team"
+              className="mt-6"
+            >
+              Reach out to engineers
+            </ButtonLink>
+          </section>
+          <section className="col-span-2 rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
             <div className="flex items-center gap-2">
               <ChatBubbleLeftRightIcon
                 aria-hidden="true"
@@ -27,7 +76,8 @@ export function HowCanWeHelp(): JSX.Element {
             </div>
             <p className="mt-4">
               Ask a question, receive guidance, share ideas or simply leave
-              feedback about our products on the Discord channel.
+              feedback about our products on the Discord channel. A vibrant
+              community of Nx users will be able to help you.
             </p>
             <ButtonLink
               href="https://go.nx.dev/community"
@@ -40,27 +90,6 @@ export function HowCanWeHelp(): JSX.Element {
             >
               <span>Ask questions on Discord</span>
               <ArrowUpRightIcon aria-hidden="true" className="h-3 w-3" />
-            </ButtonLink>
-          </section>
-          <section className="rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
-            <div className="flex items-center gap-2">
-              <UsersIcon aria-hidden="true" className="h-5 w-5 shrink-0" />
-              <h3 className="text-xl font-medium text-slate-700 dark:text-slate-300">
-                Get in touch with our sales team
-              </h3>
-            </div>
-            <p className="mt-4">
-              Contact our sales and support teams for demos, onboarding
-              assistance, pricing or product questions.
-            </p>
-            <ButtonLink
-              href="/contact/sales"
-              variant="primary"
-              size="default"
-              title="Talk to our sales team"
-              className="mt-6"
-            >
-              Contact sales
             </ButtonLink>
           </section>
         </div>

--- a/nx-dev/ui-contact/src/lib/talk-to-our-engineering-team.tsx
+++ b/nx-dev/ui-contact/src/lib/talk-to-our-engineering-team.tsx
@@ -1,23 +1,24 @@
 import { SectionHeading } from '@nx/nx-dev/ui-common';
 import { HubspotForm } from './hubspot-form';
 
-export function TalkToOurSalesTeam(): JSX.Element {
+export function TalkToOurEngineeringTeam(): JSX.Element {
   return (
     <section id="contact-sales">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
           <SectionHeading as="h1" variant="display" id="how-can-we-help">
-            Talk to our sales team
+            Talk to our engineering team
           </SectionHeading>
         </div>
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-12 md:grid-cols-2 lg:gap-8">
           <section className="mt-4">
             <p className="text-lg leading-relaxed">
-              We’re here to help you find the right plan and pricing for your
-              needs and discuss{' '}
+              Contact our Developer Productivity Engineers for demos, onboarding
+              assistance, and technical support. Share your requirements and
+              challenges with us, and{' '}
               <span className="font-medium">
-                how Nx Cloud Enterprise can drive better business outcomes for
-                your organization
+                we will help you utilize Nx Enterprise to enhance your
+                organization's product development
               </span>
               .
             </p>
@@ -142,7 +143,7 @@ export function TalkToOurSalesTeam(): JSX.Element {
             <HubspotForm
               region="na1"
               portalId="2757427"
-              formId="2e492124-843c-4a6d-87fe-93db27ab4323"
+              formId="c88140bc-0b93-4238-b838-77dd4047bb32"
               noScript={true}
               loading={<div>Loading...</div>}
             />

--- a/nx-dev/ui-enterprise/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-enterprise/src/lib/call-to-action.tsx
@@ -62,7 +62,13 @@ export function CallToAction(): JSX.Element {
             href="/contact/sales"
             className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
           >
-            Contact us
+            Contact sales
+          </Link>
+          <Link
+            href="/contact/enigeering"
+            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+          >
+            Contact engineers
           </Link>
           {/*<Link*/}
           {/*  href="/enterprise#talk"*/}

--- a/nx-dev/ui-enterprise/src/lib/hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/hero.tsx
@@ -26,6 +26,14 @@ export function Hero(): JSX.Element {
             >
               Contact sales
             </ButtonLink>
+            <ButtonLink
+              href="/contact/engineering"
+              title="Contact sales"
+              variant="primary"
+              size="default"
+            >
+              Contact engineers
+            </ButtonLink>
 
             {/*<Link*/}
             {/*  className="group text-sm font-semibold leading-6 text-slate-950 dark:text-white"*/}


### PR DESCRIPTION
Implemented a new component for the Engineers contact page which can be accessed from `nx-dev/pages/contact/engineering.tsx`. Additionally, refactored UI components to enhance the contact options. Functionality for users to get in touch with the sales and engineer teams was added.
