### PR TITLE
feat(nx-cloud): add 'generate-token' option to connect

### DIFF
--- a/docs/generated/cli/connect.md
+++ b/docs/generated/cli/connect.md
@@ -17,11 +17,23 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
+### generateToken
+
+Type: `boolean`
+
+Explicitly asks for a token to be created, do not override existing tokens from Nx Cloud
+
 ### help
 
 Type: `boolean`
 
 Show help
+
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
 
 ### version
 

--- a/docs/generated/packages/nx/documents/connect-to-nx-cloud.md
+++ b/docs/generated/packages/nx/documents/connect-to-nx-cloud.md
@@ -17,11 +17,23 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
+### generateToken
+
+Type: `boolean`
+
+Explicitly asks for a token to be created, do not override existing tokens from Nx Cloud
+
 ### help
 
 Type: `boolean`
 
 Show help
+
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
 
 ### version
 

--- a/docs/generated/packages/nx/generators/connect-to-nx-cloud.json
+++ b/docs/generated/packages/nx/generators/connect-to-nx-cloud.json
@@ -24,6 +24,10 @@
         "description": "Hide formatting logs",
         "x-priority": "internal"
       },
+      "generateToken": {
+        "type": "boolean",
+        "description": "Explicitly asks for a token to be created, do not override existing tokens from Nx Cloud"
+      },
       "github": {
         "type": "boolean",
         "description": "If the user will be using GitHub as their git hosting provider",

--- a/packages/nx/src/command-line/connect/command-object.ts
+++ b/packages/nx/src/command-line/connect/command-object.ts
@@ -1,14 +1,16 @@
-import { CommandModule } from 'yargs';
+import { Argv, CommandModule } from 'yargs';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
 import { nxVersion } from '../../utils/versions';
+import { withVerbose } from '../yargs-utils/shared-options';
 
 export const yargsConnectCommand: CommandModule = {
   command: 'connect',
   aliases: ['connect-to-nx-cloud'],
   describe: `Connect workspace to Nx Cloud`,
-  builder: (yargs) => linkToNxDevAndExamples(yargs, 'connect-to-nx-cloud'),
-  handler: async () => {
-    await (await import('./connect-to-nx-cloud')).connectToNxCloudCommand();
+  builder: (yargs) =>
+    linkToNxDevAndExamples(withConnectOptions(yargs), 'connect-to-nx-cloud'),
+  handler: async (args: any) => {
+    await (await import('./connect-to-nx-cloud')).connectToNxCloudCommand(args);
     await (
       await import('../../utils/ab-testing')
     ).recordStat({
@@ -19,6 +21,14 @@ export const yargsConnectCommand: CommandModule = {
     process.exit(0);
   },
 };
+
+function withConnectOptions(yargs: Argv) {
+  return withVerbose(yargs).option('generateToken', {
+    type: 'boolean',
+    description:
+      'Explicitly asks for a token to be created, do not override existing tokens from Nx Cloud',
+  });
+}
 
 export const yargsViewLogsCommand: CommandModule = {
   command: 'view-logs',

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -70,6 +70,7 @@ export async function connectWorkspaceToCloud(
 }
 
 export async function connectToNxCloudCommand(
+  options: { generateToken?: boolean },
   command?: string
 ): Promise<boolean> {
   const nxJson = readNxJson();
@@ -90,7 +91,8 @@ export async function connectToNxCloudCommand(
     }
     const connectCloudUrl = await createNxCloudOnboardingURL(
       installationSource,
-      token
+      token,
+      options?.generateToken !== true
     );
     output.log({
       title: '✔ This workspace already has Nx Cloud set up',
@@ -104,10 +106,15 @@ export async function connectToNxCloudCommand(
     return false;
   }
   const token = await connectWorkspaceToCloud({
+    generateToken: options?.generateToken,
     installationSource: command ?? installationSource,
   });
 
-  const connectCloudUrl = await createNxCloudOnboardingURL('nx-connect', token);
+  const connectCloudUrl = await createNxCloudOnboardingURL(
+    'nx-connect',
+    token,
+    options?.generateToken !== true
+  );
   try {
     const cloudConnectSpinner = ora(
       `Opening Nx Cloud ${connectCloudUrl} in your browser to connect your workspace.`
@@ -153,7 +160,9 @@ export async function connectExistingRepoToNxCloudPrompt(
 export async function connectToNxCloudWithPrompt(command: string) {
   const setNxCloud = await nxCloudPrompt('setupNxCloud');
   const useCloud =
-    setNxCloud === 'yes' ? await connectToNxCloudCommand(command) : false;
+    setNxCloud === 'yes'
+      ? await connectToNxCloudCommand({ generateToken: false }, command)
+      : false;
   await recordStat({
     command,
     nxVersion,

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json
@@ -21,6 +21,10 @@
       "description": "Hide formatting logs",
       "x-priority": "internal"
     },
+    "generateToken": {
+      "type": "boolean",
+      "description": "Explicitly asks for a token to be created, do not override existing tokens from Nx Cloud"
+    },
     "github": {
       "type": "boolean",
       "description": "If the user will be using GitHub as their git hosting provider",


### PR DESCRIPTION
This update introduces a new 'genreate-token' option to force local token creation. It ensures tokens are not created for GitHub-based setups unless explicitly overridden. Adjustments include updated logic in the generator function and schema to accommodate the new option.
