### PR TITLE
fix(nx-dev): Footer add spacing to show hidden content

### DIFF
--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -144,7 +144,7 @@ export function Footer(): JSX.Element {
       <h2 id="footer-heading" className="sr-only">
         Footer
       </h2>
-      <div className="mx-auto max-w-7xl px-4 pt-12 opacity-50 transition-opacity hover:opacity-100 sm:px-6 lg:px-8 lg:pt-16">
+      <div className="mx-auto max-w-7xl px-4 py-12 opacity-50 transition-opacity hover:opacity-100 sm:px-6 lg:px-8 lg:pt-16">
         <div className="xl:grid xl:grid-cols-3 xl:gap-8">
           <div className="space-y-4 text-slate-700 xl:col-span-1 dark:text-slate-300">
             <svg


### PR DESCRIPTION
Before:
<img width="1436" alt="Screenshot 2024-07-08 at 1 03 30 PM" src="https://github.com/nrwl/nx/assets/338948/63319892-ed06-4dd0-90bc-dff8d7146892">


After: 
<img width="1352" alt="Screenshot 2024-07-08 at 1 04 29 PM" src="https://github.com/nrwl/nx/assets/338948/84ed2a9f-a2f9-4acd-abd6-3663828dfca7">
