### PR TITLE
fix(module-federation): ensure shared packages can be shared from host #27162

### DIFF
--- a/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -127,9 +127,12 @@ export async function* moduleFederationDevServerExecutor(
   options.staticRemotesPort ??= remotes.staticRemotePort;
 
   // Set NX_MF_DEV_REMOTES for the Nx Runtime Library Control Plugin
-  process.env.NX_MF_DEV_REMOTES = JSON.stringify(
-    remotes.devRemotes.map((r) => (typeof r === 'string' ? r : r.remoteName))
-  );
+  process.env.NX_MF_DEV_REMOTES = JSON.stringify([
+    ...(remotes.devRemotes.map((r) =>
+      typeof r === 'string' ? r : r.remoteName
+    ) ?? []),
+    project.name,
+  ]);
 
   const staticRemotesConfig = parseStaticRemotesConfig(
     [...remotes.staticRemotes, ...remotes.dynamicRemotes],

--- a/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -123,7 +123,10 @@ export async function* moduleFederationSsrDevServerExecutor(
   );
 
   // Set NX_MF_DEV_REMOTES for the Nx Runtime Library Control Plugin
-  process.env.NX_MF_DEV_REMOTES = JSON.stringify(options.devRemotes);
+  process.env.NX_MF_DEV_REMOTES = JSON.stringify([
+    ...(options.devRemotes ?? []),
+    project.name,
+  ]);
 
   const devRemotes = await startRemotes(
     remotes.devRemotes,

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -332,9 +332,12 @@ export default async function* moduleFederationDevServer(
   options.staticRemotesPort ??= remotes.staticRemotePort;
 
   // Set NX_MF_DEV_REMOTES for the Nx Runtime Library Control Plugin
-  process.env.NX_MF_DEV_REMOTES = JSON.stringify(
-    remotes.devRemotes.map((r) => (typeof r === 'string' ? r : r.remoteName))
-  );
+  process.env.NX_MF_DEV_REMOTES = JSON.stringify([
+    ...(remotes.devRemotes.map((r) =>
+      typeof r === 'string' ? r : r.remoteName
+    ) ?? []),
+    p.name,
+  ]);
 
   const staticRemotesConfig = parseStaticRemotesConfig(
     [...remotes.staticRemotes, ...remotes.dynamicRemotes],

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -310,9 +310,12 @@ export default async function* moduleFederationSsrDevServer(
 
   options.staticRemotesPort ??= remotes.staticRemotePort;
 
-  process.env.NX_MF_DEV_REMOTES = JSON.stringify(
-    remotes.devRemotes.map((r) => (typeof r === 'string' ? r : r.remoteName))
-  );
+  process.env.NX_MF_DEV_REMOTES = JSON.stringify([
+    ...(remotes.devRemotes.map((r) =>
+      typeof r === 'string' ? r : r.remoteName
+    ) ?? []),
+    projectConfig.name,
+  ]);
 
   const staticRemotesConfig = parseStaticSsrRemotesConfig(
     [...remotes.staticRemotes, ...remotes.dynamicRemotes],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The host application is never set as a candidate to share packages from.
Particularly in angular, this causes issues with the injection context


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Host application should be a valid option for sharing packages

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27162
