### PR TITLE
chore(repo): cache documentation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -376,7 +376,26 @@
       "check-lock-files",
       "check-codeowners",
       "documentation"
-    ]
+    ],
+    "targets": {
+      "documentation": {
+        "cache": true,
+        "inputs": [
+          "{workspaceRoot}/packages/**", 
+          "{workspaceRoot}/docs/**",
+          "{workspaceRoot}/scripts/documentation/**",
+          "!{workspaceRoot}/docs/generated", 
+          "!{workspaceRoot}/packages/**/*.spec.ts",
+          "!{workspaceRoot}/packages/**/project.json",
+          "!{workspaceRoot}/packages/**/tsconfig.json",
+          "!{workspaceRoot}/packages/**/tsconfig.lib.json",
+          "!{workspaceRoot}/packages/**/tsconfig.spec.json",
+          "!{workspaceRoot}/packages/**/jest.config.{ts,js}",
+          "!{workspaceRoot}/packages/**/.eslintrc.json"
+        ]
+      },
+      "outputs": ["{workspaceRoot}/docs/generated"]
+    }
   },
   "packageManager": "pnpm@8.15.7"
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
`documentation` is not cacheable. It is reran everytime someone tries to push, including the following flow:

- git push, fails as docs changes found
- git commit -am "chore(repo): add docs"
- git push, runs full docs cycle again in pre-push hook

## Expected Behavior
`documentation` is cacheable, and avoids rerunning when no fs changes are made

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
