### PR TITLE
feat(nx-cloud): add nxCloudId field for auth

### DIFF
--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -31,6 +31,7 @@ Nx.json configuration
 - [neverConnectToCloud](../../devkit/documents/NxJsonConfiguration#neverconnecttocloud): boolean
 - [nxCloudAccessToken](../../devkit/documents/NxJsonConfiguration#nxcloudaccesstoken): string
 - [nxCloudEncryptionKey](../../devkit/documents/NxJsonConfiguration#nxcloudencryptionkey): string
+- [nxCloudId](../../devkit/documents/NxJsonConfiguration#nxcloudid): string
 - [nxCloudUrl](../../devkit/documents/NxJsonConfiguration#nxcloudurl): string
 - [parallel](../../devkit/documents/NxJsonConfiguration#parallel): number
 - [plugins](../../devkit/documents/NxJsonConfiguration#plugins): PluginConfiguration[]
@@ -186,6 +187,15 @@ To use a different runner that accepts an access token, define it in [tasksRunne
 • `Optional` **nxCloudEncryptionKey**: `string`
 
 Specifies the encryption key used to encrypt artifacts data before sending it to nx cloud.
+
+---
+
+### nxCloudId
+
+• `Optional` **nxCloudId**: `string`
+
+If specified Nx will use nx-cloud by default with the given cloud id.
+To use a different runner that accepts a cloud id, define it in [tasksRunnerOptions](../../devkit/documents/NxJsonConfiguration#tasksrunneroptions)
 
 ---
 

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -29,6 +29,7 @@ use ProjectsConfigurations or NxJsonConfiguration
 - [neverConnectToCloud](../../devkit/documents/Workspace#neverconnecttocloud): boolean
 - [nxCloudAccessToken](../../devkit/documents/Workspace#nxcloudaccesstoken): string
 - [nxCloudEncryptionKey](../../devkit/documents/Workspace#nxcloudencryptionkey): string
+- [nxCloudId](../../devkit/documents/Workspace#nxcloudid): string
 - [nxCloudUrl](../../devkit/documents/Workspace#nxcloudurl): string
 - [parallel](../../devkit/documents/Workspace#parallel): number
 - [plugins](../../devkit/documents/Workspace#plugins): PluginConfiguration[]
@@ -238,6 +239,19 @@ Specifies the encryption key used to encrypt artifacts data before sending it to
 #### Inherited from
 
 [NxJsonConfiguration](../../devkit/documents/NxJsonConfiguration).[nxCloudEncryptionKey](../../devkit/documents/NxJsonConfiguration#nxcloudencryptionkey)
+
+---
+
+### nxCloudId
+
+• `Optional` **nxCloudId**: `string`
+
+If specified Nx will use nx-cloud by default with the given cloud id.
+To use a different runner that accepts a cloud id, define it in [tasksRunnerOptions](../../devkit/documents/NxJsonConfiguration#tasksrunneroptions)
+
+#### Inherited from
+
+[NxJsonConfiguration](../../devkit/documents/NxJsonConfiguration).[nxCloudId](../../devkit/documents/NxJsonConfiguration#nxcloudid)
 
 ---
 

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -397,6 +397,9 @@
             "accessToken": {
               "type": "string"
             },
+            "nxCloudId": {
+              "type": "string"
+            },
             "captureStderr": {
               "type": "boolean",
               "description": "Defines whether the cache captures stderr or just stdout."

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -71,6 +71,7 @@ export const allowedWorkspaceExtensions = [
   'installation',
   'release',
   'nxCloudAccessToken',
+  'nxCloudId',
   'nxCloudUrl',
   'nxCloudEncryptionKey',
   'parallel',

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.spec.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.spec.ts
@@ -17,6 +17,21 @@ describe('connect-to-nx-cloud', () => {
       ).toBe(false);
     });
 
+    it('should say no if tasks runner options is undefined and nxCloudId is set', () => {
+      expect(
+        withEnvironmentVariables(
+          {
+            NX_ENABLE_LOGIN: 'true',
+          },
+          () =>
+            onlyDefaultRunnerIsUsed({
+              nxCloudId: 'xxxxxxx',
+              nxCloudUrl: 'https://my-nx-cloud.app',
+            })
+        )
+      ).toBe(false);
+    });
+
     it('should say no if cloud access token is in env', () => {
       const defaultRunnerUsed = withEnvironmentVariables(
         {
@@ -28,7 +43,7 @@ describe('connect-to-nx-cloud', () => {
       expect(defaultRunnerUsed).toBe(false);
     });
 
-    it('should say yes if tasks runner options is undefined and nxCloudAccessToken is not set', () => {
+    it('should say yes if tasks runner options is undefined and nxCloudAccessToken/nxCloudId is not set', () => {
       expect(
         withEnvironmentVariables(
           {

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -29,7 +29,10 @@ export function onlyDefaultRunnerIsUsed(nxJson: NxJsonConfiguration) {
     // No tasks runner options OR no default runner defined:
     // - If access token defined, uses cloud runner
     // - If no access token defined, uses default
-    return !(nxJson.nxCloudAccessToken ?? process.env.NX_CLOUD_ACCESS_TOKEN);
+    return (
+      !(nxJson.nxCloudAccessToken ?? process.env.NX_CLOUD_ACCESS_TOKEN) &&
+      !nxJson.nxCloudId
+    );
   }
 
   return defaultRunner === 'nx/tasks-runners/default';

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -416,6 +416,12 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
   nxCloudAccessToken?: string;
 
   /**
+   * If specified Nx will use nx-cloud by default with the given cloud id.
+   * To use a different runner that accepts a cloud id, define it in {@link tasksRunnerOptions}
+   */
+  nxCloudId?: string;
+
+  /**
    * Specifies the url pointing to an instance of nx cloud. Used for remote
    * caching and displaying run links.
    */

--- a/packages/nx/src/nx-cloud/nx-cloud-tasks-runner-shell.ts
+++ b/packages/nx/src/nx-cloud/nx-cloud-tasks-runner-shell.ts
@@ -23,6 +23,7 @@ export interface CloudTaskRunnerOptions extends DefaultTasksRunnerOptions {
   url?: string;
   useLightClient?: boolean;
   clientVersion?: string;
+  nxCloudId?: string;
 }
 
 export const nxCloudTasksRunnerShell: TasksRunner<

--- a/packages/nx/src/nx-cloud/utilities/axios.ts
+++ b/packages/nx/src/nx-cloud/utilities/axios.ts
@@ -18,9 +18,15 @@ export function createApiAxiosInstance(options: CloudTaskRunnerOptions) {
 
   // TODO(lourw): Update message with NxCloudId once it is supported
   if (!accessToken && !nxCloudId) {
-    throw new Error(
-      `Unable to authenticate. Either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable. If you do not want to use Nx Cloud for this command, either set NX_NO_CLOUD=true, or pass the --no-cloud flag.`
-    );
+    if (process.env.NX_ENABLE_LOGIN === 'true' && !nxCloudId) {
+      throw new Error(
+        `Unable to authenticate. Please connect your workspace to Nx Cloud to define a valid Nx Cloud Id. If you are in a CI context, please set the NX_CLOUD_ACCESS_TOKEN environment variable or define an access token in your nx.json.`
+      );
+    } else {
+      throw new Error(
+        `Unable to authenticate. Either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable. If you do not want to use Nx Cloud for this command, either set NX_NO_CLOUD=true, or pass the --no-cloud flag.`
+      );
+    }
   }
 
   if (options.customProxyConfigPath) {

--- a/packages/nx/src/nx-cloud/utilities/axios.ts
+++ b/packages/nx/src/nx-cloud/utilities/axios.ts
@@ -14,10 +14,12 @@ export function createApiAxiosInstance(options: CloudTaskRunnerOptions) {
   const baseUrl =
     process.env.NX_CLOUD_API || options.url || 'https://cloud.nx.app';
   const accessToken = ACCESS_TOKEN ? ACCESS_TOKEN : options.accessToken!;
+  const nxCloudId = options.nxCloudId;
 
-  if (!accessToken) {
+  // TODO(lourw): Update message with NxCloudId once it is supported
+  if (!accessToken && !nxCloudId) {
     throw new Error(
-      `Unable to authenticate. Either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable.`
+      `Unable to authenticate. Either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable. If you do not want to use Nx Cloud for this command, either set NX_NO_CLOUD=true, or pass the --no-cloud flag.`
     );
   }
 

--- a/packages/nx/src/tasks-runner/run-command.spec.ts
+++ b/packages/nx/src/tasks-runner/run-command.spec.ts
@@ -106,6 +106,24 @@ describe('getRunner', () => {
     `);
   });
 
+  it('uses cloud runner when tasksRunnerOptions are not present and nxCloudId is specified', () => {
+    const { tasksRunner, runnerOptions } = getRunner(
+      {},
+      {
+        nxCloudId: 'XXXX-XXX',
+        nxCloudUrl: 'https://my-nx-cloud.app',
+      }
+    )
+
+    expect(tasksRunner).toEqual(nxCloudTasksRunnerShell);
+    expect(runnerOptions).toMatchInlineSnapshot(`
+      {
+        "nxCloudId": "XXXX-XXX",
+        "url": "https://my-nx-cloud.app",
+      }
+    `);
+  })
+
   it('uses cloud runner when tasksRunnerOptions are not present and accessToken is set in env', () => {
     const { tasksRunner } = withEnvironmentVariables(
       {

--- a/packages/nx/src/tasks-runner/run-command.spec.ts
+++ b/packages/nx/src/tasks-runner/run-command.spec.ts
@@ -113,7 +113,7 @@ describe('getRunner', () => {
         nxCloudId: 'XXXX-XXX',
         nxCloudUrl: 'https://my-nx-cloud.app',
       }
-    )
+    );
 
     expect(tasksRunner).toEqual(nxCloudTasksRunnerShell);
     expect(runnerOptions).toMatchInlineSnapshot(`
@@ -122,7 +122,7 @@ describe('getRunner', () => {
         "url": "https://my-nx-cloud.app",
       }
     `);
-  })
+  });
 
   it('uses cloud runner when tasksRunnerOptions are not present and accessToken is set in env', () => {
     const { tasksRunner } = withEnvironmentVariables(

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -490,7 +490,9 @@ function getTasksRunnerPath(
     // No runner prop in tasks runner options, check if access token is set.
     nxJson.tasksRunnerOptions?.[runner]?.options?.accessToken ||
     // Cloud access token specified in env var.
-    process.env.NX_CLOUD_ACCESS_TOKEN;
+    process.env.NX_CLOUD_ACCESS_TOKEN ||
+    // Nx Cloud Id specified in nxJson
+    nxJson.nxCloudId;
 
   return isCloudRunner ? 'nx-cloud' : require.resolve('./default-tasks-runner');
 }
@@ -520,6 +522,10 @@ export function getRunnerOptions(
   // leaving it as is for now.
   if (nxJson.nxCloudAccessToken && isCloudDefault) {
     result.accessToken ??= nxJson.nxCloudAccessToken;
+  }
+
+  if (nxJson.nxCloudId && isCloudDefault) {
+    result.nxCloudId ??= nxJson.nxCloudId;
   }
 
   if (nxJson.nxCloudUrl && isCloudDefault) {

--- a/packages/nx/src/utils/nx-cloud-utils.ts
+++ b/packages/nx/src/utils/nx-cloud-utils.ts
@@ -4,6 +4,7 @@ export function isNxCloudUsed(nxJson: NxJsonConfiguration): boolean {
   return (
     !!process.env.NX_CLOUD_ACCESS_TOKEN ||
     !!nxJson.nxCloudAccessToken ||
+    !!nxJson.nxCloudId ||
     !!Object.values(nxJson.tasksRunnerOptions ?? {}).find(
       (r) => r.runner == '@nrwl/nx-cloud' || r.runner == 'nx-cloud'
     )
@@ -16,7 +17,8 @@ export function getNxCloudUrl(nxJson: NxJsonConfiguration): string {
   );
   if (
     !cloudRunner &&
-    !(nxJson.nxCloudAccessToken || process.env.NX_CLOUD_ACCESS_TOKEN)
+    !(nxJson.nxCloudAccessToken || process.env.NX_CLOUD_ACCESS_TOKEN) &&
+    !nxJson.nxCloudId
   )
     throw new Error('nx-cloud runner not found in nx.json');
   return cloudRunner?.options?.url ?? nxJson.nxCloudUrl ?? 'https://nx.app';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Instead of `nxCloudAccessToken`, users can now connect to nx-cloud with `nxCloudId`. This value will also default the runner to the cloud runner. 

Also modified the `connect-to-nx-cloud` generator such that it hits a new API endpoint to grab a workspace's nxCloudId instead of access token. (This feature is gated).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
