### PR TITLE
fix(vite): Only attempt to amend test object if one exists

### DIFF
--- a/packages/vite/src/migrations/update-17-3-0/lib/fix-coverage-and-reporters.ts
+++ b/packages/vite/src/migrations/update-17-3-0/lib/fix-coverage-and-reporters.ts
@@ -102,11 +102,14 @@ export function fixCoverageAndRerporters(
       configNode,
       `PropertyAssignment:has(Identifier[name="test"])`
     )?.[0];
-    changes.push({
-      type: ChangeType.Insert,
-      index: testObject.getStart() + `test: {`.length + 1,
-      text: `reporters: ['default'],`,
-    });
+
+    if (testObject) {
+      changes.push({
+        type: ChangeType.Insert,
+        index: testObject.getStart() + `test: {`.length + 1,
+        text: `reporters: ['default'],`,
+      });
+    }
   }
 
   if (changes.length > 0) {


### PR DESCRIPTION
Test object is assigned using optional chaining but previously did not check that any value had actually been assigned which would cause the `getStart` call to fail resulting in a failed migration.

## Current Behavior
Migration fails if no matching test object is found.

## Expected Behavior
Migration should not fail.

## Related Issue(s)
I haven't opened an issue, just the PR. I can open an issue if required for tracking.
