### PR TITLE
fix(core): ensure tuple passed to aggregate create nodes error

### DIFF
--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -226,6 +226,21 @@ export class AggregateCreateNodesError extends Error {
   ) {
     super('Failed to create nodes');
     this.name = this.constructor.name;
+    if (
+      // Errors should be an array
+      !Array.isArray(errors) ||
+      !errors.every(
+        // Where every element is a tuple
+        (errorTuple) =>
+          Array.isArray(errorTuple) &&
+          // That has a length of 2
+          errorTuple.length === 2
+      )
+    ) {
+      throw new Error(
+        'AggregateCreateNodesError must be constructed with an array of tuples where the first element is a filename or undefined and the second element is the underlying error.'
+      );
+    }
   }
 }
 

--- a/packages/nx/src/project-graph/plugins/internal-api.ts
+++ b/packages/nx/src/project-graph/plugins/internal-api.ts
@@ -101,7 +101,7 @@ export class LoadedNxPlugin {
             throw e;
           }
           // The underlying plugin errored out. We can't know any partial results.
-          throw new AggregateCreateNodesError([null, e], []);
+          throw new AggregateCreateNodesError([[null, e]], []);
         } finally {
           performance.mark(`${plugin.name}:createNodes - end`);
           performance.measure(

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -386,9 +386,14 @@ export async function createProjectConfigurations(
         : // This represents a single plugin erroring out with a hard error.
           new AggregateCreateNodesError([[null, e]], []);
 
-      errorBodyLines.push(
-        ...error.errors.map(([file, e]) => `  - ${file}: ${e.message}`)
-      );
+      const innerErrors = error.errors;
+      for (const [file, e] of innerErrors) {
+        if (file) {
+          errorBodyLines.push(`  - ${file}: ${e.message}`);
+        } else {
+          errorBodyLines.push(`  - ${e.message}`);
+        }
+      }
 
       error.message = errorBodyLines.join('\n');
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We throw an invalid aggregate create nodes error if a plugin hard-fails

## Expected Behavior
All aggregate create nodes errors are Array<tuple>

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
