### PR TITLE
fix(core): do not mutate target defaults

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1524,6 +1524,41 @@ describe('project-configuration-utils', () => {
         }
       `);
     });
+    it('should not mutate the target', () => {
+      const config = {
+        name: 'project',
+        root: 'libs/project',
+        targets: {
+          foo: {
+            executor: 'nx:noop',
+            options: {
+              config: '{projectRoot}/config.json',
+            },
+            configurations: {
+              prod: {
+                config: '{projectRoot}/config.json',
+              },
+            },
+          },
+          bar: {
+            command: 'echo {projectRoot}',
+            options: {
+              config: '{projectRoot}/config.json',
+            },
+            configurations: {
+              prod: {
+                config: '{projectRoot}/config.json',
+              },
+            },
+          },
+        },
+      };
+      const originalConfig = JSON.stringify(config, null, 2);
+
+      normalizeTarget(config.targets.foo, config);
+      normalizeTarget(config.targets.bar, config);
+      expect(JSON.stringify(config, null, 2)).toEqual(originalConfig);
+    });
   });
 
   describe('createProjectConfigurations', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -1105,6 +1105,13 @@ export function normalizeTarget(
   target: TargetConfiguration,
   project: ProjectConfiguration
 ) {
+  target = {
+    ...target,
+    configurations: {
+      ...target.configurations,
+    },
+  };
+
   target = resolveCommandSyntacticSugar(target, project.root);
 
   target.options = resolveNxTokensInOptions(
@@ -1113,7 +1120,6 @@ export function normalizeTarget(
     `${project.root}:${target}`
   );
 
-  target.configurations ??= {};
   for (const configuration in target.configurations) {
     target.configurations[configuration] = resolveNxTokensInOptions(
       target.configurations[configuration],


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Target defaults is mutated when the target is normalized. Subsequent targets are normalized with the mutated version yielding the incorrect projects configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Target defaults is not mutated and all targets are correct.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
