### PR TITLE
fix(core): change remoteCache to getRemoteCache

### DIFF
--- a/packages/nx/src/nx-cloud/update-manager.ts
+++ b/packages/nx/src/nx-cloud/update-manager.ts
@@ -56,7 +56,7 @@ export interface NxCloudClient {
   configureLightClientRequire: () => (paths: string[]) => void;
   commands: Record<string, () => Promise<void>>;
   nxCloudTasksRunner: TasksRunner<CloudTaskRunnerOptions>;
-  remoteCache: RemoteCacheV2;
+  getRemoteCache: () => RemoteCacheV2;
 }
 export async function verifyOrUpdateNxCloudClient(
   options: CloudTaskRunnerOptions

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -119,8 +119,8 @@ export class DbCache {
     if (isNxCloudUsed(nxJson)) {
       const options = getCloudOptions();
       const { nxCloudClient } = await verifyOrUpdateNxCloudClient(options);
-      if (nxCloudClient.remoteCache) {
-        return nxCloudClient.remoteCache;
+      if (nxCloudClient.getRemoteCache) {
+        return nxCloudClient.getRemoteCache();
       } else {
         // old nx cloud instance
         return await RemoteCacheV2.fromCacheV1(this.options.nxCloudRemoteCache);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Calling remoteCache directly for the Nx cloud package causes issues with how nx cloud deals with imports

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`remoteCache` is now a function call so that the nx cloud package functions properly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
