### PR TITLE
fix(core): decrease initial memory for wasm

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -173,7 +173,7 @@
     "binaryName": "nx",
     "packageName": "@nx/nx",
     "wasm": {
-      "initialMemory": 16384,
+      "initialMemory": 1024,
       "maximumMemory": 32768
     },
     "targets": [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx fails to import Wasm if there is not 16 gigs of memory available which is.. pretty often.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx fails to import wasm if there 1 gig of memory available which should be not often.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
