### PR TITLE
fix(core): ensure context is available when updating files in context

### DIFF
--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -236,7 +236,11 @@ async function processFilesAndCreateAndSerializeProjectGraph(
     performance.mark('hash-watched-changes-start');
     const updatedFiles = [...collectedUpdatedFiles.values()];
     const deletedFiles = [...collectedDeletedFiles.values()];
-    let updatedFileHashes = updateFilesInContext(updatedFiles, deletedFiles);
+    let updatedFileHashes = updateFilesInContext(
+      workspaceRoot,
+      updatedFiles,
+      deletedFiles
+    );
     performance.mark('hash-watched-changes-end');
     performance.measure(
       'hash changed files from watcher',

--- a/packages/nx/src/utils/sync-generators.ts
+++ b/packages/nx/src/utils/sync-generators.ts
@@ -221,7 +221,12 @@ async function flushSyncGeneratorChangesToDisk(
   }
 
   // Update the context files
-  await updateContextWithChangedFiles(createdFiles, updatedFiles, deletedFiles);
+  await updateContextWithChangedFiles(
+    workspaceRoot,
+    createdFiles,
+    updatedFiles,
+    deletedFiles
+  );
   performance.mark('flush-sync-generator-changes-to-disk:end');
   performance.measure(
     'flush sync generator changes to disk',

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -75,12 +75,17 @@ export async function hashWithWorkspaceContext(
 }
 
 export async function updateContextWithChangedFiles(
+  workspaceRoot: string,
   createdFiles: string[],
   updatedFiles: string[],
   deletedFiles: string[]
 ) {
   if (!daemonClient.enabled()) {
-    updateFilesInContext([...createdFiles, ...updatedFiles], deletedFiles);
+    updateFilesInContext(
+      workspaceRoot,
+      [...createdFiles, ...updatedFiles],
+      deletedFiles
+    );
   } else if (isOnDaemon()) {
     // make sure to only import this when running on the daemon
     const { addUpdatedAndDeletedFiles } = await import(
@@ -99,9 +104,11 @@ export async function updateContextWithChangedFiles(
 }
 
 export function updateFilesInContext(
+  workspaceRoot: string,
   updatedFiles: string[],
   deletedFiles: string[]
 ) {
+  ensureContextAvailable(workspaceRoot);
   return workspaceContext?.incrementalUpdate(updatedFiles, deletedFiles);
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

There is an error when `updateFilesInContext` is called without a `workspaceContext` available.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`updateFilesInContext` ensures there is a `workspaceContext` available.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
