### PR TITLE
docs(testing): moved the cleanup func calls into the func that be export default

### DIFF
--- a/docs/generated/packages/jest/documents/overview.md
+++ b/docs/generated/packages/jest/documents/overview.md
@@ -274,9 +274,10 @@ const cleanupRegisteredPaths = registerTsProject('./tsconfig.base.json');
 import { yourFancyFunction } from '@some-org/my-util-library';
 export default async function () {
   yourFancyFunction();
+
+  // make sure to run the clean up!
+  cleanupRegisteredPaths();
 }
-// make sure to run the clean up!
-cleanupRegisteredPaths();
 ```
 
 If you're using `@swc/jest` and a global setup/teardown file, you have to set the `noInterop: false` and use dynamic imports within the setup function:

--- a/docs/shared/packages/jest/jest-plugin.md
+++ b/docs/shared/packages/jest/jest-plugin.md
@@ -274,9 +274,10 @@ const cleanupRegisteredPaths = registerTsProject('./tsconfig.base.json');
 import { yourFancyFunction } from '@some-org/my-util-library';
 export default async function () {
   yourFancyFunction();
+
+  // make sure to run the clean up!
+  cleanupRegisteredPaths();
 }
-// make sure to run the clean up!
-cleanupRegisteredPaths();
 ```
 
 If you're using `@swc/jest` and a global setup/teardown file, you have to set the `noInterop: false` and use dynamic imports within the setup function:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The cleanup function is called **immediately** when the file is imported if it is placed outside of the exported function in jest global setup file.

<img width="1202" alt="Screenshot 2024-08-02 at 7 45 12 AM" src="https://github.com/user-attachments/assets/caa9cc2b-9212-4c91-b557-d44e6ba7ae05">

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The cleanup func in jest global setup file, should be call inside the default export function.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A!
