### PR TITLE
fix(core): do not load transpiler when within tsx environment

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -1,15 +1,50 @@
-import { dirname, join } from 'path';
+import { dirname, join, sep } from 'path';
 import type { TsConfigOptions } from 'ts-node';
 import type { CompilerOptions } from 'typescript';
-import { logger, NX_PREFIX, stripIndent } from '../../../utils/logger';
-import { existsSync } from 'fs';
-import { workspaceRoot } from '../../../utils/workspace-root';
+import { NX_PREFIX, logger, stripIndent } from '../../../utils/logger';
 
 const swcNodeInstalled = packageIsInstalled('@swc-node/register');
 const tsNodeInstalled = packageIsInstalled('ts-node/register');
 let ts: typeof import('typescript');
 
 let isTsEsmLoaderRegistered = false;
+
+/**
+ * tsx is a utility to run TypeScript files in node which is growing in popularity:
+ * https://tsx.is
+ *
+ * Behind the scenes it is invoking node with relevant --require and --import flags.
+ *
+ * If the user is invoking Nx via a script which is being invoked via tsx, then we
+ * do not need to register any transpiler at all as the environment will have already
+ * been configured by tsx. In fact, registering a transpiler such as ts-node or swc
+ * in this case causes issues.
+ *
+ * Because node is being invoked by tsx, the tsx binary does not end up in the final
+ * process.argv and so we need to check a few possible things to account for usage
+ * via different package managers (e.g. pnpm does not set process._ to tsx, but rather
+ * pnpm itself, modern yarn does not set process._ at all etc.).
+ */
+const isInvokedByTsx: boolean = (() => {
+  if (process.env._?.endsWith(`${sep}tsx`)) {
+    return true;
+  }
+  const requireArgs: string[] = [];
+  const importArgs: string[] = [];
+  (process.execArgv ?? []).forEach((arg, i) => {
+    if (arg === '-r' || arg === '--require') {
+      requireArgs.push(process.execArgv[i + 1]);
+    }
+    if (arg === '--import') {
+      importArgs.push(process.execArgv[i + 1]);
+    }
+  });
+  const isTsxPath = (p: string) => p.includes(`${sep}tsx${sep}`);
+  return (
+    requireArgs.some((a) => isTsxPath(a)) ||
+    importArgs.some((a) => isTsxPath(a))
+  );
+})();
 
 /**
  * Optionally, if swc-node and tsconfig-paths are available in the current workspace, apply the require
@@ -38,6 +73,11 @@ export function registerTsProject(
   path: string,
   configFilename?: string
 ): () => void {
+  // See explanation alongside isInvokedByTsx declaration
+  if (isInvokedByTsx) {
+    return () => {};
+  }
+
   const tsConfigPath = configFilename ? join(path, configFilename) : path;
   const compilerOptions: CompilerOptions = readCompilerOptions(tsConfigPath);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

If a user writes a custom script which wraps Nx (e.g. for `nx release` using our programmatic API) they may want to write it using TypeScript. If so, `tsx` (https://tsx.is) is becoming a more and more popular choice for invoking such a script because it supports a ton of different file and module combinations with zero config.

If a user invokes their script with `tsx` it is already priming node to be able to resolve TypeScript files and ESM files (and the combination of the two, `.mts` files). Therefore if we perform our usual register logic in this case and further add `swc` or `ts-node` into the mix, it causes conflicts in the node environment leading to hard to understand/troubleshoot errors such as:

```sh
[ERR_INVALID_URL_SCHEME]: The URL must be of scheme file
    at fileURLToPath (node:internal/url:1461:11)
    at finalizeResolution (node:internal/modules/esm/resolve:266:42)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1157:11)
    at nextResolve (node:internal/modules/esm/hooks:866:28)
    at F (file:///Users/james/Repos/open-source/typescript-eslint/typescript-eslint/node_modules/tsx/dist/esm/index.mjs?1719486022657:2:3049)
    at nextResolve (node:internal/modules/esm/hooks:866:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:304:30)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:352:35)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:234:38) {
  code: 'ERR_INVALID_URL_SCHEME'
}
```

And

```sh
TypeError: Cannot assign to read only property '.mjs' of object '[object Object]'
    at /Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/pirates/lib/index.js:101:44
    at Array.forEach (<anonymous>)
    at addHook (/Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/pirates/lib/index.js:95:8)
    at register (/Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/@swc-node/register/register.ts:135:17)
    at getSwcTranspiler (/Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/nx/src/plugins/js/utils/register.js:40:23)
    at /Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/nx/src/plugins/js/utils/register.js:119:22
    at registerTranspiler (/Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/nx/src/plugins/js/utils/register.js:143:12)
    at registerTsProject (/Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/nx/src/plugins/js/utils/register.js:15:9)
    at resolveChangelogRenderer (/Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/nx/src/command-line/release/utils/resolve-changelog-renderer.js:18:66)
    at ensureChangelogRenderersAreResolvable (/Users/james/Repos/open-source/angular-eslint/angular-eslint-alt/node_modules/nx/src/command-line/release/config/config.js:693:77)
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We detect when the current node process has been invoked via `tsx` and make our register logic a noop because everything in subsequent require/import calls should just work thanks to `tsx`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
