### PR TITLE
fix(core): ensure better create nodes error messaging

### DIFF
--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -42,7 +42,14 @@ export class ProjectGraphError extends Error {
     this.#partialProjectGraph = partialProjectGraph;
     this.#partialSourceMaps = partialSourceMaps;
     this.stack = `${this.message}\n  ${errors
-      .map((error) => error.stack.split('\n').join('\n  '))
+      .map((error) => {
+        if (isAggregateCreateNodesError(error)) {
+          // AggregateCreateNodesError has a custom error message that shows more detail than the stack.
+          return error.message;
+        } else {
+          return error.stack.split('\n').join('\n  ');
+        }
+      })
       .join('\n')}`;
   }
 

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -42,14 +42,7 @@ export class ProjectGraphError extends Error {
     this.#partialProjectGraph = partialProjectGraph;
     this.#partialSourceMaps = partialSourceMaps;
     this.stack = `${this.message}\n  ${errors
-      .map((error) => {
-        if (isAggregateCreateNodesError(error)) {
-          // AggregateCreateNodesError has a custom error message that shows more detail than the stack.
-          return error.message;
-        } else {
-          return error.stack.split('\n').join('\n  ');
-        }
-      })
+      .map((error) => error.stack.split('\n').join('\n  '))
       .join('\n')}`;
   }
 

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -106,7 +106,7 @@ export interface PluginCreateMetadataResult {
       }
     | {
         success: false;
-        error: string;
+        error: Error;
         tx: string;
       };
 }

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -121,7 +121,11 @@ const server = createServer((socket) => {
           } catch (e) {
             return {
               type: 'createMetadataResult',
-              payload: { success: false, error: e.stack, tx },
+              payload: {
+                success: false,
+                error: createSerializableError(e),
+                tx,
+              },
             };
           }
         },

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -371,9 +371,11 @@ export async function createProjectConfigurations(
         } else {
           errorBodyLines.push(`  - ${e.message}`);
         }
+        const innerStackTrace = '    ' + e.stack.split('\n').join('\n    ');
+        errorBodyLines.push(innerStackTrace);
       }
 
-      error.message = errorBodyLines.join('\n');
+      error.stack = errorBodyLines.join('\n');
 
       // This represents a single plugin erroring out with a hard error.
       errors.push(error);

--- a/packages/nx/src/utils/serializable-error.ts
+++ b/packages/nx/src/utils/serializable-error.ts
@@ -17,6 +17,13 @@ export function createSerializableError<T extends Error>(error: T): T {
       value = value.map((v) => {
         if (typeof v === 'object' && v instanceof Error) {
           return createSerializableError(v);
+          // Support for AggregateCreateNodesError
+        } else if (
+          Array.isArray(v) &&
+          v.length === 2 &&
+          v[1] instanceof Error
+        ) {
+          return [v[0], createSerializableError(v[1])];
         }
         return v;
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
We see a stack trace pointing to where the aggregate create nodes error is thrown rather than the messaging about the individual errors

<img width="911" alt="image" src="https://github.com/nrwl/nx/assets/6933928/61907d8c-bb77-4a39-b55f-42fa38c0ed19">

## Expected Behavior
The message is shown

<img width="946" alt="image" src="https://github.com/nrwl/nx/assets/6933928/f79f5aeb-e5b2-4ff1-9cbc-a7f10e8f910e">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
