### PR TITLE
fix(release): allow specifier override for version command when version plans are enabled

### DIFF
--- a/e2e/release/src/version-plans.test.ts
+++ b/e2e/release/src/version-plans.test.ts
@@ -830,84 +830,29 @@ Update packages in both groups with a mix #2
       silenceError: true,
     });
 
-    expect(versionResult).toMatchInlineSnapshot(`
-      Skipping version plan discovery as a specifier was provided
+    expect(versionResult).toContain(
+      'Skipping version plan discovery as a specifier was provided'
+    );
+    expect(versionResult).toContain(
+      `${pkg1} 📄 Using the provided version specifier "major".`
+    );
+    expect(versionResult).toContain(
+      `${pkg2} 📄 Using the provided version specifier "major".`
+    );
+    expect(versionResult).toContain(
+      `${pkg3} 📄 Using the provided version specifier "major".`
+    );
+    expect(versionResult).toContain(
+      `${pkg4} 📄 Using the provided version specifier "major".`
+    );
+    expect(versionResult).toContain(
+      `${pkg5} 📄 Using the provided version specifier "major".`
+    );
 
-      NX   Running release version for project: {project-name}
+    expect(versionResult).toContain(
+      `git add ${pkg1}/package.json ${pkg2}/package.json ${pkg3}/package.json ${pkg4}/package.json ${pkg5}/package.json`
+    );
 
-      {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
-      {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
-      {project-name} 📄 Using the provided version specifier "major".
-      {project-name} ✍️  New version 1.0.0 written to {project-name}/package.json
-
-      NX   Running release version for project: {project-name}
-
-      {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
-      {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
-      {project-name} 📄 Using the provided version specifier "major".
-      {project-name} ✍️  New version 1.0.0 written to {project-name}/package.json
-
-      NX   Running release version for project: {project-name}
-
-      {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
-      {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
-      {project-name} 📄 Using the provided version specifier "major".
-      {project-name} ✍️  New version 1.0.0 written to {project-name}/package.json
-
-      NX   Running release version for project: {project-name}
-
-      {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
-      {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
-      {project-name} 📄 Using the provided version specifier "major".
-      {project-name} ✍️  New version 1.0.0 written to {project-name}/package.json
-
-      NX   Running release version for project: {project-name}
-
-      {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
-      {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
-      {project-name} 📄 Using the provided version specifier "major".
-      {project-name} ✍️  New version 1.0.0 written to {project-name}/package.json
-
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.0",
-      +   "version": "1.0.0",
-      "scripts": {
-
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.0",
-      +   "version": "1.0.0",
-      "scripts": {
-
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.0",
-      +   "version": "1.0.0",
-      "scripts": {
-
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.0",
-      +   "version": "1.0.0",
-      "scripts": {
-
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.0",
-      +   "version": "1.0.0",
-      "scripts": {
-
-
-      Skipped lock file update because npm workspaces are not enabled.
-
-      Skipped lock file update because npm workspaces are not enabled.
-
-      NX   Staging changed files with git
-
-      Staging files in git with the following command:
-      git add {project-name}/package.json {project-name}/package.json {project-name}/package.json {project-name}/package.json {project-name}/package.json
-
-    `);
+    expect(readdirSync(versionPlansDir).length).toEqual(2);
   });
 });

--- a/e2e/release/src/version-plans.test.ts
+++ b/e2e/release/src/version-plans.test.ts
@@ -139,7 +139,7 @@ Here is another line in the message.
       `git commit -m "chore: add version plans for fixed and independent groups"`
     );
 
