### PR TITLE
fix(core): allow isolated plugins to shut themselves down

### DIFF
--- a/packages/nx/src/daemon/message-types/force-shutdown.ts
+++ b/packages/nx/src/daemon/message-types/force-shutdown.ts
@@ -1,0 +1,16 @@
+export const FORCE_SHUTDOWN = 'FORCE_SHUTDOWN' as const;
+
+export type HandleForceShutdownMessage = {
+  type: typeof FORCE_SHUTDOWN;
+};
+
+export function isHandleForceShutdownMessage(
+  message: unknown
+): message is HandleForceShutdownMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === FORCE_SHUTDOWN
+  );
+}

--- a/packages/nx/src/daemon/server/handle-force-shutdown.ts
+++ b/packages/nx/src/daemon/server/handle-force-shutdown.ts
@@ -1,0 +1,17 @@
+import { Server } from 'net';
+import { handleServerProcessTermination } from './shutdown-utils';
+import { openSockets } from './server';
+
+export async function handleForceShutdown(server: Server) {
+  setTimeout(async () => {
+    await handleServerProcessTermination({
+      server,
+      reason: 'Request to shutdown',
+      sockets: openSockets,
+    });
+  });
+  return {
+    description: 'Shutdown initiated',
+    response: '{}',
+  };
+}

--- a/packages/nx/src/daemon/server/handle-request-shutdown.ts
+++ b/packages/nx/src/daemon/server/handle-request-shutdown.ts
@@ -1,5 +1,6 @@
 import { Server } from 'net';
 import { handleServerProcessTermination } from './shutdown-utils';
+import { openSockets } from './server';
 
 export async function handleRequestShutdown(
   server: Server,
@@ -16,6 +17,7 @@ export async function handleRequestShutdown(
       await handleServerProcessTermination({
         server,
         reason: 'Request to shutdown',
+        sockets: openSockets,
       });
     }, 0);
     return {

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -12,6 +12,7 @@ import {
 import { platform } from 'os';
 import { getDaemonProcessIdSync, serverProcessJsonPath } from '../cache';
 import type { WatchEvent } from '../../native';
+import { openSockets } from './server';
 
 const ALWAYS_IGNORE = [
   ...getAlwaysIgnore(workspaceRoot),
@@ -44,6 +45,7 @@ export async function watchWorkspace(server: Server, cb: FileWatcherCallback) {
         handleServerProcessTermination({
           server,
           reason: 'this process is no longer the current daemon (native)',
+          sockets: openSockets,
         });
       }
 
@@ -53,6 +55,7 @@ export async function watchWorkspace(server: Server, cb: FileWatcherCallback) {
           server,
           reason:
             'Stopping the daemon the set of ignored files changed (native)',
+          sockets: openSockets,
         });
       }
     }

--- a/packages/nx/src/project-graph/plugins/internal-api.ts
+++ b/packages/nx/src/project-graph/plugins/internal-api.ts
@@ -146,19 +146,32 @@ export const nxPluginCache: Map<
   [Promise<LoadedNxPlugin>, () => void]
 > = new Map();
 
+function isIsolationEnabled() {
+  // Explicitly enabled, regardless of further conditions
+  if (process.env.NX_ISOLATE_PLUGINS === 'true') {
+    return true;
+  }
+  if (
+    // Explicitly disabled
+    process.env.NX_ISOLATE_PLUGINS === 'false' ||
+    // Isolation is disabled on WASM builds currently.
+    IS_WASM
+  ) {
+    return false;
+  }
+  // Default value
+  return true;
+}
+
 export async function loadNxPlugins(
   plugins: PluginConfiguration[],
   root = workspaceRoot
 ): Promise<readonly [LoadedNxPlugin[], () => void]> {
   performance.mark('loadNxPlugins:start');
 
-  const loadingMethod =
-    process.env.NX_ISOLATE_PLUGINS === 'true' ||
-    (!IS_WASM &&
-      platform() !== 'win32' &&
-      process.env.NX_ISOLATE_PLUGINS !== 'false')
-      ? loadNxPluginInIsolation
-      : loadNxPlugin;
+  const loadingMethod = isIsolationEnabled()
+    ? loadNxPluginInIsolation
+    : loadNxPlugin;
 
   plugins = await normalizePlugins(plugins, root);
 

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -135,8 +135,14 @@ export interface PluginWorkerProcessProjectGraphResult {
       };
 }
 
+export interface PluginWorkerShutdownMessage {
+  type: 'shutdown';
+  payload: {};
+}
+
 export type PluginWorkerMessage =
   | PluginWorkerLoadMessage
+  | PluginWorkerShutdownMessage
   | PluginWorkerCreateNodesMessage
   | PluginCreateDependenciesMessage
   | PluginWorkerProcessProjectGraphMessage
@@ -162,6 +168,7 @@ export function isPluginWorkerMessage(
       'createDependencies',
       'processProjectGraph',
       'createMetadata',
+      'shutdown',
     ].includes(message.type)
   );
 }

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -53,8 +53,8 @@ export async function loadRemoteNxPlugin(
 
   const cleanupFunction = () => {
     worker.off('exit', exitHandler);
+    shutdownPluginWorker(socket);
     socket.destroy();
-    shutdownPluginWorker(worker);
     nxPluginWorkerCache.delete(cacheKey);
   };
 
@@ -94,13 +94,8 @@ export async function loadRemoteNxPlugin(
   return [pluginPromise, cleanupFunction];
 }
 
-function shutdownPluginWorker(worker: ChildProcess) {
-  // Clears the plugin cache so no refs to the workers are held
-  nxPluginCache.clear();
-
-  // logger.verbose(`[plugin-pool] starting worker shutdown`);
-
-  worker.kill('SIGINT');
+function shutdownPluginWorker(socket: Socket) {
+  sendMessageOverSocket(socket, { type: 'shutdown', payload: {} });
 }
 
 /**
@@ -249,6 +244,7 @@ function createWorkerExitHandler(
 
 let cleanedUp = false;
 const exitHandler = () => {
+  nxPluginCache.clear();
   for (const fn of cleanupFunctions) {
     fn();
   }

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -58,6 +58,20 @@ const server = createServer((socket) => {
             };
           }
         },
+        shutdown: async () => {
+          // Stops accepting new connections, but existing connections are
+          // not closed immediately.
+          server.close(() => {
+            try {
+              unlinkSync(socketPath);
+            } catch (e) {}
+            process.exit(0);
+          });
+          // Closes existing connection.
+          socket.end();
+          // Destroys the socket once it's fully closed.
+          socket.destroySoon();
+        },
         createNodes: async ({ configFiles, context, tx }) => {
           try {
             const result = await plugin.createNodes[1](configFiles, context);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Isolated plugin workers are shutdown via `childProcess.kill()` in a `process.on('exit)` handler.

## Expected Behavior
Isolated plugin workers are shutdown via a message sent over their socket, which tells the to clean themselves up

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
