### PR TITLE
feat(core): ci-workflow adds workflow file to sharedGlobal inputs

### DIFF
--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -212,4 +212,20 @@ describe('CI Workflow generator', () => {
       expect(tree.read('bitbucket-pipelines.yml', 'utf-8')).toMatchSnapshot();
     });
   });
+
+  it('should add workflow files to namedInputs.sharedGlobals', async () => {
+    await ciWorkflowGenerator(tree, { ci: 'azure', name: 'CI' });
+    await ciWorkflowGenerator(tree, { ci: 'bitbucket-pipelines', name: 'CI' });
+    await ciWorkflowGenerator(tree, { ci: 'circleci', name: 'CI' });
+    await ciWorkflowGenerator(tree, { ci: 'github', name: 'CI' });
+    await ciWorkflowGenerator(tree, { ci: 'gitlab', name: 'CI' });
+
+    expect(readJson(tree, 'nx.json').namedInputs.sharedGlobals).toEqual([
+      '{workspaceRoot}/azure-pipelines.yml',
+      '{workspaceRoot}/bitbucket-pipelines.yml',
+      '{workspaceRoot}/.circleci/config.yml',
+      '{workspaceRoot}/.github/workflows/ci.yml',
+      '{workspaceRoot}/.gitlab-ci.yml',
+    ]);
+  });
 });

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
@@ -1,13 +1,13 @@
 import {
-  Tree,
-  names,
+  detectPackageManager,
+  formatFiles,
   generateFiles,
   getPackageManagerCommand,
-  readJson,
+  names,
   NxJsonConfiguration,
-  formatFiles,
+  readJson,
+  Tree,
   writeJson,
-  detectPackageManager,
 } from '@nx/devkit';
 import { deduceDefaultBase } from '../../utilities/default-base';
 import { join } from 'path';
@@ -20,14 +20,19 @@ export interface Schema {
 
 export async function ciWorkflowGenerator(tree: Tree, schema: Schema) {
   const ci = schema.ci;
-
+  const options = normalizeOptions(schema, tree);
   const nxJson: NxJsonConfiguration = readJson(tree, 'nx.json');
+
   if (ci === 'bitbucket-pipelines' && defaultBranchNeedsOriginPrefix(nxJson)) {
-    writeJson(tree, 'nx.json', appendOriginPrefix(nxJson));
+    appendOriginPrefix(nxJson);
   }
 
-  const options = normalizeOptions(schema, tree);
   generateFiles(tree, join(__dirname, 'files', ci), '', options);
+
+  addWorkflowFileToSharedGlobals(nxJson, schema.ci, options.workflowFileName);
+
+  writeJson(tree, 'nx.json', nxJson);
+
   await formatFiles(tree);
 }
 
@@ -93,12 +98,31 @@ function defaultBranchNeedsOriginPrefix(nxJson: NxJsonConfiguration): boolean {
   return !base?.startsWith('origin/');
 }
 
-function appendOriginPrefix(nxJson: NxJsonConfiguration): NxJsonConfiguration {
+function appendOriginPrefix(nxJson: NxJsonConfiguration): void {
   if (nxJson?.affected?.defaultBase) {
     nxJson.affected.defaultBase = `origin/${nxJson.affected.defaultBase}`;
   }
   if (nxJson.defaultBase || !nxJson.affected) {
     nxJson.defaultBase = `origin/${nxJson.defaultBase ?? deduceDefaultBase()}`;
   }
-  return nxJson;
+}
+
+const ciWorkflowInputs: Record<Schema['ci'], string> = {
+  azure: 'azure-pipelines.yml',
+  'bitbucket-pipelines': 'bitbucket-pipelines.yml',
+  circleci: '.circleci/config.yml',
+  github: '.github/workflows/',
+  gitlab: '.gitlab-ci.yml',
+};
+
+function addWorkflowFileToSharedGlobals(
+  nxJson: NxJsonConfiguration,
+  ci: Schema['ci'],
+  workflowFileName: string
+): void {
+  let input = `{workspaceRoot}/${ciWorkflowInputs[ci]}`;
+  if (ci === 'github') input += `${workflowFileName}.yml`;
+  nxJson.namedInputs ??= {};
+  nxJson.namedInputs.sharedGlobals ??= [];
+  nxJson.namedInputs.sharedGlobals.push(input);
 }


### PR DESCRIPTION
When we generate the workflow file, users should also add the new workflow file to the `sharedGlobals` named input, otherwise changes may land without verifying that all tasks are successful.

This is already called out in the CI tutorials, and doing it automatically improves the DX.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
