### PR TITLE
fix(testing): resolve jest utils in plugin from the @jest/core package location that jest uses

### DIFF
--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -436,6 +436,7 @@ function resolveJestPath(projectRoot: string, workspaceRoot: string): string {
   return resolvedJestPaths[projectRoot];
 }
 
+let resolvedJestCorePaths: Record<string, string>;
 /**
  * Resolves a jest util package version that `jest` is using.
  */
@@ -446,5 +447,15 @@ function requireJestUtil<T>(
 ): T {
   const jestPath = resolveJestPath(projectRoot, workspaceRoot);
 
-  return require(require.resolve(packageName, { paths: [dirname(jestPath)] }));
+  resolvedJestCorePaths ??= {};
+  if (!resolvedJestCorePaths[jestPath]) {
+    // nx-ignore-next-line
+    resolvedJestCorePaths[jestPath] = require.resolve('@jest/core', {
+      paths: [dirname(jestPath)],
+    });
+  }
+
+  return require(require.resolve(packageName, {
+    paths: [dirname(resolvedJestCorePaths[jestPath])],
+  }));
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

In the `@nx/jest/plugin` some jest utils are imported from the location of the `jest` package to ensure the plugin uses the same utils the `jest` package would use. This is not entirely correct because the `jest` package doesn't directly depend on those utils, so they might not be resolved correctly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/jest/plugin` should import those jest utils from the location of the `@jest/core` package resolved from the `jest` package location, to ensure the plugin uses the same utils the `jest` package would use.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
