### PR TITLE
fix(core): don't infer scripts as targets if sibling project json declares them

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -217,6 +217,7 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
       const packageJson = readJson<PackageJson>(tree, projectFile);
       const config = buildProjectConfigurationFromPackageJson(
         packageJson,
+        tree.root,
         projectFile,
         readNxJson(tree)
       );

--- a/packages/nx/src/plugins/package-json-workspaces/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json-workspaces/create-nodes.ts
@@ -90,6 +90,16 @@ export function buildProjectConfigurationFromPackageJson(
   const normalizedPath = path.split('\\').join('/');
   const directory = dirname(normalizedPath);
 
+  const siblingProjectJson = tryReadJson<ProjectConfiguration>(
+    join(directory, 'project.json')
+  );
+
+  if (siblingProjectJson) {
+    for (const target of Object.keys(siblingProjectJson?.targets ?? {})) {
+      delete packageJson.scripts?.[target];
+    }
+  }
+
   if (!packageJson.name && directory === '.') {
     throw new Error(
       'Nx requires the root package.json to specify a name if it is being used as an Nx project.'
@@ -184,4 +194,12 @@ function normalizePatterns(patterns: string[]): string[] {
 
 function removeRelativePath(pattern: string): string {
   return pattern.startsWith('./') ? pattern.substring(2) : pattern;
+}
+
+function tryReadJson<T extends Object = any>(path: string): T | null {
+  try {
+    return readJsonFile<T>(path);
+  } catch {
+    return null;
+  }
 }

--- a/packages/nx/src/project-graph/file-utils.ts
+++ b/packages/nx/src/project-graph/file-utils.ts
@@ -215,6 +215,7 @@ function getProjectsSync(
       const packageJson = readJsonFile<PackageJson>(projectFile);
       const config = buildProjectConfigurationFromPackageJson(
         packageJson,
+        root,
         projectFile,
         nxJson
       );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Inferring some scripts during package-json-workspaces causes some thrashing

## Expected Behavior

We only infer a script as a target if its not in project.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
