### PR TITLE
fix(core): always load task envs from workspace root instead of relative to cwd

### DIFF
--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -2,6 +2,7 @@ import { Task } from '../config/task-graph';
 import { config as loadDotEnvFile } from 'dotenv';
 import { expand } from 'dotenv-expand';
 import { workspaceRoot } from '../utils/workspace-root';
+import { join } from 'node:path';
 
 export function getEnvVariablesForBatchProcess(
   skipNxCache: boolean,
@@ -221,14 +222,14 @@ function loadDotEnvFilesForTask(
 ) {
   const dotEnvFiles = getEnvFilesForTask(task);
   for (const file of dotEnvFiles) {
-    loadAndExpandDotEnvFile(file, environmentVariables);
+    loadAndExpandDotEnvFile(join(workspaceRoot, file), environmentVariables);
   }
   return environmentVariables;
 }
 
 function unloadDotEnvFiles(environmentVariables: NodeJS.ProcessEnv) {
   for (const file of ['.env', '.local.env', '.env.local']) {
-    unloadDotEnvFile(file, environmentVariables);
+    unloadDotEnvFile(join(workspaceRoot, file), environmentVariables);
   }
   return environmentVariables;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
[task-specific .env files](https://nx.dev/recipes/tips-n-tricks/define-environment-variables) are only loaded when you're running from the workspace root.

## Expected Behavior
task-specific .env files should be loaded regardless of the directory you're running from.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/22846
