### PR TITLE
chore(core): nx plugin submissions @nx-extend/docusaurus

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -300,6 +300,11 @@
     "url": "https://github.com/tripss/nx-extend/tree/master/packages/shadcn-ui"
   },
   {
+    "name": "@nx-extend/docusaurus",
+    "description": "Nx plugin adding first class support for Docusaurus in your Nx workspace.",
+    "url": "https://github.com/tripss/nx-extend/tree/master/packages/docusaurus"
+  },
+  {
     "name": "@nativescript/nx",
     "description": "Nx Plugin adding first class support for NativeScript in your Nx workspace",
     "url": "https://github.com/nativescript/nx"


### PR DESCRIPTION
ZachJW34/nx-plus stopt supporting their docusaurus so @nx-extend is now supporting an up to date version.