### PR TITLE
fix(node): ensure artifacts are built before serving app

### DIFF
--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -51,9 +51,13 @@ describe('app', () => {
                 },
               },
               "defaultConfiguration": "development",
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:node",
               "options": {
                 "buildTarget": "my-node-app:build",
+                "runBuildTargetDependencies": false,
               },
             },
           },
@@ -235,9 +239,13 @@ describe('app', () => {
                 },
               },
               "defaultConfiguration": "development",
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:node",
               "options": {
                 "buildTarget": "my-node-app:build",
+                "runBuildTargetDependencies": false,
               },
             },
           },

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -134,8 +134,14 @@ function getServeConfig(options: NormalizedSchema): TargetConfiguration {
   return {
     executor: '@nx/js:node',
     defaultConfiguration: 'development',
+    // Run build, which includes dependency on "^build" by default, so the first run
+    // won't error out due to missing build artifacts.
+    dependsOn: ['build'],
     options: {
       buildTarget: `${options.name}:build`,
+      // Even though `false` is the default, set this option so users know it
+      // exists if they want to always run dependencies during each rebuild.
+      runBuildTargetDependencies: false,
     },
     configurations: {
       development: {


### PR DESCRIPTION
This PR ensures that all dependencies are built before serving the Node app.
<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
If users don't manually run `nx build <app>` first, then the dependencies won't build because when `@nx/js:node` executor runs, it uses `runExecutor` which skips dependencies.

## Expected Behavior
Set `dependsOn` on the `serve` target so run `<app>:build` first, which would ensure dependencies are all built. Also add `runBuildTargetDependencies: false` to the target options for visibility, so users could toggle it on if they want to re-build deps whenever there is a change (during watch). The option will slow things down, so we still want it to be `false` by default.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18964
