### PR TITLE
fix(core): correctly detect Windows Bamboo agents as CI environments

### DIFF
--- a/packages/nx/src/utils/is-ci.ts
+++ b/packages/nx/src/utils/is-ci.ts
@@ -8,6 +8,7 @@ export function isCI() {
     process.env.CIRRUS_CI === 'true' ||
     process.env.TRAVIS === 'true' ||
     !!process.env['bamboo.buildKey'] ||
+    !!process.env['bamboo_buildKey'] ||
     !!process.env.CODEBUILD_BUILD_ID ||
     !!process.env.GITLAB_CI ||
     !!process.env.HEROKU_TEST_RUN_ID ||


### PR DESCRIPTION
This will treat the `bamboo_buildKey` environment variable as an indicator
that the current environment is a CI environment.

Fixes #26698

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
