### PR TITLE
fix(core): remove additional quotes around cache path while pruning

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -34,7 +34,7 @@ export class Cache {
     if (shouldSpawnProcess) {
       const scriptPath = require.resolve('./remove-old-cache-records.js');
       try {
-        const p = spawn('node', [scriptPath, `"${this.cachePath}"`], {
+        const p = spawn('node', [scriptPath, `${this.cachePath}`], {
           stdio: 'ignore',
           detached: true,
           shell: false,


### PR DESCRIPTION
Old cache entries are not removed because the path to the cache is wrong.

It throws a silent error `no such file or directory, scandir '"PATH_TO_PROJECT/.nx/cache"/terminalOutputs'`

closed #27206
