### PR TITLE
fix(nuxt): generate tsconfig files correctly

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -42,7 +42,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: './tsconfig.app.json',
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -137,6 +137,7 @@ exports[`app generated files content - as-provided general application should co
     "composite": true
   },
   "include": [
+    ".nuxt/nuxt.d.ts",
     "vite.config.ts",
     "vitest.config.ts",
     "src/**/*.test.ts",
@@ -223,7 +224,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: './tsconfig.app.json',
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -255,7 +256,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: './tsconfig.app.json',
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -287,7 +288,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: './tsconfig.app.json',
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -319,7 +320,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: './tsconfig.app.json',
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -26,6 +26,7 @@ import { addVitest } from './lib/add-vitest';
 import { vueTestUtilsVersion, vitePluginVueVersion } from '@nx/vue';
 import { ensureDependencies } from './lib/ensure-dependencies';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
+import { execSync } from 'node:child_process';
 
 export async function applicationGenerator(tree: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
@@ -119,6 +120,16 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
   if (options.js) toJS(tree);
 
   if (!options.skipFormat) await formatFiles(tree);
+
+  tasks.push(() => {
+    try {
+      execSync(`npx -y nuxi prepare`, { cwd: options.appProjectRoot });
+    } catch (e) {
+      console.error(
+        `Failed to run \`nuxi prepare\` in "${options.appProjectRoot}". Please run the command manually.`
+      );
+    }
+  });
 
   tasks.push(() => {
     logShowProjectCommand(options.projectName);

--- a/packages/nuxt/src/generators/application/files/nuxt.config.ts__tmpl__
+++ b/packages/nuxt/src/generators/application/files/nuxt.config.ts__tmpl__
@@ -13,7 +13,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: './tsconfig.app.json',
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the `./.nuxt/tsconfig.json`, therefore it needs to be relative to that directory
     },
   },
   imports: {

--- a/packages/nuxt/src/generators/application/lib/add-vitest.ts
+++ b/packages/nuxt/src/generators/application/lib/add-vitest.ts
@@ -48,6 +48,7 @@ export async function addVitest(tree: Tree, options: NormalizedSchema) {
   updateJson(tree, `${options.appProjectRoot}/tsconfig.spec.json`, (json) => {
     json.compilerOptions ??= {};
     json.compilerOptions.composite = true;
+    json.include = ['.nuxt/nuxt.d.ts', ...(json.include ?? [])];
     return json;
   });
 

--- a/packages/nuxt/src/utils/create-ts-config.ts
+++ b/packages/nuxt/src/utils/create-ts-config.ts
@@ -49,6 +49,7 @@ function createAppTsConfig(host: Tree, options: { projectRoot: string }) {
     compilerOptions: {
       composite: true,
     },
+    include: ['.nuxt/nuxt.d.ts', 'src/**/*'],
     exclude: [],
   };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The TsConfig files we generate when creating a Nuxt application do not apply the types from `nuxt.d.ts` correctly.
This leads to IDE errors with Nuxt Auto Imports.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the TsConfig files are generated correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26120 #21862
