### PR TITLE
feat(testing): support positional arg for jest executor

### DIFF
--- a/docs/generated/packages/jest/documents/overview.md
+++ b/docs/generated/packages/jest/documents/overview.md
@@ -161,6 +161,16 @@ To run Jest tests via nx use
 nx test frontend
 ```
 
+### Testing Specific Files
+
+Using a single positional argument or the `--testFile` flag will run all test files matching the regex. For more info check out the [Jest documentation](https://jestjs.io/docs/cli#jest-regexfortestfiles).
+
+```shell
+nx test frontend HomePage.tsx
+# or
+nx test frontend --testFile HomePage.tsx
+```
+
 ### Watching for Changes
 
 Using the `--watch` flag will run the tests whenever a file changes.

--- a/docs/generated/packages/jest/executors/jest.json
+++ b/docs/generated/packages/jest/executors/jest.json
@@ -51,7 +51,8 @@
       },
       "testFile": {
         "description": "The name of the file to test.",
-        "type": "string"
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 }
       },
       "tsConfig": {
         "description": "The name of the Typescript configuration file.",

--- a/docs/shared/packages/jest/jest-plugin.md
+++ b/docs/shared/packages/jest/jest-plugin.md
@@ -161,6 +161,16 @@ To run Jest tests via nx use
 nx test frontend
 ```
 
+### Testing Specific Files
+
+Using a single positional argument or the `--testFile` flag will run all test files matching the regex. For more info check out the [Jest documentation](https://jestjs.io/docs/cli#jest-regexfortestfiles).
+
+```shell
+nx test frontend HomePage.tsx
+# or
+nx test frontend --testFile HomePage.tsx
+```
+
 ### Watching for Changes
 
 Using the `--watch` flag will run the tests whenever a file changes.

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -53,7 +53,11 @@
     },
     "testFile": {
       "description": "The name of the file to test.",
-      "type": "string"
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
     },
     "tsConfig": {
       "description": "The name of the Typescript configuration file.",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

The syntax to test a single file is different when using the jest executor versus the jest cli

```sh
jest <file>
# vs
nx test project --testFile <file>
```

## Expected Behavior

I would expect the jest executor to support a single positional argument as well

```sh
nx test project <file>
```

This is one of the common questions/complaints that I hear from developers when transitioning from our standalone apps to our monorepo

This change supports both syntaxes so that this is not a breaking change and prints a warning when both are used