### PR TITLE
fix(core): improve the dx of the sync commands and gracefully handle exiting the prompt when running tasks

### DIFF
--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -369,7 +369,7 @@ async function promptForApplyingSyncGeneratorChanges(): Promise<boolean> {
     return await prompt<{ applyChanges: 'yes' | 'no' }>([promptConfig]).then(
       ({ applyChanges }) => applyChanges === 'yes'
     );
-  } catch (e) {
+  } catch {
     process.exit(1);
   }
 }

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -257,7 +257,7 @@ async function ensureWorkspaceIsInSyncAndGetGraphs(
   }
 
   const outOfSyncTitle = 'The workspace is out of sync';
-  const resultBodyLines = syncGeneratorResultsToMessageLines(results);
+  const resultBodyLines = [...syncGeneratorResultsToMessageLines(results), ''];
   const fixMessage =
     'You can manually run `nx sync` to update your workspace or you can set `sync.applyChanges` to `true` in your `nx.json` to apply the changes automatically when running tasks.';
   const willErrorOnCiMessage = 'Please note that this will be an error on CI.';
@@ -344,30 +344,34 @@ Please make sure to commit the changes to your repository.`);
 }
 
 async function promptForApplyingSyncGeneratorChanges(): Promise<boolean> {
-  const promptConfig = {
-    name: 'applyChanges',
-    type: 'select',
-    message:
-      'Would you like to sync the changes to get your worskpace up to date?',
-    choices: [
-      {
-        name: 'yes',
-        message: 'Yes, sync the changes and run the tasks',
-      },
-      {
-        name: 'no',
-        message: 'No, run the tasks without syncing the changes',
-      },
-    ],
-    footer: () =>
-      chalk.dim(
-        '\nYou can skip this prompt by setting the `sync.applyChanges` option in your `nx.json`.'
-      ),
-  };
+  try {
+    const promptConfig = {
+      name: 'applyChanges',
+      type: 'select',
+      message:
+        'Would you like to sync the changes to get your worskpace up to date?',
+      choices: [
+        {
+          name: 'yes',
+          message: 'Yes, sync the changes and run the tasks',
+        },
+        {
+          name: 'no',
+          message: 'No, run the tasks without syncing the changes',
+        },
+      ],
+      footer: () =>
+        chalk.dim(
+          '\nYou can skip this prompt by setting the `sync.applyChanges` option in your `nx.json`.'
+        ),
+    };
 
-  return await prompt<{ applyChanges: 'yes' | 'no' }>([promptConfig]).then(
-    ({ applyChanges }) => applyChanges === 'yes'
-  );
+    return await prompt<{ applyChanges: 'yes' | 'no' }>([promptConfig]).then(
+      ({ applyChanges }) => applyChanges === 'yes'
+    );
+  } catch (e) {
+    process.exit(1);
+  }
 }
 
 function setEnvVarsBasedOnArgs(nxArgs: NxArgs, loadDotEnvFiles: boolean) {

--- a/packages/nx/src/utils/sync-generators.ts
+++ b/packages/nx/src/utils/sync-generators.ts
@@ -182,7 +182,6 @@ export function syncGeneratorResultsToMessageLines(
     if (result.outOfSyncMessage) {
       messageLines.push(result.outOfSyncMessage);
     }
-    messageLines.push('');
   }
 
   return messageLines;


### PR DESCRIPTION
- Update the `nx sync` output when there are changes to sync (currently there's no output)
- Update the `nx sync` and `nx sync:check` output when there are no changes to sync (currently there's no output)
- Handle exiting the prompt for applying sync generator changes when running tasks

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
