### PR TITLE
fix(core): update napi-build dependency to 2.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9130fccc5f763cf2069b34a089a18f0d0883c66aceb81f2fad541a3d823c43"
+checksum = "e1c0f5d67ee408a4685b61f5ab7e58605c8ae3f2b4189f0127d804ff13d5560a"
 
 [[package]]
 name = "napi-derive"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -63,7 +63,7 @@ watchexec-signals = "2.1.0"
 crate-type = ['cdylib']
 
 [build-dependencies]
-napi-build = '2.0.1'
+napi-build = '2.1.3'
 
 [dev-dependencies]
 assert_fs = "1.0.10"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Current `napi-build` dependency causes some functions not to export properly for wasm.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`napi-build` exports all functions properly. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
