### PR TITLE
fix(misc): rename @nrwl/* to @nx/* in init generator descriptions

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -502,7 +502,7 @@
     },
     "generators": {
       "/nx-api/cypress/generators/init": {
-        "description": "Initialize the `@nrwl/cypress` plugin.",
+        "description": "Initialize the `@nx/cypress` plugin.",
         "file": "generated/packages/cypress/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -591,7 +591,7 @@
     },
     "generators": {
       "/nx-api/detox/generators/init": {
-        "description": "Initialize the `@nrwl/detox` plugin.",
+        "description": "Initialize the `@nx/detox` plugin.",
         "file": "generated/packages/detox/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -679,7 +679,7 @@
     },
     "generators": {
       "/nx-api/esbuild/generators/init": {
-        "description": "Initialize the `@nrwl/esbuild` plugin.",
+        "description": "Initialize the `@nx/esbuild` plugin.",
         "file": "generated/packages/esbuild/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1018,7 +1018,7 @@
     "executors": {},
     "generators": {
       "/nx-api/express/generators/init": {
-        "description": "Initialize the `@nrwl/express` plugin.",
+        "description": "Initialize the `@nx/express` plugin.",
         "file": "generated/packages/express/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1114,7 +1114,7 @@
     },
     "generators": {
       "/nx-api/jest/generators/init": {
-        "description": "Initialize the `@nrwl/jest` plugin.",
+        "description": "Initialize the `@nx/jest` plugin.",
         "file": "generated/packages/jest/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1309,7 +1309,7 @@
         "type": "generator"
       },
       "/nx-api/nest/generators/init": {
-        "description": "Initialize the `@nrwl/nest` plugin.",
+        "description": "Initialize the `@nx/nest` plugin.",
         "file": "generated/packages/nest/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1515,7 +1515,7 @@
     },
     "generators": {
       "/nx-api/next/generators/init": {
-        "description": "Initialize the `@nrwl/next` plugin.",
+        "description": "Initialize the `@nx/next` plugin.",
         "file": "generated/packages/next/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1603,7 +1603,7 @@
     "executors": {},
     "generators": {
       "/nx-api/node/generators/init": {
-        "description": "Initialize the `@nrwl/node` plugin.",
+        "description": "Initialize the `@nx/node` plugin.",
         "file": "generated/packages/node/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -2187,7 +2187,7 @@
     },
     "generators": {
       "/nx-api/react/generators/init": {
-        "description": "Initialize the `@nrwl/react` plugin.",
+        "description": "Initialize the `@nx/react` plugin.",
         "file": "generated/packages/react/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -2748,7 +2748,7 @@
     },
     "generators": {
       "/nx-api/rollup/generators/init": {
-        "description": "Initialize the `@nrwl/rollup` plugin.",
+        "description": "Initialize the `@nx/rollup` plugin.",
         "file": "generated/packages/rollup/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -3199,7 +3199,7 @@
     },
     "generators": {
       "/nx-api/webpack/generators/init": {
-        "description": "Initialize the `@nrwl/webpack` plugin.",
+        "description": "Initialize the `@nx/webpack` plugin.",
         "file": "generated/packages/webpack/generators/init.json",
         "hidden": true,
         "name": "init",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -494,7 +494,7 @@
     ],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/cypress` plugin.",
+        "description": "Initialize the `@nx/cypress` plugin.",
         "file": "generated/packages/cypress/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -582,7 +582,7 @@
     ],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/detox` plugin.",
+        "description": "Initialize the `@nx/detox` plugin.",
         "file": "generated/packages/detox/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -668,7 +668,7 @@
     ],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/esbuild` plugin.",
+        "description": "Initialize the `@nx/esbuild` plugin.",
         "file": "generated/packages/esbuild/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1003,7 +1003,7 @@
     "executors": [],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/express` plugin.",
+        "description": "Initialize the `@nx/express` plugin.",
         "file": "generated/packages/express/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1097,7 +1097,7 @@
     ],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/jest` plugin.",
+        "description": "Initialize the `@nx/jest` plugin.",
         "file": "generated/packages/jest/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1290,7 +1290,7 @@
         "type": "generator"
       },
       {
-        "description": "Initialize the `@nrwl/nest` plugin.",
+        "description": "Initialize the `@nx/nest` plugin.",
         "file": "generated/packages/nest/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1495,7 +1495,7 @@
     ],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/next` plugin.",
+        "description": "Initialize the `@nx/next` plugin.",
         "file": "generated/packages/next/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -1582,7 +1582,7 @@
     "executors": [],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/node` plugin.",
+        "description": "Initialize the `@nx/node` plugin.",
         "file": "generated/packages/node/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -2161,7 +2161,7 @@
     ],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/react` plugin.",
+        "description": "Initialize the `@nx/react` plugin.",
         "file": "generated/packages/react/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -2719,7 +2719,7 @@
     ],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/rollup` plugin.",
+        "description": "Initialize the `@nx/rollup` plugin.",
         "file": "generated/packages/rollup/generators/init.json",
         "hidden": true,
         "name": "init",
@@ -3164,7 +3164,7 @@
     ],
     "generators": [
       {
-        "description": "Initialize the `@nrwl/webpack` plugin.",
+        "description": "Initialize the `@nx/webpack` plugin.",
         "file": "generated/packages/webpack/generators/init.json",
         "hidden": true,
         "name": "init",

--- a/docs/generated/packages/cypress/generators/init.json
+++ b/docs/generated/packages/cypress/generators/init.json
@@ -36,7 +36,7 @@
     },
     "presets": []
   },
-  "description": "Initialize the `@nrwl/cypress` plugin.",
+  "description": "Initialize the `@nx/cypress` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/cypress/src/generators/init/init#cypressInitGeneratorInternal.ts",

--- a/docs/generated/packages/detox/generators/init.json
+++ b/docs/generated/packages/detox/generators/init.json
@@ -35,7 +35,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/detox` plugin.",
+  "description": "Initialize the `@nx/detox` plugin.",
   "hidden": true,
   "implementation": "/packages/detox/src/generators/init/init#detoxInitGeneratorInternal.ts",
   "aliases": [],

--- a/docs/generated/packages/esbuild/generators/init.json
+++ b/docs/generated/packages/esbuild/generators/init.json
@@ -29,7 +29,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/esbuild` plugin.",
+  "description": "Initialize the `@nx/esbuild` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/esbuild/src/generators/init/init#esbuildInitGenerator.ts",

--- a/docs/generated/packages/express/generators/init.json
+++ b/docs/generated/packages/express/generators/init.json
@@ -29,7 +29,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/express` plugin.",
+  "description": "Initialize the `@nx/express` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/express/src/generators/init/init#initGenerator.ts",

--- a/docs/generated/packages/jest/generators/init.json
+++ b/docs/generated/packages/jest/generators/init.json
@@ -37,7 +37,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/jest` plugin.",
+  "description": "Initialize the `@nx/jest` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/jest/src/generators/init/init#jestInitGeneratorInternal.ts",

--- a/docs/generated/packages/nest/generators/init.json
+++ b/docs/generated/packages/nest/generators/init.json
@@ -30,7 +30,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/nest` plugin.",
+  "description": "Initialize the `@nx/nest` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/nest/src/generators/init/init.ts",

--- a/docs/generated/packages/next/generators/init.json
+++ b/docs/generated/packages/next/generators/init.json
@@ -36,7 +36,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/next` plugin.",
+  "description": "Initialize the `@nx/next` plugin.",
   "hidden": true,
   "implementation": "/packages/next/src/generators/init/init#nextInitGeneratorInternal.ts",
   "aliases": [],

--- a/docs/generated/packages/node/generators/init.json
+++ b/docs/generated/packages/node/generators/init.json
@@ -29,7 +29,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/node` plugin.",
+  "description": "Initialize the `@nx/node` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/node/src/generators/init/init.ts",

--- a/docs/generated/packages/react/generators/init.json
+++ b/docs/generated/packages/react/generators/init.json
@@ -29,7 +29,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/react` plugin.",
+  "description": "Initialize the `@nx/react` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/react/src/generators/init/init#reactInitGenerator.ts",

--- a/docs/generated/packages/rollup/generators/init.json
+++ b/docs/generated/packages/rollup/generators/init.json
@@ -35,7 +35,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/rollup` plugin.",
+  "description": "Initialize the `@nx/rollup` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/rollup/src/generators/init/init#rollupInitGenerator.ts",

--- a/docs/generated/packages/webpack/generators/init.json
+++ b/docs/generated/packages/webpack/generators/init.json
@@ -35,7 +35,7 @@
     "required": [],
     "presets": []
   },
-  "description": "Initialize the `@nrwl/webpack` plugin.",
+  "description": "Initialize the `@nx/webpack` plugin.",
   "aliases": ["ng-add"],
   "hidden": true,
   "implementation": "/packages/webpack/src/generators/init/init#webpackInitGeneratorInternal.ts",

--- a/packages/cypress/generators.json
+++ b/packages/cypress/generators.json
@@ -5,7 +5,7 @@
     "init": {
       "factory": "./src/generators/init/init#cypressInitGeneratorInternal",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/cypress` plugin.",
+      "description": "Initialize the `@nx/cypress` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },

--- a/packages/detox/generators.json
+++ b/packages/detox/generators.json
@@ -6,7 +6,7 @@
     "init": {
       "factory": "./src/generators/init/init#detoxInitGeneratorInternal",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/detox` plugin.",
+      "description": "Initialize the `@nx/detox` plugin.",
       "hidden": true
     },
     "application": {

--- a/packages/esbuild/generators.json
+++ b/packages/esbuild/generators.json
@@ -5,7 +5,7 @@
     "init": {
       "factory": "./src/generators/init/init#esbuildInitGenerator",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/esbuild` plugin.",
+      "description": "Initialize the `@nx/esbuild` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },

--- a/packages/express/generators.json
+++ b/packages/express/generators.json
@@ -6,7 +6,7 @@
     "init": {
       "factory": "./src/generators/init/init#initGenerator",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/express` plugin.",
+      "description": "Initialize the `@nx/express` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },

--- a/packages/jest/generators.json
+++ b/packages/jest/generators.json
@@ -5,7 +5,7 @@
     "init": {
       "factory": "./src/generators/init/init#jestInitGeneratorInternal",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/jest` plugin.",
+      "description": "Initialize the `@nx/jest` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },

--- a/packages/nest/generators.json
+++ b/packages/nest/generators.json
@@ -13,7 +13,7 @@
     "init": {
       "factory": "./src/generators/init/init",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/nest` plugin.",
+      "description": "Initialize the `@nx/nest` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },

--- a/packages/next/generators.json
+++ b/packages/next/generators.json
@@ -6,7 +6,7 @@
     "init": {
       "factory": "./src/generators/init/init#nextInitGeneratorInternal",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/next` plugin.",
+      "description": "Initialize the `@nx/next` plugin.",
       "hidden": true
     },
     "application": {

--- a/packages/node/generators.json
+++ b/packages/node/generators.json
@@ -6,7 +6,7 @@
     "init": {
       "factory": "./src/generators/init/init",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/node` plugin.",
+      "description": "Initialize the `@nx/node` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },

--- a/packages/react/generators.json
+++ b/packages/react/generators.json
@@ -6,7 +6,7 @@
     "init": {
       "factory": "./src/generators/init/init#reactInitGenerator",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/react` plugin.",
+      "description": "Initialize the `@nx/react` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },

--- a/packages/rollup/generators.json
+++ b/packages/rollup/generators.json
@@ -5,7 +5,7 @@
     "init": {
       "factory": "./src/generators/init/init#rollupInitGenerator",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/rollup` plugin.",
+      "description": "Initialize the `@nx/rollup` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },

--- a/packages/webpack/generators.json
+++ b/packages/webpack/generators.json
@@ -5,7 +5,7 @@
     "init": {
       "factory": "./src/generators/init/init#webpackInitGeneratorInternal",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initialize the `@nrwl/webpack` plugin.",
+      "description": "Initialize the `@nx/webpack` plugin.",
       "aliases": ["ng-add"],
       "hidden": true
     },


### PR DESCRIPTION
We forgot to rename these in the init generator descriptions. This affects tutorials since we've been including the terminal output with the wrong scope.


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
