### PR TITLE
fix(react): handle more scenarios when collecting component props for generating stories

### DIFF
--- a/packages/react/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
+++ b/packages/react/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
@@ -721,6 +721,42 @@ export const Primary = {
   args: {
     name: '',
     displayAge: false,
+    style: '',
+  },
+};
+
+export const Heading: Story = {
+  args: {
+    name: '',
+    displayAge: false,
+    style: '',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+  },
+};
+"
+`;
+
+exports[`react:component-story default setup component with props should setup controls based on the component destructured props defined in an inline literal type 1`] = `
+"import type { Meta, StoryObj } from '@storybook/react';
+import { Test } from './test-ui-lib';
+
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta: Meta<typeof Test> = {
+  component: Test,
+  title: 'Test',
+};
+export default meta;
+type Story = StoryObj<typeof Test>;
+
+export const Primary = {
+  args: {
+    name: '',
+    displayAge: false,
   },
 };
 
@@ -737,7 +773,109 @@ export const Heading: Story = {
 "
 `;
 
-exports[`react:component-story default setup component with props should setup controls based on the component props 1`] = `
+exports[`react:component-story default setup component with props should setup controls based on the component destructured props without type 1`] = `
+"import type { Meta, StoryObj } from '@storybook/react';
+import { Test } from './test-ui-lib';
+
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta: Meta<typeof Test> = {
+  component: Test,
+  title: 'Test',
+};
+export default meta;
+type Story = StoryObj<typeof Test>;
+
+export const Primary = {
+  args: {
+    name: '',
+    displayAge: '',
+  },
+};
+
+export const Heading: Story = {
+  args: {
+    name: '',
+    displayAge: '',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+  },
+};
+"
+`;
+
+exports[`react:component-story default setup component with props should setup controls based on the component props defined in a literal type 1`] = `
+"import type { Meta, StoryObj } from '@storybook/react';
+import { Test } from './test-ui-lib';
+
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta: Meta<typeof Test> = {
+  component: Test,
+  title: 'Test',
+};
+export default meta;
+type Story = StoryObj<typeof Test>;
+
+export const Primary = {
+  args: {
+    name: '',
+    displayAge: false,
+  },
+};
+
+export const Heading: Story = {
+  args: {
+    name: '',
+    displayAge: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+  },
+};
+"
+`;
+
+exports[`react:component-story default setup component with props should setup controls based on the component props defined in an inline literal type 1`] = `
+"import type { Meta, StoryObj } from '@storybook/react';
+import { Test } from './test-ui-lib';
+
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta: Meta<typeof Test> = {
+  component: Test,
+  title: 'Test',
+};
+export default meta;
+type Story = StoryObj<typeof Test>;
+
+export const Primary = {
+  args: {
+    name: '',
+    displayAge: false,
+  },
+};
+
+export const Heading: Story = {
+  args: {
+    name: '',
+    displayAge: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+  },
+};
+"
+`;
+
+exports[`react:component-story default setup component with props should setup controls based on the component props defined in an interface 1`] = `
 "import type { Meta, StoryObj } from '@storybook/react';
 import { Test } from './test-ui-lib';
 

--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -126,24 +126,16 @@ describe('react:component-story', () => {
     });
 
     describe('component with props', () => {
-      beforeEach(async () => {
+      it('should setup controls based on the component props defined in an interface', async () => {
         appTree.write(
           cmpPath,
-          `import React from 'react';
-
-          import './test.scss';
-
-          export interface TestProps {
+          `export interface TestProps {
             name: string;
             displayAge: boolean;
           }
 
           export const Test = (props: TestProps) => {
-            return (
-              <div>
-                <h1>Welcome to test component, {props.name}</h1>
-              </div>
-            );
+            return <h1>Welcome to test component, {props.name}</h1>;
           };
 
           export default Test;
@@ -154,9 +146,88 @@ describe('react:component-story', () => {
           componentPath: 'lib/test-ui-lib.tsx',
           project: 'test-ui-lib',
         });
+
+        expect(appTree.read(storyFilePath, 'utf-8')).toMatchSnapshot();
       });
 
-      it('should setup controls based on the component props', () => {
+      it('should setup controls based on the component props defined in a literal type', async () => {
+        appTree.write(
+          cmpPath,
+          `export type TestProps = {
+            name: string;
+            displayAge: boolean;
+          }
+
+          export const Test = (props: TestProps) => {
+            return <h1>Welcome to test component, {props.name}</h1>;
+          };
+
+          export default Test;
+          `
+        );
+
+        await componentStoryGenerator(appTree, {
+          componentPath: 'lib/test-ui-lib.tsx',
+          project: 'test-ui-lib',
+        });
+
+        expect(appTree.read(storyFilePath, 'utf-8')).toMatchSnapshot();
+      });
+
+      it('should setup controls based on the component props defined in an inline literal type', async () => {
+        appTree.write(
+          cmpPath,
+          `export const Test = (props: { name: string; displayAge: boolean }) => {
+            return <h1>Welcome to test component, {props.name}</h1>;
+          };
+
+          export default Test;
+          `
+        );
+
+        await componentStoryGenerator(appTree, {
+          componentPath: 'lib/test-ui-lib.tsx',
+          project: 'test-ui-lib',
+        });
+
+        expect(appTree.read(storyFilePath, 'utf-8')).toMatchSnapshot();
+      });
+
+      it('should setup controls based on the component destructured props defined in an inline literal type', async () => {
+        appTree.write(
+          cmpPath,
+          `export const Test = ({ name, displayAge }: { name: string; displayAge: boolean }) => {
+            return <h1>Welcome to test component, {props.name}</h1>;
+          };
+
+          export default Test;
+          `
+        );
+
+        await componentStoryGenerator(appTree, {
+          componentPath: 'lib/test-ui-lib.tsx',
+          project: 'test-ui-lib',
+        });
+
+        expect(appTree.read(storyFilePath, 'utf-8')).toMatchSnapshot();
+      });
+
+      it('should setup controls based on the component destructured props without type', async () => {
+        appTree.write(
+          cmpPath,
+          `export const Test = ({ name, displayAge }) => {
+            return <h1>Welcome to test component, {props.name}</h1>;
+          };
+
+          export default Test;
+          `
+        );
+
+        await componentStoryGenerator(appTree, {
+          componentPath: 'lib/test-ui-lib.tsx',
+          project: 'test-ui-lib',
+        });
+
         expect(appTree.read(storyFilePath, 'utf-8')).toMatchSnapshot();
       });
     });

--- a/packages/react/src/generators/component-story/component-story.ts
+++ b/packages/react/src/generators/component-story/component-story.ts
@@ -11,7 +11,7 @@ import {
   findExportDeclarationsForJsx,
   getComponentNode,
 } from '../../utils/ast-utils';
-import { getDefaultsForComponent } from '../../utils/component-props';
+import { getComponentPropDefaults } from '../../utils/component-props';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
 
 let tsModule: typeof import('typescript');
@@ -108,7 +108,7 @@ export function findPropsAndGenerateFile(
   isPlainJs: boolean,
   fromNodeArray?: boolean
 ) {
-  const { propsTypeName, props, argTypes } = getDefaultsForComponent(
+  const { props, argTypes } = getComponentPropDefaults(
     sourceFile,
     cmpDeclaration
   );
@@ -123,7 +123,6 @@ export function findPropsAndGenerateFile(
         ? `${name}--${(cmpDeclaration as any).name.text}`
         : name,
       componentImportFileName: name,
-      propsTypeName,
       props,
       argTypes,
       componentName: (cmpDeclaration as any).name.text,

--- a/packages/react/src/generators/component-test/__snapshots__/component-test.spec.ts.snap
+++ b/packages/react/src/generators/component-test/__snapshots__/component-test.spec.ts.snap
@@ -138,6 +138,36 @@ describe(AnotherCmp.name, () => {
 "
 `;
 
+exports[`componentTestGenerator single component per file should handle destructured props with no type 1`] = `
+"import * as React from 'react'
+import { AnotherCmp } from './some-lib'
+
+
+describe(AnotherCmp.name, () => {
+  let props: {
+handleClick: unknown;
+text: unknown;
+count: unknown;
+isOkay: unknown;
+};
+
+  beforeEach(() => {
+    props = {
+      handleClick: '',
+      text: '',
+      count: '',
+      isOkay: '',
+    }
+  })
+
+  it('renders', () => {
+    cy.mount(<AnotherCmp {...props}/>)
+  })
+})
+
+"
+`;
+
 exports[`componentTestGenerator single component per file should handle named exports 1`] = `
 "import * as React from 'react'
 import { AnotherCmpProps, AnotherCmp } from './some-lib'
@@ -184,6 +214,36 @@ import { AnotherCmpProps, AnotherCmp } from './some-lib'
 
 describe(AnotherCmp.name, () => {
   let props: AnotherCmpProps;
+
+  beforeEach(() => {
+    props = {
+      text: '',
+      count: 0,
+      isOkay: false,
+      handleClick: undefined
+    }
+  })
+
+  it('renders', () => {
+    cy.mount(<AnotherCmp {...props}/>)
+  })
+})
+
+"
+`;
+
+exports[`componentTestGenerator single component per file should handle props with inline type 1`] = `
+"import * as React from 'react'
+import { AnotherCmp } from './some-lib'
+
+
+describe(AnotherCmp.name, () => {
+  let props: {
+  handleClick: () => void;
+  text: string;
+  count: number;
+  isOkay: boolean;
+};
 
   beforeEach(() => {
     props = {

--- a/packages/react/src/generators/component-test/component-test.spec.ts
+++ b/packages/react/src/generators/component-test/component-test.spec.ts
@@ -321,6 +321,79 @@ export function AnotherCmp(props: AnotherCmpProps) {
         tree.read('some-lib/src/lib/some-lib.cy.tsx', 'utf-8')
       ).toMatchSnapshot();
     });
+
+    it('should handle props with inline type', async () => {
+      mockedAssertMinimumCypressVersion.mockReturnValue();
+      await libraryGenerator(tree, {
+        linter: Linter.EsLint,
+        name: 'some-lib',
+        skipFormat: true,
+        skipTsConfig: false,
+        style: 'scss',
+        unitTestRunner: 'none',
+        component: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
+
+      tree.write(
+        'some-lib/src/lib/some-lib.tsx',
+        `export function AnotherCmp(props: {
+  handleClick: () => void;
+  text: string;
+  count: number;
+  isOkay: boolean;
+}) {
+ return <button onClick='{handleClick}'>{props.text}</button>;
+}
+`
+      );
+      await componentTestGenerator(tree, {
+        project: 'some-lib',
+        componentPath: 'some-lib/src/lib/some-lib.tsx',
+      });
+
+      expect(tree.exists('some-lib/src/lib/some-lib.cy.tsx')).toBeTruthy();
+      expect(
+        tree.read('some-lib/src/lib/some-lib.cy.tsx', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should handle destructured props with no type', async () => {
+      mockedAssertMinimumCypressVersion.mockReturnValue();
+      await libraryGenerator(tree, {
+        linter: Linter.EsLint,
+        name: 'some-lib',
+        skipFormat: true,
+        skipTsConfig: false,
+        style: 'scss',
+        unitTestRunner: 'none',
+        component: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
+
+      tree.write(
+        'some-lib/src/lib/some-lib.tsx',
+        `export function AnotherCmp({
+  handleClick,
+  text,
+  count,
+  isOkay,
+}) {
+ return <button onClick='{handleClick}'>{props.text}</button>;
+}
+`
+      );
+      await componentTestGenerator(tree, {
+        project: 'some-lib',
+        componentPath: 'some-lib/src/lib/some-lib.tsx',
+      });
+
+      expect(tree.exists('some-lib/src/lib/some-lib.cy.tsx')).toBeTruthy();
+      expect(
+        tree.read('some-lib/src/lib/some-lib.cy.tsx', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
     it('should handle no props', async () => {
       // this is the default behavior of the library component generator
       mockedAssertMinimumCypressVersion.mockReturnValue();

--- a/packages/react/src/generators/component-test/component-test.ts
+++ b/packages/react/src/generators/component-test/component-test.ts
@@ -10,7 +10,7 @@ import {
   findExportDeclarationsForJsx,
   getComponentNode,
 } from '../../utils/ast-utils';
-import { getDefaultsForComponent } from '../../utils/component-props';
+import { getComponentPropDefaults } from '../../utils/component-props';
 import { nxVersion } from '../../utils/versions';
 import { ComponentTestSchema } from './schema';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
@@ -72,7 +72,7 @@ function generateSpecsForComponents(tree: Tree, filePath: string) {
 
   if (cmpNodes?.length) {
     const components = cmpNodes.map((cmp) => {
-      const defaults = getDefaultsForComponent(sourceFile, cmp);
+      const defaults = getComponentPropDefaults(sourceFile, cmp);
       const isDefaultExport = defaultExport
         ? (defaultExport as any).name.text === (cmp as any).name.text
         : false;
@@ -81,6 +81,7 @@ function generateSpecsForComponents(tree: Tree, filePath: string) {
         props: [...defaults.props, ...defaults.argTypes],
         name: (cmp as any).name.text as string,
         typeName: defaults.propsTypeName,
+        inlineTypeString: defaults.inlineTypeString,
       };
     });
     const namedImports = components

--- a/packages/react/src/generators/component-test/files/__fileName__.cy__ext__
+++ b/packages/react/src/generators/component-test/files/__fileName__.cy__ext__
@@ -2,8 +2,8 @@ import * as React from 'react'
 <%- importStatement %>
 
 <% for (let cmp of components) { %>
-describe(<%= cmp.name %>.name, () => {<% if (cmp.typeName) { %>
-  let props: <%= cmp.typeName%>;
+describe(<%= cmp.name %>.name, () => {<% if (cmp.props.length > 0) { %>
+  let props: <% if (cmp.typeName) { %><%= cmp.typeName %><% } else if (cmp.inlineTypeString) { %><%- cmp.inlineTypeString %><% } else { %>unknown<% } %>;
 
   beforeEach(() => {
     props = {<% for (let prop of cmp.props) { %>

--- a/packages/react/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
+++ b/packages/react/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
@@ -15,11 +15,15 @@ export default meta;
 type Story = StoryObj<typeof NxWelcome>;
 
 export const Primary = {
-  args: {},
+  args: {
+    title: '',
+  },
 };
 
 export const Heading: Story = {
-  args: {},
+  args: {
+    title: '',
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     expect(canvas.getByText(/Welcome to NxWelcome!/gi)).toBeTruthy();
@@ -74,7 +78,9 @@ export default meta;
 type Story = StoryObj<typeof NxWelcome>;
 
 export const Primary = {
-  args: {},
+  args: {
+    title: '',
+  },
 };
 "
 `;

--- a/packages/react/src/utils/ast-utils.spec.ts
+++ b/packages/react/src/utils/ast-utils.spec.ts
@@ -592,3 +592,221 @@ describe('getComponentNode', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('parseComponentPropsInfo', () => {
+  it('should parse props from a function with typed props using an interface', () => {
+    const sourceCode = `export interface TestProps {
+      name: string;
+      age: number;
+    }
+    export function Test(props: TestProps) {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[1]);
+
+    expect(result.props.length).toBe(2);
+    expect(result.props[0].name.getText()).toBe('name');
+    expect((result.props[0] as ts.PropertySignature).type.getText()).toBe(
+      'string'
+    );
+    expect(result.props[1].name.getText()).toBe('age');
+    expect((result.props[1] as ts.PropertySignature).type.getText()).toBe(
+      'number'
+    );
+    expect(result.propsTypeName).toBe('TestProps');
+    expect(result.inlineTypeString).toBeNull();
+  });
+
+  it('should parse props from a function with destructured typed props using an interface', () => {
+    const sourceCode = `export interface TestProps {
+      name: string;
+      age: number;
+    }
+    export function Test({ name, age }: TestProps) {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[1]);
+
+    expect(result.props.length).toBe(2);
+    expect(result.props[0].name.getText()).toBe('name');
+    expect((result.props[0] as ts.PropertySignature).type.getText()).toBe(
+      'string'
+    );
+    expect(result.props[1].name.getText()).toBe('age');
+    expect((result.props[1] as ts.PropertySignature).type.getText()).toBe(
+      'number'
+    );
+    expect(result.propsTypeName).toBe('TestProps');
+    expect(result.inlineTypeString).toBeNull();
+  });
+
+  it('should parse props from a function with typed props using a literal type', () => {
+    const sourceCode = `export type TestProps = {
+      name: string;
+      age: number;
+    }
+    export function Test(props: TestProps) {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[1]);
+
+    expect(result.props.length).toBe(2);
+    expect(result.props[0].name.getText()).toBe('name');
+    expect((result.props[0] as ts.PropertySignature).type.getText()).toBe(
+      'string'
+    );
+    expect(result.props[1].name.getText()).toBe('age');
+    expect((result.props[1] as ts.PropertySignature).type.getText()).toBe(
+      'number'
+    );
+    expect(result.propsTypeName).toBe('TestProps');
+    expect(result.inlineTypeString).toBeNull();
+  });
+
+  it('should parse props from a function with destructured typed props using a literal type', () => {
+    const sourceCode = `export type TestProps = {
+      name: string;
+      age: number;
+    }
+    export function Test({ name, age }: TestProps) {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[1]);
+
+    expect(result.props.length).toBe(2);
+    expect(result.props[0].name.getText()).toBe('name');
+    expect((result.props[0] as ts.PropertySignature).type.getText()).toBe(
+      'string'
+    );
+    expect(result.props[1].name.getText()).toBe('age');
+    expect((result.props[1] as ts.PropertySignature).type.getText()).toBe(
+      'number'
+    );
+    expect(result.propsTypeName).toBe('TestProps');
+    expect(result.inlineTypeString).toBeNull();
+  });
+
+  it('should parse props from a function with typed props using an inline type', () => {
+    const sourceCode = `export function Test(props: { name: string; age: number }) {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[0]);
+
+    expect(result).toBeDefined();
+    expect(result.props.length).toBe(2);
+    expect(result.props[0].name.getText()).toBe('name');
+    expect((result.props[0] as ts.PropertySignature).type.getText()).toBe(
+      'string'
+    );
+    expect(result.props[1].name.getText()).toBe('age');
+    expect((result.props[1] as ts.PropertySignature).type.getText()).toBe(
+      'number'
+    );
+    expect(result.propsTypeName).toBeNull();
+    expect(result.inlineTypeString).toMatchInlineSnapshot(
+      `"{ name: string; age: number }"`
+    );
+  });
+
+  it('should parse props from a function with destructured typed props using an inline type', () => {
+    const sourceCode = `export function Test({ name, age }: { name: string; age: number }) {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[0]);
+
+    expect(result.props.length).toBe(2);
+    expect(result.props[0].name.getText()).toBe('name');
+    expect((result.props[0] as ts.PropertySignature).type.getText()).toBe(
+      'string'
+    );
+    expect(result.props[1].name.getText()).toBe('age');
+    expect((result.props[1] as ts.PropertySignature).type.getText()).toBe(
+      'number'
+    );
+    expect(result.propsTypeName).toBeNull();
+    expect(result.inlineTypeString).toMatchInlineSnapshot(
+      `"{ name: string; age: number }"`
+    );
+  });
+
+  it('should parse props from a function with no type', () => {
+    const sourceCode = `export function Test({ name, age }) {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[0]);
+
+    expect(result.props.length).toBe(2);
+    expect(result.props[0].name.getText()).toBe('name');
+    expect(result.props[1].name.getText()).toBe('age');
+    expect(result.propsTypeName).toBeNull();
+    expect(result.inlineTypeString).toMatchInlineSnapshot(`
+      "{
+      name: unknown;
+      age: unknown;
+      }"
+    `);
+  });
+
+  it('should return null when the props are not destructured and have not type', () => {
+    const sourceCode = `export function Test(props) {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[0]);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when there are no props', () => {
+    const sourceCode = `export function Test() {}`;
+    const source = ts.createSourceFile(
+      'some-component.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = utils.parseComponentPropsInfo(source, source.statements[0]);
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Stories generation for React components only handles components receiving a `props` argument typed with an `Interface`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Stories generation for React components should handle receiving the props with any name or as a destructured object and typed with an `Interface`, a type literal definition, or an inline type literal. In case it's a destructured object, it also supports having no type, in which case the story args will have those properties with type `unknown`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22053 
