### PR TITLE
feat(core): return task results from imperative task runner

### DIFF
--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -8,6 +8,7 @@ import { InvokeRunnerTerminalOutputLifeCycle } from './life-cycles/invoke-runner
 import { performance } from 'perf_hooks';
 import { getOutputs } from './utils';
 import { loadRootEnvFiles } from '../utils/dotenv';
+import { TaskResult } from './life-cycle';
 
 export async function initTasksRunner(nxArgs: NxArgs) {
   performance.mark('init-local');
@@ -22,7 +23,11 @@ export async function initTasksRunner(nxArgs: NxArgs) {
     invoke: async (opts: {
       tasks: Task[];
       parallel: number;
-    }): Promise<{ status: number; taskGraph: TaskGraph }> => {
+    }): Promise<{
+      status: number;
+      taskGraph: TaskGraph;
+      taskResults: Record<string, TaskResult>;
+    }> => {
       performance.mark('code-loading:end');
 
       // TODO: This polyfills the outputs if someone doesn't pass a task with outputs. Remove this in Nx 20
@@ -60,6 +65,7 @@ export async function initTasksRunner(nxArgs: NxArgs) {
       return {
         status,
         taskGraph,
+        taskResults: lifeCycle.getTaskResults(),
       };
     },
   };


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Imperatively running tasks does not return task results.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Imperatively running tasks returns task results along with the overall status and the task graph

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
