### PR TITLE
fix(core): fix --e2eTestRunner for create-nx-workspace with react native

### DIFF
--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -307,6 +307,7 @@ describe('create-nx-workspace', () => {
       preset: 'react-native',
       appName,
       packageManager: 'npm',
+      e2eTestRunner: 'none',
     });
 
     expectNoAngularDevkit();
@@ -320,6 +321,7 @@ describe('create-nx-workspace', () => {
       preset: 'expo',
       appName,
       packageManager: 'npm',
+      e2eTestRunner: 'none',
     });
 
     expectNoAngularDevkit();

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -555,7 +555,9 @@ async function determineReactOptions(
     e2eTestRunner = await determineE2eTestRunner(parsedArgs);
   } else if (
     preset === Preset.RemixMonorepo ||
-    preset === Preset.RemixStandalone
+    preset === Preset.RemixStandalone ||
+    preset === Preset.ReactNative ||
+    preset === Preset.Expo
   ) {
     e2eTestRunner = await determineE2eTestRunner(parsedArgs);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
--e2eTestRunner option is not working when create-nx-workspace with preset react native

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
--e2eTestRunner option should be working when create-nx-workspace with preset react native

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
