### PR TITLE
fix(vite): ensure typecheck is using correct tsconfig #21844

### DIFF
--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -37,7 +37,11 @@ export async function* viteBuildExecutor(
     await loadViteDynamicImport();
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
-  createBuildableTsConfig(projectRoot, options, context);
+  const tsConfigForBuild = createBuildableTsConfig(
+    projectRoot,
+    options,
+    context
+  );
 
   const viteConfigPath = normalizeViteConfigFilePath(
     context.root,
@@ -83,7 +87,7 @@ export async function* viteBuildExecutor(
     await validateTypes({
       workspaceRoot: context.root,
       projectRoot: projectRoot,
-      tsconfig: options.tsConfig ?? getProjectTsConfigPath(projectRoot),
+      tsconfig: tsConfigForBuild,
     });
   }
 

--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -16,7 +16,9 @@ export async function validateTypes(opts: {
 }): Promise<void> {
   const result = await runTypeCheck({
     workspaceRoot: opts.workspaceRoot,
-    tsConfigPath: join(opts.workspaceRoot, opts.tsconfig),
+    tsConfigPath: opts.tsconfig.startsWith(opts.workspaceRoot)
+      ? opts.tsconfig
+      : join(opts.workspaceRoot, opts.tsconfig),
     mode: 'noEmit',
   });
 
@@ -29,10 +31,10 @@ export async function validateTypes(opts: {
 
 export function createBuildableTsConfig(
   projectRoot: string,
-  options: ViteBuildExecutorOptions | ViteDevServerExecutorOptions,
+  options: { tsConfig?: string; buildLibsFromSource?: boolean },
   context: ExecutorContext
 ) {
-  const tsConfig = getProjectTsConfigPath(projectRoot);
+  const tsConfig = options.tsConfig ?? getProjectTsConfigPath(projectRoot);
   options['buildLibsFromSource'] ??= true;
 
   if (!options['buildLibsFromSource']) {
@@ -55,7 +57,9 @@ export function createBuildableTsConfig(
       dependencies
     );
     process.env.NX_TSCONFIG_PATH = tmpTsConfigPath;
+    return tmpTsConfigPath;
   }
+  return tsConfig;
 }
 
 export function loadViteDynamicImport() {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running typecheck, we use the provided tsconfig or find the projects tsconfig.
This doesn't take into consideration the buildLibsFromSource which creates a tmp tsconfig to map buildable libraries.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the correct tsconfig is used when running typecheck

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21844
