### PR TITLE
fix(core): move plugin worker to socket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,6 @@ jobs:
       NX_E2E_RUN_E2E: 'true'
       NX_CI_EXECUTION_ENV: 'linux'
       NX_CLOUD_DTE_V2: 'true'
-      NX_VERBOSE_LOGGING: 'true'
-      NX_E2E_VERBOSE_LOGGING: 'true'
     steps:
       - checkout
       - nx/set-shas:
@@ -108,7 +106,21 @@ jobs:
           name: Run Checks/Lint/Test/Build
           no_output_timeout: 60m
           command: |
-            pnpm nx e2e-ci e2e-react
+            pids=()
+
+            pnpm nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD &
+            pids+=($!)
+
+            pnpm nx run-many -t check-imports check-commit check-lock-files check-codeowners documentation --parallel=1 --no-dte &
+            pids+=($!)
+
+            (pnpm nx affected --targets=lint,test,build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &&
+            pnpm nx affected --targets=e2e,e2e-ci --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
+            pids+=($!)
+
+            for pid in "${pids[@]}"; do
+              wait "$pid"
+            done
   # -------------------------
   #     JOBS: Main-MacOS
   # -------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,8 @@ jobs:
       NX_E2E_RUN_E2E: 'true'
       NX_CI_EXECUTION_ENV: 'linux'
       NX_CLOUD_DTE_V2: 'true'
+      NX_VERBOSE_LOGGING: 'true'
+      NX_E2E_VERBOSE_LOGGING: 'true'
     steps:
       - checkout
       - nx/set-shas:
@@ -106,21 +108,7 @@ jobs:
           name: Run Checks/Lint/Test/Build
           no_output_timeout: 60m
           command: |
-            pids=()
-
-            pnpm nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD &
-            pids+=($!)
-
-            pnpm nx run-many -t check-imports check-commit check-lock-files check-codeowners documentation --parallel=1 --no-dte &
-            pids+=($!)
-
-            (pnpm nx affected --targets=lint,test,build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &&
-            pnpm nx affected --targets=e2e,e2e-ci --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
-            pids+=($!)
-
-            for pid in "${pids[@]}"; do
-              wait "$pid"
-            done
+            pnpm nx e2e-ci e2e-react
   # -------------------------
   #     JOBS: Main-MacOS
   # -------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,10 @@ jobs:
       - run-pnpm-install:
           os: linux
       - run:
+          name: Check Documentation
+          command: pnpm nx documentation --no-dte
+          no_output_timeout: 20m
+      - run:
           name: Run Checks/Lint/Test/Build
           no_output_timeout: 60m
           command: |
@@ -110,7 +114,7 @@ jobs:
             pnpm nx run-many -t check-imports check-commit check-lock-files check-codeowners documentation --parallel=1 --no-dte &
             pids+=($!)
 
-            (pnpm nx affected --targets=lint,test,build --base=$NX_BASE --head=$NX_HEAD --parallel=3 --exclude nx &&
+            (pnpm nx affected --targets=lint,test,build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &&
             pnpm nx affected --targets=e2e,e2e-ci --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
             pids+=($!)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,10 +99,6 @@ jobs:
       - run-pnpm-install:
           os: linux
       - run:
-          name: Check Documentation
-          command: pnpm nx documentation --no-dte
-          no_output_timeout: 20m
-      - run:
           name: Run Checks/Lint/Test/Build
           no_output_timeout: 60m
           command: |
@@ -114,7 +110,7 @@ jobs:
             pnpm nx run-many -t check-imports check-commit check-lock-files check-codeowners documentation --parallel=1 --no-dte &
             pids+=($!)
 
-            (pnpm nx affected --targets=lint,test,build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &&
+            (pnpm nx affected --targets=lint,test,build --base=$NX_BASE --head=$NX_HEAD --parallel=3 --exclude nx &&
             pnpm nx affected --targets=e2e,e2e-ci --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
             pids+=($!)
 

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NX_ISOLATE_PLUGINS=true

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ out
 .angular
 
 # Local dev files
-.env
+.env.local
 .bashrc
 .nx
 

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -160,7 +160,7 @@ export function getStrippedEnvironmentVariables() {
         return true;
       }
 
-      const allowedKeys = ['NX_ADD_PLUGINS'];
+      const allowedKeys = ['NX_ADD_PLUGINS', 'NX_ISOLATE_PLUGINS'];
 
       if (key.startsWith('NX_') && !allowedKeys.includes(key)) {
         return false;

--- a/nx.json
+++ b/nx.json
@@ -212,6 +212,6 @@
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
   "cacheDirectory": "/tmp/nx-cache",
-  "bust": 5,
+  "bust": 6,
   "defaultBase": "master"
 }

--- a/nx.json
+++ b/nx.json
@@ -212,6 +212,6 @@
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
   "cacheDirectory": "/tmp/nx-cache",
-  "bust": 6,
+  "bust": 7,
   "defaultBase": "master"
 }

--- a/packages/nx/src/command-line/run/command-object.ts
+++ b/packages/nx/src/command-line/run/command-object.ts
@@ -37,7 +37,7 @@ export const yargsNxInfixCommand: CommandModule = {
   command: '$0 <target> [project] [_..]',
   describe: 'Run a target for a project',
   handler: async (args) => {
-    await handleErrors(
+    const exitCode = await handleErrors(
       (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
       async () => {
         return (await import('./run-one')).runOne(
@@ -46,5 +46,6 @@ export const yargsNxInfixCommand: CommandModule = {
         );
       }
     );
+    process.exit(exitCode);
   },
 };

--- a/packages/nx/src/daemon/socket-utils.ts
+++ b/packages/nx/src/daemon/socket-utils.ts
@@ -22,6 +22,11 @@ export const getForkedProcessOsSocketPath = (id: string) => {
   return isWindows ? '\\\\.\\pipe\\nx\\' + resolve(path) : resolve(path);
 };
 
+export const getPluginOsSocketPath = (id: string) => {
+  let path = resolve(join(getSocketDir(), 'plugin' + id + '.sock'));
+  return isWindows ? '\\\\.\\pipe\\nx\\' + resolve(path) : resolve(path);
+};
+
 export function killSocketOrPath(): void {
   try {
     unlinkSync(getFullOsSocketPath());

--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
@@ -296,7 +296,7 @@ describe('getTouchedNpmPackages', () => {
   });
 
   it('should handle and log workspace package.json changes when the changes are not in `npmPackages` (projectGraph.externalNodes)', () => {
-    jest.spyOn(logger, 'warn');
+    jest.spyOn(logger, 'warn').mockImplementation(() => {});
     expect(() => {
       getTouchedNpmPackages(
         [

--- a/packages/nx/src/project-graph/plugins/internal-api.ts
+++ b/packages/nx/src/project-graph/plugins/internal-api.ts
@@ -159,7 +159,7 @@ export async function loadNxPlugins(
 
   const cleanupFunctions: Array<() => void> = [];
   for (const plugin of plugins) {
-    const [loadedPluginPromise, cleanup] = loadingMethod(plugin, root);
+    const [loadedPluginPromise, cleanup] = await loadingMethod(plugin, root);
     result.push(loadedPluginPromise);
     cleanupFunctions.push(cleanup);
   }

--- a/packages/nx/src/project-graph/plugins/isolation/index.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/index.ts
@@ -11,17 +11,17 @@ const remotePluginCache = new Map<
   readonly [Promise<LoadedNxPlugin>, () => void]
 >();
 
-export function loadNxPluginInIsolation(
+export async function loadNxPluginInIsolation(
   plugin: PluginConfiguration,
   root = workspaceRoot
-): readonly [Promise<LoadedNxPlugin>, () => void] {
+): Promise<readonly [Promise<LoadedNxPlugin>, () => void]> {
   const cacheKey = JSON.stringify(plugin);
 
   if (remotePluginCache.has(cacheKey)) {
     return remotePluginCache.get(cacheKey);
   }
 
-  const [loadingPlugin, cleanup] = loadRemoteNxPlugin(plugin, root);
+  const [loadingPlugin, cleanup] = await loadRemoteNxPlugin(plugin, root);
   // We clean up plugin workers when Nx process completes.
   const val = [
     loadingPlugin,

--- a/packages/nx/src/project-graph/plugins/isolation/index.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/index.ts
@@ -3,33 +3,15 @@ import { PluginConfiguration } from '../../../config/nx-json';
 import { LoadedNxPlugin } from '../internal-api';
 import { loadRemoteNxPlugin } from './plugin-pool';
 
-/**
- * Used to ensure 1 plugin : 1 worker
- */
-const remotePluginCache = new Map<
-  string,
-  readonly [Promise<LoadedNxPlugin>, () => void]
->();
-
 export async function loadNxPluginInIsolation(
   plugin: PluginConfiguration,
   root = workspaceRoot
 ): Promise<readonly [Promise<LoadedNxPlugin>, () => void]> {
-  const cacheKey = JSON.stringify(plugin);
-
-  if (remotePluginCache.has(cacheKey)) {
-    return remotePluginCache.get(cacheKey);
-  }
-
   const [loadingPlugin, cleanup] = await loadRemoteNxPlugin(plugin, root);
-  // We clean up plugin workers when Nx process completes.
-  const val = [
+  return [
     loadingPlugin,
     () => {
       cleanup();
-      remotePluginCache.delete(cacheKey);
     },
   ] as const;
-  remotePluginCache.set(cacheKey, val);
-  return val;
 }

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -7,9 +7,11 @@ import {
   CreateDependenciesContext,
   CreateMetadataContext,
   CreateNodesContext,
+  CreateNodesContextV2,
 } from '../public-api';
 import { LoadedNxPlugin } from '../internal-api';
 import { Serializable } from 'child_process';
+import { Socket } from 'net';
 
 export interface PluginWorkerLoadMessage {
   type: 'load';
@@ -42,7 +44,7 @@ export interface PluginWorkerCreateNodesMessage {
   type: 'createNodes';
   payload: {
     configFiles: string[];
-    context: CreateNodesContext;
+    context: CreateNodesContextV2;
     tx: string;
   };
 }
@@ -192,6 +194,7 @@ type MessageHandlerReturn<T extends PluginWorkerMessage | PluginWorkerResult> =
 export async function consumeMessage<
   T extends PluginWorkerMessage | PluginWorkerResult
 >(
+  socket: Socket,
   raw: T,
   handlers: {
     [K in T['type']]: (
@@ -205,7 +208,14 @@ export async function consumeMessage<
   if (handler) {
     const response = await handler(message.payload);
     if (response) {
-      process.send!(response);
+      sendMessageOverSocket(socket, response);
     }
   }
+}
+
+export function sendMessageOverSocket(
+  socket: Socket,
+  message: PluginWorkerMessage | PluginWorkerResult
+) {
+  socket.write(JSON.stringify(message) + String.fromCodePoint(4));
 }

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -161,6 +161,7 @@ export function isPluginWorkerMessage(
       'createNodes',
       'createDependencies',
       'processProjectGraph',
+      'createMetadata',
     ].includes(message.type)
   );
 }
@@ -177,6 +178,7 @@ export function isPluginWorkerResult(
       'createNodesResult',
       'createDependenciesResult',
       'processProjectGraphResult',
+      'createMetadataResult',
     ].includes(message.type)
   );
 }

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -16,7 +16,6 @@ import {
   sendMessageOverSocket,
 } from './messaging';
 import { Socket, connect } from 'net';
-import { unlinkSync } from 'fs';
 
 const cleanupFunctions = new Set<() => void>();
 
@@ -99,6 +98,8 @@ function createWorkerHandler(
 ) {
   let pluginName: string;
 
+  let txId = 0;
+
   return function (raw: string) {
     const message = JSON.parse(raw);
 
@@ -120,10 +121,7 @@ function createWorkerHandler(
                   createNodesPattern,
                   (configFiles, ctx) => {
                     const tx =
-                      pluginName +
-                      worker.pid +
-                      ':createNodes:' +
-                      performance.now();
+                      pluginName + worker.pid + ':createNodes:' + txId++;
                     return registerPendingPromise(tx, pending, () => {
                       sendMessageOverSocket(socket, {
                         type: 'createNodes',
@@ -136,10 +134,7 @@ function createWorkerHandler(
             createDependencies: result.hasCreateDependencies
               ? (ctx) => {
                   const tx =
-                    pluginName +
-                    worker.pid +
-                    ':createDependencies:' +
-                    performance.now();
+                    pluginName + worker.pid + ':createDependencies:' + txId++;
                   return registerPendingPromise(tx, pending, () => {
                     sendMessageOverSocket(socket, {
                       type: 'createDependencies',
@@ -151,10 +146,7 @@ function createWorkerHandler(
             processProjectGraph: result.hasProcessProjectGraph
               ? (graph, ctx) => {
                   const tx =
-                    pluginName +
-                    worker.pid +
-                    ':processProjectGraph:' +
-                    performance.now();
+                    pluginName + worker.pid + ':processProjectGraph:' + txId++;
                   return registerPendingPromise(tx, pending, () => {
                     sendMessageOverSocket(socket, {
                       type: 'processProjectGraph',
@@ -166,10 +158,7 @@ function createWorkerHandler(
             createMetadata: result.hasCreateMetadata
               ? (graph, ctx) => {
                   const tx =
-                    pluginName +
-                    worker.pid +
-                    ':createMetadata:' +
-                    performance.now();
+                    pluginName + worker.pid + ':createMetadata:' + txId++;
                   return registerPendingPromise(tx, pending, () => {
                     sendMessageOverSocket(socket, {
                       type: 'createMetadata',
@@ -262,7 +251,7 @@ function registerPendingPromise(
 
     callback();
   }).finally(() => {
-    pending.delete(tx);
+    // pending.delete(tx);
   });
 
   pending.set(tx, {

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -42,7 +42,7 @@ export async function loadRemoteNxPlugin(
     return [nxPluginWorkerCache.get(cacheKey), () => {}];
   }
 
-  const { ipcPath, worker } = await startPluginWorker(plugin);
+  const { ipcPath, worker } = await startPluginWorker();
 
   const socket = await new Promise<Socket>((res, rej) => {
     const socket = connect(ipcPath, () => {
@@ -277,7 +277,7 @@ function registerPendingPromise(
 }
 
 global.nxPluginWorkerCount ??= 0;
-async function startPluginWorker(plugin: PluginConfiguration) {
+async function startPluginWorker() {
   // this should only really be true when running unit tests within
   // the Nx repo. We still need to start the worker in this case,
   // but its typescript.

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -1,8 +1,10 @@
 import { consumeMessage, isPluginWorkerMessage } from './messaging';
 import { LoadedNxPlugin } from '../internal-api';
 import { loadNxPlugin } from '../loader';
-import { Serializable } from 'child_process';
 import { createSerializableError } from '../../../utils/serializable-error';
+import { createServer } from 'net';
+import { consumeMessagesFromSocket } from '../../../utils/consume-messages-from-socket';
+import { unlinkSync } from 'fs';
 
 if (process.env.NX_PERF_LOGGING === 'true') {
   require('../../../utils/perf-logging');
@@ -12,109 +14,127 @@ global.NX_GRAPH_CREATION = true;
 
 let plugin: LoadedNxPlugin;
 
-process.on('message', async (message: Serializable) => {
-  if (!isPluginWorkerMessage(message)) {
-    return;
-  }
-  return consumeMessage(message, {
-    load: async ({ plugin: pluginConfiguration, root }) => {
-      process.chdir(root);
-      try {
-        const [promise] = loadNxPlugin(pluginConfiguration, root);
-        plugin = await promise;
-        return {
-          type: 'load-result',
-          payload: {
-            name: plugin.name,
-            include: plugin.include,
-            exclude: plugin.exclude,
-            createNodesPattern: plugin.createNodes?.[0],
-            hasCreateDependencies:
-              'createDependencies' in plugin && !!plugin.createDependencies,
-            hasProcessProjectGraph:
-              'processProjectGraph' in plugin && !!plugin.processProjectGraph,
-            hasCreateMetadata:
-              'createMetadata' in plugin && !!plugin.createMetadata,
-            success: true,
-          },
-        };
-      } catch (e) {
-        return {
-          type: 'load-result',
-          payload: {
-            success: false,
-            error: createSerializableError(e),
-          },
-        };
+const socketPath = process.argv[2];
+
+const server = createServer((socket) => {
+  socket.on(
+    'data',
+    consumeMessagesFromSocket((raw) => {
+      const message = JSON.parse(raw.toString());
+      if (!isPluginWorkerMessage(message)) {
+        return;
       }
-    },
-    createNodes: async ({ configFiles, context, tx }) => {
-      try {
-        const result = await plugin.createNodes[1](configFiles, context);
-        return {
-          type: 'createNodesResult',
-          payload: { result, success: true, tx },
-        };
-      } catch (e) {
-        return {
-          type: 'createNodesResult',
-          payload: {
-            success: false,
-            error: createSerializableError(e),
-            tx,
-          },
-        };
-      }
-    },
-    createDependencies: async ({ context, tx }) => {
-      try {
-        const result = await plugin.createDependencies(context);
-        return {
-          type: 'createDependenciesResult',
-          payload: { dependencies: result, success: true, tx },
-        };
-      } catch (e) {
-        return {
-          type: 'createDependenciesResult',
-          payload: {
-            success: false,
-            error: createSerializableError(e),
-            tx,
-          },
-        };
-      }
-    },
-    processProjectGraph: async ({ graph, ctx, tx }) => {
-      try {
-        const result = await plugin.processProjectGraph(graph, ctx);
-        return {
-          type: 'processProjectGraphResult',
-          payload: { graph: result, success: true, tx },
-        };
-      } catch (e) {
-        return {
-          type: 'processProjectGraphResult',
-          payload: {
-            success: false,
-            error: createSerializableError(e),
-            tx,
-          },
-        };
-      }
-    },
-    createMetadata: async ({ graph, context, tx }) => {
-      try {
-        const result = await plugin.createMetadata(graph, context);
-        return {
-          type: 'createMetadataResult',
-          payload: { metadata: result, success: true, tx },
-        };
-      } catch (e) {
-        return {
-          type: 'createMetadataResult',
-          payload: { success: false, error: e.stack, tx },
-        };
-      }
-    },
-  });
+      return consumeMessage(socket, message, {
+        load: async ({ plugin: pluginConfiguration, root }) => {
+          process.chdir(root);
+          try {
+            const [promise] = loadNxPlugin(pluginConfiguration, root);
+            plugin = await promise;
+            return {
+              type: 'load-result',
+              payload: {
+                name: plugin.name,
+                include: plugin.include,
+                exclude: plugin.exclude,
+                createNodesPattern: plugin.createNodes?.[0],
+                hasCreateDependencies:
+                  'createDependencies' in plugin && !!plugin.createDependencies,
+                hasProcessProjectGraph:
+                  'processProjectGraph' in plugin &&
+                  !!plugin.processProjectGraph,
+                hasCreateMetadata:
+                  'createMetadata' in plugin && !!plugin.createMetadata,
+                success: true,
+              },
+            };
+          } catch (e) {
+            return {
+              type: 'load-result',
+              payload: {
+                success: false,
+                error: createSerializableError(e),
+              },
+            };
+          }
+        },
+        createNodes: async ({ configFiles, context, tx }) => {
+          try {
+            const result = await plugin.createNodes[1](configFiles, context);
+            return {
+              type: 'createNodesResult',
+              payload: { result, success: true, tx },
+            };
+          } catch (e) {
+            return {
+              type: 'createNodesResult',
+              payload: {
+                success: false,
+                error: createSerializableError(e),
+                tx,
+              },
+            };
+          }
+        },
+        createDependencies: async ({ context, tx }) => {
+          try {
+            const result = await plugin.createDependencies(context);
+            return {
+              type: 'createDependenciesResult',
+              payload: { dependencies: result, success: true, tx },
+            };
+          } catch (e) {
+            return {
+              type: 'createDependenciesResult',
+              payload: {
+                success: false,
+                error: createSerializableError(e),
+                tx,
+              },
+            };
+          }
+        },
+        processProjectGraph: async ({ graph, ctx, tx }) => {
+          try {
+            const result = await plugin.processProjectGraph(graph, ctx);
+            return {
+              type: 'processProjectGraphResult',
+              payload: { graph: result, success: true, tx },
+            };
+          } catch (e) {
+            return {
+              type: 'processProjectGraphResult',
+              payload: {
+                success: false,
+                error: createSerializableError(e),
+                tx,
+              },
+            };
+          }
+        },
+        createMetadata: async ({ graph, context, tx }) => {
+          try {
+            const result = await plugin.createMetadata(graph, context);
+            return {
+              type: 'createMetadataResult',
+              payload: { metadata: result, success: true, tx },
+            };
+          } catch (e) {
+            return {
+              type: 'createMetadataResult',
+              payload: { success: false, error: e.stack, tx },
+            };
+          }
+        },
+      });
+    })
+  );
+});
+
+server.listen(socketPath);
+
+process.on('exit', () => {
+  server.close();
+  try {
+    unlinkSync(socketPath);
+  } catch (e) {}
 });

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -132,9 +132,16 @@ const server = createServer((socket) => {
 
 server.listen(socketPath);
 
-process.on('exit', () => {
+const exitHandler = (exitCode: number) => () => {
   server.close();
   try {
     unlinkSync(socketPath);
   } catch (e) {}
-});
+  process.exit(exitCode);
+};
+
+const events = ['SIGINT', 'SIGTERM', 'SIGQUIT', 'exit'];
+
+events.forEach((event) => process.once(event, exitHandler(0)));
+process.once('uncaughtException', exitHandler(1));
+process.once('unhandledRejection', exitHandler(1));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Plugin isolation communicates with workers via built-in node IPC with forked processes. When doing this, the parent process will not exit until the child process has exited, in case more messages would be sent. This requires an explicit call to shut down the plugin workers.

We set this up as a `process.on('exit')` listener, to shutdown the workers whenever the main Nx process dies. This is "fine", but requires explicit calls to `process.exit` as node won't exit on its own otherwise.

## Expected Behavior
To allow plugin workers to clean themselves up on exit, but not require explicit `process.exit` calls, we need to detach them from the main process and call `unref`. This only works when IPC is not being used. As such, we need a different way to communicate with the worker. 

This PR updates the communication method to mirror the daemon, and communicate over a socket. Additionally, this PR enables isolation during the Nx repo's E2E tests.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
