### PR TITLE
fix(core): don't load env vars when insantiating daemon client

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -66,8 +66,6 @@ enum DaemonStatus {
 export class DaemonClient {
   private readonly nxJson: NxJsonConfiguration | null;
   constructor() {
-    loadRootEnvFiles(workspaceRoot);
-
     try {
       this.nxJson = readNxJson();
     } catch (e) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Constructing the daemon client automatically loads root env files. This happens as soon as the daemon client module has been loaded.

## Expected Behavior
The nx process already loads root env files when the process starts. We shouldn't load them twice, and loading them here breaks some behavior in lerna.

nx-console will be updated to load .env files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
