### PR TITLE
feat(js): add skipPackageManager option to build executors in order to skip generating "packageManager" entry in package.json

### DIFF
--- a/docs/generated/packages/next/executors/build.json
+++ b/docs/generated/packages/next/executors/build.json
@@ -61,6 +61,10 @@
         "default": false,
         "x-priority": "internal"
       },
+      "skipPackageManager": {
+        "type": "boolean",
+        "description": "Do not add a `packageManager` entry to the generated package.json file."
+      },
       "debug": {
         "type": "boolean",
         "description": "Enable Next.js debug build logging"

--- a/docs/generated/packages/remix/executors/build.json
+++ b/docs/generated/packages/remix/executors/build.json
@@ -31,6 +31,10 @@
         "description": "Generate a lockfile (e.g. package-lock.json) that matches the workspace lockfile to ensure package versions match.",
         "default": false
       },
+      "skipPackageManager": {
+        "type": "boolean",
+        "description": "Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option."
+      },
       "sourcemap": {
         "type": "boolean",
         "description": "Generate source maps for production.",

--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -50,6 +50,10 @@
       "includeDevDependenciesInPackageJson": {
         "description": "Include devDependencies in the generated package.json.",
         "type": "boolean"
+      },
+      "skipPackageManager": {
+        "type": "boolean",
+        "description": "Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option."
       }
     },
     "definitions": {},

--- a/docs/generated/packages/webpack/executors/webpack.json
+++ b/docs/generated/packages/webpack/executors/webpack.json
@@ -239,6 +239,10 @@
         "type": "boolean",
         "description": "Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated."
       },
+      "skipPackageManager": {
+        "type": "boolean",
+        "description": "Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option."
+      },
       "transformers": {
         "type": "array",
         "description": "List of TypeScript Compiler Transfomers Plugins.",

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -81,6 +81,7 @@ export default async function buildExecutor(
       target: context.targetName,
       root: context.root,
       isProduction: !options.includeDevDependenciesInPackageJson, // By default we remove devDependencies since this is a production build.
+      skipPackageManager: options.skipPackageManager,
     }
   );
 

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -58,6 +58,10 @@
       "default": false,
       "x-priority": "internal"
     },
+    "skipPackageManager": {
+      "type": "boolean",
+      "description": "Do not add a `packageManager` entry to the generated package.json file."
+    },
     "debug": {
       "type": "boolean",
       "description": "Enable Next.js debug build logging"

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -28,18 +28,19 @@ export interface FileReplacement {
 }
 
 export interface NextBuildBuilderOptions {
-  outputPath: string;
-  fileReplacements: FileReplacement[];
   assets?: any[];
-  nextConfig?: string;
   buildLibsFromSource?: boolean;
-  includeDevDependenciesInPackageJson?: boolean;
-  generateLockfile?: boolean;
-  watch?: boolean;
   debug?: boolean;
-  profile?: boolean;
   experimentalAppOnly?: boolean;
   experimentalBuildMode?: 'compile' | 'generate';
+  fileReplacements: FileReplacement[];
+  generateLockfile?: boolean;
+  includeDevDependenciesInPackageJson?: boolean;
+  nextConfig?: string;
+  outputPath: string;
+  profile?: boolean;
+  skipPackageManager?: boolean;
+  watch?: boolean;
 }
 
 export interface NextServeBuilderOptions {

--- a/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
@@ -697,6 +697,39 @@ describe('createPackageJson', () => {
       });
     });
 
