### PR TITLE
docs(core): document wildcard support for dependsOn field

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -434,7 +434,7 @@ Starting from v19.5.0, wildcards can be used to define dependencies in the `depe
         "build-*", // support for using wildcards in dependsOn, matches: "build-css", "build-js" targets of dependencies
         "*build-*" // matches tasks: "build-css", "build-js" as well as "task-with-build-in-middle" targets of dependencies.
       ]
-    },
+    }
   }
 }
 ```

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -431,13 +431,10 @@ Starting from v19.5.0, wildcards can be used to define dependencies in the `depe
           "target": "build", // target name
           "params": "ignore" // "forward" or "ignore", defaults to "ignore"
         },
-        "build-*", // support for using wildcards in dependsOn, matches: build-css, build-js and also then-build-something-else
-        "^build-*" // matches only build-css, build-js
+        "build-*", // support for using wildcards in dependsOn, matches: "build-css", "build-js" targets of dependencies
+        "*build-*" // matches tasks: "build-css", "build-js" as well as "task-with-build-in-middle" targets of dependencies.
       ]
     },
-    "build-css": {},
-    "build-js": {},
-    "then-build-something-else": {}
   }
 }
 ```

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -340,34 +340,9 @@ instance, `"dependsOn": ["build"]` of
 the `test` target tells Nx that before it can test `mylib` it needs to make sure that `mylib` is built, which will
 result in `mylib`'s dependencies being built as well.
 
-Starting from v19.5.0, wildcards can be used to define dependencies in the `dependsOn` field.
-
 You can also express task dependencies with an object syntax:
 
 {% tabs %}
-{% tab label="Version >=19.5.0" %}
-
-```json
-{
-  "targets": {
-    "test": {
-      "dependsOn": [
-        {
-          "target": "build", // target name
-          "params": "ignore" // "forward" or "ignore", defaults to "ignore"
-        },
-        "build-*", // support for using wildcards in dependsOn, matches: build-css, build-js and also then-build-something-else
-        "^build-*" // matches only build-css, build-js
-      ]
-    },
-    "build-css": {},
-    "build-js": {},
-    "then-build-something-else": {}
-  }
-}
-```
-
-{% /tab %}
 {% tab label="Version 16+ (self)" %}
 
 ```json
@@ -444,6 +419,28 @@ You can also express task dependencies with an object syntax:
 
 {% /tab %}
 {% /tabs %}
+
+Starting from v19.5.0, wildcards can be used to define dependencies in the `dependsOn` field.
+
+```json
+{
+  "targets": {
+    "test": {
+      "dependsOn": [
+        {
+          "target": "build", // target name
+          "params": "ignore" // "forward" or "ignore", defaults to "ignore"
+        },
+        "build-*", // support for using wildcards in dependsOn, matches: build-css, build-js and also then-build-something-else
+        "^build-*" // matches only build-css, build-js
+      ]
+    },
+    "build-css": {},
+    "build-js": {},
+    "then-build-something-else": {}
+  }
+}
+```
 
 #### Examples
 

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -340,9 +340,34 @@ instance, `"dependsOn": ["build"]` of
 the `test` target tells Nx that before it can test `mylib` it needs to make sure that `mylib` is built, which will
 result in `mylib`'s dependencies being built as well.
 
+Starting from v19.5.0, wildcards can be used to define dependencies in the `dependsOn` field.
+
 You can also express task dependencies with an object syntax:
 
 {% tabs %}
+{% tab label="Version >=19.5.0" %}
+
+```json
+{
+  "targets": {
+    "test": {
+      "dependsOn": [
+        {
+          "target": "build", // target name
+          "params": "ignore" // "forward" or "ignore", defaults to "ignore"
+        },
+        "build-*", // support for using wildcards in dependsOn, matches: build-css, build-js and also then-build-something-else
+        "^build-*" // matches only build-css, build-js
+      ]
+    },
+    "build-css": {},
+    "build-js": {},
+    "then-build-something-else": {}
+  }
+}
+```
+
+{% /tab %}
 {% tab label="Version 16+ (self)" %}
 
 ```json

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -431,8 +431,10 @@ Starting from v19.5.0, wildcards can be used to define dependencies in the `depe
           "target": "build", // target name
           "params": "ignore" // "forward" or "ignore", defaults to "ignore"
         },
-        "build-*", // support for using wildcards in dependsOn, matches: "build-css", "build-js" targets of dependencies
-        "*build-*" // matches tasks: "build-css", "build-js" as well as "task-with-build-in-middle" targets of dependencies.
+        "build-*", // support for using wildcards in dependsOn, matches: "build-css", "build-js" targets of current project
+        "^build-*", // matches tasks: "build-css", "build-js" targets of dependencies
+        "*build-*", // matches tasks: "build-css", "build-js" as well as "task-with-build-in-middle" targets of current project
+        "^*build-*" // matches tasks: "build-css", "build-js" as well as "task-with-build-in-middle" targets of dependencies
       ]
     }
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
This feature is not yet documented...

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Document wildcard support in `dependsOn` field for project configurations.

Note: Reading through the PR below that impls. this wildcard support, I couldn't quite figure out if it was actually able to also work in case of object syntax and whether this will also work for `targetDefaults`... so if you know any better, please lemme know so I can update this PR 🙏 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

documents #19611