### PR TITLE
fix(core): do not stream output when static output style is enabled

### DIFF
--- a/packages/nx/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/default-tasks-runner.ts
@@ -136,7 +136,8 @@ async function runAllTasks(
     context.taskGraph,
     options,
     context.nxArgs?.nxBail,
-    context.daemon
+    context.daemon,
+    context.nxArgs?.outputStyle
   );
 
   return orchestrator.run();

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -80,7 +80,8 @@ export class TaskOrchestrator {
     private readonly taskGraph: TaskGraph,
     private readonly options: DefaultTasksRunnerOptions,
     private readonly bail: boolean,
-    private readonly daemon: DaemonClient
+    private readonly daemon: DaemonClient,
+    private readonly outputStyle: string
   ) {}
 
   async run() {
@@ -360,7 +361,10 @@ export class TaskOrchestrator {
     const pipeOutput = await this.pipeOutputCapture(task);
     // obtain metadata
     const temporaryOutputPath = this.cache.temporaryOutputPath(task);
-    const streamOutput = shouldStreamOutput(task, this.initiatingProject);
+    const streamOutput =
+      this.outputStyle === 'static'
+        ? false
+        : shouldStreamOutput(task, this.initiatingProject);
 
     let env = pipeOutput
       ? getEnvVariablesForTask(


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Output is still streamed sometimes when `--outputStyle static` is used.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Output is not streamed when `--outputStyle static` is used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
