### PR TITLE
docs(nx-dev): add bitbucket cloud redirection

### DIFF
--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -421,6 +421,8 @@ const nxCloudUrls = {
     '/ci/recipes/source-control-integration/bitbucket',
   '/nx-cloud/recipes/source-control-integration/bitbucket-cloud':
     '/ci/recipes/source-control-integration/bitbucket',
+  '/ci/recipes/source-control-integration/bitbucket-cloud':
+    '/ci/recipes/source-control-integration/bitbucket',
   '/nx-cloud/set-up/gitlab':
     '/nx-cloud/recipes/source-control-integration/gitlab',
   '/core-features/remote-cache': '/ci/features/remote-cache',


### PR DESCRIPTION
Link on Nx Cloud is broken. This ensures the link is fixed also for OnPrem customers.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
