### PR TITLE
test(nx-dev): make test pass on windows

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/nodes/helpers/transform-image-path.spec.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/helpers/transform-image-path.spec.ts
@@ -10,8 +10,12 @@ describe('transformImagePath', () => {
     expect(transform('./test.png')).toEqual(
       sep + join('documentation', 'shared', 'using-nx', 'test.png')
     );
-    expect(transform('../test.png')).toEqual(sep + join('documentation', 'shared', 'test.png'));
-    expect(transform('../../test.png')).toEqual(sep + join('documentation', 'test.png'));
+    expect(transform('../test.png')).toEqual(
+      sep + join('documentation', 'shared', 'test.png')
+    );
+    expect(transform('../../test.png')).toEqual(
+      sep + join('documentation', 'test.png')
+    );
   });
 
   it('should transform absolute paths', () => {

--- a/nx-dev/ui-markdoc/src/lib/nodes/helpers/transform-image-path.spec.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/helpers/transform-image-path.spec.ts
@@ -1,4 +1,5 @@
 import { transformImagePath } from './transform-image-path';
+import { join, sep } from 'path';
 
 describe('transformImagePath', () => {
   it('should transform relative paths', () => {
@@ -7,10 +8,10 @@ describe('transformImagePath', () => {
     );
 
     expect(transform('./test.png')).toEqual(
-      '/documentation/shared/using-nx/test.png'
+      sep + join('documentation', 'shared', 'using-nx', 'test.png')
     );
-    expect(transform('../test.png')).toEqual('/documentation/shared/test.png');
-    expect(transform('../../test.png')).toEqual('/documentation/test.png');
+    expect(transform('../test.png')).toEqual(sep + join('documentation', 'shared', 'test.png'));
+    expect(transform('../../test.png')).toEqual(sep + join('documentation', 'test.png'));
   });
 
   it('should transform absolute paths', () => {


### PR DESCRIPTION
## Current Behavior
running `nx test nx-dev-ui-markdoc` fails on windows

## Expected Behavior
running `nx test nx-dev-ui-markdoc` pass on windows