### PR TITLE
docs(core): contact dpe for eu cluster

### DIFF
--- a/docs/nx-cloud/enterprise/on-premise/auth-saml-managed.md
+++ b/docs/nx-cloud/enterprise/on-premise/auth-saml-managed.md
@@ -19,12 +19,14 @@ You'll be entering it in the instructions below.
 
    1. The Single Sign On URL needs to be:
       - If using the main-US cluster: `https://auth.nx.app/login/callback?connection=SAML-IDENTIFIER`
-      - If using the EU cluster: `https://auth.eu.nx.app/login/callback?connection=SAML-IDENTIFIER`
    2. The Audience should be `urn:auth0:nrwl:SAML-IDENTIFIER`
       - If using the main-US cluster: `urn:auth0:nrwl:SAML-IDENTIFIER`
-      - If using the EU cluster: `urn:auth0:nxcloud-eu:SAML-IDENTIFIER`
 
-   ![Okta 4](/nx-cloud/enterprise/on-premise/images/saml/okta_4_public.png)
+{% callout type="note" title="EU Cluster" %}
+Contact your developer productivity engineer (DPE) to configure SAML auth in the EU cluster. The EU cluster is only available for enterprise customers.
+{% /callout %}
+
+![Okta 4](/nx-cloud/enterprise/on-premise/images/saml/okta_4_public.png)
 
 4. Scroll down to attribute statements and configure them as per below:
 

--- a/docs/nx-cloud/features/nx-enterprise-on-prem.md
+++ b/docs/nx-cloud/features/nx-enterprise-on-prem.md
@@ -11,7 +11,7 @@ We offer multiple ways of running Nx Cloud for our Enterprise customers. The bel
 The quickest and easiest way to start using Nx Cloud is by utilizing our pre-existing secure, multi-tenant managed clusters:
 
 - [https://nx.app/](https://nx.app/)
-- [https://eu.nx.app/](https://eu.nx.app/) if you have special restrictions and your data needs to be hosted in Europe.
+- Enterprise customers can contact their developer productivity engineer (DPE) to configure the EU hosted version of Nx Cloud.
 
 You get the **same level of security**, **dedicated support**, and **predictable seat-based pricing** as all our other hosting options. But you won't have to manage the instance yourself.
 


### PR DESCRIPTION
Adds note explaining that enterprise customers need to work with their DPE to use the EU hosted version of Nx Cloud