### PR TITLE
chore(repo): make publishing depend on build targets

### DIFF
--- a/nx-dev/util-ai/package.json
+++ b/nx-dev/util-ai/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@nx/nx-dev/util-ai",
+  "private": true,
   "version": "0.0.1",
   "dependencies": {
     "@supabase/supabase-js": "^2.26.0",

--- a/nx.json
+++ b/nx.json
@@ -139,18 +139,12 @@
     "e2e-ci--**/*": {
       "inputs": ["e2eInputs", "^production"],
       "parallelism": false,
-      "dependsOn": [
-        "nx:build-native",
-        "@nx/nx-source:populate-local-registry-storage"
-      ]
+      "dependsOn": ["@nx/nx-source:populate-local-registry-storage"]
     },
     "e2e-macos-ci--**/*": {
       "inputs": ["e2eInputs", "^production"],
       "parallelism": false,
-      "dependsOn": [
-        "nx:build-native",
-        "@nx/nx-source:populate-local-registry-storage"
-      ]
+      "dependsOn": ["@nx/nx-source:populate-local-registry-storage"]
     },
     "e2e-base": {
       "inputs": ["default", "^production"]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://nx.dev",
   "private": true,
   "scripts": {
-    "build": "nx run-many --target build --parallel 8 --exclude nx-dev,typedoc-theme,tools-documentation-create-embeddings",
+    "build": "nx run-many --target build --parallel 8 --exclude nx-dev,typedoc-theme,tools-documentation-create-embeddings,nx-dev-util-ai",
     "commit": "czg",
     "check-commit": "node ./scripts/commit-lint.js",
     "check-format": "nx format:check --all",
@@ -12,7 +12,7 @@
     "check-lock-files": "node ./scripts/check-lock-files.js",
     "check-documentation-map": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/map-link-checker.ts",
     "check-codeowners": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/check-codeowners.ts",
-    "nx-release": "ts-node -P ./scripts/tsconfig.release.json ./scripts/nx-release",
+    "nx-release": "nx nx-release @nx/nx-source --parallel 8",
     "prepublishOnly": "node ./scripts/update-package-group.js",
     "local-registry": "nx local-registry @nx/nx-source",
     "documentation": "ts-node -P scripts/tsconfig.scripts.json ./scripts/documentation/generators/main.ts && pnpm check-documentation-map",

--- a/project.json
+++ b/project.json
@@ -15,16 +15,26 @@
       "inputs": [
         {
           "input": "production",
-          "projects": [
-            "*",
-            "!nx-dev",
-            "!typedoc-theme",
-            "!tools-documentation-create-embeddings"
-          ]
+          "projects": ["tag:npm:public"]
+        }
+      ],
+      "dependsOn": [
+        {
+          "target": "build",
+          "projects": ["tag:npm:public"]
         }
       ],
       "command": "node ./scripts/local-registry/run-populate-storage.mjs",
       "outputs": ["{workspaceRoot}/build/local-registry/storage"]
+    },
+    "nx-release": {
+      "dependsOn": [
+        {
+          "target": "build",
+          "projects": ["tag:npm:public"]
+        }
+      ],
+      "command": "ts-node -P ./scripts/tsconfig.release.json ./scripts/nx-release"
     }
   }
 }

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -31,13 +31,6 @@ const VALID_AUTHORS_FOR_LATEST = [
     });
   }
 
-  const buildCommand = 'pnpm build';
-  console.log(`> ${buildCommand}`);
-  execSync(buildCommand, {
-    stdio: [0, 1, 2],
-    maxBuffer: LARGE_BUFFER,
-  });
-
   // Ensure all the native-packages directories are available at the top level of the build directory, enabling consistent packageRoot structure
   execSync(`pnpm nx copy-native-package-directories nx`, {
     stdio: isVerboseLogging ? [0, 1, 2] : 'ignore',

--- a/typedoc-theme/package.json
+++ b/typedoc-theme/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@nx/typedoc-theme",
+  "private": true,
   "version": "0.0.1",
   "keywords": [
     "typedocplugin"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Populating the local registry for e2e tests is not dependent on the builds but runs them. It sometimes gets cache misses for some builds thus making that inconsistent.

https://staging.nx.app/runs/FxIwbj6UQo/task/%40nx%2Fnx-source%3Apopulate-local-registry-storage

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Populating the local registry for e2e tests is dependent on the builds and does not run them within itself. In the CI pipeline, this ensures that the build tasks are run first.

https://staging.nx.app/runs/NUrFeUBbQk/task/%40nx%2Fnx-source%3Apopulate-local-registry-storage

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
