### PR TITLE
fix(module-federation): dynamic remotes external to workspace should be skipped correctly #26551

### DIFF
--- a/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
+++ b/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
@@ -103,7 +103,7 @@ export function getRemotes(
   );
 
   const knownDynamicRemotes = dynamicRemotes.filter(
-    (r) => !remotesToSkip.has(r)
+    (r) => !remotesToSkip.has(r) && context.projectGraph.nodes[r]
   );
 
   logger.info(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Module Federation utils were not checking if the remotes defined dynamically in the `module-federation.manifest.json` were in the project graph.



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Check that the dynamic remotes exist in the project graph before trying to do work with them

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26551
