### PR TITLE
fix(bundling): load rollup config using the rollup version installed in the workspace

### DIFF
--- a/packages/rollup/src/plugins/plugin.spec.ts
+++ b/packages/rollup/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { type CreateNodesContext, joinPathFragments } from '@nx/devkit';
+import { type CreateNodesContext } from '@nx/devkit';
 import { createNodes } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
@@ -9,9 +9,6 @@ jest.mock('rollup/loadConfigFile', () => {
     loadConfigFile: jest.fn(),
   };
 });
-
-// @ts-ignore
-import { loadConfigFile } from 'rollup/loadConfigFile';
 
 describe('@nx/rollup/plugin', () => {
   let createNodesFunction = createNodes[1];
@@ -65,6 +62,7 @@ describe('@nx/rollup/plugin', () => {
       }`
       );
 
+      const { loadConfigFile } = require('rollup/loadConfigFile');
       loadConfigFile.mockReturnValue(rollupConfigOptions);
 
       process.chdir(tempFs.tempDir);
@@ -140,6 +138,8 @@ describe('@nx/rollup/plugin', () => {
       console.log("hello world");
       }`
       );
+
+      const { loadConfigFile } = require('rollup/loadConfigFile');
       loadConfigFile.mockReturnValue(rollupConfigOptions);
 
       process.chdir(tempFs.tempDir);

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -2,23 +2,19 @@ import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { basename, dirname, join } from 'path';
 import { existsSync, readdirSync } from 'fs';
 import {
-  type TargetConfiguration,
   type CreateDependencies,
   type CreateNodes,
-  readJsonFile,
-  writeJsonFile,
-  detectPackageManager,
   CreateNodesContext,
+  detectPackageManager,
   joinPathFragments,
+  readJsonFile,
+  type TargetConfiguration,
+  writeJsonFile,
 } from '@nx/devkit';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getLockFileName } from '@nx/js';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { type RollupOptions } from 'rollup';
-
-// This import causes an error due to the module resolution used. If we switch to bundler or nodenext in the future we remove this ignore.
-// @ts-ignore
-import { loadConfigFile } from 'rollup/loadConfigFile';
 
 const cachePath = join(workspaceDataDirectory, 'rollup.hash');
 const targetsCache = readTargetsCache();
@@ -94,6 +90,27 @@ async function buildRollupTarget(
   options: RollupPluginOptions,
   context: CreateNodesContext
 ): Promise<Record<string, TargetConfiguration>> {
+  let loadConfigFile: (
+    path: string,
+    commandOptions: unknown,
+    watchMode: boolean
+  ) => Promise<{ options: RollupOptions[] }>;
+
+  try {
+    // Try to load the workspace version of rollup first (it should already exist).
+    // Using the workspace rollup ensures that the config file is compatible with the `loadConfigFile` function.
+    // e.g. rollup@2 supports having `require` calls in rollup config, but rollup@4 does not.
+    const m = require(require.resolve('rollup/loadConfigFile', {
+      paths: [dirname(configFilePath)],
+    }));
+    // Rollup 2 has this has default export, but it is named in 3 and 4.
+    // See: https://www.unpkg.com/browse/rollup@2.79.1/dist/loadConfigFile.js
+    loadConfigFile = typeof m === 'function' ? m : m.loadConfigFile;
+  } catch {
+    // Fallback to our own if needed.
+    loadConfigFile = require('rollup/loadConfigFile').loadConfigFile;
+  }
+
   const namedInputs = getNamedInputs(projectRoot, context);
   const rollupConfig = (
     (await loadConfigFile(


### PR DESCRIPTION
This PR updates `@nx/rollup/plugin` so it loads the config file using `loadConfigFile` from the Rollup version installed in the workspace.

This fixes the issue when initializing in the [axios](https://github.com/axios/axios) repo, since the `require` call in their config is no longer valid ESM in Rollup 4.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
