### PR TITLE
repo(chore): pull in latest doc changes to website-19

### DIFF
--- a/docs/changelog/19_6_0.md
+++ b/docs/changelog/19_6_0.md
@@ -4,7 +4,12 @@
 
 {% cards cols="2" %}
 {% card title="Explain with AI" type="document" url="/ci/features/explain-with-ai" /%}
+{% card title="File-Based Versioning for Nx Release (Version Plans)" type="document" url="/recipes/nx-release/file-based-versioning-version-plans" /%}
+{% card title="Migrate to Inferred Tasks (Project Crystal)" type="document" url="/recipes/running-tasks/convert-to-inferred" /%}
 {% card title="Angular 18.2.0 Support" type="document" url="https://github.com/nrwl/nx/pull/27379" /%}
 {% card title="Storybook 8 Support" type="document" url="https://github.com/nrwl/nx/pull/27214" /%}
-{% card title="Jest 29.7.0 Support" type="document" url="https://github.com/nrwl/nx/pull/27301" /%}
 {% /cards %}
+
+## Breaking Changes
+
+We updated `webpack-dev-server` to v5 in `@nx/webpack`, which comes with some breaking changes. See their [migration guide](https://github.com/webpack/webpack-dev-server/blob/master/migration-v5.md) for more details.

--- a/docs/generated/packages/eslint-plugin/documents/dependency-checks.md
+++ b/docs/generated/packages/eslint-plugin/documents/dependency-checks.md
@@ -6,6 +6,10 @@ The rule uses the project graph to collect all the dependencies of your project,
 
 We use the version numbers of the installed packages when checking whether the version specifier in `package.json` is correct. We do this because this is the only version for which we can "guarantee" that things work and were tested. If you specify a range outside of that version, that would mean that you are shipping potentially untested code.
 
+{% callout type="check" title="Keep the Package Manager Lock File Up-to-Date" %}
+The `@nx/dependency-checks` rule requires the presence of an up-to-date lock file in the workspace root to detect installed packages and their versions correctly. If the `package.json` file has changes that are not reflected in the lock file, make sure to perform a package installation.
+{% /callout %}
+
 ## Usage
 
 Library generators from `@nx` packages will configure this rule automatically when you opt-in for bundler/build setup. This rule is intended for publishable/buildable libraries, so it will only run if a `build` target is detected in the configuration (this name can be modified - see [options](#options)).

--- a/docs/nx-cloud/tutorial/circle.md
+++ b/docs/nx-cloud/tutorial/circle.md
@@ -111,7 +111,7 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx-cloud record -- echo Hello World
-      - run: pnpm exec nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build
+      - run: pnpm exec nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build e2e-ci
 
 workflows:
   version: 2
@@ -224,7 +224,7 @@ The affected command and Nx Replay help speed up the average CI time, but there 
 
 The Nx Agents feature
 
-- takes a command (e.g. `run-many -t build lint test e2e-ci`) and splits it into individual tasks which it then distributes across multiple agents
+- takes a command (e.g. `nx affected -t build lint test e2e-ci`) and splits it into individual tasks which it then distributes across multiple agents
 - distributes tasks by considering the dependencies between them; e.g. if `e2e-ci` depends on `build`, Nx Cloud will make sure that `build` is executed before `e2e-ci`; it does this across machines
 - distributes tasks to optimize for CPU processing time and reduce idle time by taking into account historical data about how long each task takes to run
 - collects the results and logs of all the tasks and presents them in a single view
@@ -261,7 +261,7 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx-cloud record -- echo Hello World
-      - run: pnpm exec nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build
+      - run: pnpm exec nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build e2e-ci
 
 workflows:
   version: 2

--- a/docs/nx-cloud/tutorial/github-actions.md
+++ b/docs/nx-cloud/tutorial/github-actions.md
@@ -94,7 +94,7 @@ jobs:
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx-cloud record -- echo Hello World
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
-      - run: pnpm exec nx affected -t lint test build
+      - run: pnpm exec nx affected -t lint test build e2e-ci
 ```
 
 The [`nx affected` command](/ci/features/affected) will run the specified tasks only for projects that have been affected by a particular PR, which can save a lot of time as repositories grow larger.
@@ -189,7 +189,7 @@ The affected command and Nx Replay help speed up the average CI time, but there 
 
 The Nx Agents feature
 
-- takes a command (e.g. `run-many -t build lint test e2e-ci`) and splits it into individual tasks which it then distributes across multiple agents
+- takes a command (e.g. `nx affected -t build lint test e2e-ci`) and splits it into individual tasks which it then distributes across multiple agents
 - distributes tasks by considering the dependencies between them; e.g. if `e2e-ci` depends on `build`, Nx Cloud will make sure that `build` is executed before `e2e-ci`; it does this across machines
 - distributes tasks to optimize for CPU processing time and reduce idle time by taking into account historical data about how long each task takes to run
 - collects the results and logs of all the tasks and presents them in a single view
@@ -229,7 +229,7 @@ jobs:
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx-cloud record -- echo Hello World
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
-      - run: pnpm exec nx affected -t lint test build
+      - run: pnpm exec nx affected -t lint test build e2e-ci
 ```
 
 We recommend you add this line right after you check out the repo, before installing node modules.

--- a/docs/shared/packages/eslint/dependency-checks.md
+++ b/docs/shared/packages/eslint/dependency-checks.md
@@ -6,6 +6,10 @@ The rule uses the project graph to collect all the dependencies of your project,
 
 We use the version numbers of the installed packages when checking whether the version specifier in `package.json` is correct. We do this because this is the only version for which we can "guarantee" that things work and were tested. If you specify a range outside of that version, that would mean that you are shipping potentially untested code.
 
+{% callout type="check" title="Keep the Package Manager Lock File Up-to-Date" %}
+The `@nx/dependency-checks` rule requires the presence of an up-to-date lock file in the workspace root to detect installed packages and their versions correctly. If the `package.json` file has changes that are not reflected in the lock file, make sure to perform a package installation.
+{% /callout %}
+
 ## Usage
 
 Library generators from `@nx` packages will configure this rule automatically when you opt-in for bundler/build setup. This rule is intended for publishable/buildable libraries, so it will only run if a `build` target is detected in the configuration (this name can be modified - see [options](#options)).


### PR DESCRIPTION
```
004fc4bd07 - docs(nx-cloud): fix missing e2e-ci mention on the CI tutorial command (6 hours ago) <Juri>
35899e3a25 - docs(linter): call out up to date lock file requirement for `@nx/dependency-checks` rule (#27587) (19 hours ago) <Leosvel Pérez Espinosa>
3d940c8884 - docs(misc): add more to 19.6 release notes (#27605) (19 hours ago) <Jack Hsu>
```