### PR TITLE
feat(nx-cloud): update gh onboarding url

### DIFF
--- a/docs/generated/packages/nx/generators/connect-to-nx-cloud.json
+++ b/docs/generated/packages/nx/generators/connect-to-nx-cloud.json
@@ -28,6 +28,11 @@
         "type": "boolean",
         "description": "If the user will be using GitHub as their git hosting provider",
         "default": false
+      },
+      "directory": {
+        "type": "string",
+        "description": "The directory where the workspace is located",
+        "x-priority": "internal"
       }
     },
     "additionalProperties": false,

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -84,3 +84,19 @@ export async function initializeGitRepo(
     await execute(['commit', `-m "${message}"`]);
   }
 }
+
+export function commitChanges(directory: string, message: string) {
+  try {
+    execSync('git add -A', { encoding: 'utf8', stdio: 'pipe', cwd: directory });
+    execSync('git commit --no-verify -F -', {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      input: message,
+      cwd: directory,
+    });
+  } catch (e) {
+    console.error(`There was an error committing your Nx Cloud token.\n 
+      Please commit the changes manually and push to your new repository.\n  
+      \n${e}`);
+  }
+}

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -19,7 +19,7 @@ export async function setupNxCloud(
       process.env.NX_NEW_CLOUD_ONBOARDING === 'true'
         ? `${
             pmc.exec
-          } nx g nx:connect-to-nx-cloud --installationSource=create-nx-workspace ${
+          } nx g nx:connect-to-nx-cloud --installationSource=create-nx-workspace --directory=${directory} ${
             useGitHub ? '--github' : ''
           } --no-interactive`
         : `${pmc.exec} nx g nx:connect-to-nx-cloud --no-interactive --quiet`,

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -50,7 +50,9 @@ export async function connectToNxCloudIfExplicitlyAsked(
   }
 }
 
