### PR TITLE
docs(nx-cloud): update CI tutorials

### DIFF
--- a/docs/nx-cloud/tutorial/circle.md
+++ b/docs/nx-cloud/tutorial/circle.md
@@ -5,14 +5,12 @@ description: In this tutorial you'll set up continuous integration with Circle C
 
 # Circle CI with Nx
 
-In this tutorial we're going to learn how to leverage Nx to setup a scalable CI pipeline on Circle CI. You're going to learn
+In this tutorial, we're going to learn how to leverage Nx to set up a scalable CI pipeline on Circle CI. As repositories get bigger, making sure that the CI is fast, reliable and maintainable can get very challenging. Nx provides a solution.
 
-- how to set up Circle CI and configure Nx
-- how to run tasks for only the projects that were affected by a given PR
-- how to enable remote caching
-- how to parallelize and distribute tasks across multiple machines
-
-Note, many of these optimizations are incremental, meaning you could set up running tasks for only affected projects and stop there. Later when you experience slow CI runs, you could add caching to further improve CI performance or even go further and distribute tasks across machines.
+- Nx reduces wasted time in CI with the [`affected` command](/ci/features/affected).
+- Nx Replay's [remote caching](/ci/features/remote-cache) will reuse task artifacts from different CI executions making sure you will never run the same computation twice.
+- Nx Agents [efficiently distribute tasks across machines](/ci/concepts/parallelization-distribution) ensuring constant CI time regardless of the repository size. The right number of machines is allocated for each PR to ensure good performance without wasting compute.
+- Nx Atomizer [automatically splits](/ci/features/split-e2e-tasks) large e2e tests to distribute them across machines. Nx can also automatically [identify and rerun flaky e2e tests](/ci/features/flaky-tasks).
 
 ## Example Repository
 
@@ -40,366 +38,135 @@ To get started:
    pnpm i
    ```
 
-3. Explore the structure of the repo using **the Nx Graph**
+3. Make sure all task are working on your machine, by running lint, test, and build on all projects of the workspace
 
    ```shell
-   pnpm nx graph
-   ```
-
-4. Finally, make sure all task are working on your machine, by running lint, test, build and e2e on all projects of the workspace
-
-   ```shell
-   pnpm nx run-many -t lint test build e2e-ci
+   pnpm nx run-many -t lint test build
    ```
 
 ## Set Up Circle CI
 
-In order to use Circle CI, you need to [sign up and create an organization](https://circleci.com/docs/first-steps/#sign-up-and-create-an-org). Follow the steps in the Circle CI documentation to connect to your GitHub repository. When you are asked to configure a pipeline, choose any option, since we'll overwrite it in the next step.
+In order to use Circle CI, you need to [sign up and create an organization](https://circleci.com/docs/first-steps/#sign-up-and-create-an-org). Follow the steps in the Circle CI documentation to connect to your GitHub repository. When you are asked to configure a pipeline, choose any option, since we'll overwrite it.
 
 To verify that Circle CI is set up correctly we'll create a pipeline that just logs a message. First, checkout a new branch:
 
-```shell
-git checkout -b circle-message
-```
+## Connect to Nx Cloud
 
-Then create (or modify) the `.circleci/config.yml` file with these contents:
+Nx Cloud is a companion app for your CI system that provides remote caching, task distribution, e2e tests deflaking, better DX and more.
 
-```yaml {% fileName=".circleci/config.yml" %}
-version: 2.1
+To connect to Nx Cloud:
 
-jobs:
-  main:
-    docker:
-      - image: cimg/node:lts-browsers
-    steps:
-      - run:
-          name: Print a message
-          command: echo "Hello Circle CI!"
-
-workflows:
-  version: 2
-
-  ci:
-    jobs:
-      - main
-```
-
-Next, commit this change, push the branch and create a PR on your forked GitHub repository:
+- Commit and push your changes
+- Go to [https://cloud.nx.app](https://cloud.nx.app), create an account, and connect your repository
 
 ```shell
-git commit -am "pipeline that logs a message"
-git push -u origin HEAD
+npx nx connect
+```
+
+Follow the steps and make sure Nx Cloud is enabled on the `main` branch before continuing.
+
+## Generate a CI Workflow
+
+Let's create a PR to add the CI workflow file.
+
+```shell
+git checkout -b ci-workflow
+```
+
+Use the following command to generate a CI workflow file.
+
+```shell
+npx nx generate ci-workflow --ci circleci
+```
+
+This generator creates a `.circleci/config.yml` file that contains a CI pipeline that will run the `lint`, `test`, `build` and `e2e-ci` tasks for projects that are affected by any given PR.
+
+The key lines in the CI pipeline are:
+
+```yml
+- run: npx nx affected -t lint test build
+- run: npx nx affected -t e2e-ci --parallel 1
+```
+
+Next, commit this change, push the branch, and create a PR on your forked GitHub repository:
+
+```shell
+git commit -am "add CI workflow file"
+git push -u origin
 ```
 
 If everything was set up correctly, you should see a message from Circle CI in the PR with a success status.
 
 ![All checks have passed in the PR](/nx-cloud/tutorial/Circle%20PR%20passed.png)
 
-Click on the job details and you should see the `Hello Circle CI` message in the logs.
-
-![The "Hello Circle CI" message is printed in the logs](/nx-cloud/tutorial/Message%20Logged.png)
-
 Merge your PR into the `main` branch when you're ready to move to the next section.
 
-## Configure Nx on Circle CI
+## Remote Caching using Nx Replay
 
-Now let's use Nx in the pipeline. The simplest way to use Nx is to run a single task, so we'll start by building our `cart` application.
+[Nx Cloud](https://nx.app) provides [Nx Replay](/ci/features/remote-cache), which is a powerful, scalable and, very importantly, secure way to share task artifacts across machines.
+
+[Nx Replay](/ci/features/remote-cache) is enabled by default. To see it in action, let's create a new PR:
 
 ```shell
