### PR TITLE
fix(bundling): rename aliases for @nx/rollup:convert-to-inferred generator

### DIFF
--- a/packages/rollup/src/generators/convert-to-inferred/lib/extract-rollup-config-from-executor-options.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/lib/extract-rollup-config-from-executor-options.ts
@@ -2,6 +2,12 @@ import { joinPathFragments, stripIndents, Tree } from '@nx/devkit';
 import { RollupExecutorOptions } from '../../../executors/rollup/schema';
 import { normalizePathOptions } from './normalize-path-options';
 
+const aliases = {
+  entryFile: 'main',
+  exports: 'generateExportsField',
+  f: 'format',
+};
+
 export function extractRollupConfigFromExecutorOptions(
   tree: Tree,
   options: RollupExecutorOptions,
@@ -36,7 +42,11 @@ export function extractRollupConfigFromExecutorOptions(
   for (const [key, value] of Object.entries(options)) {
     if (key === 'watch') continue;
     delete options[key];
-    defaultOptions[key] = value;
+    if (aliases[key]) {
+      defaultOptions[aliases[key]] = value;
+    } else {
+      defaultOptions[key] = value;
+    }
   }
   let configurationOptions: Record<string, Record<string, unknown>>;
   if (hasConfigurations) {

--- a/packages/rollup/src/plugins/with-nx/with-nx-options.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx-options.ts
@@ -1,24 +1,76 @@
-// TODO: Add TSDoc
 export interface RollupWithNxPluginOptions {
+  /**
+   * Additional entry-points to add to exports field in the package.json file.
+   * */
   additionalEntryPoints?: string[];
+  /**
+   * Allow JavaScript files to be compiled.
+   */
   allowJs?: boolean;
+  /**
+   * List of static assets.
+   */
   assets?: any[];
+  /**
+   * Whether to set rootmode to upward. See https://babeljs.io/docs/en/options#rootmode
+   */
   babelUpwardRootMode?: boolean;
+  /**
+   * Which compiler to use.
+   */
   compiler?: 'babel' | 'tsc' | 'swc';
+  /**
+   * Delete the output path before building. Defaults to true.
+   */
   deleteOutputPath?: boolean;
+  /**
+   * A list of external modules that will not be bundled (`react`, `react-dom`, etc.). Can also be set to `all` (bundle nothing) or `none` (bundle everything).
+   */
   external?: string[] | 'all' | 'none';
+  /**
+   * CSS files will be extracted to the output folder. Alternatively custom filename can be provided (e.g. styles.css)
+   */
   extractCss?: boolean | string;
+  /**
+   * List of module formats to output. Defaults to matching format from tsconfig (e.g. CJS for CommonJS, and ESM otherwise).
+   */
   format?: ('cjs' | 'esm')[];
+  /**
+   * Update the output package.json file's 'exports' field. This field is used by Node and bundles.
+   */
   generateExportsField?: boolean;
+  /**
+   * Sets `javascriptEnabled` option for less loader
+   */
   javascriptEnabled?: boolean;
+  /**
+   * The path to the entry file, relative to project.
+   */
   main: string;
-  /** @deprecated Do not set this. The package.json file in project root is detected automatically. */
+  /**
+   * The path to package.json file.
+   * @deprecated Do not set this. The package.json file in project root is detected automatically.
+   */
   project?: string;
+  /**
+   * Name of the main output file. Defaults same basename as 'main' file.
+   */
   outputFileName?: string;
+  /**
+   * The output path of the generated files.
+   */
   outputPath: string;
-  rollupConfig?: string | string[];
+  /**
+   * Whether to skip TypeScript type checking.
+   */
   skipTypeCheck?: boolean;
+  /**
+   * Prevents 'type' field from being added to compiled package.json file. Use this if you are having an issue with this field.
+   */
   skipTypeField?: boolean;
+  /**
+   * The path to tsconfig file.
+   */
   tsConfig: string;
 }
 


### PR DESCRIPTION
If you use `entryFile`, `f`, or `exports` in `project.json`, these fields do not migrate correctly to `rollup.config.js`.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
