### PR TITLE
fix(release): do not add groups to commit message when their projects have no changes

### DIFF
--- a/packages/nx/src/command-line/release/utils/shared.spec.ts
+++ b/packages/nx/src/command-line/release/utils/shared.spec.ts
@@ -70,6 +70,71 @@ describe('shared', () => {
         `);
       });
 
+      it('should not add release groups to the commit message whose projects have no changes', () => {
+        const releaseGroups: ReleaseGroupWithName[] = [
+          {
+            name: 'one',
+            projectsRelationship: 'independent',
+            projects: ['foo'], // single project, will get flattened in the final commit message
+            version: {
+              conventionalCommits: false,
+              generator: '@nx/js:version',
+              generatorOptions: {},
+            },
+            changelog: false,
+            releaseTagPattern: '{projectName}-{version}',
+            versionPlans: false,
+          },
+          {
+            name: 'two',
+            projectsRelationship: 'fixed',
+            projects: ['bar', 'baz'],
+            version: {
+              conventionalCommits: false,
+              generator: '@nx/js:version',
+              generatorOptions: {},
+            },
+            changelog: false,
+            releaseTagPattern: '{projectName}-{version}',
+            versionPlans: false,
+          },
+        ];
+        const releaseGroupToFilteredProjects = new Map()
+          .set(releaseGroups[0], new Set(['foo']))
+          .set(releaseGroups[1], new Set(['bar', 'baz']));
+        const versionData = {
+          foo: {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: '1.0.1',
+          },
+          bar: {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: null, // no changes
+          },
+          baz: {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: null, // no changes
+          },
+        };
+        const userCommitMessage =
+          'chore(release): publish {projectName} v{version}';
+        const result = createCommitMessageValues(
+          releaseGroups,
+          releaseGroupToFilteredProjects,
+          versionData,
+          userCommitMessage
+        );
+        expect(result).toMatchInlineSnapshot(`
+          [
+            "chore(release): publish",
+            "- project: foo 1.0.1",
+          ]
+        `);
+      });
+
       it('should interpolate the {projectName} and {version} within the main commit message if a single project within a single independent release group is being committed', () => {
         const releaseGroups: ReleaseGroupWithName[] = [
           {

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -212,14 +212,15 @@ export function createCommitMessageValues(
 
     // One entry for the whole group for fixed groups
     const projectVersionData = versionData[releaseGroupProjectNames[0]]; // all at the same version, so we can just pick the first one
-    const releaseVersion = new ReleaseVersion({
-      version: projectVersionData.newVersion,
-      releaseTagPattern: releaseGroup.releaseTagPattern,
-    });
-
-    commitMessageValues.push(
-      `- release-group: ${releaseGroup.name} ${releaseVersion.rawVersion}`
-    );
+    if (projectVersionData.newVersion !== null) {
+      const releaseVersion = new ReleaseVersion({
+        version: projectVersionData.newVersion,
+        releaseTagPattern: releaseGroup.releaseTagPattern,
+      });
+      commitMessageValues.push(
+        `- release-group: ${releaseGroup.name} ${releaseVersion.rawVersion}`
+      );
+    }
   }
 
   return commitMessageValues;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When using release groups and conventional commits or version plans, the group names can end up in the commit message even if their projects had no changes.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Release groups are only written to commit messages when their projects have changes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
