### PR TITLE
feat(bundling): add nxCopyAssetsPlugin for Vite to use in JS libs

### DIFF
--- a/docs/shared/packages/vite/configure-vite.md
+++ b/docs/shared/packages/vite/configure-vite.md
@@ -79,6 +79,32 @@ export default defineConfig({
 
 You can read more about the configuration options in the [`vite-plugin-dts` plugin documentation](https://www.npmjs.com/package/vite-plugin-dts).
 
+## Copying assets
+
+If you have assets outside of [`publicDir`](https://vitejs.dev/config/shared-options.html#publicdir) that need to be copied the output folder, then you can use `nxCopyAssetsPlugin` from `@nx/vite`.
+
+```ts {% fileName="vite.config.ts" highlightLines=[4, 12]}
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+// ...
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/libs/testlib',
+
+  plugins: [
+    nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
+    dts({
+      entryRoot: 'src',
+      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+    }),
+  ],
+  // ...
+});
+```
+
 ## For testing
 
 If you're using `vitest`, make sure your `test` object in your `vite.config.ts` file looks like this:

--- a/e2e/react/src/react-vite.test.ts
+++ b/e2e/react/src/react-vite.test.ts
@@ -148,7 +148,8 @@ describe('Build React applications and libraries with Vite', () => {
     checkFilesExist(
       `dist/libs/${nonBuildableLib}/index.d.ts`,
       `dist/libs/${nonBuildableLib}/index.js`,
-      `dist/libs/${nonBuildableLib}/index.mjs`
+      `dist/libs/${nonBuildableLib}/index.mjs`,
+      `dist/libs/${nonBuildableLib}/README.md`
     );
   }, 300_000);
 

--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -99,12 +99,13 @@ exports[`app generated files content - as-provided - my-app general application 
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../node_modules/.vite/my-app',
 
-  plugins: [vue(), nxViteTsPaths()],
+  plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -438,12 +439,13 @@ exports[`app generated files content - as-provided - myApp general application s
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../node_modules/.vite/myApp',
 
-  plugins: [vue(), nxViteTsPaths()],
+  plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {

--- a/packages/react/src/generators/application/__snapshots__/application.legacy.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.legacy.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`react app generator (legacy) should setup vite 1`] = `
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,
@@ -22,7 +23,8 @@ exports[`react app generator (legacy) should setup vite 1`] = `
     },
         
         plugins: [react(),
-nxViteTsPaths()],
+nxViteTsPaths(),
+nxCopyAssetsPlugin(['*.md'])],
         
     // Uncomment this if you are using workers. 
     // worker: {

--- a/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -94,6 +94,7 @@ exports[`app --style @emotion/styled should not break if bundler is vite 1`] = `
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,
@@ -110,7 +111,8 @@ exports[`app --style @emotion/styled should not break if bundler is vite 1`] = `
     },
         
         plugins: [react(),
-nxViteTsPaths()],
+nxViteTsPaths(),
+nxCopyAssetsPlugin(['*.md'])],
         
     // Uncomment this if you are using workers. 
     // worker: {
@@ -173,6 +175,7 @@ exports[`app --style none should not break if bundler is vite 1`] = `
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,
@@ -189,7 +192,8 @@ exports[`app --style none should not break if bundler is vite 1`] = `
     },
         
         plugins: [react(),
-nxViteTsPaths()],
+nxViteTsPaths(),
+nxCopyAssetsPlugin(['*.md'])],
         
     // Uncomment this if you are using workers. 
     // worker: {
@@ -216,6 +220,7 @@ exports[`app not nested should add vite types to tsconfigs 1`] = `
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,
@@ -232,7 +237,8 @@ exports[`app not nested should add vite types to tsconfigs 1`] = `
     },
         
         plugins: [react(),
-nxViteTsPaths()],
+nxViteTsPaths(),
+nxCopyAssetsPlugin(['*.md'])],
         
     // Uncomment this if you are using workers. 
     // worker: {
@@ -361,6 +367,7 @@ exports[`app not nested should use preview vite types to tsconfigs 1`] = `
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,
@@ -377,7 +384,8 @@ exports[`app not nested should use preview vite types to tsconfigs 1`] = `
     },
         
         plugins: [react(),
-nxViteTsPaths()],
+nxViteTsPaths(),
+nxCopyAssetsPlugin(['*.md'])],
         
     // Uncomment this if you are using workers. 
     // worker: {
