### PR TITLE
fix(nextjs): Fix order, and wrong number call to createWebpackConfig()

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -212,7 +212,12 @@ function withNx(
 
       const userWebpackConfig = nextConfig.webpack;
 
-      const { createWebpackConfig } = require('@nx/next/src/utils/config');
+      const { createWebpackConfig } = require(require.resolve(
+        '@nx/next/src/utils/config',
+        {
+          paths: [workspaceRoot],
+        }
+      )) as typeof import('@nx/next/src/utils/config');
       // If we have file replacements or assets, inside of the next config we pass the workspaceRoot as a join of the workspaceRoot and the projectDirectory
       // Because the file replacements and assets are relative to the projectRoot, not the workspaceRoot
       nextConfig.webpack = (a, b) =>
@@ -221,8 +226,8 @@ function withNx(
             ? joinPathFragments(workspaceRoot, projectDirectory)
             : workspaceRoot,
           projectDirectory,
-          _nextConfig.nx?.fileReplacements || options.fileReplacements,
-          _nextConfig.nx?.assets || options.assets
+          _nextConfig.nx?.assets || options.assets,
+          _nextConfig.nx?.fileReplacements || options.fileReplacements
         )(userWebpackConfig ? userWebpackConfig(a, b) : a, b);
 
       return nextConfig;

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -226,8 +226,8 @@ function withNx(
             ? joinPathFragments(workspaceRoot, projectDirectory)
             : workspaceRoot,
           projectDirectory,
-          _nextConfig.nx?.assets || options.assets,
-          _nextConfig.nx?.fileReplacements || options.fileReplacements
+          _nextConfig.nx?.fileReplacements || options.fileReplacements,
+          _nextConfig.nx?.assets || options.assets
         )(userWebpackConfig ? userWebpackConfig(a, b) : a, b);
 
       return nextConfig;

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -220,8 +220,9 @@ function withNx(
           _nextConfig.nx?.fileReplacements
             ? joinPathFragments(workspaceRoot, projectDirectory)
             : workspaceRoot,
-          _nextConfig.nx?.assets || options.assets,
-          _nextConfig.nx?.fileReplacements || options.fileReplacements
+          projectDirectory,
+          _nextConfig.nx?.fileReplacements || options.fileReplacements,
+          _nextConfig.nx?.assets || options.assets
         )(userWebpackConfig ? userWebpackConfig(a, b) : a, b);
 
       return nextConfig;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Assets are not copied to the dist folder after running @nx/next:build

## Expected Behavior
Assets should be copied to the dist folder after @nx/next:build

## Related Issue(s)
https://github.com/nrwl/nx/issues/26900

Fixes #
Fix the order, and wrong number of parameters call to createWebpackConfig()