### PR TITLE
feat(misc): add more logging while running migrations

### DIFF
--- a/e2e/lerna-smoke-tests/src/lerna-smoke-tests.test.ts
+++ b/e2e/lerna-smoke-tests/src/lerna-smoke-tests.test.ts
@@ -39,7 +39,15 @@ describe('Lerna Smoke Tests', () => {
     // If this snapshot fails it means that nx repair generators are making assumptions which don't hold true for lerna workspaces
     it('should complete successfully on a new lerna workspace', async () => {
       let result = runLernaCLI(`repair`);
-      result = result.replace(/.*\/node_modules\/.*\n/, ''); // yarn adds "$ /node_modules/.bin/lerna repair" to the output
+      result = result
+        .replace(/.*\/node_modules\/.*\n/, '') // yarn adds "$ /node_modules/.bin/lerna repair" to the output
+        .replace(
+          /Running the following migrations:\n(?:.*\n)*---------------------------------------------------------\n\n/,
+          ''
+        ) // sorted list of all migrations to be run
+        .replace(/Running migration.*\n/g, '') // start of individual migration run
+        .replace(/Ran .* from .*\n  .*\n\n/g, '') // end of individual migration run
+        .replace(/No changes were made\n\n/g, ''); // no changes during individual migration run
       expect(result).toMatchInlineSnapshot(`
 
         Lerna   No changes were necessary. This workspace is up to date!

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1427,7 +1427,14 @@ export async function executeMigrations(
       : 1;
   });
 
+  logger.info(`Running the following migrations:`);
+  sortedMigrations.forEach((m) =>
+    logger.info(`- ${m.package}: ${m.name} (${m.description})`)
+  );
+  logger.info(`---------------------------------------------------------\n`);
+
   for (const m of sortedMigrations) {
+    logger.info(`Running migration ${m.package}: ${m.name}`);
     try {
       const { collection, collectionPath } = readMigrationCollection(
         m.package,
@@ -1441,15 +1448,17 @@ export async function executeMigrations(
           m.name
         );
 
+        logger.info(`Ran ${m.name} from ${m.package}`);
+        logger.info(`  ${m.description}\n`);
         if (changes.length < 1) {
+          logger.info(`No changes were made\n`);
           migrationsWithNoChanges.push(m);
-          // If no changes are made, continue on without printing anything
           continue;
         }
 
-        logger.info(`Ran ${m.name} from ${m.package}`);
-        logger.info(`  ${m.description}\n`);
+        logger.info('Changes:');
         printChanges(changes, '  ');
+        logger.info('');
       } else {
         const ngCliAdapter = await getNgCompatLayer();
         const { madeChanges, loggingQueue } = await ngCliAdapter.runMigration(
@@ -1462,15 +1471,17 @@ export async function executeMigrations(
           isVerbose
         );
 
+        logger.info(`Ran ${m.name} from ${m.package}`);
+        logger.info(`  ${m.description}\n`);
         if (!madeChanges) {
+          logger.info(`No changes were made\n`);
           migrationsWithNoChanges.push(m);
-          // If no changes are made, continue on without printing anything
           continue;
         }
 
-        logger.info(`Ran ${m.name} from ${m.package}`);
-        logger.info(`  ${m.description}\n`);
+        logger.info('Changes:');
         loggingQueue.forEach((log) => logger.info('  ' + log));
+        logger.info('');
       }
 
       if (shouldCreateCommits) {


### PR DESCRIPTION
## Current Behavior

When running migrations, the user currently only sees any logging feedback when a migration has done any changes.

This causes the following problems:
1. Especially for large codebases and/or long-running migrations, this can result in nothing being shown for a long time. In my case, running the migrations for Nx 18 => 19 (which also upgrades Angular 17 => 18) this takes several hours, with almost no feedback on what has been done so far.
2. Before the migrations are run, they are sorted. However, the sorted list is not displayed to the user. The user may be confused as to why a migration is run "out-of-order". Also, if the migrations are aborted (either manually or due to a crash), it is difficult for the user to know which migrations have been run already, and thus could be skipped.

## Expected Behavior

This adds some more logging:

1. Before the migrations are run, displays the sorted list of migrations
2. Before each migration is run, displays the migration which will be run
3. After each migration is run, always displays a completion message. If no changes were made, also displays that as message.

> Note that I marked this as "feature", but I'm not sure if it is a new feature, or a "chore" or a "fix"
