### PR TITLE
feat(misc): prioritize github onboarding flow

### DIFF
--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -3,7 +3,7 @@ import { readNxJson } from '../../config/configuration';
 import { FsTree, flushChanges } from '../../generators/tree';
 import { connectToNxCloud } from '../../nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud';
 import { shortenedCloudUrl } from '../../nx-cloud/utilities/url-shorten';
-import { getNxCloudUrl, isNxCloudUsed } from '../../utils/nx-cloud-utils';
+import { isNxCloudUsed } from '../../utils/nx-cloud-utils';
 import { runNxSync } from '../../utils/child-process';
 import { NxJsonConfiguration } from '../../config/nx-json';
 import { NxArgs } from '../../utils/command-line-utils';

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -70,10 +70,9 @@ async function createNxCloudWorkspace(
 }
 
 async function printSuccessMessage(
-  url: string,
   token: string | undefined,
   installationSource: string,
-  usesGithub?: boolean,
+  usesGithub: boolean,
   directory?: string
 ) {
   const connectCloudUrl = await shortenedCloudUrl(
@@ -205,10 +204,8 @@ export async function connectToNxCloud(
         silent: schema.hideFormatLogs,
       });
     }
-    const apiUrl = getCloudUrl();
     return async () =>
       await printSuccessMessage(
-        responseFromCreateNxCloudWorkspace?.url ?? apiUrl,
         responseFromCreateNxCloudWorkspace?.token,
         schema.installationSource,
         usesGithub,

--- a/packages/nx/src/nx-cloud/utilities/url-shorten.spec.ts
+++ b/packages/nx/src/nx-cloud/utilities/url-shorten.spec.ts
@@ -1,12 +1,24 @@
+import { getGithubSlugOrNull } from '../../utils/git-utils';
 import {
   removeVersionModifier,
   compareCleanCloudVersions,
   getNxCloudVersion,
   versionIsValid,
+  getURLifShortenFailed,
+  repoUsesGithub,
 } from './url-shorten';
+import { getCloudUrl } from './get-cloud-options';
 
 jest.mock('axios', () => ({
   get: jest.fn(),
+}));
+
+jest.mock('../../utils/git-utils', () => ({
+  getGithubSlugOrNull: jest.fn(),
+}));
+
+jest.mock('./get-cloud-options', () => ({
+  getCloudUrl: jest.fn(),
 }));
 
 describe('URL shorten various functions', () => {
@@ -98,6 +110,149 @@ describe('URL shorten various functions', () => {
       expect(versionIsValid('2312.26.')).toBe(false); // Extra period at the end
       expect(versionIsValid('.2312.26.100')).toBe(false); // Extra period at the beginning
       expect(versionIsValid('2312.26.extra')).toBe(false); // Non-numeric build number
+    });
+  });
+
+  describe('getURLifShortenFailed', () => {
+    const apiUrl = 'https://example.com';
+    const source = 'source-test';
+    const accessToken = 'access-token';
+
+    test('should return GitHub URL with slug when usesGithub is true and githubSlug is provided', () => {
+      const usesGithub = true;
+      const githubSlug = 'user/repo';
+
+      const result = getURLifShortenFailed(
+        usesGithub,
+        githubSlug,
+        apiUrl,
+        source
+      );
+
+      expect(result).toBe(
+        `${apiUrl}/setup/connect-workspace/github/connect?name=${encodeURIComponent(
+          githubSlug
+        )}&source=${source}`
+      );
+    });
+
+    test('should return GitHub select URL when usesGithub is true and githubSlug is not provided', () => {
+      const usesGithub = true;
+      const githubSlug = null;
+
+      const result = getURLifShortenFailed(
+        usesGithub,
+        githubSlug,
+        apiUrl,
+        source
+      );
+
+      expect(result).toBe(
+        `${apiUrl}/setup/connect-workspace/github/select&source=${source}`
+      );
+    });
+
+    test('should return manual URL when usesGithub is false', () => {
+      const usesGithub = false;
+      const githubSlug = 'user/repo';
+
+      const result = getURLifShortenFailed(
+        usesGithub,
+        githubSlug,
+        apiUrl,
+        source,
+        accessToken
+      );
+
+      expect(result).toBe(
+        `${apiUrl}/setup/connect-workspace/manual?accessToken=${accessToken}&source=${source}`
+      );
+    });
+
+    test('should return manual URL when usesGithub is false and accessToken is not provided', () => {
+      const usesGithub = false;
+      const githubSlug = null;
+
+      const result = getURLifShortenFailed(
+        usesGithub,
+        githubSlug,
+        apiUrl,
+        source
+      );
+
+      expect(result).toBe(
+        `${apiUrl}/setup/connect-workspace/manual?accessToken=undefined&source=${source}`
+      );
+    });
+  });
+
+  describe('repoUsesGithub', () => {
+    const axios = require('axios');
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should return true when githubSlug is provided and apiUrl includes cloud.nx.app', async () => {
+      (getGithubSlugOrNull as jest.Mock).mockReturnValue('user/repo');
+      (getCloudUrl as jest.Mock).mockReturnValue('https://cloud.nx.app');
+      axios.get.mockResolvedValue({
+        data: { isGithubIntegrationEnabled: false },
+      });
+      const result = await repoUsesGithub(
+        false,
+        'user/repo',
+        'https://cloud.nx.app'
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when github is true and installation supports GitHub', async () => {
+      (getGithubSlugOrNull as jest.Mock).mockReturnValue(null);
+      (getCloudUrl as jest.Mock).mockReturnValue('https://api.other.app');
+      axios.get.mockResolvedValue({
+        data: { isGithubIntegrationEnabled: true },
+      });
+      const result = await repoUsesGithub(
+        true,
+        undefined,
+        'https://api.other.app'
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when githubSlug and github are not provided and installation does not support GitHub', async () => {
+      (getGithubSlugOrNull as jest.Mock).mockReturnValue(null);
+      (getCloudUrl as jest.Mock).mockReturnValue('https://api.other.app');
+      axios.get.mockResolvedValue({
+        data: { isGithubIntegrationEnabled: false },
+      });
+      const result = await repoUsesGithub();
+      expect(result).toBe(false);
+    });
+
+    it('should return true when githubSlug is not provided but github is true and apiUrl includes eu.nx.app', async () => {
+      (getGithubSlugOrNull as jest.Mock).mockReturnValue(null);
+      (getCloudUrl as jest.Mock).mockReturnValue('https://eu.nx.app');
+      axios.get.mockResolvedValue({
+        data: { isGithubIntegrationEnabled: false },
+      });
+      const result = await repoUsesGithub(true, undefined, 'https://eu.nx.app');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when apiUrl is not provided but githubSlug is provided and installation supports GitHub', async () => {
+      (getGithubSlugOrNull as jest.Mock).mockReturnValue('user/repo');
+      (getCloudUrl as jest.Mock).mockReturnValue('https://api.other.app');
+      axios.get.mockResolvedValue({
+        data: { isGithubIntegrationEnabled: true },
+      });
+      const result = await repoUsesGithub(false, 'user/repo');
+
+      expect(result).toBe(true);
+      expect(getCloudUrl).toHaveBeenCalled();
     });
   });
 });

