### PR TITLE
fix(angular): tests on windows

### DIFF
--- a/packages/angular/src/generators/component-test/component-test.spec.ts
+++ b/packages/angular/src/generators/component-test/component-test.spec.ts
@@ -8,6 +8,7 @@ import { UnitTestRunner } from '../../utils/test-runners';
 import { componentGenerator } from '../component/component';
 import { generateTestLibrary } from '../utils/testing';
 import { componentTestGenerator } from './component-test';
+import { EOL } from 'node:os';
 
 jest.mock('@nx/cypress/src/utils/cypress-version');
 
@@ -226,7 +227,9 @@ describe(MyLibComponent.name, () => {
       skipFormat: true,
     });
     expect(
-      tree.read('my-lib/src/lib/my-lib/my-lib.component.cy.ts', 'utf-8')
+      tree
+        .read('my-lib/src/lib/my-lib/my-lib.component.cy.ts', 'utf-8')
+        .replaceAll(EOL, '\n')
     ).toEqual(expected);
 
     await componentTestGenerator(tree, {
@@ -237,7 +240,9 @@ describe(MyLibComponent.name, () => {
       skipFormat: true,
     });
     expect(
-      tree.read('my-lib/src/lib/my-lib/my-lib.component.cy.ts', 'utf-8')
+      tree
+        .read('my-lib/src/lib/my-lib/my-lib.component.cy.ts', 'utf-8')
+        .replaceAll(EOL, '\n')
     ).toEqual(expected);
   });
 });

--- a/packages/angular/src/generators/utils/storybook-ast/component-info.ts
+++ b/packages/angular/src/generators/utils/storybook-ast/component-info.ts
@@ -6,7 +6,7 @@ import {
   visitNotIgnoredFiles,
 } from '@nx/devkit';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
-import { basename, dirname, extname, join, relative, sep } from 'path';
+import { basename, dirname, extname, relative } from 'path';
 import type { Identifier, SourceFile, Statement } from 'typescript';
 import { getTsSourceFile } from '../../../utils/nx-devkit/ast-utils';
 import { getInstalledAngularVersionInfo } from '../version-utils';
@@ -261,7 +261,7 @@ function getComponentInfoFromDir(
 
   const componentImportPathChildren: string[] = [];
   visitNotIgnoredFiles(tree, dir, (filePath) => {
-    componentImportPathChildren.push(filePath);
+    componentImportPathChildren.push(normalizePath(filePath));
   });
 
   for (const candidateFile of componentImportPathChildren) {
@@ -273,10 +273,10 @@ function getComponentInfoFromDir(
       );
       if (content.match(classAndComponentRegex)) {
         path = candidateFile
-          .slice(0, candidateFile.lastIndexOf(sep))
-          .replace(join(moduleFolderPath), '.');
+          .slice(0, candidateFile.lastIndexOf('/'))
+          .replace(moduleFolderPath, '.');
         componentFileName = candidateFile.slice(
-          candidateFile.lastIndexOf(sep) + 1,
+          candidateFile.lastIndexOf('/') + 1,
           candidateFile.lastIndexOf('.')
         );
         break;

--- a/packages/angular/src/generators/utils/storybook-ast/component-info.ts
+++ b/packages/angular/src/generators/utils/storybook-ast/component-info.ts
@@ -6,7 +6,7 @@ import {
   visitNotIgnoredFiles,
 } from '@nx/devkit';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
-import { basename, dirname, extname, relative } from 'path';
+import { basename, dirname, extname, join, relative, sep } from 'path';
 import type { Identifier, SourceFile, Statement } from 'typescript';
 import { getTsSourceFile } from '../../../utils/nx-devkit/ast-utils';
 import { getInstalledAngularVersionInfo } from '../version-utils';
@@ -273,10 +273,10 @@ function getComponentInfoFromDir(
       );
       if (content.match(classAndComponentRegex)) {
         path = candidateFile
-          .slice(0, candidateFile.lastIndexOf('/'))
-          .replace(moduleFolderPath, '.');
+          .slice(0, candidateFile.lastIndexOf(sep))
+          .replace(join(moduleFolderPath), '.');
         componentFileName = candidateFile.slice(
-          candidateFile.lastIndexOf('/') + 1,
+          candidateFile.lastIndexOf(sep) + 1,
           candidateFile.lastIndexOf('.')
         );
         break;

--- a/packages/nx/src/generators/tree.spec.ts
+++ b/packages/nx/src/generators/tree.spec.ts
@@ -391,7 +391,7 @@ describe('tree', () => {
         tree.write('parent/child/child-file2.txt', 'new child content');
         tree.write('parent/new-child/new-child-file.txt', 'new child content');
 
-        expect(tree.children('parent')).toEqual([
+        expect(tree.children('parent').sort()).toEqual([
           'child',
           'new-child',
           'parent-file-with-write-options.txt',

--- a/packages/nx/src/generators/tree.spec.ts
+++ b/packages/nx/src/generators/tree.spec.ts
@@ -393,9 +393,9 @@ describe('tree', () => {
 
         expect(tree.children('parent')).toEqual([
           'child',
+          'new-child',
           'parent-file-with-write-options.txt',
           'parent-file.txt',
-          'new-child',
         ]);
         expect(tree.children('parent/child')).toEqual([
           'child-file.txt',

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -291,7 +291,10 @@ export class FsTree implements Tree {
       return !r?.isDeleted;
     });
     // Dedupe
-    return Array.from(new Set(res));
+    res = Array.from(new Set(res));
+    // in windows the result may not be sorted
+    res.sort();
+    return res;
   }
 
   listChanges(): FileChange[] {

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -291,10 +291,7 @@ export class FsTree implements Tree {
       return !r?.isDeleted;
     });
     // Dedupe
-    res = Array.from(new Set(res));
-    // in windows the result may not be sorted
-    res.sort();
-    return res;
+    return Array.from(new Set(res));
   }
 
   listChanges(): FileChange[] {


### PR DESCRIPTION
## Current Behavior
`nx test angular` fail on windows

## Expected Behavior
`nx test angular` to pass on windows

## notes
in `packages/angular/src/generators/utils/storybook-ast/component-info.ts` file I used `join(moduleFolderPath)` to convert it from always being `/` to be OS separator
there are two other options I can do, but I don't have enough knowledge to take the decision
1. to generate `moduleFolderPath` with OS separator instead of always `/`
2. to make `candidateFile` to always be `/`

## Related Issue(s)
it might Fixes #22248
because now I see that when a new file is added, it's added to the end of the tree, but when you reset it's then added to its place
also it explain why same code sometimes hit cache in windows, but miss cache on linux, as the returned result different between the OSs
this should make sure that the returned result is always the same