### PR TITLE
fix(core): disable plugin isolation by default on windows for now

### DIFF
--- a/packages/nx/src/project-graph/plugins/internal-api.ts
+++ b/packages/nx/src/project-graph/plugins/internal-api.ts
@@ -29,6 +29,7 @@ import {
   isAggregateCreateNodesError,
 } from '../error-types';
 import { IS_WASM } from '../../native';
+import { platform } from 'os';
 
 export class LoadedNxPlugin {
   readonly name: string;
@@ -153,7 +154,9 @@ export async function loadNxPlugins(
 
   const loadingMethod =
     process.env.NX_ISOLATE_PLUGINS === 'true' ||
-    (!IS_WASM && process.env.NX_ISOLATE_PLUGINS !== 'false')
+    (!IS_WASM &&
+      platform() !== 'win32' &&
+      process.env.NX_ISOLATE_PLUGINS !== 'false')
       ? loadNxPluginInIsolation
       : loadNxPlugin;
 


### PR DESCRIPTION
it's causing issues right now so we need time to fix it.