### PR TITLE
cleanup(js): fix test cases on windows

### DIFF
--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -1,5 +1,10 @@
 import * as ts from 'typescript';
-import { ExecutorContext, isDaemonEnabled, output } from '@nx/devkit';
+import {
+  ExecutorContext,
+  isDaemonEnabled,
+  joinPathFragments,
+  output,
+} from '@nx/devkit';
 import type { TypeScriptCompilationOptions } from '@nx/workspace/src/utilities/typescript/compilation';
 import { CopyAssetsHandler } from '../../utils/assets/copy-assets-handler';
 import { checkDependencies } from '../../utils/check-dependencies';
@@ -41,11 +46,11 @@ export function createTypeScriptCompilationOptions(
   context: ExecutorContext
 ): TypeScriptCompilationOptions {
   return {
-    outputPath: normalizedOptions.outputPath,
+    outputPath: joinPathFragments(normalizedOptions.outputPath),
     projectName: context.projectName,
     projectRoot: normalizedOptions.projectRoot,
-    rootDir: normalizedOptions.rootDir,
-    tsConfig: normalizedOptions.tsConfig,
+    rootDir: joinPathFragments(normalizedOptions.rootDir),
+    tsConfig: joinPathFragments(normalizedOptions.tsConfig),
     watch: normalizedOptions.watch,
     deleteOutputPath: normalizedOptions.clean,
     getCustomTransformers: getCustomTrasformersFactory(

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -251,7 +251,10 @@ async function addProject(tree: Tree, options: NormalizedSchema) {
     }
 
     if (options.publishable) {
-      const packageRoot = join(defaultOutputDirectory, '{projectRoot}');
+      const packageRoot = joinPathFragments(
+        defaultOutputDirectory,
+        '{projectRoot}'
+      );
 
       projectConfiguration.targets ??= {};
       projectConfiguration.targets['nx-release-publish'] = {

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -140,7 +140,7 @@ Valid values are: ${validReleaseVersionPrefixes
         );
       }
 
-      const packageJsonPath = join(packageRoot, 'package.json');
+      const packageJsonPath = joinPathFragments(packageRoot, 'package.json');
       if (!tree.exists(packageJsonPath)) {
         throw new Error(
           `The project "${projectName}" does not have a package.json available at ${packageJsonPath}.
@@ -830,7 +830,7 @@ To fix this you will either need to add a package.json file at that location, or
             `The project "${dependencyProjectName}" does not have a packageRoot available. Please report this issue on https://github.com/nrwl/nx`
           );
         }
-        const dependencyPackageJsonPath = join(
+        const dependencyPackageJsonPath = joinPathFragments(
           dependencyPackageRoot,
           'package.json'
         );

--- a/packages/js/src/generators/release-version/utils/resolve-version-spec.spec.ts
+++ b/packages/js/src/generators/release-version/utils/resolve-version-spec.spec.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import { resolveVersionSpec } from './resolve-version-spec';
 
 describe('resolveVersionSpec()', () => {
@@ -67,7 +66,7 @@ describe('resolveVersionSpec()', () => {
         'file:../projectB',
         '/packages/projectB'
       )
-    ).toEqual(expect.stringContaining(join('/packages/projectB')));
+    ).toEqual(expect.stringContaining('/packages/projectB'));
   });
 
   it('should work for a yarn classic style link reference', async () => {
@@ -78,6 +77,6 @@ describe('resolveVersionSpec()', () => {
         'link:../projectB',
         '/packages/projectB'
       )
-    ).toEqual(expect.stringContaining(join('/packages/projectB')));
+    ).toEqual(expect.stringContaining('/packages/projectB'));
   });
 });


### PR DESCRIPTION
## Current Behavior
running `nx test js` fail on windows

## Expected Behavior
running `nx test js` succeed

## side notes
1. I was skipping `packages/js/src/plugins/typescript/plugin.spec.ts` because it makes all tests fail, and even in wsl it's very flaky, it fail 90% of the times, but I couldn't figure out why
I think it's worth looking at from someone with more experience with the repo
2. for some of the cases that I fixed I'm not sure if I should change the code to always return `/` or should change the test to adapt `/` in linux and `\` in windows, so please if I mistaken one of them let me know and I will do it the other way around but I believe it should be fine since in windows `foo/bar` does work as a path still