### PR TITLE
feat(module-federation): support setremotedefinition api

### DIFF
--- a/packages/angular/mf/mf.ts
+++ b/packages/angular/mf/mf.ts
@@ -12,9 +12,13 @@ export function setRemoteUrlResolver(
   resolveRemoteUrl = _resolveRemoteUrl;
 }
 
-let remoteUrlDefinitions: Record<string, string>;
+let remoteUrlDefinitions: Record<string, string> = {};
 export function setRemoteDefinitions(definitions: Record<string, string>) {
   remoteUrlDefinitions = definitions;
+}
+
+export function setRemoteDefinition(remoteName: string, remoteUrl: string) {
+  remoteUrlDefinitions[remoteName] = remoteUrl;
 }
 
 let remoteModuleMap = new Map<string, unknown>();

--- a/packages/react/mf/dynamic-federation.ts
+++ b/packages/react/mf/dynamic-federation.ts
@@ -15,7 +15,7 @@ declare const document: {
 
 declare const __webpack_init_sharing__: (scope: 'default') => Promise<void>;
 declare const __webpack_share_scopes__: { default: unknown };
-let remoteUrlDefinitions: Record<string, string>;
+let remoteUrlDefinitions: Record<string, string> = {};
 let resolveRemoteUrl: ResolveRemoteUrlFunction;
 const remoteModuleMap = new Map<string, unknown>();
 const remoteContainerMap = new Map<string, unknown>();
@@ -29,6 +29,10 @@ export function setRemoteUrlResolver(
 
 export function setRemoteDefinitions(definitions: Record<string, string>) {
   remoteUrlDefinitions = definitions;
+}
+
+export function setRemoteDefinition(remoteName: string, remoteUrl: string) {
+  remoteUrlDefinitions[remoteName] = remoteUrl;
 }
 
 export async function loadRemoteModule(remoteName: string, moduleName: string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The only method available to manage remotes is `setRemoteDefinitions` method, that overwrite the previous state, as expected. The problem is that in some cases, when it needed to add more remotes dynamically, this API replace it current state, removing the previous remotes.

## Expected Behavior
Expose a new API called `setRemoteDefinition(remoteName: string, remoteUrl: string)` that adds or replace a new remote definition in the remotes map, without overwrite the remotes map.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27050
