### PR TITLE
fix(devkit): remove --web from being logged to show project details

### DIFF
--- a/packages/devkit/src/utils/log-show-project-command.ts
+++ b/packages/devkit/src/utils/log-show-project-command.ts
@@ -4,7 +4,7 @@ export function logShowProjectCommand(projectName: string): void {
   output.log({
     title: `👀 View Details of ${projectName}`,
     bodyLines: [
-      `Run "nx show project ${projectName} --web" to view details about this project.`,
+      `Run "nx show project ${projectName}" to view details about this project.`,
     ],
   });
 }


### PR DESCRIPTION
The `--web` option isn't needed in Nx 19 as it is the default. Updating the devkit util to reflect that change.
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
