### PR TITLE
fix(core): record stats for more commands

### DIFF
--- a/packages/nx/src/command-line/connect/command-object.ts
+++ b/packages/nx/src/command-line/connect/command-object.ts
@@ -1,5 +1,6 @@
 import { CommandModule } from 'yargs';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
+import { nxVersion } from '../../utils/versions';
 
 export const yargsConnectCommand: CommandModule = {
   command: 'connect',
@@ -8,6 +9,13 @@ export const yargsConnectCommand: CommandModule = {
   builder: (yargs) => linkToNxDevAndExamples(yargs, 'connect-to-nx-cloud'),
   handler: async () => {
     await (await import('./connect-to-nx-cloud')).connectToNxCloudCommand();
+    await (
+      await import('../../utils/ab-testing')
+    ).recordStat({
+      command: 'connect',
+      nxVersion,
+      useCloud: true,
+    });
     process.exit(0);
   },
 };

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -88,6 +88,22 @@ export async function connectToNxCloudCommand(
   return true;
 }
 
+export async function connectExistingRepoToNxCloudPrompt(
+  command = 'init',
+  key: MessageKey = 'setupNxCloud'
+): Promise<boolean> {
+  const res = await nxCloudPrompt(key).then(
+    (value: MessageOptionKey) => value === 'yes'
+  );
+  await recordStat({
+    command,
+    nxVersion,
+    useCloud: res,
+    meta: messages.codeOfSelectedPromptMessage(key),
+  });
+  return res;
+}
+
 export async function connectToNxCloudWithPrompt(command: string) {
   const setNxCloud = await nxCloudPrompt('setupNxCloud');
   const useCloud =
@@ -98,12 +114,6 @@ export async function connectToNxCloudWithPrompt(command: string) {
     useCloud,
     meta: messages.codeOfSelectedPromptMessage('setupNxCloud'),
   });
-}
-
-export async function connectExistingRepoToNxCloudPrompt(
-  key: MessageKey = 'setupNxCloud'
-): Promise<boolean> {
-  return nxCloudPrompt(key).then((value: MessageOptionKey) => value === 'yes');
 }
 
 async function nxCloudPrompt(key: MessageKey): Promise<MessageOptionKey> {

--- a/packages/nx/src/command-line/connect/view-logs.ts
+++ b/packages/nx/src/command-line/connect/view-logs.ts
@@ -19,6 +19,7 @@ export async function viewLogs(): Promise<number> {
   }
 
   const setupNxCloud = await connectExistingRepoToNxCloudPrompt(
+    'view-logs',
     'setupViewLogs'
   );
   if (!setupNxCloud) {

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -1,5 +1,4 @@
 import { execSync } from 'child_process';
-import { URL } from 'node:url';
 import { output } from '../../../utils/output';
 import { Tree } from '../../../generators/tree';
 import { readJson } from '../../../generators/utils/json';
@@ -7,6 +6,7 @@ import { NxJsonConfiguration } from '../../../config/nx-json';
 import { readNxJson, updateNxJson } from '../../../generators/utils/nx-json';
 import { formatChangedFilesWithPrettierIfAvailable } from '../../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 import { repoUsesGithub, shortenedCloudUrl } from '../../utilities/url-shorten';
+import { getCloudUrl } from '../../utilities/get-cloud-options';
 import { commitChanges } from '../../../utils/git-utils';
 import * as ora from 'ora';
 import * as open from 'open';
@@ -31,11 +31,6 @@ function getRootPackageName(tree: Tree): string {
   } catch (e) {}
   return packageJson?.name ?? 'my-workspace';
 }
-function removeTrailingSlash(apiUrl: string) {
-  return apiUrl[apiUrl.length - 1] === '/'
-    ? apiUrl.substr(0, apiUrl.length - 1)
-    : apiUrl;
-}
 
 function getNxInitDate(): string | null {
   try {
@@ -57,9 +52,7 @@ async function createNxCloudWorkspace(
   installationSource: string,
   nxInitDate: string | null
 ): Promise<{ token: string; url: string }> {
-  const apiUrl = removeTrailingSlash(
-    process.env.NX_CLOUD_API || process.env.NRWL_API || `https://cloud.nx.app`
-  );
+  const apiUrl = getCloudUrl();
   const response = await require('axios').post(
     `${apiUrl}/nx-cloud/create-org-and-workspace`,
     {
@@ -212,9 +205,7 @@ export async function connectToNxCloud(
         silent: schema.hideFormatLogs,
       });
     }
-    const apiUrl = removeTrailingSlash(
-      process.env.NX_CLOUD_API || process.env.NRWL_API || `https://cloud.nx.app`
-    );
+    const apiUrl = getCloudUrl();
     return async () =>
       await printSuccessMessage(
         responseFromCreateNxCloudWorkspace?.url ?? apiUrl,

--- a/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
+++ b/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
@@ -8,3 +8,13 @@ export function getCloudOptions(): CloudTaskRunnerOptions {
   // TODO: The default is not always cloud? But it's not handled at the moment
   return getRunnerOptions('default', nxJson, {}, true);
 }
+
+export function getCloudUrl() {
+  return removeTrailingSlash(
+    process.env.NX_CLOUD_API || process.env.NRWL_API || `https://cloud.nx.app`
+  );
+}
+
+export function removeTrailingSlash(apiUrl: string) {
+  return apiUrl[apiUrl.length - 1] === '/' ? apiUrl.slice(0, -1) : apiUrl;
+}

--- a/packages/nx/src/nx-cloud/utilities/url-shorten.ts
+++ b/packages/nx/src/nx-cloud/utilities/url-shorten.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../devkit-exports';
 import { getGithubSlugOrNull } from '../../utils/git-utils';
+import { getCloudUrl } from './get-cloud-options';
 
 export async function shortenedCloudUrl(
   installationSource: string,
@@ -8,9 +9,7 @@ export async function shortenedCloudUrl(
 ) {
   const githubSlug = getGithubSlugOrNull();
 
-  const apiUrl = removeTrailingSlash(
-    process.env.NX_CLOUD_API || process.env.NRWL_API || `https://cloud.nx.app`
-  );
+  const apiUrl = getCloudUrl();
 
   try {
     const version = await getNxCloudVersion(apiUrl);
@@ -62,9 +61,7 @@ export async function shortenedCloudUrl(
 export async function repoUsesGithub(github?: boolean) {
   const githubSlug = getGithubSlugOrNull();
 
-  const apiUrl = removeTrailingSlash(
-    process.env.NX_CLOUD_API || process.env.NRWL_API || `https://cloud.nx.app`
-  );
+  const apiUrl = getCloudUrl();
 
   const installationSupportsGitHub = await getInstallationSupportsGitHub(
     apiUrl
@@ -76,10 +73,6 @@ export async function repoUsesGithub(github?: boolean) {
       apiUrl.includes('eu.nx.app') ||
       installationSupportsGitHub)
   );
-}
-
-export function removeTrailingSlash(apiUrl: string) {
-  return apiUrl[apiUrl.length - 1] === '/' ? apiUrl.slice(0, -1) : apiUrl;
 }
 
 function getSource(

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { isCI } from './is-ci';
 import { getPackageManagerCommand } from './package-manager';
+import { getCloudUrl } from '../nx-cloud/utilities/get-cloud-options';
 
 export type MessageOptionKey = 'yes' | 'skip';
 
@@ -74,7 +75,7 @@ export async function recordStat(opts: {
   command: string;
   nxVersion: string;
   useCloud: boolean;
-  meta: string;
+  meta?: string;
 }) {
   try {
     if (!shouldRecordStats()) {
@@ -83,7 +84,7 @@ export async function recordStat(opts: {
     const axios = require('axios');
     await (axios['default'] ?? axios)
       .create({
-        baseURL: 'https://cloud.nx.app',
+        baseURL: getCloudUrl(),
         timeout: 400,
       })
       .post('/nx-cloud/stats', {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Stats are not recorded for `nx connect`, `nx view-logs`, and `nx init`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Stats are recorded for those commands and they get sent to the right URL

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
