### PR TITLE
fix(vite): vitest executor should continue to load plugins #22001

### DIFF
--- a/packages/vite/src/executors/test/lib/utils.ts
+++ b/packages/vite/src/executors/test/lib/utils.ts
@@ -78,7 +78,10 @@ export async function getOptions(
     configFile: viteConfigPath,
   };
 
-  return mergeConfig(resolved?.config?.['test'] ?? {}, settings);
+  return {
+    resolvedOptions: mergeConfig(resolved?.config?.['test'] ?? {}, settings),
+    plugins: resolved?.config?.plugins,
+  };
 }
 
 export function getOptionsAsArgv(obj: Record<string, any>): string[] {

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -19,7 +19,7 @@ export async function* vitestExecutor(
   // Allows ESM to be required in CJS modules. Vite will be published as ESM in the future.
   const { startVitest } = await loadVitestDynamicImport();
 
-  const resolvedOptions =
+  const { resolvedOptions, plugins } =
     (await getOptions(options, context, projectRoot)) ?? {};
 
   const watch = resolvedOptions['watch'] === true;
@@ -37,7 +37,8 @@ export async function* vitestExecutor(
   const ctx = await startVitest(
     resolvedOptions['mode'] ?? 'test',
     cliFilters,
-    resolvedOptions
+    resolvedOptions,
+    { plugins }
   );
 
   let hasErrors = false;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Plugins were not being loaded by vitest executor when calling `startVitest` when using a vite config file with a custom name.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Correctly load the plugins found in the resolved config file, regardless of the config file name


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22001
