### PR TITLE
feat(nx-dev): update text on enterprise & contact screens

### DIFF
--- a/nx-dev/ui-contact/src/lib/how-can-we-help.tsx
+++ b/nx-dev/ui-contact/src/lib/how-can-we-help.tsx
@@ -26,9 +26,8 @@ export function HowCanWeHelp(): JSX.Element {
               </h3>
             </div>
             <p className="mt-4">
-              Contact our sales team to discuss plans, expected usage,
-              certifications, organization constraints, and get the best pricing
-              for your team.
+              Contact our sales team to discuss pricing, terms, certifications,
+              and your unique constraints.
             </p>
             <ButtonLink
               href="/contact/sales"
@@ -51,8 +50,8 @@ export function HowCanWeHelp(): JSX.Element {
               </h3>
             </div>
             <p className="mt-4">
-              Contact our developer productivity engineers team for demos,
-              onboarding assistance, and technical product questions.
+              Contact our developer productivity engineers for demos, onboarding
+              assistance, and technical product questions.
             </p>
             <ButtonLink
               href="/contact/engineering"

--- a/nx-dev/ui-enterprise/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-enterprise/src/lib/call-to-action.tsx
@@ -57,19 +57,25 @@ export function CallToAction(): JSX.Element {
           <br />
           starts now
         </h2>
-        <div className="mt-10 flex items-center justify-center gap-x-6">
-          <Link
-            href="/contact/sales"
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
-          >
-            Contact sales
-          </Link>
+        <div className="mt-10">
           <Link
             href="/contact/engineering"
+            title="Talk to the engineering team"
             className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
           >
-            Contact engineers
+            Talk to engineering
           </Link>
+          <p className="mt-6 italic">
+            Ready to talk terms?{' '}
+            <Link
+              href="/contact/sales"
+              title="Talk to the sales team"
+              className="font-semibold underline"
+            >
+              Speak directly to sales
+            </Link>
+            .
+          </p>
         </div>
       </div>
     </section>

--- a/nx-dev/ui-enterprise/src/lib/hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/hero.tsx
@@ -1,5 +1,6 @@
 import { SectionHeading } from './temp/typography';
 import { ButtonLink } from '@nx/nx-dev/ui-common';
+import Link from 'next/link';
 
 export function Hero(): JSX.Element {
   return (
@@ -17,37 +18,26 @@ export function Hero(): JSX.Element {
             Accelerate your organization's journey to tighter collaboration,
             better developer experience, and speed…lots of speed.
           </SectionHeading>
-          <div className="mt-10 flex items-center justify-center gap-x-6">
-            <ButtonLink
-              href="/contact/sales"
-              title="Contact sales"
-              variant="primary"
-              size="default"
-            >
-              Contact sales
-            </ButtonLink>
+          <div className="mt-10">
             <ButtonLink
               href="/contact/engineering"
-              title="Contact sales"
+              title="Talk to the engineering team"
               variant="primary"
               size="default"
             >
-              Contact engineers
+              Talk to engineering
             </ButtonLink>
-
-            {/*<Link*/}
-            {/*  className="group text-sm font-semibold leading-6 text-slate-950 dark:text-white"*/}
-            {/*  href="/contact/sales"*/}
-            {/*  rel="nofollow"*/}
-            {/*>*/}
-            {/*  Book a demo{' '}*/}
-            {/*  <span*/}
-            {/*    aria-hidden="true"*/}
-            {/*    className="inline-block transition group-hover:translate-x-1"*/}
-            {/*  >*/}
-            {/*    →*/}
-            {/*  </span>*/}
-            {/*</Link>*/}
+            <p className="mt-6 italic">
+              Ready to talk terms?{' '}
+              <Link
+                href="/contact/sales"
+                title="Talk to the sales team"
+                className="font-semibold underline"
+              >
+                Speak directly to sales
+              </Link>
+              .
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Adjusted the Contact Us wording and changed the primary contact link on the website from sales to engineering. The sales link is also presented with a more engaging prompt.
