### PR TITLE
fix(vite): allow experimental vitest 2 support

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "vite": "^5.0.0",
-    "vitest": "^1.3.1"
+    "vitest": "^1.3.1 || ^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13366,7 +13366,7 @@ packages:
     resolution: {integrity: sha512-Aa4L+1od6oOtIZuVrXNm4gJHGXtGyZj7il2gd1QJ/uFckaMMcFyXYEcx626u0NsDKCKGlDlPtRkb7c4+XcfJtQ==}
     peerDependencies:
       vite: ^5.0.0
-      vitest: ^1.3.1
+      vitest: ^1.3.1 || ^2.0.0
     dependencies:
       '@nrwl/vite': 19.6.0-beta.6(@swc-node/register@1.9.1)(@swc/core@1.5.7)(@types/node@18.19.8)(nx@19.6.0-beta.6)(typescript@5.5.3)(verdaccio@5.31.0)(vite@5.0.8)(vitest@1.3.1)
       '@nx/devkit': 19.6.0-beta.6(nx@19.6.0-beta.6)


### PR DESCRIPTION
Allows consumers to use vitest 2 with the @nx/vite plugin.

closed #27259

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Users cannot use Vitest 2 with @nx/vite.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users can use Vitest 2 with @nx/vite.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27259
