### PR TITLE
fix(gradle): pass process.env when running gradle

### DIFF
--- a/packages/gradle/src/utils/exec-gradle.ts
+++ b/packages/gradle/src/utils/exec-gradle.ts
@@ -30,6 +30,7 @@ export function execGradleAsync(
       ...execOptions,
       shell: true,
       windowsHide: true,
+      env: process.env,
     });
 
     let stdout = Buffer.from('');


### PR DESCRIPTION

## Current Behavior
we do not pass any env variables to gradle, which means it can't access things read or set by the nx cli.

## Expected Behavior
environment variables should be available to the gradle process.

