### PR TITLE
fix(esbuild): declaration:true should find the correct package root regardless of cwd #26261

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -282,15 +282,13 @@ describe('EsBuild Plugin', () => {
       `
     );
 
-    runCLI(
-      `build ${declarationPkg} --declaration=true --declarationRootDir='libs/${declarationPkg}/src'`
-    );
+    runCLI(`build ${declarationPkg} --declaration=true`);
 
     checkFilesExist(
       `dist/libs/${declarationPkg}/index.cjs`,
-      `dist/libs/${declarationPkg}/index.d.ts`,
-      `dist/libs/${declarationPkg}/lib/${declarationPkg}.d.ts`,
-      `dist/libs/${declarationPkg}/lib/testDir/sub.d.ts`
+      `dist/libs/${declarationPkg}/src/index.d.ts`,
+      `dist/libs/${declarationPkg}/src/lib/${declarationPkg}.d.ts`,
+      `dist/libs/${declarationPkg}/src/lib/testDir/sub.d.ts`
     );
 
     expect(runCommand(`node dist/libs/${declarationPkg}`)).toMatch(

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -22,7 +22,7 @@ import {
 } from './lib/build-esbuild-options';
 import { getExtraDependencies } from './lib/get-extra-dependencies';
 import { DependentBuildableProjectNode } from '@nx/js/src/utils/buildable-libs-utils';
-import { join } from 'path';
+import { join, relative } from 'path';
 
 const BUILD_WATCH_FAILED = `[ ${chalk.red(
   'watch'
@@ -57,6 +57,7 @@ export async function* esbuildExecutor(
           node: externalNode,
         });
       }
+      return acc;
       return acc;
     }, []);
 
@@ -210,6 +211,7 @@ function getTypeCheckOptions(
   context: ExecutorContext
 ) {
   const { watch, tsConfig, outputPath } = options;
+  const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
 
   const typeCheckOptions: TypeCheckOptions = {
     ...(options.declaration
@@ -220,9 +222,10 @@ function getTypeCheckOptions(
       : {
           mode: 'noEmit',
         }),
-    tsConfigPath: tsConfig,
+    tsConfigPath: relative(process.cwd(), join(context.root, tsConfig)),
     workspaceRoot: context.root,
     rootDir: options.declarationRootDir ?? context.root,
+    projectRoot,
   };
 
   if (watch) {

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -63,7 +63,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'browser',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: [],
       outExtension: {
         '.js': '.js',
@@ -104,7 +105,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'browser',
       outdir: 'dist/apps/myapp',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: [],
       outExtension: {
         '.js': '.js',
@@ -144,7 +146,8 @@ describe('buildEsbuildOptions', () => {
       format: 'cjs',
       platform: 'browser',
       outfile: 'dist/apps/myapp/index.cjs',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: [],
       outExtension: {
         '.js': '.cjs',
@@ -181,7 +184,8 @@ describe('buildEsbuildOptions', () => {
       format: 'cjs',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.cjs',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: [],
       outExtension: {
         '.js': '.cjs',
@@ -222,7 +226,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.mjs',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: [],
       outExtension: {
         '.js': '.mjs',
@@ -261,7 +266,8 @@ describe('buildEsbuildOptions', () => {
       format: 'cjs',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: [],
       outExtension: {
         '.js': '.js',
@@ -301,7 +307,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: [],
       outExtension: {
         '.js': '.js',
@@ -340,7 +347,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: ['bar', 'foo'],
       outExtension: {
         '.js': '.js',
@@ -376,7 +384,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: undefined,
       outExtension: {
         '.js': '.js',
@@ -414,7 +423,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: undefined,
       sourcemap: true,
       outExtension: {
@@ -451,7 +461,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: undefined,
       metafile: undefined,
       minify: undefined,
@@ -490,7 +501,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: undefined,
       sourcemap: true,
       metafile: undefined,
@@ -530,7 +542,8 @@ describe('buildEsbuildOptions', () => {
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig: 'apps/myapp/tsconfig.app.json',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
       external: undefined,
       sourcemap: true,
       metafile: undefined,

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -6,11 +6,13 @@ import {
   joinPathFragments,
   normalizePath,
   ProjectGraphProjectNode,
+  workspaceRoot,
 } from '@nx/devkit';
 
 import { getClientEnvironment } from '../../../utils/environment-variables';
 import { NormalizedEsBuildExecutorOptions } from '../schema';
 import { getEntryPoints } from '../../../utils/get-entry-points';
+import { join, relative } from 'path';
 
 const ESM_FILE_EXTENSION = '.js';
 const CJS_FILE_EXTENSION = '.cjs';
@@ -38,7 +40,7 @@ export function buildEsbuildOptions(
     platform: options.platform,
     target: options.target,
     metafile: options.metafile,
-    tsconfig: options.tsConfig,
+    tsconfig: relative(process.cwd(), join(context.root, options.tsConfig)),
     sourcemap:
       (options.sourcemap ?? options.userDefinedBuildOptions?.sourcemap) ||
       false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The types that are generated for esbuild packages are not placed into the correct folder structure in the built package and is very dependent of the CWD.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The declaration files should be generated correctly to match the package and not dependent on CWD

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26261 #26376