-pnpm nx build cart
+git checkout -b feat-1
 ```
 
-We need to adjust a couple of things on our CI pipeline to make this work:
+We'll make a small change to the shared header library.
 
-- clone the repository
-- install NPM dependencies (in our nx-shop using PNPM)
-- use Nx to run the `build` command
-
-Nx is an [npm package](https://www.npmjs.com/package/nx) so once NPM packages are installed we will be able to use it.
-
-Create a new branch called `build-one-app` and paste this code into the Circle CI config.
-
-```yaml {% fileName=".circleci/config.yml" highlightLines=["8-14"] %}
-version: 2.1
-
-jobs:
-  main:
-    docker:
-      - image: cimg/node:lts-browsers
-    steps:
-      - checkout
-      - run:
-          name: install dependencies
-          command: pnpm install --frozen-lockfile
-      - run:
-          name: Run build
-          command: pnpm nx build cart
-
-workflows:
-  version: 2
-
-  ci:
-    jobs:
-      - main
+```ts {% filename="libs/shared/header/src/index.ts" highlightLines=[1] %}
+// Some change
+export * from './lib/header/header.element';
 ```
 
-Once `node_modules` are in place, you can run normal Nx commands. In this case, we run `pnpm nx build cart`. Push the changes to your repository by creating a new PR and verifying the new CI pipeline correctly builds our application.
+Commit and open a new PR.
 
