### PR TITLE
fix(module-federation): turn dts off by default #27198

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -413,6 +413,12 @@
       },
       "description": "Update the @angular/cli package version to ~18.1.0.",
       "factory": "./src/migrations/update-19-5-0/update-angular-cli"
+    },
+    "update-19-6-0": {
+      "cli": "nx",
+      "version": "19.6.0-beta.4",
+      "description": "Ensure Module Federation DTS is turned off by default.",
+      "factory": "./src/migrations/update-19-6-0/turn-off-dts-by-default"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -254,7 +254,12 @@ exports[`Host App Generator --ssr should generate the correct files 6`] = `
 exports[`Host App Generator --ssr should generate the correct files 7`] = `
 "const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederationForSSR(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederationForSSR(config, { dts: false });
 "
 `;
 
@@ -438,7 +443,12 @@ exports[`Host App Generator --ssr should generate the correct files for standalo
 exports[`Host App Generator --ssr should generate the correct files for standalone 6`] = `
 "const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederationForSSR(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederationForSSR(config, { dts: false });
 "
 `;
 
@@ -653,7 +663,12 @@ exports[`Host App Generator --ssr should generate the correct files for standalo
 "import { withModuleFederationForSSR } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederationForSSR(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederationForSSR(config, { dts: false });
 "
 `;
 
@@ -883,7 +898,12 @@ exports[`Host App Generator --ssr should generate the correct files when --types
 "import { withModuleFederationForSSR } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederationForSSR(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederationForSSR(config, { dts: false });
 "
 `;
 
@@ -948,14 +968,26 @@ exports[`Host App Generator --ssr should generate the correct files when --types
 exports[`Host App Generator should generate a host app with a remote 1`] = `
 "const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });
 "
 `;
 
 exports[`Host App Generator should generate a host app with a remote 2`] = `
 "const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -963,7 +995,12 @@ exports[`Host App Generator should generate a host app with a remote when --type
 "import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -971,14 +1008,25 @@ exports[`Host App Generator should generate a host app with a remote when --type
 "import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });
 "
 `;
 
 exports[`Host App Generator should generate a host app with no remotes 1`] = `
 "const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -986,7 +1034,12 @@ exports[`Host App Generator should generate a host app with no remotes when --ty
 "import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });
 "
 `;
 

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -255,7 +255,7 @@ exports[`Host App Generator --ssr should generate the correct files 7`] = `
 "const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -444,7 +444,7 @@ exports[`Host App Generator --ssr should generate the correct files for standalo
 "const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -664,7 +664,7 @@ exports[`Host App Generator --ssr should generate the correct files for standalo
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -899,7 +899,7 @@ exports[`Host App Generator --ssr should generate the correct files when --types
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -970,7 +970,7 @@ exports[`Host App Generator should generate a host app with a remote 1`] = `
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -983,7 +983,7 @@ exports[`Host App Generator should generate a host app with a remote 2`] = `
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -996,7 +996,7 @@ exports[`Host App Generator should generate a host app with a remote when --type
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -1009,7 +1009,7 @@ exports[`Host App Generator should generate a host app with a remote when --type
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -1022,7 +1022,7 @@ exports[`Host App Generator should generate a host app with no remotes 1`] = `
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -1035,7 +1035,7 @@ exports[`Host App Generator should generate a host app with no remotes when --ty
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/host/files/js/webpack.server.config.js__tmpl__
+++ b/packages/angular/src/generators/host/files/js/webpack.server.config.js__tmpl__
@@ -1,7 +1,7 @@
 const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/host/files/js/webpack.server.config.js__tmpl__
+++ b/packages/angular/src/generators/host/files/js/webpack.server.config.js__tmpl__
@@ -1,3 +1,8 @@
 const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederationForSSR(config)
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederationForSSR(config, { dts: false });

--- a/packages/angular/src/generators/host/files/ts/webpack.server.config.ts__tmpl__
+++ b/packages/angular/src/generators/host/files/ts/webpack.server.config.ts__tmpl__
@@ -1,4 +1,9 @@
 import { withModuleFederationForSSR } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederationForSSR(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederationForSSR(config, { dts: false });

--- a/packages/angular/src/generators/host/files/ts/webpack.server.config.ts__tmpl__
+++ b/packages/angular/src/generators/host/files/ts/webpack.server.config.ts__tmpl__
@@ -2,7 +2,7 @@ import { withModuleFederationForSSR } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -218,7 +218,13 @@ exports[`MF Remote App Generator --ssr should generate the correct files 6`] = `
 exports[`MF Remote App Generator --ssr should generate the correct files 7`] = `
 "const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederationForSSR(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederationForSSR(config, { dts: false });
 "
 `;
 
@@ -443,7 +449,12 @@ exports[`MF Remote App Generator --ssr should generate the correct files when --
 "import { withModuleFederationForSSR } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederationForSSR(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederationForSSR(config, { dts: false });
 "
 `;
 
@@ -525,14 +536,26 @@ exports[`MF Remote App Generator --ssr should generate the correct files when --
 exports[`MF Remote App Generator should generate a remote mf app with a host 1`] = `
 "const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });
 "
 `;
 
 exports[`MF Remote App Generator should generate a remote mf app with a host 2`] = `
 "const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -540,7 +563,12 @@ exports[`MF Remote App Generator should generate a remote mf app with a host whe
 "import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -548,14 +576,25 @@ exports[`MF Remote App Generator should generate a remote mf app with a host whe
 "import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });
 "
 `;
 
 exports[`MF Remote App Generator should generate a remote mf app with no host 1`] = `
 "const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -563,7 +602,12 @@ exports[`MF Remote App Generator should generate a remote mf app with no host wh
 "import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });
 "
 `;
 

--- a/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`MF Remote App Generator --ssr should generate the correct files 7`] = `
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -450,7 +450,7 @@ exports[`MF Remote App Generator --ssr should generate the correct files when --
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -538,7 +538,7 @@ exports[`MF Remote App Generator should generate a remote mf app with a host 1`]
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -551,7 +551,7 @@ exports[`MF Remote App Generator should generate a remote mf app with a host 2`]
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -564,7 +564,7 @@ exports[`MF Remote App Generator should generate a remote mf app with a host whe
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -577,7 +577,7 @@ exports[`MF Remote App Generator should generate a remote mf app with a host whe
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -590,7 +590,7 @@ exports[`MF Remote App Generator should generate a remote mf app with no host 1`
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -603,7 +603,7 @@ exports[`MF Remote App Generator should generate a remote mf app with no host wh
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/remote/files/base-ts/webpack.server.config.ts__tmpl__
+++ b/packages/angular/src/generators/remote/files/base-ts/webpack.server.config.ts__tmpl__
@@ -1,4 +1,9 @@
 import { withModuleFederationForSSR } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederationForSSR(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederationForSSR(config, { dts: false });

--- a/packages/angular/src/generators/remote/files/base-ts/webpack.server.config.ts__tmpl__
+++ b/packages/angular/src/generators/remote/files/base-ts/webpack.server.config.ts__tmpl__
@@ -2,7 +2,7 @@ import { withModuleFederationForSSR } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/remote/files/base/webpack.server.config.js__tmpl__
+++ b/packages/angular/src/generators/remote/files/base/webpack.server.config.js__tmpl__
@@ -1,3 +1,9 @@
 const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederationForSSR(config)
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederationForSSR(config, { dts: false })

--- a/packages/angular/src/generators/remote/files/base/webpack.server.config.js__tmpl__
+++ b/packages/angular/src/generators/remote/files/base/webpack.server.config.js__tmpl__
@@ -2,7 +2,7 @@ const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/setup-mf/__snapshots__/setup-mf.spec.ts.snap
+++ b/packages/angular/src/generators/setup-mf/__snapshots__/setup-mf.spec.ts.snap
@@ -197,7 +197,13 @@ export const appRoutes: Route[] = [
 exports[`Init MF should create webpack and mf configs correctly 1`] = `
 "const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -224,7 +230,13 @@ exports[`Init MF should create webpack and mf configs correctly 2`] = `
 exports[`Init MF should create webpack and mf configs correctly 3`] = `
 "const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -242,7 +254,12 @@ exports[`Init MF should create webpack and mf configs correctly when --typescrip
 "import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });
 "
 `;
 
@@ -274,7 +291,12 @@ exports[`Init MF should create webpack and mf configs correctly when --typescrip
 "import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });
 "
 `;
 

--- a/packages/angular/src/generators/setup-mf/__snapshots__/setup-mf.spec.ts.snap
+++ b/packages/angular/src/generators/setup-mf/__snapshots__/setup-mf.spec.ts.snap
@@ -199,7 +199,7 @@ exports[`Init MF should create webpack and mf configs correctly 1`] = `
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -232,7 +232,7 @@ exports[`Init MF should create webpack and mf configs correctly 3`] = `
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -255,7 +255,7 @@ exports[`Init MF should create webpack and mf configs correctly when --typescrip
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -292,7 +292,7 @@ exports[`Init MF should create webpack and mf configs correctly when --typescrip
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/setup-mf/files/ts-webpack/webpack.config.ts__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/ts-webpack/webpack.config.ts__tmpl__
@@ -1,4 +1,9 @@
 import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
-export default withModuleFederation(config);
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default withModuleFederation(config, { dts: false });

--- a/packages/angular/src/generators/setup-mf/files/ts-webpack/webpack.config.ts__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/ts-webpack/webpack.config.ts__tmpl__
@@ -2,7 +2,7 @@ import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/setup-mf/files/ts-webpack/webpack.prod.config.ts__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/ts-webpack/webpack.prod.config.ts__tmpl__
@@ -1,6 +1,11 @@
 import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
 export default withModuleFederation({
   ...config,
   /*
@@ -13,4 +18,4 @@ export default withModuleFederation({
    *   ['app2', 'https://app2.example.com'],
    * ]
    */
-});
+}, { dts: false });

--- a/packages/angular/src/generators/setup-mf/files/ts-webpack/webpack.prod.config.ts__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/ts-webpack/webpack.prod.config.ts__tmpl__
@@ -2,7 +2,7 @@ import { withModuleFederation } from '@nx/angular/module-federation';
 import config from './module-federation.config';
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/setup-mf/files/webpack/webpack.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/webpack/webpack.config.js__tmpl__
@@ -2,7 +2,7 @@ const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/setup-mf/files/webpack/webpack.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/webpack/webpack.config.js__tmpl__
@@ -1,3 +1,9 @@
 const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
-module.exports = withModuleFederation(config);
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = withModuleFederation(config, { dts: false });

--- a/packages/angular/src/generators/setup-mf/files/webpack/webpack.prod.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/webpack/webpack.prod.config.js__tmpl__
@@ -2,7 +2,7 @@ const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
 
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/angular/src/generators/setup-mf/files/webpack/webpack.prod.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/webpack/webpack.prod.config.js__tmpl__
@@ -1,5 +1,11 @@
 const { withModuleFederation } = require('@nx/angular/module-federation');
 const config = require('./module-federation.config');
+
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
 module.exports = withModuleFederation({
     ...config,
     /*
@@ -12,4 +18,4 @@ module.exports = withModuleFederation({
      *   ['app2', 'https://app2.example.com'],
      * ]
      */
-});
+}, { dts: false });

--- a/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.spec.ts
+++ b/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.spec.ts
@@ -143,6 +143,44 @@ describe('turnOffDtsByDefault', () => {
         "
       `);
     });
+
+    it('should not update the webpack.config file to set {dts: false} when it already exists in that object and the config is an object with an object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.server.ts',
+        `import { withModuleFederation } from '@nx/angular/module-federation';
+      export default withModuleFederation({remotes: {"remote1": "something"}}, {dts: true, runtimePlugins: {foo: "bar"}});`
+      );
+      tree.write(
+        'app/webpack.config.server.js',
+        `const { withModuleFederation } = require('@nx/angular/module-federation');
+      module.exports = withModuleFederation({remotes: {"remote1": "something"}}, {dts: true, runtimePlugins: {foo: "bar"}});`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.server.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/angular/module-federation';
+        export default withModuleFederation(
+          { remotes: { remote1: 'something' } },
+          { dts: true, runtimePlugins: { foo: 'bar' } }
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.server.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/angular/module-federation');
+        module.exports = withModuleFederation(
+          { remotes: { remote1: 'something' } },
+          { dts: true, runtimePlugins: { foo: 'bar' } }
+        );
+        "
+      `);
+    });
   });
   describe('withModuleFederationForSSR', () => {
     it('should update the webpack.config file to set {dts: false}', async () => {

--- a/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.spec.ts
+++ b/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.spec.ts
@@ -1,0 +1,258 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import turnOffDtsByDefault from './turn-off-dts-by-default';
+
+describe('turnOffDtsByDefault', () => {
+  describe('withModuleFederation', () => {
+    it('should update the webpack.config file to set {dts: false}', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.ts',
+        `import { withModuleFederation } from '@nx/angular/module-federation';
+      export default withModuleFederation(config)`
+      );
+      tree.write(
+        'app/webpack.prod.config.js',
+        `const { withModuleFederation } = require('@nx/angular/module-federation');
+      module.exports = withModuleFederation(config);`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/angular/module-federation';
+        export default withModuleFederation(config, { dts: false });
+        "
+      `);
+      expect(tree.read('app/webpack.prod.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/angular/module-federation');
+        module.exports = withModuleFederation(config, { dts: false });
+        "
+      `);
+    });
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.custom.ts',
+        `import { withModuleFederation } from '@nx/angular/module-federation';
+      export default withModuleFederation(config, {runtimePlugins: []});`
+      );
+      tree.write(
+        'app/webpack.config.js',
+        `const { withModuleFederation } = require('@nx/angular/module-federation');
+      module.exports = withModuleFederation(config, {runtimePlugins: []});`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.custom.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/angular/module-federation';
+        export default withModuleFederation(config, { dts: false, runtimePlugins: [] });
+        "
+      `);
+      expect(tree.read('app/webpack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/angular/module-federation');
+        module.exports = withModuleFederation(config, {
+          dts: false,
+          runtimePlugins: [],
+        });
+        "
+      `);
+    });
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object and the config is an object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.server.ts',
+        `import { withModuleFederation } from '@nx/angular/module-federation';
+      export default withModuleFederation({remotes: []}, {runtimePlugins: []});`
+      );
+      tree.write(
+        'app/webpack.config.server.js',
+        `const { withModuleFederation } = require('@nx/angular/module-federation');
+      module.exports = withModuleFederation({remotes: []}, {runtimePlugins: []});`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.server.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/angular/module-federation';
+        export default withModuleFederation(
+          { remotes: [] },
+          { dts: false, runtimePlugins: [] }
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.server.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/angular/module-federation');
+        module.exports = withModuleFederation(
+          { remotes: [] },
+          { dts: false, runtimePlugins: [] }
+        );
+        "
+      `);
+    });
+
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object and the config is an object with an object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.server.ts',
+        `import { withModuleFederation } from '@nx/angular/module-federation';
+      export default withModuleFederation({remotes: {"remote1": "something"}}, {runtimePlugins: {foo: "bar"}});`
+      );
+      tree.write(
+        'app/webpack.config.server.js',
+        `const { withModuleFederation } = require('@nx/angular/module-federation');
+      module.exports = withModuleFederation({remotes: {"remote1": "something"}}, {runtimePlugins: {foo: "bar"}});`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.server.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/angular/module-federation';
+        export default withModuleFederation(
+          { remotes: { remote1: 'something' } },
+          { dts: false, runtimePlugins: { foo: 'bar' } }
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.server.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/angular/module-federation');
+        module.exports = withModuleFederation(
+          { remotes: { remote1: 'something' } },
+          { dts: false, runtimePlugins: { foo: 'bar' } }
+        );
+        "
+      `);
+    });
+  });
+  describe('withModuleFederationForSSR', () => {
+    it('should update the webpack.config file to set {dts: false}', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.ts',
+        `import { withModuleFederationForSSR } from '@nx/angular/module-federation';
+      export default withModuleFederationForSSR(config);`
+      );
+      tree.write(
+        'app/webpack.server.config.js',
+        `const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
+      module.exports = withModuleFederationForSSR(config);`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederationForSSR } from '@nx/angular/module-federation';
+        export default withModuleFederationForSSR(config, { dts: false });
+        "
+      `);
+      expect(tree.read('app/webpack.server.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
+        module.exports = withModuleFederationForSSR(config, { dts: false });
+        "
+      `);
+    });
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.custom.ts',
+        `import { withModuleFederationForSSR } from '@nx/angular/module-federation';
+      export default withModuleFederationForSSR(config, {runtimePlugins: []});`
+      );
+      tree.write(
+        'app/webpack.config.js',
+        `const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
+      module.exports = withModuleFederationForSSR(config, {runtimePlugins: []});`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.custom.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederationForSSR } from '@nx/angular/module-federation';
+        export default withModuleFederationForSSR(config, {
+          dts: false,
+          runtimePlugins: [],
+        });
+        "
+      `);
+      expect(tree.read('app/webpack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
+        module.exports = withModuleFederationForSSR(config, {
+          dts: false,
+          runtimePlugins: [],
+        });
+        "
+      `);
+    });
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object and the config is an object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.ts',
+        `import { withModuleFederationForSSR } from '@nx/angular/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederationForSSR({remotes: []}, {runtimePlugins: []}));`
+      );
+      tree.write(
+        'app/webpack.config.js',
+        `const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
+      module.exports = withModuleFederationForSSR({remotes: []}, {runtimePlugins: []});`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederationForSSR } from '@nx/angular/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederationForSSR(
+            { remotes: [] },
+            { dts: false, runtimePlugins: [] }
+          )
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederationForSSR } = require('@nx/angular/module-federation');
+        module.exports = withModuleFederationForSSR(
+          { remotes: [] },
+          { dts: false, runtimePlugins: [] }
+        );
+        "
+      `);
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
+++ b/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
@@ -1,0 +1,76 @@
+import { type Tree, formatFiles, visitNotIgnoredFiles } from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+import { minimatch } from 'minimatch';
+import { tsquery } from '@phenomnomnominal/tsquery';
+
+export default async function (tree: Tree) {
+  visitNotIgnoredFiles(tree, '', (path) => {
+    const webpackConfigGlob = '**/webpack*.config*.{js,ts,mjs,cjs}';
+    const result = minimatch(path, webpackConfigGlob);
+    if (!minimatch(path, webpackConfigGlob)) {
+      return;
+    }
+    let webpackConfigContents = tree.read(path, 'utf-8');
+    if (
+      !/withModuleFederationSSR|withModuleFederation/.test(
+        webpackConfigContents
+      )
+    ) {
+      return;
+    }
+
+    const WITH_MODULE_FEDERATION_SELECTOR =
+      'CallExpression:has(Identifier[name=withModuleFederation]),CallExpression:has(Identifier[name=withModuleFederationForSSR])';
+    const EXISTING_MF_OVERRIDES_SELECTOR = 'ObjectLiteralExpression';
+
+    const ast = tsquery.ast(webpackConfigContents);
+    const withModuleFederationNodes = tsquery(
+      ast,
+      WITH_MODULE_FEDERATION_SELECTOR,
+      { visitAllChildren: true }
+    );
+    if (!withModuleFederationNodes.length) {
+      return;
+    }
+
+    const withModuleFederationNode = withModuleFederationNodes[0];
+    const existingOverridesNodes = tsquery(
+      withModuleFederationNode,
+      EXISTING_MF_OVERRIDES_SELECTOR,
+      { visitAllChildren: true }
+    );
+    if (!existingOverridesNodes.length) {
+      // doesn't exist, add it
+      webpackConfigContents = `${webpackConfigContents.slice(
+        0,
+        withModuleFederationNode.getEnd() - 1
+      )},${JSON.stringify({ dts: false })}${webpackConfigContents.slice(
+        withModuleFederationNode.getEnd() - 1
+      )}`;
+    } else {
+      let existingOverrideNode;
+      for (const node of existingOverridesNodes) {
+        if (!existingOverrideNode) {
+          existingOverrideNode = node;
+        }
+        if (existingOverrideNode.getText().includes(node.getText())) {
+          continue;
+        }
+        existingOverrideNode = node;
+      }
+
+      const newOverrides = `{ dts: false, ${existingOverrideNode
+        .getText()
+        .slice(1)}`;
+      webpackConfigContents = `${webpackConfigContents.slice(
+        0,
+        existingOverrideNode.getStart()
+      )}${newOverrides}${webpackConfigContents.slice(
+        existingOverrideNode.getEnd()
+      )}`;
+    }
+    tree.write(path, webpackConfigContents);
+  });
+
+  await formatFiles(tree);
+}

--- a/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
+++ b/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
@@ -7,7 +7,7 @@ export default async function (tree: Tree) {
   visitNotIgnoredFiles(tree, '', (path) => {
     const webpackConfigGlob = '**/webpack*.config*.{js,ts,mjs,cjs}';
     const result = minimatch(path, webpackConfigGlob);
-    if (!minimatch(path, webpackConfigGlob)) {
+    if (!result) {
       return;
     }
     let webpackConfigContents = tree.read(path, 'utf-8');

--- a/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
+++ b/packages/angular/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
@@ -58,6 +58,15 @@ export default async function (tree: Tree) {
         }
         existingOverrideNode = node;
       }
+      const DTS_PROPERTY_SELECTOR = 'PropertyAssignment > Identifier[name=dts]';
+      const dtsPropertyNode = tsquery(
+        existingOverrideNode,
+        DTS_PROPERTY_SELECTOR
+      );
+      if (dtsPropertyNode.length) {
+        // dts already exists, do nothing
+        return;
+      }
 
       const newOverrides = `{ dts: false, ${existingOverrideNode
         .getText()

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -41,6 +41,12 @@
       "version": "18.1.1-beta.0",
       "description": "Ensure targetDefaults inputs for task hashing when '@nx/webpack:webpack' is used are correct for Module Federation.",
       "factory": "./src/migrations/update-18-1-1/fix-target-defaults-inputs"
+    },
+    "update-19-6-0-turn-module-federation-dts-off": {
+      "cli": "nx",
+      "version": "19.6.0-beta.4",
+      "description": "Ensure Module Federation DTS is turned off by default.",
+      "factory": "./src/migrations/update-19-6-0/turn-off-dts-by-default"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/react/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -13,7 +13,7 @@ const defaultConfig = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -53,7 +53,7 @@ const defaultConfig = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -90,7 +90,7 @@ const config = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */
@@ -135,7 +135,7 @@ const config: ModuleFederationConfig = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/react/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/react/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -12,10 +12,15 @@ const defaultConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
 module.exports = composePlugins(
   withNx(),
   withReact({ ssr: true }),
-  withModuleFederationForSSR(defaultConfig)
+  withModuleFederationForSSR(defaultConfig, { dts: false })
 );
 "
 `;
@@ -47,10 +52,15 @@ const defaultConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
 export default composePlugins(
   withNx(),
   withReact({ ssr: true }),
-  withModuleFederationForSSR(defaultConfig)
+  withModuleFederationForSSR(defaultConfig, { dts: false })
 );
 "
 `;
@@ -79,10 +89,15 @@ const config = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
 module.exports = composePlugins(
   withNx(),
   withReact(),
-  withModuleFederation(config)
+  withModuleFederation(config, { dts: false })
 );
 "
 `;
@@ -119,7 +134,12 @@ const config: ModuleFederationConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-export default composePlugins(withNx(), withReact(), withModuleFederation(config));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default composePlugins(withNx(), withReact(), withModuleFederation(config, { dts: false }));
 "
 `;
 

--- a/packages/react/src/generators/host/files/module-federation-ssr-ts/webpack.server.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ssr-ts/webpack.server.config.ts__tmpl__
@@ -10,7 +10,7 @@ const defaultConfig = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/react/src/generators/host/files/module-federation-ssr-ts/webpack.server.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ssr-ts/webpack.server.config.ts__tmpl__
@@ -9,4 +9,9 @@ const defaultConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-export default composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig, { dts: false }));

--- a/packages/react/src/generators/host/files/module-federation-ssr/webpack.server.config.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ssr/webpack.server.config.js__tmpl__
@@ -9,4 +9,9 @@ const defaultConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig, { dts: false }));

--- a/packages/react/src/generators/host/files/module-federation-ssr/webpack.server.config.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ssr/webpack.server.config.js__tmpl__
@@ -10,7 +10,7 @@ const defaultConfig = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/react/src/generators/host/files/module-federation-ts/webpack.config.prod.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ts/webpack.config.prod.ts__tmpl__
@@ -30,4 +30,9 @@ const prodConfig: ModuleFederationConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-export default composePlugins(withNx(), withReact(), withModuleFederation(prodConfig));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default composePlugins(withNx(), withReact(), withModuleFederation(prodConfig, { dts: false }));

--- a/packages/react/src/generators/host/files/module-federation-ts/webpack.config.prod.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ts/webpack.config.prod.ts__tmpl__
@@ -31,7 +31,7 @@ const prodConfig: ModuleFederationConfig = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/react/src/generators/host/files/module-federation-ts/webpack.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ts/webpack.config.ts__tmpl__
@@ -10,7 +10,7 @@ const config: ModuleFederationConfig = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/react/src/generators/host/files/module-federation-ts/webpack.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ts/webpack.config.ts__tmpl__
@@ -9,4 +9,9 @@ const config: ModuleFederationConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-export default composePlugins(withNx(), withReact(), withModuleFederation(config));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default composePlugins(withNx(), withReact(), withModuleFederation(config, { dts: false }));

--- a/packages/react/src/generators/host/files/module-federation/webpack.config.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation/webpack.config.js__tmpl__
@@ -9,4 +9,9 @@ const config = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config, { dts: false }));

--- a/packages/react/src/generators/host/files/module-federation/webpack.config.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation/webpack.config.js__tmpl__
@@ -10,7 +10,7 @@ const config = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/react/src/generators/host/files/module-federation/webpack.config.prod.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation/webpack.config.prod.js__tmpl__
@@ -30,7 +30,7 @@ const prodConfig = {
 
 // Nx plugins for webpack to build config object from Nx options and context.
 /**
- * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
  * The DTS Plugin can be enabled by setting dts: true
  * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
  */

--- a/packages/react/src/generators/host/files/module-federation/webpack.config.prod.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation/webpack.config.prod.js__tmpl__
@@ -29,4 +29,9 @@ const prodConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact(), withModuleFederation(prodConfig));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = composePlugins(withNx(), withReact(), withModuleFederation(prodConfig, { dts: false }));

--- a/packages/react/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/react/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -12,7 +12,12 @@ const config = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config, { dts: false }));
 "
 `;
 
@@ -41,7 +46,12 @@ const config = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config, { dts: false }));
 "
 `;
 
@@ -70,10 +80,15 @@ const config = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
 export default composePlugins(
   withNx(),
   withReact(),
-  withModuleFederation(config)
+  withModuleFederation(config, { dts: false })
 );
 "
 `;
@@ -110,7 +125,12 @@ const defaultConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig, { dts: false }));
 "
 `;
 
@@ -136,10 +156,15 @@ const defaultConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
 export default composePlugins(
   withNx(),
   withReact({ ssr: true }),
-  withModuleFederationForSSR(defaultConfig)
+  withModuleFederationForSSR(defaultConfig, { dts: false })
 );
 "
 `;

--- a/packages/react/src/generators/remote/files/module-federation-ssr-ts/webpack.server.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/module-federation-ssr-ts/webpack.server.config.ts__tmpl__
@@ -9,4 +9,9 @@ const defaultConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-export default composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig, { dts: false }));

--- a/packages/react/src/generators/remote/files/module-federation-ssr/webpack.server.config.js__tmpl__
+++ b/packages/react/src/generators/remote/files/module-federation-ssr/webpack.server.config.js__tmpl__
@@ -9,4 +9,9 @@ const defaultConfig = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = composePlugins(withNx(), withReact({ssr: true}), withModuleFederationForSSR(defaultConfig, { dts: false }));

--- a/packages/react/src/generators/remote/files/module-federation-ts/webpack.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/module-federation-ts/webpack.config.ts__tmpl__
@@ -9,4 +9,9 @@ const config = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-export default composePlugins(withNx(), withReact(), withModuleFederation(config));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+export default composePlugins(withNx(), withReact(), withModuleFederation(config, { dts: false }));

--- a/packages/react/src/generators/remote/files/module-federation/webpack.config.js__tmpl__
+++ b/packages/react/src/generators/remote/files/module-federation/webpack.config.js__tmpl__
@@ -9,4 +9,9 @@ const config = {
 };
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config));
+/**
+ * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+ * The DTS Plugin can be enabled by setting dts: true
+ * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+ */
+module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config, { dts: false }));

--- a/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.spec.ts
+++ b/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.spec.ts
@@ -166,6 +166,52 @@ describe('turnOffDtsByDefault', () => {
         "
       `);
     });
+
+    it('should not update the webpack.config file to set {dts: false} when it exists in that object and the config is an object with an object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.server.ts',
+        `import { withModuleFederation } from '@nx/react/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederation({remotes: {"remote1": "something"}}, {dts: true, runtimePlugins: {foo: "bar"}}));`
+      );
+      tree.write(
+        'app/webpack.config.server.js',
+        `const { withModuleFederation } = require('@nx/react/module-federation');
+      module.exports = composePlugins(withNx(), withReact(), withModuleFederation({remotes: {"remote1": "something"}}, {dts: true, runtimePlugins: {foo: "bar"}}));`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.server.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/react/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation(
+            { remotes: { remote1: 'something' } },
+            { dts: true, runtimePlugins: { foo: 'bar' } }
+          )
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.server.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/react/module-federation');
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation(
+            { remotes: { remote1: 'something' } },
+            { dts: true, runtimePlugins: { foo: 'bar' } }
+          )
+        );
+        "
+      `);
+    });
   });
   describe('withModuleFederationForSSR', () => {
     it('should update the webpack.config file to set {dts: false}', async () => {

--- a/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.spec.ts
+++ b/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.spec.ts
@@ -1,0 +1,295 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import turnOffDtsByDefault from './turn-off-dts-by-default';
+
+describe('turnOffDtsByDefault', () => {
+  describe('withModuleFederation', () => {
+    it('should update the webpack.config file to set {dts: false}', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.ts',
+        `import { withModuleFederation } from '@nx/react/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederation(config));`
+      );
+      tree.write(
+        'app/webpack.prod.config.js',
+        `const { withModuleFederation } = require('@nx/react/module-federation');
+      module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config));`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/react/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation(config, { dts: false })
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.prod.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/react/module-federation');
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation(config, { dts: false })
+        );
+        "
+      `);
+    });
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.custom.ts',
+        `import { withModuleFederation } from '@nx/react/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederation(config, {runtimePlugins: []}));`
+      );
+      tree.write(
+        'app/webpack.config.js',
+        `const { withModuleFederation } = require('@nx/react/module-federation');
+      module.exports = composePlugins(withNx(), withReact(), withModuleFederation(config, {runtimePlugins: []}));`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.custom.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/react/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation(config, { dts: false, runtimePlugins: [] })
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/react/module-federation');
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation(config, { dts: false, runtimePlugins: [] })
+        );
+        "
+      `);
+    });
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object and the config is an object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.server.ts',
+        `import { withModuleFederation } from '@nx/react/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederation({remotes: []}, {runtimePlugins: []}));`
+      );
+      tree.write(
+        'app/webpack.config.server.js',
+        `const { withModuleFederation } = require('@nx/react/module-federation');
+      module.exports = composePlugins(withNx(), withReact(), withModuleFederation({remotes: []}, {runtimePlugins: []}));`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.server.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/react/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation({ remotes: [] }, { dts: false, runtimePlugins: [] })
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.server.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/react/module-federation');
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation({ remotes: [] }, { dts: false, runtimePlugins: [] })
+        );
+        "
+      `);
+    });
+
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object and the config is an object with an object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.server.ts',
+        `import { withModuleFederation } from '@nx/react/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederation({remotes: {"remote1": "something"}}, {runtimePlugins: {foo: "bar"}}));`
+      );
+      tree.write(
+        'app/webpack.config.server.js',
+        `const { withModuleFederation } = require('@nx/react/module-federation');
+      module.exports = composePlugins(withNx(), withReact(), withModuleFederation({remotes: {"remote1": "something"}}, {runtimePlugins: {foo: "bar"}}));`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.server.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/react/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation(
+            { remotes: { remote1: 'something' } },
+            { dts: false, runtimePlugins: { foo: 'bar' } }
+          )
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.server.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederation } = require('@nx/react/module-federation');
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederation(
+            { remotes: { remote1: 'something' } },
+            { dts: false, runtimePlugins: { foo: 'bar' } }
+          )
+        );
+        "
+      `);
+    });
+  });
+  describe('withModuleFederationForSSR', () => {
+    it('should update the webpack.config file to set {dts: false}', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.ts',
+        `import { withModuleFederationForSSR } from '@nx/react/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederationForSSR(config));`
+      );
+      tree.write(
+        'app/webpack.prod.config.js',
+        `const { withModuleFederationForSSR } = require('@nx/react/module-federation');
+      module.exports = composePlugins(withNx(), withReact(), withModuleFederationForSSR(config));`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederationForSSR } from '@nx/react/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederationForSSR(config, { dts: false })
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.prod.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederationForSSR } = require('@nx/react/module-federation');
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederationForSSR(config, { dts: false })
+        );
+        "
+      `);
+    });
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.custom.ts',
+        `import { withModuleFederationForSSR } from '@nx/react/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederationForSSR(config, {runtimePlugins: []}));`
+      );
+      tree.write(
+        'app/webpack.config.js',
+        `const { withModuleFederationForSSR } = require('@nx/react/module-federation');
+      module.exports = composePlugins(withNx(), withReact(), withModuleFederationForSSR(config, {runtimePlugins: []}));`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.custom.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederationForSSR } from '@nx/react/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederationForSSR(config, { dts: false, runtimePlugins: [] })
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederationForSSR } = require('@nx/react/module-federation');
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederationForSSR(config, { dts: false, runtimePlugins: [] })
+        );
+        "
+      `);
+    });
+    it('should update the webpack.config file to set {dts: false} when other properties exist in that object and the config is an object', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'app/webpack.config.ts',
+        `import { withModuleFederationForSSR } from '@nx/react/module-federation';
+      export default composePlugins(withNx(), withReact(), withModuleFederationForSSR({remotes: []}, {runtimePlugins: []}));`
+      );
+      tree.write(
+        'app/webpack.config.js',
+        `const { withModuleFederationForSSR } = require('@nx/react/module-federation');
+      module.exports = composePlugins(withNx(), withReact(), withModuleFederationForSSR({remotes: []}, {runtimePlugins: []}));`
+      );
+
+      // ACT
+      await turnOffDtsByDefault(tree);
+
+      // ASSERT
+      expect(tree.read('app/webpack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederationForSSR } from '@nx/react/module-federation';
+        export default composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederationForSSR(
+            { remotes: [] },
+            { dts: false, runtimePlugins: [] }
+          )
+        );
+        "
+      `);
+      expect(tree.read('app/webpack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederationForSSR } = require('@nx/react/module-federation');
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withModuleFederationForSSR(
+            { remotes: [] },
+            { dts: false, runtimePlugins: [] }
+          )
+        );
+        "
+      `);
+    });
+  });
+});

--- a/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
+++ b/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
@@ -1,0 +1,76 @@
+import { type Tree, formatFiles, visitNotIgnoredFiles } from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+import { minimatch } from 'minimatch';
+import { tsquery } from '@phenomnomnominal/tsquery';
+
+export default async function (tree: Tree) {
+  visitNotIgnoredFiles(tree, '', (path) => {
+    const webpackConfigGlob = '**/webpack*.config*.{js,ts,mjs,cjs}';
+    const result = minimatch(path, webpackConfigGlob);
+    if (!minimatch(path, webpackConfigGlob)) {
+      return;
+    }
+    let webpackConfigContents = tree.read(path, 'utf-8');
+    if (
+      !/withModuleFederationSSR|withModuleFederation/.test(
+        webpackConfigContents
+      )
+    ) {
+      return;
+    }
+
+    const WITH_MODULE_FEDERATION_SELECTOR =
+      'CallExpression:has(Identifier[name=composePlugins]) > CallExpression:has(Identifier[name=withModuleFederation]),CallExpression:has(Identifier[name=composePlugins]) > CallExpression:has(Identifier[name=withModuleFederationForSSR])';
+    const EXISTING_MF_OVERRIDES_SELECTOR = 'ObjectLiteralExpression';
+
+    const ast = tsquery.ast(webpackConfigContents);
+    const withModuleFederationNodes = tsquery(
+      ast,
+      WITH_MODULE_FEDERATION_SELECTOR,
+      { visitAllChildren: true }
+    );
+    if (!withModuleFederationNodes.length) {
+      return;
+    }
+
+    const withModuleFederationNode = withModuleFederationNodes[0];
+    const existingOverridesNodes = tsquery(
+      withModuleFederationNode,
+      EXISTING_MF_OVERRIDES_SELECTOR,
+      { visitAllChildren: true }
+    );
+    if (!existingOverridesNodes.length) {
+      // doesn't exist, add it
+      webpackConfigContents = `${webpackConfigContents.slice(
+        0,
+        withModuleFederationNode.getEnd() - 1
+      )},${JSON.stringify({ dts: false })}${webpackConfigContents.slice(
+        withModuleFederationNode.getEnd() - 1
+      )}`;
+    } else {
+      let existingOverrideNode;
+      for (const node of existingOverridesNodes) {
+        if (!existingOverrideNode) {
+          existingOverrideNode = node;
+        }
+        if (existingOverrideNode.getText().includes(node.getText())) {
+          continue;
+        }
+        existingOverrideNode = node;
+      }
+
+      const newOverrides = `{ dts: false, ${existingOverrideNode
+        .getText()
+        .slice(1)}`;
+      webpackConfigContents = `${webpackConfigContents.slice(
+        0,
+        existingOverrideNode.getStart()
+      )}${newOverrides}${webpackConfigContents.slice(
+        existingOverrideNode.getEnd()
+      )}`;
+    }
+    tree.write(path, webpackConfigContents);
+  });
+
+  await formatFiles(tree);
+}

--- a/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
+++ b/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
@@ -7,7 +7,7 @@ export default async function (tree: Tree) {
   visitNotIgnoredFiles(tree, '', (path) => {
     const webpackConfigGlob = '**/webpack*.config*.{js,ts,mjs,cjs}';
     const result = minimatch(path, webpackConfigGlob);
-    if (!minimatch(path, webpackConfigGlob)) {
+    if (!result) {
       return;
     }
     let webpackConfigContents = tree.read(path, 'utf-8');

--- a/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
+++ b/packages/react/src/migrations/update-19-6-0/turn-off-dts-by-default.ts
@@ -58,6 +58,15 @@ export default async function (tree: Tree) {
         }
         existingOverrideNode = node;
       }
+      const DTS_PROPERTY_SELECTOR = 'PropertyAssignment > Identifier[name=dts]';
+      const dtsPropertyNode = tsquery(
+        existingOverrideNode,
+        DTS_PROPERTY_SELECTOR
+      );
+      if (dtsPropertyNode.length) {
+        // dts already exists, do nothing
+        return;
+      }
 
       const newOverrides = `{ dts: false, ${existingOverrideNode
         .getText()


### PR DESCRIPTION
- fix(angular): turn mf dts off by default #27198
- fix(react): turn mf dts off by default
- fix(react): add migration to turn module federation dts off by default
- fix(angular): add migration to turn module federation dts off by default

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx already provides Typing support for Module Federation projects. The `@module-federation/enhanced` package has typing support turned on by default but it can be problematic.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Turn off `@module-federation/enhanced` own dts plugin providing typing support in favour of Nx's own typing support

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27198
