### PR TITLE
fix(expo): add cacheVersion to metro.config

### DIFF
--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -104,7 +104,7 @@ function buildExpoTargets(
     },
     [options.serveTargetName]: {
       command: `expo start --web`,
-      options: { cwd: projectRoot },
+      options: { cwd: projectRoot, args: ['--clear'] },
     },
     [options.runIosTargetName]: {
       command: `expo run:ios`,
@@ -116,7 +116,7 @@ function buildExpoTargets(
     },
     [options.exportTargetName]: {
       command: `expo export`,
-      options: { cwd: projectRoot },
+      options: { cwd: projectRoot, args: ['--clear'] },
       cache: true,
       dependsOn: [`^${options.exportTargetName}`],
       inputs: getInputs(namedInputs),

--- a/packages/expo/src/generators/application/files/base/metro.config.js.template
+++ b/packages/expo/src/generators/application/files/base/metro.config.js.template
@@ -12,6 +12,7 @@ const { assetExts, sourceExts } = defaultConfig.resolver;
  * @type {import('metro-config').MetroConfig}
  */
 const customConfig = {
+  cacheVersion: "<%= projectName %>",
   transformer: {
     babelTransformerPath: require.resolve('react-native-svg-transformer'),
   },

--- a/packages/react-native/src/generators/application/files/app/metro.config.js.template
+++ b/packages/react-native/src/generators/application/files/app/metro.config.js.template
@@ -11,6 +11,7 @@ const { assetExts, sourceExts } = defaultConfig.resolver;
  * @type {import('metro-config').MetroConfig}
  */
 const customConfig = {
+  cacheVersion: "<%= projectName %>",
   transformer: {
     babelTransformerPath: require.resolve('react-native-svg-transformer'),
   },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
expo tends to cache the output if there is no change in metro.config.js
we don't need to explicitly set the args --clear when https://github.com/expo/expo/issues/30930 is fixed

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/27392
