### PR TITLE
fix(webpack): host skip external remotes Fixes #26551

### DIFF
--- a/packages/webpack/src/generators/convert-to-inferred/utils/serve-post-target-transformer.ts
+++ b/packages/webpack/src/generators/convert-to-inferred/utils/serve-post-target-transformer.ts
@@ -213,18 +213,21 @@ function applyDefaults(
   options: WebpackConfigDevServerOptions,
   buildOptions: any
 ) {
-  if (options.port === undefined) {
-    options.port = 4200;
+  if (options) {
+    if (options.port === undefined) {
+      options.port = 4200;
+    }
+
+    options.headers = { 'Access-Control-Allow-Origin': '*' };
+
+    const servePath = buildServePath(buildOptions);
+    options.historyApiFallback = {
+      index:
+        buildOptions.index && `${servePath}${basename(buildOptions.index)}`,
+      disableDotRule: true,
+      htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
+    };
   }
-
-  options.headers = { 'Access-Control-Allow-Origin': '*' };
-
-  const servePath = buildServePath(buildOptions);
-  options.historyApiFallback = {
-    index: buildOptions.index && `${servePath}${basename(buildOptions.index)}`,
-    disableDotRule: true,
-    htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
-  };
 }
 
 function getProxyConfig(root: string, proxyConfig: string) {

--- a/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
+++ b/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
@@ -86,24 +86,24 @@ export function getRemotes(
     pathToManifestFile
   );
   remotes.forEach((r) => collectRemoteProjects(r, collectedRemotes, context));
-  const remotesToSkip = new Set(
+  const workspaceRemotesToSkip = new Set(
     findMatchingProjects(skipRemotes, context.projectGraph.nodes) ?? []
   );
 
-  if (remotesToSkip.size > 0) {
+  if (workspaceRemotesToSkip.size > 0) {
     logger.info(
-      `Remotes not served automatically: ${[...remotesToSkip.values()].join(
-        ', '
-      )}`
+      `Remotes not served automatically: ${[
+        ...workspaceRemotesToSkip.values(),
+      ].join(', ')}`
     );
   }
 
   const knownRemotes = Array.from(collectedRemotes).filter(
-    (r) => !remotesToSkip.has(r)
+    (r) => !workspaceRemotesToSkip.has(r)
   );
 
   const knownDynamicRemotes = dynamicRemotes.filter(
-    (r) => !remotesToSkip.has(r)
+    (r) => !workspaceRemotesToSkip.has(r)
   );
 
   logger.info(
@@ -120,12 +120,14 @@ export function getRemotes(
       : findMatchingProjects([devRemotes], context.projectGraph.nodes)
   );
 
+  const skipRemotesSet = new Set(skipRemotes);
+
   const staticRemotes = knownRemotes.filter((r) => !devServeApps.has(r));
-  const devServeRemotes = [...knownRemotes, ...dynamicRemotes].filter((r) =>
-    devServeApps.has(r)
+  const devServeRemotes = [...knownRemotes, ...dynamicRemotes].filter(
+    (r) => devServeApps.has(r) && !skipRemotesSet.has(r)
   );
   const staticDynamicRemotes = knownDynamicRemotes.filter(
-    (r) => !devServeApps.has(r)
+    (r) => !devServeApps.has(r) && !skipRemotesSet.has(r)
   );
   const remotePorts = [...devServeRemotes, ...staticDynamicRemotes].map(
     (r) => context.projectGraph.nodes[r].data.targets['serve'].options.port

--- a/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
+++ b/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
@@ -129,9 +129,11 @@ export function getRemotes(
   const staticDynamicRemotes = knownDynamicRemotes.filter(
     (r) => !devServeApps.has(r) && !skipRemotesSet.has(r)
   );
-  const remotePorts = [...devServeRemotes, ...staticDynamicRemotes].map(
-    (r) => context.projectGraph.nodes[r].data.targets['serve'].options.port
-  );
+  const remotePorts = [...devServeRemotes, ...staticDynamicRemotes]
+    .filter((r) => context.projectGraph.nodes[r]) // Check app's existence
+    .map(
+      (r) => context.projectGraph.nodes[r].data.targets['serve'].options.port
+    );
 
   return {
     staticRemotes,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Host ignores `skipRemotes` if located in an external workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Host correctly skips serving the remotes declared in the `skipRemotes` option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26551
