### PR TITLE
fix(storybook): update version check

### DIFF
--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -14,8 +14,10 @@ export default async function* storybookExecutor(
   success: boolean;
   info?: { port: number; baseUrl?: string };
 }> {
-  const storybook7 = storybookMajorVersion() >= 7;
-  if (!storybook7) {
+  const sbVersion = storybookMajorVersion();
+  const sbLessThan7 = sbVersion < 7 && sbVersion > 0;
+
+  if (sbLessThan7) {
     throw pleaseUpgrade();
   }
   storybookConfigExistsCheck(options.configDir, context.projectName);

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -268,7 +268,7 @@ export function getTsSourceFile(host: Tree, path: string): ts.SourceFile {
 
 export function pleaseUpgrade(): string {
   return `
-    Storybook 6 is no longer maintained, and not supported in Nx. 
+    Storybook 6 and lower are no longer maintained, and not supported in Nx. 
     Please upgrade to Storybook 7.
 
     Here is a guide on how to upgrade:


### PR DESCRIPTION
Previously the check would see if the version of storybook is less than 7 and would throw an error. This causes an issue when testing canary releases of storybook since they are labeled 0.0.0-[pr-info...]

Update pleaseUpgrade text

One of the checks is to see if storybook is less than 7. The text is updated so it matches for the very unlikely scenario that someone with version 5 or lower runs this plugin.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The storybook plugin throws and error if the storybook version [is less than 7](https://github.com/nrwl/nx/blob/239f47c8d0eaf4df191acf1844b87e333b956e84/packages/storybook/src/executors/storybook/storybook.impl.ts#L17-L20).

```ts
const storybook7 = storybookMajorVersion() >= 7;
if (!storybook7) {
  throw pleaseUpgrade();
}
```

When testing a canary release for storybook the version is 0.0.0-[pr info] so when spinning up storybook it will display:

```
> nx run component-lib:storybook

 NX   

    Storybook 6 is no longer maintained, and not supported in Nx. 
    Please upgrade to Storybook 7.

    Here is a guide on how to upgrade:
    https://nx.dev/nx-api/storybook/generators/migrate-7

```

## Expected Behavior
Storybook spins up when running a canary release. Modifying the version check to not include v0 solves the problem:
```ts
const sbVersion = storybookMajorVersion();
const sbLessThan7 = sbVersion < 7 && sbVersion > 0;

if (sbLessThan7) {
  throw pleaseUpgrade();
}
```

then running Storybook with that modification:

```
╭──────────────────────────────────────────────────────────────────────╮
│                                                                      │
│   Storybook 0.0.0-pr-28752-sha-a65743e5 for react-webpack5 started   │
│   307 ms for manager and 7.73 s for preview                          │
│                                                                      │
│    Local:            http://localhost:4402/                          │
│    On your network:  http://192.168.4.41:4402/                       │
│                                                                      │
╰──────────────────────────────────────────────────────────────────────╯
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27277
