### PR TITLE
fix(vue): bump vue-tsc version to 2.x.x

### DIFF
--- a/packages/vue/migrations.json
+++ b/packages/vue/migrations.json
@@ -1,6 +1,15 @@
 {
   "generators": {},
   "packageJsonUpdates": {
+    "19.4.3": {
+      "version": "19.4.3-beta.0",
+      "packages": {
+        "vue-tsc": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
     "17.2.0": {
       "version": "17.2.0-beta.2",
       "packages": {

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -193,7 +193,7 @@ exports[`lib should add vue, vite and vitest to package.json 1`] = `
     "typescript": "~5.4.2",
     "vite": "^5.0.0",
     "vitest": "^1.3.1",
-    "vue-tsc": "^1.8.8",
+    "vue-tsc": "^2.0.0",
   },
   "name": "@proj/source",
 }

--- a/packages/vue/src/utils/versions.ts
+++ b/packages/vue/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxVersion = require('../../package.json').version;
 
 // vue core
 export const vueVersion = '^3.3.4';
-export const vueTscVersion = '^1.8.8';
+export const vueTscVersion = '^2.0.0';
 export const vueRouterVersion = '^4.2.4';
 
 // test deps


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Building a newly created Nuxt workspace/application fails with:

```bash
Nuxt Build Error: Cannot find module '@volar/typescript/lib/node/proxyCreateProgram'
```

This can be seen in current CI runs like the following: https://staging.nx.app/runs/bszKddEenc/task/e2e-nuxt%3Ae2e-ci--src%2Fnuxt.test.ts.

This is happening because the `vite-plugin-checker` (used by Nuxt) requires `vue-tsc@>=2.0.0`, but the `@nx/vue` plugin installs `vue-tsc@^1.8.8`.

```bash
└─┬ nuxt 3.12.3
  └─┬ @nuxt/vite-builder 3.12.3
    └─┬ vite-plugin-checker 0.7.1
      └── ✕ unmet peer vue-tsc@>=2.0.0: found 1.8.27
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Newly created Nuxt workspaces/applications should build successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
