### PR TITLE
fix(misc): properly set the value of the bitbucket option for ci work…

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -121,7 +121,7 @@ Generate a 'src/' directory for Next.js
 
 Type: `string`
 
-Choices: [github, circleci, gitlab, azure, bitbucket, skip, yes]
+Choices: [github, circleci, gitlab, azure, bitbucket-pipelines, skip, yes]
 
 Which CI provider would you like to use?
 

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -121,7 +121,7 @@ Generate a 'src/' directory for Next.js
 
 Type: `string`
 
-Choices: [github, circleci, gitlab, azure, bitbucket, skip, yes]
+Choices: [github, circleci, gitlab, azure, bitbucket-pipelines, skip, yes]
 
 Which CI provider would you like to use?
 

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -7,7 +7,7 @@ export const NxCloudChoices = [
   'circleci',
   'gitlab',
   'azure',
-  'bitbucket',
+  'bitbucket-pipelines',
   'skip',
   'yes', // Deprecated but still handled
 ];
@@ -23,7 +23,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'circleci', name: 'Circle CI' },
         { value: 'gitlab', name: 'Gitlab' },
         { value: 'azure', name: 'Azure DevOps' },
-        { value: 'bitbucket', name: 'BitBucket Pipelines' },
+        { value: 'bitbucket-pipelines', name: 'BitBucket Pipelines' },
         { value: 'skip', name: '\nDo it later' },
       ],
       footer:
@@ -40,7 +40,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'gitlab', name: 'Gitlab' },
         { value: 'azure', name: 'Azure DevOps' },
         {
-          value: 'bitbucket',
+          value: 'bitbucket-pipelines',
           name: 'BitBucket Pipelines',
         },
         { value: 'skip', name: '\nDo it later' },


### PR DESCRIPTION
…flows

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Selecting `BitBucket Pipelines` yields `bitbucket`, an incorrect value for `nx g ci-workflow` and causes an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Selecting `BitBucket Pipelines` yields `bitbucket-pipelines`, an correct value for `nx g ci-workflow` and generates a ci workflow.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
