### PR TITLE
fix(testing): do not migrate cypress projects when webpack plugin is …

### DIFF
--- a/packages/cypress/src/migrations/update-19-6-0/update-ci-webserver-for-static-serve.ts
+++ b/packages/cypress/src/migrations/update-19-6-0/update-ci-webserver-for-static-serve.ts
@@ -101,12 +101,17 @@ export default async function (tree: Tree) {
           '@nx/webpack/plugin',
           pathToWebpackConfig
         );
-        const serveStaticTargetName = matchingWebpackPlugin
-          ? typeof matchingWebpackPlugin === 'string'
+
+        // Do not migrate project if no webpack plugin handles the config file
+        if (!matchingWebpackPlugin) {
+          continue;
+        }
+
+        const serveStaticTargetName =
+          typeof matchingWebpackPlugin === 'string'
             ? 'serve-static'
             : (matchingWebpackPlugin.options as any)?.serveStaticTargetName ??
-              'serve-static'
-          : 'serve-static';
+              'serve-static';
 
         const newCommand = ciWebServerCommand.replace(
           /nx.*[^"']/,


### PR DESCRIPTION
…not used

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The cypress migration migrates projects to use `serve-static` even if the project does not have a `serve-static` because `@nx/webpack/plugin` is not used.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The cypress migration does not migrate projects to use `serve-static` if they do not have `serve-static`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
