### PR TITLE
fix(release): skip dependents of projects without changes in conventional commits

### DIFF
--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -397,6 +397,11 @@ export async function releaseChangelog(
       continue;
     }
     for (const project of releaseGroup.projects) {
+      // If the project does not have any changes, do not process its dependents
+      if (projectsVersionData[project].newVersion === null) {
+        continue;
+      }
+
       const dependentProjects = (
         projectsVersionData[project]?.dependentProjects || []
       )

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -398,12 +398,15 @@ export async function releaseChangelog(
     }
     for (const project of releaseGroup.projects) {
       // If the project does not have any changes, do not process its dependents
-      if (projectsVersionData[project].newVersion === null) {
+      if (
+        !projectsVersionData[project] ||
+        projectsVersionData[project].newVersion === null
+      ) {
         continue;
       }
 
       const dependentProjects = (
-        projectsVersionData[project]?.dependentProjects || []
+        projectsVersionData[project].dependentProjects || []
       )
         .map((dep) => {
           return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

In a repo, with this structure:

<img width="1223" alt="image" src="https://github.com/nrwl/nx/assets/900523/0b157f72-ed28-40b6-b946-f82bd464460d">

...using `nx release` with conventional commits, when a change is made to `A`, there will be an erroneous printing of `null` for package `E` under the dependency bumps section for the changelog of `C`

<img width="889" alt="image" src="https://github.com/nrwl/nx/assets/900523/d7cefa92-ed48-4fc6-ba06-20a03d7ba0ac">


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

After this change, the dependency bumps section for `C` (and all others in this setup) is correct:

<img width="877" alt="image" src="https://github.com/nrwl/nx/assets/900523/e7b68c81-a7f7-412a-b07e-25085f4737d7">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26564
