### PR TITLE
fix(core): catch nonexistent user error when requiring native code

### DIFF
--- a/packages/nx/src/native/native-file-cache-location.ts
+++ b/packages/nx/src/native/native-file-cache-location.ts
@@ -7,11 +7,17 @@ export function getNativeFileCacheLocation() {
   if (process.env.NX_NATIVE_FILE_CACHE_DIRECTORY) {
     return process.env.NX_NATIVE_FILE_CACHE_DIRECTORY;
   } else {
-    const shortHash = createHash('sha256')
-      .update(userInfo().username)
-      .update(workspaceRoot)
-      .digest('hex')
-      .substring(0, 7);
-    return join(tmpdir(), `nx-native-file-cache-${shortHash}`);
+    const hash = createHash('sha256').update(workspaceRoot);
+
+    try {
+      hash.update(userInfo().username);
+    } catch (e) {
+      // if there's no user, we only use the workspace root for the hash and move on
+    }
+
+    return join(
+      tmpdir(),
+      `nx-native-file-cache-${hash.digest('hex').substring(0, 7)}`
+    );
   }
 }


### PR DESCRIPTION

## Current Behavior
On certain environments, calling node's `userInfo()` errors, leading to native code not being loaded correctly.

## Expected Behavior
We should be resilient towards this and not error.


Fixes https://github.com/nrwl/nx/issues/26351
