### PR TITLE
docs(misc): move videos further down because it looks weird

### DIFF
--- a/docs/blog/2023-10-20-nx-17-release.md
+++ b/docs/blog/2023-10-20-nx-17-release.md
@@ -6,8 +6,6 @@ cover_image: '/blog/images/2023-10-20/featured_img.png'
 tags: [nx, design]
 ---
 
-{% youtube src="https://www.youtube.com/embed/1Z0iA9K1o8M?si=9XxIboXSZ5yxFpIt" /%}
-
 We’re excited to announce the release of Nx version 17!
 
 This article will cover the main things you need to know to get the most out of Nx 17!
@@ -26,6 +24,12 @@ Here’s a Table of Contents so you can skip straight to the updates you care ab
 - [New Experimental Feature: Nx Release](#new-experimental-feature-nx-release)
 - [Experimental: Nx Project Inference API v2](#experimental-nx-project-inference-api-v2)
 - [20k Github Stars!!](#20k-github-stars)
+
+**Prefer a video?**
+
+{% youtube src="https://www.youtube.com/embed/1Z0iA9K1o8M?si=9XxIboXSZ5yxFpIt" /%}
+
+---
 
 ## It’s a Vue-tiful Day for Nx!
 

--- a/docs/blog/2024-05-08-nx-19-release.md
+++ b/docs/blog/2024-05-08-nx-19-release.md
@@ -6,11 +6,6 @@ cover_image: '/blog/images/2024-05-08/nx-19-thumbnail.png'
 tags: [nx, release]
 ---
 
-{% youtube
-src="https://youtu.be/U6eO8-w9DR0"
-title="Nx 19.0 Has Landed!!"
-width="100%" /%}
-
 Hey folks!
 
 It's been awhile since February, where in the midsts our big launch week, we launched Nx 18. Nx 18 introduced the biggest new enhancement to Nx to date: Project Crystal.
@@ -36,6 +31,15 @@ Here's the rundown of the major things we'll cover in this update:
 - [New Conference: Monorepo World 2024](#new-conference-monorepo-world-2024)
 - [Wrapping Up, And A Heartfelt Thank You](#wrapping-up-and-a-heartfelt-thank-you)
 - [Learn More](#learn-more)
+
+**Prefer a video?**
+
+{% youtube
+src="https://youtu.be/U6eO8-w9DR0"
+title="Nx 19.0 Has Landed!!"
+width="100%" /%}
+
+---
 
 ## NEW PLUGIN: @nx/gradle
 


### PR DESCRIPTION
Moves the videos further down in the blog post as otherwise the blog thumbnail and video (which has the same) follow one after the other which looks super weird.