### PR TITLE
feat(core): avoid forking process for nx:noop

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -456,6 +456,13 @@ export class TaskOrchestrator {
             terminalOutput,
           });
         }
+      } else if (targetConfiguration.executor === 'nx:noop') {
+        writeFileSync(temporaryOutputPath, '');
+        results.push({
+          task,
+          status: 'success',
+          terminalOutput: '',
+        });
       } else {
         // cache prep
         const { code, terminalOutput } = await this.runTaskInForkedProcess(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When we run a task with executor nx:noop we still fork a process for that executor to run.

## Expected Behavior
`nx:noop` is a fixed executor which never does anything. We can skip forking the process.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
