### PR TITLE
fix(nx-dev): update section layout in 'how-can-we-help' component

### DIFF
--- a/nx-dev/ui-contact/src/lib/how-can-we-help.tsx
+++ b/nx-dev/ui-contact/src/lib/how-can-we-help.tsx
@@ -64,7 +64,7 @@ export function HowCanWeHelp(): JSX.Element {
               Reach out to engineers
             </ButtonLink>
           </section>
-          <section className="col-span-2 rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
+          <section className="rounded-xl border border-slate-200 bg-slate-50/20 p-8 md:col-span-2 dark:border-slate-800/40 dark:bg-slate-800/60">
             <div className="flex items-center gap-2">
               <ChatBubbleLeftRightIcon
                 aria-hidden="true"


### PR DESCRIPTION
The layout for a section in the 'how-can-we-help' component has been adjusted to better suit different screen sizes. The 'col-span-2' class has been moved within a media query ('md') to apply only for medium and larger screens, which will improve the responsiveness on smaller devices.
