### PR TITLE
cleanup(linter): batch globbing to improve @nx/eslint/plugin perf

### DIFF
--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -44,7 +44,9 @@ const ESLINT_CONFIG_GLOB_V2 = combineGlobPatterns([
 function readTargetsCache(
   cachePath: string
 ): Record<string, CreateNodesResult['projects']> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
+  return process.env.NX_CACHE_PROJECT_GRAPH !== 'false' && existsSync(cachePath)
+    ? readJsonFile(cachePath)
+    : {};
 }
 
 function writeTargetsToCache(
@@ -118,10 +120,7 @@ const internalCreateNodes = async (
         [...parentConfigs, join(childProjectRoot, '.eslintignore')]
       );
 
-      if (
-        process.env.NX_CACHE_PROJECT_GRAPH !== 'false' &&
-        projectsCache[hash]
-      ) {
+      if (projectsCache[hash]) {
         // We can reuse the projects in the cache.
         Object.assign(projects, projectsCache[hash]);
         return;
@@ -200,10 +199,7 @@ const internalCreateNodesV2 = async (
         [...parentConfigs, join(projectRoot, '.eslintignore')]
       );
 
-      if (
-        process.env.NX_CACHE_PROJECT_GRAPH !== 'false' &&
-        projectsCache[hash]
-      ) {
+      if (projectsCache[hash]) {
         // We can reuse the projects in the cache.
         Object.assign(projects, projectsCache[hash]);
         return;

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -506,17 +506,20 @@ function buildEslintTargets(
 }
 
 function normalizeOptions(options: EslintPluginOptions): EslintPluginOptions {
-  options ??= {};
-  options.targetName ??= 'lint';
+  const normalizedOptions: EslintPluginOptions = {
+    targetName: options.targetName ?? 'lint',
+  };
 
   // Normalize user input for extensions (strip leading . characters)
   if (Array.isArray(options.extensions)) {
-    options.extensions = options.extensions.map((f) => f.replace(/^\.+/, ''));
+    normalizedOptions.extensions = options.extensions.map((f) =>
+      f.replace(/^\.+/, '')
+    );
   } else {
-    options.extensions = DEFAULT_EXTENSIONS;
+    normalizedOptions.extensions = DEFAULT_EXTENSIONS;
   }
 
-  return options;
+  return normalizedOptions;
 }
 
 /**

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -386,18 +386,15 @@ function getRootForDirectory(
   roots: Map<string, string[]>
 ): string {
   let currentPath = normalize(directory);
-  if (roots.has(currentPath)) {
-    return currentPath;
-  }
 
   while (currentPath !== dirname(currentPath)) {
-    currentPath = dirname(currentPath);
     if (roots.has(currentPath)) {
       return currentPath;
     }
+    currentPath = dirname(currentPath);
   }
 
-  return null;
+  return roots.has(currentPath) ? currentPath : null;
 }
 
 function getProjectUsingESLintConfig(


### PR DESCRIPTION
Below are the benchmark results running the changes in the Nx repo:

**No cache**:
Command: `NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false NX_PERF_LOGGING=true NX_ISOLATE_PLUGINS=true pnpm nx graph --no-open`
Current: **1780ms**
After the changes: **1089ms**
**~39%** less time
**~1.6x** faster

**Full cache**:
Command: `NX_DAEMON=false NX_PERF_LOGGING=true NX_ISOLATE_PLUGINS=true pnpm nx graph --no-open`
Current: **1527ms**
After the changes: **377ms**
**~75%** less time
**~4x** faster

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
