### PR TITLE
fix(js): keep refs to ignored files and allow opting out of pruning stale refs in typescript sync generator

### DIFF
--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -391,7 +391,7 @@ describe('syncGenerator()', () => {
       `);
     });
 
-    it('should not prune existing external project references that are not dependencies but are ignored', async () => {
+    it('should not prune existing external project references that are not dependencies but are git ignored', async () => {
       writeJson(tree, 'packages/b/tsconfig.json', {
         compilerOptions: {
           composite: true,
@@ -399,8 +399,8 @@ describe('syncGenerator()', () => {
         references: [
           { path: './some/thing' },
           { path: './another/one' },
-          { path: '../../some-path/dir' }, // this is not a dependency but it's ignored, should not be pruned
-          { path: '../c' }, // this is not a dependency and it's not ignored, should be pruned
+          { path: '../../some-path/dir' }, // this is not a dependency but it's git ignored, should not be pruned
+          { path: '../c' }, // this is not a dependency and it's not git ignored, should be pruned
         ],
       });
       tree.write('some-path/dir/tsconfig.json', '{}');
@@ -429,15 +429,6 @@ describe('syncGenerator()', () => {
     });
 
     it('should not prune stale project references from projects included in `nx.sync.ignoredReferences`', async () => {
-      const nxJson = readNxJson(tree);
-      nxJson.sync = {
-        generatorOptions: {
-          '@nx/js:typescript-sync': {
-            projectsToKeepStaleReferences: ['b'],
-          },
-        },
-      };
-      updateNxJson(tree, nxJson);
       writeJson(tree, 'packages/b/tsconfig.json', {
         compilerOptions: {
           composite: true,
@@ -445,7 +436,7 @@ describe('syncGenerator()', () => {
         references: [
           { path: './some/thing' },
           { path: './another/one' },
-          // this is not a dependency and it's not ignored, it would normally be pruned,
+          // this is not a dependency and it's not git ignored, it would normally be pruned,
           // but it's included in `nx.sync.ignoredReferences`, so we don't prune it
           { path: '../c' },
         ],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When the `@nx/js:typescript-sync` generator updates a tsconfig file of an Nx project, it prunes project references pointing to a path that's not part of the Nx project files (including paths inside a nested project) if they don't belong to a project that is a dependency.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When the `@nx/js:typescript-sync` generator updates a tsconfig file of an Nx project, it should only prune project references pointing to a path that's not part of the Nx project files if it's not ignored and not part of a dependency.

Additionally, a new `nx.sync.ignoredReferences` top-level option in tsconfig files allows specifying custom project references that the `@nx/js:typescript-sync` sync generator should ignore and not prune.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
<!-- Fixes NXC-905 -->

Fixes #
