### PR TITLE
fix(core): do not create projects twice from package.json

### DIFF
--- a/packages/nx/src/plugins/project-json/build-nodes/package-json-next-to-project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/package-json-next-to-project-json.spec.ts
@@ -18,9 +18,13 @@ describe('nx project.json plugin', () => {
     };
   });
 
-  it('should build projects from project.json', () => {
+  it('should build projects from package.json next to project.json', () => {
     memfs.vol.fromJSON(
       {
+        'package.json': JSON.stringify({
+          name: 'lib-a',
+          description: 'lib-a project description',
+        }),
         'packages/lib-a/project.json': JSON.stringify({
           name: 'lib-a',
           description: 'lib-a project description',
@@ -84,5 +88,39 @@ describe('nx project.json plugin', () => {
         },
       }
     `);
+  });
+
+  it('should not build package manager workspace projects from package.json next to project.json', () => {
+    memfs.vol.fromJSON(
+      {
+        'package.json': JSON.stringify({
+          name: 'lib-a',
+          description: 'lib-a project description',
+          workspaces: ['packages/lib-a'],
+        }),
+        'packages/lib-a/project.json': JSON.stringify({
+          name: 'lib-a',
+          description: 'lib-a project description',
+          targets: {
+            build: {
+              executor: 'nx:run-commands',
+              options: {},
+            },
+          },
+        }),
+        'packages/lib-a/package.json': JSON.stringify({
+          name: 'lib-a',
+          description: 'lib-a package description',
+          scripts: {
+            test: 'jest',
+          },
+        }),
+      },
+      '/root'
+    );
+
+    expect(
+      createNodesFunction('packages/lib-a/project.json', undefined, context)
+    ).toMatchInlineSnapshot(`{}`);
   });
 });

--- a/packages/nx/src/plugins/project-json/build-nodes/package-json-next-to-project-json.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/package-json-next-to-project-json.ts
@@ -9,6 +9,7 @@ import {
   getTagsFromPackageJson,
   readTargetsFromPackageJson,
 } from '../../../utils/package-json';
+import { buildPackageJsonWorkspacesMatcher } from '../../package-json-workspaces';
 
 // TODO: Remove this one day, this should not need to be done.
 
@@ -42,8 +43,16 @@ function createProjectFromPackageJsonNextToProjectJson(
   workspaceRoot: string
 ): ProjectConfiguration | null {
   const root = dirname(projectJsonPath);
-  const packageJsonPath = join(workspaceRoot, root, 'package.json');
-  if (!existsSync(packageJsonPath)) {
+  const relativePackageJsonPath = join(root, 'package.json');
+  const packageJsonPath = join(workspaceRoot, relativePackageJsonPath);
+  const readJson = (f) => readJsonFile(join(workspaceRoot, f));
+
+  // Do not create projects for package.json files
+  // that are part of the package manager workspaces
+  // Those package.json files will be processed later on
+  const matcher = buildPackageJsonWorkspacesMatcher(workspaceRoot, readJson);
+
+  if (!existsSync(packageJsonPath) || matcher(relativePackageJsonPath)) {
     return null;
   }
   try {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

NPM scripts show up twice in the project details view.

![image](https://github.com/nrwl/nx/assets/8104246/98c55a03-7e71-430f-9fc3-de91ce180e26)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

NPM scripts only show up once in the project details view.

![image](https://github.com/nrwl/nx/assets/8104246/27787794-a8ef-40be-b00a-c9b1d26182f2)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
