### PR TITLE
fix(graph): use bg-inherit on target group headers

### DIFF
--- a/graph/ui-project-details/src/lib/target-configuration-details-group-container/target-configuration-details-group-container.tsx
+++ b/graph/ui-project-details/src/lib/target-configuration-details-group-container/target-configuration-details-group-container.tsx
@@ -16,7 +16,7 @@ export function TargetConfigurationGroupContainer({
       <TargetConfigurationGroupHeader
         targetGroupName={targetGroupName}
         targetsNumber={targetsNumber}
-        className="sticky top-0 z-10 bg-white dark:bg-slate-900"
+        className="sticky top-0 z-10 bg-inherit"
       />
       <div className="rounded-md border border-slate-200 p-2 dark:border-slate-700">
         {children}


### PR DESCRIPTION
In Nx Console, where we have different background colors, the hardcoded bg was causing issues.
## Current Behavior
![image](https://github.com/nrwl/nx/assets/34165455/57727b47-7709-4cc3-be9b-78a1011e73c5)


## Expected Behavior
![image](https://github.com/nrwl/nx/assets/34165455/6165fd01-77a9-4f61-9521-495870fcdda3)