-export async function connectToNxCloudCommand(): Promise<boolean> {
+export async function connectToNxCloudCommand(
+  command?: string
+): Promise<boolean> {
   const nxJson = readNxJson();
 
   if (isNxCloudUsed(nxJson)) {
@@ -85,7 +87,9 @@ export async function connectToNxCloudCommand(): Promise<boolean> {
   }
 
   const tree = new FsTree(workspaceRoot, false, 'connect-to-nx-cloud');
-  const callback = await connectToNxCloud(tree, {});
+  const callback = await connectToNxCloud(tree, {
+    installationSource: command ?? 'nx-connect',
+  });
   tree.lock();
   flushChanges(workspaceRoot, tree.listChanges());
   await callback();
@@ -96,7 +100,7 @@ export async function connectToNxCloudCommand(): Promise<boolean> {
 export async function connectToNxCloudWithPrompt(command: string) {
   const setNxCloud = await nxCloudPrompt('setupNxCloud');
   const useCloud =
-    setNxCloud === 'yes' ? await connectToNxCloudCommand() : false;
+    setNxCloud === 'yes' ? await connectToNxCloudCommand(command) : false;
   await recordStat({
     command,
     nxVersion,

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -6,7 +6,10 @@ import { readJson } from '../../../generators/utils/json';
 import { NxJsonConfiguration } from '../../../config/nx-json';
 import { readNxJson, updateNxJson } from '../../../generators/utils/nx-json';
 import { formatChangedFilesWithPrettierIfAvailable } from '../../../generators/internal-utils/format-changed-files-with-prettier-if-available';
-import { shortenedCloudUrl } from '../../utilities/url-shorten';
+import { repoUsesGithub, shortenedCloudUrl } from '../../utilities/url-shorten';
+import { commitChanges } from '../../../utils/git-utils';
+import * as ora from 'ora';
+import * as open from 'open';
 
 function printCloudConnectionDisabledMessage() {
   output.error({
@@ -75,9 +78,10 @@ async function createNxCloudWorkspace(
 
 async function printSuccessMessage(
   url: string,
-  token: string,
+  token: string | undefined,
   installationSource: string,
-  github: boolean
+  usesGithub?: boolean,
+  directory?: string
 ) {
   if (process.env.NX_NEW_CLOUD_ONBOARDING !== 'true') {
     let origin = 'https://nx.app';
@@ -97,20 +101,63 @@ async function printSuccessMessage(
     const connectCloudUrl = await shortenedCloudUrl(
       installationSource,
       token,
-      github
+      usesGithub
     );
 
-    output.note({
-      title: `Your Nx Cloud workspace is ready.`,
-      bodyLines: [
-        `To claim it, connect it to your Nx Cloud account:`,
-        `- Commit and push your changes.`,
-        `- Create a pull request for the changes.`,
-        `- Go to the following URL to connect your workspace to Nx Cloud: 
-        
-        ${connectCloudUrl}`,
-      ],
-    });
+    if (installationSource === 'nx-connect' && usesGithub) {
+      try {
+        const cloudConnectSpinner = ora(
+          `Opening Nx Cloud ${connectCloudUrl} in your browser to connect your workspace.`
+        ).start();
+        await sleep(2000);
+        open(connectCloudUrl);
+        cloudConnectSpinner.succeed();
+      } catch (e) {
+        output.note({
+          title: `Your Nx Cloud workspace is ready.`,
+          bodyLines: [
+            `To claim it, connect it to your Nx Cloud account:`,
+            `- Go to the following URL to connect your workspace to Nx Cloud:`,
+            '',
+            `${connectCloudUrl}`,
+          ],
+        });
+      }
+    } else {
+      if (installationSource === 'create-nx-workspace') {
+        output.note({
+          title: `Your Nx Cloud workspace is ready.`,
+          bodyLines: [
+            `To claim it, connect it to your Nx Cloud account:`,
+            `- Push your repository to your git hosting provider.`,
+            `- Go to the following URL to connect your workspace to Nx Cloud:`,
+            '',
+            `${connectCloudUrl}`,
+          ],
+        });
+        commitChanges(
+          `feat(nx): Added Nx Cloud token to your nx.json
+          
+          To connect your workspace to Nx Cloud, push your repository 
+          to your git hosting provider and go to the following URL:   
+          
+          ${connectCloudUrl}`,
+          directory
+        );
+      } else {
+        output.note({
+          title: `Your Nx Cloud workspace is ready.`,
+          bodyLines: [
+            `To claim it, connect it to your Nx Cloud account:`,
+            `- Commit and push your changes.`,
+            `- Create a pull request for the changes.`,
+            `- Go to the following URL to connect your workspace to Nx Cloud:`,
+            '',
+            `${connectCloudUrl}`,
+          ],
+        });
+      }
+    }
   }
 }
 
@@ -119,6 +166,7 @@ interface ConnectToNxCloudOptions {
   installationSource?: string;
   hideFormatLogs?: boolean;
   github?: boolean;
+  directory?: string;
 }
 
 function addNxCloudOptionsToNxJson(
@@ -152,27 +200,70 @@ export async function connectToNxCloud(
       printCloudConnectionDisabledMessage();
     };
   } else {
-    // TODO: Change to using loading light client when that is enabled by default
-    const r = await createNxCloudWorkspace(
-      getRootPackageName(tree),
-      schema.installationSource,
-      getNxInitDate()
-    );
-
-    addNxCloudOptionsToNxJson(tree, nxJson, r.token);
-
-    await formatChangedFilesWithPrettierIfAvailable(tree, {
-      silent: schema.hideFormatLogs,
-    });
-
-    return async () =>
-      await printSuccessMessage(
-        r.url,
-        r.token,
+    if (process.env.NX_NEW_CLOUD_ONBOARDING !== 'true') {
+      // TODO: Change to using loading light client when that is enabled by default
+      const r = await createNxCloudWorkspace(
+        getRootPackageName(tree),
         schema.installationSource,
-        schema.github
+        getNxInitDate()
       );
+
+      addNxCloudOptionsToNxJson(tree, nxJson, r.token);
+
+      await formatChangedFilesWithPrettierIfAvailable(tree, {
+        silent: schema.hideFormatLogs,
+      });
+
+      return async () =>
+        await printSuccessMessage(r.url, r.token, schema.installationSource);
+    } else {
+      const usesGithub = await repoUsesGithub(schema.github);
+
+      let responseFromCreateNxCloudWorkspace:
+        | {
+            token: string;
+            url: string;
+          }
+        | undefined;
+
+      // do NOT create Nx Cloud token (createNxCloudWorkspace)
+      // if user is using github and is running nx-connect
+      if (!(usesGithub && schema.installationSource === 'nx-connect')) {
+        responseFromCreateNxCloudWorkspace = await createNxCloudWorkspace(
+          getRootPackageName(tree),
+          schema.installationSource,
+          getNxInitDate()
+        );
+
+        addNxCloudOptionsToNxJson(
+          tree,
+          nxJson,
+          responseFromCreateNxCloudWorkspace?.token
+        );
+
+        await formatChangedFilesWithPrettierIfAvailable(tree, {
+          silent: schema.hideFormatLogs,
+        });
+      }
+      const apiUrl = removeTrailingSlash(
+        process.env.NX_CLOUD_API ||
+          process.env.NRWL_API ||
+          `https://cloud.nx.app`
+      );
+      return async () =>
+        await printSuccessMessage(
+          responseFromCreateNxCloudWorkspace?.url ?? apiUrl,
+          responseFromCreateNxCloudWorkspace?.token,
+          schema.installationSource,
+          usesGithub,
+          schema.directory
+        );
+    }
   }
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export default connectToNxCloud;

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json
@@ -25,6 +25,11 @@
       "type": "boolean",
       "description": "If the user will be using GitHub as their git hosting provider",
       "default": false
+    },
+    "directory": {
+      "type": "string",
+      "description": "The directory where the workspace is located",
+      "x-priority": "internal"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Unhiding the changes: https://github.com/nrwl/nx/pull/26623

## Features

* update GitHub onboarding URL

* Do not generate token on nx-connect if user uses GitHub and do not change their `nx.json`

* open browser to connect to Nx Cloud automatically when user is on `nx connect` and uses GitHub

* Create separate commit for Nx cloud token and CI on `create-nx-workspace`

* Fix the messaging for `create-nx-workspace`

* Updated git commit and fixed body lines when printing connect URL

* check Nx Cloud version - if less than 2406.11.5 then just print a URL to the root of the site

## Wed 19 Jun updates

* Add URL to `nx connect` message for opening browser

<img width="579" alt="Screenshot 2024-06-19 at 4 34 26 PM" src="https://github.com/nrwl/nx/assets/6603745/e7018dd9-cae2-4d19-b50c-49c16eac5fac">

* Include "connect to cloud" URL in the `create-nx-workspace` commit message

<img width="759" alt="Screenshot 2024-06-19 at 4 26 31 PM" src="https://github.com/nrwl/nx/assets/6603745/ee8c8bfe-ec7b-4114-97a5-158e274d7ed6">

* change `stop` to `succeed` for `ora` spinner

## Videos

I have created two looms for this, they are attached to the Linear issues related to this PR.

