### PR TITLE
fix(vite): respect existing package.json type #27057

### DIFF
--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -129,7 +129,7 @@ export async function* viteBuildExecutor(
       }
     );
 
-    builtPackageJson.type = 'module';
+    builtPackageJson.type ??= 'module';
 
     writeJsonFile(
       `${outDirRelativeToWorkspaceRoot}/package.json`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/vite:build` executor is always overwriting the `packageJson.type` field when generating a packageJson.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `@nx/vite:build` executor should respect the existing type in packageJson

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27057
