### PR TITLE
fix(node): build-esbuild-options.ts browser user define envs by config

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -49,7 +49,10 @@ export function buildEsbuildOptions(
   };
 
   if (options.platform === 'browser') {
-    esbuildOptions.define = getClientEnvironment();
+    esbuildOptions.define = {
+      ...getClientEnvironment(),
+      ...options.userDefinedBuildOptions?.define,
+    };
   }
 
   if (!esbuildOptions.outfile && !esbuildOptions.outdir) {


### PR DESCRIPTION
## Current Behavior
When you use esbuild in 'browser' mode you have to provide all 'define' attributes as environment variables and only with "NX_PUBLIC_" prefix

## Expected Behavior
Esbuild configuration has to work as it is described in docs. And prefix feature has to work as an additional functionality

## Related Issue(s)
This issue will be fixed: https://github.com/nrwl/nx/issues/19106
