### PR TITLE
fix(vite): nxViteTsPaths plugin should not run-many for vitest

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -83,7 +83,11 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
 There should at least be a tsconfig.base.json or tsconfig.json in the root of the workspace ${workspaceRoot}`);
       }
 
-      if (!options.buildLibsFromSource && !global.NX_GRAPH_CREATION) {
+      if (
+        !options.buildLibsFromSource &&
+        !global.NX_GRAPH_CREATION &&
+        config.mode !== 'test'
+      ) {
         const projectGraph = await createProjectGraphAsync({
           exitOnError: false,
           resetDaemonClient: true,
@@ -123,7 +127,7 @@ There should at least be a tsconfig.base.json or tsconfig.json in the root of th
 
       logIt('first parsed tsconfig: ', parsed);
       if (parsed.resultType === 'failed') {
-        throw new Error(`Failed loading tsonfig at ${foundTsConfigPath}`);
+        throw new Error(`Failed loading tsconfig at ${foundTsConfigPath}`);
       }
       tsConfigPathsEsm = parsed;
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`nxViteTsPaths` does not check if the mode is test and only filters the `run-many` command based on whether Vite's config.command === serve.

Vitest will set `config.command` to serve, even for `test` targets.
It does set `mode = test` however.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When `mode === test`, we do not invoke `nx run-many`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
