### PR TITLE
fix(angular): module-federation-ssr-dev-server should call correct builder

### DIFF
--- a/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -25,7 +25,7 @@ import { createBuilderContext } from 'nx/src/adapter/ngcli-adapter';
 import { normalizeOptions } from './lib/normalize-options';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
 import { startSsrRemoteProxies } from '@nx/webpack/src/utils/module-federation/start-ssr-remote-proxies';
-import { executeDevServerBuilder } from '../../builders/dev-server/dev-server.impl';
+import { getInstalledAngularVersionInfo } from '../utilities/angular-version-utils';
 
 export async function* moduleFederationSsrDevServerExecutor(
   schema: Schema,
@@ -34,8 +34,14 @@ export async function* moduleFederationSsrDevServerExecutor(
   const nxBin = require.resolve('nx/bin/nx');
   const options = normalizeOptions(schema);
 
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo();
+  const { executeSSRDevServerBuilder } =
+    angularMajorVersion >= 17
+      ? require('@angular-devkit/build-angular')
+      : require('@nguniversal/builders');
+
   const currIter = eachValueFrom(
-    executeDevServerBuilder(
+    executeSSRDevServerBuilder(
       options,
       await createBuilderContext(
         {

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -167,8 +167,8 @@ export async function createBuilderContext(
     logger: getLogger(),
     id: 1,
     currentDirectory: process.cwd(),
-    scheduleTarget: architect.scheduleTarget,
-    scheduleBuilder: architect.scheduleBuilder,
+    scheduleTarget: (...args) => architect.scheduleTarget(...args),
+    scheduleBuilder: (...args) => architect.scheduleBuilder(...args),
     addTeardown(teardown: () => Promise<void> | void) {
       // No-op as Nx doesn't require an implementation of this function
       return;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`module-federation-ssr-dev-server` is calling `dev-server` builder instead of `ssr-dev-server` builder

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`module-federation-ssr-dev-server` calls the correct builder

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
