### PR TITLE
fix(nuxt): ensure .output directory is marked as an output

### DIFF
--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -26,6 +26,7 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
           },
           "outputs": [
             "{workspaceRoot}/dist/my-app/.nuxt",
+            "{projectRoot}/.output",
           ],
         },
         "acme-serve-static": {
@@ -57,6 +58,7 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
           },
           "outputs": [
             "{workspaceRoot}/dist/my-app/.nuxt",
+            "{projectRoot}/.output",
           ],
         },
         "my-serve": {
@@ -97,6 +99,7 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
           },
           "outputs": [
             "dist/my-app/.nuxt",
+            "{projectRoot}/.output",
           ],
         },
         "build-static": {
@@ -119,6 +122,7 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
           },
           "outputs": [
             "dist/my-app/.nuxt",
+            "{projectRoot}/.output",
           ],
         },
         "serve": {

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -233,7 +233,7 @@ function getOutputs(
   );
 
   return {
-    buildOutputs: [buildOutputPath],
+    buildOutputs: [buildOutputPath, '{projectRoot}/.output'],
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nuxt states that the `.output` folder is created with a production build, regardless of the `buildDir` set in the `nuxt.config.ts` file.
We do not have this folder listed as an output and therefore it is not cached and restored correctly


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the `.output` folder is listed correctly as an output

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
