### PR TITLE
fix(core): don't throw when hashing undefined object

### DIFF
--- a/packages/nx/src/hasher/file-hasher.ts
+++ b/packages/nx/src/hasher/file-hasher.ts
@@ -8,7 +8,7 @@ export function hashObject(obj: object): string {
   const { hashArray } = require('../native');
   const parts: string[] = [];
 
-  for (const key of Object.keys(obj).sort()) {
+  for (const key of Object.keys(obj ?? {}).sort()) {
     parts.push(key);
     parts.push(JSON.stringify(obj[key]));
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Plugins call hashObject w/ options, which is sometimes undefined. This causes hashObject to throw

## Expected Behavior
hashObject doesn't throw

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
