### PR TITLE
fix(testing): e2e-ci targetDefaults migration should handle self deps

### DIFF
--- a/packages/cypress/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.ts
+++ b/packages/cypress/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.ts
@@ -15,6 +15,7 @@ import {
 } from 'nx/src/devkit-internals';
 import { tsquery } from '@phenomnomnominal/tsquery';
 import { type CypressPluginOptions } from '../../plugins/plugin';
+import { dirname } from 'path';
 
 export default async function addE2eCiTargetDefaults(tree: Tree) {
   const pluginName = '@nx/cypress/plugin';
@@ -81,6 +82,9 @@ export default async function addE2eCiTargetDefaults(tree: Tree) {
         graph
       );
 
+      const targetDependsOnSelf =
+        graph.nodes[project].data.root === dirname(configFile);
+
       const serveStaticTarget = graph.nodes[project].data.targets[target];
       let resolvedBuildTarget: string;
       if (serveStaticTarget.dependsOn) {
@@ -92,7 +96,9 @@ export default async function addE2eCiTargetDefaults(tree: Tree) {
             : serveStaticTarget.options.buildTarget) ?? 'build';
       }
 
-      const buildTarget = `^${resolvedBuildTarget}`;
+      const buildTarget = `${
+        targetDependsOnSelf ? '' : '^'
+      }${resolvedBuildTarget}`;
 
       await _addE2eCiTargetDefaults(tree, pluginName, buildTarget, configFile);
     }

--- a/packages/cypress/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.ts
+++ b/packages/cypress/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.ts
@@ -86,8 +86,11 @@ export default async function addE2eCiTargetDefaults(tree: Tree) {
         graph.nodes[project].data.root === dirname(configFile);
 
       const serveStaticTarget = graph.nodes[project].data.targets[target];
+      if (!serveStaticTarget) {
+        continue;
+      }
       let resolvedBuildTarget: string;
-      if (serveStaticTarget.dependsOn) {
+      if (serveStaticTarget?.dependsOn) {
         resolvedBuildTarget = serveStaticTarget.dependsOn.join(',');
       } else {
         resolvedBuildTarget =

--- a/packages/playwright/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.ts
+++ b/packages/playwright/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.ts
@@ -96,7 +96,9 @@ export default async function addE2eCiTargetDefaults(tree: Tree) {
 
       const resolvedServeStaticTarget =
         graph.nodes[serveStaticProject].data.targets[serveStaticTarget];
-
+      if (!resolvedServeStaticTarget) {
+        continue;
+      }
       let resolvedBuildTarget: string;
       if (resolvedServeStaticTarget.dependsOn) {
         resolvedBuildTarget = resolvedServeStaticTarget.dependsOn.join(',');

--- a/packages/playwright/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.ts
+++ b/packages/playwright/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.ts
@@ -1,7 +1,6 @@
 import {
   type Tree,
   type CreateNodesV2,
-  formatFiles,
   readNxJson,
   createProjectGraphAsync,
   parseTargetString,
@@ -15,6 +14,7 @@ import {
 } from 'nx/src/devkit-internals';
 import { tsquery } from '@phenomnomnominal/tsquery';
 import { type PlaywrightPluginOptions } from '../../plugins/plugin';
+import { dirname } from 'path';
 
 export default async function addE2eCiTargetDefaults(tree: Tree) {
   const pluginName = '@nx/playwright/plugin';
@@ -108,7 +108,11 @@ export default async function addE2eCiTargetDefaults(tree: Tree) {
             : resolvedServeStaticTarget.options.buildTarget) ?? 'build';
       }
 
-      const buildTarget = `^${resolvedBuildTarget}`;
+      const targetDependsOnSelf =
+        graph.nodes[serveStaticProject].data.root === dirname(configFile);
+      const buildTarget = `${
+        targetDependsOnSelf ? '' : '^'
+      }${resolvedBuildTarget}`;
 
       await _addE2eCiTargetDefaults(tree, pluginName, buildTarget, configFile);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
If the `ciWebServerCommand` depends on a target that exists on the e2e project, the `dependsOn` is still added with `^` expecting the project to be an implicit dep.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The migration should handle when e2e project depends on itself for the `e2e-ci` command

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
