### PR TITLE
docs(linter): call out up to date lock file requirement for `@nx/dependency-checks` rule

### DIFF
--- a/docs/generated/packages/eslint-plugin/documents/dependency-checks.md
+++ b/docs/generated/packages/eslint-plugin/documents/dependency-checks.md
@@ -6,6 +6,10 @@ The rule uses the project graph to collect all the dependencies of your project,
 
 We use the version numbers of the installed packages when checking whether the version specifier in `package.json` is correct. We do this because this is the only version for which we can "guarantee" that things work and were tested. If you specify a range outside of that version, that would mean that you are shipping potentially untested code.
 
+{% callout type="check" title="Keep the Package Manager Lock File Up-to-Date" %}
+The `@nx/dependency-checks` rule requires the presence of an up-to-date lock file in the workspace root to detect installed packages and their versions correctly. If the `package.json` file has changes that are not reflected in the lock file, make sure to perform a package installation.
+{% /callout %}
+
 ## Usage
 
 Library generators from `@nx` packages will configure this rule automatically when you opt-in for bundler/build setup. This rule is intended for publishable/buildable libraries, so it will only run if a `build` target is detected in the configuration (this name can be modified - see [options](#options)).

--- a/docs/shared/packages/eslint/dependency-checks.md
+++ b/docs/shared/packages/eslint/dependency-checks.md
@@ -6,6 +6,10 @@ The rule uses the project graph to collect all the dependencies of your project,
 
 We use the version numbers of the installed packages when checking whether the version specifier in `package.json` is correct. We do this because this is the only version for which we can "guarantee" that things work and were tested. If you specify a range outside of that version, that would mean that you are shipping potentially untested code.
 
+{% callout type="check" title="Keep the Package Manager Lock File Up-to-Date" %}
+The `@nx/dependency-checks` rule requires the presence of an up-to-date lock file in the workspace root to detect installed packages and their versions correctly. If the `package.json` file has changes that are not reflected in the lock file, make sure to perform a package installation.
+{% /callout %}
+
 ## Usage
 
 Library generators from `@nx` packages will configure this rule automatically when you opt-in for bundler/build setup. This rule is intended for publishable/buildable libraries, so it will only run if a `build` target is detected in the configuration (this name can be modified - see [options](#options)).


### PR DESCRIPTION
Updated doc: https://nx-dev-git-docs-dependency-checks-lock-file-callout-nrwl.vercel.app/nx-api/eslint-plugin/documents/dependency-checks

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22442 
