### PR TITLE
fix(nx-plugin): allow create-package without e2eProject

### DIFF
--- a/docs/generated/packages/plugin/generators/create-package.json
+++ b/docs/generated/packages/plugin/generators/create-package.json
@@ -65,10 +65,7 @@
       },
       "e2eProject": {
         "type": "string",
-        "description": "The name of the e2e project.",
-        "alias": "p",
-        "$default": { "$source": "projectName" },
-        "x-prompt": "What is the name of the e2e project?"
+        "description": "The name of the e2e project."
       }
     },
     "required": ["name", "project"],

--- a/docs/generated/packages/plugin/generators/create-package.json
+++ b/docs/generated/packages/plugin/generators/create-package.json
@@ -65,7 +65,8 @@
       },
       "e2eProject": {
         "type": "string",
-        "description": "The name of the e2e project."
+        "description": "The name of the e2e project.",
+        "x-prompt": "What is the name of the e2e project? Leave blank to skip e2e tests"
       }
     },
     "required": ["name", "project"],

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -423,6 +423,26 @@ describe('Nx Plugin', () => {
     }, 90000);
   });
 
+  it('should be able to generate a create-package plugin without e2e tests', async () => {
+    const plugin = uniq('plugin');
+    const createAppName = `create-${plugin}-app`;
+    runCLI(
+      `generate @nx/plugin:plugin ${plugin} --e2eTestRunner jest --publishable`
+    );
+    runCLI(
+      `generate @nx/plugin:create-package ${createAppName} --project=${plugin}`
+    );
+
+    const buildResults = runCLI(`build ${createAppName}`);
+    expect(buildResults).toContain('Done compiling TypeScript files');
+
+    checkFilesExist(
+      `libs/${plugin}/src/generators/preset`,
+      `libs/${createAppName}`,
+      `dist/libs/${createAppName}/bin/index.js`
+    );
+  });
+
   it('should be able to generate a create-package plugin ', async () => {
     const plugin = uniq('plugin');
     const createAppName = `create-${plugin}-app`;
@@ -449,7 +469,7 @@ describe('Nx Plugin', () => {
     const plugin = uniq('plugin');
     expect(() =>
       runCLI(
-        `generate @nx/plugin:create-package ${plugin} --project=invalid-plugin`
+        `generate @nx/plugin:create-package create-${plugin} --project=invalid-plugin`
       )
     ).toThrow();
   });

--- a/packages/plugin/src/generators/create-package/schema.json
+++ b/packages/plugin/src/generators/create-package/schema.json
@@ -67,7 +67,8 @@
     },
     "e2eProject": {
       "type": "string",
-      "description": "The name of the e2e project."
+      "description": "The name of the e2e project.",
+      "x-prompt": "What is the name of the e2e project? Leave blank to skip e2e tests"
     }
   },
   "required": ["name", "project"]

--- a/packages/plugin/src/generators/create-package/schema.json
+++ b/packages/plugin/src/generators/create-package/schema.json
@@ -67,12 +67,7 @@
     },
     "e2eProject": {
       "type": "string",
-      "description": "The name of the e2e project.",
-      "alias": "p",
-      "$default": {
-        "$source": "projectName"
-      },
-      "x-prompt": "What is the name of the e2e project?"
+      "description": "The name of the e2e project."
     }
   },
   "required": ["name", "project"]


### PR DESCRIPTION
Current behavior:
`nx g create-package create-my-plugin --project my-plugin` fails because `e2eProject` defaults to the root project.

Expected behavior:
`nx g create-package create-my-plugin --project my-plugin` succeeds.
