### PR TITLE
fix(core): ensure the error has message before reading indexOf #27078

### DIFF
--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -291,7 +291,7 @@ export async function createProjectGraphAndSourceMapsAsync(
       );
       return projectGraphAndSourceMaps;
     } catch (e) {
-      if (e.message.indexOf('inotify_add_watch') > -1) {
+      if (e.message && e.message.indexOf('inotify_add_watch') > -1) {
         // common errors with the daemon due to OS settings (cannot watch all the files available)
         output.note({
           title: `Unable to start Nx Daemon due to the limited amount of inotify watches, continuing without the daemon.`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Project graph error handling is always expecting the `message` property to exist on the error. This may not always be the case.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Only attempt to run `indexOf` if the `message` property exists.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27078