-    const result = runCLI('release --verbose', {
+    const result = runCLI('release --verbose --skip-publish', {
       silenceError: true,
     });
 
@@ -597,7 +597,7 @@ Update packages in both groups with a mix #2
     // dry-run should not remove the version plan
     expect(exists(join(versionPlansDir, 'bump-mixed1.md'))).toBeTruthy();
 
-    const result2 = runCLI('release --verbose', {
+    const result2 = runCLI('release --verbose --skip-publish', {
       silenceError: true,
     });
 
@@ -815,7 +815,7 @@ Update packages in both groups with a mix #2
       `git commit -m "chore: add version plans for fixed and independent groups again"`
     );
 
-    const releaseResult = runCLI('release major --verbose', {
+    const releaseResult = runCLI('release major --verbose --skip-publish', {
       silenceError: true,
     });
 

--- a/e2e/release/src/version-plans.test.ts
+++ b/e2e/release/src/version-plans.test.ts
@@ -819,11 +819,12 @@ Update packages in both groups with a mix #2
       silenceError: true,
     });
 
-    expect(releaseResult).toMatchInlineSnapshot(`
-      NX   A specifier option cannot be provided when using version plans.
-
-      To override this behavior, use the Nx Release programmatic API directly (https://nx.dev/features/manage-releases#using-the-programmatic-api-for-nx-release).
-    `);
+    expect(releaseResult).toContain(
+      `NX   A specifier option cannot be provided when using version plans.`
+    );
+    expect(releaseResult).toContain(
+      `To override this behavior, use the Nx Release programmatic API directly (https://nx.dev/features/manage-releases#using-the-programmatic-api-for-nx-release).`
+    );
 
     const versionResult = runCLI('release version major --verbose', {
       silenceError: true,

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -81,6 +81,7 @@ export type PlanCheckOptions = BaseNxReleaseArgs & {
 
 export type ReleaseOptions = NxReleaseArgs &
   FirstReleaseArgs & {
+    specifier?: string;
     yes?: boolean;
     skipPublish?: boolean;
   };

--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -94,6 +94,18 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       });
     }
 
+    const rawVersionPlans = await readRawVersionPlans();
+
+    if (args.specifier && rawVersionPlans.length > 0) {
+      output.error({
+        title: `A specifier option cannot be provided when using version plans.`,
+        bodyLines: [
+          `To override this behavior, use the Nx Release programmatic API directly (https://nx.dev/features/manage-releases#using-the-programmatic-api-for-nx-release).`,
+        ],
+      });
+      process.exit(1);
+    }
+
     // These properties must never be undefined as this command should
     // always explicitly override the git operations of the subcommands.
     const shouldCommit = userProvidedReleaseConfig.git?.commit ?? true;
@@ -134,7 +146,7 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       output.error(filterError);
       process.exit(1);
     }
-    const rawVersionPlans = await readRawVersionPlans();
+
     setResolvedVersionPlansOnGroups(
       rawVersionPlans,
       releaseGroups,

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -197,7 +197,7 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
         Object.keys(projectGraph.nodes)
       );
     } else {
-      if (args.verbose) {
+      if (args.verbose && releaseGroups.some((g) => !!g.versionPlans)) {
         console.log(
           `Skipping version plan discovery as a specifier was provided`
         );

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -189,12 +189,20 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       output.error(filterError);
       process.exit(1);
     }
-    const rawVersionPlans = await readRawVersionPlans();
-    setResolvedVersionPlansOnGroups(
-      rawVersionPlans,
-      releaseGroups,
-      Object.keys(projectGraph.nodes)
-    );
+    if (!args.specifier) {
+      const rawVersionPlans = await readRawVersionPlans();
+      setResolvedVersionPlansOnGroups(
+        rawVersionPlans,
+        releaseGroups,
+        Object.keys(projectGraph.nodes)
+      );
+    } else {
+      if (args.verbose) {
+        console.log(
+          `Skipping version plan discovery as a specifier was provided`
+        );
+      }
+    }
 
     if (args.deleteVersionPlans === undefined) {
       // default to not delete version plans after versioning as they may be needed for changelog generation


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Specifier overrides are implicitly allowed for the version and release commands.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Specifier overrides are explicitly allowed for the version subcommand, but not allowed for the release command.

```
// This will correctly override version plans, even if they are enabled
$ nx release version minor

// This is not allowed if version plans are enabled
$ nx release minor
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
