### PR TITLE
fix(repo): fix native cache inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -23,6 +23,9 @@
       "{projectRoot}/**/Cargo.*",
       {
         "runtime": "node -p '`${process.platform}_${process.arch}`'"
+      },
+      {
+        "externalDependencies": ["npm:@monodon/rust", "npm:@napi-rs/cli"]
       }
     ],
     "e2eInputs": [

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -12,6 +12,7 @@
   "targets": {
     "build-native-wasm": {
       "cache": true,
+      "inputs": ["native"],
       "outputs": [
         "{projectRoot}/src/native/*.wasm",
         "{projectRoot}/src/native/*.js",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The inputs for `build-native-wasm` and other native tasks are not set properly resulting in incorrect cache hits/misses.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The inputs for `build-native-wasm` and other native tasks are set properly resulting in correct cache hits/misses.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
