### PR TITLE
fix(web): add shell true

### DIFF
--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -170,6 +170,8 @@ export default async function* fileServerExecutor(
           const args = getBuildTargetCommand(options, context);
           execFileSync(pmCmd, args, {
             stdio: [0, 1, 2],
+            shell: true,
+            windowsHide: true,
           });
         } catch {
           throw new Error(


### PR DESCRIPTION
Add option `shell: true` to allow child process on Windows

Closes #26161
