### PR TITLE
feat(core): allow defining target with only dependsOn

### DIFF
--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
@@ -43,7 +43,7 @@ export async function normalizeProjectNodes(
       partialProjectGraphNodes
     );
 
-    p.targets = normalizeProjectTargets(p, key);
+    p.targets ??= {};
 
     // TODO: remove in v16
     const projectType =
@@ -78,25 +78,6 @@ export async function normalizeProjectNodes(
       data: n.data,
     });
   });
-}
-
-/**
- * Apply target defaults and normalization
- */
-export function normalizeProjectTargets(
-  project: ProjectConfiguration,
-  projectName: string
-): Record<string, TargetConfiguration> {
-  // Any node on the graph will have a targets object, it just may be empty
-  const targets = project.targets ?? {};
-
-  for (const target in targets) {
-    if (!targets[target].command && !targets[target].executor) {
-      delete targets[target];
-      continue;
-    }
-  }
-  return targets;
 }
 
 export function normalizeImplicitDependencies(

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -641,10 +641,21 @@ function validateAndNormalizeProjectRootMap(
       );
 
       if (
+        // If the target has no executor or command, it doesn't do anything
         !project.targets[targetName].executor &&
         !project.targets[targetName].command
       ) {
-        delete project.targets[targetName];
+        // But it may have dependencies that do something
+        if (
+          project.targets[targetName].dependsOn &&
+          project.targets[targetName].dependsOn.length > 0
+        ) {
+          project.targets[targetName].executor = 'nx:noop';
+        } else {
+          // If it does nothing, and has no depenencies,
+          // we can remove it.
+          delete project.targets[targetName];
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
You must specify either `executor` or `command`, otherwise the target is removed.

## Expected Behavior
If a target specifies `dependsOn` it is not removed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
