### PR TITLE
Remove brackets for list of capabilities of a plugin when using `nx list` if it has none

### DIFF
--- a/packages/nx/src/utils/plugins/output.ts
+++ b/packages/nx/src/utils/plugins/output.ts
@@ -31,7 +31,11 @@ export function listPlugins(
     if (p.projectInference) {
       capabilities.push('project-inference');
     }
-    bodyLines.push(`${chalk.bold(p.name)} (${capabilities.join()})`);
+    bodyLines.push(
+      `${chalk.bold(p.name)} ${
+        capabilities.length >= 1 ? `(${capabilities.join(', ')})` : ''
+      }`
+    );
   }
 
   output.log({

--- a/packages/nx/src/utils/plugins/output.ts
+++ b/packages/nx/src/utils/plugins/output.ts
@@ -33,7 +33,7 @@ export function listPlugins(
     }
     bodyLines.push(
       `${chalk.bold(p.name)} ${
-        capabilities.length >= 1 ? `(${capabilities.join(', ')})` : ''
+        capabilities.length >= 1 ? `(${capabilities.join()})` : ''
       }`
     );
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `nx list`, if a plugin has no capabilities (i.e. `@nx/eslint-plugin`), it will show brackets with an empty list of capabilities.

```shell
$ nx list                                                                                                                                                                                                  
                                                                                                                                                                                                                                            
 NX   Installed plugins:                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                         
@nx/eslint (executors,generators)                                                                                                                                                                                                                        
@nx/eslint-plugin ()                                                                                                                                                                                                                                     
@nx/js (executors,generators)                                                                                                                                                                                                                            
@nx/workspace (executors,generators)                                                                                                                                                                                                                     
nx (executors,generators)                                                                                                                                                                                                                          
```

https://asciinema.org/a/XxJjVyoIoQgjj8fsM6fb0TXQT

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When running `nx list`, if a plugin has no capabilities (i.e. `@nx/eslint-plugin`), it won't show brackets with an empty list of capabilities.

```shell
$ nx list
nx list                                                                                                                                
                                                                                                                                                                                                      
 NX   Installed plugins:                                                                                                                                                                              
                                                                                                                                                                                                      
@nx/eslint (executors,generators)                                                                                                                                                                     
@nx/eslint-plugin                                                                                                                                                                                     
@nx/js (executors,generators)                                                                                                                                                                         
nx (executors,generators)                                                                                                                                                                             
```

https://asciinema.org/a/CHPkcO6hRURZRuBRJxUSRayGx

## Related Issue(s)
N/A

