### PR TITLE
feat(nx-cloud): remove first time using nx message from cnw

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -7,7 +7,7 @@ import { createWorkspace } from '../src/create-workspace';
 import { isKnownPreset, Preset } from '../src/utils/preset/preset';
 import { CLIErrorMessageConfig, output } from '../src/utils/output';
 import { nxVersion } from '../src/utils/nx/nx-version';
-import { pointToTutorialAndCourse } from '../src/utils/preset/point-to-tutorial-and-course';
+// import { pointToTutorialAndCourse } from '../src/utils/preset/point-to-tutorial-and-course';
 
 import { yargsDecorator } from './decorator';
 import { getPackageNameFromThirdPartyPreset } from '../src/utils/preset/get-third-party-preset';
@@ -236,13 +236,14 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
     printNxCloudSuccessMessage(workspaceInfo.nxCloudInfo);
   }
 
-  if (isKnownPreset(parsedArgs.preset)) {
-    pointToTutorialAndCourse(parsedArgs.preset as Preset);
-  } else {
-    output.log({
-      title: `Successfully applied preset: ${parsedArgs.preset}`,
-    });
-  }
+  // Commenting out for now
+  // if (isKnownPreset(parsedArgs.preset)) {
+  //   pointToTutorialAndCourse(parsedArgs.preset as Preset);
+  // } else {
+  //   output.log({
+  //     title: `Successfully applied preset: ${parsedArgs.preset}`,
+  //   });
+  // }
 }
 
 /**


### PR DESCRIPTION
Remove the "First time using Nx" message from CNW, to make sure the last log the user sees is the Cloud onboarding URL.

![Screenshot 2024-06-26 at 7 00 11 PM](https://github.com/nrwl/nx/assets/6603745/cb67e42c-945f-4206-8766-1806473255e0)


