### PR TITLE
fix(js): respect "watch" option when "runBuildTargetDependencies" is true

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -276,8 +276,10 @@ export async function* nodeExecutor(
             } else if (err) {
               logger.error(`Watch error: ${err?.message ?? 'Unknown'}`);
             } else {
-              logger.info(`NX File change detected. Restarting...`);
-              await runBuild();
+              if (options.watch) {
+                logger.info(`NX File change detected. Restarting...`);
+                await runBuild();
+              }
             }
           }
         );


### PR DESCRIPTION
This PR fixes and issue when `watch: false` and `runBuildTargetDependencies: true` results in the server process restarting, but no build happens.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20963
