### PR TITLE
fix(core): pick up changes to plugins configuration in daemon

### DIFF
--- a/packages/nx/src/daemon/server/plugins.ts
+++ b/packages/nx/src/daemon/server/plugins.ts
@@ -1,3 +1,4 @@
+import { hashObject } from '../../hasher/file-hasher';
 import { readNxJson } from '../../config/nx-json';
 import {
   LoadedNxPlugin,
@@ -5,14 +6,28 @@ import {
 } from '../../project-graph/plugins/internal-api';
 import { workspaceRoot } from '../../utils/workspace-root';
 
+let currentPluginsConfigurationHash: string;
 let loadedPlugins: LoadedNxPlugin[];
 let cleanup: () => void;
 
 export async function getPlugins() {
-  if (loadedPlugins) {
+  const pluginsConfiguration = readNxJson().plugins ?? [];
+  const pluginsConfigurationHash = hashObject(pluginsConfiguration);
+
+  // If the plugins configuration has not changed, reuse the current plugins
+  if (
+    loadedPlugins &&
+    pluginsConfigurationHash === currentPluginsConfigurationHash
+  ) {
     return loadedPlugins;
   }
-  const pluginsConfiguration = readNxJson().plugins ?? [];
+
+  // Cleanup current plugins before loading new ones
+  if (cleanup) {
+    cleanup();
+  }
+
+  currentPluginsConfigurationHash = pluginsConfigurationHash;
   const [result, cleanupFn] = await loadNxPlugins(
     pluginsConfiguration,
     workspaceRoot


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The previous set of plugins are reused even when the plugins configuration change (plugins are added/removed or have their options changed).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Plugins are cleaned up and reloaded when the plugins configuration change.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
