### PR TITLE
fix(core): Fix wrong task graph calculation

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -644,10 +644,12 @@ function normalizeTargets(
     const projectSourceMaps = sourceMaps[project.root];
 
     const targetConfig = project.targets[targetName];
-    const targetDefaults = readTargetDefaultsForTarget(
-      targetName,
-      nxJsonConfiguration.targetDefaults,
-      targetConfig.executor
+    const targetDefaults = deepClone(
+      readTargetDefaultsForTarget(
+        targetName,
+        nxJsonConfiguration.targetDefaults,
+        targetConfig.executor
+      )
     );
 
     // We only apply defaults if they exist
@@ -718,6 +720,10 @@ function targetDefaultShouldBeApplied(
   return !plugin?.startsWith('nx/');
 }
 
+function deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
 export function mergeTargetDefaultWithTargetDefinition(
   targetName: string,
   project: ProjectConfiguration,
@@ -725,7 +731,7 @@ export function mergeTargetDefaultWithTargetDefinition(
   sourceMap: Record<string, SourceInformation>
 ): TargetConfiguration {
   const targetDefinition = project.targets[targetName] ?? {};
-  const result = JSON.parse(JSON.stringify(targetDefinition));
+  const result = deepClone(targetDefinition);
 
   for (const key in targetDefault) {
     switch (key) {


### PR DESCRIPTION
Same copy of target default is shared along projects and is mutated, leading to wrong task graph.  Occur only when running without daemon, probably because the daemon communication cause cloning by unmarshalling the object.

Fix by deepcloning `targetDefaults`

Fixes https://github.com/nrwl/nx/issues/27346
