### PR TITLE
fix(core): make sure env vars specified in run-commands envFile option take priority over other loaded env files

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -21,7 +21,7 @@ const childProcesses = new Set<ChildProcess | PseudoTtyProcess>();
 
 function loadEnvVarsFile(path: string, env: Record<string, string> = {}) {
   unloadDotEnvFile(path, env);
-  const result = loadAndExpandDotEnvFile(path, env);
+  const result = loadAndExpandDotEnvFile(path, env, true);
   if (result.error) {
     throw result.error;
   }
@@ -484,14 +484,19 @@ function processEnv(
   envFile?: string
 ) {
   const localEnv = appendLocalEnv({ cwd: cwd ?? process.cwd() });
-  const res = {
+  let res = {
     ...process.env,
     ...localEnv,
-    ...env,
   };
+  // env file from envFile option takes priority over process env
   if (process.env.NX_LOAD_DOT_ENV_FILES !== 'false') {
     loadEnvVars(envFile, res);
   }
+  // env variables from env option takes priority over everything else
+  res = {
+    ...res,
+    ...env,
+  };
   // need to override PATH to make sure we are using the local node_modules
   if (localEnv.PATH) res.PATH = localEnv.PATH; // UNIX-like
   if (localEnv.Path) res.Path = localEnv.Path; // Windows

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -124,9 +124,9 @@ function getNxEnvVariablesForTask(
 
 /**
  * This function loads a .env file and expands the variables in it.
- * It is going to override existing environmentVariables.
- * @param filename
- * @param environmentVariables
+ * @param filename the .env file to load
+ * @param environmentVariables the object to load environment variables into
+ * @param override whether to override existing environment variables
  */
 export function loadAndExpandDotEnvFile(
   filename: string,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When you specify the `envFile` property on a `nx:run-commands` executor, values in that file don't override values from other loaded env files (like `.env` and others that are loaded by the task runner). 


## Expected Behavior
`envFile` contents should take precedence. The properties specified in the `env` option should still override this.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
