### PR TITLE
docs(core): added missing close bracket

### DIFF
--- a/docs/shared/features/cache-task-results.md
+++ b/docs/shared/features/cache-task-results.md
@@ -87,7 +87,7 @@ To achieve this, we can add an `inputs` and `outputs` definition globally for al
   "targetDefaults": {
     "build": {
       "inputs": ["{projectRoot}/**/*", "!{projectRoot}/**/*.md"],
-      "outputs": ["{workspaceRoot}/dist/{projectName"]
+      "outputs": ["{workspaceRoot}/dist/{projectName}"]
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

There is a missing closing bracket in the [cache-task-result](https://nx.dev/features/cache-task-results#finetune-caching-with-inputs-and-outputs)

<img width="696" alt="Screenshot 2024-07-21 at 2 22 01 PM" src="https://github.com/user-attachments/assets/4a798a3a-3869-46e9-bd0b-cb762034a70f">


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Add the missing closing bracket: change `{projectName` to `{projectName}`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
N/A!