--- a/packages/nx/src/utils/git-utils.spec.ts
+++ b/packages/nx/src/utils/git-utils.spec.ts
@@ -1,84 +1,223 @@
-import { extractUserAndRepoFromGitHubUrl } from './git-utils';
+import {
+  extractUserAndRepoFromGitHubUrl,
+  getGithubSlugOrNull,
+} from './git-utils';
+import { execSync } from 'child_process';
 
-describe('extractUserAndRepoFromGitHubUrl', () => {
-  describe('ssh cases', () => {
-    it('should return the github user + repo info for origin', () => {
-      expect(
-        extractUserAndRepoFromGitHubUrl(
-          `
+jest.mock('child_process');
+
+describe('git utils tests', () => {
+  describe('getGithubSlugOrNull', () => {
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should return the github slug from the remote URL', () => {
+      (execSync as jest.Mock).mockReturnValue(`
+      origin	git@github.com:origin-user/repo-name.git (fetch)
+      origin	git@github.com:origin-user/repo-name.git (push)
+    `);
+
+      const result = getGithubSlugOrNull();
+
+      expect(result).toBe('origin-user/repo-name');
+      expect(execSync).toHaveBeenCalledWith('git remote -v');
+    });
+
+    it('should return "github" if there are no remotes', () => {
+      (execSync as jest.Mock).mockReturnValue('');
+
+      const result = getGithubSlugOrNull();
+
+      expect(result).toBe('github');
+      expect(execSync).toHaveBeenCalledWith('git remote -v');
+    });
+
+    it('should return "github" if execSync throws an error', () => {
+      (execSync as jest.Mock).mockImplementation(() => {
+        throw new Error('error');
+      });
+
+      const result = getGithubSlugOrNull();
+
+      expect(result).toBe('github');
+      expect(execSync).toHaveBeenCalledWith('git remote -v');
+    });
+
+    it('should return the first github remote slug if no origin is present', () => {
+      (execSync as jest.Mock).mockReturnValue(`
+      upstream	git@github.com:upstream-user/repo-name.git (fetch)
+      upstream	git@github.com:upstream-user/repo-name.git (push)
+    `);
+
+      const result = getGithubSlugOrNull();
+
+      expect(result).toBe('upstream-user/repo-name');
+      expect(execSync).toHaveBeenCalledWith('git remote -v');
+    });
+
+    it('should return null if remote is set up but not github', () => {
+      (execSync as jest.Mock).mockReturnValue(`
+      upstream	git@gitlab.com:upstream-user/repo-name.git (fetch)
+      upstream	git@gitlab.com:upstream-user/repo-name.git (push)
+    `);
+
+      const result = getGithubSlugOrNull();
+
+      expect(result).toBeNull();
+      expect(execSync).toHaveBeenCalledWith('git remote -v');
+    });
+
+    it('should return the first github remote slug for HTTPS URLs', () => {
+      (execSync as jest.Mock).mockReturnValue(`
+      origin	https://github.com/origin-user/repo-name.git (fetch)
+      origin	https://github.com/origin-user/repo-name.git (push)
+    `);
+
+      const result = getGithubSlugOrNull();
+
+      expect(result).toBe('origin-user/repo-name');
+      expect(execSync).toHaveBeenCalledWith('git remote -v');
+    });
+  });
+
+  describe('extractUserAndRepoFromGitHubUrl', () => {
+    describe('ssh cases', () => {
+      it('should return the github user + repo info for origin', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
           upstream	git@github.com:upstream-user/repo-name.git (fetch)
           upstream	git@github.com:upstream-user/repo-name.git (push)
           origin	git@github.com:origin-user/repo-name.git (fetch)
           origin	git@github.com:origin-user/repo-name.git (push)
         `
-        )
-      ).toBe('origin-user/repo-name');
-    });
+          )
+        ).toBe('origin-user/repo-name');
+      });
 
