### PR TITLE
fix(core): shorten socket length for plugin workers

### DIFF
--- a/packages/nx/src/daemon/socket-utils.ts
+++ b/packages/nx/src/daemon/socket-utils.ts
@@ -23,7 +23,7 @@ export const getForkedProcessOsSocketPath = (id: string) => {
 };
 
 export const getPluginOsSocketPath = (id: string) => {
-  let path = resolve(join(getSocketDir(), 'plugin' + id + '.sock'));
+  let path = resolve(join(getSocketDir(true), 'plugin' + id + '.sock'));
   return isWindows ? '\\\\.\\pipe\\nx\\' + resolve(path) : resolve(path);
 };
 

--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -58,9 +58,11 @@ function socketDirName() {
  * We try to create a socket file in a tmp dir, but if it doesn't work because
  * for instance we don't have permissions, we create it in DAEMON_DIR_FOR_CURRENT_WORKSPACE
  */
-export function getSocketDir() {
+export function getSocketDir(alreadyUnique = false) {
   try {
-    const dir = process.env.NX_DAEMON_SOCKET_DIR ?? socketDirName();
+    const dir =
+      process.env.NX_DAEMON_SOCKET_DIR ??
+      (alreadyUnique ? tmpdir : socketDirName());
     ensureDirSync(dir);
     return dir;
   } catch (e) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Plugin worker's socket path includes a hash digest of the workspace root. This is not needed, as the socket path already includes the process pid in it which is unique. The hash digest adds an additional 20 characters to the path and as the path is too long on some unix systems the uniqueness is dropped, causing the plugin transactions to get hit inappropriately.

## Expected Behavior
The plugin socket path doesn't contain extra characters, so it should be unique.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Possibly related #27040
