### PR TITLE
fix(core): repair sourcemaps that had file & plugin swapped

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1772,6 +1772,60 @@ describe('project-configuration-utils', () => {
         `);
       }
     });
+
+    it('should correctly set source maps', async () => {
+      const { sourceMaps } = await createProjectConfigurations(
+        undefined,
+        {},
+        ['libs/a/project.json'],
+        [
+          new LoadedNxPlugin(fakeTargetsPlugin, 'fake-targets-plugin'),
+          new LoadedNxPlugin(fakeTagPlugin, 'fake-tag-plugin'),
+        ]
+      );
+      expect(sourceMaps).toMatchInlineSnapshot(`
+        {
+          "libs/a": {
+            "name": [
+              "libs/a/project.json",
+              "fake-tag-plugin",
+            ],
+            "root": [
+              "libs/a/project.json",
+              "fake-tag-plugin",
+            ],
+            "tags": [
+              "libs/a/project.json",
+              "fake-tag-plugin",
+            ],
+            "tags.fake-lib": [
+              "libs/a/project.json",
+              "fake-tag-plugin",
+            ],
+            "targets": [
+              "libs/a/project.json",
+              "fake-targets-plugin",
+            ],
+            "targets.build": [
+              "libs/a/project.json",
+              "fake-targets-plugin",
+            ],
+            "targets.build.executor": [
+              "libs/a/project.json",
+              "fake-targets-plugin",
+            ],
+            "targets.build.options": [
+              "libs/a/project.json",
+              "fake-targets-plugin",
+            ],
+            "targets.build.options.command": [
+              "libs/a/project.json",
+              "fake-targets-plugin",
+            ],
+          },
+        }
+      `);
+    });
   });
 });
 

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -459,7 +459,7 @@ function mergeCreateNodesResults(
   > = {};
 
   for (const result of results.flat()) {
-    const [file, pluginName, nodes] = result;
+    const [pluginName, file, nodes] = result;
 
     const { projects: projectNodes, externalNodes: pluginExternalNodes } =
       nodes;


### PR DESCRIPTION

## Current Behavior
File & Plugin are swapped, causing issues in the PDV & Nx Console

## Expected Behavior
SourceInfo should be `[file: string | null, plugin: string];` instead of `[plugin: string, file: string | null];`