-![Building a single app with nx](/nx-cloud/tutorial/circle-single-build-success.jpg)
-
-You might have noticed that there's also a build running for `shared-header`, `shared-product-types` and `shared-product-ui`. These are projects in our workspace that `cart` depends on. Thanks to the [Nx task pipeline](/concepts/task-pipeline-configuration), Nx knows that it needs to build these projects first before building `cart`. This already helps us simplify our pipeline as we
-
-- don't need to define these builds automatically
-- don't need to make any changes to our pipeline as our `cart` app grows and depends on more projects
-- don't need to worry about the order of the builds
-
-Merge your PR into the `main` branch when you're ready to move to the next section.
-
-## Optimize our CI by caching NPM dependencies
-
-While this isn't related to Nx specifically, it's a good idea to cache NPM dependencies in CI. This will speed up the CI pipeline by avoiding downloading the same dependencies over and over again. Circle CI has [a docs page on how to cache NPM dependencies](https://circleci.com/docs/caching/).
-
-Adjust your CI pipeline script as follows
-
-```yaml {% fileName=".circleci/config.yml" highlightLines=["10-11", "17-21"] %}
-version: 2.1
-
-jobs:
-  main:
-    docker:
-      - image: cimg/node:lts-browsers
-    steps:
-      - checkout
-      # look for existing cache and restore if found
-      - restore_cache:
-          key: npm-dependencies-{{ checksum "pnpm-lock.yaml" }}
-      # install dependencies
-      - run:
-          name: install dependencies
-          command: pnpm install --frozen-lockfile
-      # save any changes to the cache
-      - save_cache:
-          key: npm-dependencies-{{ checksum "pnpm-lock.yaml" }}
-          paths:
-            - node_modules
-            - ~/.cache/Cypress # needed for the Cypress binary
-      - run:
-          name: Run build
-          command: pnpm nx build cart
-
-workflows:
-  version: 2
-
-  ci:
-    jobs:
-      - main
+```shell
+git -am 'update header'
+git push origin feat-1
 ```
 
-The `restore_cache` and `save_cache` steps are using a hash key that is created from the contents of the `pnpm-lock.yaml` file. This way if the `pnpm-lock.yaml` file remains the same, the next CI pipeline can pull from the cache instead of downloading `node_modules` again. This is similar to the way [Nx hashes input files to cache the results of tasks](/features/cache-task-results).
+Wait a few minutes for the CI checks to finish, and then make a change to the `README.md`.
 
-Create a new branch with these changes and submit a PR to your repo to test them. Merge your PR into the `main` branch when you're ready to move to the next section.
+```md {% filename="README.md" highlightLines=[1] %}
+# NxCloud CI example repo (updated)
 
-## Process Only Affected Projects
+This repo is based on the [Nx Examples](https://github.com/nrwl/nx-examples) repo
+but setup in a way to illustrate some of the benefits of using Nx and NxCloud together to setup CI.
 
-So far we only ran the build for our `cart` application. There are other apps in our monorepo workspace though, namely `admin`, `landing-page` and `products`. We could now adjust our CI pipeline to add these builds as well:
-
-```plaintext
-pnpm nx build cart
-pnpm nx build admin
-pnpm nx build landing-page
+...
 ```
 
-Clearly this is not a scalable solution as it requires us to manually add every new app to the pipeline (and it doesn't include other tasks like `lint`, `test` etc). To improve this we can change the command to run the `build` for all projects like
+Commit and push to the existing PR.
 
-```{% command="nx run-many -t build" %}
-✔  nx run shared-product-types:build (429ms)
-✔  nx run shared-product-ui:build (455ms)
-✔  nx run shared-header:build (467ms)
-✔  nx run landing-page:build:production (3s)
-✔  nx run admin:build:production (3s)
-✔  nx run cart:build:production (3s)
-
-————————————————————————————————————————————————————————————————
-
-NX   Successfully ran target build for 6 projects (10s)
+```shell
+git -am 'update readme'
+git push origin feat-1
 ```
 
-This change makes our CI pipeline configuration more maintainable. For a small repository, this might be good enough, but after a little bit of growth this approach will cause your CI times to become unmanageable.
-
-Nx comes with a dedicated ["affected" command](/ci/features/affected) to help with that by only running tasks for projects that were affected by the changes in a given PR.
-
-```{% command="nx affected -t build" %}
-✔  nx run shared-product-types:build (404ms)
-✔  nx run shared-product-ui:build (445ms)
-✔  nx run shared-header:build (465ms)
-✔  nx run cart:build:production (3s)
-
-——————————————————————————————————————————————————————————————————————————————————————
-
-NX   Successfully ran target build for project cart and 3 tasks it depends on (4s)
-```
-
-### Configuring the Comparison Range for Affected Commands
-
-To understand which projects are affected, Nx uses the Git history and the [project graph](/features/explore-graph). Git knows which files changed, and the Nx project graph knows which projects those files belong to.
-
-The affected command takes a `base` and `head` commit. The default `base` is your `main` branch and the default `head` is your current file system. This is generally what you want when developing locally, but in CI, you need to customize these values.
-
-The goal of the CI pipeline is to make sure that the current state of the repository is a good one. To ensure this, we want to verify all the changes **since the last successful CI run** - not just since the last commit on `main`.
-
-While you could calculate this yourself, we created the [`nrwl/nx` Circle CI orb](https://github.com/nrwl/nx-orb#background) to help with that. It provides you with the `nx/set-shas` step which automatically sets the `$NX_BASE` and `$NX_HEAD` environment variables to the correct commit SHAs for you to use in the affected command.
-
-In order to use the `nrwl/nx` orb, you need to enable the use of third-party Circle CI orbs in your organization settings. In the Circle CI project dashboard, go to `Organization Settings -> Security` and select `Yes` under Orb Security Settings: Allow Uncertified Orbs.
-
-![Adjust ORB Security Settings in Circle CI](/nx-cloud/tutorial/circle-orb-security.png)
-
-### Using the Affected Commands in our Pipeline
-
-Let's adjust our CI pipeline configuration to use the affected command. Create a new branch called `ci-affected` and create a PR with the following configuration:
-
-```yaml {% fileName=".circleci/config.yml" highlightLines=[2,3,20,22,23] %}
-version: 2.1
-orbs:
-  nx: nrwl/nx@1.5.1
-jobs:
-  main:
-    docker:
-      - image: cimg/node:lts-browsers
-    steps:
-      - checkout
-      - restore_cache:
-          key: npm-dependencies-{{ checksum "pnpm-lock.yaml" }}
-      - run:
-          name: install dependencies
-          command: pnpm install --frozen-lockfile
-      - save_cache:
-          key: npm-dependencies-{{ checksum "pnpm-lock.yaml" }}
-          paths:
-            - node_modules
-            - ~/.cache/Cypress
-      - nx/set-shas
-
-      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build --parallel=3
-      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD -t e2e-ci --parallel=1
-workflows:
-  build:
-    jobs:
-      - main
-```
-
-Notice how we're using the `$NX_BASE` and `$NX_HEAD` environment variables to set the correct `base` and `head` commits to use for file comparisons.
-
-We're also using the `--parallel` flag to run up to 3 `lint`, `test` or `build` tasks at once, but we want to make sure that only 1 `e2e` task is running at a time.
-
-When you check the CI logs for this PR, you'll notice that no tasks were run by the `affected` command. That's because the `.circleci/config.yml` file is not an input for any task. We should really double check every task whenever we make changes to the CI pipeline, so let's fix that by adding an entry in the `sharedGlobals` array in the `nx.json` file.
-
-```jsonc {% fileName="nx.json" %}
-{
-  "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
-    "sharedGlobals": [
-      "{workspaceRoot}/babel.config.json",
-      "{workspaceRoot}/.circleci/config.yml" // add this line
-    ]
-    // etc...
-  }
-}
-```
-
-Merge your PR into the `main` branch when you're ready to move to the next section.
-
-## Enable Remote Caching And Distributed Task Execution Using Nx Cloud
-
-Only running necessary tasks via [affected commands](/ci/features/affected) (as seen in the previous section) is helpful, but might not be enough. By default [Nx caches the results of tasks](/features/cache-task-results) on your local machine. But CI and other developer machines will still perform the same tasks on the same code - wasting time and money. Also, as your repository grows, running all the tasks on a single agent will cause the CI pipeline to take too long. The only way to decrease the CI pipeline time is to distribute your CI across many machines. Let's solve both of these problems using Nx Cloud.
-
-### Connect Your Workspace to Nx Cloud
-
-Create an account on [nx.app](https://nx.app). There are several ways to connect your repository to Nx Cloud.
-
-#### Connect Directly Through GitHub
-
-The easiest way is to create an Nx Cloud organization based on your GitHub organization.
-
-![Connect Your VCS Account](/nx-cloud/tutorial/connect-vcs-account.png)
-
-After that, connect you repository.
-
-![Connect Your Repository](/nx-cloud/tutorial/connect-repository.png)
-
-This will send a pull request to your repository that will add the `nxCloudAccessToken` property to `nx.json`.
-
-![Nx Cloud Setup PR](/nx-cloud/tutorial/nx-cloud-setup-pr.png)
-
-This wires up all the CI for you and configures access. Folks who can see your repository can see your workspace on nx.app.
-
-#### Manually Connect Your Workspace
-
-To manually connect your workspace to Nx Cloud, run the following command in your repository:
-
-```{% command="pnpm nx connect" %}
-$ nx g nx:connect-to-nx-cloud --quiet --no-interactive
-
-NX   Your Nx Cloud workspace is public
-
-To restrict access, connect it to your Nx Cloud account:
-- Push your changes
-- Login at https://cloud.nx.app to connect your repository
-```
-
-Click the link in the terminal to claim your workspace on [nx.app](https://nx.app).
-
-The command generates an `nxCloudAccessToken` property inside of `nx.json`. This is a read-only token that should be committed to the repository.
-
-### Enable Remote Caching using Nx Replay
-
-[Nx Cloud](https://nx.app) provides [Nx Replay](/ci/features/remote-cache), which is a powerful, scalable and, very importantly, secure way to share task artifacts across machines. It lets you configure permissions and guarantees the cached artifacts cannot be tempered with.
-
-[Nx Replay](/ci/features/remote-cache) is enabled by default. To see it in action, rerun the CI for the PR opened by Nx Cloud.
-
-When Circle CI now processes our tasks they'll only take a fraction of the usual time. If you inspect the logs a little closer you'll see a note saying `[remote cache]`, indicating that the output has been pulled from the remote cache rather than running it. The full log of each command will still be printed since Nx restores that from the cache as well.
-
-![Circle CI after enabling remote caching](/nx-cloud/tutorial/circle-ci-remote-cache.png)
+When Circle CI now processes our tasks they'll only take a fraction of the usual time. If you inspect the logs a little closer you'll see a note saying `[remote cache]`, indicating that the output has been pulled from the remote cache rather than running it. Since `README.md` is not an input of our `build`, `test`, `lint`, `e2e-ci` tasks , Nx Replay will read the results from cache.
 
 ![Run Details with remote cache hits](/nx-cloud/tutorial/nx-cloud-run-details.png)
-
-What is more, if you run tasks locally, you will also get cache hits:
-
-```{% command="nx run-many -t build" %}
-...
-✔  nx run express-legacy:build  [remote cache]
-✔  nx run nx-plugin-legacy:build  [remote cache]
-✔  nx run esbuild-legacy:build  [remote cache]
-✔  nx run react-native-legacy:build  [remote cache]
-✔  nx run angular-legacy:build  [remote cache]
-✔  nx run remix-legacy:build  [remote cache]
-
-————————————————————————————————————————————————
-
-NX   Successfully ran target build for 58 projects and 62 tasks they depend on (1m)
-
-Nx read the output from the cache instead of running the command for 116 out of 120 tasks.
-```
 
 You might also want to learn more about [how to fine-tune caching](/recipes/running-tasks/configure-inputs) to get even better results.
 
 Merge your PR into the `main` branch when you're ready to move to the next section.
 
-### Parallelize Tasks Across Multiple Machines Using Nx Agents
+## Parallelize Tasks Across Multiple Machines Using Nx Agents
 
 The affected command and Nx Replay help speed up the average CI time, but there will be some PRs that affect everything in the repository. The only way to speed up that worst case scenario is through efficient parallelization. The best way to parallelize CI with Nx is to use Nx Agents.
 
 The Nx Agents feature
 
-- takes a command (e.g. `run-many -t build lint test e2e-ci`) and splits it into individual tasks which it then distributes across multiple agents
+- takes a command (e.g. `run-many -t build lint test`) and splits it into individual tasks which it then distributes across multiple agents
 - distributes tasks by considering the dependencies between them; e.g. if `e2e-ci` depends on `build`, Nx Cloud will make sure that `build` is executed before `e2e-ci`; it does this across machines
 - distributes tasks to optimize for CPU processing time and reduce idle time by taking into account historical data about how long each task takes to run
 - collects the results and logs of all the tasks and presents them in a single view
 - automatically shuts down agents when they are no longer needed
 
-Let's enable Nx Agents
+Nx Agents are enabled by the following line.
 
 ```
-pnpm exec nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 ```
 
 We recommend you add this line right after you check out the repo, before installing node modules.
@@ -429,7 +196,7 @@ jobs:
       - image: cimg/node:lts-browsers
     steps:
       - checkout
-      - run: pnpm exec nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
       - restore_cache:
           key: npm-dependencies-{{ checksum "pnpm-lock.yaml" }}
       - run:
@@ -442,8 +209,8 @@ jobs:
             - ~/.cache/Cypress
       - nx/set-shas
 
-      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build --parallel=3
-      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD -t e2e-ci --parallel=1
+      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build --parallel 3
+      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD -t e2e-ci --parallel 1
       - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD -t deploy --no-agents # run without distribution
 workflows:
   build:

--- a/docs/nx-cloud/tutorial/github-actions.md
+++ b/docs/nx-cloud/tutorial/github-actions.md
@@ -5,14 +5,12 @@ description: In this tutorial you'll set up continuous integration with GitHub A
 
 # GitHub Actions with Nx
 
-In this tutorial we're going to learn how to leverage Nx to setup a scalable CI pipeline on GitHub Actions. You're going to learn
+In this tutorial, we're going to learn how to leverage Nx to set up a scalable CI pipeline on Circle CI. As repositories get bigger, making sure that the CI is fast, reliable and maintainable can get very challenging. Nx provides a solution.
 
-- how to set up GitHub Actions and configure Nx
-- how to run tasks for only the projects that were affected by a given PR
-- how to enable remote caching
-- how to parallelize and distribute tasks across multiple machines
-
-Note, many of these optimizations are incremental, meaning you could set up running tasks for only affected projects and stop there. Later when you experience slow CI runs, you could add caching to further improve CI performance or even go further and distribute tasks across machines.
+- Nx reduces wasted time in CI with the [`affected` command](/ci/features/affected).
+- Nx Replay's [remote caching](/ci/features/remote-cache) will reuse task artifacts from different CI executions making sure you will never run the same computation twice.
+- Nx Agents [efficiently distribute tasks across machines](/ci/concepts/parallelization-distribution) ensuring constant CI time regardless of the repository size. The right number of machines is allocated for each PR to ensure good performance without wasting compute.
+- Nx Atomizer [automatically splits](/ci/features/split-e2e-tasks) large e2e tests to distribute them across machines. Nx can also automatically [identify and rerun flaky e2e tests](/ci/features/flaky-tasks).
 
 ## Example Repository
 
@@ -40,370 +38,129 @@ To get started:
    pnpm i
    ```
 
-3. Explore the structure of the repo using **the Nx Graph**
+3. Make sure all task are working on your machine, by running lint, test, and build on all projects of the workspace
 
    ```shell
-   pnpm nx graph
+   pnpm nx run-many -t lint test build
    ```
 
-4. Finally, make sure all task are working on your machine, by running lint, test, build and e2e on all projects of the workspace
+## Connect to Nx Cloud
 
-   ```shell
-   pnpm nx run-many -t lint test build e2e
-   ```
+Nx Cloud is a companion app for your CI system that provides remote caching, task distribution, e2e tests deflaking, better DX and more.
 
-## Set Up GitHub Actions
+To connect to Nx Cloud:
 
-To get started with GitHub Actions, we'll create a pipeline that just logs a message. First, checkout a new branch:
-
-```shell
-git checkout -b ci-message
-```
-
-Then create (or modify) the `.github/workflows/ci.yml` file with these contents:
-
-```yaml {% fileName=".github/workflows/ci.yml" %}
-name: CI
-on:
-  push:
-    branches:
-      # Change this if your primary branch is not main
-      - main
-  pull_request:
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Hello GitHub Actions!"
-```
-
-Next, commit this change, push the branch and create a PR on your forked GitHub repository:
+- Commit and push your changes
+- Go to [https://cloud.nx.app](https://cloud.nx.app), create an account, and connect your repository
 
 ```shell
-git commit -am "pipeline that logs a message"
-git push -u origin HEAD
+npx nx connect
+```
+
+Follow the steps and make sure Nx Cloud is enabled on the `main` branch before continuing.
+
+## Generate a CI Workflow
+
+Let's create a PR to add the CI workflow file.
+
+```shell
+git checkout -b ci-workflow
+```
+
+Use the following command to generate a CI workflow file.
+
+```shell
+npx nx generate ci-workflow --ci github
+```
+
+This generator creates a `.circleci/config.yml` file that contains a CI pipeline that will run the `lint`, `test`, `build` and `e2e-ci` tasks for projects that are affected by any given PR.
+
+The key lines in the CI pipeline are:
+
+```yml
+- run: npx nx affected -t lint test build
+- run: npx nx affected -t e2e-ci --parallel 1
+```
+
+Next, commit this change, push the branch, and create a PR on your forked GitHub repository:
+
+```shell
+git commit -am "add CI workflow file"
+git push -u origin
 ```
 
 If everything was set up correctly, you should see a message from GitHub Actions in the PR with a success status.
 
 ![All checks have passed in the PR](/nx-cloud/tutorial/gh-pr-passed.png)
 
-Click on the job details and you should see the `Hello GitHub Actions` message in the logs.
-
-![The "Hello GitHub Actions" message is printed in the logs](/nx-cloud/tutorial/gh-message.png)
-
 Merge your PR into the `main` branch when you're ready to move to the next section.
 
-## Configure Nx on GitHub Actions
+## Remote Caching using Nx Replay
 
-Now let's use Nx in the pipeline. The simplest way to use Nx is to run a single task, so we'll start by building our `cart` application.
+[Nx Cloud](https://nx.app) provides [Nx Replay](/ci/features/remote-cache), which is a powerful, scalable and, very importantly, secure way to share task artifacts across machines.
+
+[Nx Replay](/ci/features/remote-cache) is enabled by default. To see it in action, let's create a new PR:
 
 ```shell
-pnpm nx build cart
+git checkout -b feat-1
 ```
 
-We need to adjust a couple of things on our CI pipeline to make this work:
+We'll make a small change to the shared header library.
 
-- clone the repository
-- install NPM dependencies (in our nx-shop using PNPM)
-- use Nx to run the `build` command
-
-Nx is an [npm package](https://www.npmjs.com/package/nx) so once NPM packages are installed we will be able to use it.
-
-Create a new branch called `build-one-app` and paste this code into the GitHub Actions config.
-
-```yaml {% fileName=".github/workflows/ci.yml" highlightLines=["12-20"] %}
-name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      # Setup pnpm
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm nx build cart
+```ts {% filename="libs/shared/header/src/index.ts" highlightLines=[1] %}
+// Some change
+export * from './lib/header/header.element';
 ```
 
-Once `node_modules` are in place, you can run normal Nx commands. In this case, we run `pnpm nx build cart`. Push the changes to your repository by creating a new PR and verifying the new CI pipeline correctly builds our application.
+Commit and open a new PR.
 
-![Building a single app with nx](/nx-cloud/tutorial/gh-single-build-success.png)
-
-You might have noticed that there's also a build running for `shared-header`, `shared-product-types` and `shared-product-ui`. These are projects in our workspace that `cart` depends on. Thanks to the [Nx task pipeline](/concepts/task-pipeline-configuration), Nx knows that it needs to build these projects first before building `cart`. This already helps us simplify our pipeline as we
-
-- don't need to define these builds automatically
-- don't need to make any changes to our pipeline as our `cart` app grows and depends on more projects
-- don't need to worry about the order of the builds
-
-Merge your PR into the `main` branch when you're ready to move to the next section.
-
-## Optimize our CI by caching NPM dependencies
-
-While this isn't related to Nx specifically, it's a good idea to cache NPM dependencies in CI. This will speed up the CI pipeline by avoiding downloading the same dependencies over and over again. GitHub Actions has [an action to cache files](https://github.com/actions/cache) that we'll use.
-
-Adjust your CI pipeline script as follows
-
-```yaml {% fileName=".github/workflows/ci.yml" highlightLines=["18-24", "26-32"] %}
-name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - name: Restore cached npm dependencies
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            node_modules
-            ~/.cache/Cypress # needed for the Cypress binary
-          key: npm-dependencies-${{ hashFiles('pnpm-lock.yaml') }}
-      - run: pnpm install --frozen-lockfile
-      - name: Cache npm dependencies
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            node_modules
-            ~/.cache/Cypress # needed for the Cypress binary
-          key: npm-dependencies-${{ hashFiles('pnpm-lock.yaml') }}
-      - run: pnpm nx build cart
+```shell
+git -am 'update header'
+git push origin feat-1
 ```
 
-The `restore_cache` and `save_cache` steps are using a hash key that is created from the contents of the `pnpm-lock.yaml` file. This way if the `pnpm-lock.yaml` file remains the same, the next CI pipeline can pull from the cache instead of downloading `node_modules` again. This is similar to the way [Nx hashes input files to cache the results of tasks](/features/cache-task-results).
+Wait a few minutes for the CI checks to finish, and then make a change to the `README.md`.
 
-Create a new branch with these changes and submit a PR to your repo to test them. Merge your PR into the `main` branch when you're ready to move to the next section.
+```md {% filename="README.md" highlightLines=[1] %}
+# NxCloud CI example repo (updated)
 
-## Process Only Affected Projects
+This repo is based on the [Nx Examples](https://github.com/nrwl/nx-examples) repo
+but setup in a way to illustrate some of the benefits of using Nx and NxCloud together to setup CI.
 
-So far we only ran the build for our `cart` application. There are other apps in our monorepo workspace though, namely `admin`, `landing-page` and `products`. We could now adjust our CI pipeline to add these builds as well:
-
-```plaintext
-pnpm nx build cart
-pnpm nx build admin
-pnpm nx build landing-page
+...
 ```
 
-Clearly this is not a scalable solution as it requires us to manually add every new app to the pipeline (and it doesn't include other tasks like `lint`, `test` etc). To improve this we can change the command to run the `build` for all projects like
+Commit and push to the existing PR.
 
-```{% command="nx run-many -t build" %}
-✔  nx run shared-product-types:build (429ms)
-✔  nx run shared-product-ui:build (455ms)
-✔  nx run shared-header:build (467ms)
-✔  nx run landing-page:build:production (3s)
-✔  nx run admin:build:production (3s)
-✔  nx run cart:build:production (3s)
-
-————————————————————————————————————————————————————————————————
-
-NX   Successfully ran target build for 6 projects (10s)
+```shell
+git -am 'update readme'
+git push origin feat-1
 ```
 
-This change makes our CI pipeline configuration more maintainable. For a small repository, this might be good enough, but after a little bit of growth this approach will cause your CI times to become unmanageable.
-
-Nx comes with a dedicated ["affected" command](/ci/features/affected) to help with that by only running tasks for projects that were affected by the changes in a given PR.
-
-```{% command="nx affected -t build" %}
-✔  nx run shared-product-types:build (404ms)
-✔  nx run shared-product-ui:build (445ms)
-✔  nx run shared-header:build (465ms)
-✔  nx run cart:build:production (3s)
-
-——————————————————————————————————————————————————————————————————————————————————————
-
-NX   Successfully ran target build for project cart and 3 tasks it depends on (4s)
-```
-
-### Configuring the Comparison Range for Affected Commands
-
-To understand which projects are affected, Nx uses the Git history and the [project graph](/features/explore-graph). Git knows which files changed, and the Nx project graph knows which projects those files belong to.
-
-The affected command takes a `base` and `head` commit. The default `base` is your `main` branch and the default `head` is your current file system. This is generally what you want when developing locally, but in CI, you need to customize these values.
-
-The goal of the CI pipeline is to make sure that the current state of the repository is a good one. To ensure this, we want to verify all the changes **since the last successful CI run** - not just since the last commit on `main`.
-
-While you could calculate this yourself, we created the [`nx-set-shas` GitHub Action](https://github.com/marketplace/actions/nx-set-shas) to help with that. It provides you with the `nrwl/nx-set-shas` action which automatically sets the `NX_BASE` and `NX_HEAD` environment variables to the correct commit SHAs. The affected command will use these environment variables when they are defined.
-
-### Using the Affected Commands in our Pipeline
-
-Let's adjust our CI pipeline configuration to use the affected command. Create a new branch called `ci-affected` and create a PR with the following configuration:
-
-```yaml {% fileName=".github/workflows/ci.yml" highlightLines=["35-39"] %}
-name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - name: Restore cached npm dependencies
-        id: cache-dependencies-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            node_modules
-            ~/.cache/Cypress # needed for the Cypress binary
-          key: npm-dependencies-${{ hashFiles('pnpm-lock.yaml') }}
-      - run: pnpm install --frozen-lockfile
-      - name: Cache npm dependencies
-        id: cache-dependencies-save
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            node_modules
-            ~/.cache/Cypress # needed for the Cypress binary
-          key: ${{ steps.cache-dependencies-restore.outputs.cache-primary-key }}
-      - uses: nrwl/nx-set-shas@v3
-      # This line is needed for nx affected to work when CI is running on a PR
-      - run: git branch --track main origin/main
-        if: ${{ github.event_name == 'pull_request' }}
-
-      - run: pnpm nx affected -t lint test build --parallel=3
-      - run: pnpm nx affected -t e2e --parallel=1
-```
-
-We're using the `--parallel` flag to run up to 3 `lint`, `test` or `build` tasks at once, but we want to make sure that only 1 `e2e` task is running at a time.
-
-When you check the CI logs for this PR, you'll notice that no tasks were run by the `affected` command. That's because the `.github/workflows/ci.yml` file is not an input for any task. We should really double check every task whenever we make changes to the CI pipeline, so let's fix that by adding an entry in the `sharedGlobals` array in the `nx.json` file.
-
-```jsonc {% fileName="nx.json" highlightLines=[6] %}
-{
-  "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
-    "sharedGlobals": [
-      "{workspaceRoot}/babel.config.json",
-      "{workspaceRoot}/.github/workflows/ci.yml" // add this line
-    ]
-    // etc...
-  }
-}
-```
-
-Merge your PR into the `main` branch when you're ready to move to the next section.
-
-## Enable Remote Caching and Distributed Task Execution Using Nx Cloud
-
-Only running necessary tasks via [affected commands](/ci/features/affected) (as seen in the previous section) is helpful, but might not be enough. By default [Nx caches the results of tasks](/features/cache-task-results) on your local machine. But CI and other developer machines will still perform the same tasks on the same code - wasting time and money. Also, as your repository grows, running all the tasks on a single agent will cause the CI pipeline to take too long. The only way to decrease the CI pipeline time is to distribute your CI across many machines. Let's solve both of these problems using Nx Cloud.
-
-### Connect Your Workspace to Nx Cloud
-
-Create an account on [nx.app](https://nx.app). The easiest way to connect your repository to Nx Cloud is to create an Nx Cloud organization based on your GitHub organization.
-
-![Connect Your VCS Account](/nx-cloud/tutorial/connect-vcs-account.png)
-
-After that, connect you repository.
-
-![Connect Your Repository](/nx-cloud/tutorial/connect-repository.png)
-
-This will send a pull request to your repository that will add the `nxCloudAccessToken` property to `nx.json`.
-
-![Nx Cloud Setup PR](/nx-cloud/tutorial/nx-cloud-setup-pr.png)
-
-This wires up all the CI for you and configures access. Folks who can see your repository can see your workspace on nx.app.
-
-### Enable Remote Caching using Nx Replay
-
-[Nx Cloud](https://nx.app) provides [Nx Replay](/ci/features/remote-cache), which is a powerful, scalable and, very importantly, secure way to share task artifacts across machines. It lets you configure permissions and guarantees the cached artifacts cannot be tempered with.
-
-[Nx Replay](/ci/features/remote-cache) is enabled by default. To see it in action, rerun the CI for the PR opened by Nx Cloud.
-
-When GitHub Actions now processes our tasks they'll only take a fraction of the usual time. If you inspect the logs a little closer you'll see a note saying `[remote cache]`, indicating that the output has been pulled from the remote cache rather than running it. The full log of each command will still be printed since Nx restores that from the cache as well.
-
-![GitHub Actions after enabling remote caching](/nx-cloud/tutorial/gh-ci-remote-cache.png)
+When GitHub Actions now processes our tasks they'll only take a fraction of the usual time. If you inspect the logs a little closer you'll see a note saying `[remote cache]`, indicating that the output has been pulled from the remote cache rather than running it. Since `README.md` is not an input of our `build`, `test`, `lint`, `e2e-ci` tasks , Nx Replay will read the results from cache.
 
 ![Run Details with remote cache hits](/nx-cloud/tutorial/nx-cloud-run-details.png)
-
-What is more, if you run tasks locally, you will also get cache hits:
-
-```{% command="nx run-many -t build" %}
-...
-✔  nx run express-legacy:build  [remote cache]
-✔  nx run nx-plugin-legacy:build  [remote cache]
-✔  nx run esbuild-legacy:build  [remote cache]
-✔  nx run react-native-legacy:build  [remote cache]
-✔  nx run angular-legacy:build  [remote cache]
-✔  nx run remix-legacy:build  [remote cache]
-
-————————————————————————————————————————————————
-
-NX   Successfully ran target build for 58 projects and 62 tasks they depend on (1m)
-
-Nx read the output from the cache instead of running the command for 116 out of 120 tasks.
-```
 
 You might also want to learn more about [how to fine-tune caching](/recipes/running-tasks/configure-inputs) to get even better results.
 
 Merge your PR into the `main` branch when you're ready to move to the next section.
 
-## Enable PR Integration
-
-The [Nx Cloud GitHub App](https://github.com/marketplace/official-nx-cloud-app) automatically creates a comment on your PRs that provides a direct link to the relevant Nx Cloud logs and quickly shows which command failed.
-
-### Install the App
-
-Install the [Nx Cloud GitHub App](https://github.com/marketplace/official-nx-cloud-app) and give it permission to access your repo.
-
-### Connecting Your Workspace
-
-Once you have installed the Nx Cloud GitHub App, you must link your workspace to the installation. To do this, sign in to Nx Cloud and navigate to the VCS Integrations setup page. Once on the VCS Integrations setup page, choose GitHub as your version control system.
-
-![Access VCS Setup](/nx-cloud/set-up/access-vcs-setup.webp)
-
-### Authenticate Via the GitHub App
-
-To use the Nx Cloud GitHub App for authentication, select the radio button and then click "Connect".
-This will verify that Nx Cloud can connect to your repo. Upon a successful test, your configuration is saved.
-
-![Use GitHub App for Authentication](/nx-cloud/set-up/use-github-app-auth.webp)
-
-Now any new PRs in your repo should have a comment automatically added that links directly to Nx Cloud. For other ways of setting up PR integration, read the [Enable GitHub PR Integration recipe](/ci/recipes/source-control-integration/github).
-
-### Parallelize Tasks Across Multiple Machines Using Nx Agents
+## Parallelize Tasks Across Multiple Machines Using Nx Agents
 
 The affected command and Nx Replay help speed up the average CI time, but there will be some PRs that affect everything in the repository. The only way to speed up that worst case scenario is through efficient parallelization. The best way to parallelize CI with Nx is to use Nx Agents.
 
 The Nx Agents feature
 
-- takes a command (e.g. `run-many -t build lint test e2e-ci`) and splits it into individual tasks which it then distributes across multiple agents
+- takes a command (e.g. `run-many -t build lint test`) and splits it into individual tasks which it then distributes across multiple agents
 - distributes tasks by considering the dependencies between them; e.g. if `e2e-ci` depends on `build`, Nx Cloud will make sure that `build` is executed before `e2e-ci`; it does this across machines
 - distributes tasks to optimize for CPU processing time and reduce idle time by taking into account historical data about how long each task takes to run
 - collects the results and logs of all the tasks and presents them in a single view
 - automatically shuts down agents when they are no longer needed
 
-Let's enable Nx Agents
+Nx Agents are enabled by the following line.
 
-```shell
-pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+```
+npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 ```
 
 We recommend you add this line right after you check out the repo, before installing node modules.
@@ -466,8 +223,8 @@ jobs:
       # This line is needed for nx affected to work when CI is running on a PR
       - run: git branch --track main origin/main
         if: ${{ github.event_name == 'pull_request' }}
-      - run: pnpm nx affected -t lint test build --parallel=3
-      - run: pnpm nx affected -t e2e-ci --parallel=1
+      - run: pnpm nx affected -t lint test build --parallel 3
+      - run: pnpm nx affected -t e2e-ci --parallel 1
       - run: pnpm nx affected -t deploy --no-agents
 ```
 


### PR DESCRIPTION
This PR cleans up the CI tutorials (CircleCI and GitHub Actions) to remove unnecessary instructions. We're also connecting to Nx Cloud first before running `nx g ci-workflow` so the experience is more streamlined.

NOTE: The nx-shops repos is out of date so it needs to be migrated and crystalized before this tutorial can be merged.

Example: https://nx-dev-git-docs-ci-tutorials-update-nrwl.vercel.app/ci/intro/tutorials/github-actions