### PR TITLE
fix(core): ensure file watcher is looking for correct config on windows

### DIFF
--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -54,7 +54,7 @@ impl Watcher {
         }
 
         Watcher {
-            origin: if cfg!(window) {
+            origin: if cfg!(windows) {
                 origin.replace('/', "\\")
             } else {
                 origin


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx build native isn't working correctly on windows, stating that `window` is not a correct option for `cfg!`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the `windows` option for `cfg!` as stated by the error message

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
