### PR TITLE
fix(vite): setup-paths-plugin should only register import once

### DIFF
--- a/packages/vite/src/generators/setup-paths-plugin/setup-paths-plugin.spec.ts
+++ b/packages/vite/src/generators/setup-paths-plugin/setup-paths-plugin.spec.ts
@@ -76,4 +76,62 @@ describe('@nx/vite:init', () => {
       "
     `);
   });
+
+  it('should not add nxViteTsPaths plugin to vite config files when it exists', async () => {
+    tree.write(
+      'proj1/vite.config.ts',
+      stripIndents`
+      import { defineConfig } from 'vite';
+      import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      export default defineConfig({});`
+    );
+    tree.write(
+      'proj2/vite.config.ts',
+      stripIndents`
+    import { defineConfig } from 'vite'
+    import react from '@vitejs/plugin-react'
+    export default defineConfig({
+      plugins: [react()],
+    })`
+    );
+    tree.write(
+      'proj3/vite.config.cts',
+      stripIndents`
+      const { defineConfig } = require('vite');
+      const react = require('@vitejs/plugin-react');
+      const { nxViteTsPaths } = require('@nx/vite/plugins/nx-tsconfig-paths.plugin');
+      module.exports = defineConfig({
+        plugins: [react()],
+      });
+      `
+    );
+
+    await setupPathsPlugin(tree, {});
+
+    expect(tree.read('proj1/vite.config.ts').toString()).toMatchInlineSnapshot(`
+      "import { defineConfig } from 'vite';
+      import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      export default defineConfig({ plugins: [nxViteTsPaths()] });
+      "
+    `);
+    expect(tree.read('proj2/vite.config.ts').toString()).toMatchInlineSnapshot(`
+      "import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+      import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      export default defineConfig({
+        plugins: [react(), nxViteTsPaths()],
+      });
+      "
+    `);
+    expect(tree.read('proj3/vite.config.cts').toString())
+      .toMatchInlineSnapshot(`
+      "const { defineConfig } = require('vite');
+      const react = require('@vitejs/plugin-react');
+      const { nxViteTsPaths } = require('@nx/vite/plugins/nx-tsconfig-paths.plugin');
+      module.exports = defineConfig({
+        plugins: [react(), nxViteTsPaths()],
+      });
+      "
+    `);
+  });
 });

--- a/packages/vite/src/generators/setup-paths-plugin/setup-paths-plugin.ts
+++ b/packages/vite/src/generators/setup-paths-plugin/setup-paths-plugin.ts
@@ -25,11 +25,14 @@ export async function setupPathsPlugin(
   }
 }
 
-function ensureImportExists(tree, file) {
+function ensureImportExists(tree: Tree, file: string) {
   const { tsquery } = require('@phenomnomnominal/tsquery');
   let content = tree.read(file, 'utf-8');
   const ast = tsquery.ast(content);
   const allImports = tsquery.query(ast, 'ImportDeclaration');
+  if (content.includes('@nx/vite/plugins/nx-tsconfig-paths.plugin')) {
+    return;
+  }
   if (allImports.length) {
     const lastImport = allImports[allImports.length - 1];
     tree.write(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/vite:setup-paths-plugin` generator is adding the import multiple times


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `@nx/vite:setup-paths-plugin` should only add the import when it does not exist

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
