### PR TITLE
fix(vite): ensure nxViteTsPaths resolve before vite internal resolver

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -66,6 +66,9 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
 
   return {
     name: 'nx-vite-ts-paths',
+    // Ensure the resolveId aspect of the plugin is called before vite's internal resolver
+    // Otherwise, issues can arise with Yarn Workspaces and Pnpm Workspaces
+    enforce: 'pre',
     async configResolved(config: any) {
       projectRoot = config.root;
       const projectRootFromWorkspaceRoot = relative(workspaceRoot, projectRoot);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
In Yarn and PNPM Workspaces, the `nxViteTsPaths`'s `resolveId` is not called because Vite has already tried to resolve the module.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the `nxViteTsPath`'s logic is run before vite's internal resolver.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20520 
