### PR TITLE
fix(gradle): fix child project deps

### DIFF
--- a/packages/gradle/src/plugin/dependencies.spec.ts
+++ b/packages/gradle/src/plugin/dependencies.spec.ts
@@ -17,12 +17,21 @@ describe('processGradleDependencies', () => {
     processGradleDependencies(
       depFilePath,
       new Map([
-        [':my-utils:number-utils', 'number-utils'],
-        [':my-utils:string-utils', 'string-utils'],
+        [':my-utils:number-utils', 'utilities/number-utils'],
+        [':my-utils:string-utils', 'utilities/string-utils'],
       ]),
       'app',
       'app',
-      {} as any,
+      {
+        projects: {
+          'utilities/number-utils': {
+            name: 'number-utils',
+          },
+          'utilities/string-utils': {
+            name: 'string-utils',
+          },
+        },
+      } as any,
       dependencies
     );
     expect(Array.from(dependencies)).toEqual([
@@ -51,13 +60,25 @@ describe('processGradleDependencies', () => {
     processGradleDependencies(
       depFilePath,
       new Map([
-        [':my-utils:number-utils', 'number-utils'],
-        [':my-utils:string-utils', 'string-utils'],
+        [':my-utils:number-utils', 'utilities/number-utils'],
+        [':my-utils:string-utils', 'utilities/string-utils'],
         [':utilities', 'utilities'],
       ]),
       'app',
       'app',
-      {} as any,
+      {
+        projects: {
+          'utilities/number-utils': {
+            name: 'number-utils',
+          },
+          'utilities/string-utils': {
+            name: 'string-utils',
+          },
+          utilities: {
+            name: 'utilities',
+          },
+        },
+      } as any,
       dependencies
     );
     expect(Array.from(dependencies)).toEqual([

--- a/packages/gradle/src/plugin/nodes.spec.ts
+++ b/packages/gradle/src/plugin/nodes.spec.ts
@@ -34,6 +34,9 @@ describe('@nx/gradle/plugin', () => {
         ['proj', new Map([['test', 'Verification']])],
       ]),
       gradleProjectToProjectName: new Map<string, string>([['proj', 'proj']]),
+      gradleProjectNameToProjectRootMap: new Map<string, string>([
+        ['proj', 'proj'],
+      ]),
       gradleProjectToChildProjects: new Map<string, string[]>(),
     };
     cwd = process.cwd();
@@ -136,6 +139,9 @@ describe('@nx/gradle/plugin', () => {
         ['proj', new Map([['test', 'Verification']])],
       ]),
       gradleProjectToProjectName: new Map<string, string>([['proj', 'proj']]),
+      gradleProjectNameToProjectRootMap: new Map<string, string>([
+        ['proj', 'proj'],
+      ]),
       gradleProjectToChildProjects: new Map<string, string[]>(),
     };
     await tempFs.createFiles({
@@ -218,6 +224,9 @@ describe('@nx/gradle/plugin', () => {
           ['proj', new Map([['test', 'Test']])],
         ]),
         gradleProjectToProjectName: new Map<string, string>([['proj', 'proj']]),
+        gradleProjectNameToProjectRootMap: new Map<string, string>([
+          ['proj', 'proj'],
+        ]),
         gradleProjectToChildProjects: new Map<string, string[]>(),
       };
       await tempFs.createFiles({

--- a/packages/gradle/src/utils/get-gradle-report.ts
+++ b/packages/gradle/src/utils/get-gradle-report.ts
@@ -11,6 +11,7 @@ import { combineGlobPatterns } from 'nx/src/utils/globs';
 
 import { execGradleAsync } from './exec-gradle';
 import { hashWithWorkspaceContext } from 'nx/src/utils/workspace-context';
+import { dirname } from 'path';
 
 export const fileSeparator = process.platform.startsWith('win')
   ? 'file:///'
@@ -26,6 +27,7 @@ export interface GradleReport {
   gradleFileToOutputDirsMap: Map<string, Map<string, string>>;
   gradleProjectToTasksTypeMap: Map<string, Map<string, string>>;
   gradleProjectToProjectName: Map<string, string>;
+  gradleProjectNameToProjectRootMap: Map<string, string>;
   gradleProjectToChildProjects: Map<string, string[]>;
 }
 
@@ -125,6 +127,7 @@ export function processProjectReports(
    */
   const gradleProjectToTasksTypeMap = new Map<string, Map<string, string>>();
   const gradleProjectToProjectName = new Map<string, string>();
+  const gradleProjectNameToProjectRootMap = new Map<string, string>();
   /**
    * Map of buildFile to dependencies report path
    */
@@ -225,6 +228,7 @@ export function processProjectReports(
         gradleFileToOutputDirsMap.set(buildFile, outputDirMap);
         gradleFileToGradleProjectMap.set(buildFile, gradleProject);
         gradleProjectToProjectName.set(gradleProject, projectName);
+        gradleProjectNameToProjectRootMap.set(projectName, dirname(buildFile));
       }
       if (line.endsWith('taskReport')) {
         const gradleProject = line.substring(
@@ -276,6 +280,7 @@ export function processProjectReports(
     gradleFileToOutputDirsMap,
     gradleProjectToTasksTypeMap,
     gradleProjectToProjectName,
+    gradleProjectNameToProjectRootMap,
     gradleProjectToChildProjects,
   };
 }


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

When the name of a gradle project is overwritten by a different plugin, the plugin throws an error creating dependencies.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The plugin uses the `CreateDependenciesContext` to get the name of a project at the project root and uses that to create the dependency.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
