### PR TITLE
docs(nx-cloud): improve launch template docs with new image release

### DIFF
--- a/docs/nx-cloud/reference/launch-templates.md
+++ b/docs/nx-cloud/reference/launch-templates.md
@@ -68,19 +68,29 @@ A launch template's `image` defines the available base software for the agent ma
 ```yaml {% fileName=".nx/workflows/agents.yaml" %}
 launch-templates:
   template-one:
-    image: 'ubuntu22.04-node20.11-v7'
+    image: 'ubuntu22.04-node20.11-v9'
 ```
 
 Nx Cloud provides the following images:
 
 > Changes added in previous images are included in newer images unless otherwise denoted
+> Images also have [go 1.22](https://go.dev/) installed
 
 - `ubuntu22.04-node20.11-v5`
   - added elevated permission access via `sudo`
 - `ubuntu22.04-node20.11-v6`
+
   - `corepack` is enabled by default
+  - default global package manager versions:
+    - `npm` v10
+    - `yarn` v1
+    - `pnpm` v8
+    - See how to install a [specific package manger version](#specific-package-manager-version)
+
 - `ubuntu22.04-node20.11-v7`
   - added java version 17
+- `ubuntu22.04-node20.11-v9`
+  - added [nvm](https://github.com/nvm-sh/nvm)
 - `windows-2022`
 
 > Note: Windows-based images can only run on Windows-based [resource classes](#launch-templatestemplate-nameresourceclass).
@@ -195,7 +205,7 @@ launch-templates:
     # see the available resource list below
     resource-class: 'docker_linux_amd64/medium'
     # see the available image list below
-    image: 'ubuntu22.04-node20.11-v7'
+    image: 'ubuntu22.04-node20.11-v9'
     # Define environment variables shared among all steps
     env:
       MY_ENV_VAR: shared
@@ -253,7 +263,7 @@ launch-templates:
   # You're not required to define a template for every resource class, only define what you need!
   my-linux-large-js:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.11-v7'
+    image: 'ubuntu22.04-node20.11-v9'
     env:
       MY_ENV_VAR: shared
     init-steps:
@@ -293,7 +303,7 @@ launch-templates:
   # template that installs rust
   my-linux-rust-large:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.11-v7'
+    image: 'ubuntu22.04-node20.11-v9'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/checkout/main.yaml'
@@ -384,7 +394,7 @@ If your project consumes packages from a private registry, you'll have to set up
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.11-v7'
+    image: 'ubuntu22.04-node20.11-v9'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/checkout/main.yaml'
@@ -406,13 +416,47 @@ nx-cloud start-ci-run --distribute-on="5 my-linux-medium-js" --with-env-vars="SO
 
 ## Custom Node Version
 
-Nx Agents come with node LTS installed. If you want to use a different version, you can create a custom step to install the desired node version. Here is a simplified launch template using [nvm](https://github.com/nvm-sh/nvm) to install a different node version.
+Nx Agents come with node LTS installed. If you want to use a different version, you can add a step to install the desired node version.
+
+{% tabs %}
+{% tab label="Pre-Built Step" %}
+
+Nx Cloud provides a [pre-built step to install a custom node version](https://github.com/nrwl/nx-cloud-workflows/tree/main/workflow-steps/install-node) within your workflow. This step is available as of `v4` of the workflow steps and requires the minimum image version to be `ubuntu22.04-node20.11-v9`.
 
 ```yaml {% fileName=".nx/workflows/agents.yaml" %}
 launch-templates:
   node-21:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.11-v7'
+    # note the image version of v9,
+    # earlier versions of the base image will not work
+    image: 'ubuntu22.04-node20.11-v9'
+    init-steps:
+      - name: Checkout
+        uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/checkout/main.yaml'
+      - name: Install Node
+        # note the step is only released as of v4 of the workflow steps
+        uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node/main.yaml'
+        inputs:
+          # can omit value if a '.nvmrc' file is within the root of the repo
+          node_version: '21'
+```
+
+{% /tab %}
+{% tab label="Manual Installation" %}
+
+Here is a simplified launch template manually installing [nvm](https://github.com/nvm-sh/nvm) to manage different node version.
+Feel free to use your preferred tool, other popular options are [volta](https://volta.sh/) or [fnm](https://github.com/Schniz/fnm).
+The steps follow the general pattern of:
+
+1. install tool
+1. install node with tool
+1. persist any environment variable changes for future steps
+
+```yaml {% fileName=".nx/workflows/agents.yaml" %}
+launch-templates:
+  node-21:
+    resource-class: 'docker_linux_amd64/medium'
+    image: 'ubuntu22.04-node20.11-v9'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/checkout/main.yaml'
@@ -434,6 +478,9 @@ launch-templates:
       # Continue setup steps as needed
 ```
 
+{% /tab %}
+{% /tabs %}
+
 ## Specific Package Manager Version
 
 Nx Agents have [corepack enabled](https://nodejs.org/api/corepack.html#corepack) by default, allowing you to define the yarn or pnpm version via the `package.json`.
@@ -445,7 +492,7 @@ Nx Agents have [corepack enabled](https://nodejs.org/api/corepack.html#corepack)
 ```
 
 {% callout type="note" title="Supported Package Managers" %}
-Currently, corepack [only supports yarn or pnpm](https://nodejs.org/api/corepack.html#supported-package-managers) as package managers. If you need to use a specific npm version, you will need to create a custom launch template and install the specific npm version.
+Currently, corepack [only supports yarn or pnpm](https://nodejs.org/api/corepack.html#supported-package-managers) as package managers. If you need to use a specific npm version, you will need to create a custom launch template and install the specific npm version, i.e. `npm install -g npm@<version>`
 {%/callout %}
 
 ## Installing Packages on Nx Agents
@@ -458,11 +505,11 @@ For example, you can install the [GitHub CLI](https://cli.github.com/) on the ag
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.11-v7'
+    image: 'ubuntu22.04-node20.11-v9'
     init-steps:
-      - name: Install GH CLI
+      - name: Install Extras
         script: |
-          sudo apt install gh -y
+          sudo apt install gh unzip zip -y
 ```
 
 {% callout type="note" title="Installing without apt" %}
@@ -486,4 +533,63 @@ Then you can pass the path to the file to the `--distribute-on` parameter.
 
 ```
 nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yaml"
+```
+
+## Debugging
+
+You can add steps to your template which print information about your workspace, toolchains, or any other needs.
+Below are some common steps people use for debugging such as running nx commands, printing file contents and/or listing directory contents.
+
+{% callout type="caution" title="Environment Variables" %}
+Exercise caution when printing out environment variables, they will be shown in plain text.
+{% /callout %}
+
+```yaml {% fileName=".nx/workflows/agents.yaml" %}
+launch-templates:
+  my-linux-medium-js:
+    resource-class: 'docker_linux_amd64/medium'
+    image: 'ubuntu22.04-node20.11-v9'
+    env:
+      # enable verbose logging for all steps
+      NX_VERBOSE_LOGGING: true
+    init-steps:
+      - name: 'Debug: Print Nx Report'
+        script: |
+          nx report
+      - name: 'Debug: List Directory Contents'
+        script: |
+          echo $HOME
+          ls -la $HOME
+          output_dir=$HOME/dist
+          # if output directory exists list it's contents
+          if [ -d output_dir ]; then
+            ls -la $output_dir
+          else
+            echo "$output_dir does not exist"
+          fi
+      - name: 'Debug: Show File Contents'
+        script: |
+          cat $HOME/.profile
+      - name: 'Debug: Check For Checkout Files'
+        script: |
+          git diff
+      - name: 'Debug: Print Versions'
+        script: |
+          # note if you use yarn and try to run pnpm, corepack might throw an error at you
+          # saying you're using the wrong package manager, in that case just remove the usage of pnpm
+          echo "Versions:"
+          echo "Node: $(node -v)"
+          echo "NPM: $(npm -v)"
+          echo "Yarn: $(yarn -v)"
+          echo "PNPM: $(pnpm -v)"
+          echo "Golang: $(go version)"
+          echo "Java: $(javac --version)"
+          # add any other toolchain you want
+      - name: 'Debug: Print env'
+        script: |
+          # !!! DO NOT RUN THIS IF YOU HAVE PASSWORD/ACCESS TOKENS IN YOUR ENV VARS !!!
+          # this will print your env as plain text values to the terminal
+          env  
+          # This is a safer approach to prevent leaking tokens/passwords
+          echo "SOME_VALUE: $SOME_VALUE"
 ```


### PR DESCRIPTION
- add info about `ubuntu22.04-node20.11-v9` image
- add debugging template starter
- add nvm to custom node section

https://nx-dev-git-docs-nx-agent-image-v9-nrwl.vercel.app/ci/reference/launch-templates