### PR TITLE
fix(misc): add cloud token during new workspace like expected

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -21,11 +21,14 @@ export async function setupNxCloud(
       // nx-ignore-next-line
     )) as typeof import('nx/src/command-line/connect/connect-to-nx-cloud');
 
-    const accessToken = await connectWorkspaceToCloud({
-      installationSource: 'create-nx-workspace',
-      directory,
-      github: useGitHub,
-    });
+    const accessToken = await connectWorkspaceToCloud(
+      {
+        installationSource: 'create-nx-workspace',
+        directory,
+        github: useGitHub,
+      },
+      directory
+    );
 
     nxCloudSpinner.succeed('Nx Cloud has been set up successfully');
     return accessToken;

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -56,12 +56,13 @@ export async function connectToNxCloudIfExplicitlyAsked(
 }
 
 export async function connectWorkspaceToCloud(
-  options: ConnectToNxCloudOptions
+  options: ConnectToNxCloudOptions,
+  directory = workspaceRoot
 ) {
-  const tree = new FsTree(workspaceRoot, false, 'connect-to-nx-cloud');
+  const tree = new FsTree(directory, false, 'connect-to-nx-cloud');
   const accessToken = await connectToNxCloud(tree, options);
   tree.lock();
-  flushChanges(workspaceRoot, tree.listChanges());
+  flushChanges(directory, tree.listChanges());
   return accessToken;
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The nx cloud access token is not written to nx.json during `create-nx-workspace`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The nx cloud access token is written to nx.json during `create-nx-workspace`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
