### PR TITLE
fix(nextjs): schema type for unitTestRunner for library

### DIFF
--- a/packages/next/src/generators/library/schema.d.ts
+++ b/packages/next/src/generators/library/schema.d.ts
@@ -13,7 +13,7 @@ export interface Schema {
   pascalCaseFiles?: boolean;
   routing?: boolean;
   appProject?: string;
-  unitTestRunner: 'jest' | 'none';
+  unitTestRunner: 'jest' | 'vitest' | 'none';
   linter: Linter | LinterType;
   component?: boolean;
   publishable?: boolean;


### PR DESCRIPTION
## Current Behavior
The [docs](https://nx.dev/nx-api/next/generators/library#unittestrunner) say that you can use vitest as a unitTestRunner option. It also worked when I tested with the following command:
```sh
nx g @nx/next:library shared --dir=modules/shared --style none --dry-run --projectNameAndRootFormat as-provided --component false --unitTestRunner vitest
```

But types say otherwise:
![CleanShot 2024-07-04 at 16 24 44@2x](https://github.com/nrwl/nx/assets/51330172/13a2d0ca-6950-413b-ac80-5d33cd64a714)

## Expected Behavior
Types will allow 'vitest' option for a unitTestRunner

## Related Issue(s)
none
