### PR TITLE
fix(testing): do not migrate projects without webpack nor vite

### DIFF
--- a/packages/playwright/src/migrations/update-19-6-0/use-serve-static-preview-for-command.ts
+++ b/packages/playwright/src/migrations/update-19-6-0/use-serve-static-preview-for-command.ts
@@ -91,13 +91,18 @@ export default async function (tree: Tree) {
       joinPathFragments(graph.nodes[project].data.root, 'webpack.config.js'),
     ].find((p) => tree.exists(p));
 
-    collectedProjects.push({
-      projectName: project,
-      configFile: pathToWebpackConfig ?? pathToViteConfig,
-      configFileType: pathToWebpackConfig ? 'webpack' : 'vite',
-      playwrightConfigFile: path,
-      commandValueNode,
-    });
+    const configFile = pathToWebpackConfig ?? pathToViteConfig;
+
+    // Only migrate projects that have a webpack or vite config file
+    if (configFile) {
+      collectedProjects.push({
+        projectName: project,
+        configFile,
+        configFileType: pathToWebpackConfig ? 'webpack' : 'vite',
+        playwrightConfigFile: path,
+        commandValueNode,
+      });
+    }
   });
 
   for (const projectToMigrate of collectedProjects) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Projects which have neither webpack or vite configs were assumed to be vite.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Projects which have neither webpack or vite configs are not migrated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
