### PR TITLE
fix(nuxt): app generation should respect as-provided for app names

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app generated files content - as-provided general application should add nuxt entries in .gitignore 1`] = `
+exports[`app generated files content - as-provided - my-app general application should add nuxt entries in .gitignore 1`] = `
 "
 # Nuxt dev/build outputs
 .output
@@ -10,7 +10,7 @@ exports[`app generated files content - as-provided general application should ad
 .cache"
 `;
 
-exports[`app generated files content - as-provided general application should configure eslint correctly 1`] = `
+exports[`app generated files content - as-provided - my-app general application should configure eslint correctly 1`] = `
 "{
   "extends": ["@nuxt/eslint-config", "../.eslintrc.json"],
   "ignorePatterns": ["!**/*", ".nuxt/**", ".output/**", "node_modules"],
@@ -26,7 +26,7 @@ exports[`app generated files content - as-provided general application should co
 "
 `;
 
-exports[`app generated files content - as-provided general application should configure nuxt correctly 1`] = `
+exports[`app generated files content - as-provided - my-app general application should configure nuxt correctly 1`] = `
 "import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { defineNuxtConfig } from 'nuxt/config';
 
@@ -56,7 +56,7 @@ export default defineNuxtConfig({
 "
 `;
 
-exports[`app generated files content - as-provided general application should configure tsconfig and project.json correctly 1`] = `
+exports[`app generated files content - as-provided - my-app general application should configure tsconfig and project.json correctly 1`] = `
 "{
   "name": "my-app",
   "$schema": "../node_modules/nx/schemas/project-schema.json",
