### PR TITLE
fix(testing): ensure project build occurs before e2es are run

### DIFF
--- a/packages/angular/src/generators/application/lib/create-project.ts
+++ b/packages/angular/src/generators/application/lib/create-project.ts
@@ -2,7 +2,7 @@ import { addProjectConfiguration, joinPathFragments, Tree } from '@nx/devkit';
 import type { AngularProjectConfiguration } from '../../../utils/types';
 import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema } from './normalized-schema';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export function createProject(tree: Tree, options: NormalizedSchema) {
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);

--- a/packages/angular/src/generators/library/lib/add-project.ts
+++ b/packages/angular/src/generators/library/lib/add-project.ts
@@ -2,7 +2,7 @@ import type { Tree } from '@nx/devkit';
 import { addProjectConfiguration, joinPathFragments } from '@nx/devkit';
 import type { AngularProjectConfiguration } from '../../../utils/types';
 import type { NormalizedSchema } from './normalized-schema';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export function addProject(
   tree: Tree,

--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -29,6 +29,12 @@
       "version": "18.1.0-beta.3",
       "description": "Update to Cypress ^13.6.6 if the workspace is using Cypress v13 to ensure workspaces don't use v13.6.5 which has an issue when verifying Cypress.",
       "implementation": "./src/migrations/update-18-1-0/update-cypress-version-13-6-6"
+    },
+    "add-e2e-ci-target-defaults": {
+      "cli": "nx",
+      "version": "19.5.4-beta.0",
+      "description": "Add ciTargetName for the @nx/cypress/plugin to targetDefaults with dependsOn:['^build'].",
+      "implementation": "./src/migrations/update-19-5-4/add-ci-target-name-target-default"
     }
   },
   "packageJsonUpdates": {

--- a/packages/cypress/src/generators/init/init.spec.ts
+++ b/packages/cypress/src/generators/init/init.spec.ts
@@ -94,6 +94,11 @@ describe('init', () => {
           "build": {
             "cache": true,
           },
+          "e2e-ci--**/*": {
+            "dependsOn": [
+              "^build",
+            ],
+          },
           "lint": {
             "cache": true,
           },

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -14,6 +14,7 @@ import { addPlugin as _addPlugin } from '@nx/devkit/src/utils/add-plugin';
 import { createNodesV2 } from '../../plugins/plugin';
 import { cypressVersion, nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
+import { addTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
 
 function setupE2ETargetDefaults(tree: Tree) {
   const nxJson = readNxJson(tree);
@@ -56,12 +57,12 @@ function updateDependencies(tree: Tree, options: Schema) {
   return runTasksInSerial(...tasks);
 }
 
-export function addPlugin(
+export async function addPlugin(
   tree: Tree,
   graph: ProjectGraph,
   updatePackageScripts: boolean
 ) {
-  return _addPlugin(
+  const pluginOptions = await _addPlugin(
     tree,
     graph,
     '@nx/cypress/plugin',
@@ -78,6 +79,13 @@ export function addPlugin(
     },
     updatePackageScripts
   );
+
+  if (pluginOptions?.ciTargetName) {
+    const ciTargetNameGlob = `${pluginOptions.ciTargetName}--**/*`;
+    addTargetDefault(tree, ciTargetNameGlob, {
+      dependsOn: ['^build'],
+    });
+  }
 }
 
 function updateProductionFileset(tree: Tree) {

--- a/packages/cypress/src/migrations/update-19-5-4/add-ci-target-name-target-default.spec.ts
+++ b/packages/cypress/src/migrations/update-19-5-4/add-ci-target-name-target-default.spec.ts
@@ -1,0 +1,125 @@
+import addCiTargetNameTargetDefault from './add-ci-target-name-target-default';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import { readNxJson, updateNxJson } from 'nx/src/devkit-exports';
+
+describe('addCiTargetNameTargetDefault', () => {
+  it('should find and add the ciTargetName to targetDefaults with dependsOn: ["^build"]', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const oldNxJson = readNxJson(tree);
+    oldNxJson.targetDefaults ??= {};
+    oldNxJson.plugins ??= [];
+    oldNxJson.plugins.push({
+      plugin: '@nx/cypress/plugin',
+      options: {
+        targetName: 'e2e',
+        openTargetName: 'open-cypress',
+        componentTestingTargetName: 'component-test',
+        ciTargetName: 'e2e-ci',
+      },
+    });
+    updateNxJson(tree, oldNxJson);
+
+    // ACT
+    addCiTargetNameTargetDefault(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "e2e-ci--**/*": {
+          "dependsOn": [
+            "^build",
+          ],
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+
+  it('should find and add the ciTargetName to targetDefaults with dependsOn: ["^build"]', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const oldNxJson = readNxJson(tree);
+    oldNxJson.targetDefaults ??= {};
+    oldNxJson.plugins ??= [];
+    oldNxJson.plugins.push({
+      plugin: '@nx/cypress/plugin',
+      options: {
+        targetName: 'e2e',
+        openTargetName: 'open-cypress',
+        componentTestingTargetName: 'component-test',
+        ciTargetName: 'cypress:e2e-ci',
+      },
+    });
+    updateNxJson(tree, oldNxJson);
+
+    // ACT
+    addCiTargetNameTargetDefault(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "cypress:e2e-ci--**/*": {
+          "dependsOn": [
+            "^build",
+          ],
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+
+  it('should find and not add the ciTargetName to targetDefaults when it already exists', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const oldNxJson = readNxJson(tree);
+    oldNxJson.targetDefaults ??= {};
+    oldNxJson.targetDefaults['cypress:e2e-ci--**/*'] = {
+      inputs: ['somefile.ts'],
+    };
+    oldNxJson.plugins ??= [];
+    oldNxJson.plugins.push({
+      plugin: '@nx/cypress/plugin',
+      options: {
+        targetName: 'e2e',
+        openTargetName: 'open-cypress',
+        componentTestingTargetName: 'component-test',
+        ciTargetName: 'cypress:e2e-ci',
+      },
+    });
+    updateNxJson(tree, oldNxJson);
+
+    // ACT
+    addCiTargetNameTargetDefault(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "cypress:e2e-ci--**/*": {
+          "inputs": [
+            "somefile.ts",
+          ],
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+});

--- a/packages/cypress/src/migrations/update-19-5-4/add-ci-target-name-target-default.ts
+++ b/packages/cypress/src/migrations/update-19-5-4/add-ci-target-name-target-default.ts
@@ -1,0 +1,41 @@
+import {
+  type ExpandedPluginConfiguration,
+  type Tree,
+  readNxJson,
+  formatFiles,
+} from '@nx/devkit';
+import { addTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import type { CypressPluginOptions } from '../../plugins/plugin';
+
+export default async function (tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson.plugins) {
+    return;
+  }
+
+  const cypressPlugin = nxJson.plugins.find((p) =>
+    typeof p === 'string'
+      ? p === '@nx/cypress/plugin'
+      : p.plugin === '@nx/cypress/plugin'
+  );
+
+  if (!cypressPlugin) {
+    return;
+  }
+
+  const ciTargetName =
+    typeof cypressPlugin === 'string'
+      ? 'e2e-ci'
+      : (cypressPlugin as ExpandedPluginConfiguration<CypressPluginOptions>)
+          .options?.ciTargetName
+      ? (cypressPlugin as ExpandedPluginConfiguration<CypressPluginOptions>)
+          .options.ciTargetName
+      : 'e2e-ci';
+
+  const ciTargetNameGlob = `${ciTargetName}--**/*`;
+  addTargetDefault(tree, ciTargetNameGlob, {
+    dependsOn: ['^build'],
+  });
+
+  await formatFiles(tree);
+}

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -121,6 +121,7 @@ describe('@nx/cypress/plugin', () => {
                       "{projectRoot}/dist/videos",
                       "{projectRoot}/dist/screenshots",
                     ],
+                    "parallelism": false,
                   },
                   "open-cypress": {
                     "command": "cypress open",
@@ -329,6 +330,7 @@ describe('@nx/cypress/plugin', () => {
                       "{projectRoot}/dist/videos",
                       "{projectRoot}/dist/screenshots",
                     ],
+                    "parallelism": false,
                   },
                   "e2e-ci": {
                     "cache": true,
@@ -369,6 +371,7 @@ describe('@nx/cypress/plugin', () => {
                       "{projectRoot}/dist/videos",
                       "{projectRoot}/dist/screenshots",
                     ],
+                    "parallelism": false,
                   },
                   "e2e-ci--src/test.cy.ts": {
                     "cache": true,
@@ -404,6 +407,7 @@ describe('@nx/cypress/plugin', () => {
                       "{projectRoot}/dist/videos",
                       "{projectRoot}/dist/screenshots",
                     ],
+                    "parallelism": false,
                   },
                   "open-cypress": {
                     "command": "cypress open",

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -121,7 +121,6 @@ describe('@nx/cypress/plugin', () => {
                       "{projectRoot}/dist/videos",
                       "{projectRoot}/dist/screenshots",
                     ],
-                    "parallelism": false,
                   },
                   "open-cypress": {
                     "command": "cypress open",
@@ -330,7 +329,6 @@ describe('@nx/cypress/plugin', () => {
                       "{projectRoot}/dist/videos",
                       "{projectRoot}/dist/screenshots",
                     ],
-                    "parallelism": false,
                   },
                   "e2e-ci": {
                     "cache": true,
@@ -371,7 +369,6 @@ describe('@nx/cypress/plugin', () => {
                       "{projectRoot}/dist/videos",
                       "{projectRoot}/dist/screenshots",
                     ],
-                    "parallelism": false,
                   },
                   "e2e-ci--src/test.cy.ts": {
                     "cache": true,
@@ -407,7 +404,6 @@ describe('@nx/cypress/plugin', () => {
                       "{projectRoot}/dist/videos",
                       "{projectRoot}/dist/screenshots",
                     ],
-                    "parallelism": false,
                   },
                   "open-cypress": {
                     "command": "cypress open",

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -1,0 +1,58 @@
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import { readNxJson, updateNxJson } from 'nx/src/devkit-exports';
+import { addTargetDefault } from './target-defaults-utils';
+
+describe('target-defaults-utils', () => {
+  it('should not add a new target default entry when one exists already', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const oldNxJson = readNxJson(tree);
+    oldNxJson.targetDefaults ??= {};
+    oldNxJson.targetDefaults['build'] = {
+      dependsOn: ['^build'],
+    };
+    updateNxJson(tree, oldNxJson);
+
+    // ACT
+    addTargetDefault(tree, 'build', { inputs: [] });
+
+    // ASSERT
+    const newNxJson = readNxJson(tree);
+    expect(newNxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "dependsOn": [
+            "^build",
+          ],
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+
+  it('should add a new target default entry when it does not already', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+
+    // ACT
+    addTargetDefault(tree, 'build-base', { inputs: [] });
+
+    // ASSERT
+    const newNxJson = readNxJson(tree);
+    expect(newNxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "build-base": {
+          "inputs": [],
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+});

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -1,4 +1,5 @@
 import { readNxJson, Tree, updateNxJson } from 'nx/src/devkit-exports';
+import type { TargetConfiguration } from 'nx/src/config/workspace-json-project-json';
 
 export function addBuildTargetDefaults(
   tree: Tree,
@@ -15,5 +16,21 @@ export function addBuildTargetDefaults(
         ? ['production', '^production']
         : ['default', '^default'],
   };
+  updateNxJson(tree, nxJson);
+}
+
+export function addTargetDefault(
+  tree: Tree,
+  targetOrExecutorName: string,
+  target: TargetConfiguration
+): void {
+  const nxJson = readNxJson(tree);
+  nxJson.targetDefaults ??= {};
+  if (targetOrExecutorName in nxJson.targetDefaults) {
+    // Do nothing, we do not want to replace user-defined config
+    return;
+  }
+
+  nxJson.targetDefaults[targetOrExecutorName] = target;
   updateNxJson(tree, nxJson);
 }

--- a/packages/devkit/src/utils/add-plugin.ts
+++ b/packages/devkit/src/utils/add-plugin.ts
@@ -33,7 +33,7 @@ export async function addPlugin<PluginOptions>(
     Record<keyof PluginOptions, PluginOptions[keyof PluginOptions][]>
   >,
   shouldUpdatePackageJsonScripts: boolean
-): Promise<void> {
+): Promise<PluginOptions> {
   return _addPluginInternal(
     tree,
     graph,
@@ -68,7 +68,7 @@ export async function addPluginV1<PluginOptions>(
     Record<keyof PluginOptions, PluginOptions[keyof PluginOptions][]>
   >,
   shouldUpdatePackageJsonScripts: boolean
-): Promise<void> {
+): Promise<PluginOptions> {
   return _addPluginInternal(
     tree,
     graph,
@@ -98,7 +98,7 @@ async function _addPluginInternal<PluginOptions>(
     Record<keyof PluginOptions, PluginOptions[keyof PluginOptions][]>
   >,
   shouldUpdatePackageJsonScripts: boolean
-) {
+): Promise<PluginOptions> {
   const graphNodes = Object.values(graph.nodes);
   const nxJson = readNxJson(tree);
 
@@ -173,6 +173,8 @@ async function _addPluginInternal<PluginOptions>(
   if (shouldUpdatePackageJsonScripts) {
     updatePackageScripts(tree, projConfigs);
   }
+
+  return pluginOptions;
 }
 
 type TargetCommand = {

--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -12,7 +12,7 @@ import { getImportPath } from '@nx/js/src/utils/get-import-path';
 import { esbuildInitGenerator } from '../init/init';
 import { EsBuildExecutorOptions } from '../../executors/esbuild/schema';
 import { EsBuildProjectSchema } from './schema';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export async function configurationGenerator(
   tree: Tree,

--- a/packages/expo/src/generators/application/lib/add-project.ts
+++ b/packages/expo/src/generators/application/lib/add-project.ts
@@ -8,7 +8,7 @@ import {
 
 import { hasExpoPlugin } from '../../../utils/has-expo-plugin';
 import { NormalizedSchema } from './normalize-options';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const nxJson = readNxJson(host);

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -32,7 +32,7 @@ import { NormalizedSchema, normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { initRootBabelConfig } from '../../utils/init-root-babel-config';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 
 export async function expoLibraryGenerator(

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -25,7 +25,7 @@ import {
   type ProjectNameAndRootOptions,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
 
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { findMatchingProjects } from 'nx/src/utils/find-matching-projects';
 import { type PackageJson } from 'nx/src/utils/package-json';

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -12,7 +12,7 @@ import { addSwcConfig } from '../../utils/swc/add-swc-config';
 import { addSwcDependencies } from '../../utils/swc/add-swc-dependencies';
 import { nxVersion } from '../../utils/versions';
 import { SetupBuildGeneratorSchema } from './schema';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export async function setupBuildGenerator(
   tree: Tree,

--- a/packages/next/src/generators/application/lib/add-project.ts
+++ b/packages/next/src/generators/application/lib/add-project.ts
@@ -5,7 +5,7 @@ import {
   readNxJson,
   Tree,
 } from '@nx/devkit';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const targets: Record<string, any> = {};

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -48,7 +48,7 @@ import { initGenerator } from '../init/init';
 import { setupDockerGenerator } from '../setup-docker/setup-docker';
 import { Schema } from './schema';
 import { hasWebpackPlugin } from '../../utils/has-webpack-plugin';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 
 export interface NormalizedSchema extends Schema {

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -22,7 +22,7 @@ import { join } from 'path';
 import { tslibVersion, typesNodeVersion } from '../../utils/versions';
 import { initGenerator } from '../init/init';
 import { Schema } from './schema';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export interface NormalizedSchema extends Schema {
   fileName: string;

--- a/packages/playwright/migrations.json
+++ b/packages/playwright/migrations.json
@@ -11,6 +11,12 @@
       "version": "18.1.0-beta.3",
       "description": "Remove invalid baseUrl option from @nx/playwright:playwright targets in project.json.",
       "implementation": "./src/migrations/update-18-1-0/remove-baseUrl-from-project-json"
+    },
+    "add-e2e-ci-target-defaults": {
+      "cli": "nx",
+      "version": "19.5.4-beta.0",
+      "description": "Add ciTargetName for the @nx/playwright/plugin to targetDefaults with dependsOn:['^build'].",
+      "implementation": "./src/migrations/update-19-5-4/add-ci-target-name-target-default"
     }
   }
 }

--- a/packages/playwright/src/generators/init/init.spec.ts
+++ b/packages/playwright/src/generators/init/init.spec.ts
@@ -33,11 +33,27 @@ describe('@nx/playwright:init', () => {
       [
         {
           "options": {
+            "ciTargetName": "e2e-ci",
             "targetName": "e2e",
           },
           "plugin": "@nx/playwright/plugin",
         },
       ]
+    `);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "e2e-ci--**/*": {
+          "dependsOn": [
+            "^build",
+          ],
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
     `);
   });
 
@@ -56,6 +72,7 @@ describe('@nx/playwright:init', () => {
         "foo",
         {
           "options": {
+            "ciTargetName": "e2e-ci",
             "targetName": "e2e",
           },
           "plugin": "@nx/playwright/plugin",

--- a/packages/playwright/src/migrations/update-19-5-4/add-ci-target-name-target-default.spec.ts
+++ b/packages/playwright/src/migrations/update-19-5-4/add-ci-target-name-target-default.spec.ts
@@ -1,0 +1,119 @@
+import addCiTargetNameTargetDefault from './add-ci-target-name-target-default';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import { readNxJson, updateNxJson } from 'nx/src/devkit-exports';
+
+describe('addCiTargetNameTargetDefault', () => {
+  it('should find and add the ciTargetName to targetDefaults with dependsOn: ["^build"]', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const oldNxJson = readNxJson(tree);
+    oldNxJson.targetDefaults ??= {};
+    oldNxJson.plugins ??= [];
+    oldNxJson.plugins.push({
+      plugin: '@nx/playwright/plugin',
+      options: {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+    });
+    updateNxJson(tree, oldNxJson);
+
+    // ACT
+    addCiTargetNameTargetDefault(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "e2e-ci--**/*": {
+          "dependsOn": [
+            "^build",
+          ],
+        },
+        "lint": {
+          "cache": true,
+        },
+      }
+    `);
+  });
+
+  it('should find and add the ciTargetName to targetDefaults with dependsOn: ["^build"]', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const oldNxJson = readNxJson(tree);
+    oldNxJson.targetDefaults ??= {};
+    oldNxJson.plugins ??= [];
+    oldNxJson.plugins.push({
+      plugin: '@nx/playwright/plugin',
+      options: {
+        targetName: 'e2e',
+        ciTargetName: 'playwright:e2e-ci',
+      },
+    });
+    updateNxJson(tree, oldNxJson);
+
+    // ACT
+    addCiTargetNameTargetDefault(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "lint": {
+          "cache": true,
+        },
+        "playwright:e2e-ci--**/*": {
+          "dependsOn": [
+            "^build",
+          ],
+        },
+      }
+    `);
+  });
+
+  it('should find and not add the ciTargetName to targetDefaults when it already exists', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    const oldNxJson = readNxJson(tree);
+    oldNxJson.targetDefaults ??= {};
+    oldNxJson.targetDefaults['playwright:e2e-ci--**/*'] = {
+      inputs: ['somefile.ts'],
+    };
+    oldNxJson.plugins ??= [];
+    oldNxJson.plugins.push({
+      plugin: '@nx/playwright/plugin',
+      options: {
+        targetName: 'e2e',
+        ciTargetName: 'playwright:e2e-ci',
+      },
+    });
+    updateNxJson(tree, oldNxJson);
+
+    // ACT
+    addCiTargetNameTargetDefault(tree);
+
+    // ASSERT
+    const nxJson = readNxJson(tree);
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "cache": true,
+        },
+        "lint": {
+          "cache": true,
+        },
+        "playwright:e2e-ci--**/*": {
+          "inputs": [
+            "somefile.ts",
+          ],
+        },
+      }
+    `);
+  });
+});

--- a/packages/playwright/src/migrations/update-19-5-4/add-ci-target-name-target-default.ts
+++ b/packages/playwright/src/migrations/update-19-5-4/add-ci-target-name-target-default.ts
@@ -1,0 +1,40 @@
+import {
+  type ExpandedPluginConfiguration,
+  type Tree,
+  readNxJson,
+} from '@nx/devkit';
+import { addTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import type { PlaywrightPluginOptions } from '../../plugins/plugin';
+
+export default async function (tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson.plugins) {
+    return;
+  }
+
+  const playwrightPlugin = nxJson.plugins.find((p) =>
+    typeof p === 'string'
+      ? p === '@nx/playwright/plugin'
+      : p.plugin === '@nx/playwright/plugin'
+  );
+
+  if (!playwrightPlugin) {
+    return;
+  }
+
+  const ciTargetName =
+    typeof playwrightPlugin === 'string'
+      ? 'e2e-ci'
+      : (
+          playwrightPlugin as ExpandedPluginConfiguration<PlaywrightPluginOptions>
+        ).options?.ciTargetName
+      ? (
+          playwrightPlugin as ExpandedPluginConfiguration<PlaywrightPluginOptions>
+        ).options.ciTargetName
+      : 'e2e-ci';
+
+  const ciTargetNameGlob = `${ciTargetName}--**/*`;
+  addTargetDefault(tree, ciTargetNameGlob, {
+    dependsOn: ['^build'],
+  });
+}

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -91,6 +91,7 @@ describe('@nx/playwright/plugin', () => {
                     "outputs": [
                       "{projectRoot}/test-results",
                     ],
+                    "parallelism": false,
                   },
                   "e2e-ci": {
                     "cache": true,
@@ -123,6 +124,7 @@ describe('@nx/playwright/plugin', () => {
                     "outputs": [
                       "{projectRoot}/test-results",
                     ],
+                    "parallelism": false,
                   },
                 },
               },
@@ -200,6 +202,7 @@ describe('@nx/playwright/plugin', () => {
                       "{projectRoot}/test-results/html",
                       "{projectRoot}/test-results",
                     ],
+                    "parallelism": false,
                   },
                   "e2e-ci": {
                     "cache": true,
@@ -235,6 +238,7 @@ describe('@nx/playwright/plugin', () => {
                       "{projectRoot}/test-results/html",
                       "{projectRoot}/test-results",
                     ],
+                    "parallelism": false,
                   },
                 },
               },
@@ -323,6 +327,7 @@ describe('@nx/playwright/plugin', () => {
         "outputs": [
           "{projectRoot}/test-results",
         ],
+        "parallelism": false,
       }
     `);
     expect(targets['e2e-ci--tests/run-me.spec.ts']).toMatchInlineSnapshot(`
@@ -358,6 +363,7 @@ describe('@nx/playwright/plugin', () => {
         "outputs": [
           "{projectRoot}/test-results",
         ],
+        "parallelism": false,
       }
     `);
     expect(targets['e2e-ci--tests/run-me-2.spec.ts']).toMatchInlineSnapshot(`
@@ -393,6 +399,7 @@ describe('@nx/playwright/plugin', () => {
         "outputs": [
           "{projectRoot}/test-results",
         ],
+        "parallelism": false,
       }
     `);
     expect(targets['e2e-ci--tests/skip-me.spec.ts']).not.toBeDefined();

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -91,7 +91,6 @@ describe('@nx/playwright/plugin', () => {
                     "outputs": [
                       "{projectRoot}/test-results",
                     ],
-                    "parallelism": false,
                   },
                   "e2e-ci": {
                     "cache": true,
@@ -124,7 +123,6 @@ describe('@nx/playwright/plugin', () => {
                     "outputs": [
                       "{projectRoot}/test-results",
                     ],
-                    "parallelism": false,
                   },
                 },
               },
@@ -202,7 +200,6 @@ describe('@nx/playwright/plugin', () => {
                       "{projectRoot}/test-results/html",
                       "{projectRoot}/test-results",
                     ],
-                    "parallelism": false,
                   },
                   "e2e-ci": {
                     "cache": true,
@@ -238,7 +235,6 @@ describe('@nx/playwright/plugin', () => {
                       "{projectRoot}/test-results/html",
                       "{projectRoot}/test-results",
                     ],
-                    "parallelism": false,
                   },
                 },
               },
@@ -327,7 +323,6 @@ describe('@nx/playwright/plugin', () => {
         "outputs": [
           "{projectRoot}/test-results",
         ],
-        "parallelism": false,
       }
     `);
     expect(targets['e2e-ci--tests/run-me.spec.ts']).toMatchInlineSnapshot(`
@@ -363,7 +358,6 @@ describe('@nx/playwright/plugin', () => {
         "outputs": [
           "{projectRoot}/test-results",
         ],
-        "parallelism": false,
       }
     `);
     expect(targets['e2e-ci--tests/run-me-2.spec.ts']).toMatchInlineSnapshot(`
@@ -399,7 +393,6 @@ describe('@nx/playwright/plugin', () => {
         "outputs": [
           "{projectRoot}/test-results",
         ],
-        "parallelism": false,
       }
     `);
     expect(targets['e2e-ci--tests/skip-me.spec.ts']).not.toBeDefined();

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -33,7 +33,7 @@ import { NxRemixGeneratorSchema } from './schema';
 import { updateDependencies } from '../utils/update-dependencies';
 import initGenerator from '../init/init';
 import { initGenerator as jsInitGenerator } from '@nx/js';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { updateJestTestMatch } from '../../utils/testing-config-utils';
 

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -16,7 +16,7 @@ import { getImportPath } from '@nx/js/src/utils/get-import-path';
 import { rollupInitGenerator } from '../init/init';
 import { RollupExecutorOptions } from '../../executors/rollup/schema';
 import { RollupProjectSchema } from './schema';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { hasPlugin } from '../../utils/has-plugin';
 import { RollupWithNxPluginOptions } from '../../plugins/with-nx/with-nx-options';

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -14,7 +14,7 @@ import { VitePreviewServerExecutorOptions } from '../executors/preview-server/sc
 import { VitestExecutorOptions } from '../executors/test/schema';
 import { ViteConfigurationGeneratorSchema } from '../generators/configuration/schema';
 import { ensureViteConfigIsCorrect } from './vite-config-edit-utils';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export type Target = 'build' | 'serve' | 'test' | 'preview';
 export type TargetFlags = Partial<Record<Target, boolean>>;

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -37,7 +37,7 @@ import { webInitGenerator } from '../init/init';
 import { Schema } from './schema';
 import { getNpmScope } from '@nx/js/src/utils/package-json/get-npm-scope';
 import { hasWebpackPlugin } from '../../utils/has-webpack-plugin';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { VitePluginOptions } from '@nx/vite/src/plugins/plugin';
 import { WebpackPluginOptions } from '@nx/webpack/src/plugins/plugin';

--- a/packages/webpack/src/generators/configuration/configuration.ts
+++ b/packages/webpack/src/generators/configuration/configuration.ts
@@ -15,7 +15,7 @@ import { webpackInitGenerator } from '../init/init';
 import { ConfigurationGeneratorSchema } from './schema';
 import { WebpackExecutorOptions } from '../../executors/webpack/schema';
 import { hasPlugin } from '../../utils/has-plugin';
-import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 
 export function configurationGenerator(


### PR DESCRIPTION
- feat(devkit): add util for adding target default to nx.json
- feat(testing): setup targetDefault for ciTargetName when @nx/cypress/plugin is added
- feat(testing): add migration to add targetDefault for ciTargetName for @nx/cypress/plugin
- feat(testing): add targetDefault for ciTargetName when setting up @nx/playwright/plugin

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Cypress and Playwright e2e targets eventually run the build of the application within the serve-static target that they have. However, the e2e tasks themselves do not dependOn build so not only is it possible that the e2e tasks end up building from scratch, they could also run first before build tasks.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the build is run before the e2e tasks

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
