### PR TITLE
fix(core): make plugin pool cleanup to be synchronous

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -61,7 +61,7 @@ export function loadRemoteNxPlugin(
 
   const cleanupFunction = () => {
     worker.off('exit', exitHandler);
-    shutdownPluginWorker(worker, pendingPromises);
+    shutdownPluginWorker(worker);
   };
 
   cleanupFunctions.add(cleanupFunction);
@@ -75,20 +75,11 @@ export function loadRemoteNxPlugin(
   });
 }
 
-async function shutdownPluginWorker(
-  worker: ChildProcess,
-  pendingPromises: Map<string, PendingPromise>
-) {
+function shutdownPluginWorker(worker: ChildProcess) {
   // Clears the plugin cache so no refs to the workers are held
   nxPluginCache.clear();
 
   // logger.verbose(`[plugin-pool] starting worker shutdown`);
-
-  // Other things may be interacting with the worker.
-  // Wait for all pending promises to be done before killing the worker
-  await Promise.all(
-    Array.from(pendingPromises.values()).map(({ promise }) => promise)
-  );
 
   worker.kill('SIGINT');
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If there are pending promises, the process on exit handler might not run asynchronous work.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The process on exit handler does not run asynchronous work and always cleans up the workers, allowing the process to exit.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
