### PR TITLE
fix(core): dynamically require string-width

### DIFF
--- a/package.json
+++ b/package.json
@@ -369,7 +369,7 @@
     "regenerator-runtime": "0.13.7",
     "send": "0.17.1",
     "shadergradient": "^1.2.14",
-    "string-width": "^4.2.3",
+    "string-width": "^7.2.0",
     "tailwind-merge": "^2.4.0",
     "tailwindcss": "3.4.4",
     "three": "^0.166.1",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -60,7 +60,7 @@
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",
     "semver": "^7.5.3",
-    "string-width": "^4.2.3",
+    "string-width": "^7.2.0",
     "tar-stream": "~2.2.0",
     "tmp": "~0.2.1",
     "tsconfig-paths": "^4.1.2",

--- a/packages/nx/src/utils/print-help.ts
+++ b/packages/nx/src/utils/print-help.ts
@@ -1,5 +1,4 @@
 import * as chalk from 'chalk';
-import * as stringWidth from 'string-width';
 import { logger } from './logger';
 import { output } from './output';
 import { Schema } from './params';
@@ -229,6 +228,8 @@ function generateOptionsOutput(schema: Schema): string {
       `--${optionName}` +
       (optionConfig.alias ? `, -${optionConfig.alias}` : '');
 
+    const { default: stringWidth } =
+      require('string-width') as typeof import('string-width');
     const renderedFlagAndAliasTrueWidth = stringWidth(renderedFlagAndAlias);
     if (
       renderedFlagAndAliasTrueWidth > requiredSpaceToRenderAllFlagsAndAliases

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^1.2.14
         version: 1.2.14(@react-spring/three@9.7.4(@react-three/fiber@8.17.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(react@18.3.1)(three@0.166.1))(@react-three/drei@9.112.0(@react-three/fiber@8.17.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(@types/react@18.3.1)(@types/three@0.166.0)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(@react-three/fiber@8.17.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(react@18.3.1)(three@0.166.1)
       string-width:
-        specifier: ^4.2.3
-        version: 4.2.3
+        specifier: ^7.2.0
+        version: 7.2.0
       tailwind-merge:
         specifier: ^2.4.0
         version: 2.5.2


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

On older versions of `yarn`, importing `string-width` has issues. Currently it's hit in `postinstall` which makes it hard to get past at all.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

On older versions of `yarn`, importing `string-width` has issues. This is now a dynamic require.. which.. may only be an issue when running `--help`. Needs further investigation but this limits the issue.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
