### PR TITLE
fix(js): filter project dependencies when calculating topological ordering

### DIFF
--- a/packages/js/src/generators/release-version/utils/sort-projects-topologically.spec.ts
+++ b/packages/js/src/generators/release-version/utils/sort-projects-topologically.spec.ts
@@ -1,114 +1,243 @@
 import { sortProjectsTopologically } from './sort-projects-topologically';
+import { DependencyType, StaticDependency } from '@nx/devkit';
 
 describe('sortProjectsTopologically', () => {
-  it('should return empty array if no projects are provided', () => {
-    const projectGraph = {
-      dependencies: {},
-      nodes: {},
-    };
-    const projectNodes = [];
-    const result = sortProjectsTopologically(projectGraph, projectNodes);
-    expect(result).toEqual([]);
+  describe('edge cases', () => {
+    it('should return empty array if no projects are provided', () => {
+      const projectGraph = {
+        dependencies: {},
+        nodes: {},
+      };
+      const projectNodes = [];
+      const result = sortProjectsTopologically(projectGraph, projectNodes);
+      expect(result).toEqual([]);
+    });
+
+    it('should return a single project if only one project is provided', () => {
+      const projectGraph = {
+        dependencies: {},
+        nodes: {
+          project1: {
+            name: 'project1',
+            data: {
+              root: '',
+            },
+            type: 'app' as const,
+          },
+        },
+      };
+      const projectNodes = [projectGraph.nodes.project1];
+      const result = sortProjectsTopologically(projectGraph, projectNodes);
+      expect(result).toEqual([projectGraph.nodes.project1]);
+    });
+
+    it('should return the original list of nodes if a circular dependency is present', () => {
+      const projectGraph = {
+        dependencies: {
+          project1: [
+            {
+              source: 'project1',
+              target: 'project2',
+              type: 'static',
+            },
+          ],
+          project2: [
+            {
+              source: 'project2',
+              target: 'project1',
+              type: 'static',
+            },
+          ],
+        },
+        nodes: {
+          project1: {
+            name: 'project1',
+            data: {
+              root: '',
+            },
+            type: 'app' as const,
+          },
+          project2: {
+            name: 'project2',
+            data: {
+              root: '',
+            },
+            type: 'app' as const,
+          },
+        },
+      };
+      const projectNodes = [
+        projectGraph.nodes.project1,
+        projectGraph.nodes.project2,
+      ];
+      const result = sortProjectsTopologically(projectGraph, projectNodes);
+      expect(result).toEqual(projectNodes);
+    });
   });
 
-  it('should return a single project if only one project is provided', () => {
-    const projectGraph = {
-      dependencies: {},
-      nodes: {
-        project1: {
-          name: 'project1',
-          data: {
-            root: '',
-          },
-          type: 'app' as const,
+  describe('complex sorting cases', () => {
+    it('should return [B,A] if A depends on B', () => {
+      const projectGraph = {
+        dependencies: {
+          project1: [
+            {
+              source: 'project1',
+              target: 'project2',
+              type: 'static',
+            },
+          ],
+          project2: [],
         },
-      },
-    };
-    const projectNodes = [projectGraph.nodes.project1];
-    const result = sortProjectsTopologically(projectGraph, projectNodes);
-    expect(result).toEqual([projectGraph.nodes.project1]);
-  });
+        nodes: {
+          project1: {
+            name: 'project1',
+            data: {
+              root: '',
+            },
+            type: 'app' as const,
+          },
+          project2: {
+            name: 'project2',
+            data: {
+              root: '',
+            },
+            type: 'app' as const,
+          },
+        },
+      };
+      const projectNodes = [
+        projectGraph.nodes.project1,
+        projectGraph.nodes.project2,
+      ];
+      const result = sortProjectsTopologically(projectGraph, projectNodes);
+      expect(result).toEqual([
+        projectGraph.nodes.project2,
+        projectGraph.nodes.project1,
+      ]);
+    });
+    it('should return [C,B,A] if A depends on B and B depends on C', () => {
+      const projectGraph = {
+        dependencies: {
+          project1: [
+            {
+              source: 'project1',
+              target: 'project2',
+              type: 'static',
+            },
+          ],
+          project2: [
+            {
+              source: 'project2',
+              target: 'project3',
+              type: 'static',
+            },
+          ],
+        },
+        nodes: {
+          project1: {
+            name: 'project1',
+            data: {
+              root: '',
+            },
+            type: 'app' as const,
+          },
+          project2: {
+            name: 'project2',
+            data: {
+              root: '',
+            },
+            type: 'app' as const,
+          },
+          project3: {
+            name: 'project3',
+            data: {
+              root: '',
+            },
+            type: 'app' as const,
+          },
+        },
+      };
+      const projectNodes = [
+        projectGraph.nodes.project1,
+        projectGraph.nodes.project2,
+        projectGraph.nodes.project3,
+      ];
+      const result = sortProjectsTopologically(projectGraph, projectNodes);
+      expect(result).toEqual([
+        projectGraph.nodes.project3,
+        projectGraph.nodes.project2,
+        projectGraph.nodes.project1,
+      ]);
+    });
 
-  it('should return projects in the correct order', () => {
-    const projectGraph = {
-      dependencies: {
-        project1: [
-          {
-            source: 'project1',
-            target: 'project2',
-            type: 'static',
-          },
-        ],
-        project2: [],
-      },
-      nodes: {
-        project1: {
-          name: 'project1',
-          data: {
-            root: '',
-          },
-          type: 'app' as const,
+    it('should return [A,B,C,D] if A has 0 dependencies, B has 1, C has 2, and D has 3', () => {
+      const graphNodes = Object.fromEntries(
+        [1, 2, 3, 4].map((n) => {
+          return [
+            `project${n}`,
+            {
+              name: `project${n}`,
+              data: { root: '' },
+              type: 'app' as const,
+            },
+          ];
+        })
+      );
+      const projectGraph = {
+        dependencies: {
+          project1: [],
+          project2: [
+            {
+              source: 'project2',
+              target: 'project1',
+              type: 'static',
+            },
+          ],
+          project3: [
+            {
+              source: 'project3',
+              target: 'project1',
+              type: 'static',
+            },
+            {
+              source: 'project3',
+              target: 'project2',
+              type: 'static',
+            },
+          ],
+          project4: [
+            {
+              source: 'project4',
+              target: 'project3',
+              type: 'static',
+            },
+            {
+              source: 'project4',
+              target: 'project2',
+              type: 'static',
+            },
+            {
+              source: 'project4',
+              target: 'project1',
+              type: 'static',
+            },
+          ],
         },
-        project2: {
-          name: 'project2',
-          data: {
-            root: '',
-          },
-          type: 'app' as const,
-        },
-      },
-    };
-    const projectNodes = [
-      projectGraph.nodes.project1,
-      projectGraph.nodes.project2,
-    ];
-    const result = sortProjectsTopologically(projectGraph, projectNodes);
-    expect(result).toEqual([
-      projectGraph.nodes.project2,
-      projectGraph.nodes.project1,
-    ]);
-  });
-
-  it('should return the original list of nodes if a circular dependency is present', () => {
-    const projectGraph = {
-      dependencies: {
-        project1: [
-          {
-            source: 'project1',
-            target: 'project2',
-            type: 'static',
-          },
-        ],
-        project2: [
-          {
-            source: 'project2',
-            target: 'project1',
-            type: 'static',
-          },
-        ],
-      },
-      nodes: {
-        project1: {
-          name: 'project1',
-          data: {
-            root: '',
-          },
-          type: 'app' as const,
-        },
-        project2: {
-          name: 'project2',
-          data: {
-            root: '',
-          },
-          type: 'app' as const,
-        },
-      },
-    };
-    const projectNodes = [
-      projectGraph.nodes.project1,
-      projectGraph.nodes.project2,
-    ];
-    const result = sortProjectsTopologically(projectGraph, projectNodes);
-    expect(result).toEqual(projectNodes);
+        nodes: graphNodes,
+      };
+      const projectNodes = [
+        projectGraph.nodes.project1,
+        projectGraph.nodes.project2,
+        projectGraph.nodes.project3,
+        projectGraph.nodes.project4,
+      ];
+      const result = sortProjectsTopologically(projectGraph, projectNodes);
+      expect(result).toEqual([
+        projectGraph.nodes.project1,
+        projectGraph.nodes.project2,
+        projectGraph.nodes.project3,
+        projectGraph.nodes.project4,
+      ]);
+    });
   });
 });

--- a/packages/js/src/generators/release-version/utils/sort-projects-topologically.spec.ts
+++ b/packages/js/src/generators/release-version/utils/sort-projects-topologically.spec.ts
@@ -1,243 +1,256 @@
 import { sortProjectsTopologically } from './sort-projects-topologically';
-import { DependencyType, StaticDependency } from '@nx/devkit';
 
 describe('sortProjectsTopologically', () => {
-  describe('edge cases', () => {
-    it('should return empty array if no projects are provided', () => {
-      const projectGraph = {
-        dependencies: {},
-        nodes: {},
-      };
-      const projectNodes = [];
-      const result = sortProjectsTopologically(projectGraph, projectNodes);
-      expect(result).toEqual([]);
-    });
-
-    it('should return a single project if only one project is provided', () => {
-      const projectGraph = {
-        dependencies: {},
-        nodes: {
-          project1: {
-            name: 'project1',
-            data: {
-              root: '',
-            },
-            type: 'app' as const,
-          },
-        },
-      };
-      const projectNodes = [projectGraph.nodes.project1];
-      const result = sortProjectsTopologically(projectGraph, projectNodes);
-      expect(result).toEqual([projectGraph.nodes.project1]);
-    });
-
-    it('should return the original list of nodes if a circular dependency is present', () => {
-      const projectGraph = {
-        dependencies: {
-          project1: [
-            {
-              source: 'project1',
-              target: 'project2',
-              type: 'static',
-            },
-          ],
-          project2: [
-            {
-              source: 'project2',
-              target: 'project1',
-              type: 'static',
-            },
-          ],
-        },
-        nodes: {
-          project1: {
-            name: 'project1',
-            data: {
-              root: '',
-            },
-            type: 'app' as const,
-          },
-          project2: {
-            name: 'project2',
-            data: {
-              root: '',
-            },
-            type: 'app' as const,
-          },
-        },
-      };
-      const projectNodes = [
-        projectGraph.nodes.project1,
-        projectGraph.nodes.project2,
-      ];
-      const result = sortProjectsTopologically(projectGraph, projectNodes);
-      expect(result).toEqual(projectNodes);
-    });
+  it('should return empty array if no projects are provided', () => {
+    const projectGraph = {
+      dependencies: {},
+      nodes: {},
+    };
+    const projectNodes = [];
+    const result = sortProjectsTopologically(projectGraph, projectNodes);
+    expect(result).toEqual([]);
   });
 
-  describe('complex sorting cases', () => {
-    it('should return [B,A] if A depends on B', () => {
-      const projectGraph = {
-        dependencies: {
-          project1: [
-            {
-              source: 'project1',
-              target: 'project2',
-              type: 'static',
-            },
-          ],
-          project2: [],
+  it('should return a single project if only one project is provided', () => {
+    const projectGraph = {
+      dependencies: {},
+      nodes: {
+        project1: {
+          name: 'project1',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
         },
-        nodes: {
-          project1: {
-            name: 'project1',
-            data: {
-              root: '',
-            },
-            type: 'app' as const,
-          },
-          project2: {
-            name: 'project2',
-            data: {
-              root: '',
-            },
-            type: 'app' as const,
-          },
-        },
-      };
-      const projectNodes = [
-        projectGraph.nodes.project1,
-        projectGraph.nodes.project2,
-      ];
-      const result = sortProjectsTopologically(projectGraph, projectNodes);
-      expect(result).toEqual([
-        projectGraph.nodes.project2,
-        projectGraph.nodes.project1,
-      ]);
-    });
-    it('should return [C,B,A] if A depends on B and B depends on C', () => {
-      const projectGraph = {
-        dependencies: {
-          project1: [
-            {
-              source: 'project1',
-              target: 'project2',
-              type: 'static',
-            },
-          ],
-          project2: [
-            {
-              source: 'project2',
-              target: 'project3',
-              type: 'static',
-            },
-          ],
-        },
-        nodes: {
-          project1: {
-            name: 'project1',
-            data: {
-              root: '',
-            },
-            type: 'app' as const,
-          },
-          project2: {
-            name: 'project2',
-            data: {
-              root: '',
-            },
-            type: 'app' as const,
-          },
-          project3: {
-            name: 'project3',
-            data: {
-              root: '',
-            },
-            type: 'app' as const,
-          },
-        },
-      };
-      const projectNodes = [
-        projectGraph.nodes.project1,
-        projectGraph.nodes.project2,
-        projectGraph.nodes.project3,
-      ];
-      const result = sortProjectsTopologically(projectGraph, projectNodes);
-      expect(result).toEqual([
-        projectGraph.nodes.project3,
-        projectGraph.nodes.project2,
-        projectGraph.nodes.project1,
-      ]);
-    });
+      },
+    };
+    const projectNodes = [projectGraph.nodes.project1];
+    const result = sortProjectsTopologically(projectGraph, projectNodes);
+    expect(result).toEqual([projectGraph.nodes.project1]);
+  });
 
-    it('should return [A,B,C,D] if A has 0 dependencies, B has 1, C has 2, and D has 3', () => {
-      const graphNodes = Object.fromEntries(
-        [1, 2, 3, 4].map((n) => {
-          return [
-            `project${n}`,
-            {
-              name: `project${n}`,
-              data: { root: '' },
-              type: 'app' as const,
-            },
-          ];
-        })
-      );
-      const projectGraph = {
-        dependencies: {
-          project1: [],
-          project2: [
-            {
-              source: 'project2',
-              target: 'project1',
-              type: 'static',
-            },
-          ],
-          project3: [
-            {
-              source: 'project3',
-              target: 'project1',
-              type: 'static',
-            },
-            {
-              source: 'project3',
-              target: 'project2',
-              type: 'static',
-            },
-          ],
-          project4: [
-            {
-              source: 'project4',
-              target: 'project3',
-              type: 'static',
-            },
-            {
-              source: 'project4',
-              target: 'project2',
-              type: 'static',
-            },
-            {
-              source: 'project4',
-              target: 'project1',
-              type: 'static',
-            },
-          ],
+  it('should return [2,1] if 1 depends on 2', () => {
+    const projectGraph = {
+      dependencies: {
+        project1: [
+          {
+            source: 'project1',
+            target: 'project2',
+            type: 'static',
+          },
+        ],
+        project2: [],
+      },
+      nodes: {
+        project1: {
+          name: 'project1',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
         },
-        nodes: graphNodes,
-      };
-      const projectNodes = [
-        projectGraph.nodes.project1,
-        projectGraph.nodes.project2,
-        projectGraph.nodes.project3,
-        projectGraph.nodes.project4,
-      ];
-      const result = sortProjectsTopologically(projectGraph, projectNodes);
-      expect(result).toEqual([
-        projectGraph.nodes.project1,
-        projectGraph.nodes.project2,
-        projectGraph.nodes.project3,
-        projectGraph.nodes.project4,
-      ]);
-    });
+        project2: {
+          name: 'project2',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+      },
+    };
+    const projectNodes = [
+      projectGraph.nodes.project1,
+      projectGraph.nodes.project2,
+    ];
+    const result = sortProjectsTopologically(projectGraph, projectNodes);
+    expect(result).toEqual([
+      projectGraph.nodes.project2,
+      projectGraph.nodes.project1,
+    ]);
+  });
+
+  it('should return the original list of nodes if a circular dependency is present', () => {
+    const projectGraph = {
+      dependencies: {
+        project1: [
+          {
+            source: 'project1',
+            target: 'project2',
+            type: 'static',
+          },
+        ],
+        project2: [
+          {
+            source: 'project2',
+            target: 'project1',
+            type: 'static',
+          },
+        ],
+      },
+      nodes: {
+        project1: {
+          name: 'project1',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+        project2: {
+          name: 'project2',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+      },
+    };
+    const projectNodes = [
+      projectGraph.nodes.project1,
+      projectGraph.nodes.project2,
+    ];
+    const result = sortProjectsTopologically(projectGraph, projectNodes);
+    expect(result).toEqual(projectNodes);
+  });
+
+  it('should return [3,2,1] if 1 depends on 2 and 2 depends on 3', () => {
+    const projectGraph = {
+      dependencies: {
+        project1: [
+          {
+            source: 'project1',
+            target: 'project2',
+            type: 'static',
+          },
+        ],
+        project2: [
+          {
+            source: 'project2',
+            target: 'project3',
+            type: 'static',
+          },
+        ],
+      },
+      nodes: {
+        project1: {
+          name: 'project1',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+        project2: {
+          name: 'project2',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+        project3: {
+          name: 'project3',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+      },
+    };
+    const projectNodes = [
+      projectGraph.nodes.project1,
+      projectGraph.nodes.project2,
+      projectGraph.nodes.project3,
+    ];
+    const result = sortProjectsTopologically(projectGraph, projectNodes);
+    expect(result).toEqual([
+      projectGraph.nodes.project3,
+      projectGraph.nodes.project2,
+      projectGraph.nodes.project1,
+    ]);
+  });
+
+  it('should return [1,2,3,4] if 1 has zero dependencies, 2 has one, 3 has two, and 4 has three', () => {
+    const projectGraph = {
+      dependencies: {
+        project1: [],
+        project2: [
+          {
+            source: 'project2',
+            target: 'project1',
+            type: 'static',
+          },
+        ],
+        project3: [
+          {
+            source: 'project3',
+            target: 'project1',
+            type: 'static',
+          },
+          {
+            source: 'project3',
+            target: 'project2',
+            type: 'static',
+          },
+        ],
+        project4: [
+          {
+            source: 'project4',
+            target: 'project3',
+            type: 'static',
+          },
+          {
+            source: 'project4',
+            target: 'project2',
+            type: 'static',
+          },
+          {
+            source: 'project4',
+            target: 'project1',
+            type: 'static',
+          },
+        ],
+      },
+      nodes: {
+        project1: {
+          name: 'project1',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+        project2: {
+          name: 'project2',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+        project3: {
+          name: 'project3',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+        project4: {
+          name: 'project4',
+          data: {
+            root: '',
+          },
+          type: 'app' as const,
+        },
+      },
+    };
+    const projectNodes = [
+      projectGraph.nodes.project1,
+      projectGraph.nodes.project2,
+      projectGraph.nodes.project3,
+      projectGraph.nodes.project4,
+    ];
+    const result = sortProjectsTopologically(projectGraph, projectNodes);
+    expect(result).toEqual([
+      projectGraph.nodes.project1,
+      projectGraph.nodes.project2,
+      projectGraph.nodes.project3,
+      projectGraph.nodes.project4,
+    ]);
   });
 });

--- a/packages/js/src/generators/release-version/utils/sort-projects-topologically.ts
+++ b/packages/js/src/generators/release-version/utils/sort-projects-topologically.ts
@@ -39,14 +39,16 @@ export function sortProjectsTopologically(
     sortedProjects.push(node);
 
     // Process each project that depends on the current node
-    filteredDependencies.forEach((dep) => {
-      const dependentNode = projectGraph.nodes[dep.source];
-      const count = edges.get(dependentNode) - 1;
-      edges.set(dependentNode, count);
-      if (count === 0) {
-        processQueue.push(dependentNode);
-      }
-    });
+    filteredDependencies
+      .filter((dep) => dep.target === node.name)
+      .forEach((dep) => {
+        const dependentNode = projectGraph.nodes[dep.source];
+        const count = edges.get(dependentNode) - 1;
+        edges.set(dependentNode, count);
+        if (count === 0) {
+          processQueue.push(dependentNode);
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
Topological ordering of projects in the graph, used when calculating versions with `@nx/js:release-version`, has a bug. Projects are not sorted topologically correctly, leading to unexpected versioning behaviour.

Fixes #26490
