### PR TITLE
fix(vite): plugin should infer ts project correctly for libs

### DIFF
--- a/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -49,7 +49,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             },
             "typecheck": {
               "cache": true,
-              "command": "tsc --noEmit",
+              "command": "tsc --noEmit -p tsconfig.lib.json",
               "inputs": [
                 "production",
                 "^production",

--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -49,7 +49,7 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
             },
             "typecheck": {
               "cache": true,
-              "command": "tsc --noEmit",
+              "command": "tsc --noEmit -p tsconfig.lib.json",
               "inputs": [
                 "production",
                 "^production",

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -206,18 +206,19 @@ async function buildViteTargets(
   }
 
   if (tsConfigFiles.length) {
-    const tsconfigToUse = tsConfigFiles.includes('tsconfig.lib.json')
-      ? 'tsconfig.lib.json'
-      : tsConfigFiles[0];
+    const tsConfigToUse =
+      ['tsconfig.app.json', 'tsconfig.lib.json', 'tsconfig.json'].find((t) =>
+        tsConfigFiles.includes(t)
+      ) ?? tsConfigFiles[0];
     targets[options.typecheckTargetName] = {
       cache: true,
       inputs: ['production', '^production'],
-      command: 'tsc --noEmit',
+      command: `tsc --noEmit -p ${tsConfigToUse}`,
       options: { cwd: joinPathFragments(projectRoot) },
       metadata: {
         description: `Run Typechecking`,
         help: {
-          command: `${pmc.exec} tsc --help -p ${tsconfigToUse}`,
+          command: `${pmc.exec} tsc --help -p ${tsConfigToUse}`,
           example: {
             options: {
               noEmit: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The vite plugin's typecheck target is not using the tsconfig.lib.json project when running typecheck for libs

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should use the correct tsconfig


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27501
