### PR TITLE
fix(module-federation): module-federation-dev-server hang caused by child process exiting too early (#26684)

### DIFF
--- a/packages/angular/src/executors/module-federation-dev-server/lib/build-static-remotes.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/lib/build-static-remotes.ts
@@ -67,13 +67,16 @@ export async function buildStaticRemotes(
       }
     });
     staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
-    staticProcess.on('exit', (code) => {
+    staticProcess.once('exit', (code) => {
       stdoutStream.end();
+      staticProcess.stdout.removeAllListeners('data');
+      staticProcess.stderr.removeAllListeners('data');
       if (code !== 0) {
         throw new Error(
           `Remote failed to start. A complete log can be found in: ${remoteBuildLogFile}`
         );
       }
+      res();
     });
     process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
     process.on('exit', () => staticProcess.kill('SIGTERM'));

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -224,13 +224,16 @@ async function buildStaticRemotes(
       }
     });
     staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
-    staticProcess.on('exit', (code) => {
+    staticProcess.once('exit', (code) => {
       stdoutStream.end();
+      staticProcess.stdout.removeAllListeners('data');
+      staticProcess.stderr.removeAllListeners('data');
       if (code !== 0) {
         throw new Error(
           `Remote failed to start. A complete log can be found in: ${remoteBuildLogFile}`
         );
       }
+      res();
     });
     process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
     process.on('exit', () => staticProcess.kill('SIGTERM'));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
See #26684 

## Expected Behavior
See #26684

Fixes #26684 

---

This fix is targeted at NX 19. For a backport to NX 18, a small, trivial change is necessary. I will file another PR targeting NX 18.
