### PR TITLE
fix(vite): infer build and serve targets when rollupOptions.input is present

### DIFF
--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -365,7 +365,7 @@ function getOutputs(
 
   const isBuildable =
     build?.lib ||
-    build?.rollupOptions?.inputs ||
+    build?.rollupOptions?.input ||
     existsSync(join(workspaceRoot, projectRoot, 'index.html'));
 
   const reportsDirectoryPath = normalizeOutputPath(


### PR DESCRIPTION
This PR adds a check for `build.rollupOptions.input` in addition to `build.rollupOptions.inputs`. Plugins like `sveltekit()` will use the former property, and we should infer build/server targets correctly in those cases.

## Current Behavior
`sveltekit()` is not supported

## Expected Behavior
`sveltekit()` and other setups using `input` are supported

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
