### PR TITLE
fix(core): handle file change conflicts between sync generators

### DIFF
--- a/packages/nx/src/daemon/server/sync-generators.spec.ts
+++ b/packages/nx/src/daemon/server/sync-generators.spec.ts
@@ -1,0 +1,66 @@
+import type { SyncGeneratorChangesResult } from '../../utils/sync-generators';
+import { _getConflictingGeneratorGroups } from './sync-generators';
+
+describe('_getConflictingGeneratorGroups', () => {
+  it('should return grouped conflicting generators', () => {
+    const results: SyncGeneratorChangesResult[] = [
+      {
+        generatorName: 'a',
+        changes: [
+          { type: 'UPDATE', path: 'file1.txt', content: Buffer.from('') },
+          { type: 'UPDATE', path: 'file2.txt', content: Buffer.from('') },
+          { type: 'UPDATE', path: 'file3.txt', content: Buffer.from('') },
+        ],
+      },
+      {
+        generatorName: 'b',
+        changes: [
+          { type: 'UPDATE', path: 'file1.txt', content: Buffer.from('') },
+        ],
+      },
+      {
+        generatorName: 'c',
+        changes: [
+          { type: 'UPDATE', path: 'file3.txt', content: Buffer.from('') },
+          { type: 'UPDATE', path: 'file4.txt', content: Buffer.from('') },
+        ],
+      },
+      {
+        generatorName: 'd',
+        changes: [
+          { type: 'UPDATE', path: 'file5.txt', content: Buffer.from('') },
+        ],
+      },
+      {
+        generatorName: 'e',
+        changes: [
+          { type: 'UPDATE', path: 'file4.txt', content: Buffer.from('') },
+          { type: 'UPDATE', path: 'file6.txt', content: Buffer.from('') },
+        ],
+      },
+      {
+        generatorName: 'f',
+        changes: [
+          { type: 'UPDATE', path: 'file7.txt', content: Buffer.from('') },
+        ],
+      },
+      {
+        generatorName: 'g',
+        changes: [
+          { type: 'UPDATE', path: 'file7.txt', content: Buffer.from('') },
+        ],
+      },
+      {
+        generatorName: 'h',
+        changes: [
+          { type: 'UPDATE', path: 'file8.txt', content: Buffer.from('') },
+        ],
+      },
+    ];
+
+    expect(_getConflictingGeneratorGroups(results)).toStrictEqual([
+      ['a', 'b', 'c', 'e'],
+      ['f', 'g'],
+    ]);
+  });
+});

--- a/packages/nx/src/daemon/server/sync-generators.ts
+++ b/packages/nx/src/daemon/server/sync-generators.ts
@@ -1,7 +1,7 @@
 import { readNxJson } from '../../config/nx-json';
 import type { ProjectGraph } from '../../config/project-graph';
 import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
