### PR TITLE
feat(nx-cloud): alias for login and logout

### DIFF
--- a/docs/generated/cli/login.md
+++ b/docs/generated/cli/login.md
@@ -1,16 +1,16 @@
 ---
 title: 'login - CLI command'
-description: 'Login to Nx Cloud'
+description: 'Login to Nx Cloud by generating a personal access token and saving it to your local machine.'
 ---
 
 # login
 
-Login to Nx Cloud
+Login to Nx Cloud by generating a personal access token and saving it to your local machine.
 
 ## Usage
 
 ```shell
-nx login
+nx login [nxCloudUrl]
 ```
 
 Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
@@ -27,7 +27,13 @@ Show help
 
 Type: `string`
 
-The Nx Cloud URL of the instance you are trying to connect to.
+The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to https://cloud.nx.app.
+
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
 
 ### version
 

--- a/docs/generated/cli/login.md
+++ b/docs/generated/cli/login.md
@@ -1,0 +1,36 @@
+---
+title: 'login - CLI command'
+description: 'Login to Nx Cloud'
+---
+
+# login
+
+Login to Nx Cloud
+
+## Usage
+
+```shell
+nx login
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### nxCloudUrl
+
+Type: `string`
+
+The Nx Cloud URL of the instance you are trying to connect to.
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/generated/cli/login.md
+++ b/docs/generated/cli/login.md
@@ -1,11 +1,11 @@
 ---
 title: 'login - CLI command'
-description: 'Login to Nx Cloud by generating a personal access token and saving it to your local machine.'
+description: 'Login to Nx Cloud'
 ---
 
 # login
 
-Login to Nx Cloud by generating a personal access token and saving it to your local machine.
+Login to Nx Cloud
 
 ## Usage
 

--- a/docs/generated/cli/logout.md
+++ b/docs/generated/cli/logout.md
@@ -1,0 +1,36 @@
+---
+title: 'logout - CLI command'
+description: 'Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.'
+---
+
+# logout
+
+Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.
+
+## Usage
+
+```shell
+nx logout
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/generated/cli/logout.md
+++ b/docs/generated/cli/logout.md
@@ -1,11 +1,11 @@
 ---
 title: 'logout - CLI command'
-description: 'Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.'
+description: 'Logout from Nx Cloud'
 ---
 
 # logout
 
-Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.
+Logout from Nx Cloud
 
 ## Usage
 

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -8720,6 +8720,14 @@
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
+              },
+              {
+                "name": "logout",
+                "path": "/nx-api/nx/documents/logout",
+                "id": "logout",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -8712,6 +8712,14 @@
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
+              },
+              {
+                "name": "login",
+                "path": "/nx-api/nx/documents/login",
+                "id": "login",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -1967,6 +1967,17 @@
         "path": "/nx-api/nx/documents/add",
         "tags": [],
         "originalFilePath": "generated/cli/add"
+      },
+      "/nx-api/nx/documents/login": {
+        "id": "login",
+        "name": "login",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/login",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/nx-api/nx/documents/login",
+        "tags": [],
+        "originalFilePath": "generated/cli/login"
       }
     },
     "root": "/packages/nx",

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -1978,6 +1978,17 @@
         "path": "/nx-api/nx/documents/login",
         "tags": [],
         "originalFilePath": "generated/cli/login"
+      },
+      "/nx-api/nx/documents/logout": {
+        "id": "logout",
+        "name": "logout",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/logout",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/nx-api/nx/documents/logout",
+        "tags": [],
+        "originalFilePath": "generated/cli/logout"
       }
     },
     "root": "/packages/nx",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1946,6 +1946,17 @@
         "path": "nx/documents/add",
         "tags": [],
         "originalFilePath": "generated/cli/add"
