### PR TITLE
fix(core): don't add quotes to exec arguments

### DIFF
--- a/docs/generated/cli/exec.md
+++ b/docs/generated/cli/exec.md
@@ -69,6 +69,13 @@ The location of current project is available through the environment variable $N
 nx exec -- echo \$NX_PROJECT_ROOT_PATH
 ```
 
+Commands with quotes or other characters that may be stripped or interpreted by the shell should be passed as a single argument:
+
+```
+nx exec -- "npm run foo && npm run bar"
+nx exec -- 'node -e "console.log(\'hello\')"'
+```
+
 ## Options
 
 ### all

--- a/docs/generated/packages/nx/documents/exec.md
+++ b/docs/generated/packages/nx/documents/exec.md
@@ -69,6 +69,13 @@ The location of current project is available through the environment variable $N
 nx exec -- echo \$NX_PROJECT_ROOT_PATH
 ```
 
+Commands with quotes or other characters that may be stripped or interpreted by the shell should be passed as a single argument:
+
+```
+nx exec -- "npm run foo && npm run bar"
+nx exec -- 'node -e "console.log(\'hello\')"'
+```
+
 ## Options
 
 ### all

--- a/docs/shared/cli/exec.md
+++ b/docs/shared/cli/exec.md
@@ -69,6 +69,13 @@ The location of current project is available through the environment variable $N
 nx exec -- echo \$NX_PROJECT_ROOT_PATH
 ```
 
+Commands with quotes or other characters that may be stripped or interpreted by the shell should be passed as a single argument:
+
+```
+nx exec -- "npm run foo && npm run bar"
+nx exec -- 'node -e "console.log(\'hello\')"'
+```
+
 ## Options
 
 ### all

--- a/packages/nx/src/command-line/exec/exec.ts
+++ b/packages/nx/src/command-line/exec/exec.ts
@@ -43,9 +43,7 @@ export async function nxExecCommand(
 
   // NX is already running
   if (process.env.NX_TASK_TARGET_PROJECT) {
-    const command = scriptArgV
-      .reduce((cmd, arg) => cmd + `"${arg}" `, '')
-      .trim();
+    const command = scriptArgV.join(' ').trim();
     execSync(command, {
       stdio: 'inherit',
       env: {
@@ -90,7 +88,7 @@ async function runScriptAsNxTarget(
     nxArgs
   );
   projectsToRun.forEach((projectName) => {
-    const command = argv.reduce((cmd, arg) => cmd + `"${arg}" `, '').trim();
+    const command = argv.join(' ').trim();
     execSync(command, {
       stdio: 'inherit',
       env: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Only a single executable + arguments can be provided, not a shell script
for example I wanted to run a command in each package based on whether certain files exist:

```sh
for i in yarn.lock pnpm-lock.yaml pnpm-workspace.yaml .npmrc; do test -e $i && git add $i; done
```

There doesn't seem to be any way to run this with nx currently, even `nx exec -- sh -c '...script...'` fails.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

you can just pass a script as a single argument and it'll run in each package

```sh
nx exec -- 'for i in yarn.lock pnpm-lock.yaml pnpm-workspace.yaml .npmrc; do test -e $i && git add $i; done'
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

I found #13457 after making this change, it should fix that use case too.
