### PR TITLE
fix(core): fix Nx Cloud detection during CI script gen for backwards compatibility

### DIFF
--- a/packages/nx/src/utils/nx-cloud-utils.ts
+++ b/packages/nx/src/utils/nx-cloud-utils.ts
@@ -5,6 +5,7 @@ export function isNxCloudUsed(nxJson: NxJsonConfiguration): boolean {
     !!process.env.NX_CLOUD_ACCESS_TOKEN ||
     !!nxJson.nxCloudAccessToken ||
     !!nxJson.nxCloudId ||
+    !!nxJson.nxCloudUrl ||
     !!Object.values(nxJson.tasksRunnerOptions ?? {}).find(
       (r) => r.runner == '@nrwl/nx-cloud' || r.runner == 'nx-cloud'
     )


### PR DESCRIPTION
I ran into a situation where
- on `main` I had an older Nx version where I connected to Nx Cloud via the browser (e.g. generating a PR and merging)
- on `upgrade` branch I had already updated Nx, rebased with the Nx Cloud connected `main` branch (which had `nxCloudUrl` set
- generated a CI script

In this case `nxCloudUrl` was not recognized and thus didn't enable the distribution instruction + asked to use `nx connect` which I had already.

I think we should keep the `nxCloudUrl` part around for a little longer just to avoid such situations