### PR TITLE
fix(react): assert test property is defined on webpack rule in nx-react-webpack-plugin

### DIFF
--- a/packages/react/plugins/nx-react-webpack-plugin/lib/apply-react-config.ts
+++ b/packages/react/plugins/nx-react-webpack-plugin/lib/apply-react-config.ts
@@ -101,7 +101,10 @@ function removeSvgLoaderIfPresent(
   config: Partial<WebpackOptionsNormalized | Configuration>
 ) {
   const svgLoaderIdx = config.module.rules.findIndex(
-    (rule) => typeof rule === 'object' && rule.test.toString().includes('svg')
+    (rule) =>
+      typeof rule === 'object' &&
+      typeof rule.test !== 'undefined' &&
+      rule.test.toString().includes('svg')
   );
   if (svgLoaderIdx === -1) return;
   config.module.rules.splice(svgLoaderIdx, 1);

--- a/packages/rspack/src/plugins/utils/apply-react-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-react-config.ts
@@ -47,7 +47,7 @@ function removeSvgLoaderIfPresent(
   config: Partial<RspackOptionsNormalized | Configuration>
 ) {
   const svgLoaderIdx = config.module.rules.findIndex(
-    (rule) => typeof rule === 'object' && rule.test.toString().includes('svg')
+    (rule) => typeof rule === 'object' && rule.test?.toString().includes('svg')
   );
   if (svgLoaderIdx === -1) return;
   config.module.rules.splice(svgLoaderIdx, 1);


### PR DESCRIPTION
The `removeSvgLoaderIfPresent` method in `apply-react-config.ts` iterates through each Webpack rule, calls `toString` on each `test` property, and checks for the presence of the string `"svg"` to see if any existing SVG plugins need to be removed.

Some of the Webpack rules in the config don't have the test property, and calling `toString` without asserting the test property is defined first throws type errors.

This commit introduces a very small change that simply asserts that `rule.test` is not `undefined` before calling `.toString()`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Running a React Webpack library with `svgr` enabled causes compilation errors.

<img width="1171" alt="Screenshot 2024-08-20 at 10 36 09 AM" src="https://github.com/user-attachments/assets/cb28d1ca-10d2-4d20-aa78-e69339a8273b">

<img width="487" alt="Screenshot 2024-08-20 at 10 39 28 AM" src="https://github.com/user-attachments/assets/c170e0d8-8674-43b0-97a3-a5dffd398c17">

## Expected Behavior
Enabling SVGR in the `NxReactWebpackPlugin` config should compile as normal.



## Related Issue(s)
N/A