### PR TITLE
chore(testing): use consistent uniq suffix length to avoid flakiness

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -650,8 +650,12 @@ export function createNonNxProjectDirectory(
   );
 }
 
-export function uniq(prefix: string) {
-  return `${prefix}${Math.floor(Math.random() * 10000000)}`;
+export function uniq(prefix: string): string {
+  // We need to ensure that the length of the random section of the name is of consistent length to avoid flakiness in tests
+  const randomSevenDigitNumber = Math.floor(Math.random() * 10000000)
+    .toString()
+    .padStart(7, '0');
+  return `${prefix}${randomSevenDigitNumber}`;
 }
 
 // Useful in order to cleanup space during CI to prevent `No space left on device` exceptions


### PR DESCRIPTION
`nx run e2e-release:e2e-ci--src/multiple-release-branches.test.ts` has had some flakiness for a while, but it wasn't immediately apparent why.

Thanks to @DanielRose's great digging, it turns out it was down to the fact that the result of the `uniq()` helper has a non-deterministic length.

This PR changes that and makes it such that the random suffix element of the function is always 7 characters long which should remove the flakiness from the above e2e test.