### PR TITLE
feat(js): added a verdaccio listen address to configuration

### DIFF
--- a/docs/generated/packages/js/executors/verdaccio.json
+++ b/docs/generated/packages/js/executors/verdaccio.json
@@ -23,6 +23,10 @@
         "type": "number",
         "description": "Port of local registry that Verdaccio should listen to"
       },
+      "listenAddress": {
+        "type": "string",
+        "description": "Listen address that Verdaccio should listen to"
+      },
       "config": {
         "type": "string",
         "description": "Path to the custom Verdaccio config file"

--- a/packages/js/src/executors/verdaccio/schema.d.ts
+++ b/packages/js/src/executors/verdaccio/schema.d.ts
@@ -2,6 +2,7 @@ export interface VerdaccioExecutorSchema {
   location: 'global' | 'user' | 'project' | 'none';
   storage?: string;
   port?: number;
+  listenAddress?: string;
   config?: string;
   clear?: boolean;
 }

--- a/packages/js/src/executors/verdaccio/schema.json
+++ b/packages/js/src/executors/verdaccio/schema.json
@@ -20,6 +20,10 @@
       "type": "number",
       "description": "Port of local registry that Verdaccio should listen to"
     },
+    "listenAddress": {
+      "type": "string",
+      "description": "Listen address that Verdaccio should listen to"
+    },
     "config": {
       "type": "string",
       "description": "Path to the custom Verdaccio config file"

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -126,7 +126,8 @@ function createVerdaccioOptions(
     options.port ??= 4873; // set default port if config is not provided
   }
   if (options.port) {
-    verdaccioArgs.push('--listen', options.port.toString());
+    const listenAddress = options.listenAddress ? `${options.listenAddress}:${options.port.toString()}` : options.port.toString();
+    verdaccioArgs.push('--listen', listenAddress);
   }
   return verdaccioArgs;
 }

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -126,7 +126,9 @@ function createVerdaccioOptions(
     options.port ??= 4873; // set default port if config is not provided
   }
   if (options.port) {
-    const listenAddress = options.listenAddress ? `${options.listenAddress}:${options.port.toString()}` : options.port.toString();
+    const listenAddress = options.listenAddress
+      ? `${options.listenAddress}:${options.port.toString()}`
+      : options.port.toString();
     verdaccioArgs.push('--listen', listenAddress);
   }
   return verdaccioArgs;


### PR DESCRIPTION
## Current Behavior
Running Verdaccio through nx always uses localhost by default to listen to.
The Verdaccio config.yaml listen address is always overridden by the executor because it sets the --listen argument.

## Expected Behavior
In our situation, where we are developing in a VM we want Verdaccio to listen to all requests by setting it to 0.0.0.0 instead of localhost.

## Related Issue(s)
No Issue registered

Fixes #
Added a listen address to the Verdaccio configuration and executor.
Decided to make it a simple implementation to prevent breaking changes.