+    it('should support skipping packageManager entry', () => {
+      spies.push(
+        jest
+          .spyOn(fs, 'existsSync')
+          .mockImplementation(
+            (path) =>
+              path === 'libs/lib1/package.json' || path === 'package.json'
+          )
+      );
+      spies.push(
+        jest
+          .spyOn(fileutilsModule, 'readJsonFile')
+          .mockImplementation((path) => {
+            if (path === 'package.json') {
+              return {
+                ...rootPackageJson(),
+                packageManager: 'yarn',
+              };
+            }
+            if (path === 'libs/lib1/package.json') {
+              return projectPackageJson();
+            }
+          })
+      );
+
+      expect(
+        createPackageJson('lib1', graph, {
+          root: '',
+          skipPackageManager: true,
+        }).packageManager
+      ).toBeUndefined();
+    });
+
     it('should replace packageManager if not in sync with root and show warning', () => {
       spies.push(
         jest.spyOn(fs, 'existsSync').mockImplementation((path) => {

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -38,6 +38,7 @@ export function createPackageJson(
     root?: string;
     isProduction?: boolean;
     helperDependencies?: string[];
+    skipPackageManager?: boolean;
   } = {},
   fileMap: ProjectFileMap = null
 ): PackageJson {
@@ -181,7 +182,7 @@ export function createPackageJson(
     packageJson.peerDependenciesMeta
   );
 
-  if (rootPackageJson.packageManager) {
+  if (rootPackageJson.packageManager && !options.skipPackageManager) {
     if (
       packageJson.packageManager &&
       packageJson.packageManager !== rootPackageJson.packageManager

--- a/packages/remix/src/executors/build/build.impl.ts
+++ b/packages/remix/src/executors/build/build.impl.ts
@@ -66,6 +66,7 @@ export default async function buildExecutor(
       target: context.targetName,
       root: context.root,
       isProduction: !options.includeDevDependenciesInPackageJson, // By default we remove devDependencies since this is a production build.
+      skipPackageManager: options.skipPackageManager,
     });
 
     // Update `package.json` to reflect how users should run the build artifacts

--- a/packages/remix/src/executors/build/schema.d.ts
+++ b/packages/remix/src/executors/build/schema.d.ts
@@ -1,7 +1,8 @@
 export interface RemixBuildSchema {
-  outputPath: string;
-  includeDevDependenciesInPackageJson?: boolean;
-  generatePackageJson?: boolean;
   generateLockfile?: boolean;
+  generatePackageJson?: boolean;
+  includeDevDependenciesInPackageJson?: boolean;
+  outputPath: string;
+  skipPackageManager?: boolean;
   sourcemap?: boolean;
 }

--- a/packages/remix/src/executors/build/schema.json
+++ b/packages/remix/src/executors/build/schema.json
@@ -28,6 +28,10 @@
       "description": "Generate a lockfile (e.g. package-lock.json) that matches the workspace lockfile to ensure package versions match.",
       "default": false
     },
+    "skipPackageManager": {
+      "type": "boolean",
+      "description": "Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option."
+    },
     "sourcemap": {
       "type": "boolean",
       "description": "Generate source maps for production.",

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -126,6 +126,7 @@ export async function* viteBuildExecutor(
         target: context.targetName,
         root: context.root,
         isProduction: !options.includeDevDependenciesInPackageJson, // By default we remove devDependencies since this is a production build.
+        skipPackageManager: options.skipPackageManager,
       }
     );
 

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -1,10 +1,11 @@
 export interface ViteBuildExecutorOptions {
-  outputPath?: string;
   buildLibsFromSource?: boolean;
-  skipTypeCheck?: boolean;
   configFile?: string;
-  watch?: boolean;
   generatePackageJson?: boolean;
   includeDevDependenciesInPackageJson?: boolean;
+  outputPath?: string;
+  skipPackageManager?: boolean;
+  skipTypeCheck?: boolean;
   tsConfig?: string;
+  watch?: boolean;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -59,6 +59,10 @@
     "includeDevDependenciesInPackageJson": {
       "description": "Include devDependencies in the generated package.json.",
       "type": "boolean"
+    },
+    "skipPackageManager": {
+      "type": "boolean",
+      "description": "Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option."
     }
   },
   "definitions": {},

--- a/packages/webpack/src/executors/webpack/schema.json
+++ b/packages/webpack/src/executors/webpack/schema.json
@@ -163,6 +163,10 @@
       "type": "boolean",
       "description": "Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated."
     },
+    "skipPackageManager": {
+      "type": "boolean",
+      "description": "Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option."
+    },
     "transformers": {
       "type": "array",
       "description": "List of TypeScript Compiler Transfomers Plugins.",

--- a/packages/webpack/src/plugins/generate-package-json-plugin.ts
+++ b/packages/webpack/src/plugins/generate-package-json-plugin.ts
@@ -18,6 +18,7 @@ const pluginName = 'GeneratePackageJsonPlugin';
 export class GeneratePackageJsonPlugin implements WebpackPluginInstance {
   constructor(
     private readonly options: {
+      skipPackageManager?: boolean;
       tsConfig: string;
       outputFileName: string;
       root: string;
@@ -65,6 +66,7 @@ export class GeneratePackageJsonPlugin implements WebpackPluginInstance {
               root: this.options.root,
               isProduction: true,
               helperDependencies: helperDependencies.map((dep) => dep.target),
+              skipPackageManager: this.options.skipPackageManager,
             }
           );
           packageJson.main = packageJson.main ?? this.options.outputFileName;

--- a/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
@@ -168,6 +168,10 @@ export interface NxAppWebpackPluginOptions {
    */
   scripts?: Array<ExtraEntryPointClass | string>;
   /**
+   * Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option.
+   */
+  skipPackageManager?: boolean;
+  /**
    * Skip type checking. Default is `false`.
    */
   skipTypeChecking?: boolean;


### PR DESCRIPTION
This PR adds `skipPackageManager` option to several build executors in order to disable generating the `packageManager` field in the resulting `package.json` file. This field may be problematic on different platforms so we want a way to work around it.

Affected executors:
- `@nx/webpack:webpack`
- `@nx/vite:build`
- `@nx/next:build`
- `@nx/remix:build`




<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27027
