### PR TITLE
chore(storybook): rename env vars so we do not cause Nx Cloud connection errors

### DIFF
--- a/e2e/storybook/src/storybook.test.ts
+++ b/e2e/storybook/src/storybook.test.ts
@@ -120,8 +120,8 @@ describe('Storybook generators and executors for monorepos', () => {
       );
       runCLI(`run ${reactStorybookApp}:build-storybook --verbose`, {
         env: {
-          NX_CLOUD_ENCRYPTION_KEY: 'MY SECRET',
-          NX_CLOUD_ACCESS_TOKEN: 'MY SECRET',
+          NX_SOME_SECRET: 'MY SECRET',
+          NX_SOME_TOKEN: 'MY SECRET',
         },
       });
 
@@ -131,8 +131,8 @@ describe('Storybook generators and executors for monorepos', () => {
       for (const file of files) {
         if (!file.endsWith('.js')) continue;
         const content = readFile(`${outDir}/${file}`);
-        expect(content).not.toMatch(/NX_CLOUD_ENCRYPTION_KEY/);
-        expect(content).not.toMatch(/NX_CLOUD_ACCESS_TOKEN/);
+        expect(content).not.toMatch(/NX_SOME_SECRET/);
+        expect(content).not.toMatch(/NX_SOME_TOKEN/);
         expect(content).not.toMatch(/MY SECRET/);
       }
     }, 300_000);


### PR DESCRIPTION
The test to ensure we don't bundle secrets/tokens is causing an error like this:

```
 NX   Connection to Nx Cloud failed with status code ERR_BAD_REQUEST
```

e.g. https://staging.nx.app/runs/0IjxPh53dK

Likely due to validation errors now in place. We shouldn't be hitting Nx Cloud from the test project, so I've renamed the variables to be something that isn't used to connect to Cloud.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
