### PR TITLE
docs(core): fix typo in npm-workspaces.md

### DIFF
--- a/docs/shared/tutorials/npm-workspaces.md
+++ b/docs/shared/tutorials/npm-workspaces.md
@@ -100,7 +100,7 @@ Second, the script asks a series of questions to help set up caching for you.
 - `Which scripts are cacheable?` - Choose `typecheck`, `build` and `lint`
 - `Does the "typecheck" script create any outputs?` - Enter nothing
 - `Does the "build" script create any outputs?` - Enter `dist`
-- `Does the "lint" script creggggggate any outputs?` - Enter nothing
+- `Does the "lint" script create any outputs?` - Enter nothing
 - `Would you like remote caching to make your build faster?` - Choose `Skip for now`
 
 ### Explore Your Workspace


### PR DESCRIPTION
type(docs): fix typo in npm-workspaces.md

Someone's cat slept on their "G" key. `creggggggate` -> `create`

## Current Behavior
Typo exists:
> Does the "lint" script creggggggate any outputs? - Enter nothing

## Expected Behavior
Typo should not exist:
> Does the "lint" script ~~creggggggate~~ create any outputs? - Enter nothing

## Related Issue(s)
N/A

Fixes #
N/A