### PR TITLE
feat(release): allow disabling GitHub username matching in default changelog renderer

### DIFF
--- a/docs/shared/recipes/nx-release/configure-changelog-format.md
+++ b/docs/shared/recipes/nx-release/configure-changelog-format.md
@@ -18,7 +18,7 @@ The default changelog renderer for `nx release` generates a changelog entry for 
 
 ## Include All Metadata
 
-There are a few options available to modify the default changelog renderer output. They can be applied to both `workspaceChangelog` and `projectChangelogs` in exactly the same way. All three options are true by default:
+There are a few options available to modify the default changelog renderer output. They can be applied to both `workspaceChangelog` and `projectChangelogs` in exactly the same way. All four options are true by default:
 
 ```json
 {
@@ -27,6 +27,7 @@ There are a few options available to modify the default changelog renderer outpu
       "projectChangelogs": {
         "renderOptions": {
           "authors": true,
+          "mapAuthorsToGitHubUsernames": true,
           "commitReferences": true,
           "versionTitleDate": true
         }
@@ -39,6 +40,12 @@ There are a few options available to modify the default changelog renderer outpu
 #### `authors`
 
 Whether the commit authors should be added to the bottom of the changelog in a "Thank You" section. Defaults to `true`.
+
+#### `mapAuthorsToGitHubUsernames`
+
+If authors is enabled, controls whether or not to try to map the authors to their GitHub usernames using https://ungh.cc (from https://github.com/unjs/ungh) and the email addresses found in the commits. Defaults to `true`.
+
+You should disable this option if you don't want to make any external requests to https://ungh.cc
 
 #### `commitReferences`
 
@@ -59,6 +66,7 @@ If you prefer a more minimalist changelog, you can set all the options to false,
       "projectChangelogs": {
         "renderOptions": {
           "authors": false,
+          "mapAuthorsToGitHubUsernames": false,
           "commitReferences": false,
           "versionTitleDate": false
         }

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -67,6 +67,12 @@ export interface DefaultChangelogRenderOptions extends ChangelogRenderOptions {
    */
   authors?: boolean;
   /**
+   * If authors is enabled, controls whether or not to try to map the authors to their GitHub usernames
+   * using https://ungh.cc (from https://github.com/unjs/ungh) and the email addresses found in the commits.
+   * Defaults to true.
+   */
+  mapAuthorsToGitHubUsernames?: boolean;
+  /**
    * Whether or not the commit references (such as commit and/or PR links) should be included in the changelog.
    * Defaults to true.
    */
@@ -290,7 +296,7 @@ const defaultChangelogRenderer: ChangelogRenderer = async ({
     }
 
     // Try to map authors to github usernames
-    if (repoSlug) {
+    if (repoSlug && changelogRenderOptions.mapAuthorsToGitHubUsernames) {
       await Promise.all(
         [..._authors.keys()].map(async (authorName) => {
           const meta = _authors.get(authorName);

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -21,6 +21,7 @@ expect.addSnapshotSerializer({
     );
   },
 });
+
 describe('createNxReleaseConfig()', () => {
   let projectGraph: ProjectGraph;
   let projectFileMap: ProjectFileMap;
@@ -149,6 +150,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -323,6 +325,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -500,6 +503,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -708,6 +712,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -900,6 +905,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -1101,6 +1107,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -1300,6 +1307,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -1484,6 +1492,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -1663,6 +1672,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -2041,6 +2051,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -2159,6 +2170,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": true,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -2344,6 +2356,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": true,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -2368,6 +2381,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": true,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -2550,6 +2564,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": true,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -2625,6 +2640,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -2809,6 +2825,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -2992,6 +3009,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -3171,6 +3189,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -3370,6 +3389,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -3547,6 +3567,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -3736,6 +3757,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -3854,6 +3876,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": true,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -4108,6 +4131,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": false,
                   "commitReferences": false,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -4119,6 +4143,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -4237,6 +4262,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": false,
                     "commitReferences": false,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -4308,6 +4334,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -4319,6 +4346,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -4437,6 +4465,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": true,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -4509,6 +4538,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -4689,6 +4719,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -4867,6 +4898,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -5067,6 +5099,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -5264,6 +5297,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -5457,6 +5491,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -5651,6 +5686,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -5848,6 +5884,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -6025,6 +6062,7 @@ describe('createNxReleaseConfig()', () => {
               createRelease: 'github', // set field in group config
               renderOptions: {
                 authors: false, // override deeply nested field in group config
+                mapAuthorsToGitHubUsernames: false, // override deeply nested field in group config
               },
             },
           },
@@ -6062,6 +6100,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -6181,6 +6220,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": false,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": false,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -6219,6 +6259,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": true,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -6300,6 +6341,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -6311,6 +6353,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -6429,6 +6472,7 @@ describe('createNxReleaseConfig()', () => {
                   "renderOptions": {
                     "authors": true,
                     "commitReferences": true,
+                    "mapAuthorsToGitHubUsernames": true,
                     "versionTitleDate": true,
                   },
                   "renderer": "<dirname>/release/changelog-renderer",
@@ -7058,6 +7102,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -7244,6 +7289,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -7429,6 +7475,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -7622,6 +7669,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -7805,6 +7853,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",
@@ -8031,6 +8080,7 @@ describe('createNxReleaseConfig()', () => {
                 "renderOptions": {
                   "authors": true,
                   "commitReferences": true,
+                  "mapAuthorsToGitHubUsernames": true,
                   "versionTitleDate": true,
                 },
                 "renderer": "<dirname>/release/changelog-renderer",

--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -226,6 +226,7 @@ export async function createNxReleaseConfig(
             renderer: defaultRendererPath,
             renderOptions: {
               authors: true,
+              mapAuthorsToGitHubUsernames: true,
               commitReferences: true,
               versionTitleDate: true,
             },
@@ -240,6 +241,7 @@ export async function createNxReleaseConfig(
             renderer: defaultRendererPath,
             renderOptions: {
               authors: true,
+              mapAuthorsToGitHubUsernames: true,
               commitReferences: true,
               versionTitleDate: true,
             },
@@ -275,6 +277,7 @@ export async function createNxReleaseConfig(
       renderer: defaultRendererPath,
       renderOptions: {
         authors: true,
+        mapAuthorsToGitHubUsernames: true,
         commitReferences: true,
         versionTitleDate: true,
       },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

If users want author data, but not for that author data to be linked to GitHub usernames (or associated requests made to `ungh.cc`), they must provide a custom changelog renderer.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users can opt out of the GitHub usernames lookup and matching by setting `mapAuthorsToGitHubUsernames` in their `renderOptions` to `false`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26311
