### PR TITLE
fix(linter): ensure too many warnings is only logged if enabled

### DIFF
--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -200,7 +200,7 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     outputPrintInfo(totals);
   }
 
-  if (totals.warnings > options.maxWarnings) {
+  if (options.maxWarnings >= 0 && totals.warnings > options.maxWarnings) {
     console.info(
       `ESLint found too many warnings (maximum: ${options.maxWarnings}).`
     );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

ESLint found too many warnings (maximum: -1).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nothing should be logged if maximum is set to -1
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
