### PR TITLE
feat(testing): support vite configOverrides for cypress

### DIFF
--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -8,6 +8,7 @@ import { NX_PLUGIN_OPTIONS } from '../src/utils/constants';
 import { spawn } from 'child_process';
 import { request as httpRequest } from 'http';
 import { request as httpsRequest } from 'https';
+import type { InlineConfig } from 'vite';
 
 // Importing the cypress type here causes the angular and next unit
 // tests to fail when transpiling, it seems like the cypress types are
@@ -133,7 +134,7 @@ export function nxE2EPreset(
         config.env?.webServerCommand ?? webServerCommands?.default;
 
       if (options?.bundler === 'vite') {
-        on('file:preprocessor', vitePreprocessor());
+        on('file:preprocessor', vitePreprocessor(options?.viteConfigOverrides));
       }
 
       if (!options?.webServerCommands) {
@@ -265,4 +266,9 @@ export type NxCypressE2EPresetOptions = {
    * Configures how the web server command is started and monitored.
    */
   webServerConfig?: WebServerConfig;
+
+  /**
+   * Configure override inside the vite config
+   */
+  viteConfigOverrides?: InlineConfig;
 };

--- a/packages/cypress/src/plugins/preprocessor-vite.ts
+++ b/packages/cypress/src/plugins/preprocessor-vite.ts
@@ -40,7 +40,9 @@ const cache = new Map<string, string>();
  * This preprocessor shouldn't be used directly.
  * Instead, use the nxE2EPreset(__filename, { bundler: 'vite' }) function instead.
  */
-function vitePreprocessor(userConfigPath?: string): CypressPreprocessor {
+function vitePreprocessor(
+  configOverrides: InlineConfig = {}
+): CypressPreprocessor {
   return async (file) => {
     const { outputPath, filePath, shouldWatch } = file;
 
@@ -79,8 +81,8 @@ function vitePreprocessor(userConfigPath?: string): CypressPreprocessor {
     >);
 
     const watcher = (await build({
-      configFile: userConfigPath,
       ...defaultConfig,
+      ...configOverrides,
     })) as BuildResult;
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
We'd like to use shared cypress commands, but that's currently not working because vite cannot resolve the import.
By allowing to pass options to the vite config we have the possibility to add an alias or a plugin to fix this.

This adds support for an **optional** `viteConfigOverrides` object.

## Current Behavior
![Screenshot 2024-06-14 at 15 19 21](https://github.com/nrwl/nx/assets/951290/78f5037f-c839-4227-a3ea-4de4142006cf)

cypress.config.ts:
```ts
import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
import { defineConfig } from 'cypress';

export default defineConfig({
  e2e: {
    ...nxE2EPreset(__filename, { cypressDir: 'cypress', bundler: 'vite' }),
  },
});
```

## Expected Behavior
![Screenshot 2024-06-14 at 15 23 56](https://github.com/nrwl/nx/assets/951290/385cde67-91b9-462e-9bfa-0c784d3947b7)

cypress.config.ts:
```ts
import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
import { defineConfig } from 'cypress';

const viteConfigOverrides = {
  resolve: {
    alias: {
      '@cypress-shared-commands': '../../../shared-cypress-commands',
    },
  },
};

export default defineConfig({
  e2e: {
    ...nxE2EPreset(__filename, { cypressDir: 'cypress', bundler: 'vite', viteConfigOverrides }),
  },
});
```
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
