### PR TITLE
fix(vite): remove deprecated cache.dir from vitest generation

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -106,9 +106,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/my-app',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -440,9 +437,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/myApp',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 

--- a/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -86,9 +86,6 @@ dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') 
         test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/my-lib'
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -386,9 +386,6 @@ export default defineConfig({
     setupFiles: ['test-setup.ts'],
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/test',
-    },
     environment: 'jsdom',
     include: ['./tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -900,9 +897,6 @@ export default defineConfig({
     setupFiles: ['test-setup.ts'],
     watch: false,
     globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest/apps/test',
-    },
     environment: 'jsdom',
     include: ['./tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -1221,9 +1215,6 @@ export default defineConfig({
     setupFiles: ['test-setup.ts'],
     watch: false,
     globals: true,
-    cache: {
-      dir: './node_modules/.vitest/test',
-    },
     environment: 'jsdom',
     include: ['./tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -51,9 +51,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/my-lib',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -270,9 +267,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest/libs/react-lib-nonb-jest',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -497,9 +491,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest/apps/my-test-react-app',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -23,9 +23,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest/apps/my-test-react-app',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     includeSource: ['src/**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
@@ -64,9 +61,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest/apps/my-test-react-app',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -100,9 +94,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest/libs/react-lib-nonb-jest',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -434,14 +434,6 @@ export function createOrEditViteConfig(
     ? `test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '${normalizedJoinPaths(
-        offsetFromRoot(projectRoot),
-        'node_modules',
-        '.vitest',
-        projectRoot === '.' ? options.project : projectRoot
-      )}'
-    },
     environment: '${options.testEnvironment ?? 'jsdom'}',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     ${

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -78,9 +78,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/TestApp',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -241,9 +238,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/test',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -53,9 +53,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/my-lib',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -150,9 +147,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../node_modules/.vitest/my-lib',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 

--- a/packages/workspace/src/generators/preset/__snapshots__/preset.spec.ts.snap
+++ b/packages/workspace/src/generators/preset/__snapshots__/preset.spec.ts.snap
@@ -108,9 +108,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: './node_modules/.vitest/proj',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -197,9 +194,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest/apps/proj',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 
@@ -252,9 +246,6 @@ export default defineConfig({
   test: {
     watch: false,
     globals: true,
-    cache: {
-      dir: './node_modules/.vitest/proj',
-    },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `cache.dir` option for `vitest` is deprecated in favour of `config.cacheDir` which we already generate.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Remove the deprecated option

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
