### PR TITLE
fix(core): convert-to-monorepo support for root project without project.json

### DIFF
--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.from-nx-init.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.from-nx-init.spec.ts
@@ -1,0 +1,34 @@
+import 'nx/src/internal-testing-utils/mock-project-graph';
+
+import {
+  readJson,
+  readProjectConfiguration,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { monorepoGenerator } from './convert-to-monorepo';
+
+describe('monorepo generator', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should convert a root package without a project.json', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.name = 'demo';
+      // Make this a root project
+      json.nx = {};
+      return json;
+    });
+
+    await monorepoGenerator(tree, {});
+
+    expect(tree.exists('packages/demo/project.json')).toBeTruthy();
+    expect(readProjectConfiguration(tree, 'demo')).toMatchObject({
+      name: 'demo',
+    });
+    expect(readJson(tree, 'package.json').name).toBe('@demo/source');
+  });
+});

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
@@ -1,6 +1,6 @@
 import 'nx/src/internal-testing-utils/mock-project-graph';
 
-import { readJson, readProjectConfiguration, Tree } from '@nx/devkit';
+import { readProjectConfiguration, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { monorepoGenerator } from './convert-to-monorepo';
 

--- a/packages/workspace/src/generators/move/lib/move-project-files.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-files.ts
@@ -18,10 +18,7 @@ export function moveProjectFiles(
   const knownRootProjectFiles = [
     // Config files
     'project.json',
-    'tsconfig.json',
-    'tsconfig.app.json',
-    'tsconfig.lib.json',
-    'tsconfig.spec.json',
+    /^tsconfig(?!\.base\.json$)((\..+)?\.json$|json$)/,
     '.babelrc',
     '.eslintrc.json',
     'eslint.config.js',


### PR DESCRIPTION
This PR fixes `convert-to-monorepo` generator, so it works after `nx init` on a single project.

## Current Behavior

If you use :

```
npm create vite react-app -- --template=react-ts
cd react-app
npx nx init
```

Then, you'll get an error when running `nx g convert-to-monorepo`.

```
 NX   The following projects are defined in multiple locations:

- react-app:
  - .
  - packages/react-app

To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name.

MultipleProjectsWithSameNameError: The following projects are defined in multiple locations:
- react-app:
  - .
  - packages/react-app
  - 
```

## Expected Behavior
The generator should work, and you can run commands successfully afterwards (e.g. `nx serve react-app`).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
