### PR TITLE
fix(nx-dev): show first tab if none selected

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/tags/tabs.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/tabs.component.tsx
@@ -23,14 +23,16 @@ export function Tabs({
   const [currentTab, setCurrentTab] = useState<string>(labels[0]);
 
   useEffect(() => {
-    const handleTabSelectedEvent = () => {
+    const handleTabSelectedEvent = (defaultTab?: string) => {
       const selectedTab = localStorage.getItem(SELECTED_TAB_KEY);
       if (selectedTab && labels.includes(selectedTab)) {
         setCurrentTab(selectedTab);
+      } else if (defaultTab) {
+        setCurrentTab(defaultTab);
       }
     };
 
-    handleTabSelectedEvent();
+    handleTabSelectedEvent(labels[0]);
     window.addEventListener(TAB_SELECTED_EVENT, handleTabSelectedEvent);
     return () =>
       window.removeEventListener(TAB_SELECTED_EVENT, handleTabSelectedEvent);


### PR DESCRIPTION
Tabs are not displaying correctly on the second page that is viewed.

Should be able to select the `project.json` tab on `Run Tasks` and then switch to `Cache Task Results` and have the `Nx >= 17` tab shown.