### PR TITLE
fix(release): ensure given preid modifies conventional commits specifier

### DIFF
--- a/docs/generated/cli/release.md
+++ b/docs/generated/cli/release.md
@@ -165,7 +165,7 @@ Show help
 
 Type: `string`
 
-The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to `prerelease`.
+The optional prerelease identifier to apply to the version. This will only be applied in the case that the specifier argument has been set to `prerelease` OR when conventional commits are enabled, in which case it will modify the resolved specifier from conventional commits to be its prerelease equivalent. E.g. minor -> preminor
 
 ##### specifier
 

--- a/docs/generated/packages/nx/documents/release.md
+++ b/docs/generated/packages/nx/documents/release.md
@@ -165,7 +165,7 @@ Show help
 
 Type: `string`
 
-The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to `prerelease`.
+The optional prerelease identifier to apply to the version. This will only be applied in the case that the specifier argument has been set to `prerelease` OR when conventional commits are enabled, in which case it will modify the resolved specifier from conventional commits to be its prerelease equivalent. E.g. minor -> preminor
 
 ##### specifier
 

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -205,7 +205,7 @@ To fix this you will either need to add a package.json file at that location, or
               )}Resolving the current version for tag "${tag}" on ${registry}`
             );
             spinner.color =
-              color.spinnerColor as typeof colors[number]['spinnerColor'];
+              color.spinnerColor as (typeof colors)[number]['spinnerColor'];
             spinner.start();
 
             try {

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -205,7 +205,7 @@ To fix this you will either need to add a package.json file at that location, or
               )}Resolving the current version for tag "${tag}" on ${registry}`
             );
             spinner.color =
-              color.spinnerColor as (typeof colors)[number]['spinnerColor'];
+              color.spinnerColor as typeof colors[number]['spinnerColor'];
             spinner.start();
 
             try {
@@ -406,8 +406,13 @@ To fix this you will either need to add a package.json file at that location, or
                 `📄 Resolved the specifier as "${specifier}" since the current version is a prerelease.`
               );
             } else {
+              let extraText = '';
+              if (options.preid && !specifier.startsWith('pre')) {
+                specifier = `pre${specifier}`;
+                extraText = `, combined with your given preid "${options.preid}"`;
+              }
               log(
-                `📄 Resolved the specifier as "${specifier}" using git history and the conventional commits standard.`
+                `📄 Resolved the specifier as "${specifier}" using git history and the conventional commits standard${extraText}.`
               );
             }
             break;

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -203,7 +203,7 @@ const versionCommand: CommandModule<NxReleaseArgs, VersionOptions> = {
           .option('preid', {
             type: 'string',
             describe:
-              'The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to `prerelease`.',
+              'The optional prerelease identifier to apply to the version. This will only be applied in the case that the specifier argument has been set to `prerelease` OR when conventional commits are enabled, in which case it will modify the resolved specifier from conventional commits to be its prerelease equivalent. E.g. minor -> preminor',
             default: '',
           })
           .option('stage-changes', {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If a user passes `--preid` when using conventional commits it will not have any impact on the derived specifier. If they were to use an explicit `--specifier` to work around this, it would override the derived conventional commits specifier entirely which is not we they want.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If a user passes `--preid` and the resolved conventional commits specifier is not already a prerelease of some kind, modify the specifier dynamically to be a prerelease (which will later be combined with the given preid).

Example (after a breaking change to bar):

![image](https://github.com/nrwl/nx/assets/900523/17d3aa1b-fb88-4bd0-afa0-b867815234ca)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23235
