### PR TITLE
feat(misc): move @module-federation/enhanced to optional peer dep

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.3.0",
     "webpack-merge": "^5.8.0",
     "webpack": "^5.88.0",
-    "@module-federation/enhanced": "~0.2.3",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
     "@nx/eslint": "file:../eslint",
@@ -70,8 +69,14 @@
     "@angular-devkit/build-angular": ">= 16.0.0 < 19.0.0",
     "@angular-devkit/core": ">= 16.0.0 < 19.0.0",
     "@angular-devkit/schematics": ">= 16.0.0 < 19.0.0",
+    "@module-federation/enhanced": "^0.2.3",
     "@schematics/angular": ">= 16.0.0 < 19.0.0",
     "rxjs": "^6.5.3 || ^7.5.0"
+  },
+  "peerDependenciesMeta": {
+    "@module-federation/enhanced": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,11 +38,18 @@
     "file-loader": "^6.2.0",
     "minimatch": "9.0.3",
     "tslib": "^2.3.0",
-    "@module-federation/enhanced": "~0.2.3",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
     "@nx/eslint": "file:../eslint",
     "@nx/web": "file:../web"
+  },
+  "peerDependencies": {
+    "@module-federation/enhanced": "~0.2.3"
+  },
+  "peerDependenciesMeta": {
+    "@module-federation/enhanced": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Move `@module-federation/enhanced` to optional peer dep of `@nx/angular` and `@nx/react`. They are installed to the workspace already, and we don't need them to be a dependency. This allows React users that don't user Webpack/MF to avoid installing this dependency, and ensures the dependency isn't nested in node_modules.


<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