-    it('should return the github user + repo info for the first one since no origin', () => {
-      expect(
-        extractUserAndRepoFromGitHubUrl(
-          `
+      it('should return the github user + repo info for upstream since no origin', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
           upstream	git@github.com:upstream-user/repo-name.git (fetch)
           upstream	git@github.com:upstream-user/repo-name.git (push)
+          base	git@github.com:base-user/repo-name.git (fetch)
+          base	git@github.com:base-user/repo-name.git (push)
           other	git@github.com:other-user/repo-name.git (fetch)
           other	git@github.com:other-user/repo-name.git (push)
         `
-        )
-      ).toBe('upstream-user/repo-name');
-    });
+          )
+        ).toBe('upstream-user/repo-name');
+      });
 
-    it('should return null since no github', () => {
-      expect(
-        extractUserAndRepoFromGitHubUrl(
-          `
+      it('should return the github user + repo info for base since no origin and upstream', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
+          base	git@github.com:base-user/repo-name.git (fetch)
+          base	git@github.com:base-user/repo-name.git (push)
+          other	git@github.com:other-user/repo-name.git (fetch)
+          other	git@github.com:other-user/repo-name.git (push)
+        `
+          )
+        ).toBe('base-user/repo-name');
+      });
+
+      it('should return the github user + repo info for the first one since no origin, upstream, or base', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
+          other	git@github.com:other-user/repo-name.git (fetch)
+          other	git@github.com:other-user/repo-name.git (push)
+          another	git@github.com:another-user/repo-name.git (fetch)
+          another	git@github.com:another-user/repo-name.git (push)
+        `
+          )
+        ).toBe('other-user/repo-name');
+      });
+
+      it('should return null since no github', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
           upstream	git@random.com:upstream-user/repo-name.git (fetch)
           upstream	git@random.com:upstream-user/repo-name.git (push)
           origin	git@random.com:other-user/repo-name.git (fetch)
           origin	git@random.com:other-user/repo-name.git (push)
         `
-        )
-      ).toBe(null);
+          )
+        ).toBe(null);
+      });
     });
