### PR TITLE
docs(misc): update pinned logic + set pinned blog posts

### DIFF
--- a/docs/blog/2024-03-21-reliable-ci.md
+++ b/docs/blog/2024-03-21-reliable-ci.md
@@ -4,6 +4,7 @@ slug: 'reliable-ci-a-new-execution-model-fixing-both-flakiness-and-slowness'
 authors: [Victor Savkin]
 cover_image: '/blog/images/2024-03-21/featured_img.png'
 tags: [nx, nx-cloud, releases]
+pinned: true
 ---
 
 The proverbial slow and flaky CI isn’t the failure of the developers or even the testing tools. It’s the failure of the CI execution model we relied on for the last 20 years.

--- a/docs/blog/2024-07-29-explain-with-ai.md
+++ b/docs/blog/2024-07-29-explain-with-ai.md
@@ -4,6 +4,7 @@ slug: 'explain-with-ai'
 authors: ['Philip Fulcher']
 cover_image: '/blog/images/2024-07-29/explain-with-ai-header.avif'
 tags: [nx, nx-cloud, ai, release]
+pinned: true
 ---
 
 It's Friday, and you absolutely, positively have to deploy to production. But you can't get CI to pass your PR. What do you do? It's an inevitable part of your life as a developer, and you've built a collection of tools to deal with it: Google, MDN, Discord, ChatGPT. We've got one more tool for your toolbox: **"Explain with AI" for [Nx Cloud](/nx-cloud)**.

--- a/docs/blog/2024-08-01-nx-19-5-update.md
+++ b/docs/blog/2024-08-01-nx-19-5-update.md
@@ -4,6 +4,7 @@ slug: 'nx-19-5-adds-stackblitz-new-features-and-more'
 authors: ['Zack DeRose']
 cover_image: '/blog/images/2024-08-01/nx-19-5-thumbnail.png'
 tags: [nx, release]
+pinned: true
 ---
 
 ## Table of Contents

--- a/nx-dev/ui-blog/src/lib/blog-container.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-container.tsx
@@ -19,6 +19,7 @@ export interface BlogContainerProps {
   blogPosts: BlogPostDataEntry[];
   tags: string[];
 }
+
 let ALL_TOPICS = [
   {
     label: 'All',
@@ -63,6 +64,17 @@ let ALL_TOPICS = [
     heading: 'Tutorials',
   },
 ];
+
+// first five blog posts contain potentially pinned plus the last published ones. They
+// should be sorted by date (not just all pinned first)
+export function sortFirstFivePosts(
+  posts: BlogPostDataEntry[]
+): BlogPostDataEntry[] {
+  return posts
+    .slice(0, 5)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
 export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
   const searchParams = useSearchParams();
   const [filteredList, setFilteredList] = useState(blogPosts);
@@ -94,9 +106,7 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
   );
 
   function updateBlogPosts() {
-    setFirstFiveBlogs(
-      filteredList.slice(0, filteredList.length > 5 ? 5 : filteredList.length)
-    );
+    setFirstFiveBlogs(sortFirstFivePosts(filteredList));
     setRemainingBlogs(filteredList.length > 5 ? filteredList.slice(5) : []);
   }
 
@@ -138,7 +148,7 @@ function initializeFilters(
   const filterBy = searchParams.get('filterBy');
 
   const defaultState = {
-    initialFirstFive: blogPosts.slice(0, 5),
+    initialFirstFive: sortFirstFivePosts(blogPosts),
     initialRest: blogPosts.slice(5),
     initialSelectedFilterHeading: 'All Blogs',
     initialSelectedFilter: 'All',
@@ -153,7 +163,7 @@ function initializeFilters(
   const initialFilter = ALL_TOPICS.find((filter) => filter.value === filterBy);
 
   return {
-    initialFirstFive: result.slice(0, 5),
+    initialFirstFive: sortFirstFivePosts(result),
     initialRest: result.length > 5 ? result.slice(5) : [],
     initialSelectedFilterHeading: initialFilter?.heading || 'All Blogs',
     initialSelectedFilter: initialFilter?.value || 'All',


### PR DESCRIPTION
- pins the last relevant blog posts (e.g. AI + latest release blog post etc)
- adjusts the first 5 blog posts logic s.t. pinned don't always come first, but the 1st 5 are also sorted by their respective date