### PR TITLE
feat(core): allow disabling registered task sync generators

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -282,6 +282,13 @@
         "applyChanges": {
           "type": "boolean",
           "description": "Whether to automatically apply sync generator changes when running tasks. If not set, the user will be prompted. If set to `true`, the user will not be prompted and the changes will be applied. If set to `false`, the user will not be prompted and the changes will not be applied."
+        },
+        "disabledTaskSyncGenerators": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of registered task sync generators to disable."
         }
       },
       "additionalProperties": false

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -321,11 +321,16 @@ export interface NxSyncConfiguration {
 
   /**
    * Whether to automatically apply sync generator changes when running tasks.
-   * If not set, the user will be prompted.
+   * If not set, the user will be prompted in interactive mode.
    * If set to `true`, the user will not be prompted and the changes will be applied.
    * If set to `false`, the user will not be prompted and the changes will not be applied.
    */
   applyChanges?: boolean;
+
+  /**
+   * List of registered task sync generators to disable.
+   */
+  disabledTaskSyncGenerators?: string[];
 }
 
 /**

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -635,6 +635,9 @@ function normalizeTargets(
   sourceMaps: ConfigurationSourceMaps,
   nxJsonConfiguration: NxJsonConfiguration<'*' | string[]>
 ) {
+  const disabledTaskSyncGenerators = new Set(
+    nxJsonConfiguration.sync?.disabledTaskSyncGenerators ?? []
+  );
   for (const targetName in project.targets) {
     project.targets[targetName] = normalizeTarget(
       project.targets[targetName],
@@ -678,6 +681,17 @@ function normalizeTargets(
         // we can remove it.
         delete project.targets[targetName];
       }
+    }
+
+    if (
+      disabledTaskSyncGenerators.size &&
+      project.targets[targetName].syncGenerators?.length
+    ) {
+      project.targets[targetName].syncGenerators = project.targets[
+        targetName
+      ].syncGenerators.filter(
+        (syncGenerator) => !disabledTaskSyncGenerators.has(syncGenerator)
+      );
     }
   }
 }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -635,9 +635,6 @@ function normalizeTargets(
   sourceMaps: ConfigurationSourceMaps,
   nxJsonConfiguration: NxJsonConfiguration<'*' | string[]>
 ) {
-  const disabledTaskSyncGenerators = new Set(
-    nxJsonConfiguration.sync?.disabledTaskSyncGenerators ?? []
-  );
   for (const targetName in project.targets) {
     project.targets[targetName] = normalizeTarget(
       project.targets[targetName],
@@ -681,17 +678,6 @@ function normalizeTargets(
         // we can remove it.
         delete project.targets[targetName];
       }
-    }
-
-    if (
-      disabledTaskSyncGenerators.size &&
-      project.targets[targetName].syncGenerators?.length
-    ) {
-      project.targets[targetName].syncGenerators = project.targets[
-        targetName
-      ].syncGenerators.filter(
-        (syncGenerator) => !disabledTaskSyncGenerators.has(syncGenerator)
-      );
     }
   }
 }

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -21,6 +21,7 @@ import { isNxCloudUsed } from '../utils/nx-cloud-utils';
 import { output } from '../utils/output';
 import { handleErrors } from '../utils/params';
 import {
+  collectEnabledTaskSyncGeneratorsFromTaskGraph,
   flushSyncGeneratorChanges,
   getSyncGeneratorChanges,
   syncGeneratorResultsToMessageLines,
@@ -233,18 +234,11 @@ async function ensureWorkspaceIsInSyncAndGetGraphs(
   );
 
   // collect unique syncGenerators from the tasks
-  const uniqueSyncGenerators = new Set<string>();
-  for (const { target } of Object.values(taskGraph.tasks)) {
-    const { syncGenerators } =
-      projectGraph.nodes[target.project].data.targets[target.target];
-    if (!syncGenerators) {
-      continue;
-    }
-
-    for (const generator of syncGenerators) {
-      uniqueSyncGenerators.add(generator);
-    }
-  }
+  const uniqueSyncGenerators = collectEnabledTaskSyncGeneratorsFromTaskGraph(
+    taskGraph,
+    projectGraph,
+    nxJson
+  );
 
   if (!uniqueSyncGenerators.size) {
     // There are no sync generators registered in the tasks to run


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

There's no way to disable sync generators registered in inferred tasks by a Crystal plugin.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There should be a way to disable sync generators registered in inferred tasks by a Crystal plugin.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
<!-- Fixes NXC-904 -->

Fixes #