-  });
-  describe('https cases', () => {
-    it('should return the github user + repo info for origin', () => {
-      expect(
-        extractUserAndRepoFromGitHubUrl(
-          `
+
+    describe('https cases', () => {
+      it('should return the github user + repo info for origin', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
           upstream	https://github.com/upstream-user/repo-name.git (fetch)
           upstream	https://github.com/upstream-user/repo-name.git (push)
           origin	https://github.com/origin-user/repo-name.git (fetch)
           origin	https://github.com/origin-user/repo-name.git (push)
         `
-        )
-      ).toBe('origin-user/repo-name');
-    });
+          )
+        ).toBe('origin-user/repo-name');
+      });
 
-    it('should return the github user + repo info for the first one since no origin', () => {
-      expect(
-        extractUserAndRepoFromGitHubUrl(
-          `
+      it('should return the github user + repo info for upstream since no origin', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
           upstream	https://github.com/upstream-user/repo-name.git (fetch)
           upstream	https://github.com/upstream-user/repo-name.git (push)
+          base	https://github.com/base-user/repo-name.git (fetch)
+          base	https://github.com/base-user/repo-name.git (push)
           other	https://github.com/other-user/repo-name.git (fetch)
           other	https://github.com/other-user/repo-name.git (push)
         `
-        )
-      ).toBe('upstream-user/repo-name');
-    });
+          )
+        ).toBe('upstream-user/repo-name');
+      });
 
-    it('should return null since no github', () => {
-      expect(
-        extractUserAndRepoFromGitHubUrl(
-          `
+      it('should return the github user + repo info for base since no origin and upstream', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
+          base	https://github.com/base-user/repo-name.git (fetch)
+          base	https://github.com/base-user/repo-name.git (push)
+          other	https://github.com/other-user/repo-name.git (fetch)
+          other	https://github.com/other-user/repo-name.git (push)
+        `
+          )
+        ).toBe('base-user/repo-name');
+      });
+
+      it('should return the github user + repo info for the first one since no origin, upstream, or base', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
+          other	https://github.com/other-user/repo-name.git (fetch)
+          other	https://github.com/other-user/repo-name.git (push)
+          another	https://github.com/another-user/repo-name.git (fetch)
+          another	https://github.com/another-user/repo-name.git (push)
+        `
+          )
+        ).toBe('other-user/repo-name');
+      });
+
+      it('should return null since no github', () => {
+        expect(
+          extractUserAndRepoFromGitHubUrl(
+            `
           upstream	https://other.com/upstream-user/repo-name.git (fetch)
           upstream	https://other.com/upstream-user/repo-name.git (push)
           origin	https://other.com/other-user/repo-name.git (fetch)
           origin	https://other.com/other-user/repo-name.git (push)
         `
-        )
-      ).toBe(null);
+          )
+        ).toBe(null);
+      });
     });
   });
 });


### PR DESCRIPTION
* Prioritized remotes in the order: `origin`, `upstream`, `base`, and then the first remote found, when trying to determine if repo uses GitHub.
* Implemented fallback to a default GitHub onboarding URL (`/setup/connect-workspace/github/select`) if no remotes are found.
* Added corresponding unit tests to verify the new remote priority order and fallback behavior.