### PR TITLE
feat(core): allow skipping sync when running tasks

### DIFF
--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -13,7 +13,7 @@ export const defaultYargsParserConfiguration: Partial<ParserConfigurationOptions
     'parse-positional-numbers': false,
   };
 
-export function withExcludeOption(yargs: Argv): Argv<ExcludeOptions> {
+export function withExcludeOption<T>(yargs: Argv<T>): Argv<T & ExcludeOptions> {
   return yargs.option('exclude', {
     describe: 'Exclude certain projects from being processed',
     type: 'string',
@@ -37,6 +37,7 @@ export interface RunOptions {
   batch: boolean;
   useAgents: boolean;
   excludeTaskDependencies: boolean;
+  skipSync: boolean;
 }
 
 export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
@@ -94,6 +95,11 @@ export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
       type: 'boolean',
       default: false,
     })
+    .option('skipSync', {
+      type: 'boolean',
+      // TODO(leo): add description and make it visible once it is stable
+      hidden: true,
+    })
     .options('cloud', {
       type: 'boolean',
       hidden: true,
@@ -106,7 +112,7 @@ export function withRunOptions<T>(yargs: Argv<T>): Argv<T & RunOptions> {
       type: 'boolean',
       hidden: true,
       alias: 'agents',
-    }) as Argv<Omit<RunOptions, 'exclude' | 'batch'>> as any;
+    }) as Argv<Omit<RunOptions, 'batch'>> as any;
 }
 
 export function withTargetAndConfigurationOption(

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -233,6 +233,10 @@ async function ensureWorkspaceIsInSyncAndGetGraphs(
     extraOptions
   );
 
+  if (nxArgs.skipSync) {
+    return { projectGraph, taskGraph };
+  }
+
   // collect unique syncGenerators from the tasks
   const uniqueSyncGenerators = collectEnabledTaskSyncGeneratorsFromTaskGraph(
     taskGraph,
@@ -255,7 +259,7 @@ async function ensureWorkspaceIsInSyncAndGetGraphs(
   const outOfSyncTitle = 'The workspace is out of sync';
   const resultBodyLines = [...syncGeneratorResultsToMessageLines(results), ''];
   const fixMessage =
-    'You can manually run `nx sync` to update your workspace or you can set `sync.applyChanges` to `true` in your `nx.json` to apply the changes automatically when running tasks.';
+    'You can manually run `nx sync` to update your workspace or you can set `sync.applyChanges` to `true` in your `nx.json` to apply the changes automatically when running tasks in interactive environments.';
   const willErrorOnCiMessage = 'Please note that this will be an error on CI.';
 
   if (isCI() || !process.stdout.isTTY) {

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -37,6 +37,7 @@ export interface NxArgs {
   type?: string;
   batch?: boolean;
   excludeTaskDependencies?: boolean;
+  skipSync?: boolean;
 }
 
 export function createOverrides(__overrides_unparsed__: string[] = []) {


### PR DESCRIPTION
- Add a new flag `--skipSync` to the run commands to skip running syncing when running tasks.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
<!-- Fixes NXC-946 -->

Fixes #
