### PR TITLE
fix(angular): migration of browserTarget to buildTarget should handle empty config #26681

### DIFF
--- a/packages/angular/src/migrations/update-17-1-0/browser-target-to-build-target.ts
+++ b/packages/angular/src/migrations/update-17-1-0/browser-target-to-build-target.ts
@@ -67,7 +67,7 @@ function updateConfig(config: {
   browserTarget?: string;
   buildTarget?: string;
 }): void {
-  if (config.browserTarget) {
+  if (config && config.browserTarget) {
     config.buildTarget ??= config.browserTarget;
     delete config.browserTarget;
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The migration from `browserTarget` to `buildTarget` assumed config would not be undefined.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The migration should check if config is undefined

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26681
