### PR TITLE
fix(core): support import detection of packages installed from git remote URL

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -479,7 +479,7 @@ describe('TargetProjectLocator', () => {
       expect(proj5).toEqual('proj5');
     });
 
-    it('should be able to resolve packages alises', () => {
+    it('should be able to resolve packages aliases', () => {
       const lodash = targetProjectLocator.findProjectFromImport(
         'lodash',
         'libs/proj/index.ts'
@@ -897,6 +897,85 @@ describe('TargetProjectLocator', () => {
         'libs/proj/index.ts'
       );
       expect(result).toEqual('npm:@json2csv/plainjs');
+    });
+  });
+
+  describe('findNpmProjectFromImport', () => {
+    it('should resolve external node when the version does not match its own package.json (i.e. git remote) ', () => {
+      const projects = {
+        proj: {
+          name: 'proj',
+          type: 'lib' as const,
+          data: {
+            root: 'proj',
+          },
+        },
+      };
+      const npmProjects = {
+        'npm:foo': {
+          name: 'npm:foo' as const,
+          type: 'npm' as const,
+          data: {
+            version:
+              'git+ssh://git@github.com/example/foo.git#6f4b450fc642abba540535f0755c990b42a16026',
+            packageName: 'foo',
+          },
+        },
+      };
+
+      const targetProjectLocator = new TargetProjectLocator(
+        projects,
+        npmProjects,
+        new Map()
+      );
+      targetProjectLocator['readPackageJson'] = () => ({
+        name: 'foo',
+        version: '0.0.1',
+      });
+      const result = targetProjectLocator.findNpmProjectFromImport(
+        'lodash',
+        'proj/index.ts'
+      );
+
+      expect(result).toEqual('npm:foo');
+    });
+
+    it('should resolve a specific version of external node', () => {
+      const projects = {
+        proj: {
+          name: 'proj',
+          type: 'lib' as const,
+          data: {
+            root: 'proj',
+          },
+        },
+      };
+      const npmProjects = {
+        'npm:foo@0.0.1': {
+          name: 'npm:foo@0.0.1' as const,
+          type: 'npm' as const,
+          data: {
+            version: '0.0.1',
+            packageName: 'foo',
+          },
+        },
+      };
+
+      const targetProjectLocator = new TargetProjectLocator(
+        projects,
+        npmProjects,
+        new Map()
+      );
+      targetProjectLocator['readPackageJson'] = () => ({
+        name: 'foo',
+        version: '0.0.1',
+      });
+      const result = targetProjectLocator.findNpmProjectFromImport(
+        'lodash',
+        'proj/index.ts'
+      );
+
+      expect(result).toEqual('npm:foo@0.0.1');
     });
   });
 });


### PR DESCRIPTION
This PR fixes an issue where installing a package from git remote URL will result in it not being picked up by Nx as a dependency whenever it is used in a project.



<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27423
