### PR TITLE
fix(core): properly handle reading target defaults

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -79,6 +79,18 @@ describe('project-configuration-utils', () => {
       ).toEqual('default-value-for-e2e-ci-file');
     });
 
+    it('should return longest matching target even if executor is passed', () => {
+      expect(
+        // This uses an executor which does not have settings in target defaults
+        // thus the target name pattern target defaults are used
+        readTargetDefaultsForTarget(
+          'e2e-ci--file-foo',
+          targetDefaults,
+          'other-executor'
+        ).options['key']
+      ).toEqual('default-value-for-e2e-ci-file');
+    });
+
     it('should not merge top level properties for incompatible targets', () => {
       expect(
         mergeTargetConfigurations(

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -1029,14 +1029,13 @@ export function readTargetDefaultsForTarget(
   targetDefaults: TargetDefaults,
   executor?: string
 ): TargetDefaults[string] {
-  if (executor) {
+  if (executor && targetDefaults?.[executor]) {
     // If an executor is defined in project.json, defaults should be read
     // from the most specific key that matches that executor.
     // e.g. If executor === run-commands, and the target is named build:
     // Use, use nx:run-commands if it is present
     // If not, use build if it is present.
-    const key = [executor, targetName].find((x) => targetDefaults?.[x]);
-    return key ? targetDefaults?.[key] : null;
+    return targetDefaults?.[executor];
   } else if (targetDefaults?.[targetName]) {
     // If the executor is not defined, the only key we have is the target name.
     return targetDefaults?.[targetName];
@@ -1057,7 +1056,7 @@ export function readTargetDefaultsForTarget(
     return targetDefaults[matchingTargetDefaultKey];
   }
 
-  return {};
+  return null;
 }
 
 function createRootMap(projectRootMap: Record<string, ProjectConfiguration>) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When targets have executors, they cannot be matched with a glob pattern

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When targets have executors, they can still be matched with a glob if the executor does not have target defaults set.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
