### PR TITLE
fix(release): false positive npm dist-tag add

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -110,7 +110,12 @@ export default async function runExecutor(
         };
       }
 
-      if (resultJson.versions.includes(currentVersion)) {
+      // If only one version of a package exists in the registry, versions will be a string instead of an array.
+      const versions = Array.isArray(resultJson.versions)
+        ? resultJson.versions
+        : [resultJson.versions];
+
+      if (versions.includes(currentVersion)) {
         try {
           if (!isDryRun) {
             execSync(npmDistTagAddCommandSegments.join(' '), {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`npm dist-tag add` can be run when not desired if exactly one version of a package exists in a registry (because in this case the data type of the `versions` field is a string instead of an array of strings (WAT)).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`npm dist-tag add` is only run when appropriate

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26240
