### PR TITLE
fix(linter): do not glob for invalid eslint config filenames in plugin

### DIFF
--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -36,8 +36,6 @@ export interface EslintPluginOptions {
 const DEFAULT_EXTENSIONS = ['ts', 'tsx', 'js', 'jsx', 'html', 'vue'];
 const ESLINT_CONFIG_GLOB = combineGlobPatterns([
   ...ESLINT_CONFIG_FILENAMES.map((f) => `**/${f}`),
-  baseEsLintConfigFile,
-  baseEsLintFlatConfigFile,
 ]);
 
 type EslintProjects = Awaited<ReturnType<typeof getProjectsUsingESLintConfig>>;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/eslint/plugin` globs for `.eslintrc.base.json` and `eslint.base.config.js` workspace root files, which are not valid ESLint config filenames. The ESLint CLI wouldn't pick them up directly, and we shouldn't infer or process them. They are only used as part of a valid config file name that extends from them.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/eslint/plugin` only globs for valid ESLint config filenames.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26388 
