### PR TITLE
fix(repo): add dependsOn to native build

### DIFF
--- a/graph/client/project.json
+++ b/graph/client/project.json
@@ -31,6 +31,7 @@
       }
     },
     "build-client": {
+      "dependsOn": ["nx:build-native"],
       "configurations": {
         "dev": {},
         "nx-console": {},


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx:build-native` updates the typings which `graph-client:build-client` uses. Not running it in the right order could result in a compilation error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx:build-native` updates the typings which `graph-client:build-client` uses so it depends on `nx:build-native`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
