### PR TITLE
fix(webpack): add comment to explain useLegacyNxPlugin and how to remove it

### DIFF
--- a/e2e/webpack/src/__snapshots__/webpack.legacy.test.ts.snap
+++ b/e2e/webpack/src/__snapshots__/webpack.legacy.test.ts.snap
@@ -20,6 +20,10 @@ module.exports = async () => ({
       // See: https://react-svgr.com/
       // svgr: false
     }),
+    // NOTE: useLegacyNxPlugin ensures that the non-standard Webpack configuration file previously used still works.
+    // To remove its usage, move options such as "plugins" into this file as standard Webpack configuration options.
+    // To enhance configurations after Nx plugins have applied, you can add a new plugin with the \\\`apply\\\` method.
+    // e.g. \\\`{ apply: (compiler) => { /* modify compiler.options */ }\\\`
     // eslint-disable-next-line react-hooks/rules-of-hooks
     await useLegacyNxPlugin(require('./webpack.config.old'), options),
   ],

--- a/packages/webpack/src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin.spec.ts
+++ b/packages/webpack/src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin.spec.ts
@@ -134,6 +134,10 @@ describe('convertConfigToWebpackPluginGenerator', () => {
             // See: https://react-svgr.com/
             // svgr: false
           }),
+          // NOTE: useLegacyNxPlugin ensures that the non-standard Webpack configuration file previously used still works.
+          // To remove its usage, move options such as "plugins" into this file as standard Webpack configuration options.
+          // To enhance configurations after Nx plugins have applied, you can add a new plugin with the \\\`apply\\\` method.
+          // e.g. \\\`{ apply: (compiler) => { /* modify compiler.options */ }\\\`
           // eslint-disable-next-line react-hooks/rules-of-hooks
           await useLegacyNxPlugin(require('./webpack.config.old'), options),
         ],
@@ -419,6 +423,10 @@ describe('convertConfigToWebpackPluginGenerator', () => {
             // See: https://react-svgr.com/
             // svgr: false
           }),
+          // NOTE: useLegacyNxPlugin ensures that the non-standard Webpack configuration file previously used still works.
+          // To remove its usage, move options such as "plugins" into this file as standard Webpack configuration options.
+          // To enhance configurations after Nx plugins have applied, you can add a new plugin with the \\\`apply\\\` method.
+          // e.g. \\\`{ apply: (compiler) => { /* modify compiler.options */ }\\\`
           // eslint-disable-next-line react-hooks/rules-of-hooks
           await useLegacyNxPlugin(require('./webpack.config.old'), options),
         ],

--- a/packages/webpack/src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin.ts
+++ b/packages/webpack/src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin.ts
@@ -111,6 +111,10 @@ export async function convertConfigToWebpackPluginGenerator(
                   // svgr: false
                   })`
                 },
+                // NOTE: useLegacyNxPlugin ensures that the non-standard Webpack configuration file previously used still works.
+                // To remove its usage, move options such as "plugins" into this file as standard Webpack configuration options.
+                // To enhance configurations after Nx plugins have applied, you can add a new plugin with the \`apply\` method.
+                // e.g. \`{ apply: (compiler) => { /* modify compiler.options */ }\`
                 // eslint-disable-next-line react-hooks/rules-of-hooks
                 await useLegacyNxPlugin(require('./webpack.config.old'), options),
               ],


### PR DESCRIPTION
This PR adds a comment when `useLegacyNxPlugin` is used so users know what it is, and how they can remove it. 

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
