### PR TITLE
feat(core): add --exclude-task-dependencies flag

### DIFF
--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -117,6 +117,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### excludeTaskDependencies
+
+Type: `boolean`
+
+Default: `false`
+
+Skips running dependent tasks first
+
 ### files
 
 Type: `string`

--- a/docs/generated/cli/release.md
+++ b/docs/generated/cli/release.md
@@ -309,6 +309,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+##### excludeTaskDependencies
+
+Type: `boolean`
+
+Default: `false`
+
+Skips running dependent tasks first
+
 ##### first-release
 
 Type: `boolean`

--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -119,6 +119,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### excludeTaskDependencies
+
+Type: `boolean`
+
+Default: `false`
+
+Skips running dependent tasks first
+
 ### graph
 
 Type: `string`

--- a/docs/generated/cli/run.md
+++ b/docs/generated/cli/run.md
@@ -87,6 +87,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### excludeTaskDependencies
+
+Type: `boolean`
+
+Default: `false`
+
+Skips running dependent tasks first
+
 ### graph
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/affected.md
+++ b/docs/generated/packages/nx/documents/affected.md
@@ -117,6 +117,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### excludeTaskDependencies
+
+Type: `boolean`
+
+Default: `false`
+
+Skips running dependent tasks first
+
 ### files
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/release.md
+++ b/docs/generated/packages/nx/documents/release.md
@@ -309,6 +309,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+##### excludeTaskDependencies
+
+Type: `boolean`
+
+Default: `false`
+
+Skips running dependent tasks first
+
 ##### first-release
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/run-many.md
+++ b/docs/generated/packages/nx/documents/run-many.md
@@ -119,6 +119,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### excludeTaskDependencies
+
+Type: `boolean`
+
+Default: `false`
+
+Skips running dependent tasks first
+
 ### graph
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/run.md
+++ b/docs/generated/packages/nx/documents/run.md
@@ -87,6 +87,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### excludeTaskDependencies
+
+Type: `boolean`
+
+Default: `false`
+
+Skips running dependent tasks first
+
 ### graph
 
 Type: `string`

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -254,6 +254,40 @@ describe('Nx Running Tests', () => {
       const output = runCLI(`echo ${mylib}`);
       expect(output).toContain('TWO');
     });
+
+    it('should not run dependencies if --no-dependencies is passed', () => {
+      const mylib = uniq('mylib');
+      runCLI(`generate @nx/js:lib ${mylib}`);
+
+      updateJson(`libs/${mylib}/project.json`, (c) => {
+        c.targets['one'] = {
+          executor: 'nx:run-commands',
+          options: {
+            command: 'echo ONE',
+          },
+        };
+        c.targets['two'] = {
+          executor: 'nx:run-commands',
+          options: {
+            command: 'echo TWO',
+          },
+          dependsOn: ['one'],
+        };
+        c.targets['three'] = {
+          executor: 'nx:run-commands',
+          options: {
+            command: 'echo THREE',
+          },
+          dependsOn: ['two'],
+        };
+        return c;
+      });
+
+      const output = runCLI(`one ${mylib} --no-deps`);
+      expect(output).toContain('ONE');
+      expect(output).not.toContain('TWO');
+      expect(output).not.toContain('THREE');
+    });
   });
 
   describe('Nx Bail', () => {

--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -32,7 +32,7 @@ export async function affected(
     (TargetDependencyConfig | string)[]
   > = {},
   extraOptions = {
-    excludeTaskDependencies: false,
+    excludeTaskDependencies: args.excludeTaskDependencies,
     loadDotEnvFiles: process.env.NX_LOAD_DOT_ENV_FILES !== 'false',
   } as {
     excludeTaskDependencies: boolean;

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -79,7 +79,9 @@ export async function releasePublish(
    * for dependencies, because that could cause projects outset of the filtered set to be published.
    */
   const shouldExcludeTaskDependencies =
-    _args.projects?.length > 0 || _args.groups?.length > 0;
+    _args.projects?.length > 0 ||
+    _args.groups?.length > 0 ||
+    args.excludeTaskDependencies;
 
   let overallExitStatus = 0;
 

--- a/packages/nx/src/command-line/run-many/run-many.ts
+++ b/packages/nx/src/command-line/run-many/run-many.ts
@@ -26,7 +26,7 @@ export async function runMany(
     (TargetDependencyConfig | string)[]
   > = {},
   extraOptions = {
-    excludeTaskDependencies: false,
+    excludeTaskDependencies: args.excludeTaskDependencies,
     loadDotEnvFiles: process.env.NX_LOAD_DOT_ENV_FILES !== 'false',
   } as {
     excludeTaskDependencies: boolean;

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -28,7 +28,7 @@ export async function runOne(
     (TargetDependencyConfig | string)[]
   > = {},
   extraOptions = {
-    excludeTaskDependencies: false,
+    excludeTaskDependencies: args.excludeTaskDependencies,
     loadDotEnvFiles: process.env.NX_LOAD_DOT_ENV_FILES !== 'false',
   } as {
     excludeTaskDependencies: boolean;

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -27,6 +27,7 @@ export interface RunOptions {
   dte: boolean;
   batch: boolean;
   useAgents: boolean;
+  excludeTaskDependencies: boolean;
 }
 
 export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
@@ -76,6 +77,11 @@ export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
     .options('skipNxCache', {
       describe:
         'Rerun the tasks even when the results are available in the cache',
+      type: 'boolean',
+      default: false,
+    })
+    .options('excludeTaskDependencies', {
+      describe: 'Skips running dependent tasks first',
       type: 'boolean',
       default: false,
     })

--- a/packages/nx/src/commands-runner/create-command-graph.ts
+++ b/packages/nx/src/commands-runner/create-command-graph.ts
@@ -50,8 +50,10 @@ export function createCommandGraph(
   nxArgs: NxArgs
 ): CommandGraph {
   const dependencies: Record<string, string[]> = {};
-  for (const projectName of projectNames) {
-    recursiveResolveDeps(projectGraph, projectName, dependencies);
+  if (!nxArgs.excludeTaskDependencies) {
+    for (const projectName of projectNames) {
+      recursiveResolveDeps(projectGraph, projectName, dependencies);
+    }
   }
   const roots = Object.keys(dependencies).filter(
     (d) => dependencies[d].length === 0

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -36,6 +36,7 @@ export interface NxArgs {
   nxIgnoreCycles?: boolean;
   type?: string;
   batch?: boolean;
+  excludeTaskDependencies?: boolean;
 }
 
 export function createOverrides(__overrides_unparsed__: string[] = []) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
There is no option to exclude dependent tasks when running Nx.

## Expected Behavior
There is a flag, `--exclude-task-dependencies`, to exclude task deps from running. This is inline with other tools:

- [dotnet cli](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build#:~:text=%2D%2Dno%2D-,dependencies,-Ignores%20project%2Dto)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18053
