### PR TITLE
fix(core): add windowsHide for depencies-and-lockfile plugin with bun

### DIFF
--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -57,6 +57,7 @@ export const createNodes: CreateNodes = [
         ? readFileSync(lockFilePath).toString()
         : execSync(`bun ${lockFilePath}`, {
             maxBuffer: 1024 * 1024 * 10,
+            windowsHide: true,
           }).toString();
     const lockFileHash = getLockFileHash(lockFileContents);
 
@@ -102,6 +103,7 @@ export const createDependencies: CreateDependencies = (
         ? readFileSync(lockFilePath).toString()
         : execSync(`bun ${lockFilePath}`, {
             maxBuffer: 1024 * 1024 * 10,
+            windowsHide: true,
           }).toString();
     const lockFileHash = getLockFileHash(lockFileContents);
 


### PR DESCRIPTION
## Current Behavior
Using bun as a package manager on windows causes cmd windows to pop up when the project graph is computed.

## Expected Behavior
We shouldn't see any windows pop up.

## Related Issue(s)

Fixes https://github.com/nrwl/nx-console/issues/2149
