### PR TITLE
docs(core): link blog to parallelism reference

### DIFF
--- a/docs/blog/2024-08-01-nx-19-5-update.md
+++ b/docs/blog/2024-08-01-nx-19-5-update.md
@@ -10,6 +10,8 @@ tags: [nx, release]
 
 In this blog post:
 
+- [Table of Contents](#table-of-contents)
+- [Video Summary](#video-summary)
 - [Announcing Nx Cloud Hobby Tier](#announcing-nx-cloud-hobby-tier)
 - [StackBlitz Support](#stackblitz-support)
 - [Bun and Pnpm v9 Support](#bun-and-pnpm-v9-support)
@@ -25,6 +27,7 @@ In this blog post:
 - [Support for React 19 (rc) and Angular 18.1](#support-for-react-19-rc-and-angular-181)
 - [Automatically Update Nx](#automatically-update-nx)
 - [Monorepo World Conference Speakers Announced!!](#monorepo-world-conference-speakers-announced)
+- [Learn more](#learn-more)
 
 ## Video Summary
 
@@ -142,7 +145,7 @@ To accommodate port collisions in end-to-end tests, we've long adjusted our gene
 
 Unfortunately, this approach is more imperative, as it instructs how to run and order your CI rather than defining what should be run. Additionally, these instructions cause `lint`, `test`, and `build` targets to run first and wait until they all complete before running `e2e-ci`, leading to inefficiencies.
 
-To address this, all tasks now support a `parallelism` property. By setting this property to `false`, you can instruct the Nx task runner not to run a specific task in parallel. This allows us to define parallelism as a task property, making our CI configuration more declarative.
+To address this, all tasks now support a [`parallelism` property](/reference/project-configuration#parallelism). By setting this property to `false`, you can instruct the Nx task runner not to run a specific task in parallel. This allows us to define parallelism as a task property, making our CI configuration more declarative.
 
 Both our `@nx/playwright` and `@nx/cypress` plugins will now automatically set `targetDefaults` for atomized tests to disable parallelism:
 


### PR DESCRIPTION
Link the parallelism blog post to the actual reference document.  Currently the blog post shows up in a search for `parallelism` but the actual reference does not.  This link can help while we work on the search.