### PR TITLE
fix(core): handle paths deleted by the ide

### DIFF
--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -110,7 +110,7 @@ impl FilesWorker {
         &self,
         workspace_root_path: &Path,
         updated_files: Vec<&str>,
-        deleted_files: Vec<&str>,
+        deleted_files_and_directories: Vec<&str>,
     ) -> HashMap<String, String> {
         let Some(files_sync) = &self.0 else {
             trace!("there were no files because the workspace root did not exist");
@@ -121,8 +121,17 @@ impl FilesWorker {
         let mut files = files_lock.lock();
         let mut map: HashMap<PathBuf, String> = files.drain(..).collect();
 
-        for deleted_file in deleted_files {
-            map.remove(&PathBuf::from(deleted_file));
+        for deleted_path in deleted_files_and_directories {
+            // If the path is a file, this removes it.
+            let removal = map.remove(&PathBuf::from(deleted_path));
+            if removal.is_none() {
+                // If the path is a directory, this retains only files not in the directory.
+                map.retain(|path, _| {
+                    let owned_deleted_path = deleted_path.to_owned();
+                    !path.starts_with(owned_deleted_path + "/")
+                });
+
+            };
         }
 
         let updated_files_hashes: HashMap<String, String> = updated_files


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When IDEs delete directories on some operating systems, the watch events are registered as deleted paths. These events were not handled so plugins were continuing to process files which did not exist.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Watch events which are directories being deleted are handled and plugins will not continue to process files which do not exist. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
