### PR TITLE
fix(vite): ensure installed version matches defined peer in package.json

### DIFF
--- a/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`@nx/vite:init dependencies for package.json should add required package
     "@nx/web": "0.0.1",
     "@vitest/ui": "^1.3.1",
     "existing": "1.0.0",
-    "vite": "~5.0.0",
+    "vite": "^5.0.0",
     "vitest": "^1.3.1",
   },
   "name": "@proj/source",

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = require('../../package.json').version;
-export const viteVersion = '~5.0.0';
+export const viteVersion = '^5.0.0';
 export const vitestVersion = '^1.3.1';
 export const vitePluginReactVersion = '^4.2.0';
 export const vitePluginReactSwcVersion = '^3.5.0';

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -197,7 +197,7 @@ exports[`lib should add vue, vite and vitest to package.json 1`] = `
     "jsdom": "~22.1.0",
     "prettier": "^2.6.2",
     "typescript": "~5.4.2",
-    "vite": "~5.0.0",
+    "vite": "^5.0.0",
     "vitest": "^1.3.1",
     "vue-tsc": "^1.8.8",
   },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Our `@nx/vite` package has a peer dep on `vite@^5.0.0` but we only install `vite@~5.0.0` creating a conflict in dependencies.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The version we install should match the peerDep range we specify in the package.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
