### PR TITLE
feat(core): pattern matching for target defaults

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -32,6 +32,16 @@ describe('project-configuration-utils', () => {
           key: 'default-value-for-targetname',
         },
       },
+      'e2e-ci--*': {
+        options: {
+          key: 'default-value-for-e2e-ci',
+        },
+      },
+      'e2e-ci--file-*': {
+        options: {
+          key: 'default-value-for-e2e-ci-file',
+        },
+      },
     };
 
     it('should prefer executor key', () => {
@@ -59,6 +69,14 @@ describe('project-configuration-utils', () => {
           'other-executor'
         )
       ).toBeNull();
+    });
+
+    it('should return first matching target', () => {
+      expect(
+        // This matches both 'e2e-ci--*' and 'e2e-ci--file-*', we expect the first match to be returned.
+        readTargetDefaultsForTarget('e2e-ci--file-foo', targetDefaults, null)
+          .options['key']
+      ).toEqual('default-value-for-e2e-ci');
     });
 
     it('should not merge top level properties for incompatible targets', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -71,12 +71,12 @@ describe('project-configuration-utils', () => {
       ).toBeNull();
     });
 
-    it('should return first matching target', () => {
+    it('should return longest matching target', () => {
       expect(
         // This matches both 'e2e-ci--*' and 'e2e-ci--file-*', we expect the first match to be returned.
         readTargetDefaultsForTarget('e2e-ci--file-foo', targetDefaults, null)
           .options['key']
-      ).toEqual('default-value-for-e2e-ci');
+      ).toEqual('default-value-for-e2e-ci-file');
     });
 
     it('should not merge top level properties for incompatible targets', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -1042,10 +1042,19 @@ export function readTargetDefaultsForTarget(
     return targetDefaults?.[targetName];
   }
 
+  let matchingTargetDefaultKey: string | null = null;
   for (const key in targetDefaults ?? {}) {
     if (isGlobPattern(key) && minimatch(targetName, key)) {
-      return targetDefaults[key];
+      if (
+        !matchingTargetDefaultKey ||
+        matchingTargetDefaultKey.length < key.length
+      ) {
+        matchingTargetDefaultKey = key;
+      }
     }
+  }
+  if (matchingTargetDefaultKey) {
+    return targetDefaults[matchingTargetDefaultKey];
   }
 
   return {};

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -15,11 +15,9 @@ import { splitByColons } from '../utils/split-target';
 import { getExecutorInformation } from '../command-line/run/executor-utils';
 import { CustomHasher, ExecutorConfig } from '../config/misc-interfaces';
 import { readProjectsConfigurationFromProjectGraph } from '../project-graph/project-graph';
-import {
-  GLOB_CHARACTERS,
-  findMatchingProjects,
-} from '../utils/find-matching-projects';
+import { findMatchingProjects } from '../utils/find-matching-projects';
 import { minimatch } from 'minimatch';
+import { isGlobPattern } from '../utils/globs';
 
 export type NormalizedTargetDependencyConfig = TargetDependencyConfig & {
   projects: string[];
@@ -122,7 +120,7 @@ export function expandWildcardTargetConfiguration(
   dependencyConfig: NormalizedTargetDependencyConfig,
   allTargetNames: string[]
 ): NormalizedTargetDependencyConfig[] {
-  if (!GLOB_CHARACTERS.some((char) => dependencyConfig.target.includes(char))) {
+  if (!isGlobPattern(dependencyConfig.target)) {
     return [dependencyConfig];
   }
   let cache = patternResultCache.get(allTargetNames);

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -1,5 +1,6 @@
 import { minimatch } from 'minimatch';
 import type { ProjectGraphProjectNode } from '../config/project-graph';
+import { isGlobPattern } from './globs';
 
 const validPatternTypes = [
   'name', // Pattern is based on the project's name
@@ -17,11 +18,6 @@ interface ProjectPattern {
   // The pattern to match against
   value: string;
 }
-
-/**
- * The presence of these characters in a string indicates that it might be a glob pattern.
- */
-export const GLOB_CHARACTERS = ['*', '|', '{', '}', '(', ')'];
 
 /**
  * Find matching project names given a list of potential project names or globs.
@@ -169,7 +165,7 @@ function addMatchingProjectsByName(
     return;
   }
 
-  if (!GLOB_CHARACTERS.some((c) => pattern.value.includes(c))) {
+  if (!isGlobPattern(pattern.value)) {
     return;
   }
 
@@ -204,7 +200,7 @@ function addMatchingProjectsByTag(
       continue;
     }
 
-    if (!GLOB_CHARACTERS.some((c) => pattern.value.includes(c))) {
+    if (!isGlobPattern(pattern.value)) {
       continue;
     }
 

--- a/packages/nx/src/utils/globs.ts
+++ b/packages/nx/src/utils/globs.ts
@@ -2,3 +2,14 @@ export function combineGlobPatterns(...patterns: (string | string[])[]) {
   const p = patterns.flat();
   return p.length > 1 ? '{' + p.join(',') + '}' : p.length === 1 ? p[0] : '';
 }
+
+export const GLOB_CHARACTERS = new Set(['*', '|', '{', '}', '(', ')', '[']);
+
+export function isGlobPattern(pattern: string) {
+  for (const c of pattern) {
+    if (GLOB_CHARACTERS.has(c)) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
TargetDefaults can be specified by keys matching either executor or target name only

## Expected Behavior
TargetDefaults can match based on a glob pattern that may match the target name. This is useful for things like `e2e-ci--*`. Only 1 target default will ever apply to a given target. We recognize this may be confusing, but is inline with current handling. If no default matches the target name or key, the first default that matches by pattern will be used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
