### PR TITLE
fix(nextjs): fix inlined workspace root in .nx-helpers

### DIFF
--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -124,7 +124,11 @@ export function getWithNxContent(
         index: getWithNxContextDeclaration.getStart(withNxSource),
         text: stripIndents`function getWithNxContext() {
           return {
-            workspaceRoot: '${workspaceRoot}',
+            workspaceRoot: '${
+              // For Windows, paths like C:\Users\foo\bar need to be written as C:\\Users\\foo\\bar,
+              // or else when the file is read back, the single "\" will be treated as an escape character.
+              workspaceRoot.replaceAll('\\', '\\\\')
+            }',
             libsDir: '${workspaceLayout().libsDir}'
           }
         }`,


### PR DESCRIPTION
This PR fixes an issue where our `withNx` function for Next.js is compiled with inlined `workspaceRoot` (to support container environments). On Windows, we write the `.nx-helpers/with-nx.js` with the following:

```js
workspaceRoot: 'C:\Users\user\projects\app',
```

The `\u` character result in a Node error: `Invalid Unicode escape sequence`.

The fix is to escape `\` as `\\`, so when the file is written, the path is valid and does not cause unicode errors.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18824