@@ -68,7 +68,7 @@ exports[`app generated files content - as-provided general application should co
 "
 `;
 
-exports[`app generated files content - as-provided general application should configure tsconfig and project.json correctly 2`] = `
+exports[`app generated files content - as-provided - my-app general application should configure tsconfig and project.json correctly 2`] = `
 "{
   "compilerOptions": {},
   "files": [],
@@ -86,7 +86,7 @@ exports[`app generated files content - as-provided general application should co
 "
 `;
 
-exports[`app generated files content - as-provided general application should configure vitest correctly 1`] = `
+exports[`app generated files content - as-provided - my-app general application should configure vitest correctly 1`] = `
 "/// <reference types='vitest' />
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
@@ -122,7 +122,7 @@ export default defineConfig({
 "
 `;
 
-exports[`app generated files content - as-provided general application should configure vitest correctly 2`] = `
+exports[`app generated files content - as-provided - my-app general application should configure vitest correctly 2`] = `
 "{
   "extends": "./tsconfig.json",
   "compilerOptions": {
@@ -154,7 +154,7 @@ exports[`app generated files content - as-provided general application should co
 "
 `;
 
-exports[`app generated files content - as-provided general application should configure vitest correctly 3`] = `
+exports[`app generated files content - as-provided - my-app general application should configure vitest correctly 3`] = `
 "{
   "compilerOptions": {},
   "files": [],
@@ -172,7 +172,7 @@ exports[`app generated files content - as-provided general application should co
 "
 `;
 
-exports[`app generated files content - as-provided general application should create all new files in the correct location 1`] = `
+exports[`app generated files content - as-provided - my-app general application should create all new files in the correct location 1`] = `
 [
   ".prettierrc",
   "package.json",
@@ -208,7 +208,7 @@ exports[`app generated files content - as-provided general application should cr
 ]
 `;
 
-exports[`app generated files content - as-provided styles setup should configure css 1`] = `
+exports[`app generated files content - as-provided - my-app styles setup should configure css 1`] = `
 "import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { defineNuxtConfig } from 'nuxt/config';
 
@@ -240,7 +240,7 @@ export default defineNuxtConfig({
 "
 `;
 
-exports[`app generated files content - as-provided styles setup should configure less 1`] = `
+exports[`app generated files content - as-provided - my-app styles setup should configure less 1`] = `
 "import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { defineNuxtConfig } from 'nuxt/config';
 
@@ -272,7 +272,7 @@ export default defineNuxtConfig({
 "
 `;
 
-exports[`app generated files content - as-provided styles setup should configure scss 1`] = `
+exports[`app generated files content - as-provided - my-app styles setup should configure scss 1`] = `
 "import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { defineNuxtConfig } from 'nuxt/config';
 
@@ -304,7 +304,341 @@ export default defineNuxtConfig({
 "
 `;
 
-exports[`app generated files content - as-provided styles setup should not configure styles 1`] = `
+exports[`app generated files content - as-provided - my-app styles setup should not configure styles 1`] = `
+"import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { defineNuxtConfig } from 'nuxt/config';
+
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  workspaceDir: '../',
+  srcDir: 'src',
+  devtools: { enabled: true },
+  devServer: {
+    host: 'localhost',
+    port: 4200,
+  },
+  typescript: {
+    typeCheck: true,
+    tsConfig: {
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+    },
+  },
+  imports: {
+    autoImport: true,
+  },
+
+  vite: {
+    plugins: [nxViteTsPaths()],
+  },
+});
+"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should add nuxt entries in .gitignore 1`] = `
+"
+# Nuxt dev/build outputs
+.output
+.data
+.nuxt
+.nitro
+.cache"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should configure eslint correctly 1`] = `
+"{
+  "extends": ["@nuxt/eslint-config", "../.eslintrc.json"],
+  "ignorePatterns": ["!**/*", ".nuxt/**", ".output/**", "node_modules"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx", "*.vue"],
+      "rules": {
+        "vue/multi-word-component-names": "off"
+      }
+    }
+  ]
+}
+"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should configure nuxt correctly 1`] = `
+"import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { defineNuxtConfig } from 'nuxt/config';
+
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  workspaceDir: '../',
+  srcDir: 'src',
+  devtools: { enabled: true },
+  devServer: {
+    host: 'localhost',
+    port: 4200,
+  },
+  typescript: {
+    typeCheck: true,
+    tsConfig: {
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+    },
+  },
+  imports: {
+    autoImport: true,
+  },
+
+  vite: {
+    plugins: [nxViteTsPaths()],
+  },
+});
+"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should configure tsconfig and project.json correctly 1`] = `
+"{
+  "name": "myApp",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "myApp/src",
+  "// targets": "to see all targets run: nx show project myApp --web",
+  "targets": {}
+}
+"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should configure tsconfig and project.json correctly 2`] = `
+"{
+  "compilerOptions": {},
+  "files": [],
+  "include": [".nuxt/nuxt.d.ts"],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../tsconfig.base.json"
+}
+"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should configure vitest correctly 1`] = `
+"/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../node_modules/.vite/myApp',
+
+  plugins: [vue(), nxViteTsPaths()],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+
+  test: {
+    watch: false,
+    globals: true,
+    cache: {
+      dir: '../node_modules/.vitest/myApp',
+    },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../coverage/myApp',
+      provider: 'v8',
+    },
+  },
+});
+"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should configure vitest correctly 2`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ],
+    "composite": true
+  },
+  "include": [
+    ".nuxt/nuxt.d.ts",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}
+"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should configure vitest correctly 3`] = `
+"{
+  "compilerOptions": {},
+  "files": [],
+  "include": [".nuxt/nuxt.d.ts"],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../tsconfig.base.json"
+}
+"
+`;
+
+exports[`app generated files content - as-provided - myApp general application should create all new files in the correct location 1`] = `
+[
+  ".prettierrc",
+  "package.json",
+  "nx.json",
+  "tsconfig.base.json",
+  ".prettierignore",
+  "myApp/project.json",
+  "myApp/.npmrc",
+  "myApp/nuxt.config.ts",
+  "myApp/src/app.vue",
+  "myApp/src/components/NxWelcome.vue",
+  "myApp/src/pages/about.vue",
+  "myApp/src/pages/index.vue",
+  "myApp/src/public/.gitkeep",
+  "myApp/src/public/favicon.ico",
+  "myApp/src/server/api/greet.ts",
+  "myApp/src/server/tsconfig.json",
+  "myApp/tsconfig.app.json",
+  "myApp/tsconfig.json",
+  ".gitignore",
+  ".eslintrc.json",
+  ".eslintignore",
+  "myApp/.eslintrc.json",
+  "myApp/tsconfig.spec.json",
+  "vitest.workspace.ts",
+  "myApp/vitest.config.ts",
+  "myApp-e2e/project.json",
+  "myApp-e2e/src/example.spec.ts",
+  "myApp-e2e/playwright.config.ts",
+  "myApp-e2e/tsconfig.json",
+  "myApp-e2e/.eslintrc.json",
+  ".vscode/extensions.json",
+]
+`;
+
+exports[`app generated files content - as-provided - myApp styles setup should configure css 1`] = `
+"import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { defineNuxtConfig } from 'nuxt/config';
+
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  workspaceDir: '../',
+  srcDir: 'src',
+  devtools: { enabled: true },
+  devServer: {
+    host: 'localhost',
+    port: 4200,
+  },
+  typescript: {
+    typeCheck: true,
+    tsConfig: {
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+    },
+  },
+  imports: {
+    autoImport: true,
+  },
+
+  css: ['~/assets/css/styles.css'],
+
+  vite: {
+    plugins: [nxViteTsPaths()],
+  },
+});
+"
+`;
+
+exports[`app generated files content - as-provided - myApp styles setup should configure less 1`] = `
+"import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { defineNuxtConfig } from 'nuxt/config';
+
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  workspaceDir: '../',
+  srcDir: 'src',
+  devtools: { enabled: true },
+  devServer: {
+    host: 'localhost',
+    port: 4200,
+  },
+  typescript: {
+    typeCheck: true,
+    tsConfig: {
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+    },
+  },
+  imports: {
+    autoImport: true,
+  },
+
+  css: ['~/assets/css/styles.less'],
+
+  vite: {
+    plugins: [nxViteTsPaths()],
+  },
+});
+"
+`;
+
+exports[`app generated files content - as-provided - myApp styles setup should configure scss 1`] = `
+"import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { defineNuxtConfig } from 'nuxt/config';
+
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  workspaceDir: '../',
+  srcDir: 'src',
+  devtools: { enabled: true },
+  devServer: {
+    host: 'localhost',
+    port: 4200,
+  },
+  typescript: {
+    typeCheck: true,
+    tsConfig: {
+      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+    },
+  },
+  imports: {
+    autoImport: true,
+  },
+
+  css: ['~/assets/css/styles.scss'],
+
+  vite: {
+    plugins: [nxViteTsPaths()],
+  },
+});
+"
+`;
+
+exports[`app generated files content - as-provided - myApp styles setup should not configure styles 1`] = `
 "import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { defineNuxtConfig } from 'nuxt/config';
 

