### PR TITLE
fix(module-federation): do not cache assets from static serve

### DIFF
--- a/packages/angular/src/executors/module-federation-dev-server/lib/start-static-remotes-file-server.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/lib/start-static-remotes-file-server.ts
@@ -56,6 +56,7 @@ export function startStaticRemotesFileServer(
       ssl: options.ssl,
       sslCert: options.sslCert,
       sslKey: options.sslKey,
+      cacheSeconds: -1,
     },
     context
   );

--- a/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -56,6 +56,7 @@ export async function* moduleFederationDevServerExecutor(
           spa: false,
           withDeps: false,
           cors: true,
+          cacheSeconds: -1,
         },
         context
       )

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -107,6 +107,7 @@ function startStaticRemotesFileServer(
       ssl: options.ssl,
       sslCert: options.sslCert,
       sslKey: options.sslKey,
+      cacheSeconds: -1,
     },
     context
   );
@@ -267,6 +268,7 @@ export default async function* moduleFederationDevServer(
           withDeps: false,
           spa: false,
           cors: true,
+          cacheSeconds: -1,
         },
         context
       )


### PR DESCRIPTION
We're currently caching files for an hour when serving the host with static remotes. This PR fixes the issue by setting `cacheSeconds: -1` on the static server (disables cache).

This affects development only.
<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
