### PR TITLE
fix(testing): cypress update ci webserver to serve-static based on plugins

### DIFF
--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -32,15 +32,9 @@
     },
     "update-19-6-0-update-ci-webserver-for-vite": {
       "cli": "nx",
-      "version": "19.6.0-beta.0",
-      "description": "Update ciWebServerCommand to use previewTargetName if Vite is detected for the application.",
-      "implementation": "./src/migrations/update-19-6-0/update-ci-webserver-for-vite"
-    },
-    "update-19-6-0-add-e2e-ci-target-defaults": {
-      "cli": "nx",
-      "version": "19.6.0-beta.0",
-      "description": "Add inferred ciTargetNames to targetDefaults with dependsOn to ensure dependent application builds are scheduled before atomized tasks.",
-      "implementation": "./src/migrations/update-19-6-0/add-e2e-ci-target-defaults"
+      "version": "19.6.0-beta.4",
+      "description": "Update ciWebServerCommand to use static serve for the application.",
+      "implementation": "./src/migrations/update-19-6-0/update-ci-webserver-for-static-serve"
     }
   },
   "packageJsonUpdates": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
We're only checking for Vite and adding `preview` as a string on its own when running the migration to update cypress.config.ts ciWebServerCommand


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Check both Vite and Webpack and update according to plugin if one exists

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
