### PR TITLE
fix(testing): migrations should look for existing target before attempting migration

### DIFF
--- a/packages/playwright/src/migrations/update-19-6-0/use-serve-static-preview-for-command.ts
+++ b/packages/playwright/src/migrations/update-19-6-0/use-serve-static-preview-for-command.ts
@@ -5,6 +5,7 @@ import {
   getPackageManagerCommand,
   joinPathFragments,
   parseTargetString,
+  ProjectGraph,
   readNxJson,
   type Tree,
   visitNotIgnoredFiles,
@@ -110,22 +111,36 @@ export default async function (tree: Tree) {
       projectToMigrate.playwrightConfigFile,
       'utf-8'
     );
-    const targetName = await getServeStaticTargetNameForConfigFile(
-      tree,
-      projectToMigrate.configFileType === 'webpack'
-        ? '@nx/webpack/plugin'
-        : '@nx/vite/plugin',
-      projectToMigrate.configFile,
-      projectToMigrate.configFileType === 'webpack'
-        ? 'serve-static'
-        : 'preview',
-      projectToMigrate.configFileType === 'webpack'
-        ? 'serveStaticTargetName'
-        : 'previewTargetName',
-      projectToMigrate.configFileType === 'webpack'
-        ? webpackCreateNodesV2
-        : viteCreateNodesV2
-    );
+    const targetName =
+      (await getServeStaticTargetNameForConfigFile(
+        tree,
+        projectToMigrate.configFileType === 'webpack'
+          ? '@nx/webpack/plugin'
+          : '@nx/vite/plugin',
+        projectToMigrate.configFile,
+        projectToMigrate.configFileType === 'webpack'
+          ? 'serve-static'
+          : 'preview',
+        projectToMigrate.configFileType === 'webpack'
+          ? 'serveStaticTargetName'
+          : 'previewTargetName',
+        projectToMigrate.configFileType === 'webpack'
+          ? webpackCreateNodesV2
+          : viteCreateNodesV2
+      )) ??
+      getServeStaticLikeTarget(
+        tree,
+        graph,
+        projectToMigrate.projectName,
+        projectToMigrate.configFileType === 'webpack'
+          ? '@nx/web:file-server'
+          : '@nx/vite:preview-server'
+      );
+
+    if (!targetName) {
+      continue;
+    }
+
     const oldCommand = projectToMigrate.commandValueNode.getText();
     const newCommand = oldCommand.replace(
       /nx.*[^"']/,
@@ -225,10 +240,10 @@ async function getServeStaticTargetNameForConfigFile<T>(
   );
 
   if (!matchingPluginRegistrations) {
-    return defaultTargetName;
+    return undefined;
   }
 
-  let targetName = defaultTargetName;
+  let targetName = undefined;
   for (const plugin of matchingPluginRegistrations) {
     let projectConfigs: ConfigurationResult;
     try {
@@ -258,4 +273,23 @@ async function getServeStaticTargetNameForConfigFile<T>(
     }
   }
   return targetName;
+}
+
+function getServeStaticLikeTarget(
+  tree: Tree,
+  graph: ProjectGraph,
+  projectName: string,
+  executorName: string
+) {
+  if (!graph.nodes[projectName]?.data?.targets) {
+    return;
+  }
+
+  for (const [targetName, targetOptions] of Object.entries(
+    graph.nodes[projectName].data.targets
+  )) {
+    if (targetOptions.executor && targetOptions.executor === executorName) {
+      return targetName;
+    }
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Migrations are naively setting `serve-static` or `preview` as the target without checking if that target exists


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Check if the target exists based on executor usage as a last port of call, and use the name of the target it is found on

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes https://github.com/nrwl/nx/pull/27439
