### PR TITLE
fix(core): use withVerbose util

### DIFF
--- a/docs/generated/cli/migrate.md
+++ b/docs/generated/cli/migrate.md
@@ -149,6 +149,12 @@ Type: `string`
 
 Use the provided versions for packages instead of the ones calculated by the migrator (e.g., --to="@nx/react@16.0.0,@nx/js@16.0.0")
 
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
+
 ### version
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/migrate.md
+++ b/docs/generated/packages/nx/documents/migrate.md
@@ -149,6 +149,12 @@ Type: `string`
 
 Use the provided versions for packages instead of the ones calculated by the migrator (e.g., --to="@nx/react@16.0.0,@nx/js@16.0.0")
 
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
+
 ### version
 
 Type: `boolean`

--- a/packages/create-nx-workspace/src/utils/error-utils.ts
+++ b/packages/create-nx-workspace/src/utils/error-utils.ts
@@ -13,7 +13,7 @@ export function mapErrorToBodyLines(error: Error): string[] {
   const errorLines = error.message?.split('\n').filter((line) => !!line.trim());
   if (errorLines.length < 3) {
     const lines = [`Error: ${error.message}`];
-    if (process.env.NX_VERBOSE_LOGGING) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
       lines.push(`Stack: ${error.stack}`);
     }
     return lines;
@@ -24,7 +24,7 @@ export function mapErrorToBodyLines(error: Error): string[] {
       ? [`Exit code: ${error.code}`, `Log file: ${error.logFile}`]
       : [];
 
-  if (process.env.NX_VERBOSE_LOGGING) {
+  if (process.env.NX_VERBOSE_LOGGING === 'true') {
     lines.push(`Error: ${error.message}`);
     lines.push(`Stack: ${error.stack}`);
   }

--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -17,12 +17,7 @@ import type { AddOptions } from './command-object';
 import { normalizeVersionForNxJson } from '../init/implementation/dot-nx/add-nx-scripts';
 
 export function addHandler(options: AddOptions): Promise<number> {
-  if (options.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-  const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
-
-  return handleErrors(isVerbose, async () => {
+  return handleErrors(options.verbose, async () => {
     output.addNewline();
 
     const [pkgName, version] = parsePackageSpecifier(options.packageSpecifier);

--- a/packages/nx/src/command-line/add/command-object.ts
+++ b/packages/nx/src/command-line/add/command-object.ts
@@ -1,5 +1,5 @@
 import { CommandModule } from 'yargs';
-import { withOverrides } from '../yargs-utils/shared-options';
+import { withOverrides, withVerbose } from '../yargs-utils/shared-options';
 
 export interface AddOptions {
   packageSpecifier: string;
@@ -15,7 +15,7 @@ export const yargsAddCommand: CommandModule<
   command: 'add <packageSpecifier>',
   describe: 'Install a plugin and initialize it.',
   builder: (yargs) =>
-    yargs
+    withVerbose(yargs)
       .parserConfiguration({
         'strip-dashed': true,
         'unknown-options-as-args': true,
@@ -29,11 +29,6 @@ export const yargsAddCommand: CommandModule<
         type: 'boolean',
         description:
           'Update `package.json` scripts with inferred targets. Defaults to `true` when the package is a core Nx plugin',
-      })
-      .option('verbose', {
-        type: 'boolean',
-        description:
-          'Prints additional information about the commands (e.g., stack traces)',
       })
       .example(
         '$0 add @nx/react',

--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -54,10 +54,6 @@ export async function affected(
     nxJson
   );
 
-  if (nxArgs.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-
   await connectToNxCloudIfExplicitlyAsked(nxArgs);
 
   const projectGraph = await createProjectGraphAsync({ exitOnError: true });

--- a/packages/nx/src/command-line/exec/exec.ts
+++ b/packages/nx/src/command-line/exec/exec.ts
@@ -38,9 +38,6 @@ export async function nxExecCommand(
     { printWarnings: args.graph !== 'stdout' },
     nxJson
   );
-  if (nxArgs.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
   const scriptArgV: string[] = readScriptArgV(overrides);
   const projectGraph = await createProjectGraphAsync({ exitOnError: true });
 

--- a/packages/nx/src/command-line/generate/command-object.ts
+++ b/packages/nx/src/command-line/generate/command-object.ts
@@ -1,6 +1,7 @@
 import { CommandModule, Argv } from 'yargs';
 import { getCwd } from '../../utils/path';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
+import { withVerbose } from '../yargs-utils/shared-options';
 
 export const yargsGenerateCommand: CommandModule = {
   command: 'generate <generator> [_..]',
@@ -19,7 +20,7 @@ export const yargsGenerateCommand: CommandModule = {
 function withGenerateOptions(yargs: Argv) {
   const generatorWillShowHelp =
     process.argv[3] && !process.argv[3].startsWith('-');
-  const res = yargs
+  const res = withVerbose(yargs)
     .positional('generator', {
       describe: 'Name of the generator (e.g., @nx/js:library, library)',
       type: 'string',
@@ -35,11 +36,6 @@ function withGenerateOptions(yargs: Argv) {
       describe: 'When false disables interactive input prompts for options',
       type: 'boolean',
       default: true,
-    })
-    .option('verbose', {
-      describe:
-        'Prints additional information about the commands (e.g., stack traces)',
-      type: 'boolean',
     })
     .option('quiet', {
       describe: 'Hides logs from tree operations (e.g. `CREATE package.json`)',

--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -302,12 +302,7 @@ export function printGenHelp(
 }
 
 export async function generate(cwd: string, args: { [k: string]: any }) {
-  if (args['verbose']) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-  const verbose = process.env.NX_VERBOSE_LOGGING === 'true';
-
-  return handleErrors(verbose, async () => {
+  return handleErrors(args.verbose, async () => {
     const nxJsonConfiguration = readNxJson();
     const projectGraph = await createProjectGraphAsync();
     const projectsConfigurations =
@@ -369,7 +364,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
         nxJsonConfiguration
       ),
       relative(workspaceRoot, cwd),
-      verbose
+      args.verbose
     );
 
     if (
@@ -382,7 +377,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
     ) {
       const host = new FsTree(
         workspaceRoot,
-        verbose,
+        args.verbose,
         `generating (${opts.collectionName}:${normalizedGeneratorName})`
       );
       const implementation = implementationFactory();
@@ -418,7 +413,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
           generatorOptions: combinedOpts,
         },
         projectsConfigurations.projects,
-        verbose
+        args.verbose
       );
     }
   });

--- a/packages/nx/src/command-line/import/command-object.ts
+++ b/packages/nx/src/command-line/import/command-object.ts
@@ -37,12 +37,9 @@ export const yargsImportCommand: CommandModule = {
       'import'
     ),
   handler: async (args) => {
-    const exitCode = await handleErrors(
-      (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
-      async () => {
-        return (await import('./import')).importHandler(args as any);
-      }
-    );
+    const exitCode = await handleErrors(args.verbose as boolean, async () => {
+      return (await import('./import')).importHandler(args as any);
+    });
     process.exit(exitCode);
   },
 };

--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/package-manager';
 import { writeJsonFile } from '../../utils/fileutils';
 import { workspaceRoot } from '../../utils/workspace-root';
+import { withVerbose } from '../yargs-utils/shared-options';
 
 export const yargsMigrateCommand: CommandModule = {
   command: 'migrate [packageAndVersion]',
@@ -39,7 +40,7 @@ export const yargsInternalMigrateCommand: CommandModule = {
 function withMigrationOptions(yargs: Argv) {
   const defaultCommitPrefix = 'chore: [nx migration] ';
 
-  return yargs
+  return withVerbose(yargs)
     .positional('packageAndVersion', {
       describe: `The target package and version (e.g, @nx/workspace@16.0.0)`,
       type: 'string',
@@ -178,7 +179,7 @@ function nxCliPath() {
     console.error(
       `Failed to install the ${version} version of the migration script. Using the current version.`
     );
-    if (process.env.NX_VERBOSE_LOGGING) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
       console.error(e);
     }
     return null;

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1636,10 +1636,6 @@ export async function migrate(
   args: { [k: string]: any },
   rawArgs: string[]
 ) {
-  if (args['verbose']) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-
   await daemonClient.stop();
 
   return handleErrors(process.env.NX_VERBOSE_LOGGING === 'true', async () => {

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -121,10 +121,6 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       overrideReleaseConfig ?? {}
     );
 
-    if (args.verbose) {
-      process.env.NX_VERBOSE_LOGGING = 'true';
-    }
-
     // Apply default configuration to any optional user configuration
     const { error: configError, nxReleaseConfig } = await createNxReleaseConfig(
       projectGraph,

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -10,6 +10,7 @@ import {
   withOutputStyleOption,
   withOverrides,
   withRunManyOptions,
+  withVerbose,
 } from '../yargs-utils/shared-options';
 import { VersionData } from './utils/shared';
 
@@ -102,7 +103,7 @@ export const yargsReleaseCommand: CommandModule<
   describe:
     'Orchestrate versioning and publishing of applications and libraries',
   builder: (yargs) =>
-    yargs
+    withVerbose(yargs)
       .command(releaseCommand)
       .command(versionCommand)
       .command(changelogCommand)
@@ -132,11 +133,6 @@ export const yargsReleaseCommand: CommandModule<
         alias: 'd',
         type: 'boolean',
         default: false,
-      })
-      .option('verbose', {
-        type: 'boolean',
-        describe:
-          'Prints additional information about the commands (e.g., stack traces)',
       })
       // NOTE: The camel case format is required for the coerce() function to be called correctly. It still supports --print-config casing.
       .option('printConfig', {

--- a/packages/nx/src/command-line/release/plan-check.ts
+++ b/packages/nx/src/command-line/release/plan-check.ts
@@ -37,10 +37,6 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       overrideReleaseConfig ?? {}
     );
 
-    if (args.verbose) {
-      process.env.NX_VERBOSE_LOGGING = 'true';
-    }
-
     // Apply default configuration to any optional user configuration
     const { error: configError, nxReleaseConfig } = await createNxReleaseConfig(
       projectGraph,

--- a/packages/nx/src/command-line/release/plan.ts
+++ b/packages/nx/src/command-line/release/plan.ts
@@ -36,10 +36,6 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       overrideReleaseConfig ?? {}
     );
 
-    if (args.verbose) {
-      process.env.NX_VERBOSE_LOGGING = 'true';
-    }
-
     // Apply default configuration to any optional user configuration
     const { error: configError, nxReleaseConfig } = await createNxReleaseConfig(
       projectGraph,

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -56,10 +56,6 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       overrideReleaseConfig ?? {}
     );
 
-    if (_args.verbose) {
-      process.env.NX_VERBOSE_LOGGING = 'true';
-    }
-
     // Apply default configuration to any optional user configuration
     const { error: configError, nxReleaseConfig } = await createNxReleaseConfig(
       projectGraph,
@@ -185,10 +181,6 @@ async function runPublishOnProjects(
      * indirectly via dependsOn can also pick up on the fact that this is a dry run.
      */
     process.env.NX_DRY_RUN = 'true';
-  }
-
-  if (args.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
   }
 
   if (args.firstRelease) {

--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -54,10 +54,6 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       overrideReleaseConfig ?? {}
     );
 
-    if (args.verbose) {
-      process.env.NX_VERBOSE_LOGGING = 'true';
-    }
-
     const hasVersionGitConfig =
       Object.keys(userProvidedReleaseConfig.version?.git ?? {}).length > 0;
     const hasChangelogGitConfig =

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -132,10 +132,6 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       overrideReleaseConfig ?? {}
     );
 
-    if (args.verbose) {
-      process.env.NX_VERBOSE_LOGGING = 'true';
-    }
-
     // Apply default configuration to any optional user configuration
     const { error: configError, nxReleaseConfig } = await createNxReleaseConfig(
       projectGraph,

--- a/packages/nx/src/command-line/repair/command-object.ts
+++ b/packages/nx/src/command-line/repair/command-object.ts
@@ -1,5 +1,6 @@
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
+import { withVerbose } from '../yargs-utils/shared-options';
 
 export const yargsRepairCommand: CommandModule = {
   command: 'repair',
@@ -13,12 +14,7 @@ export const yargsRepairCommand: CommandModule = {
     If your repository has only ever updated to newer versions of Nx with
     \`nx migrate\`, running \`nx repair\` should do nothing.
   `,
-  builder: (yargs) =>
-    linkToNxDevAndExamples(yargs, 'repair').option('verbose', {
-      type: 'boolean',
-      describe:
-        'Prints additional information about the commands (e.g., stack traces)',
-    }),
+  builder: (yargs) => linkToNxDevAndExamples(withVerbose(yargs), 'repair'),
   handler: async (args: ArgumentsCamelCase<{ verbose: boolean }>) =>
     process.exit(await (await import('./repair')).repair(args)),
 };

--- a/packages/nx/src/command-line/repair/repair.ts
+++ b/packages/nx/src/command-line/repair/repair.ts
@@ -7,11 +7,7 @@ export async function repair(
   args: { verbose: boolean },
   extraMigrations = [] as any[]
 ) {
-  if (args['verbose']) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-  const verbose = process.env.NX_VERBOSE_LOGGING === 'true';
-  return handleErrors(verbose, async () => {
+  return handleErrors(args.verbose, async () => {
     const nxMigrations = Object.entries(migrationsJson.generators).reduce(
       (agg, [name, migration]) => {
         const skip = migration['x-repair-skip'];
@@ -33,7 +29,7 @@ export async function repair(
     const migrationsThatMadeNoChanges = await executeMigrations(
       process.cwd(),
       migrations,
-      verbose,
+      args.verbose,
       false,
       ''
     );

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -55,9 +55,6 @@ export async function runOne(
     nxJson
   );
 
-  if (nxArgs.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
   if (nxArgs.help) {
     await (await import('./run')).printTargetRunHelp(opts, workspaceRoot);
     process.exit(0);

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -124,13 +124,10 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
         'Show affected projects in the workspace, excluding end-to-end projects'
       ) as any,
   handler: async (args) => {
-    const exitCode = await handleErrors(
-      args.verbose ?? process.env.NX_VERBOSE_LOGGING === 'true',
-      async () => {
-        const { showProjectsHandler } = await import('./projects');
-        await showProjectsHandler(args);
-      }
-    );
+    const exitCode = await handleErrors(args.verbose as boolean, async () => {
+      const { showProjectsHandler } = await import('./projects');
+      await showProjectsHandler(args);
+    });
     process.exit(exitCode);
   },
 };
@@ -178,13 +175,10 @@ const showProjectCommand: CommandModule<NxShowArgs, ShowProjectOptions> = {
         'View project information for my-app in the browser'
       ),
   handler: async (args) => {
-    const exitCode = await handleErrors(
-      args.verbose ?? process.env.NX_VERBOSE_LOGGING === 'true',
-      async () => {
-        const { showProjectHandler } = await import('./project');
-        await showProjectHandler(args);
-      }
-    );
+    const exitCode = await handleErrors(args.verbose as boolean, async () => {
+      const { showProjectHandler } = await import('./project');
+      await showProjectHandler(args);
+    });
     process.exit(exitCode);
   },
 };

--- a/packages/nx/src/command-line/sync/command-object.ts
+++ b/packages/nx/src/command-line/sync/command-object.ts
@@ -1,4 +1,5 @@
 import type { CommandModule } from 'yargs';
+import { withVerbose } from '../yargs-utils/shared-options';
 
 export interface SyncArgs {
   verbose?: boolean;
@@ -10,12 +11,7 @@ export const yargsSyncCommand: CommandModule<
 > = {
   command: 'sync',
   describe: false,
-  builder: (yargs) =>
-    yargs.option('verbose', {
-      type: 'boolean',
-      description:
-        'Prints additional information about the commands (e.g., stack traces)',
-    }),
+  builder: (yargs) => withVerbose(yargs),
   handler: async (args) => {
     process.exit(await import('./sync').then((m) => m.syncHandler(args)));
   },
@@ -27,12 +23,7 @@ export const yargsSyncCheckCommand: CommandModule<
 > = {
   command: 'sync:check',
   describe: false,
-  builder: (yargs) =>
-    yargs.option('verbose', {
-      type: 'boolean',
-      description:
-        'Prints additional information about the commands (e.g., stack traces)',
-    }),
+  builder: (yargs) => withVerbose(yargs),
   handler: async (args) => {
     process.exit(
       await import('./sync').then((m) =>

--- a/packages/nx/src/command-line/sync/sync.ts
+++ b/packages/nx/src/command-line/sync/sync.ts
@@ -16,12 +16,7 @@ interface SyncOptions extends SyncArgs {
 }
 
 export function syncHandler(options: SyncOptions): Promise<number> {
-  if (options.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-  const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
-
-  return handleErrors(isVerbose, async () => {
+  return handleErrors(options.verbose, async () => {
     const projectGraph = await createProjectGraphAsync();
     const syncGenerators = await collectAllRegisteredSyncGenerators(
       projectGraph

--- a/packages/nx/src/command-line/watch/command-object.ts
+++ b/packages/nx/src/command-line/watch/command-object.ts
@@ -1,7 +1,7 @@
 import { Argv, CommandModule } from 'yargs';
 import { WatchArguments } from './watch';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
-import { parseCSV } from '../yargs-utils/shared-options';
+import { parseCSV, withVerbose } from '../yargs-utils/shared-options';
 
 export const yargsWatchCommand: CommandModule = {
   command: 'watch',
@@ -13,7 +13,7 @@ export const yargsWatchCommand: CommandModule = {
 };
 
 function withWatchOptions(yargs: Argv) {
-  return yargs
+  return withVerbose(yargs)
     .parserConfiguration({
       'strip-dashed': true,
       'populate--': true,

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -155,10 +155,6 @@ export async function watch(args: WatchArguments) {
     'g'
   );
 
-  if (args.verbose) {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-  }
-
   if (!daemonClient.enabled()) {
     output.error({
       title:

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -132,9 +132,9 @@ export function withVerbose<T>(yargs: Argv<T>) {
       type: 'boolean',
     })
     .middleware((args) => {
-      if (args.verbose) {
-        process.env.NX_VERBOSE_LOGGING = 'true';
-      }
+      args.verbose ??= process.env.NX_VERBOSE_LOGGING === 'true';
+      // If NX_VERBOSE_LOGGING=false and --verbose is passed, we want to set it to true favoring the arg
+      process.env.NX_VERBOSE_LOGGING = args.verbose.toString();
     });
 }
 

--- a/packages/nx/src/native/assert-supported-platform.ts
+++ b/packages/nx/src/native/assert-supported-platform.ts
@@ -17,7 +17,7 @@ export function assertSupportedPlatform() {
         `The Nx CLI could not find or load the native binary for your supported platform (${process.platform}-${process.arch}).`,
         'This likely means that optional dependencies were not installed correctly, or your system is missing some system dependencies.',
       ];
-      if (process.env.NX_VERBOSE_LOGGING == 'true') {
+      if (process.env.NX_VERBOSE_LOGGING === 'true') {
         bodyLines.push('', 'Additional error information:', e.message);
       }
     } else {

--- a/packages/nx/src/nx-cloud/utilities/url-shorten.ts
+++ b/packages/nx/src/nx-cloud/utilities/url-shorten.ts
@@ -133,7 +133,7 @@ async function getInstallationSupportsGitHub(apiUrl: string): Promise<boolean> {
     }
     return !!response.data.isGithubIntegrationEnabled;
   } catch (e) {
-    if (process.env.NX_VERBOSE_LOGGING) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
       logger.warn(`Failed to access system features. GitHub integration assumed to be disabled. 
     ${e}`);
     }

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -52,7 +52,7 @@ export class Cache {
       try {
         this._currentMachineId = await machineId();
       } catch (e) {
-        if (process.env.NX_VERBOSE_LOGGING == 'true') {
+        if (process.env.NX_VERBOSE_LOGGING === 'true') {
           console.log(`Unable to get machineId. Error: ${e.message}`);
         }
         this._currentMachineId = '';

--- a/packages/nx/src/utils/logger.ts
+++ b/packages/nx/src/utils/logger.ts
@@ -32,7 +32,7 @@ export const logger = {
     console.error(...s);
   },
   verbose: (...s) => {
-    if (process.env.NX_VERBOSE_LOGGING) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
       console.log(...s);
     }
   },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The `withVerbose` util is only used in a few places.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `withVerbose` util is used throughout and also contains middleware to default to the value in `process.env.NX_VERBOSE_LOGGING === 'true'`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
