### PR TITLE
fix(misc): init should run add for .nx workspaces on windows

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -51,7 +51,7 @@ export async function initHandler(options: InitArgs): Promise<void> {
     generateDotNxSetup(version);
     const { plugins } = await detectPlugins();
     plugins.forEach((plugin) => {
-      execSync(`./nx add ${plugin}`, {
+      runNxSync(`add ${plugin}`, {
         stdio: 'inherit',
       });
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
We execute `execSync('./nx ...')` inside nx init

## Expected Behavior
We use `runNx`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