+      },
+      {
+        "id": "login",
+        "name": "login",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/login",
+        "itemList": [],
+        "isExternal": false,
+        "path": "nx/documents/login",
+        "tags": [],
+        "originalFilePath": "generated/cli/login"
       }
     ],
     "executors": [

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1957,6 +1957,17 @@
         "path": "nx/documents/login",
         "tags": [],
         "originalFilePath": "generated/cli/login"
+      },
+      {
+        "id": "logout",
+        "name": "logout",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/logout",
+        "itemList": [],
+        "isExternal": false,
+        "path": "nx/documents/logout",
+        "tags": [],
+        "originalFilePath": "generated/cli/logout"
       }
     ],
     "executors": [

--- a/docs/generated/packages/nx/documents/login.md
+++ b/docs/generated/packages/nx/documents/login.md
@@ -1,16 +1,16 @@
 ---
 title: 'login - CLI command'
-description: 'Login to Nx Cloud'
+description: 'Login to Nx Cloud by generating a personal access token and saving it to your local machine.'
 ---
 
 # login
 
-Login to Nx Cloud
+Login to Nx Cloud by generating a personal access token and saving it to your local machine.
 
 ## Usage
 
 ```shell
-nx login
+nx login [nxCloudUrl]
 ```
 
 Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
@@ -27,7 +27,13 @@ Show help
 
 Type: `string`
 
-The Nx Cloud URL of the instance you are trying to connect to.
+The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to https://cloud.nx.app.
+
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
 
 ### version
 

--- a/docs/generated/packages/nx/documents/login.md
+++ b/docs/generated/packages/nx/documents/login.md
@@ -1,0 +1,36 @@
+---
+title: 'login - CLI command'
+description: 'Login to Nx Cloud'
+---
+
+# login
+
+Login to Nx Cloud
+
+## Usage
+
+```shell
+nx login
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### nxCloudUrl
+
+Type: `string`
+
+The Nx Cloud URL of the instance you are trying to connect to.
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/generated/packages/nx/documents/login.md
+++ b/docs/generated/packages/nx/documents/login.md
@@ -1,11 +1,11 @@
 ---
 title: 'login - CLI command'
-description: 'Login to Nx Cloud by generating a personal access token and saving it to your local machine.'
+description: 'Login to Nx Cloud'
 ---
 
 # login
 
-Login to Nx Cloud by generating a personal access token and saving it to your local machine.
+Login to Nx Cloud
 
 ## Usage
 

--- a/docs/generated/packages/nx/documents/logout.md
+++ b/docs/generated/packages/nx/documents/logout.md
@@ -1,0 +1,36 @@
+---
+title: 'logout - CLI command'
+description: 'Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.'
+---
+
+# logout
+
+Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.
+
+## Usage
+
+```shell
+nx logout
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/generated/packages/nx/documents/logout.md
+++ b/docs/generated/packages/nx/documents/logout.md
@@ -1,11 +1,11 @@
 ---
 title: 'logout - CLI command'
-description: 'Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.'
+description: 'Logout from Nx Cloud'
 ---
 
 # logout
 
-Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.
+Logout from Nx Cloud
 
 ## Usage
 

--- a/docs/map.json
+++ b/docs/map.json
@@ -2112,6 +2112,11 @@
               "name": "add",
               "id": "add",
               "file": "generated/cli/add"
+            },
+            {
+              "name": "login",
+              "id": "login",
+              "file": "generated/cli/login"
             }
           ]
         },

--- a/docs/map.json
+++ b/docs/map.json
@@ -2117,6 +2117,11 @@
               "name": "login",
               "id": "login",
               "file": "generated/cli/login"
+            },
+            {
+              "name": "logout",
+              "id": "logout",
+              "file": "generated/cli/logout"
             }
           ]
         },

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -558,6 +558,7 @@
       - [view-logs](/nx-api/nx/documents/view-logs)
       - [release](/nx-api/nx/documents/release)
       - [add](/nx-api/nx/documents/add)
+      - [login](/nx-api/nx/documents/login)
     - [executors](/nx-api/nx/executors)
       - [noop](/nx-api/nx/executors/noop)
       - [run-commands](/nx-api/nx/executors/run-commands)

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -559,6 +559,7 @@
       - [release](/nx-api/nx/documents/release)
       - [add](/nx-api/nx/documents/add)
       - [login](/nx-api/nx/documents/login)
