### PR TITLE
fix(js): ensure assets option in tsc executor defaults to empty array for programmatic usage

### DIFF
--- a/packages/js/src/executors/tsc/lib/normalize-options.ts
+++ b/packages/js/src/executors/tsc/lib/normalize-options.ts
@@ -37,6 +37,7 @@ export function normalizeOptions(
     }
   }
 
+  options.assets ??= [];
   const files: FileInputOutput[] = assetGlobsToFiles(
     options.assets,
     contextRoot,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19911 
Fixes #27421 
