### PR TITLE
fix(linter): update the @nx/dependency-checks rule to read the package.json content from the rule context

### DIFF
--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -478,13 +478,21 @@ describe('Linter', () => {
             `import { names } from '@nx/devkit';\n\n` +
             content.replace(/=> .*;/, `=> names('${mylib}').className;`)
         );
+        // intentionally set an obsolete dependency
+        updateJson(`libs/${mylib}/package.json`, (json) => {
+          json.dependencies['@nx/js'] = nxVersion;
+          return json;
+        });
 
-        // output should now report missing dependency
+        // output should now report missing dependency and obsolete dependency
         out = runCLI(`lint ${mylib}`, { silenceError: true });
         expect(out).toContain('they are missing');
         expect(out).toContain('@nx/devkit');
+        expect(out).toContain(
+          `The "@nx/js" package is not used by "${mylib}" project`
+        );
 
-        // should fix the missing dependency issue
+        // should fix the missing and obsolete dependency issues
         out = runCLI(`lint ${mylib} --fix`, { silenceError: true });
         expect(out).toContain(
           `Successfully ran target lint for project ${mylib}`

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -8,6 +8,7 @@ import { satisfies } from 'semver';
 import {
   getAllDependencies,
   getPackageJson,
+  getProductionDependencies,
 } from '../utils/package-json-utils';
 import { readProjectGraph } from '../utils/project-graph-utils';
 import {
@@ -152,11 +153,7 @@ export default ESLintUtils.RuleCreator(
     const expectedDependencyNames = Object.keys(npmDependencies);
 
     const packageJson = JSON.parse(context.sourceCode.getText());
-    const projPackageJsonDeps = {
-      ...packageJson.dependencies,
-      ...packageJson.peerDependencies,
-      ...packageJson.optionalDependencies,
-    };
+    const projPackageJsonDeps = getProductionDependencies(packageJson);
 
     const rootPackageJsonDeps = getAllDependencies(rootPackageJson);
 

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -8,7 +8,6 @@ import { satisfies } from 'semver';
 import {
   getAllDependencies,
   getPackageJson,
-  getProductionDependencies,
 } from '../utils/package-json-utils';
 import { readProjectGraph } from '../utils/project-graph-utils';
 import {
@@ -152,14 +151,13 @@ export default ESLintUtils.RuleCreator(
     );
     const expectedDependencyNames = Object.keys(npmDependencies);
 
-    const projPackageJsonPath = join(
-      workspaceRoot,
-      sourceProject.data.root,
-      'package.json'
-    );
+    const packageJson = JSON.parse(context.sourceCode.getText());
+    const projPackageJsonDeps = {
+      ...packageJson.dependencies,
+      ...packageJson.peerDependencies,
+      ...packageJson.optionalDependencies,
+    };
 
-    const projPackageJsonDeps: Record<string, string> =
-      getProductionDependencies(projPackageJsonPath);
     const rootPackageJsonDeps = getAllDependencies(rootPackageJson);
 
     function validateMissingDependencies(node: AST.JSONProperty) {

--- a/packages/eslint-plugin/src/utils/package-json-utils.ts
+++ b/packages/eslint-plugin/src/utils/package-json-utils.ts
@@ -1,7 +1,6 @@
 import { readJsonFile } from '@nx/devkit';
 import { existsSync } from 'fs';
-import { PackageJson } from 'nx/src/utils/package-json';
-import { isTerminalRun } from './runtime-lint-utils';
+import type { PackageJson } from 'nx/src/utils/package-json';
 
 export function getAllDependencies(
   packageJson: PackageJson
@@ -15,23 +14,13 @@ export function getAllDependencies(
 }
 
 export function getProductionDependencies(
-  packageJsonPath: string
+  packageJson: PackageJson
 ): Record<string, string> {
-  if (
-    !globalThis.projPackageJsonDeps ||
-    !globalThis.projPackageJsonDeps[packageJsonPath] ||
-    !isTerminalRun()
-  ) {
-    const packageJson = getPackageJson(packageJsonPath);
-    globalThis.projPackageJsonDeps = globalThis.projPackageJsonDeps || {};
-    globalThis.projPackageJsonDeps[packageJsonPath] = {
-      ...packageJson.dependencies,
-      ...packageJson.peerDependencies,
-      ...packageJson.optionalDependencies,
-    };
-  }
-
-  return globalThis.projPackageJsonDeps[packageJsonPath];
+  return {
+    ...packageJson.dependencies,
+    ...packageJson.peerDependencies,
+    ...packageJson.optionalDependencies,
+  };
 }
 
 export function getPackageJson(path: string): PackageJson {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/dependency-checks` rule sometimes doesn't apply all identified fixes and wrongly succeeds. ESLint performs multiple passes to try to apply fixes, and in each pass the rule receives the updated source code with the previously applied fixes. This allows merging different fixes, but the `@nx/dependency-checks` rule always reads the `package.json` file from the filesystem, caches it globally, and mutates it. It never uses the updated source code provided in the rule context.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/dependency-checks` rule should apply all identified fixes [as long as they don't conflict](https://eslint.org/docs/latest/extend/custom-rules#conflicting-fixes).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27412 
