### PR TITLE
fix(core): fix watch daemon error

### DIFF
--- a/e2e/nx/src/watch.test.ts
+++ b/e2e/nx/src/watch.test.ts
@@ -174,6 +174,7 @@ async function runWatch(command: string) {
         CI: 'true',
         ...getStrippedEnvironmentVariables(),
         FORCE_COLOR: 'false',
+        NX_DAEMON: 'true',
       },
       shell: true,
       stdio: 'pipe',

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -159,7 +159,7 @@ export async function watch(args: WatchArguments) {
     process.env.NX_VERBOSE_LOGGING = 'true';
   }
 
-  if (daemonClient.enabled()) {
+  if (!daemonClient.enabled()) {
     output.error({
       title:
         'Daemon is not running. The watch command is not supported without the Nx Daemon.',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx watch` throws an error saying the daemon is not running when the daemon is indeed running.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx watch` does not throw an error saying the daemon is not running when the daemon is indeed running.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
