### PR TITLE
fix(remix): don't add @remix-run/eslint-config dependency to new remix apps

### DIFF
--- a/e2e/remix/src/nx-remix.test.ts
+++ b/e2e/remix/src/nx-remix.test.ts
@@ -8,15 +8,34 @@ import {
   uniq,
   updateFile,
   runCommandAsync,
-  listFiles,
 } from '@nx/e2e/utils';
 
 describe('Remix E2E Tests', () => {
-  describe('--integrated', () => {
-    let proj: string;
-
+  describe('--integrated (npm)', () => {
     beforeAll(() => {
-      proj = newProject({ packages: ['@nx/remix', '@nx/react'] });
+      newProject({
+        packages: ['@nx/remix', '@nx/react'],
+        packageManager: 'npm',
+      });
+    });
+
+    afterAll(() => {
+      killPorts();
+      cleanupProject();
+    });
+
+    it('should not cause peer dependency conflicts', async () => {
+      const plugin = uniq('remix');
+      runCLI(
+        `generate @nx/remix:app ${plugin} --projectNameAndRootFormat=as-provided`
+      );
+
+      await runCommandAsync('npm install');
+    }, 120000);
+  });
+  describe('--integrated (yarn)', () => {
+    beforeAll(() => {
+      newProject({ packages: ['@nx/remix', '@nx/react'] });
     });
 
     afterAll(() => {

--- a/packages/remix/src/generators/application/files/integrated/package.json__tmpl__
+++ b/packages/remix/src/generators/application/files/integrated/package.json__tmpl__
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@remix-run/dev": "<%= remixVersion %>",
-    "@remix-run/eslint-config": "<%= remixVersion %>",
     "@types/react": "<%= typesReactVersion %>",
     "@types/react-dom": "<%= typesReactDomVersion %>",
     "eslint": "<%= eslintVersion %>",

--- a/packages/remix/src/generators/utils/update-dependencies.ts
+++ b/packages/remix/src/generators/utils/update-dependencies.ts
@@ -21,7 +21,6 @@ export function updateDependencies(tree: Tree) {
       'react-dom': reactDomVersion,
     },
     {
-      '@remix-run/eslint-config': remixVersion,
       '@types/react': typesReactVersion,
       '@types/react-dom': typesReactDomVersion,
       eslint: eslintVersion,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When a new remix app is generated with @nx/remix, it can't be installed due to peer dependencies that are introduced by @remix-run/eslint-config. This dependency though is not used in the nx workspace and has also been removed from the official create-remix method.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running `npm install` should not throw errors after a remix application was added to the nx workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26540 
