### PR TITLE
fix(angular): ensure target default for '@nx/angular:webpack-browser' is set #26483

### DIFF
--- a/docs/shared/guides/setup-incremental-builds-angular.md
+++ b/docs/shared/guides/setup-incremental-builds-angular.md
@@ -61,6 +61,7 @@ executor to `@nx/angular:dev-server` as shown below:
   ...
   "targets": {
     "build": {
+      "dependsOn": ["^build"],
       "executor": "@nx/angular:webpack-browser",
       "outputs": [
         "{options.outputPath}"
@@ -90,6 +91,19 @@ executor to `@nx/angular:dev-server` as shown below:
   }
 },
 ```
+
+{% callout type="note" title="Add Executor to Target Defaults" %}
+If you'd like to avoid adding `"dependsOn": ["^build"]` to every application in your workspace that uses `@nx/angular:webpack-browser` you can add it to the `"targetDefaults"` section of the `nx.json`:
+
+```json
+"targetDefaults": {
+  "@nx/angular:webpack-browser": {
+    "dependsOn": ["^build"]
+  }
+}
+```
+
+{% /callout %}
 
 ## Running and serving incremental builds
 

--- a/packages/angular/src/generators/setup-mf/lib/change-build-target.ts
+++ b/packages/angular/src/generators/setup-mf/lib/change-build-target.ts
@@ -5,6 +5,7 @@ import {
   readProjectConfiguration,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 
 export function changeBuildTarget(host: Tree, options: Schema) {
   const appConfig = readProjectConfiguration(host, options.appName);
@@ -27,4 +28,6 @@ export function changeBuildTarget(host: Tree, options: Schema) {
   };
 
   updateProjectConfiguration(host, options.appName, appConfig);
+
+  addBuildTargetDefaults(host, '@nx/angular:webpack-browser');
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When using incremental builds with `@nx/angular:webpack-browser` the dependent libraries need to be built. 
However, there is no target default to force a build to build dependents.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add a targetDefault and update docs to reflect this requirement

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26483