+      - [logout](/nx-api/nx/documents/logout)
     - [executors](/nx-api/nx/executors)
       - [noop](/nx-api/nx/executors/noop)
       - [run-commands](/nx-api/nx/executors/run-commands)

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -80,7 +80,9 @@ export async function connectToNxCloudCommand(
 
   if (isNxCloudUsed(nxJson)) {
     const token =
-      process.env.NX_CLOUD_ACCESS_TOKEN || nxJson.nxCloudAccessToken;
+      process.env.NX_CLOUD_ACCESS_TOKEN ||
+      nxJson.nxCloudAccessToken ||
+      nxJson.nxCloudId;
     if (!token) {
       throw new Error(
         `Unable to authenticate. Either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable.`
@@ -94,9 +96,9 @@ export async function connectToNxCloudCommand(
       title: '✔ This workspace already has Nx Cloud set up',
       bodyLines: [
         'If you have not done so already, connect your workspace to your Nx Cloud account:',
-        `- Connect with Nx Cloud at: 
-      
-        ${connectCloudUrl}`,
+        '- Connect with Nx Cloud at:',
+        '',
+        `${connectCloudUrl}`,
       ],
     });
 

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -85,7 +85,7 @@ export async function connectToNxCloudCommand(
       nxJson.nxCloudId;
     if (!token) {
       throw new Error(
-        `Unable to authenticate. Either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable.`
+        `Unable to authenticate. If you are connecting to Nx Cloud locally, set Nx Cloud ID in nx.json. If you are connecting in a CI context, either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable.`
       );
     }
     const connectCloudUrl = await createNxCloudOnboardingURL(
@@ -95,8 +95,7 @@ export async function connectToNxCloudCommand(
     output.log({
       title: '✔ This workspace already has Nx Cloud set up',
       bodyLines: [
-        'If you have not done so already, connect your workspace to your Nx Cloud account:',
-        '- Connect with Nx Cloud at:',
+        'If you have not done so already, connect your workspace to your Nx Cloud account with the following URL:',
         '',
         `${connectCloudUrl}`,
       ],

--- a/packages/nx/src/command-line/login/command-object.ts
+++ b/packages/nx/src/command-line/login/command-object.ts
@@ -1,22 +1,19 @@
-import { Argv, CommandModule } from 'yargs';
+import { CommandModule } from 'yargs';
+import { withVerbose } from '../../command-line/yargs-utils/shared-options';
 
 export const yargsLoginCommand: CommandModule = {
   command: 'login [nxCloudUrl]',
   describe:
     'Login to Nx Cloud by generating a personal access token and saving it to your local machine.',
   builder: (yargs) =>
-    yargs
-      .positional('nxCloudUrl', {
+    withVerbose(
+      yargs.positional('nxCloudUrl', {
         describe:
           'The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to https://cloud.nx.app.',
         type: 'string',
         required: false,
       })
-      .option('verbose', {
-        type: 'boolean',
-        description:
-          'Prints additional information about the commands (e.g., stack traces)',
-      }),
+    ),
   handler: async (args: any) => {
     process.exit(await (await import('./login')).loginHandler(args));
   },

--- a/packages/nx/src/command-line/login/command-object.ts
+++ b/packages/nx/src/command-line/login/command-object.ts
@@ -1,33 +1,15 @@
-import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
 import { Argv, CommandModule } from 'yargs';
-import { handleErrors } from '../../utils/params';
-import { nxVersion } from '../../utils/versions';
-import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
 
 export const yargsLoginCommand: CommandModule = {
   command: 'login',
   describe: false,
-  builder: (yargs) => withLoginOptions(yargs),
-  handler: async (args) => {
-    args._ = args._.slice(1);
-
+  builder: (yargs) =>
+    yargs.positional('nxCloudUrl', {
+      describe: 'The Nx Cloud URL of the instance you are trying to connect to.',
+      type: 'string',
+      required: false,
+    }),
+  handler: async (args: any) => {
     process.exit(await (await import('./login')).loginHandler(args));
   },
 };
-
-function withLoginOptions(yargs: Argv) {
-  const loginWillShowHelp = process.argv[3] && !process.argv[3].startsWith('-');
-  const res = yargs.positional('nxCloudUrl', {
-    describe: 'The Nx Cloud URL of the instance you are trying to connect to.',
-    type: 'string',
-    required: false,
-  });
-
-  if (loginWillShowHelp) {
-    return res.help(false);
-  } else {
-    return res.epilog(
-      `Run "nx login --help" to see information about this command`
-    );
-  }
-}

--- a/packages/nx/src/command-line/login/command-object.ts
+++ b/packages/nx/src/command-line/login/command-object.ts
@@ -1,0 +1,33 @@
+import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
+import { Argv, CommandModule } from 'yargs';
+import { handleErrors } from '../../utils/params';
+import { nxVersion } from '../../utils/versions';
+import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
+
+export const yargsLoginCommand: CommandModule = {
+  command: 'login',
+  describe: false,
+  builder: (yargs) => withLoginOptions(yargs),
+  handler: async (args) => {
+    args._ = args._.slice(1);
+
+    process.exit(await (await import('./login')).loginHandler(args));
+  },
+};
+
+function withLoginOptions(yargs: Argv) {
+  const loginWillShowHelp = process.argv[3] && !process.argv[3].startsWith('-');
+  const res = yargs.positional('nxCloudUrl', {
+    describe: 'The Nx Cloud URL of the instance you are trying to connect to.',
+    type: 'string',
+    required: false,
+  });
+
+  if (loginWillShowHelp) {
+    return res.help(false);
+  } else {
+    return res.epilog(
+      `Run "nx login --help" to see information about this command`
+    );
+  }
+}

--- a/packages/nx/src/command-line/login/command-object.ts
+++ b/packages/nx/src/command-line/login/command-object.ts
@@ -1,14 +1,22 @@
 import { Argv, CommandModule } from 'yargs';
 
 export const yargsLoginCommand: CommandModule = {
-  command: 'login',
-  describe: false,
+  command: 'login [nxCloudUrl]',
+  describe:
+    'Login to Nx Cloud by generating a personal access token and saving it to your local machine.',
   builder: (yargs) =>
-    yargs.positional('nxCloudUrl', {
-      describe: 'The Nx Cloud URL of the instance you are trying to connect to.',
-      type: 'string',
-      required: false,
-    }),
+    yargs
+      .positional('nxCloudUrl', {
+        describe:
+          'The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to https://cloud.nx.app.',
+        type: 'string',
+        required: false,
+      })
+      .option('verbose', {
+        type: 'boolean',
+        description:
+          'Prints additional information about the commands (e.g., stack traces)',
+      }),
   handler: async (args: any) => {
     process.exit(await (await import('./login')).loginHandler(args));
   },

--- a/packages/nx/src/command-line/login/command-object.ts
+++ b/packages/nx/src/command-line/login/command-object.ts
@@ -3,8 +3,7 @@ import { withVerbose } from '../../command-line/yargs-utils/shared-options';
 
 export const yargsLoginCommand: CommandModule = {
   command: 'login [nxCloudUrl]',
-  describe:
-    'Login to Nx Cloud by generating a personal access token and saving it to your local machine.',
+  describe: 'Login to Nx Cloud',
   builder: (yargs) =>
     withVerbose(
       yargs.positional('nxCloudUrl', {

--- a/packages/nx/src/command-line/login/login.ts
+++ b/packages/nx/src/command-line/login/login.ts
@@ -2,16 +2,16 @@ import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
 import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
 import { handleErrors } from '../../utils/params';
 
-export interface LoginOptions {
+export interface LoginArgs {
   nxCloudUrl?: string;
-  verbose?: boolean;
 }
 
-export function loginHandler(options: LoginOptions): Promise<number> {
-  if (options.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
+export function loginHandler(args: LoginArgs): Promise<number> {
   const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
+
+  if (args.nxCloudUrl) {
+    process.env.NX_CLOUD_LOGIN_URL = args.nxCloudUrl
+  }
 
   return handleErrors(isVerbose, async () => {
     const nxCloudClient = (

--- a/packages/nx/src/command-line/login/login.ts
+++ b/packages/nx/src/command-line/login/login.ts
@@ -8,18 +8,17 @@ export interface LoginArgs {
 }
 
 export function loginHandler(args: LoginArgs): Promise<number> {
-  if (args.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-  const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
-
   if (args.nxCloudUrl) {
-    process.env.NX_CLOUD_LOGIN_URL = args.nxCloudUrl;
+    process.env.NX_CLOUD_API = args.nxCloudUrl;
   }
 
-  return handleErrors(isVerbose, async () => {
-    const nxCloudClient = (await verifyOrUpdateNxCloudClient(getCloudOptions()))
-      .nxCloudClient;
-    await nxCloudClient.commands.login();
-  });
+  return handleErrors(
+    (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+    async () => {
+      const nxCloudClient = (
+        await verifyOrUpdateNxCloudClient(getCloudOptions())
+      ).nxCloudClient;
+      await nxCloudClient.commands.login();
+    }
+  );
 }

--- a/packages/nx/src/command-line/login/login.ts
+++ b/packages/nx/src/command-line/login/login.ts
@@ -1,0 +1,22 @@
+import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
+import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
+import { handleErrors } from '../../utils/params';
+
+export interface LoginOptions {
+  nxCloudUrl?: string;
+  verbose?: boolean;
+}
+
+export function loginHandler(options: LoginOptions): Promise<number> {
+  if (options.verbose) {
+    process.env.NX_VERBOSE_LOGGING = 'true';
+  }
+  const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
+
+  return handleErrors(isVerbose, async () => {
+    const nxCloudClient = (
+      await verifyOrUpdateNxCloudClient(getCloudOptions())
+    ).nxCloudClient;
+    await nxCloudClient.commands.login();
+  });
+}

--- a/packages/nx/src/command-line/login/login.ts
+++ b/packages/nx/src/command-line/login/login.ts
@@ -12,13 +12,9 @@ export function loginHandler(args: LoginArgs): Promise<number> {
     process.env.NX_CLOUD_API = args.nxCloudUrl;
   }
 
-  return handleErrors(
-    (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
-    async () => {
-      const nxCloudClient = (
-        await verifyOrUpdateNxCloudClient(getCloudOptions())
-      ).nxCloudClient;
-      await nxCloudClient.commands.login();
-    }
-  );
+  return handleErrors(args.verbose, async () => {
+    const nxCloudClient = (await verifyOrUpdateNxCloudClient(getCloudOptions()))
+      .nxCloudClient;
+    await nxCloudClient.commands.login();
+  });
 }

--- a/packages/nx/src/command-line/logout/command-object.ts
+++ b/packages/nx/src/command-line/logout/command-object.ts
@@ -1,0 +1,16 @@
+import { CommandModule } from 'yargs';
+
+export const yargsLogoutCommand: CommandModule = {
+  command: 'logout',
+  describe:
+    'Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.',
+  builder: (yargs) =>
+    yargs.option('verbose', {
+      type: 'boolean',
+      description:
+        'Prints additional information about the commands (e.g., stack traces)',
+    }),
+  handler: async (args: any) => {
+    process.exit(await (await import('./logout')).logoutHandler(args));
+  },
+};

--- a/packages/nx/src/command-line/logout/command-object.ts
+++ b/packages/nx/src/command-line/logout/command-object.ts
@@ -1,15 +1,11 @@
 import { CommandModule } from 'yargs';
+import { withVerbose } from '../../command-line/yargs-utils/shared-options';
 
 export const yargsLogoutCommand: CommandModule = {
   command: 'logout',
   describe:
     'Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.',
-  builder: (yargs) =>
-    yargs.option('verbose', {
-      type: 'boolean',
-      description:
-        'Prints additional information about the commands (e.g., stack traces)',
-    }),
+  builder: (yargs) => withVerbose(yargs),
   handler: async (args: any) => {
     process.exit(await (await import('./logout')).logoutHandler(args));
   },

--- a/packages/nx/src/command-line/logout/command-object.ts
+++ b/packages/nx/src/command-line/logout/command-object.ts
@@ -3,8 +3,7 @@ import { withVerbose } from '../../command-line/yargs-utils/shared-options';
 
 export const yargsLogoutCommand: CommandModule = {
   command: 'logout',
-  describe:
-    'Logout from Nx Cloud by removing a personal access token from your local machine. The personal access token will be revoked from Nx Cloud and you will need to login again to regain access to Nx Cloud.',
+  describe: 'Logout from Nx Cloud',
   builder: (yargs) => withVerbose(yargs),
   handler: async (args: any) => {
     process.exit(await (await import('./logout')).logoutHandler(args));

--- a/packages/nx/src/command-line/logout/logout.ts
+++ b/packages/nx/src/command-line/logout/logout.ts
@@ -7,14 +7,13 @@ export interface LogoutArgs {
 }
 
 export function logoutHandler(args: LogoutArgs): Promise<number> {
-  if (args.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-  const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
-
-  return handleErrors(isVerbose, async () => {
-    const nxCloudClient = (await verifyOrUpdateNxCloudClient(getCloudOptions()))
-      .nxCloudClient;
-    await nxCloudClient.commands.logout();
-  });
+  return handleErrors(
+    (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
+    async () => {
+      const nxCloudClient = (
+        await verifyOrUpdateNxCloudClient(getCloudOptions())
+      ).nxCloudClient;
+      await nxCloudClient.commands.logout();
+    }
+  );
 }

--- a/packages/nx/src/command-line/logout/logout.ts
+++ b/packages/nx/src/command-line/logout/logout.ts
@@ -2,24 +2,19 @@ import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
 import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
 import { handleErrors } from '../../utils/params';
 
-export interface LoginArgs {
-  nxCloudUrl?: string;
+export interface LogoutArgs {
   verbose?: boolean;
 }
 
-export function loginHandler(args: LoginArgs): Promise<number> {
+export function logoutHandler(args: LogoutArgs): Promise<number> {
   if (args.verbose) {
     process.env.NX_VERBOSE_LOGGING = 'true';
   }
   const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
 
-  if (args.nxCloudUrl) {
-    process.env.NX_CLOUD_LOGIN_URL = args.nxCloudUrl;
-  }
-
   return handleErrors(isVerbose, async () => {
     const nxCloudClient = (await verifyOrUpdateNxCloudClient(getCloudOptions()))
       .nxCloudClient;
-    await nxCloudClient.commands.login();
+    await nxCloudClient.commands.logout();
   });
 }

--- a/packages/nx/src/command-line/logout/logout.ts
+++ b/packages/nx/src/command-line/logout/logout.ts
@@ -7,13 +7,9 @@ export interface LogoutArgs {
 }
 
 export function logoutHandler(args: LogoutArgs): Promise<number> {
-  return handleErrors(
-    (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
-    async () => {
-      const nxCloudClient = (
-        await verifyOrUpdateNxCloudClient(getCloudOptions())
-      ).nxCloudClient;
-      await nxCloudClient.commands.logout();
-    }
-  );
+  return handleErrors(args.verbose, async () => {
+    const nxCloudClient = (await verifyOrUpdateNxCloudClient(getCloudOptions()))
+      .nxCloudClient;
+    await nxCloudClient.commands.logout();
+  });
 }

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -38,6 +38,7 @@ import { yargsResetCommand } from './reset/command-object';
 import { yargsReleaseCommand } from './release/command-object';
 import { yargsAddCommand } from './add/command-object';
 import { yargsLoginCommand } from './login/command-object';
+import { yargsLogoutCommand } from './logout/command-object';
 import {
   yargsPrintAffectedCommand,
   yargsAffectedGraphCommand,
@@ -96,6 +97,7 @@ export const commandsObject = yargs
   .command(yargsWatchCommand)
   .command(yargsNxInfixCommand)
   .command(yargsLoginCommand)
+  .command(yargsLogoutCommand)
   .scriptName('nx')
   .help()
   // NOTE: we handle --version in nx.ts, this just tells yargs that the option exists

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -37,6 +37,7 @@ import { yargsWatchCommand } from './watch/command-object';
 import { yargsResetCommand } from './reset/command-object';
 import { yargsReleaseCommand } from './release/command-object';
 import { yargsAddCommand } from './add/command-object';
+import { yargsLoginCommand } from './login/command-object';
 import {
   yargsPrintAffectedCommand,
   yargsAffectedGraphCommand,
@@ -94,6 +95,7 @@ export const commandsObject = yargs
   .command(yargsViewLogsCommand)
   .command(yargsWatchCommand)
   .command(yargsNxInfixCommand)
+  .command(yargsLoginCommand)
   .scriptName('nx')
   .help()
   // NOTE: we handle --version in nx.ts, this just tells yargs that the option exists

--- a/packages/nx/src/nx-cloud/utilities/axios.ts
+++ b/packages/nx/src/nx-cloud/utilities/axios.ts
@@ -18,15 +18,9 @@ export function createApiAxiosInstance(options: CloudTaskRunnerOptions) {
 
   // TODO(lourw): Update message with NxCloudId once it is supported
   if (!accessToken && !nxCloudId) {
-    if (process.env.NX_ENABLE_LOGIN === 'true' && !nxCloudId) {
-      throw new Error(
-        `Unable to authenticate. Please connect your workspace to Nx Cloud to define a valid Nx Cloud Id. If you are in a CI context, please set the NX_CLOUD_ACCESS_TOKEN environment variable or define an access token in your nx.json.`
-      );
-    } else {
-      throw new Error(
-        `Unable to authenticate. Either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable. If you do not want to use Nx Cloud for this command, either set NX_NO_CLOUD=true, or pass the --no-cloud flag.`
-      );
-    }
+    throw new Error(
+      `Unable to authenticate. Please connect your workspace to Nx Cloud to define a valid Nx Cloud ID. If you are in a CI context, please set the NX_CLOUD_ACCESS_TOKEN environment variable or define an access token in your nx.json.`
+    );
   }
 
   if (options.customProxyConfigPath) {

--- a/packages/nx/src/nx-cloud/utilities/axios.ts
+++ b/packages/nx/src/nx-cloud/utilities/axios.ts
@@ -19,7 +19,7 @@ export function createApiAxiosInstance(options: CloudTaskRunnerOptions) {
   // TODO(lourw): Update message with NxCloudId once it is supported
   if (!accessToken && !nxCloudId) {
     throw new Error(
-      `Unable to authenticate. Please connect your workspace to Nx Cloud to define a valid Nx Cloud ID. If you are in a CI context, please set the NX_CLOUD_ACCESS_TOKEN environment variable or define an access token in your nx.json.`
+      `Unable to authenticate. If you are connecting to Nx Cloud locally, set an Nx Cloud ID in your nx.json with "nx connect". If you are in a CI context, please set the NX_CLOUD_ACCESS_TOKEN environment variable or define an access token in your nx.json.`
     );
   }
 

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -671,7 +671,7 @@ function getTasksRunnerPath(
     nxJson.tasksRunnerOptions?.[runner]?.options?.accessToken ||
     // Cloud access token specified in env var.
     process.env.NX_CLOUD_ACCESS_TOKEN ||
-    // Nx Cloud Id specified in nxJson
+    // Nx Cloud ID specified in nxJson
     nxJson.nxCloudId;
 
   return isCloudRunner ? 'nx-cloud' : require.resolve('./default-tasks-runner');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

N/A

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running `npx nx login`, a file server should open and take you to Nx Cloud to create a new personal access token.

When running `npx nx logout`, the user should be prompted with Nx Cloud URLs of instances that they can revoke personal access tokens to. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
