### PR TITLE
fix(core): enable using the daemon in docker if enabled explicitly

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -131,10 +131,13 @@ export class DaemonClient {
       // CI=true,env=undefined => no daemon
       // CI=true,env=false => no daemon
       // CI=true,env=true => daemon
+
+      // docker=true,env=undefined => no daemon
+      // docker=true,env=false => no daemon
+      // docker=true,env=true => daemon
       // WASM => no daemon because file watching does not work
       if (
-        (isCI() && env !== 'true') ||
-        isDocker() ||
+        ((isCI() || isDocker()) && env !== 'true') ||
         isDaemonDisabled() ||
         nxJsonIsNotPresent() ||
         (useDaemonProcessOption === undefined && env === 'false') ||


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The daemon is hard-disabled in docker, even if you try to explicilty enable it using the `NX_DAEMON` env var.

## Expected Behavior
We should disable the daemon by default in docker but allow users to opt-in using the env var. There might be issues that come with that but since it's opt-in, it will be at their own risk.

## Related Issue(s)

Fixes https://github.com/nrwl/nx/issues/14126