### PR TITLE
fix(js): add default baseUrl when extracting tsconfig.base.json or building libs will fail

### DIFF
--- a/packages/js/src/utils/typescript/create-ts-config.spec.ts
+++ b/packages/js/src/utils/typescript/create-ts-config.spec.ts
@@ -1,0 +1,30 @@
+import { readJson, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { extractTsConfigBase } from './create-ts-config';
+
+describe('extractTsConfigBase', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add default rootDir if it was not set', () => {
+    tree.delete('tsconfig.base.json');
+    tree.write(
+      'tsconfig.json',
+      JSON.stringify({
+        compilerOptions: {},
+      })
+    );
+
+    extractTsConfigBase(tree);
+
+    expect(readJson(tree, 'tsconfig.base.json')).toEqual({
+      compileOnSave: false,
+      compilerOptions: {
+        baseUrl: '.',
+      },
+    });
+  });
+});

--- a/packages/js/src/utils/typescript/create-ts-config.ts
+++ b/packages/js/src/utils/typescript/create-ts-config.ts
@@ -31,6 +31,10 @@ export function extractTsConfigBase(host: Tree) {
       delete tsconfig.compilerOptions[compilerOption];
     }
   }
+  // If we don't set baseDir then builds will fail when more than one projects exist.
+  if (typeof baseCompilerOptions.baseUrl === 'undefined') {
+    baseCompilerOptions.baseUrl = '.';
+  }
   writeJson(host, 'tsconfig.base.json', {
     compileOnSave: false,
     compilerOptions: baseCompilerOptions,


### PR DESCRIPTION
This PR ensures that `"rootDir": "."` is set in `tsconfig.base.json` is set, or else generating libs in a standalone project will fail with and error like this:

```
error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
```

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
