### PR TITLE
fix(nextjs): should not fail when running outside of nx cli

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -121,12 +121,17 @@ function withNx(
     const { PHASE_PRODUCTION_SERVER, PHASE_DEVELOPMENT_SERVER } = await import(
       'next/constants'
     );
-    // Two scenarios where we want to skip graph creation:
+    // Three scenarios where we want to skip graph creation:
     // 1. Running production server means the build is already done so we just need to start the Next.js server.
     // 2. During graph creation (i.e. create nodes), we won't have a graph to read, and it is not needed anyway since it's a build-time concern.
+    // 3. Running outside of Nx, we don't have a graph to read.
     //
     // NOTE: Avoid any `require(...)` or `import(...)` statements here. Development dependencies are not available at production runtime.
-    if (PHASE_PRODUCTION_SERVER === phase || global.NX_GRAPH_CREATION) {
+    if (
+      PHASE_PRODUCTION_SERVER === phase ||
+      global.NX_GRAPH_CREATION ||
+      !process.env.NX_TASK_TARGET_TARGET
+    ) {
       const { nx, ...validNextConfig } = _nextConfig;
       return {
         distDir: '.next',


### PR DESCRIPTION
fixes: #22450

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, if you run any next target outside of nx the build will fail because we only fallback for graph creation of if running prod server.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Targets should work if they are run outside of the Nx cli

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
