### PR TITLE
Fix(webpack): If the style path is relative do not normalize

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-web-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-web-config.ts
@@ -22,8 +22,6 @@ import {
 import { instantiateScriptPlugins } from './instantiate-script-plugins';
 import CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 import MiniCssExtractPlugin = require('mini-css-extract-plugin');
-import { getDevServerOptions } from '../../../executors/dev-server/lib/get-dev-server-config';
-import { NormalizedWebpackExecutorOptions } from '../../../executors/webpack/schema';
 
 export function applyWebConfig(
   options: NormalizedNxAppWebpackPluginOptions,
@@ -114,7 +112,9 @@ export function applyWebConfig(
   // Process global styles.
   if (options.styles.length > 0) {
     normalizeExtraEntryPoints(options.styles, 'styles').forEach((style) => {
-      const resolvedPath = path.resolve(options.root, style.input);
+      const resolvedPath = style.input.startsWith('.')
+        ? style.input
+        : path.resolve(options.root, style.input);
       // Add style entry points.
       if (entries[style.bundleName]) {
         entries[style.bundleName].import.push(resolvedPath);


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When a style path is passed to the `NxAppWebpackPlugin` we normalize it to the `projectRoot`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When a style path is passed to the `NxAppWebpackPlugin` if it is already normalized i.e. it is relative to the project we should assume the path is correct.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
