### PR TITLE
feat(js): @nx/js:init generator does not generate prettier and tsconfig.base.json files by default

### DIFF
--- a/docs/generated/packages/js/generators/init.json
+++ b/docs/generated/packages/js/generators/init.json
@@ -30,10 +30,22 @@
         "description": "Keep existing dependencies versions",
         "default": false
       },
+      "addTsConfigBase": {
+        "type": "boolean",
+        "description": "Add a base tsconfig file to the workspace.",
+        "x-priority": "internal",
+        "default": false
+      },
       "tsConfigName": {
         "type": "string",
-        "description": "Customize the generated tsconfig file name.",
+        "description": "Customize the generated base tsconfig file name.",
         "x-priority": "internal"
+      },
+      "setUpPrettier": {
+        "type": "boolean",
+        "description": "Add Prettier and corresponding configuration files.",
+        "x-priority": "internal",
+        "default": false
       }
     },
     "presets": []

--- a/packages/js/src/generators/init/init.spec.ts
+++ b/packages/js/src/generators/init/init.spec.ts
@@ -8,6 +8,9 @@ describe('js init generator', () => {
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+    // Remove files that should be part of the init generator
+    tree.delete('tsconfig.base.json');
+    tree.delete('.prettierrc');
   });
 
   it('should install prettier package', async () => {
@@ -116,5 +119,24 @@ describe('js init generator', () => {
     expect(packageJson.devDependencies['typescript']).not.toBe(
       typescriptVersion
     );
+  });
+
+  it('should support skipping base tsconfig file', async () => {
+    await init(tree, {
+      addTsConfigBase: false,
+    });
+
+    expect(tree.exists('tsconfig.base.json')).toBeFalsy();
+  });
+
+  it('should support skipping prettier setup', async () => {
+    await init(tree, {
+      setUpPrettier: false,
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['prettier']).toBeUndefined();
+    expect(tree.exists('.prettierignore')).toBeFalsy();
+    expect(tree.exists('.prettierrc')).toBeFalsy();
   });
 });

--- a/packages/js/src/generators/init/schema.d.ts
+++ b/packages/js/src/generators/init/schema.d.ts
@@ -1,7 +1,9 @@
 export interface InitSchema {
+  addTsConfigBase?: boolean;
   js?: boolean;
+  keepExistingVersions?: boolean;
+  setUpPrettier?: boolean;
   skipFormat?: boolean;
   skipPackageJson?: boolean;
-  keepExistingVersions?: boolean;
   tsConfigName?: string;
 }

--- a/packages/js/src/generators/init/schema.json
+++ b/packages/js/src/generators/init/schema.json
@@ -27,10 +27,22 @@
       "description": "Keep existing dependencies versions",
       "default": false
     },
+    "addTsConfigBase": {
+      "type": "boolean",
+      "description": "Add a base tsconfig file to the workspace.",
+      "x-priority": "internal",
+      "default": false
+    },
     "tsConfigName": {
       "type": "string",
-      "description": "Customize the generated tsconfig file name.",
+      "description": "Customize the generated base tsconfig file name.",
       "x-priority": "internal"
+    },
+    "setUpPrettier": {
+      "type": "boolean",
+      "description": "Add Prettier and corresponding configuration files.",
+      "x-priority": "internal",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
In order to use `nx release` you must run `nx add @nx/js`. However, the init generator will add Prettier and `tsconfig.base.json` files by default, which is not what the user wants.

This PR adds two options:
- `addTsConfigBase` - generates `tsconfig.base.json` when `true`. Default to`false`
- `setUpPrettier` - adds `prettier` and generates `.prettierrc` and `.prettierignore` files when `true`. Defaults to `false`.

The programmatic `initGenerator` API defaults both options to `true` to usages remain unaffected.

The one behavior change is if users run `nx g @nx/js:init` then the two options default to `false`. However, since this is an internal API, the actual usages should be through `nx add` or the programmatic API.



<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
