### PR TITLE
feat(bundling): add option to generate sourcemaps for Rollup build

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -158,7 +158,8 @@
         "type": "boolean",
         "description": "Prevents 'type' field from being added to compiled package.json file. Use this if you are having an issue with this field.",
         "default": false
-      }
+      },
+      "sourceMap": { "description": "Output sourcemaps.", "type": "boolean" }
     },
     "required": ["tsConfig", "main", "outputPath"],
     "definitions": {

--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -103,7 +103,7 @@ describe('Rollup Plugin', () => {
     expect(output).toMatch(/Hello/);
   }, 500000);
 
-  it('should support additional entry-points', async () => {
+  it('should support additional entry-points and sourcemaps', async () => {
     const myPkg = uniq('my-pkg');
     runCLI(`generate @nx/js:lib ${myPkg} --bundler=none`);
     runCLI(
@@ -120,7 +120,8 @@ describe('Rollup Plugin', () => {
         compiler: 'tsc',
         generateExportsField: true,
         additionalEntryPoints: ['./src/{foo,bar}.ts'],
-        format: ['cjs', 'esm']
+        format: ['cjs', 'esm'],
+        sourceMap: true,
       });
     `
     );
@@ -131,12 +132,18 @@ describe('Rollup Plugin', () => {
     runCLI(`build ${myPkg}`);
 
     checkFilesExist(`dist/libs/${myPkg}/index.esm.js`);
+    checkFilesExist(`dist/libs/${myPkg}/index.esm.js.map`);
     checkFilesExist(`dist/libs/${myPkg}/index.cjs.js`);
+    checkFilesExist(`dist/libs/${myPkg}/index.cjs.js.map`);
     checkFilesExist(`dist/libs/${myPkg}/index.cjs.d.ts`);
     checkFilesExist(`dist/libs/${myPkg}/foo.esm.js`);
+    checkFilesExist(`dist/libs/${myPkg}/foo.esm.js.map`);
     checkFilesExist(`dist/libs/${myPkg}/foo.cjs.js`);
+    checkFilesExist(`dist/libs/${myPkg}/foo.cjs.js.map`);
     checkFilesExist(`dist/libs/${myPkg}/bar.esm.js`);
+    checkFilesExist(`dist/libs/${myPkg}/bar.esm.js.map`);
     checkFilesExist(`dist/libs/${myPkg}/bar.cjs.js`);
+    checkFilesExist(`dist/libs/${myPkg}/bar.cjs.js.map`);
     expect(readJson(`dist/libs/${myPkg}/package.json`).exports).toEqual({
       './package.json': './package.json',
       '.': {

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -147,6 +147,10 @@
       "type": "boolean",
       "description": "Prevents 'type' field from being added to compiled package.json file. Use this if you are having an issue with this field.",
       "default": false
+    },
+    "sourceMap": {
+      "description": "Output sourcemaps.",
+      "type": "boolean"
     }
   },
   "required": ["tsConfig", "main", "outputPath"],

--- a/packages/rollup/src/plugins/with-nx/with-nx-options.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx-options.ts
@@ -69,6 +69,10 @@ export interface RollupWithNxPluginOptions {
    */
   skipTypeField?: boolean;
   /**
+   * Output sourcemaps.
+   */
+  sourceMap?: boolean;
+  /**
    * The path to tsconfig file.
    */
   tsConfig: string;

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -127,6 +127,7 @@ export function withNx(
           // Cannot be joined with workspace root now, but will be handled by @nx/rollup/plugin.
           options.outputPath
         : join(workspaceRoot, options.outputPath),
+      sourcemap: options.sourceMap,
     }));
   }
 


### PR DESCRIPTION
This PR adds `sourceMap` option to `@nx/rollup:rollup` executor and the `withNx` util (for Project Crystal). The same option is used for Webpack.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9119
