### PR TITLE
feat(nx-cloud): automatically open cloud URL in browser

### DIFF
--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -80,6 +80,12 @@ export async function connectToNxCloudCommand(): Promise<boolean> {
         ${connectCloudUrl}`,
         ],
       });
+      const open = require('open');
+      await open(connectCloudUrl)
+        .then(() => {
+          console.info(`Follow up in the browser to complete the setup.`);
+        })
+        .catch(() => {});
     }
     return false;
   }

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -111,6 +111,12 @@ async function printSuccessMessage(
         ${connectCloudUrl}`,
       ],
     });
+    const open = require('open');
+    await open(connectCloudUrl)
+      .then(() => {
+        console.info(`Follow up in the browser to complete the setup.`);
+      })
+      .catch(() => {});
   }
 }
 


### PR DESCRIPTION
Marking as draft because we're not sure if we want this functionality or not.


Automatically open the browser with the cloud onboarding URL.
