### PR TITLE
feat(core): add ability to stream logs from daemon

### DIFF
--- a/docs/generated/cli/daemon.md
+++ b/docs/generated/cli/daemon.md
@@ -35,6 +35,14 @@ Type: `boolean`
 
 Default: `false`
 
+### stream
+
+Type: `boolean`
+
+Default: `false`
+
+Stream the logs from the daemon process
+
 ### version
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/daemon.md
+++ b/docs/generated/packages/nx/documents/daemon.md
@@ -35,6 +35,14 @@ Type: `boolean`
 
 Default: `false`
 
+### stream
+
+Type: `boolean`
+
+Default: `false`
+
+Stream the logs from the daemon process
+
 ### version
 
 Type: `boolean`

--- a/packages/nx/src/command-line/daemon/command-object.ts
+++ b/packages/nx/src/command-line/daemon/command-object.ts
@@ -19,5 +19,10 @@ function withDaemonOptions(yargs: Argv): Argv {
     .option('stop', {
       type: 'boolean',
       default: false,
+    })
+    .option('stream', {
+      type: 'boolean',
+      default: false,
+      description: 'Stream the logs from the daemon process',
     });
 }

--- a/packages/nx/src/command-line/daemon/daemon.ts
+++ b/packages/nx/src/command-line/daemon/daemon.ts
@@ -2,6 +2,7 @@ import type { Arguments } from 'yargs';
 import { DAEMON_OUTPUT_LOG_FILE } from '../../daemon/tmp-dir';
 import { output } from '../../utils/output';
 import { generateDaemonHelpOutput } from '../../daemon/client/generate-help-output';
+import { streamLogs } from '../../daemon/client/stream-logs';
 
 export async function daemonHandler(args: Arguments) {
   if (args.start) {
@@ -19,6 +20,8 @@ export async function daemonHandler(args: Arguments) {
     const { daemonClient } = await import('../../daemon/client/client');
     await daemonClient.stop();
     output.log({ title: 'Daemon Server - Stopped' });
+  } else if (args.stream) {
+    streamLogs(true);
   } else {
     console.log(generateDaemonHelpOutput());
   }

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -66,6 +66,7 @@ import {
   FLUSH_SYNC_GENERATOR_CHANGES_TO_DISK,
   type HandleFlushSyncGeneratorChangesToDiskMessage,
 } from '../message-types/flush-sync-generator-changes-to-disk';
+import { streamLogs } from './stream-logs';
 
 const DAEMON_ENV_SETTINGS = {
   NX_PROJECT_GLOB_CACHE: 'false',
@@ -484,6 +485,10 @@ export class DaemonClient {
   }
 
   private async sendMessageToDaemon(message: Message): Promise<any> {
+    if (process.env.NX_DAEMON_STREAM_LOGS) {
+      streamLogs();
+    }
+
     if (this._daemonStatus == DaemonStatus.DISCONNECTED) {
       this._daemonStatus = DaemonStatus.CONNECTING;
 

--- a/packages/nx/src/daemon/client/stream-logs.ts
+++ b/packages/nx/src/daemon/client/stream-logs.ts
@@ -1,0 +1,60 @@
+import { PathOrFileDescriptor, createReadStream, openSync, readFile } from 'fs';
+import { DAEMON_OUTPUT_LOG_FILE } from '../tmp-dir';
+
+const NX_DAEMON_LOG_POLLING_INTERVAL = process.env
+  .NX_DAEMON_LOG_POLLING_INTERVAL
+  ? parseInt(process.env.NX_DAEMON_LOG_POLLING_INTERVAL)
+  : 20;
+
+let streaming = false;
+
+export async function streamLogs(keepAlive = false) {
+  // Prevents streaming multiple times
+  if (streaming) {
+    return;
+  }
+  streaming = true;
+
+  let fd: PathOrFileDescriptor;
+  let consumed = 0;
+  let initial = true;
+
+  const interval = setInterval(() => {
+    // fd is cleared when the stream ends
+    if (fd) {
+      return; // previous interval hasn't finished yet
+    }
+
+    try {
+      fd = openSync(DAEMON_OUTPUT_LOG_FILE, 'r');
+    } catch {
+      // The file doesn't exist yet
+      return;
+    }
+
+    const stream = createReadStream(null, {
+      fd,
+      encoding: 'utf8',
+      start: consumed,
+    });
+
+    stream.on('data', function (chunk) {
+      consumed += chunk.length;
+    });
+
+    // the stream ends automatically when the end of the file is reached
+    stream.on('end', function () {
+      fd = null;
+      initial = false;
+    });
+
+    // The first time we read the file, we don't want to print the whole file
+    if (!initial) {
+      stream.pipe(process.stdout);
+    }
+  }, NX_DAEMON_LOG_POLLING_INTERVAL);
+
+  if (!keepAlive) {
+    interval.unref();
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Daemon logs live in a file, which is great, but we can't expose them in the main process

## Expected Behavior
Users can optionally stream logs from the daemon by setting NX_DAEMON_STREAM_LOGS=true and control the polling interval with NX_DAEMON_LOG_POLLING_INTERVAL. `tail` also uses polling, as there's not really a good way to say "hey this file updated" from the client side and we don't want to rely on daemon file watcher to diagnose daemon issues.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
