### PR TITLE
fix(vite): incremental builds tmp tsconfig should have baseUrl set to workspace root

### DIFF
--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -430,7 +430,8 @@ export function createTmpTsConfig(
   tsconfigPath: string,
   workspaceRoot: string,
   projectRoot: string,
-  dependencies: DependentBuildableProjectNode[]
+  dependencies: DependentBuildableProjectNode[],
+  useWorkspaceAsBaseUrl: boolean = false
 ) {
   const tmpTsConfigPath = join(
     workspaceRoot,
@@ -445,6 +446,12 @@ export function createTmpTsConfig(
     dependencies
   );
   process.on('exit', () => cleanupTmpTsConfigFile(tmpTsConfigPath));
+
+  if (useWorkspaceAsBaseUrl) {
+    parsedTSConfig.compilerOptions ??= {};
+    parsedTSConfig.compilerOptions.baseUrl = workspaceRoot;
+  }
+
   writeJsonFile(tmpTsConfigPath, parsedTSConfig);
   return join(tmpTsConfigPath);
 }

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -110,7 +110,8 @@ There should at least be a tsconfig.base.json or tsconfig.json in the root of th
           foundTsConfigPath,
           workspaceRoot,
           relative(workspaceRoot, projectRoot),
-          dependencies
+          dependencies,
+          true
         );
 
         if (config.command === 'serve') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When nxViteTsPaths resolves the tmp tsconfig we create for the buildable libs, it uses the absoluteBaseUrl of the tsconfig to when creating the ESM matcher for resolving files.
There is no baseUrl set, therefore the absoluteBaseUrl becomes the directory of the tmp tsconfig
This means the paths to the built artifacts are incorrect


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the workspace root, which lines up with the output locations for built artifacts, for the baseUrl for the tmp tsconfig


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
