### PR TITLE
fix(storybook): output should match CLI flag

### DIFF
--- a/packages/storybook/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/storybook/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -235,7 +235,7 @@ describe('Storybook - Convert To Inferred', () => {
               "output-dir": "../../dist/storybook/apps/app1",
             },
             "outputs": [
-              "{projectRoot}/{options.outputDir}",
+              "{projectRoot}/{options.output-dir}",
               "{workspaceRoot}/{projectRoot}/storybook-static",
               "{options.output-dir}",
               "{options.outputDir}",
@@ -311,7 +311,7 @@ describe('Storybook - Convert To Inferred', () => {
               "output-dir": "../../dist/storybook/apps/app1",
             },
             "outputs": [
-              "{projectRoot}/{options.outputDir}",
+              "{projectRoot}/{options.output-dir}",
               "{workspaceRoot}/{projectRoot}/storybook-static",
               "{options.output-dir}",
               "{options.outputDir}",
@@ -386,7 +386,7 @@ describe('Storybook - Convert To Inferred', () => {
               "webpack-stats-json": true,
             },
             "outputs": [
-              "{projectRoot}/{options.outputDir}",
+              "{projectRoot}/{options.output-dir}",
               "{workspaceRoot}/{projectRoot}/storybook-static",
               "{options.output-dir}",
               "{options.outputDir}",
@@ -445,7 +445,7 @@ describe('Storybook - Convert To Inferred', () => {
               "output-dir": "../../dist/storybook/apps/app1",
             },
             "outputs": [
-              "{projectRoot}/{options.outputDir}",
+              "{projectRoot}/{options.output-dir}",
               "{workspaceRoot}/{projectRoot}/storybook-static",
               "{options.output-dir}",
               "{options.outputDir}",
@@ -564,7 +564,7 @@ describe('Storybook - Convert To Inferred', () => {
               "output-dir": "../../dist/storybook/apps/app1",
             },
             "outputs": [
-              "{projectRoot}/{options.outputDir}",
+              "{projectRoot}/{options.output-dir}",
               "{workspaceRoot}/{projectRoot}/storybook-static",
               "{options.output-dir}",
               "{options.outputDir}",
@@ -596,7 +596,7 @@ describe('Storybook - Convert To Inferred', () => {
               "output-dir": "../../dist/storybook/apps/project2",
             },
             "outputs": [
-              "{projectRoot}/{options.outputDir}",
+              "{projectRoot}/{options.output-dir}",
               "{workspaceRoot}/{projectRoot}/storybook-static",
               "{options.output-dir}",
               "{options.outputDir}",

--- a/packages/storybook/src/generators/convert-to-inferred/lib/build-post-target-transformer.spec.ts
+++ b/packages/storybook/src/generators/convert-to-inferred/lib/build-post-target-transformer.spec.ts
@@ -70,13 +70,17 @@ describe('buildPostTargetTransformer', () => {
         export default config;"
       `);
       expect(target).toMatchInlineSnapshot(`
-              {
-                "options": {
-                  "config-dir": ".storybook",
-                  "output-dir": "../../dist/storybook/myapp",
-                },
-              }
-          `);
+        {
+          "options": {
+            "config-dir": ".storybook",
+            "output-dir": "../../dist/storybook/myapp",
+          },
+          "outputs": [
+            "{projectRoot}/{options.output-dir}",
+            "{projectRoot}/{options.outputDir}",
+          ],
+        }
+      `);
     });
 
     it('should handle configurations correctly and migrate docsMode and staticDir to storybook config correctly', () => {
@@ -157,19 +161,23 @@ describe('buildPostTargetTransformer', () => {
         export default config;"
       `);
       expect(target).toMatchInlineSnapshot(`
-              {
-                "configurations": {
-                  "dev": {
-                    "config-dir": "./dev/.storybook",
-                    "output-dir": "../../dist/storybook/myapp/dev",
-                  },
-                },
-                "options": {
-                  "config-dir": ".storybook",
-                  "output-dir": "../../dist/storybook/myapp",
-                },
-              }
-          `);
+        {
+          "configurations": {
+            "dev": {
+              "config-dir": "./dev/.storybook",
+              "output-dir": "../../dist/storybook/myapp/dev",
+            },
+          },
+          "options": {
+            "config-dir": ".storybook",
+            "output-dir": "../../dist/storybook/myapp",
+          },
+          "outputs": [
+            "{projectRoot}/{options.output-dir}",
+            "{projectRoot}/{options.outputDir}",
+          ],
+        }
+      `);
       const devConfigFile = tree.read(
         'apps/myapp/dev/.storybook/main.ts',
         'utf-8'
@@ -262,13 +270,17 @@ describe('buildPostTargetTransformer', () => {
         export default config;"
       `);
       expect(target).toMatchInlineSnapshot(`
-              {
-                "options": {
-                  "config-dir": ".storybook",
-                  "output-dir": "../../dist/storybook/myapp",
-                },
-              }
-          `);
+        {
+          "options": {
+            "config-dir": ".storybook",
+            "output-dir": "../../dist/storybook/myapp",
+          },
+          "outputs": [
+            "{projectRoot}/{options.output-dir}",
+            "{projectRoot}/{options.outputDir}",
+          ],
+        }
+      `);
     });
 
     it('should handle configurations correctly and migrate docsMode and staticDir to storybook config correctly', () => {
@@ -349,19 +361,23 @@ describe('buildPostTargetTransformer', () => {
         export default config;"
       `);
       expect(target).toMatchInlineSnapshot(`
-              {
-                "configurations": {
-                  "dev": {
-                    "config-dir": "./dev/.storybook",
-                    "output-dir": "../../dist/storybook/myapp/dev",
-                  },
-                },
-                "options": {
-                  "config-dir": ".storybook",
-                  "output-dir": "../../dist/storybook/myapp",
-                },
-              }
-          `);
+        {
+          "configurations": {
+            "dev": {
+              "config-dir": "./dev/.storybook",
+              "output-dir": "../../dist/storybook/myapp/dev",
+            },
+          },
+          "options": {
+            "config-dir": ".storybook",
+            "output-dir": "../../dist/storybook/myapp",
+          },
+          "outputs": [
+            "{projectRoot}/{options.output-dir}",
+            "{projectRoot}/{options.outputDir}",
+          ],
+        }
+      `);
       const devConfigFile = tree.read(
         'apps/myapp/dev/.storybook/main.ts',
         'utf-8'
@@ -454,13 +470,17 @@ describe('buildPostTargetTransformer', () => {
         export default config;"
       `);
       expect(target).toMatchInlineSnapshot(`
-              {
-                "options": {
-                  "config-dir": ".storybook",
-                  "output-dir": "../../dist/storybook/myapp",
-                },
-              }
-          `);
+        {
+          "options": {
+            "config-dir": ".storybook",
+            "output-dir": "../../dist/storybook/myapp",
+          },
+          "outputs": [
+            "{projectRoot}/{options.output-dir}",
+            "{projectRoot}/{options.outputDir}",
+          ],
+        }
+      `);
     });
 
     it('should handle configurations correctly and migrate docsMode and staticDir to storybook config correctly', () => {
@@ -541,19 +561,23 @@ describe('buildPostTargetTransformer', () => {
         export default config;"
       `);
       expect(target).toMatchInlineSnapshot(`
-              {
-                "configurations": {
-                  "dev": {
-                    "config-dir": "./dev/.storybook",
-                    "output-dir": "../../dist/storybook/myapp/dev",
-                  },
-                },
-                "options": {
-                  "config-dir": ".storybook",
-                  "output-dir": "../../dist/storybook/myapp",
-                },
-              }
-          `);
+        {
+          "configurations": {
+            "dev": {
+              "config-dir": "./dev/.storybook",
+              "output-dir": "../../dist/storybook/myapp/dev",
+            },
+          },
+          "options": {
+            "config-dir": ".storybook",
+            "output-dir": "../../dist/storybook/myapp",
+          },
+          "outputs": [
+            "{projectRoot}/{options.output-dir}",
+            "{projectRoot}/{options.outputDir}",
+          ],
+        }
+      `);
       const devConfigFile = tree.read(
         'apps/myapp/dev/.storybook/main.ts',
         'utf-8'

--- a/packages/storybook/src/generators/convert-to-inferred/lib/build-post-target-transformer.ts
+++ b/packages/storybook/src/generators/convert-to-inferred/lib/build-post-target-transformer.ts
@@ -107,7 +107,7 @@ export function buildPostTargetTransformer(migrationLogs: AggregatedLog) {
     if (target.outputs) {
       processTargetOutputs(
         target,
-        [{ newName: 'outputDir', oldName: 'outputDir' }],
+        [{ newName: 'output-dir', oldName: 'outputDir' }],
         inferredTargetConfiguration,
         {
           projectName: projectDetails.projectName,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Output option is not renamed to match CLI flag

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Output option shuold be renamed to match CLI flag

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
