### PR TITLE
chore(repo): enable summary table for local runs when in DTE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,9 @@ jobs:
       NX_E2E_RUN_E2E: 'true'
       NX_CI_EXECUTION_ENV: 'linux'
       NX_CLOUD_DTE_V2: 'true'
-      NX_CLOUD_DTE_SUMMARY: 'true'
+      NX_CLOUD_LOCAL_SUMMARY_TABLE: 'true'
+      NX_VERBOSE_LOGGING: 'true'
+
     steps:
       - checkout
       - nx/set-shas:

--- a/nx.json
+++ b/nx.json
@@ -233,6 +233,6 @@
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
   "cacheDirectory": "/tmp/nx-cache",
-  "bust": 8,
+  "bust": 9,
   "defaultBase": "master"
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

No summary table when running run-many in DTE with --no-dte

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Print summary table when running run-many in DTE with --no-dte

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
