### PR TITLE
fix(nx-dev): Turn off next.js cache for careers api

### DIFF
--- a/nx-dev/data-access-careers/src/lib/api.ts
+++ b/nx-dev/data-access-careers/src/lib/api.ts
@@ -3,7 +3,7 @@ import { Job, LeverJob } from './models';
 export async function fetchJobsList(): Promise<Job[]> {
   const apiUrl = 'https://api.lever.co/v0/postings/nrwl?mode=json';
 
-  const res = await fetch(apiUrl);
+  const res = await fetch(apiUrl, { cache: 'no-store' });
 
   if (res.ok) {
     const data = (await res.json()) as LeverJob[];

--- a/nx-dev/data-access-careers/tsconfig.lib.json
+++ b/nx-dev/data-access-careers/tsconfig.lib.json
@@ -4,10 +4,10 @@
     "outDir": "../../dist/out-tsc",
     "types": [
       "node",
-
       "@nx/react/typings/cssmodule.d.ts",
       "@nx/react/typings/image.d.ts"
-    ]
+    ],
+    "lib": ["dom"]
   },
   "exclude": [
     "jest.config.ts",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, in Next.js 14 the `fetch` API is cached by default, which we do not want on the careers page.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Each visit to the careers page should do a fresh API call.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
