### PR TITLE
docs(webpack): present correct config file formats for inferred tasks

### DIFF
--- a/docs/generated/packages/webpack/documents/overview.md
+++ b/docs/generated/packages/webpack/documents/overview.md
@@ -49,9 +49,7 @@ The `@nx/webpack` plugin will create a task for any project that has a Webpack c
 - `webpack.config.js`
 - `webpack.config.ts`
 - `webpack.config.mjs`
-- `webpack.config.mts`
 - `webpack.config.cjs`
-- `webpack.config.cts`
 
 ### View Inferred Tasks
 

--- a/docs/shared/packages/webpack/plugin-overview.md
+++ b/docs/shared/packages/webpack/plugin-overview.md
@@ -49,9 +49,7 @@ The `@nx/webpack` plugin will create a task for any project that has a Webpack c
 - `webpack.config.js`
 - `webpack.config.ts`
 - `webpack.config.mjs`
-- `webpack.config.mts`
 - `webpack.config.cjs`
-- `webpack.config.cts`
 
 ### View Inferred Tasks
 


### PR DESCRIPTION
We're showing `.cts` and `.mts` files as supported, but Webpack CLI will not load them.

The language support is outlined here: https://webpack.js.org/configuration/configuration-languages/#typescript

This PR removes those extensions to match what our plugin actually infers from.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27438
