### PR TITLE
fix(release): ensure @org/package style names are wrapped in quotes in version plans

### DIFF
--- a/packages/nx/src/command-line/release/plan.ts
+++ b/packages/nx/src/command-line/release/plan.ts
@@ -15,6 +15,7 @@ import {
 } from './config/config';
 import { filterReleaseGroups } from './config/filter-release-groups';
 import { getVersionPlansAbsolutePath } from './config/version-plans';
+import { generateVersionPlanContent } from './utils/generate-version-plan-content';
 import { parseConventionalCommitsMessage } from './utils/git';
 import { printDiff } from './utils/print-changes';
 
@@ -136,7 +137,7 @@ export async function releasePlan(args: PlanOptions): Promise<string | number> {
   }
 
   const versionPlanMessage = args.message || (await promptForMessage());
-  const versionPlanFileContent = getVersionPlanFileContent(
+  const versionPlanFileContent = generateVersionPlanContent(
     versionPlanBumps,
     versionPlanMessage
   );
@@ -228,19 +229,4 @@ async function _promptForMessage(): Promise<string> {
     });
     process.exit(0);
   }
-}
-
-function getVersionPlanFileContent(
-  bumps: Record<string, string>,
-  message: string
-): string {
-  return `---
-${Object.entries(bumps)
-  .filter(([_, version]) => version !== 'none')
-  .map(([projectOrGroup, version]) => `${projectOrGroup}: ${version}`)
-  .join('\n')}
----
-
-${message}
-`;
 }

--- a/packages/nx/src/command-line/release/utils/generate-version-plan-content.spec.ts
+++ b/packages/nx/src/command-line/release/utils/generate-version-plan-content.spec.ts
@@ -1,0 +1,32 @@
+import { generateVersionPlanContent } from './generate-version-plan-content';
+
+describe('generateVersionPlanContent()', () => {
+  it('should generate the version plan content', () => {
+    expect(generateVersionPlanContent({ proj: '1.0.0' }, 'message'))
+      .toMatchInlineSnapshot(`
+      "---
+      proj: 1.0.0
+      ---
+
+      message
+      "
+    `);
+  });
+
+  it('should wrap project keys in quotes if they start with an @ symbol', () => {
+    expect(
+      generateVersionPlanContent(
+        { '@proj/foo': '1.0.0', 'a-b-c': '2.3.4' },
+        'message'
+      )
+    ).toMatchInlineSnapshot(`
+      "---
+      '@proj/foo': 1.0.0
+      a-b-c: 2.3.4
+      ---
+
+      message
+      "
+    `);
+  });
+});

--- a/packages/nx/src/command-line/release/utils/generate-version-plan-content.ts
+++ b/packages/nx/src/command-line/release/utils/generate-version-plan-content.ts
@@ -1,0 +1,21 @@
+export function generateVersionPlanContent(
+  bumps: Record<string, string>,
+  message: string
+): string {
+  return `---
+${Object.entries(bumps)
+  .filter(([_, version]) => version !== 'none')
+  .map(([projectOrGroup, version]) => {
+    let key = projectOrGroup;
+    // frontmatter parsing will blow up if we don't wrap @org/package style project names in quotes
+    if (key.startsWith('@')) {
+      key = `'${key}'`;
+    }
+    return `${key}: ${version}`;
+  })
+  .join('\n')}
+---
+
+${message}
+`;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Version plans created via the nx CLI do not wrap `@org/package` style names in quotes, causing parsing issues at versioning time.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@org/package` style names are generated with surrounding quotes and there are no parsing issues at versioning time.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27010