--- a/packages/nuxt/src/generators/application/application.spec.ts
+++ b/packages/nuxt/src/generators/application/application.spec.ts
@@ -6,139 +6,147 @@ import { applicationGenerator } from './application';
 
 describe('app', () => {
   let tree: Tree;
-  const name = 'my-app';
 
-  describe('generated files content - as-provided', () => {
-    describe('general application', () => {
-      beforeEach(async () => {
-        tree = createTreeWithEmptyWorkspace();
-        await applicationGenerator(tree, {
-          name,
-          projectNameAndRootFormat: 'as-provided',
-          unitTestRunner: 'vitest',
+  describe.each(['my-app', 'myApp'])(
+    'generated files content - as-provided - %s',
+    (name: string) => {
+      describe('general application', () => {
+        beforeEach(async () => {
+          tree = createTreeWithEmptyWorkspace();
+          await applicationGenerator(tree, {
+            name,
+            projectNameAndRootFormat: 'as-provided',
+            unitTestRunner: 'vitest',
+          });
+        });
+
+        it('should not add targets', async () => {
+          const projectConfig = readProjectConfiguration(tree, name);
+          expect(projectConfig.targets.build).toBeUndefined();
+          expect(projectConfig.targets.serve).toBeUndefined();
+          expect(projectConfig.targets.test).toBeUndefined();
+          expect(projectConfig.targets['build-static']).toBeUndefined();
+          expect(projectConfig.targets['serve-static']).toBeUndefined();
+        });
+
+        it('should create all new files in the correct location', async () => {
+          const newFiles = tree.listChanges().map((change) => change.path);
+          expect(newFiles).toMatchSnapshot();
+        });
+
+        it('should add nuxt entries in .gitignore', () => {
+          expect(tree.read('.gitignore', 'utf-8')).toMatchSnapshot();
+        });
+
+        it('should configure nuxt correctly', () => {
+          expect(
+            tree.read(`${name}/nuxt.config.ts`, 'utf-8')
+          ).toMatchSnapshot();
+        });
+
+        it('should configure eslint correctly', () => {
+          expect(
+            tree.read(`${name}/.eslintrc.json`, 'utf-8')
+          ).toMatchSnapshot();
+        });
+
+        it('should configure vitest correctly', () => {
+          expect(
+            tree.read(`${name}/vitest.config.ts`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(
+            tree.read(`${name}/tsconfig.spec.json`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(tree.read(`${name}/tsconfig.json`, 'utf-8')).toMatchSnapshot();
+          const packageJson = readJson(tree, 'package.json');
+          expect(packageJson.devDependencies['vitest']).toEqual('^1.3.1');
+        });
+
+        it('should configure tsconfig and project.json correctly', () => {
+          expect(tree.read(`${name}/project.json`, 'utf-8')).toMatchSnapshot();
+          expect(tree.read(`${name}/tsconfig.json`, 'utf-8')).toMatchSnapshot();
+        });
+
+        it('should add the nuxt and vitest plugins', () => {
+          const nxJson = readJson(tree, 'nx.json');
+          expect(nxJson.plugins).toMatchObject([
+            {
+              plugin: '@nx/eslint/plugin',
+              options: { targetName: 'lint' },
+            },
+            {
+              plugin: '@nx/vite/plugin',
+              options: { testTargetName: 'test' },
+            },
+            {
+              plugin: '@nx/nuxt/plugin',
+              options: { buildTargetName: 'build', serveTargetName: 'serve' },
+            },
+            {
+              plugin: '@nx/playwright/plugin',
+              options: { targetName: 'e2e' },
+            },
+          ]);
+          expect(
+            nxJson.plugins.indexOf(
+              nxJson.plugins.find((p) => p.plugin === '@nx/nuxt/plugin')
+            )
+          ).toBeGreaterThan(
+            nxJson.plugins.indexOf(
+              nxJson.plugins.find((p) => p.plugin === '@nx/vite/plugin')
+            )
+          );
         });
       });
 
-      it('should not add targets', async () => {
-        const projectConfig = readProjectConfiguration(tree, name);
-        expect(projectConfig.targets.build).toBeUndefined();
-        expect(projectConfig.targets.serve).toBeUndefined();
-        expect(projectConfig.targets.test).toBeUndefined();
-        expect(projectConfig.targets['build-static']).toBeUndefined();
-        expect(projectConfig.targets['serve-static']).toBeUndefined();
-      });
-
-      it('should create all new files in the correct location', async () => {
-        const newFiles = tree.listChanges().map((change) => change.path);
-        expect(newFiles).toMatchSnapshot();
-      });
-
-      it('should add nuxt entries in .gitignore', () => {
-        expect(tree.read('.gitignore', 'utf-8')).toMatchSnapshot();
-      });
-
-      it('should configure nuxt correctly', () => {
-        expect(tree.read('my-app/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
-      });
-
-      it('should configure eslint correctly', () => {
-        expect(tree.read('my-app/.eslintrc.json', 'utf-8')).toMatchSnapshot();
-      });
-
-      it('should configure vitest correctly', () => {
-        expect(tree.read('my-app/vitest.config.ts', 'utf-8')).toMatchSnapshot();
-        expect(
-          tree.read('my-app/tsconfig.spec.json', 'utf-8')
-        ).toMatchSnapshot();
-        expect(tree.read('my-app/tsconfig.json', 'utf-8')).toMatchSnapshot();
-        const packageJson = readJson(tree, 'package.json');
-        expect(packageJson.devDependencies['vitest']).toEqual('^1.3.1');
-      });
-
-      it('should configure tsconfig and project.json correctly', () => {
-        expect(tree.read('my-app/project.json', 'utf-8')).toMatchSnapshot();
-        expect(tree.read('my-app/tsconfig.json', 'utf-8')).toMatchSnapshot();
-      });
-
-      it('should add the nuxt and vitest plugins', () => {
-        const nxJson = readJson(tree, 'nx.json');
-        expect(nxJson.plugins).toMatchObject([
-          {
-            plugin: '@nx/eslint/plugin',
-            options: { targetName: 'lint' },
-          },
-          {
-            plugin: '@nx/vite/plugin',
-            options: { testTargetName: 'test' },
-          },
-          {
-            plugin: '@nx/nuxt/plugin',
-            options: { buildTargetName: 'build', serveTargetName: 'serve' },
-          },
-          {
-            plugin: '@nx/playwright/plugin',
-            options: { targetName: 'e2e' },
-          },
-        ]);
-        expect(
-          nxJson.plugins.indexOf(
-            nxJson.plugins.find((p) => p.plugin === '@nx/nuxt/plugin')
-          )
-        ).toBeGreaterThan(
-          nxJson.plugins.indexOf(
-            nxJson.plugins.find((p) => p.plugin === '@nx/vite/plugin')
-          )
-        );
-      });
-    });
-
-    describe('styles setup', () => {
-      beforeAll(async () => {
-        tree = createTreeWithEmptyWorkspace();
-      });
-      it('should configure css', async () => {
-        await applicationGenerator(tree, {
-          name: 'myapp1',
-          projectNameAndRootFormat: 'as-provided',
-          unitTestRunner: 'none',
-          style: 'css',
+      describe('styles setup', () => {
+        beforeAll(async () => {
+          tree = createTreeWithEmptyWorkspace();
         });
-        expect(tree.exists('myapp1/src/assets/css/styles.css')).toBeTruthy();
-        expect(tree.read('myapp1/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
-      });
-
-      it('should configure scss', async () => {
-        await applicationGenerator(tree, {
-          name: 'myapp2',
-          projectNameAndRootFormat: 'as-provided',
-          unitTestRunner: 'none',
-          style: 'scss',
+        it('should configure css', async () => {
+          await applicationGenerator(tree, {
+            name: 'myapp1',
+            projectNameAndRootFormat: 'as-provided',
+            unitTestRunner: 'none',
+            style: 'css',
+          });
+          expect(tree.exists('myapp1/src/assets/css/styles.css')).toBeTruthy();
+          expect(tree.read('myapp1/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
         });
-        expect(tree.exists('myapp2/src/assets/css/styles.scss')).toBeTruthy();
-        expect(tree.read('myapp2/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
-      });
 
-      it('should configure less', async () => {
-        await applicationGenerator(tree, {
-          name: 'myapp3',
-          projectNameAndRootFormat: 'as-provided',
-          unitTestRunner: 'none',
-          style: 'less',
+        it('should configure scss', async () => {
+          await applicationGenerator(tree, {
+            name: 'myapp2',
+            projectNameAndRootFormat: 'as-provided',
+            unitTestRunner: 'none',
+            style: 'scss',
+          });
+          expect(tree.exists('myapp2/src/assets/css/styles.scss')).toBeTruthy();
+          expect(tree.read('myapp2/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
         });
-        expect(tree.exists('myapp3/src/assets/css/styles.less')).toBeTruthy();
-        expect(tree.read('myapp3/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
-      });
 
-      it('should not configure styles', async () => {
-        await applicationGenerator(tree, {
-          name: 'myapp4',
-          projectNameAndRootFormat: 'as-provided',
-          unitTestRunner: 'none',
-          style: 'none',
+        it('should configure less', async () => {
+          await applicationGenerator(tree, {
+            name: 'myapp3',
+            projectNameAndRootFormat: 'as-provided',
+            unitTestRunner: 'none',
+            style: 'less',
+          });
+          expect(tree.exists('myapp3/src/assets/css/styles.less')).toBeTruthy();
+          expect(tree.read('myapp3/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
         });
-        expect(tree.exists('myapp4/src/assets/css/styles.css')).toBeFalsy();
-        expect(tree.read('myapp4/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
+
+        it('should not configure styles', async () => {
+          await applicationGenerator(tree, {
+            name: 'myapp4',
+            projectNameAndRootFormat: 'as-provided',
+            unitTestRunner: 'none',
+            style: 'none',
+          });
+          expect(tree.exists('myapp4/src/assets/css/styles.css')).toBeFalsy();
+          expect(tree.read('myapp4/nuxt.config.ts', 'utf-8')).toMatchSnapshot();
+        });
       });
-    });
-  });
+    }
+  );
 });

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -43,7 +43,7 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
   tasks.push(jsInitTask);
   tasks.push(ensureDependencies(tree, options));
 
-  addProjectConfiguration(tree, options.name, {
+  addProjectConfiguration(tree, options.projectName, {
     root: options.appProjectRoot,
     projectType: 'application',
     sourceRoot: `${options.appProjectRoot}/src`,

--- a/packages/nuxt/src/generators/application/files/src/server/api/greet.ts__tmpl__
+++ b/packages/nuxt/src/generators/application/files/src/server/api/greet.ts__tmpl__
@@ -5,6 +5,6 @@ export default defineEventHandler((event) => {
   const name = q.name || 'World';
 
   return {
-    message: `Hello ${name}`,
+    message: `Hello ${projectName}`,
   };
 });

--- a/packages/nuxt/src/generators/application/lib/add-vitest.ts
+++ b/packages/nuxt/src/generators/application/lib/add-vitest.ts
@@ -19,7 +19,7 @@ export async function addVitest(tree: Tree, options: NormalizedSchema) {
   const vitestTask = await vitestGenerator(
     tree,
     {
-      project: options.name,
+      project: options.projectName,
       uiFramework: 'none',
       coverageProvider: 'v8',
       skipFormat: true,
@@ -33,7 +33,7 @@ export async function addVitest(tree: Tree, options: NormalizedSchema) {
   createOrEditViteConfig(
     tree,
     {
-      project: options.name,
+      project: options.projectName,
       includeLib: false,
       includeVitest: true,
       testEnvironment: 'jsdom',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Trying to generate an app called `myApp` fails because the `@nx/nuxt:app` generator is using a mix of correct and incorrect mapped project names when `as-provided` is used.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the value coming from `determineProjectRootAndFormat` for projectName is used when referencing the project

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
