### PR TITLE
fix(nx-cloud): add nxCloudId to nxJson when connecting with generator

### DIFF
--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -150,7 +150,7 @@ function addNxCloudOptionsToNxJson(
 function addNxCloudIdToNxJson(
   tree: Tree,
   nxCloudId: string,
-  directory: string = tree.root
+  directory: string = ''
 ) {
   const nxJsonPath = join(directory, 'nx.json');
   if (tree.exists(nxJsonPath)) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When connecting via NxCloudId, the resulting Id would not be written to nx.json

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Correctly writes nxCloudId to nx.json after running `npx nx g connect-to-nx-cloud`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
