### PR TITLE
feat(angular): deprecate data persistence operators

### DIFF
--- a/packages/angular/src/runtime/nx/data-persistence.ts
+++ b/packages/angular/src/runtime/nx/data-persistence.ts
@@ -54,7 +54,6 @@ export type ActionStateStream<T, A> = Observable<
 >;
 
 /**
- *
  * @whatItDoes Handles pessimistic updates (updating the server first).
  *
  * Updating the server, when implemented naively, suffers from race conditions and poor error handling.
@@ -109,6 +108,8 @@ export type ActionStateStream<T, A> = Observable<
  * ```
  *
  * @param opts
+ *
+ * @deprecated This will be removed in Nx v21. Import `pessimisticUpdate` from `@ngrx/router-store/data-persistence` instead.
  */
 export function pessimisticUpdate<T extends Array<unknown>, A extends Action>(
   opts: PessimisticUpdateOpts<T, A>
@@ -122,7 +123,6 @@ export function pessimisticUpdate<T extends Array<unknown>, A extends Action>(
 }
 
 /**
- *
  * @whatItDoes Handles optimistic updates (updating the client first).
  *
  * It runs all fetches in order, which removes race conditions and forces the developer to handle errors.
@@ -178,6 +178,8 @@ export function pessimisticUpdate<T extends Array<unknown>, A extends Action>(
  * ```
  *
  * @param opts
+ *
+ * @deprecated This will be removed in Nx v21. Import `optimisticUpdate` from `@ngrx/router-store/data-persistence` instead.
  */
 export function optimisticUpdate<T extends Array<unknown>, A extends Action>(
   opts: OptimisticUpdateOpts<T, A>
@@ -191,7 +193,6 @@ export function optimisticUpdate<T extends Array<unknown>, A extends Action>(
 }
 
 /**
- *
  * @whatItDoes Handles data fetching.
  *
  * Data fetching implemented naively suffers from race conditions and poor error handling.
@@ -267,6 +268,8 @@ export function optimisticUpdate<T extends Array<unknown>, A extends Action>(
  * In addition, if there are multiple requests for Todo 1 scheduled, it will only run the last one.
  *
  * @param opts
+ *
+ * @deprecated This will be removed in Nx v21. Import `fetch` from `@ngrx/router-store/data-persistence` instead.
  */
 export function fetch<T extends Array<unknown>, A extends Action>(
   opts: FetchOpts<T, A>
@@ -342,6 +345,8 @@ export function fetch<T extends Array<unknown>, A extends Action>(
  *
  * @param component
  * @param opts
+ *
+ * @deprecated This will be removed in Nx v21. Import `navigation` from `@ngrx/router-store/data-persistence` instead.
  */
 export function navigation<T extends Array<unknown>, A extends Action>(
   component: Type<any>,

--- a/packages/angular/testing/src/testing-utils.ts
+++ b/packages/angular/testing/src/testing-utils.ts
@@ -2,7 +2,8 @@ import type { Observable } from 'rxjs';
 import { first, toArray } from 'rxjs/operators';
 
 /**
- * @deprecated This will be removed in a later version of Nx. Since RxJS 7, use firstValueFrom(obs$.pipe(toArray())) or lastValueFrom(obs$.pipe(toArray())).
+ * @deprecated This will be removed in Nx v21. If using RxJS 7, use `firstValueFrom(obs$.pipe(toArray()))`
+ * or `lastValueFrom(obs$.pipe(toArray()))`. If using RxJS 6, use `obs$.pipe(toArray()).toPromise()`.
  *
  * @whatItDoes reads all the values from an observable and returns a promise
  * with an array of all values. This should be used in combination with async/await.
@@ -20,7 +21,8 @@ export function readAll<T>(o: Observable<T>): Promise<T[]> {
 }
 
 /**
- * @deprecated This will be removed in a later version of Nx. Since RxJS 7, use firstValueFrom(obs$)
+ * @deprecated This will be removed in Nx v21. Since RxJS 7, use `firstValueFrom(obs$)`. If using RxJS 6,
+ * use `obs$.pipe(first()).toPromise()`.
  *
  * @whatItDoes reads the first value from an observable and returns a promise
  * with it. This should be used in combination with async/await.


### PR DESCRIPTION
- Deprecate the `@nx/angular` data persistence operators in favor of importing them from `@ngrx/router-store/data-persistence`. The operator will be removed from the `@nx/angular` package in Nx v21.
- Update the deprecation message for `@nx/angular/testing` helpers to communicate that they will be removed in Nx v21.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
