### PR TITLE
fix(release): only include relevant authors in project changelogs

### DIFF
--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -287,6 +287,182 @@ describe('defaultChangelogRenderer()', () => {
         - James Henry"
       `);
     });
+
+    it('should only include authors relevant to the specific project', async () => {
+      const changes: ChangelogChange[] = [
+        {
+          shortHash: '4130f65',
+          author: {
+            name: 'Author 1',
+            email: 'author-1@example.com',
+          },
+          body: '"\n\nM\tpackages/pkg-a/src/index.ts\nM\tpackages/pkg-b/src/index.ts\n"',
+          description: 'all packages fixed',
+          type: 'fix',
+          scope: '',
+          githubReferences: [
+            {
+              value: '4130f65',
+              type: 'hash',
+            },
+          ],
+          isBreaking: false,
+          revertedHashes: [],
+          affectedProjects: ['pkg-a', 'pkg-b'],
+        },
+        {
+          shortHash: '7dc5ec3',
+          author: {
+            name: 'Author 2',
+            email: 'author-2@example.com',
+          },
+          body: '"\n\nM\tpackages/pkg-b/src/index.ts\n"',
+          description: 'and another new capability',
+          type: 'feat',
+          scope: 'pkg-b',
+          githubReferences: [
+            {
+              value: '7dc5ec3',
+              type: 'hash',
+            },
+          ],
+          isBreaking: false,
+          revertedHashes: [],
+          affectedProjects: ['pkg-b'],
+        },
+        {
+          shortHash: 'd7a58a2',
+          author: {
+            name: 'Author 3',
+            email: 'author-3@example.com',
+          },
+          body: '"\n\nM\tpackages/pkg-a/src/index.ts\n"',
+          description: 'new hotness',
+          type: 'feat',
+          scope: 'pkg-a',
+          githubReferences: [
+            {
+              value: 'd7a58a2',
+              type: 'hash',
+            },
+          ],
+          isBreaking: false,
+          revertedHashes: [],
+          affectedProjects: ['pkg-a'],
+        },
+        {
+          shortHash: 'feace4a',
+          author: {
+            name: 'Author 4',
+            email: 'author-4@example.com',
+          },
+          body: '"\n\nM\tpackages/pkg-b/src/index.ts\n"',
+          description: 'brand new thing',
+          type: 'feat',
+          scope: 'pkg-b',
+          githubReferences: [
+            {
+              value: 'feace4a',
+              type: 'hash',
+            },
+          ],
+          isBreaking: false,
+          revertedHashes: [],
+          affectedProjects: ['pkg-b'],
+        },
+        {
+          shortHash: '6301405',
+          author: {
+            name: 'Author 5',
+            email: 'author-5@example.com',
+          },
+          body: '"\n\nM\tpackages/pkg-a/src/index.ts\n',
+          description: 'squashing bugs',
+          type: 'fix',
+          scope: 'pkg-a',
+          githubReferences: [
+            {
+              value: '6301405',
+              type: 'hash',
+            },
+          ],
+          isBreaking: false,
+          revertedHashes: [],
+          affectedProjects: ['pkg-a'],
+        },
+      ];
+
+      const otherOpts = {
+        projectGraph,
+        changes,
+        releaseVersion: 'v1.1.0',
+        entryWhenNoChanges: false as const,
+        changelogRenderOptions: {
+          authors: true,
+        },
+        conventionalCommitsConfig: DEFAULT_CONVENTIONAL_COMMITS_CONFIG,
+      };
+
+      expect(
+        await defaultChangelogRenderer({
+          ...otherOpts,
+          project: 'pkg-a',
+        })
+      ).toMatchInlineSnapshot(`
+        "## v1.1.0
+
+
+        ### 🚀 Features
+
+        - **pkg-a:** new hotness
+
+
+        ### 🩹 Fixes
+
+        - all packages fixed
+
+        - **pkg-a:** squashing bugs
+
+
+        ### ❤️  Thank You
+
+        - Author 1
+        - Author 2
+        - Author 3
+        - Author 4
+        - Author 5"
+      `);
+
+      expect(
+        await defaultChangelogRenderer({
+          ...otherOpts,
+          project: 'pkg-b',
+        })
+      ).toMatchInlineSnapshot(`
+        "## v1.1.0
+
+
+        ### 🚀 Features
+
+        - **pkg-b:** brand new thing
+
+        - **pkg-b:** and another new capability
+
+
+        ### 🩹 Fixes
+
+        - all packages fixed
+
+
+        ### ❤️  Thank You
+
+        - Author 1
+        - Author 2
+        - Author 3
+        - Author 4
+        - Author 5"
+      `);
+    });
   });
 
   describe('entryWhenNoChanges', () => {

--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -427,9 +427,7 @@ describe('defaultChangelogRenderer()', () => {
         ### ❤️  Thank You
 
         - Author 1
-        - Author 2
         - Author 3
-        - Author 4
         - Author 5"
       `);
 
@@ -458,9 +456,7 @@ describe('defaultChangelogRenderer()', () => {
 
         - Author 1
         - Author 2
-        - Author 3
-        - Author 4
-        - Author 5"
+        - Author 4"
       `);
     });
   });

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -118,10 +118,12 @@ const defaultChangelogRenderer: ChangelogRenderer = async ({
     }
   }
 
+  let relevantChanges = changes;
+
   // workspace root level changelog
   if (project === null) {
     // No changes for the workspace
-    if (changes.length === 0) {
+    if (relevantChanges.length === 0) {
       if (dependencyBumps?.length) {
         applyAdditionalDependencyBumps({
           markdownLines,
@@ -143,7 +145,7 @@ const defaultChangelogRenderer: ChangelogRenderer = async ({
     }
 
     const typeGroups: Record<string, ChangelogChange[]> = groupBy(
-      changes,
+      relevantChanges,
       'type'
     );
 
@@ -197,7 +199,7 @@ const defaultChangelogRenderer: ChangelogRenderer = async ({
     }
   } else {
     // project level changelog
-    const relevantChanges = changes.filter(
+    relevantChanges = relevantChanges.filter(
       (c) =>
         c.affectedProjects &&
         (c.affectedProjects === '*' || c.affectedProjects.includes(project))
@@ -279,7 +281,7 @@ const defaultChangelogRenderer: ChangelogRenderer = async ({
 
   if (changelogRenderOptions.authors) {
     const _authors = new Map<string, { email: Set<string>; github?: string }>();
-    for (const change of changes) {
+    for (const change of relevantChanges) {
       if (!change.author) {
         continue;
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

I added an initial commit (https://github.com/nrwl/nx/pull/27181/commits/fff1d8a373872caa4301195ada51153173c71810) showing the current behaviour in a unit test. We capture all possible authors for the current release in each project level changelog, which is not really appropriate.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We only capture the authors relevant to each project's changes in project level changelogs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26949 
