### PR TITLE
fix(core): fix compat for old remote caches

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -123,7 +123,7 @@ export class DbCache {
         return nxCloudClient.remoteCache;
       } else {
         // old nx cloud instance
-        return RemoteCacheV2.fromCacheV1(this.options.nxCloudRemoteCache);
+        return await RemoteCacheV2.fromCacheV1(this.options.nxCloudRemoteCache);
       }
     } else {
       return null;

--- a/packages/nx/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/default-tasks-runner.ts
@@ -7,7 +7,8 @@ import { NxJsonConfiguration } from '../config/nx-json';
 import { Task, TaskGraph } from '../config/task-graph';
 import { NxArgs } from '../utils/command-line-utils';
 import { DaemonClient } from '../daemon/client/client';
-import { readFile, writeFile } from 'fs/promises';
+import { cacheDir } from '../utils/cache-directory';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { CachedResult } from '../native';
 
@@ -17,18 +18,28 @@ export interface RemoteCache {
 }
 
 export abstract class RemoteCacheV2 {
-  static fromCacheV1(cache: RemoteCache): RemoteCacheV2 {
+  static async fromCacheV1(cache: RemoteCache): Promise<RemoteCacheV2> {
+    await mkdir(join(cacheDir, 'terminalOutputs'), { recursive: true });
+
     return {
       retrieve: async (hash, cacheDirectory) => {
-        const res = cache.retrieve(hash, cacheDirectory);
-        const [terminalOutput, code] = await Promise.all([
-          readFile(join(cacheDirectory, hash, 'terminalOutputs'), 'utf-8'),
-          readFile(join(cacheDirectory, hash, 'code'), 'utf-8').then((s) => +s),
-        ]);
+        const res = await cache.retrieve(hash, cacheDirectory);
         if (res) {
+          const [terminalOutput, oldTerminalOutput, code] = await Promise.all([
+            readFile(
+              join(cacheDirectory, hash, 'terminalOutputs'),
+              'utf-8'
+            ).catch(() => null),
+            readFile(join(cacheDir, 'terminalOutputs', hash), 'utf-8').catch(
+              () => null
+            ),
+            readFile(join(cacheDirectory, hash, 'code'), 'utf-8').then(
+              (s) => +s
+            ),
+          ]);
           return {
             outputsPath: cacheDirectory,
-            terminalOutput,
+            terminalOutput: terminalOutput ?? oldTerminalOutput,
             code,
           };
         } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The old remote caches are broken with the new db cache.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The old remote caches are working properly with the new db cache.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
