### PR TITLE
fix(linter): Correctly collect lintable files for project in @nx/eslint plugin

### DIFF
--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -13,7 +13,7 @@ import {
 } from '@nx/devkit';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { existsSync } from 'node:fs';
-import { basename, dirname, join, normalize, sep } from 'node:path';
+import { basename, dirname, join, normalize, sep } from 'node:path/posix';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { combineGlobPatterns } from 'nx/src/utils/globs';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
On Windows, the different path separators cause issues in determining whether a project has files that can be linted.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The project should correctly identify lintable files on Windows, regardless of the path separator used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Fixes #