### PR TITLE
feat(react): add skipPackageJson flag to remote and host generators

### DIFF
--- a/docs/generated/packages/react/generators/host.json
+++ b/docs/generated/packages/react/generators/host.json
@@ -171,6 +171,12 @@
         "type": "boolean",
         "description": "Whether the module federation configuration and webpack configuration files should use TS. When --js is used, this flag is ignored.",
         "default": true
+      },
+      "skipPackageJson": {
+        "description": "Do not add dependencies to `package.json`.",
+        "type": "boolean",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "required": ["name"],

--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -170,6 +170,12 @@
         "type": "boolean",
         "description": "Whether the module federation configuration and webpack configuration files should use TS. When --js is used, this flag is ignored.",
         "default": true
+      },
+      "skipPackageJson": {
+        "description": "Do not add dependencies to `package.json`.",
+        "type": "boolean",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "required": ["name"],

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -97,6 +97,7 @@ export async function hostGeneratorInternal(
         js: options.js,
         dynamic: options.dynamic,
         host: options.name,
+        skipPackageJson: options.skipPackageJson,
       });
       tasks.push(remoteTask);
       remotePort++;

--- a/packages/react/src/generators/host/schema.d.ts
+++ b/packages/react/src/generators/host/schema.d.ts
@@ -18,6 +18,7 @@ export interface Schema {
   setParserOptionsProject?: boolean;
   skipFormat?: boolean;
   skipNxJson?: boolean;
+  skipPackageJson?: boolean;
   ssr?: boolean;
   strict?: boolean;
   style: SupportedStyles;

--- a/packages/react/src/generators/host/schema.json
+++ b/packages/react/src/generators/host/schema.json
@@ -177,6 +177,12 @@
       "type": "boolean",
       "description": "Whether the module federation configuration and webpack configuration files should use TS. When --js is used, this flag is ignored.",
       "default": true
+    },
+    "skipPackageJson": {
+      "description": "Do not add dependencies to `package.json`.",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "required": ["name"],

--- a/packages/react/src/generators/remote/schema.d.ts
+++ b/packages/react/src/generators/remote/schema.d.ts
@@ -20,6 +20,7 @@ export interface Schema {
   setParserOptionsProject?: boolean;
   skipFormat: boolean;
   skipNxJson?: boolean;
+  skipPackageJson?: boolean;
   ssr?: boolean;
   strict?: boolean;
   style: SupportedStyles;

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -176,6 +176,12 @@
       "type": "boolean",
       "description": "Whether the module federation configuration and webpack configuration files should use TS. When --js is used, this flag is ignored.",
       "default": true
+    },
+    "skipPackageJson": {
+      "description": "Do not add dependencies to `package.json`.",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "required": ["name"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `host` and `remote` generators do not have an option to skip package install.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add the `skipPackageJson` flag to the remote and host generators

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
