### PR TITLE
fix(core): fixes an issue where using "node:test" results in infinite loop

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -34,6 +34,13 @@ const defaultNpmResolutionCache: NpmResolutionCache = new Map();
 const builtInModuleSet = new Set<string>([
   ...builtinModules,
   ...builtinModules.map((x) => `node:${x}`),
+  // These are missing in the builtinModules list
+  // See: https://github.com/nodejs/node/issues/42785
+  // TODO(v20): We should be safe to use `isBuiltin` function instead of keep the set here (https://nodejs.org/api/module.html#moduleisbuiltinmodulename)
+  'test',
+  'node:test',
+  'node:sea',
+  'node:sqlite',
 ]);
 
 export function isBuiltinModuleImport(importExpr: string): boolean {
@@ -364,7 +371,7 @@ export class TargetProjectLocator {
         packageJsonPath ?? resolveRelativeToDir(packageName, relativeToDir);
       let dir = dirname(pathOfFileInPackage);
 
-      while (dir !== parse(dir).root) {
+      while (dir !== dirname(dir)) {
         const packageJsonPath = join(dir, 'package.json');
         try {
           const parsedPackageJson = readJsonFile(packageJsonPath);


### PR DESCRIPTION
This PR fixes an issue with `node:test` not being recognized as a built-in Node module, and since it is not in `node_modules` with a resolvable `package.json`, it hits an infinite loop.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
