### PR TITLE
fix(core): don't cache full dependency configuration when expanding target name

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1878,6 +1878,46 @@ describe('project-configuration-utils', () => {
       // other source map entries should be left unchanged
       expect(sourceMap['targets']).toEqual(['dummy', 'dummy.ts']);
     });
+
+    it('should not overwrite dependsOn', () => {
+      const sourceMap: Record<string, SourceInformation> = {
+        targets: ['dummy', 'dummy.ts'],
+        'targets.build': ['dummy', 'dummy.ts'],
+        'targets.build.options': ['dummy', 'dummy.ts'],
+        'targets.build.options.command': ['dummy', 'dummy.ts'],
+        'targets.build.options.cwd': ['project.json', 'nx/project-json'],
+        'targets.build.dependsOn': ['project.json', 'nx/project-json'],
+      };
+      const result = mergeTargetDefaultWithTargetDefinition(
+        'build',
+        {
+          name: 'myapp',
+          root: 'apps/myapp',
+          targets: {
+            build: {
+              executor: 'nx:run-commands',
+              options: {
+                command: 'echo',
+                cwd: '{workspaceRoot}',
+              },
+              dependsOn: [],
+            },
+          },
+        },
+        {
+          options: {
+            command: 'tsc',
+            cwd: 'apps/myapp',
+          },
+          dependsOn: ['^build'],
+        },
+        sourceMap
+      );
+
+      // Command was defined by a core plugin so it should
+      // not be replaced by target default
+      expect(result.dependsOn).toEqual([]);
+    });
   });
 });
 

--- a/packages/nx/src/utils/globs.spec.ts
+++ b/packages/nx/src/utils/globs.spec.ts
@@ -1,0 +1,11 @@
+import { isGlobPattern } from './globs';
+
+describe('isGlobPattern', () => {
+  it.each([
+    [true, '{a,b}'],
+    [true, 'a*'],
+    [false, 'some-project'],
+  ])('should return %s for %s', (expected, pattern) => {
+    expect(isGlobPattern(pattern)).toBe(expected);
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
There is a cache that maps target pattern -> dependency configuration, but the dependency configuration contains more than just the target name. This results in retrieving cached dependency configurations that contain the wrong projects to run.

## Expected Behavior
The cache maps target pattern -> target names, which we can then map to the full dependency configuration with the extra info we know.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
