### PR TITLE
chore(repo): update agent base image

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -1,7 +1,7 @@
 launch-templates:
   linux-medium:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.11-v3'
+    image: 'ubuntu22.04-node20.11-v10'
     env:
       GIT_AUTHOR_EMAIL: test@test.com
       GIT_AUTHOR_NAME: Test

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -21,7 +21,7 @@ launch-templates:
             ~/.cache/Cypress
             ~/.cache/ms-playwright
             ~/.pnpm-store
-          base-branch: 'master'
+          base_branch: 'master'
       - name: Install e2e deps
         script: |
           sudo apt-get update


### PR DESCRIPTION
- uses the new base image with docker always embedded 
- up until now, whenever somebody opened a new branch, we had not been restoring the npm cache form the `master` branch - this PR fixes it by using the correct input