-import { FsTree } from '../../generators/tree';
+import { FsTree, type Tree } from '../../generators/tree';
 import { hashArray } from '../../hasher/file-hasher';
 import { readProjectsConfigurationFromProjectGraph } from '../../project-graph/project-graph';
 import {
@@ -34,7 +34,6 @@ const log = (...messageParts: unknown[]) => {
   serverLogger.log('[SYNC]:', ...messageParts);
 };
 
-// TODO(leo): check conflicts and reuse the Tree where possible
 export async function getCachedSyncGeneratorChanges(
   generators: string[]
 ): Promise<SyncGeneratorChangesResult[]> {
@@ -50,66 +49,17 @@ export async function getCachedSyncGeneratorChanges(
     // reset the wait time
     waitPeriod = 100;
 
-    let projects: Record<string, ProjectConfiguration> | null;
-    let errored = false;
-    const getProjectsConfigurations = async () => {
-      if (projects || errored) {
-        return projects;
-      }
+    const results = await getFromCacheOrRunGenerators(generators);
 
-      const { projectGraph, error } =
-        await getCachedSerializedProjectGraphPromise();
-      projects = projectGraph
-        ? readProjectsConfigurationFromProjectGraph(projectGraph).projects
-        : null;
-      errored = error !== undefined;
+    const conflicts = _getConflictingGeneratorGroups(results);
+    if (!conflicts.length) {
+      // there are no conflicts
+      return results;
+    }
 
-      return projects;
-    };
-
-    return (
-      await Promise.all(
-        generators.map(async (generator) => {
-          if (
-            scheduledGenerators.has(generator) ||
-            !syncGeneratorsCacheResultPromises.has(generator)
-          ) {
-            // it's scheduled to run (there are pending changes to process) or
-            // it's not scheduled and there's no cached result, so run it
-            const projects = await getProjectsConfigurations();
-            if (projects) {
-              log(generator, 'already scheduled or not cached, running it now');
-              runGenerator(generator, projects);
-            } else {
-              log(
-                generator,
-                'already scheduled or not cached, project graph errored'
-              );
-              /**
-               * This should never happen. This is invoked imperatively, and by
-               * the time it is invoked, the project graph would have already
-               * been requested. If it errored, it would have been reported and
-               * this wouldn't have been invoked. We handle it just in case.
-               *
-               * Since the project graph would be reported by the relevant
-               * handlers separately, we just ignore the error, don't cache
-               * any result and return an empty result, the next time this is
-               * invoked the process will repeat until it eventually recovers
-               * when the project graph is fixed.
-               */
-              return Promise.resolve({ changes: [], generatorName: generator });
-            }
-          } else {
-            log(
-              generator,
-              'not scheduled and has cached result, returning cached result'
-            );
-          }
-
-          return syncGeneratorsCacheResultPromises.get(generator);
-        })
-      )
-    ).flat();
+    // there are conflicts, so we need to re-run the conflicting generators
+    // using the same tree
+    return await processConflictingGenerators(conflicts, results);
   } catch (e) {
     console.error(e);
     syncGeneratorsCacheResultPromises.clear();
@@ -179,7 +129,10 @@ export function collectAndScheduleSyncGenerators(
       readProjectsConfigurationFromProjectGraph(projectGraph);
 
     for (const generator of scheduledGenerators) {
-      runGenerator(generator, projects);
+      syncGeneratorsCacheResultPromises.set(
+        generator,
+        runGenerator(generator, projects)
+      );
     }
 
     await Promise.all(syncGeneratorsCacheResultPromises.values());
@@ -197,6 +150,218 @@ export async function getCachedRegisteredSyncGenerators(): Promise<string[]> {
   }
 
   return [...registeredSyncGenerators];
+}
+
+async function getFromCacheOrRunGenerators(
+  generators: string[]
+): Promise<SyncGeneratorChangesResult[]> {
+  let projects: Record<string, ProjectConfiguration> | null;
+  let errored = false;
+  const getProjectsConfigurations = async () => {
+    if (projects || errored) {
+      return projects;
+    }
+
+    const { projectGraph, error } =
+      await getCachedSerializedProjectGraphPromise();
+    projects = projectGraph
+      ? readProjectsConfigurationFromProjectGraph(projectGraph).projects
+      : null;
+    errored = error !== undefined;
+
+    return projects;
+  };
+
+  return (
+    await Promise.all(
+      generators.map(async (generator) => {
+        if (
+          scheduledGenerators.has(generator) ||
+          !syncGeneratorsCacheResultPromises.has(generator)
+        ) {
+          // it's scheduled to run (there are pending changes to process) or
+          // it's not scheduled and there's no cached result, so run it
+          const projects = await getProjectsConfigurations();
+          if (projects) {
+            log(generator, 'already scheduled or not cached, running it now');
+            syncGeneratorsCacheResultPromises.set(
+              generator,
+              runGenerator(generator, projects)
+            );
+          } else {
+            log(
+              generator,
+              'already scheduled or not cached, project graph errored'
+            );
+            /**
+             * This should never happen. This is invoked imperatively, and by
+             * the time it is invoked, the project graph would have already
+             * been requested. If it errored, it would have been reported and
+             * this wouldn't have been invoked. We handle it just in case.
+             *
+             * Since the project graph would be reported by the relevant
+             * handlers separately, we just ignore the error, don't cache
+             * any result and return an empty result, the next time this is
+             * invoked the process will repeat until it eventually recovers
+             * when the project graph is fixed.
+             */
+            return Promise.resolve({ changes: [], generatorName: generator });
+          }
+        } else {
+          log(
+            generator,
+            'not scheduled and has cached result, returning cached result'
+          );
+        }
+
+        return syncGeneratorsCacheResultPromises.get(generator);
+      })
+    )
+  ).flat();
+}
+
+async function runConflictingGenerators(
+  tree: Tree,
+  generators: string[]
+): Promise<SyncGeneratorChangesResult[]> {
+  const { projectGraph } = await getCachedSerializedProjectGraphPromise();
+  const projects = projectGraph
+    ? readProjectsConfigurationFromProjectGraph(projectGraph).projects
+    : null;
+
+  if (!projects) {
+    /**
+     * This should never happen. This is invoked imperatively, and by
+     * the time it is invoked, the project graph would have already
+     * been requested. If it errored, it would have been reported and
+     * this wouldn't have been invoked. We handle it just in case.
+     *
+     * Since the project graph would be reported by the relevant
+     * handlers separately, we just ignore the error.
+     */
+    return generators.map((generator) => ({
+      changes: [],
+      generatorName: generator,
+    }));
+  }
+
+  // we need to run conflicting generators sequentially because they use the same tree
+  const results: SyncGeneratorChangesResult[] = [];
+  for (const generator of generators) {
+    log(generator, 'running it now');
+    results.push(await runGenerator(generator, projects, tree));
+  }
+
+  return results;
+}
+
+async function processConflictingGenerators(
+  conflicts: string[][],
+  initialResults: SyncGeneratorChangesResult[]
+): Promise<SyncGeneratorChangesResult[]> {
+  const conflictRunResults = (
+    await Promise.all(
+      conflicts.map((generators) => {
+        const [firstGenerator, ...generatorsToRun] = generators;
+        // it must exists because the conflicts were identified from the initial results
+        const firstGeneratorResult = initialResults.find(
+          (r) => r.generatorName === firstGenerator
+        )!;
+
+        const tree = new FsTree(
+          workspaceRoot,
+          false,
+          `running sync generators ${generators.join(',')}`
+        );
+        // pre-apply the changes from the first generator to avoid running it
+        for (const change of firstGeneratorResult.changes) {
+          if (change.type === 'CREATE' || change.type === 'UPDATE') {
+            tree.write(change.path, change.content, change.options);
+          } else if (change.type === 'DELETE') {
+            tree.delete(change.path);
+          }
+        }
+
+        /**
+         * We don't cache the results of conflicting generators because they
+         * use the same tree, so some files might contain results from multiple
+         * generators and we don't have guarantees that the same combination of
+         * generators will run together.
+         */
+        return runConflictingGenerators(tree, generatorsToRun);
+      })
+    )
+  ).flat();
+
+  /**
+   * The order of the results from the re-run generators is important because
+   * the last result from a group of conflicting generators will contain the
+   * changes from the previous conflicting generators. So, instead of replacing
+   * in-place the initial results, we first add the results from the re-run
+   * generators, and then add the initial results that were not from a
+   * conflicting generator.
+   */
+  const results = [...conflictRunResults];
+  for (const result of initialResults) {
+    if (
+      conflictRunResults.every((r) => r.generatorName !== result.generatorName)
+    ) {
+      // this result is not from a conflicting generator, so we add it to the
+      // results
+      results.push(result);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * @internal
+ */
+export function _getConflictingGeneratorGroups(
+  results: SyncGeneratorChangesResult[]
+): string[][] {
+  const changedFileToGeneratorMap = new Map<string, Set<string>>();
+  for (const result of results) {
+    for (const change of result.changes) {
+      if (!changedFileToGeneratorMap.has(change.path)) {
+        changedFileToGeneratorMap.set(change.path, new Set());
+      }
+      changedFileToGeneratorMap.get(change.path)!.add(result.generatorName);
+    }
+  }
+
+  const conflicts: Set<string>[] = [];
+  for (const generatorSet of changedFileToGeneratorMap.values()) {
+    if (generatorSet.size === 1) {
+      // no conflicts
+      continue;
+    }
+
+    if (conflicts.length === 0) {
+      // there are no conflicts yet, so we just add the first group
+      conflicts.push(new Set(generatorSet));
+      continue;
+    }
+
+    // identify if any of the current generator sets intersect with any of the
+    // existing conflict groups
+    const generatorsArray = Array.from(generatorSet);
+    const existingConflictGroup = conflicts.find((group) =>
+      generatorsArray.some((generator) => group.has(generator))
+    );
+    if (existingConflictGroup) {
+      // there's an intersecting group, so we merge the two
+      for (const generator of generatorsArray) {
+        existingConflictGroup.add(generator);
+      }
+    } else {
+      // there's no intersecting group, so we create a new one
+      conflicts.push(new Set(generatorsArray));
+    }
+  }
+
+  return conflicts.map((group) => Array.from(group));
 }
 
 function collectAllRegisteredSyncGenerators(projectGraph: ProjectGraph): void {
@@ -252,25 +417,22 @@ function collectAllRegisteredSyncGenerators(projectGraph: ProjectGraph): void {
 
 function runGenerator(
   generator: string,
-  projects: Record<string, ProjectConfiguration>
-): void {
+  projects: Record<string, ProjectConfiguration>,
+  tree?: Tree
+): Promise<SyncGeneratorChangesResult> {
   log('running scheduled generator', generator);
   // remove it from the scheduled set
   scheduledGenerators.delete(generator);
-  const tree = new FsTree(
+  tree ??= new FsTree(
     workspaceRoot,
     false,
     `running sync generator ${generator}`
   );
 
-  // run the generator and cache the result
-  syncGeneratorsCacheResultPromises.set(
-    generator,
-    runSyncGenerator(tree, generator, projects).then((result) => {
-      log(generator, 'changes:', result.changes.map((c) => c.path).join(', '));
-      return result;
-    })
-  );
+  return runSyncGenerator(tree, generator, projects).then((result) => {
+    log(generator, 'changes:', result.changes.map((c) => c.path).join(', '));
+    return result;
+  });
 }
 
 function hashProjectGraph(projectGraph: ProjectGraph): string {

--- a/packages/nx/src/utils/sync-generators.ts
+++ b/packages/nx/src/utils/sync-generators.ts
@@ -87,7 +87,7 @@ export async function collectAllRegisteredSyncGenerators(
 }
 
 export async function runSyncGenerator(
-  tree: FsTree,
+  tree: Tree,
   generatorSpecifier: string,
   projects: Record<string, ProjectConfiguration>
 ): Promise<SyncGeneratorChangesResult> {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When running sync generators in the background (daemon) to cache the results for when needed, they are isolated from each other (each run with its own `Tree`). This is done because there's no guarantee which sync generator will be run together since that would depend on each specific task graph being run. When a task is run, a task graph is constructed, and sync generators are collected from it and run/retrieved from the cache.

Currently, when we run a task and ask the daemon to run the relevant generators, if there are cached results for a generator that ran in isolation, we return it. We don't check if its file changes conflict with those of another generator included in the task graph. This results in the changes for those conflicting files of the first generator getting overwritten by the changes of the second generator.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running tasks for which there are conflicting file changes between generators in the daemon, the conflicting generators should be re-run sequentially using the same `Tree` to guarantee that file changes are not overwritten and lost.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
<!-- Fixes NXC-903 -->

Fixes #
