### PR TITLE
chore(repo): add sync generator for e2e configs

### DIFF
--- a/e2e/detox/project.json
+++ b/e2e/detox/project.json
@@ -24,14 +24,14 @@
         "nx:build-native",
         "@nx/nx-source:populate-local-registry-storage"
       ],
-      "inputs": ["e2eInputs"]
+      "inputs": ["e2eInputs", "^production"]
     },
     "e2e-ci--src/detox.test.ts": {
       "dependsOn": [
         "nx:build-native",
         "@nx/nx-source:populate-local-registry-storage"
       ],
-      "inputs": ["e2eInputs"]
+      "inputs": ["e2eInputs", "^production"]
     }
   }
 }

--- a/e2e/expo/project.json
+++ b/e2e/expo/project.json
@@ -10,6 +10,20 @@
     },
     "e2e-macos-ci--src/expo-legacy.test.ts": {
       "inputs": ["e2eInputs", "^production"]
+    },
+    "e2e-ci--src/expo-legacy.test.ts": {
+      "dependsOn": [
+        "nx:build-native",
+        "@nx/nx-source:populate-local-registry-storage"
+      ],
+      "inputs": ["e2eInputs", "^production"]
+    },
+    "e2e-ci--src/expo.test.ts": {
+      "dependsOn": [
+        "nx:build-native",
+        "@nx/nx-source:populate-local-registry-storage"
+      ],
+      "inputs": ["e2eInputs", "^production"]
     }
   }
 }

--- a/e2e/react-native/project.json
+++ b/e2e/react-native/project.json
@@ -10,6 +10,20 @@
     },
     "e2e-macos-ci--src/react-native.test.ts": {
       "inputs": ["e2eInputs", "^production"]
+    },
+    "e2e-ci--src/react-native-legacy.test.ts": {
+      "dependsOn": [
+        "nx:build-native",
+        "@nx/nx-source:populate-local-registry-storage"
+      ],
+      "inputs": ["e2eInputs", "^production"]
+    },
+    "e2e-ci--src/react-native.test.ts": {
+      "dependsOn": [
+        "nx:build-native",
+        "@nx/nx-source:populate-local-registry-storage"
+      ],
+      "inputs": ["e2eInputs", "^production"]
     }
   }
 }

--- a/e2e/react/project.json
+++ b/e2e/react/project.json
@@ -53,6 +53,13 @@
         "@nx/nx-source:populate-local-registry-storage"
       ],
       "inputs": ["e2eInputs", "^production"]
+    },
+    "e2e-ci--src/react-package-legacy.test.ts": {
+      "dependsOn": [
+        "nx:build-native",
+        "@nx/nx-source:populate-local-registry-storage"
+      ],
+      "inputs": ["e2eInputs", "^production"]
     }
   }
 }

--- a/e2e/remix/project.json
+++ b/e2e/remix/project.json
@@ -4,7 +4,6 @@
   "sourceRoot": "e2e/remix",
   "projectType": "application",
   "implicitDependencies": ["remix"],
-  "// targets": "to see all targets run: nx show project e2e-remix --web",
   "targets": {
     "e2e-ci--src/nx-remix.test.ts": {
       "dependsOn": [

--- a/e2e/rollup/project.json
+++ b/e2e/rollup/project.json
@@ -11,6 +11,13 @@
         "@nx/nx-source:populate-local-registry-storage"
       ],
       "inputs": ["e2eInputs", "^production"]
+    },
+    "e2e-ci--src/rollup-legacy.test.ts": {
+      "dependsOn": [
+        "nx:build-native",
+        "@nx/nx-source:populate-local-registry-storage"
+      ],
+      "inputs": ["e2eInputs", "^production"]
     }
   }
 }

--- a/tools/workspace-plugin/generators.json
+++ b/tools/workspace-plugin/generators.json
@@ -9,6 +9,11 @@
       "factory": "./src/generators/create-nodes-plugin/generator",
       "schema": "./src/generators/create-nodes-plugin/schema.json",
       "description": "Workspace Generator to create a create-nodes-plugin"
+    },
+    "sync-e2e-configs": {
+      "factory": "./src/generators/sync-e2e-config/generator",
+      "schema": "./src/generators/sync-e2e-config/schema.json",
+      "description": "Generator to sync configuration for our e2e targets"
     }
   }
 }

--- a/tools/workspace-plugin/src/generators/sync-e2e-config/generator.ts
+++ b/tools/workspace-plugin/src/generators/sync-e2e-config/generator.ts
@@ -1,0 +1,35 @@
+import {
+  formatFiles,
+  getProjects,
+  globAsync,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { relative } from 'node:path';
+import { join } from 'path';
+
+export async function syncE2eConfigsGenerator(tree: Tree) {
+  for (const [projName, projectConfig] of getProjects(tree)) {
+    const { root, targets } = projectConfig;
+    if (!root.startsWith('e2e/')) {
+      continue;
+    }
+
+    const testFiles = await globAsync(tree, [join(root, `**/*.test.ts`)]);
+
+    for (const testFile of testFiles) {
+      const relativePath = relative(root, testFile);
+      let target = (targets[`e2e-ci--${relativePath}`] ??= {});
+      target.dependsOn = [
+        'nx:build-native',
+        '@nx/nx-source:populate-local-registry-storage',
+      ];
+      target.inputs = ['e2eInputs', '^production'];
+    }
+    updateProjectConfiguration(tree, projName, projectConfig);
+  }
+
+  await formatFiles(tree);
+}
+
+export default syncE2eConfigsGenerator;

--- a/tools/workspace-plugin/src/generators/sync-e2e-config/schema.json
+++ b/tools/workspace-plugin/src/generators/sync-e2e-config/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "SyncE2eConfigs",
+  "title": "",
+  "description": "Generator to sync configuration for our e2e targets.",
+  "type": "object",
+  "properties": {},
+  "required": []
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some e2e tasks are not configured properly. And there is no easy way to sync them. Whenever new test files are created... they need to have configuration added for them in `project.json`.. and that doesn't happen sometimes.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

e2e tasks are configured properly. There's a sync generator which syncs the e2e configs which can be run with `nx g sync-e2e-configs`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
