### PR TITLE
fix(misc): ensure custom reporters are usable with @nx/playwright:playwright

### DIFF
--- a/docs/generated/packages/playwright/executors/playwright.json
+++ b/docs/generated/packages/playwright/executors/playwright.json
@@ -104,18 +104,7 @@
       },
       "reporter": {
         "type": "string",
-        "enum": [
-          "list",
-          "line",
-          "dot",
-          "json",
-          "junit",
-          "null",
-          "github",
-          "html",
-          "blob"
-        ],
-        "description": "Reporter to use, comma-separated, can be 'list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob'. To configure reporter options, use the playwright configuration."
+        "description": "Common Reporter values to use, comma-separated, 'list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob'. To configure reporter options, use the playwright configuration."
       },
       "retries": {
         "type": "number",

--- a/packages/playwright/src/executors/playwright/schema.json
+++ b/packages/playwright/src/executors/playwright/schema.json
@@ -105,7 +105,7 @@
     },
     "reporter": {
       "type": "string",
-      "enum": [
+      "items": [
         "list",
         "line",
         "dot",
@@ -116,7 +116,7 @@
         "html",
         "blob"
       ],
-      "description": "Reporter to use, comma-separated, can be 'list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob'. To configure reporter options, use the playwright configuration."
+      "description": "Common Reporter values to use, comma-separated, 'list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob'. To configure reporter options, use the playwright configuration."
     },
     "retries": {
       "type": "number",

--- a/packages/playwright/src/executors/playwright/schema.json
+++ b/packages/playwright/src/executors/playwright/schema.json
@@ -105,17 +105,6 @@
     },
     "reporter": {
       "type": "string",
-      "items": [
-        "list",
-        "line",
-        "dot",
-        "json",
-        "junit",
-        "null",
-        "github",
-        "html",
-        "blob"
-      ],
       "description": "Common Reporter values to use, comma-separated, 'list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob'. To configure reporter options, use the playwright configuration."
     },
     "retries": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Custom reporters are not usable because we enforce an enum on the schema

## Expected Behavior
Custom reporters can be specified

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
