### PR TITLE
fix(module-federation): optimization should not be overwritten #27201

### DIFF
--- a/packages/react/src/module-federation/with-module-federation-ssr.ts
+++ b/packages/react/src/module-federation/with-module-federation-ssr.ts
@@ -21,6 +21,7 @@ export async function withModuleFederationForSSR(
     config.target = false;
     config.output.uniqueName = options.name;
     config.optimization = {
+      ...(config.optimization ?? {}),
       runtimeChunk: false,
     };
 

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -34,6 +34,7 @@ export async function withModuleFederation(
     }
 
     config.optimization = {
+      ...(config.optimization ?? {}),
       runtimeChunk: false,
     };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`withModuleFederation` is overwriting `config.optimization` rather than merging it.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`config.optimization` should be merged

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27201
