### PR TITLE
cleanup(repo): remove unused deprecated dependency `url-loader`

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,7 +289,6 @@
     "typescript": "~5.5.2",
     "unist-builder": "^4.0.0",
     "unzipper": "^0.10.11",
-    "url-loader": "^4.1.1",
     "use-sync-external-store": "^1.2.0",
     "verdaccio": "^5.30.0",
     "vite": "5.0.8",

--- a/packages/next/.eslintrc.json
+++ b/packages/next/.eslintrc.json
@@ -89,7 +89,6 @@
               // require.resovle is used for these
               "@babel/plugin-proposal-decorators",
               "file-loader",
-              "url-loader",
               "@svgr/webpack"
             ]
           }

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -77,7 +77,6 @@
               "stylus-loader",
               "swc-loader",
               "tsconfig-paths-webpack-plugin",
-              "url-loader",
               "webpack",
               "webpack-merge",
               // used via the CT react plugin installed via vite plugin

--- a/packages/remix/.eslintrc.json
+++ b/packages/remix/.eslintrc.json
@@ -78,7 +78,6 @@
               "stylus-loader",
               "swc-loader",
               "tsconfig-paths-webpack-plugin",
-              "url-loader",
               "webpack",
               "webpack-merge",
               // used via the CT react plugin installed via vite plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,9 +958,6 @@ importers:
       unzipper:
         specifier: ^0.10.11
         version: 0.10.11
-      url-loader:
-        specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
       use-sync-external-store:
         specifier: ^1.2.0
         version: 1.2.0(react@18.3.1)
@@ -17588,16 +17585,6 @@ packages:
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
-
-  url-loader@4.1.1:
-    resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      file-loader: '*'
-      webpack: ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      file-loader:
-        optional: true
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -40961,15 +40948,6 @@ snapshots:
       punycode: 2.3.0
 
   url-join@4.0.1: {}
-
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)):
-    dependencies:
-      loader-utils: 2.0.4
-      mime-types: 2.1.35
-      schema-utils: 3.1.2
-      webpack: 5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)
-    optionalDependencies:
-      file-loader: 6.2.0(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
 
   url-parse@1.5.10:
     dependencies:


### PR DESCRIPTION
removes the unused and deprecated depdendency `url-loader` and references in dependency-check eslint rules

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
