### PR TITLE
fix(bundling): get workspace package prefix length correctly #20817

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -291,7 +291,16 @@ require('${mainFile}');
 }
 
 function getPrefixLength(pattern: string): number {
-  return pattern.substring(0, pattern.indexOf('*')).length;
+  const prefixIfWildcard = pattern.substring(0, pattern.indexOf('*')).length;
+  const prefixWithoutWildcard = pattern.substring(
+    0,
+    pattern.lastIndexOf('/')
+  ).length;
+  // if the pattern doesn't contain '*', then the length is always 0
+  // This causes issues when there are sub packages such as
+  // @nx/core
+  // @nx/core/testing
+  return prefixIfWildcard || prefixWithoutWildcard;
 }
 
 function getTsConfigCompilerPaths(context: ExecutorContext): {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When there are workspace libraries with the following import paths:

```
@org/core
@org/core/db
@org/core/acme
```

They need to be sorted for the manifest such that matching finds the most specific first.
The logic for this is currently based off whether an `*` exists, which doesn't work when the paths are specific.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Try to use `*` first and fallback to `/` to determine package prefix length.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20817
