### PR TITLE
docs(core): update nx connect feature page

### DIFF
--- a/docs/generated/manifests/ci.json
+++ b/docs/generated/manifests/ci.json
@@ -29,14 +29,14 @@
         "tags": []
       },
       {
-        "id": "connect-to-cloud",
-        "name": "Connect Nx Cloud",
+        "id": "connect-to-nx-cloud",
+        "name": "Connect to Nx Cloud",
         "description": "",
         "mediaImage": "",
         "file": "nx-cloud/intro/connect-to-cloud",
         "itemList": [],
         "isExternal": false,
-        "path": "/ci/intro/connect-to-cloud",
+        "path": "/ci/intro/connect-to-nx-cloud",
         "tags": []
       },
       {
@@ -100,15 +100,15 @@
     "path": "/ci/intro/why-nx-cloud",
     "tags": []
   },
-  "/ci/intro/connect-to-cloud": {
-    "id": "connect-to-cloud",
-    "name": "Connect Nx Cloud",
+  "/ci/intro/connect-to-nx-cloud": {
+    "id": "connect-to-nx-cloud",
+    "name": "Connect to Nx Cloud",
     "description": "",
     "mediaImage": "",
     "file": "nx-cloud/intro/connect-to-cloud",
     "itemList": [],
     "isExternal": false,
-    "path": "/ci/intro/connect-to-cloud",
+    "path": "/ci/intro/connect-to-nx-cloud",
     "tags": []
   },
   "/ci/intro/tutorials": {

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5170,9 +5170,9 @@
             "disableCollapsible": false
           },
           {
-            "name": "Connect Nx Cloud",
-            "path": "/ci/intro/connect-to-cloud",
-            "id": "connect-to-cloud",
+            "name": "Connect to Nx Cloud",
+            "path": "/ci/intro/connect-to-nx-cloud",
+            "id": "connect-to-nx-cloud",
             "isExternal": false,
             "children": [],
             "disableCollapsible": false
@@ -5222,9 +5222,9 @@
         "disableCollapsible": false
       },
       {
-        "name": "Connect Nx Cloud",
-        "path": "/ci/intro/connect-to-cloud",
-        "id": "connect-to-cloud",
+        "name": "Connect to Nx Cloud",
+        "path": "/ci/intro/connect-to-nx-cloud",
+        "id": "connect-to-nx-cloud",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/map.json
+++ b/docs/map.json
@@ -1570,8 +1570,8 @@
               "file": "nx-cloud/intro/why-nx-cloud"
             },
             {
-              "name": "Connect Nx Cloud",
-              "id": "connect-to-cloud",
+              "name": "Connect to Nx Cloud",
+              "id": "connect-to-nx-cloud",
               "file": "nx-cloud/intro/connect-to-cloud"
             },
             {

--- a/docs/nx-cloud/intro/connect-to-cloud.md
+++ b/docs/nx-cloud/intro/connect-to-cloud.md
@@ -32,12 +32,12 @@ Or, check out our [recipes for the various CI providers](/ci/recipes/set-up).
 **Step 3: Run your Nx commands as usual**
 
 ```yml
-- run: npx nx-cloud record -- nx format:check
+- run: npx nx-cloud record -- node tools/custom-script.js
 - run: npx nx affected -t lint test build
 - run: npx nx affected -t e2e-ci --parallel 1
 ```
 
-All these commands are automatically picked up by Nx Cloud, split up into smaller tasks and distributed across the specified number of machines.
+All these commands are automatically picked up by Nx Cloud, split up into smaller tasks and distributed across the specified number of machines. Nx Cloud works with Nx tasks automatically, or you can [record non-Nx commands with `nx-cloud record`](/ci/recipes/other/record-commands).
 
 **Step 4: All results are played back automatically**
 

--- a/docs/nx-cloud/intro/why-nx-cloud.md
+++ b/docs/nx-cloud/intro/why-nx-cloud.md
@@ -23,7 +23,7 @@ Read more about individual features of Nx Cloud in the [features section](/ci/fe
 
 ## Integrate Nx Cloud into my CI setup
 
-Ready to experience fast CI? Read the [connect to Nx Cloud](/ci/intro/connect-to-cloud) page for more details.
+Ready to experience fast CI? Read the [connect to Nx Cloud](/ci/intro/connect-to-nx-cloud) page for more details.
 
 ## Learn more
 

--- a/docs/shared/features/remote-cache.md
+++ b/docs/shared/features/remote-cache.md
@@ -10,7 +10,7 @@ In this diagram, Teika runs the build once on his machine, then CI, Kimiko and J
 
 ## Setting Up Nx Cloud
 
-To use **Nx Replay** you need to connect your workspace to Nx Cloud. See the [connect to Nx Cloud recipe](/ci/intro/connect-to-cloud).
+To use **Nx Replay** you need to connect your workspace to Nx Cloud. See the [connect to Nx Cloud recipe](/ci/intro/connect-to-nx-cloud).
 
 ## See Remote Caching in Action
 

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -246,7 +246,7 @@
   - [Intro](/ci/intro)
     - [CI with Nx](/ci/intro/ci-with-nx)
     - [Why Nx Cloud?](/ci/intro/why-nx-cloud)
-    - [Connect Nx Cloud](/ci/intro/connect-to-cloud)
+    - [Connect to Nx Cloud](/ci/intro/connect-to-nx-cloud)
     - [Tutorials](/ci/intro/tutorials)
       - [Circle CI with Nx](/ci/intro/tutorials/circle)
       - [GitHub Actions with Nx](/ci/intro/tutorials/github-actions)

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -482,7 +482,8 @@ const nxCloudUrls = {
     '/ci/concepts/parallelization-distribution',
   '/nx-cloud/:path*': '/ci/:path*',
   '/core-features/:path*': '/features/:path*',
-  '/ci/recipes/set-up/connect-to-cloud': '/ci/intro/connect-to-cloud',
+  '/ci/recipes/set-up/connect-to-cloud': '/ci/intro/connect-to-nx-cloud',
+  '/ci/intro/connect-to-cloud': '/ci/intro/connect-to-nx-cloud',
 };
 
 /**


### PR DESCRIPTION
Fix the title of "Connect to Nx Cloud" to be consistent

Old inconsistent titles:
![Screenshot 2024-07-16 at 10 09 47 AM](https://github.com/user-attachments/assets/8122aa79-edaf-46a9-b278-a3c4e2fa214d)

Also adds a sentence explaining the `nx-cloud record` line in step 3, since that isn't obvious what it is doing.