### PR TITLE
fix(release): correct issue generation lockfiles for PNPM

### DIFF
--- a/packages/js/src/generators/release-version/utils/update-lock-file.ts
+++ b/packages/js/src/generators/release-version/utils/update-lock-file.ts
@@ -5,8 +5,9 @@ import {
   isWorkspacesEnabled,
   output,
 } from '@nx/devkit';
-import { execSync } from 'child_process';
+
 import { daemonClient } from 'nx/src/daemon/client/client';
+import { execSync } from 'child_process';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getLockFileName } from 'nx/src/plugins/js/lock-file/lock-file';
 import { gte } from 'semver';
@@ -128,6 +129,8 @@ function execLockFileUpdate(
     const LARGE_BUFFER = 1024 * 1000000;
     execSync(command, {
       cwd,
+      stdio: 'inherit',
+      shell: 'true',
       maxBuffer: LARGE_BUFFER,
       env: {
         ...process.env,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
We recently switched from NPM to PNPM. When running the command `npx nx release --skip-publish --verbose;` I get an error updating the lock file.

Running `pnpm install --lockfile-only` from the workspace root and it executed just fine.

I believe the issue is because the `execSync` command in `update-lock-file.ts` needs the params: `stdio: 'inherit'` and `shell: true`. When I add these, it works.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
PNPM lockfile generation is successful when making a release.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27238
