### PR TITLE
fix(devkit): detect package manager based on install location

### DIFF
--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -20,7 +20,7 @@ export function installPackagesTask(
   tree: Tree,
   alwaysRun: boolean = false,
   cwd: string = '',
-  packageManager: PackageManager = detectPackageManager(cwd)
+  packageManager: PackageManager = detectPackageManager(join(tree.root, cwd))
 ): void {
   if (
     !tree


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The package manager is detected based off of the relative `cwd` which in most cases is `''`. This incorrectly goes off of the `cwd` of the command rather than the location of the `package.json` file being modified. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The package manager is detected based off the absolute path of the directory containing the `package.json` file being modified. So if this is the root, it will detect the package manager at the root rather than the `cwd`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/19831
