### PR TITLE
fix(vite): add typecheck inferred target for vite plugin #27501

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -35,7 +35,8 @@
     "@swc/helpers": "~0.5.0",
     "enquirer": "~2.3.6",
     "@nx/js": "file:../js",
-    "tsconfig-paths": "^4.1.2"
+    "tsconfig-paths": "^4.1.2",
+    "minimatch": "9.0.3"
   },
   "peerDependencies": {
     "vite": "^5.0.0",

--- a/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -533,6 +533,20 @@ describe('Vite - Convert Executors To Plugin', () => {
           },
           {
             "include": [
+              "existing/**/*",
+            ],
+            "options": {
+              "buildTargetName": "build",
+              "previewTargetName": "preview",
+              "serveStaticTargetName": "serve-static",
+              "serveTargetName": "serve",
+              "testTargetName": "test",
+              "typecheckTargetName": "typecheck",
+            },
+            "plugin": "@nx/vite/plugin",
+          },
+          {
+            "include": [
               "myapp/**/*",
               "second/**/*",
             ],
@@ -542,6 +556,7 @@ describe('Vite - Convert Executors To Plugin', () => {
               "serveStaticTargetName": "serve-static",
               "serveTargetName": "serve",
               "testTargetName": "test",
+              "typecheckTargetName": "typecheck",
             },
             "plugin": "@nx/vite/plugin",
           },
@@ -555,6 +570,7 @@ describe('Vite - Convert Executors To Plugin', () => {
               "serveStaticTargetName": "serve-static",
               "serveTargetName": "serve",
               "testTargetName": "test",
+              "typecheckTargetName": "typecheck",
             },
             "plugin": "@nx/vite/plugin",
           },

--- a/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -47,6 +47,28 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
                 "{projectRoot}/coverage",
               ],
             },
+            "typecheck": {
+              "cache": true,
+              "command": "tsc --noEmit",
+              "inputs": [
+                "production",
+                "^production",
+              ],
+              "metadata": {
+                "description": "Run Typechecking",
+                "help": {
+                  "command": "npx tsc --help -p tsconfig.lib.json",
+                  "example": {
+                    "options": {
+                      "noEmit": true,
+                    },
+                  },
+                },
+              },
+              "options": {
+                "cwd": ".",
+              },
+            },
           },
         },
       },

--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -47,6 +47,28 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
                 "{projectRoot}/coverage",
               ],
             },
+            "typecheck": {
+              "cache": true,
+              "command": "tsc --noEmit",
+              "inputs": [
+                "production",
+                "^production",
+              ],
+              "metadata": {
+                "description": "Run Typechecking",
+                "help": {
+                  "command": "npx tsc --help -p tsconfig.lib.json",
+                  "example": {
+                    "options": {
+                      "noEmit": true,
+                    },
+                  },
+                },
+              },
+              "options": {
+                "cwd": ".",
+              },
+            },
           },
         },
       },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Vite intentionally does not run typechecking on projects. They recommend running `tsc --noEmit` separately.
The `@nx/vite/plugin` could make this easier by adding a `typecheck` when it detects a `tsconfig` file in the `projectRoot`.
This can then be added to the build pipeline on CI. Or users can add it to a `dependsOn` for the `build` target if they wish.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `@nx/vite/plugin` could make this easier by adding a `typecheck` when it detects a `tsconfig` file in the `projectRoot`.
This can then be added to the build pipeline on CI. Or users can add it to a `dependsOn` for the `build` target if they wish.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27501 
