### PR TITLE
fix(nextjs): Should be able to run custom server targets with swc

### DIFF
--- a/packages/next/src/utils/add-swc-to-custom-server.ts
+++ b/packages/next/src/utils/add-swc-to-custom-server.ts
@@ -6,7 +6,12 @@ import {
   readJson,
   updateJson,
 } from '@nx/devkit';
-import { swcCliVersion, swcCoreVersion, swcNodeVersion } from './versions';
+import {
+  swcCliVersion,
+  swcCoreVersion,
+  swcNodeVersion,
+  swcHelpersVersion,
+} from '@nx/js/src/utils/versions';
 import { addSwcConfig } from '@nx/js/src/utils/swc/add-swc-config';
 
 export function configureForSwc(tree: Tree, projectRoot: string) {
@@ -43,7 +48,9 @@ export function configureForSwc(tree: Tree, projectRoot: string) {
 function addSwcDependencies(tree: Tree) {
   return addDependenciesToPackageJson(
     tree,
-    {},
+    {
+      '@swc/helpers': swcHelpersVersion,
+    },
     {
       '@swc-node/register': swcNodeVersion,
       '@swc/cli': swcCliVersion,

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -7,8 +7,3 @@ export const lessLoader = '11.1.0';
 export const emotionServerVersion = '11.11.0';
 export const babelPluginStyledComponentsVersion = '1.10.7';
 export const tsLibVersion = '^2.3.0';
-
-export const swcCliVersion = '~0.1.62';
-export const swcCoreVersion = '~1.3.85';
-export const swcHelpersVersion = '~0.5.2';
-export const swcNodeVersion = '~1.8.0';


### PR DESCRIPTION
## Currently
When we installed swc from the Next.js generator it installed an older version that expected version of swc this caused the node & build generator to not work.

## Expected
With these changes the version will be in sync with what the `@nx/js:swc` executor is expecting. With that in mind the build should now work as expected and by extension the serve target for custom server as well.

fixes: #27222 