@@ -480,6 +488,7 @@ exports[`app should setup vite if bundler is vite 1`] = `
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,
@@ -496,7 +505,8 @@ exports[`app should setup vite if bundler is vite 1`] = `
     },
         
         plugins: [react(),
-nxViteTsPaths()],
+nxViteTsPaths(),
+nxCopyAssetsPlugin(['*.md'])],
         
     // Uncomment this if you are using workers. 
     // worker: {

--- a/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`lib --bundler none, unit test runner vitest should configure vite 1`] =
 import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,
@@ -14,6 +15,7 @@ import { defineConfig } from 'vite';
         
         plugins: [react(),
 nxViteTsPaths(),
+nxCopyAssetsPlugin(['*.md']),
 ],
         
     // Uncomment this if you are using workers. 
@@ -42,6 +44,7 @@ exports[`lib should add vite types to tsconfigs 1`] = `
 import dts from 'vite-plugin-dts';
 import * as path from 'path';
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,
@@ -51,6 +54,7 @@ import * as path from 'path';
         
         plugins: [react(),
 nxViteTsPaths(),
+nxCopyAssetsPlugin(['*.md']),
 dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') })],
         
     // Uncomment this if you are using workers. 

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -370,12 +370,13 @@ exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provide
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../node_modules/.vite/test',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -881,12 +882,13 @@ exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/apps/test',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -1199,12 +1201,13 @@ exports[`Remix Application Standalone Project Repo --unitTestRunner should gener
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: './node_modules/.vite/test',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {

--- a/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
+++ b/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
@@ -27,12 +27,13 @@ exports[`Remix Library Generator -projectNameAndRootFormat=as-provided --unitTes
 "import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../node_modules/.vite/test',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -105,12 +106,13 @@ exports[`Remix Library Generator -projectNameAndRootFormat=derived --unitTestRun
 "import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/libs/test',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {

--- a/packages/remix/src/generators/storybook-configuration/__snapshots__/storybook-configuration.impl.spec.ts.snap
+++ b/packages/remix/src/generators/storybook-configuration/__snapshots__/storybook-configuration.impl.spec.ts.snap
@@ -90,12 +90,13 @@ exports[`Storybook Configuration it should create a storybook configuration and 
 "import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/libs/storybook-test',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -56,6 +56,7 @@
     "./src/executors/*/schema.json": "./src/executors/*/schema.json",
     "./src/executors/*.impl": "./src/executors/*.impl.js",
     "./src/executors/*/compat": "./src/executors/*/compat.js",
+    "./plugins/nx-copy-assets.plugin": "./plugins/nx-copy-assets.plugin.js",
     "./plugins/nx-tsconfig-paths.plugin": "./plugins/nx-tsconfig-paths.plugin.js",
     "./plugins/rollup-replace-files.plugin": "./plugins/rollup-replace-files.plugin.js"
   }

--- a/packages/vite/plugins/nx-copy-assets.plugin.ts
+++ b/packages/vite/plugins/nx-copy-assets.plugin.ts
@@ -1,0 +1,46 @@
+import { join, relative } from 'node:path';
+import type { Plugin, ResolvedConfig } from 'vite';
+import { joinPathFragments, workspaceRoot } from '@nx/devkit';
+import { AssetGlob } from '@nx/js/src/utils/assets/assets';
+import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
+
+export function nxCopyAssetsPlugin(_assets: (string | AssetGlob)[]): Plugin {
+  let config: ResolvedConfig;
+  let handler: CopyAssetsHandler;
+  let dispose: () => void;
+
+  return {
+    name: 'nx-copy-assets-plugin',
+    configResolved(_config) {
+      config = _config;
+    },
+    async buildStart() {
+      const relativeProjectRoot = relative(workspaceRoot, config.root);
+      const assets = _assets.map((a) => {
+        if (typeof a === 'string') {
+          return joinPathFragments(relativeProjectRoot, a);
+        } else {
+          return {
+            ...a,
+            input: joinPathFragments(relativeProjectRoot, a.input),
+          };
+        }
+      });
+      handler = new CopyAssetsHandler({
+        rootDir: workspaceRoot,
+        projectDir: config.root,
+        outputDir: join(config.root, config.build.outDir),
+        assets,
+      });
+      if (this.meta.watchMode) {
+        dispose = await handler.watchAndProcessOnAssetChange();
+      }
+    },
+    async writeBundle() {
+      await handler.processAllAssetsOnce();
+    },
+    async closeWatcher() {
+      dispose == null ? void 0 : dispose();
+    },
+  };
+}

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -6,6 +6,7 @@ import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import * as path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -13,6 +14,7 @@ export default defineConfig({
 
   plugins: [
     nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
@@ -168,6 +170,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import * as path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -176,6 +179,7 @@ export default defineConfig({
   plugins: [
     react(),
     nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
@@ -221,6 +225,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import * as path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -229,6 +234,7 @@ export default defineConfig({
   plugins: [
     react(),
     nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
@@ -315,6 +321,7 @@ export default defineConfig({
   plugins: [
     nxViteTsPaths(),
     react(),
+    nxCopyAssetsPlugin(['*.md']),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
@@ -340,6 +347,7 @@ exports[`@nx/vite:configuration transform React app to use Vite should create vi
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -355,7 +363,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -398,6 +406,7 @@ exports[`@nx/vite:configuration transform Web app to use Vite should create vite
 import { defineConfig } from 'vite';
 
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -413,7 +422,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [nxViteTsPaths()],
+  plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -456,6 +465,7 @@ exports[`@nx/vite:configuration vitest should create a vitest configuration if "
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -471,7 +481,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -5,12 +5,13 @@ exports[`vitest generator insourceTests should add the insourceSource option in 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/apps/my-test-react-app',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -46,12 +47,13 @@ exports[`vitest generator vite.config should create correct vite.config.ts file 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/apps/my-test-react-app',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -79,12 +81,13 @@ exports[`vitest generator vite.config should create correct vite.config.ts file 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/libs/react-lib-nonb-jest',
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -417,8 +417,8 @@ export function createOrEditViteConfig(
   let viteConfigContent = '';
 
   const plugins = options.plugins
-    ? [...options.plugins, `nxViteTsPaths()`]
-    : [`nxViteTsPaths()`];
+    ? [...options.plugins, `nxViteTsPaths()`, `nxCopyAssetsPlugin(['*.md'])`]
+    : [`nxViteTsPaths()`, `nxCopyAssetsPlugin(['*.md'])`];
 
   if (!onlyVitest && options.includeLib) {
     plugins.push(
@@ -515,6 +515,7 @@ export function createOrEditViteConfig(
       import { defineConfig } from 'vite';
       ${imports.join(';\n')}${imports.length ? ';' : ''}
       import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
       
       export default defineConfig({
         root: __dirname,

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -44,6 +44,7 @@ exports[`application generator should set up project correctly for cypress 2`] =
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -59,7 +60,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [vue(), nxViteTsPaths()],
+  plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -196,6 +197,7 @@ exports[`application generator should set up project correctly with PascalCase n
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -211,7 +213,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [vue(), nxViteTsPaths()],
+  plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {
@@ -356,6 +358,7 @@ exports[`application generator should set up project correctly with given option
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -371,7 +374,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [vue(), nxViteTsPaths()],
+  plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
 
   // Uncomment this if you are using workers.
   // worker: {

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -7,6 +7,7 @@ import vue from '@vitejs/plugin-vue';
 import dts from 'vite-plugin-dts';
 import * as path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -15,6 +16,7 @@ export default defineConfig({
   plugins: [
     vue(),
     nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
@@ -101,6 +103,7 @@ import vue from '@vitejs/plugin-vue';
 import dts from 'vite-plugin-dts';
 import * as path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
@@ -109,6 +112,7 @@ export default defineConfig({
   plugins: [
     vue(),
     nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),


### PR DESCRIPTION
This PR adds a `nxCopyAssetsPlugin` for Vite to brings it to parity with the other compilers/bundlers (tsc, swc, esbuild, rollup, and webpack).

When generate a lib with Vite (e.g.`nx g @nx/js:lib --bundler=vite` or `nx g @nx/react:lib --bundler=vite`), we expect it to at least copy `README.md` as an asset.

Note: Vite has support for copying assets from `public/` but that is less flexible and more intended for apps, not libs.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27351
