### PR TITLE
fix(node): generate webpack server apps with generatePackageJson:true by default

### DIFF
--- a/packages/node/src/generators/application/application.legacy.spec.ts
+++ b/packages/node/src/generators/application/application.legacy.spec.ts
@@ -42,6 +42,7 @@ describe('node app generator (legacy)', () => {
             "my-node-app/src/assets",
           ],
           "compiler": "tsc",
+          "generatePackageJson": true,
           "main": "my-node-app/src/main.ts",
           "outputPath": "dist/my-node-app",
           "target": "node",

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -63,6 +63,30 @@ describe('app', () => {
           },
         }
       `);
+      expect(tree.read(`my-node-app/webpack.config.js`, 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
+        const { join } = require('path');
+
+        module.exports = {
+          output: {
+            path: join(__dirname, '../dist/my-node-app'),
+          },
+          plugins: [
+            new NxAppWebpackPlugin({
+              target: 'node',
+              compiler: 'tsc',
+              main: './src/main.ts',
+              tsConfig: './tsconfig.app.json',
+              assets: ['./src/assets'],
+              optimization: false,
+              outputHashing: 'none',
+              generatePackageJson: true,
+            }),
+          ],
+        };
+        "
+      `);
       expect(() =>
         readProjectConfiguration(tree, 'my-node-app-e2e')
       ).not.toThrow();

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -79,6 +79,7 @@ function getWebpackBuildConfig(
         options.appProjectRoot,
         'webpack.config.js'
       ),
+      generatePackageJson: true,
     },
     configurations: {
       development: {},

--- a/packages/node/src/generators/application/files/common/webpack.config.js__tmpl__
+++ b/packages/node/src/generators/application/files/common/webpack.config.js__tmpl__
@@ -15,6 +15,7 @@ module.exports = {
       assets: <%- JSON.stringify(webpackPluginOptions.assets) %>,
       optimization: false,
       outputHashing: 'none',
+      generatePackageJson: true,
     })
   ],
 };


### PR DESCRIPTION
We already do this for esbuild apps (e.g. express, fastify, koa), but we don't do it for webpack (nest).

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27389
