### PR TITLE
fix(core): move token generation into new

### DIFF
--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -28,6 +28,7 @@ Nx.json configuration
 - [implicitDependencies](../../devkit/documents/NxJsonConfiguration#implicitdependencies): ImplicitDependencyEntry<T>
 - [installation](../../devkit/documents/NxJsonConfiguration#installation): NxInstallationConfiguration
 - [namedInputs](../../devkit/documents/NxJsonConfiguration#namedinputs): Object
+- [neverConnectToCloud](../../devkit/documents/NxJsonConfiguration#neverconnecttocloud): boolean
 - [nxCloudAccessToken](../../devkit/documents/NxJsonConfiguration#nxcloudaccesstoken): string
 - [nxCloudEncryptionKey](../../devkit/documents/NxJsonConfiguration#nxcloudencryptionkey): string
 - [nxCloudUrl](../../devkit/documents/NxJsonConfiguration#nxcloudurl): string
@@ -160,6 +161,14 @@ Named inputs targets can refer to reduce duplication
 #### Index signature
 
 ▪ [inputName: `string`]: (`string` \| `InputDefinition`)[]
+
+---
+
+### neverConnectToCloud
+
+• `Optional` **neverConnectToCloud**: `boolean`
+
+Set this to false to disable connection to Nx Cloud
 
 ---
 

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -26,6 +26,7 @@ use ProjectsConfigurations or NxJsonConfiguration
 - [implicitDependencies](../../devkit/documents/Workspace#implicitdependencies): ImplicitDependencyEntry<string[] | "\*">
 - [installation](../../devkit/documents/Workspace#installation): NxInstallationConfiguration
 - [namedInputs](../../devkit/documents/Workspace#namedinputs): Object
+- [neverConnectToCloud](../../devkit/documents/Workspace#neverconnecttocloud): boolean
 - [nxCloudAccessToken](../../devkit/documents/Workspace#nxcloudaccesstoken): string
 - [nxCloudEncryptionKey](../../devkit/documents/Workspace#nxcloudencryptionkey): string
 - [nxCloudUrl](../../devkit/documents/Workspace#nxcloudurl): string
@@ -200,6 +201,18 @@ Named inputs targets can refer to reduce duplication
 #### Inherited from
 
 [NxJsonConfiguration](../../devkit/documents/NxJsonConfiguration).[namedInputs](../../devkit/documents/NxJsonConfiguration#namedinputs)
+
+---
+
+### neverConnectToCloud
+
+• `Optional` **neverConnectToCloud**: `boolean`
+
+Set this to false to disable connection to Nx Cloud
+
+#### Inherited from
+
+[NxJsonConfiguration](../../devkit/documents/NxJsonConfiguration).[neverConnectToCloud](../../devkit/documents/NxJsonConfiguration#neverconnecttocloud)
 
 ---
 

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -1,6 +1,6 @@
 import { CreateWorkspaceOptions } from './create-workspace-options';
 import { output } from './utils/output';
-import { getOnboardingInfo, setupNxCloud } from './utils/nx/nx-cloud';
+import { getOnboardingInfo, readNxCloudToken } from './utils/nx/nx-cloud';
 import { createSandbox } from './create-sandbox';
 import { createEmptyWorkspace } from './create-empty-workspace';
 import { createPreset } from './create-preset';
@@ -54,7 +54,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
   let connectUrl: string | undefined;
   let nxCloudInfo: string | undefined;
   if (nxCloud !== 'skip') {
-    const token = await setupNxCloud(directory, nxCloud, useGitHub);
+    const token = readNxCloudToken(directory) as string;
 
     if (nxCloud !== 'yes') {
       await setupCI(directory, nxCloud, packageManager);

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -77,6 +77,7 @@ export const allowedWorkspaceExtensions = [
   'cacheDirectory',
   'useDaemonProcess',
   'useInferencePlugins',
+  'neverConnectToCloud',
 ] as const;
 
 if (!patched) {

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -445,6 +445,11 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    * Set this to false to disable adding inference plugins when generating new projects
    */
   useInferencePlugins?: boolean;
+
+  /**
+   * Set this to false to disable connection to Nx Cloud
+   */
+  neverConnectToCloud?: boolean;
 }
 
 export type PluginConfiguration = string | ExpandedPluginConfiguration;

--- a/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
+++ b/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
@@ -1,9 +1,12 @@
 import { CloudTaskRunnerOptions } from '../nx-cloud-tasks-runner-shell';
 import { readNxJson } from '../../config/nx-json';
 import { getRunnerOptions } from '../../tasks-runner/run-command';
+import { workspaceRoot } from '../../utils/workspace-root';
 
-export function getCloudOptions(): CloudTaskRunnerOptions {
-  const nxJson = readNxJson();
+export function getCloudOptions(
+  directory = workspaceRoot
+): CloudTaskRunnerOptions {
+  const nxJson = readNxJson(directory);
 
   // TODO: The default is not always cloud? But it's not handled at the moment
   return getRunnerOptions('default', nxJson, {}, true);

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -1,4 +1,5 @@
 import {
+  formatFiles,
   getPackageManagerCommand,
   installPackagesTask,
   joinPathFragments,
@@ -34,6 +35,8 @@ interface Schema {
   e2eTestRunner?: 'cypress' | 'playwright' | 'detox' | 'jest' | 'none';
   ssr?: boolean;
   prefix?: string;
+  useGitHub?: boolean;
+  nxCloud?: 'yes' | 'skip' | 'circleci' | 'github';
 }
 
 export interface NormalizedSchema extends Schema {
@@ -48,6 +51,8 @@ export async function newGenerator(tree: Tree, opts: Schema) {
   await generateWorkspaceFiles(tree, { ...options, nxCloud: undefined } as any);
 
   addPresetDependencies(tree, options);
+
+  await formatFiles(tree);
 
   return async () => {
     if (!options.skipInstall) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The Nx Cloud token is generated after the workspace and preset have been generated. This makes it hard to use the Nx Cloud token for generating the workspace and preset.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Nx Cloud token is generated in the workspace creation. This makes it easier to use the Nx Cloud token during the workspace creation process.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
