### PR TITLE
fix(rollup): always generate package.json when using @nx/rollup:rollup

### DIFF
--- a/packages/rollup/src/plugins/package-json/generate-package-json.ts
+++ b/packages/rollup/src/plugins/package-json/generate-package-json.ts
@@ -12,12 +12,14 @@ export interface GeneratePackageJsonOptions {
   additionalEntryPoints?: string[];
 }
 
+export const pluginName = 'rollup-plugin-nx-generate-package-json';
+
 export function generatePackageJson(
   options: GeneratePackageJsonOptions,
   packageJson: PackageJson
 ): Plugin {
   return {
-    name: 'rollup-plugin-nx-generate-package-json',
+    name: pluginName,
     writeBundle: () => {
       updatePackageJson(options, packageJson);
     },


### PR DESCRIPTION
Prior to Nx 19.4, the `@nx/rollup:rollup` executor generates `package.json` outside of the actual Rollup build. Nx 19.4 changed this to be a proper Rollup plugin in order to support inferred targets better. This led to a slight regression, where projects that override `plugins` array in their `rollup.config.js` file will also remove the `generatePackageJson` plugin.

This PR brings the behavior back, so the `package.json` file is _always_ generated regardless of how the `plugins` array is customized.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
