### PR TITLE
fix(linter): log a message when the number of warnings exceeds the specified maxWarnings for the lint executor

### DIFF
--- a/packages/eslint/src/executors/lint/lint.impl.spec.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.spec.ts
@@ -738,6 +738,38 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     expect(output.success).toBeTruthy();
   });
 
+  it('should be a failure if there are more warnings than the set maxWarnings', async () => {
+    mockReports = [
+      {
+        errorCount: 0,
+        warningCount: 4,
+        results: [],
+        usedDeprecatedRules: [],
+      },
+      {
+        errorCount: 0,
+        warningCount: 6,
+        results: [],
+        usedDeprecatedRules: [],
+      },
+    ];
+    setupMocks();
+    const output = await lintExecutor(
+      createValidRunBuilderOptions({
+        eslintConfig: './.eslintrc.json',
+        lintFilePatterns: ['includedFile1'],
+        format: 'json',
+        silent: true,
+        maxWarnings: 3,
+      }),
+      mockContext
+    );
+    expect(output.success).toBe(false);
+    expect(console.info).toHaveBeenCalledWith(
+      'ESLint found too many warnings (maximum: 3).'
+    );
+  });
+
   it('should be a success if there are errors but the force flag is true', async () => {
     mockReports = [
       {

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -200,6 +200,12 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     outputPrintInfo(totals);
   }
 
+  if (totals.warnings > options.maxWarnings) {
+    console.info(
+      `ESLint found too many warnings (maximum: ${options.maxWarnings}).`
+    );
+  }
+
   return {
     success:
       normalizedOptions.force ||


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26906 
