### PR TITLE
fix(nextjs): update @nx/next/babel preset to remove conflicting plugins when testing in Jest

### DIFF
--- a/packages/next/babel.ts
+++ b/packages/next/babel.ts
@@ -3,6 +3,39 @@
  */
 module.exports = function (api, options) {
   api.assertVersion(7);
+  // When running from Jest with babel-jest, remove @babel/plugin-syntax-import-assertions since babel-jest-preset
+  // comes with @babel/plugin-syntax-import-attributes. These plugins are incompatible. If we don't remove the
+  // conflicting plugin from `next/babel`, then an error will be thrown.
+  // e.g. "Cannot combine importAssertions and importAttributes plugins"
+  // NOTE: We don't want to do this outside of Jest since it may affect `next build`--although the default is SWC anyway.
+  if (process.env.JEST_WORKER_ID) {
+    const nextBabel = require('next/babel').default;
+    const {
+      presets: nextBabelPresets,
+      plugins: nextBabelPlugins,
+      ...rest
+    } = nextBabel(api, options);
+    api.assertVersion(7);
+
+    try {
+      const conflictingPlugin =
+        require('next/dist/compiled/babel/plugin-syntax-import-assertions').default;
+      return {
+        ...rest,
+        presets: nextBabelPresets,
+        plugins: [
+          ...nextBabelPlugins.filter((p) => p.default !== conflictingPlugin),
+          [
+            require.resolve('@babel/plugin-proposal-decorators'),
+            { legacy: true },
+          ],
+        ],
+      };
+    } catch {
+      // If this plugin cannot be import, continue as usual. It could be removed in future versions of Next.js.
+    }
+  }
+
   return {
     presets: [['next/babel', options]],
     plugins: [


### PR DESCRIPTION
The `next/babel` and `babel-jest-preset` Babel presets bring in conflicting plugins. This will cause Jest tests to fail.

This PR updates our own `@nx/next/babel` preset to remove the conflicting plugin from `next/babel`. Import assertions are out of date anyway, and we should be using import attributes (which `babel-jest-preset` supports).

See: https://github.com/tc39/proposal-import-attributes
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
