### PR TITLE
docs(testing): remove wrong cypress config filenames from plugin overview

### DIFF
--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -56,9 +56,7 @@ The `@nx/cypress` plugin will create a task for any project that has a Cypress c
 - `cypress.config.js`
 - `cypress.config.ts`
 - `cypress.config.mjs`
-- `cypress.config.mts`
 - `cypress.config.cjs`
-- `cypress.config.cts`
 
 ### View Inferred Tasks
 

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -56,9 +56,7 @@ The `@nx/cypress` plugin will create a task for any project that has a Cypress c
 - `cypress.config.js`
 - `cypress.config.ts`
 - `cypress.config.mjs`
-- `cypress.config.mts`
 - `cypress.config.cjs`
-- `cypress.config.cts`
 
 ### View Inferred Tasks
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The cypress plugin overview lists `cypress.config.mts` and `cypress.config.cts` filenames, which are not configuration filenames supported by Cypress by default.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The cypress plugin overview only lists valid configuration filenames supported by Cypress.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
