### PR TITLE
fix(core): script-based targets should be able to be modified in a project.json file

### DIFF
--- a/packages/nx/src/plugins/package-json/create-nodes.spec.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.spec.ts
@@ -570,12 +570,16 @@ describe('nx package.json workspaces plugin', () => {
             name: 'root',
             scripts: {
               build: 'echo build',
+              test: 'echo test',
             },
           }),
           'packages/a/project.json': JSON.stringify({
             targets: {
               'something-other-than-build': {
                 command: 'echo something-other-than-build',
+              },
+              test: {
+                dependsOn: ['build-native'],
               },
             },
           }),
@@ -597,6 +601,7 @@ describe('nx package.json workspaces plugin', () => {
                     "targetGroups": {
                       "NPM Scripts": [
                         "build",
+                        "test",
                       ],
                     },
                   },
@@ -623,6 +628,16 @@ describe('nx package.json workspaces plugin', () => {
                       ],
                       "executor": "@nx/js:release-publish",
                       "options": {},
+                    },
+                    "test": {
+                      "executor": "nx:run-script",
+                      "metadata": {
+                        "runCommand": "npm run test",
+                        "scriptContent": "echo test",
+                      },
+                      "options": {
+                        "script": "test",
+                      },
                     },
                   },
                 },

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -151,7 +151,16 @@ export function buildProjectConfigurationFromPackageJson(
 
   if (siblingProjectJson) {
     for (const target of Object.keys(siblingProjectJson?.targets ?? {})) {
-      delete packageJson.scripts?.[target];
+      const { executor, command, options } = siblingProjectJson.targets[target];
+      if (
+        // will use run-commands, different target
+        command ||
+        // Either uses a different executor or runs a different script
+        (executor &&
+          (executor !== 'nx:run-script' || options?.script !== target))
+      ) {
+        delete packageJson.scripts?.[target];
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
We don't infer scripts if any info for that target is present in project.json. This results in the target dissapearing if the user tries to modify the inferred target by providing info in project.json, for example by providing dependsOn or similar.

A minimal repro of the issue looks something like this:

> packages/foo/package.json
```json
{
  "name": "foo",
  "scripts": {
    "build": "echo build"
  }
}
```

> packages/foo/project.json
```json
{
  "name": "foo",
  "targets": {
    "build": {
      "dependsOn": []
    }
  }
}
```

Attempting to run `nx build foo` results in "Cannot find configuration for task foo:build", as we remove the target for not having an executor.

## Expected Behavior
The target remains as it can run the script, so we have to infer the script to begin with.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27258
