### PR TITLE
fix(js): handle arbitrary nested ts path mappings when re-mapping them to the outputs

### DIFF
--- a/packages/js/src/utils/buildable-libs-utils.spec.ts
+++ b/packages/js/src/utils/buildable-libs-utils.spec.ts
@@ -8,7 +8,11 @@ import {
 
 describe('updatePaths', () => {
   const deps: DependentBuildableProjectNode[] = [
-    { name: '@proj/lib', node: {} as any, outputs: ['dist/libs/lib'] },
+    {
+      name: '@proj/lib',
+      node: { data: { root: 'libs/lib' } } as any,
+      outputs: ['dist/libs/lib'],
+    },
   ];
 
   it('should add path', () => {
@@ -30,7 +34,11 @@ describe('updatePaths', () => {
     updatePaths(deps, paths);
     expect(paths).toEqual({
       '@proj/lib': ['dist/libs/lib'],
-      '@proj/lib/sub': ['dist/libs/lib/sub'],
+      '@proj/lib/sub': [
+        'dist/libs/lib/sub',
+        'dist/libs/lib/sub/src/index',
+        'dist/libs/lib/sub/src/index.ts',
+      ],
     });
   });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When re-mapping a TS path mapping like `"@foo/lib1/plugins/some-file": ["packages/lib1/src/plugins/some-file.ts"]`, it results in:

```json
"@foo/lib1/plugins/some-file": [
  "dist/packages/lib1/plugins/some-file",
  "dist/packages/lib1/src/plugins/some-file.ts"
]
```

The first path is wrong because it's missing the `src` directory, and the second one has a file extension that's not in the output.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When re-mapping a TS path mapping like `"@foo/lib1/plugins/some-file": ["packages/lib1/src/plugins/some-file.ts"]`, it should result in:

```json
"@foo/lib1/plugins/some-file": [
  "dist/packages/lib1/plugins/some-file",
  "dist/packages/lib1/src/plugins/some-file",
  "dist/packages/lib1/src/plugins/some-file.ts"
]
```

In this case, the second path would correctly point to the output. It doesn't have an extension, which allows the compiler to pick up the correct one.

Note that while the first and third paths are still not valid for this specific use case, they could still be valid for other use cases, and in any case, they're still kept for backward compatibility. The util to re-map these paths is currently very generic and generates potentially valid paths. The invalid paths for a given use case won't throw an error as long as there's one that's valid.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21699 
