### PR TITLE
feat(nx-cloud): add new Webinars link in menu-items

### DIFF
--- a/nx-dev/ui-common/src/lib/headers/menu-items.ts
+++ b/nx-dev/ui-common/src/lib/headers/menu-items.ts
@@ -216,7 +216,7 @@ export const eventItems: MenuItem[] = [
     name: 'Webinars',
     description:
       'Virtual courses to get a deeper understanding on monorepos animated by the Nx team.',
-    href: 'https://go.nx.dev/april-webinar',
+    href: 'https://go.nx.dev/webinar',
     icon: null,
     isNew: false,
     isHighlight: false,


### PR DESCRIPTION
The href for the Webinars section in the `menu-items.ts` file has been updated.
