### PR TITLE
fix(vite): load the correct config file from @nx/vite:test executor

### DIFF
--- a/docs/generated/packages/vite/executors/test.json
+++ b/docs/generated/packages/vite/executors/test.json
@@ -11,7 +11,7 @@
     "properties": {
       "configFile": {
         "type": "string",
-        "description": "The path to the local vitest config",
+        "description": "The path to the local vitest config, relative to the workspace root.",
         "x-completion-type": "file",
         "x-completion-glob": "@(vitest|vite).config@(.js|.ts)",
         "aliases": ["config"]

--- a/e2e/vue/src/vue-legacy.test.ts
+++ b/e2e/vue/src/vue-legacy.test.ts
@@ -1,0 +1,45 @@
+import { cleanupProject, newProject, runCLI, uniq } from '@nx/e2e/utils';
+
+describe('Vue Plugin (legacy)', () => {
+  let proj: string;
+
+  beforeAll(() => {
+    proj = newProject({
+      packages: ['@nx/vue'],
+      unsetProjectNameAndRootFormat: false,
+    });
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('should serve application in dev mode', async () => {
+    const app = uniq('app');
+
+    runCLI(
+      `generate @nx/vue:app ${app} --unitTestRunner=vitest --e2eTestRunner=playwright`,
+      { env: { NX_ADD_PLUGINS: 'false' } }
+    );
+    let result = runCLI(`test ${app}`);
+    expect(result).toContain(`Successfully ran target test for project ${app}`);
+
+    result = runCLI(`build ${app}`);
+    expect(result).toContain(
+      `Successfully ran target build for project ${app}`
+    );
+  }, 200_000);
+
+  it('should build library', async () => {
+    const lib = uniq('lib');
+
+    runCLI(
+      `generate @nx/vue:lib ${lib} --bundler=vite --unitTestRunner=vitest`,
+
+      { env: { NX_ADD_PLUGINS: 'false' } }
+    );
+
+    const result = runCLI(`build ${lib}`);
+    expect(result).toContain(
+      `Successfully ran target build for project ${lib}`
+    );
+  });
+});

--- a/packages/vite/src/executors/test/lib/utils.ts
+++ b/packages/vite/src/executors/test/lib/utils.ts
@@ -75,13 +75,10 @@ export async function getOptions(
     // This should not be needed as it's going to be set in vite.config.ts
     // but leaving it here in case someone did not migrate correctly
     root: resolved.config.root ?? root,
-    configFile: viteConfigPath,
+    config: viteConfigPath,
   };
 
-  return {
-    resolvedOptions: mergeConfig(resolved?.config?.['test'] ?? {}, settings),
-    plugins: resolved?.config?.plugins,
-  };
+  return mergeConfig(resolved?.config?.['test'] ?? {}, settings);
 }
 
 export function getOptionsAsArgv(obj: Record<string, any>): string[] {

--- a/packages/vite/src/executors/test/schema.json
+++ b/packages/vite/src/executors/test/schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "configFile": {
       "type": "string",
-      "description": "The path to the local vitest config",
+      "description": "The path to the local vitest config, relative to the workspace root.",
       "x-completion-type": "file",
       "x-completion-glob": "@(vitest|vite).config@(.js|.ts)",
       "aliases": ["config"]

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -19,7 +19,7 @@ export async function* vitestExecutor(
   // Allows ESM to be required in CJS modules. Vite will be published as ESM in the future.
   const { startVitest } = await loadVitestDynamicImport();
 
-  const { resolvedOptions, plugins } =
+  const resolvedOptions =
     (await getOptions(options, context, projectRoot)) ?? {};
 
   const watch = resolvedOptions['watch'] === true;
@@ -37,8 +37,7 @@ export async function* vitestExecutor(
   const ctx = await startVitest(
     resolvedOptions['mode'] ?? 'test',
     cliFilters,
-    resolvedOptions,
-    { plugins }
+    resolvedOptions
   );
 
   let hasErrors = false;

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -18,7 +18,7 @@ export function normalizeViteConfigFilePath(
   configFile?: string
 ): string | undefined {
   if (configFile) {
-    const normalized = joinPathFragments(configFile);
+    const normalized = joinPathFragments(contextRoot, configFile);
     if (!existsSync(normalized)) {
       throw new Error(
         `Could not find vite config at provided path "${normalized}".`


### PR DESCRIPTION
This PR ensures that we pass Vite config file to the programmatic `startTest` API from Vitest. It fixes the issue with plugins not loading as well as other issues with the config file not being used.

This mainly affects a custom `configFile` option being passed to the executor. The previous fix to additionally load in `plugins` via overrides is causing plugins to load twice when the Vite config file is picked up by Vitest (e.g. #27500).

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27500, #22001
