### PR TITLE
fix(misc): respect useInferencePlugin in nx.json when generating apps and libs

### DIFF
--- a/packages/rollup/src/generators/init/init.ts
+++ b/packages/rollup/src/generators/init/init.ts
@@ -3,6 +3,7 @@ import {
   createProjectGraphAsync,
   formatFiles,
   GeneratorCallback,
+  readNxJson,
   Tree,
 } from '@nx/devkit';
 import { nxVersion, rollupVersion } from '../../utils/versions';
@@ -12,7 +13,10 @@ import { createNodes } from '../../plugins/plugin';
 
 export async function rollupInitGenerator(tree: Tree, schema: Schema) {
   let task: GeneratorCallback = () => {};
-  schema.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';
+  const nxJson = readNxJson(tree);
+  schema.addPlugin ??=
+    process.env.NX_ADD_PLUGINS !== 'false' &&
+    nxJson.useInferencePlugins !== false;
 
   if (!schema.skipPackageJson) {
     const devDependencies = { '@nx/rollup': nxVersion };

--- a/packages/vue/src/generators/application/application.ts
+++ b/packages/vue/src/generators/application/application.ts
@@ -2,6 +2,7 @@ import {
   addProjectConfiguration,
   formatFiles,
   GeneratorCallback,
+  readNxJson,
   runTasksInSerial,
   toJS,
   Tree,
@@ -28,7 +29,11 @@ export async function applicationGeneratorInternal(
   _options: Schema
 ): Promise<GeneratorCallback> {
   const options = await normalizeOptions(tree, _options);
-  options.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';
+  const nxJson = readNxJson(tree);
+
+  options.addPlugin ??=
+    process.env.NX_ADD_PLUGINS !== 'false' &&
+    nxJson.useInferencePlugins !== false;
 
   const tasks: GeneratorCallback[] = [];
 

--- a/packages/vue/src/generators/library/lib/normalize-options.ts
+++ b/packages/vue/src/generators/library/lib/normalize-options.ts
@@ -1,4 +1,10 @@
-import { getProjects, logger, normalizePath, Tree } from '@nx/devkit';
+import {
+  getProjects,
+  logger,
+  normalizePath,
+  readNxJson,
+  Tree,
+} from '@nx/devkit';
 import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { NormalizedSchema, Schema } from '../schema';
 
@@ -36,9 +42,14 @@ export async function normalizeOptions(
       bundler = 'vite';
     }
   }
+  const nxJson = readNxJson(host);
+
+  const addPlugin =
+    process.env.NX_ADD_PLUGINS !== 'false' &&
+    nxJson.useInferencePlugins !== false;
 
   const normalized = {
-    addPlugin: process.env.NX_ADD_PLUGINS !== 'false',
+    addPlugin,
     ...options,
     bundler,
     fileName,


### PR DESCRIPTION
The `@nx/vue:app` and `@nx/vue:lib` generators do not respect `useInferencePlugins` set in `nx.json`. This PR fixes the generators. Same for `@nx/rollup:init`.
<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
