### PR TITLE
feat(remix): infer targets for remix vite in @nx/remix/plugin

### DIFF
--- a/packages/remix/plugin.ts
+++ b/packages/remix/plugin.ts
@@ -1,5 +1,6 @@
 export {
   createNodes,
+  createNodesV2,
   createDependencies,
   RemixPluginOptions,
 } from './src/plugins/plugin';

--- a/packages/remix/src/generators/init/init.spec.ts
+++ b/packages/remix/src/generators/init/init.spec.ts
@@ -39,6 +39,7 @@ describe('Remix Init Generator', () => {
             "options": {
               "buildTargetName": "build",
               "devTargetName": "dev",
+              "serveStaticTargetName": "serve-static",
               "startTargetName": "start",
               "typecheckTargetName": "typecheck",
             },

--- a/packages/remix/src/generators/init/init.ts
+++ b/packages/remix/src/generators/init/init.ts
@@ -8,10 +8,10 @@ import {
   createProjectGraphAsync,
 } from '@nx/devkit';
 import {
-  addPluginV1,
+  addPlugin,
   generateCombinations,
 } from '@nx/devkit/src/utils/add-plugin';
-import { createNodes } from '../../plugins/plugin';
+import { createNodesV2 } from '../../plugins/plugin';
 import { nxVersion, remixVersion } from '../../utils/versions';
 import { type Schema } from './schema';
 
@@ -44,11 +44,11 @@ export async function remixInitGeneratorInternal(tree: Tree, options: Schema) {
     nxJson.useInferencePlugins !== false;
   options.addPlugin ??= addPluginDefault;
   if (options.addPlugin) {
-    await addPluginV1(
+    await addPlugin(
       tree,
       await createProjectGraphAsync(),
       '@nx/remix/plugin',
-      createNodes,
+      createNodesV2,
       {
         startTargetName: ['start', 'remix:start', 'remix-start'],
         buildTargetName: ['build', 'remix:build', 'remix-build'],

--- a/packages/remix/src/generators/init/init.ts
+++ b/packages/remix/src/generators/init/init.ts
@@ -58,6 +58,11 @@ export async function remixInitGeneratorInternal(tree: Tree, options: Schema) {
           'remix:typecheck',
           'remix-typecheck',
         ],
+        serveStaticTargetName: [
+          'serve-static',
+          'vite:serve-static',
+          'vite-serve-static',
+        ],
       },
       options.updatePackageScripts
     );

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -1,169 +1,359 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@nx/remix/plugin non-root project should create nodes 1`] = `
-{
-  "projects": {
-    "my-app": {
-      "root": "my-app",
-      "targets": {
-        "build": {
-          "cache": true,
-          "command": "remix build",
-          "dependsOn": [
-            "^build",
-          ],
-          "inputs": [
-            "production",
-            "^production",
-            {
-              "externalDependencies": [
-                "@remix-run/dev",
+exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create nodes 1`] = `
+[
+  [
+    "my-app/remix.config.cjs",
+    {
+      "projects": {
+        "my-app": {
+          "metadata": {},
+          "root": "my-app",
+          "targets": {
+            "build": {
+              "cache": true,
+              "command": "remix build",
+              "dependsOn": [
+                "^build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+              "outputs": [
+                "{workspaceRoot}/my-app/build",
+                "{workspaceRoot}/my-app/public/build",
               ],
             },
-          ],
-          "options": {
-            "cwd": "my-app",
-          },
-          "outputs": [
-            "{workspaceRoot}/my-app/build",
-            "{workspaceRoot}/my-app/public/build",
-          ],
-        },
-        "dev": {
-          "command": "remix dev --manual",
-          "options": {
-            "cwd": "my-app",
-          },
-        },
-        "serve-static": {
-          "command": "remix-serve build/index.js",
-          "dependsOn": [
-            "build",
-          ],
-          "options": {
-            "cwd": "my-app",
-          },
-        },
-        "start": {
-          "command": "remix-serve build/index.js",
-          "dependsOn": [
-            "build",
-          ],
-          "options": {
-            "cwd": "my-app",
-          },
-        },
-        "static-serve": {
-          "command": "remix-serve build/index.js",
-          "dependsOn": [
-            "build",
-          ],
-          "options": {
-            "cwd": "my-app",
-          },
-        },
-        "tsc": {
-          "cache": true,
-          "command": "tsc",
-          "inputs": [
-            "production",
-            "^production",
-            {
-              "externalDependencies": [
-                "typescript",
-              ],
+            "dev": {
+              "command": "remix dev --manual",
+              "options": {
+                "cwd": "my-app",
+              },
             },
-          ],
-          "options": {
-            "cwd": "my-app",
+            "serve-static": {
+              "command": "remix-serve build/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "start": {
+              "command": "remix-serve build/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "static-serve": {
+              "command": "remix-serve build/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "tsc": {
+              "cache": true,
+              "command": "tsc",
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "typescript",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+            },
           },
         },
       },
     },
-  },
-}
+  ],
+]
 `;
 
-exports[`@nx/remix/plugin root project should create nodes 1`] = `
-{
-  "projects": {
-    ".": {
-      "root": ".",
-      "targets": {
-        "build": {
-          "cache": true,
-          "command": "remix build",
-          "dependsOn": [
-            "^build",
-          ],
-          "inputs": [
-            "production",
-            "^production",
-            {
-              "externalDependencies": [
-                "@remix-run/dev",
+exports[`@nx/remix/plugin Remix Classic Compiler root project should create nodes 1`] = `
+[
+  [
+    "remix.config.cjs",
+    {
+      "projects": {
+        ".": {
+          "metadata": {},
+          "root": ".",
+          "targets": {
+            "build": {
+              "cache": true,
+              "command": "remix build",
+              "dependsOn": [
+                "^build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": ".",
+              },
+              "outputs": [
+                "{workspaceRoot}/build",
+                "{workspaceRoot}/public/build",
               ],
             },
-          ],
-          "options": {
-            "cwd": ".",
-          },
-          "outputs": [
-            "{workspaceRoot}/build",
-            "{workspaceRoot}/public/build",
-          ],
-        },
-        "dev": {
-          "command": "remix dev --manual",
-          "options": {
-            "cwd": ".",
-          },
-        },
-        "serve-static": {
-          "command": "remix-serve build/index.js",
-          "dependsOn": [
-            "build",
-          ],
-          "options": {
-            "cwd": ".",
-          },
-        },
-        "start": {
-          "command": "remix-serve build/index.js",
-          "dependsOn": [
-            "build",
-          ],
-          "options": {
-            "cwd": ".",
-          },
-        },
-        "static-serve": {
-          "command": "remix-serve build/index.js",
-          "dependsOn": [
-            "build",
-          ],
-          "options": {
-            "cwd": ".",
-          },
-        },
-        "typecheck": {
-          "cache": true,
-          "command": "tsc",
-          "inputs": [
-            "production",
-            "^production",
-            {
-              "externalDependencies": [
-                "typescript",
-              ],
+            "dev": {
+              "command": "remix dev --manual",
+              "options": {
+                "cwd": ".",
+              },
             },
-          ],
-          "options": {
-            "cwd": ".",
+            "serve-static": {
+              "command": "remix-serve build/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": ".",
+              },
+            },
+            "start": {
+              "command": "remix-serve build/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": ".",
+              },
+            },
+            "static-serve": {
+              "command": "remix-serve build/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": ".",
+              },
+            },
+            "typecheck": {
+              "cache": true,
+              "command": "tsc",
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "typescript",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": ".",
+              },
+            },
           },
         },
       },
     },
-  },
-}
+  ],
+]
+`;
+
+exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nodes 1`] = `
+[
+  [
+    "my-app/vite.config.js",
+    {
+      "projects": {
+        "my-app": {
+          "metadata": {},
+          "root": "my-app",
+          "targets": {
+            "build": {
+              "cache": true,
+              "command": "remix vite:build",
+              "dependsOn": [
+                "^build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+              "outputs": [
+                "{workspaceRoot}/my-app/build",
+              ],
+            },
+            "dev": {
+              "command": "remix vite:dev",
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "serve-static": {
+              "command": "remix-serve build/server/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "start": {
+              "command": "remix-serve build/server/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "static-serve": {
+              "command": "remix-serve build/server/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "tsc": {
+              "cache": true,
+              "command": "tsc",
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "typescript",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`@nx/remix/plugin Remix Vite Compiler root project should create nodes 1`] = `
+[
+  [
+    "vite.config.js",
+    {
+      "projects": {
+        ".": {
+          "metadata": {},
+          "root": ".",
+          "targets": {
+            "build": {
+              "cache": true,
+              "command": "remix vite:build",
+              "dependsOn": [
+                "^build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": ".",
+              },
+              "outputs": [
+                "{workspaceRoot}/build",
+              ],
+            },
+            "dev": {
+              "command": "remix vite:dev",
+              "options": {
+                "cwd": ".",
+              },
+            },
+            "serve-static": {
+              "command": "remix-serve build/server/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": ".",
+              },
+            },
+            "start": {
+              "command": "remix-serve build/server/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": ".",
+              },
+            },
+            "static-serve": {
+              "command": "remix-serve build/server/index.js",
+              "dependsOn": [
+                "build",
+              ],
+              "options": {
+                "cwd": ".",
+              },
+            },
+            "typecheck": {
+              "cache": true,
+              "command": "tsc",
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "typescript",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": ".",
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+]
 `;

--- a/packages/remix/src/plugins/plugin.spec.ts
+++ b/packages/remix/src/plugins/plugin.spec.ts
@@ -1,48 +1,56 @@
 import { type CreateNodesContext, joinPathFragments } from '@nx/devkit';
-import { createNodes } from './plugin';
+import { createNodesV2 as createNodes } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { loadViteDynamicImport } from '../utils/executor-utils';
+
+jest.mock('../utils/executor-utils', () => ({
+  loadViteDynamicImport: jest.fn().mockResolvedValue({
+    resolveConfig: jest.fn().mockResolvedValue({}),
+  }),
+}));
 
 describe('@nx/remix/plugin', () => {
   let createNodesFunction = createNodes[1];
   let context: CreateNodesContext;
   let cwd = process.cwd();
 
-  describe('root project', () => {
-    const tempFs = new TempFs('test');
+  describe('Remix Classic Compiler', () => {
+    describe('root project', () => {
+      const tempFs = new TempFs('test');
 
-    beforeEach(() => {
-      context = {
-        nxJsonConfiguration: {
-          targetDefaults: {
-            build: {
-              cache: false,
-              inputs: ['foo', '^foo'],
+      beforeEach(() => {
+        context = {
+          nxJsonConfiguration: {
+            targetDefaults: {
+              build: {
+                cache: false,
+                inputs: ['foo', '^foo'],
+              },
+              dev: {
+                command: 'npm run dev',
+              },
+              start: {
+                command: 'npm run start',
+              },
+              typecheck: {
+                command: 'tsc',
+              },
             },
-            dev: {
-              command: 'npm run dev',
-            },
-            start: {
-              command: 'npm run start',
-            },
-            typecheck: {
-              command: 'tsc',
+            namedInputs: {
+              default: ['{projectRoot}/**/*'],
+              production: ['!{projectRoot}/**/*.spec.ts'],
             },
           },
-          namedInputs: {
-            default: ['{projectRoot}/**/*'],
-            production: ['!{projectRoot}/**/*.spec.ts'],
-          },
-        },
-        workspaceRoot: tempFs.tempDir,
-        configFiles: [],
-      };
-      tempFs.createFileSync(
-        'package.json',
-        JSON.stringify('{name: "my-app", type: "module"}')
-      );
-      tempFs.createFileSync(
-        'remix.config.cjs',
-        `/**
+          workspaceRoot: tempFs.tempDir,
+          configFiles: [],
+        };
+        tempFs.createFileSync(
+          'package.json',
+          JSON.stringify('{name: "my-app", type: "module"}')
+        );
+        tempFs.createFileSync(
+          'remix.config.cjs',
+          `/**
  * @type {import('@remix-run/dev').AppConfig}
  */
 module.exports = {
@@ -50,92 +58,241 @@ module.exports = {
   watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
 };
 `
-      );
-      process.chdir(tempFs.tempDir);
+        );
+        process.chdir(tempFs.tempDir);
+      });
+
+      afterEach(() => {
+        jest.resetModules();
+        tempFs.cleanup();
+        process.chdir(cwd);
+      });
+
+      it('should create nodes', async () => {
+        // ACT
+        const nodes = await createNodesFunction(
+          ['remix.config.cjs'],
+          {
+            buildTargetName: 'build',
+            devTargetName: 'dev',
+            startTargetName: 'start',
+            typecheckTargetName: 'typecheck',
+            staticServeTargetName: 'static-serve',
+          },
+          context
+        );
+
+        // ASSERT
+        expect(nodes).toMatchSnapshot();
+      });
     });
 
-    afterEach(() => {
-      jest.resetModules();
-      tempFs.cleanup();
-      process.chdir(cwd);
-    });
+    describe('non-root project', () => {
+      const tempFs = new TempFs('test');
 
-    it('should create nodes', async () => {
-      // ACT
-      const nodes = await createNodesFunction(
-        'remix.config.cjs',
-        {
-          buildTargetName: 'build',
-          devTargetName: 'dev',
-          startTargetName: 'start',
-          typecheckTargetName: 'typecheck',
-          staticServeTargetName: 'static-serve',
-        },
-        context
-      );
+      beforeEach(() => {
+        context = {
+          nxJsonConfiguration: {
+            namedInputs: {
+              default: ['{projectRoot}/**/*'],
+              production: ['!{projectRoot}/**/*.spec.ts'],
+            },
+          },
+          workspaceRoot: tempFs.tempDir,
+          configFiles: [],
+        };
 
-      // ASSERT
-      expect(nodes).toMatchSnapshot();
+        tempFs.createFileSync(
+          'my-app/project.json',
+          JSON.stringify({ name: 'my-app' })
+        );
+
+        tempFs.createFileSync(
+          'my-app/remix.config.cjs',
+          `/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+`
+        );
+
+        process.chdir(tempFs.tempDir);
+      });
+
+      afterEach(() => {
+        jest.resetModules();
+        tempFs.cleanup();
+        process.chdir(cwd);
+      });
+
+      it('should create nodes', async () => {
+        // ACT
+        const nodes = await createNodesFunction(
+          ['my-app/remix.config.cjs'],
+          {
+            buildTargetName: 'build',
+            devTargetName: 'dev',
+            startTargetName: 'start',
+            typecheckTargetName: 'tsc',
+            staticServeTargetName: 'static-serve',
+          },
+          context
+        );
+
+        // ASSERT
+        expect(nodes).toMatchSnapshot();
+      });
     });
   });
 
-  describe('non-root project', () => {
-    const tempFs = new TempFs('test');
+  describe('Remix Vite Compiler', () => {
+    describe('root project', () => {
+      const tempFs = new TempFs('test');
 
-    beforeEach(() => {
-      context = {
-        nxJsonConfiguration: {
-          namedInputs: {
-            default: ['{projectRoot}/**/*'],
-            production: ['!{projectRoot}/**/*.spec.ts'],
+      beforeEach(() => {
+        context = {
+          nxJsonConfiguration: {
+            targetDefaults: {
+              build: {
+                cache: false,
+                inputs: ['foo', '^foo'],
+              },
+              dev: {
+                command: 'npm run dev',
+              },
+              start: {
+                command: 'npm run start',
+              },
+              typecheck: {
+                command: 'tsc',
+              },
+            },
+            namedInputs: {
+              default: ['{projectRoot}/**/*'],
+              production: ['!{projectRoot}/**/*.spec.ts'],
+            },
           },
-        },
-        workspaceRoot: tempFs.tempDir,
-        configFiles: [],
-      };
+          workspaceRoot: tempFs.tempDir,
+          configFiles: [],
+        };
+        tempFs.createFileSync(
+          'package.json',
+          JSON.stringify('{name: "my-app", type: "module"}')
+        );
+        tempFs.createFileSync(
+          'vite.config.js',
+          `const {defineConfig} = require('vite');
+          const { vitePlugin: remix } = require('@remix-run/dev');
+          module.exports = defineConfig({
+             plugins:[remix()]
+          });`
+        );
+        process.chdir(tempFs.tempDir);
+        (loadViteDynamicImport as jest.Mock).mockResolvedValue({
+          resolveConfig: jest.fn().mockResolvedValue({
+            build: {
+              lib: {
+                entry: 'index.ts',
+                name: 'my-app',
+              },
+            },
+          }),
+        });
+      });
 
-      tempFs.createFileSync(
-        'my-app/project.json',
-        JSON.stringify({ name: 'my-app' })
-      );
+      afterEach(() => {
+        jest.resetModules();
+        tempFs.cleanup();
+        process.chdir(cwd);
+      });
 
-      tempFs.createFileSync(
-        'my-app/remix.config.cjs',
-        `/**
- * @type {import('@remix-run/dev').AppConfig}
- */
-module.exports = {
-  ignoredRouteFiles: ['**/.*'],
-  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
-};
-`
-      );
+      it('should create nodes', async () => {
+        // ACT
+        const nodes = await createNodesFunction(
+          ['vite.config.js'],
+          {
+            buildTargetName: 'build',
+            devTargetName: 'dev',
+            startTargetName: 'start',
+            typecheckTargetName: 'typecheck',
+            staticServeTargetName: 'static-serve',
+          },
+          context
+        );
 
-      process.chdir(tempFs.tempDir);
+        // ASSERT
+        expect(nodes).toMatchSnapshot();
+      });
     });
 
-    afterEach(() => {
-      jest.resetModules();
-      tempFs.cleanup();
-      process.chdir(cwd);
-    });
+    describe('non-root project', () => {
+      const tempFs = new TempFs('test');
 
-    it('should create nodes', async () => {
-      // ACT
-      const nodes = await createNodesFunction(
-        'my-app/remix.config.cjs',
-        {
-          buildTargetName: 'build',
-          devTargetName: 'dev',
-          startTargetName: 'start',
-          typecheckTargetName: 'tsc',
-          staticServeTargetName: 'static-serve',
-        },
-        context
-      );
+      beforeEach(() => {
+        context = {
+          nxJsonConfiguration: {
+            namedInputs: {
+              default: ['{projectRoot}/**/*'],
+              production: ['!{projectRoot}/**/*.spec.ts'],
+            },
+          },
+          workspaceRoot: tempFs.tempDir,
+          configFiles: [],
+        };
 
-      // ASSERT
-      expect(nodes).toMatchSnapshot();
+        tempFs.createFileSync(
+          'my-app/project.json',
+          JSON.stringify({ name: 'my-app' })
+        );
+
+        tempFs.createFileSync(
+          'my-app/vite.config.js',
+          `const {defineConfig} = require('vite');
+          const { vitePlugin: remix } = require('@remix-run/dev');
+          module.exports = defineConfig({
+             plugins:[remix()]
+          });`
+        );
+        (loadViteDynamicImport as jest.Mock).mockResolvedValue({
+          resolveConfig: jest.fn().mockResolvedValue({
+            build: {
+              lib: {
+                entry: 'index.ts',
+                name: 'my-app',
+              },
+            },
+          }),
+        });
+
+        process.chdir(tempFs.tempDir);
+      });
+
+      afterEach(() => {
+        jest.resetModules();
+        tempFs.cleanup();
+        process.chdir(cwd);
+      });
+
+      it('should create nodes', async () => {
+        // ACT
+        const nodes = await createNodesFunction(
+          ['my-app/vite.config.js'],
+          {
+            buildTargetName: 'build',
+            devTargetName: 'dev',
+            startTargetName: 'start',
+            typecheckTargetName: 'tsc',
+            staticServeTargetName: 'static-serve',
+          },
+          context
+        );
+
+        // ASSERT
+        expect(nodes).toMatchSnapshot();
+      });
     });
   });
 });

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -1,44 +1,26 @@
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
+import { hashObject } from 'nx/src/hasher/file-hasher';
 import {
   type CreateDependencies,
   type CreateNodes,
   type CreateNodesContext,
+  createNodesFromFiles,
+  CreateNodesV2,
   detectPackageManager,
   joinPathFragments,
+  logger,
+  ProjectConfiguration,
   readJsonFile,
   type TargetConfiguration,
   writeJsonFile,
 } from '@nx/devkit';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
+import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 import { getLockFileName } from '@nx/js';
 import { type AppConfig } from '@remix-run/dev';
 import { dirname, join } from 'path';
 import { existsSync, readdirSync } from 'fs';
-import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
-
-const cachePath = join(workspaceDataDirectory, 'remix.hash');
-const targetsCache = readTargetsCache();
-
-function readTargetsCache(): Record<
-  string,
-  Record<string, TargetConfiguration>
-> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsToCache() {
-  const oldCache = readTargetsCache();
-  writeJsonFile(cachePath, {
-    ...oldCache,
-    ...targetsCache,
-  });
-}
-
-export const createDependencies: CreateDependencies = () => {
-  writeTargetsToCache();
-  return [];
-};
 
 export interface RemixPluginOptions {
   buildTargetName?: string;
@@ -51,49 +33,109 @@ export interface RemixPluginOptions {
   staticServeTargetName?: string;
   serveStaticTargetName?: string;
 }
+type RemixTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
-export const createNodes: CreateNodes<RemixPluginOptions> = [
-  '**/remix.config.{js,cjs,mjs}',
-  async (configFilePath, options, context) => {
-    const projectRoot = dirname(configFilePath);
-    const fullyQualifiedProjectRoot = join(context.workspaceRoot, projectRoot);
-    // Do not create a project if package.json and project.json isn't there
-    const siblingFiles = readdirSync(fullyQualifiedProjectRoot);
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json') &&
-      !siblingFiles.includes('vite.config.ts') &&
-      !siblingFiles.includes('vite.config.js')
-    ) {
-      return {};
+function readTargetsCache(
+  cachePath: string
+): Record<string, Record<string, TargetConfiguration>> {
+  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
+}
+
+function writeTargetsToCache(
+  cachePath: string,
+  results: Record<string, RemixTargets>
+) {
+  writeJsonFile(cachePath, results);
+}
+
+/**
+ * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
+ */
+export const createDependencies: CreateDependencies = () => {
+  return [];
+};
+
+const remixConfigGlob = '**/{remix|vite}.config.{js,cjs,mjs}';
+
+export const createNodesV2: CreateNodesV2<RemixPluginOptions> = [
+  remixConfigGlob,
+  async (configFilePaths, options, context) => {
+    const optionsHash = hashObject(options);
+    const cachePath = join(workspaceDataDirectory, `remix-${optionsHash}.hash`);
+    const targetsCache = readTargetsCache(cachePath);
+    try {
+      return await createNodesFromFiles(
+        (configFile, options, context) =>
+          createNodesInternal(configFile, options, context, targetsCache),
+        configFilePaths,
+        options,
+        context
+      );
+    } finally {
+      writeTargetsToCache(cachePath, targetsCache);
     }
-
-    options = normalizeOptions(options);
-
-    const hash = await calculateHashForCreateNodes(
-      projectRoot,
-      options,
-      context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
-    );
-    targetsCache[hash] ??= await buildRemixTargets(
-      configFilePath,
-      projectRoot,
-      options,
-      context,
-      siblingFiles
-    );
-
-    return {
-      projects: {
-        [projectRoot]: {
-          root: projectRoot,
-          targets: targetsCache[hash],
-        },
-      },
-    };
   },
 ];
+
+export const createNodes: CreateNodes<RemixPluginOptions> = [
+  remixConfigGlob,
+  async (configFilePath, options, context) => {
+    logger.warn(
+      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
+    );
+    return createNodesInternal(configFilePath, options, context, {});
+  },
+];
+
+async function createNodesInternal(
+  configFilePath: string,
+  options: RemixPluginOptions,
+  context: CreateNodesContext,
+  targetsCache: Record<string, RemixTargets>
+) {
+  const projectRoot = dirname(configFilePath);
+  const fullyQualifiedProjectRoot = join(context.workspaceRoot, projectRoot);
+  // Do not create a project if package.json and project.json isn't there
+  const siblingFiles = readdirSync(fullyQualifiedProjectRoot);
+  if (
+    !siblingFiles.includes('package.json') &&
+    !siblingFiles.includes('project.json') &&
+    !siblingFiles.includes('vite.config.ts') &&
+    !siblingFiles.includes('vite.config.js')
+  ) {
+    return {};
+  }
+
+  options = normalizeOptions(options);
+
+  const hash = await calculateHashForCreateNodes(
+    projectRoot,
+    options,
+    context,
+    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+  );
+  targetsCache[hash] ??= await buildRemixTargets(
+    configFilePath,
+    projectRoot,
+    options,
+    context,
+    siblingFiles
+  );
+
+  const { targets, metadata } = targetsCache[hash];
+
+  const project: ProjectConfiguration = {
+    root: projectRoot,
+    targets,
+    metadata,
+  };
+
+  return {
+    projects: {
+      [projectRoot]: project,
+    },
+  };
+}
 
 async function buildRemixTargets(
   configFilePath: string,

--- a/packages/remix/src/utils/executor-utils.ts
+++ b/packages/remix/src/utils/executor-utils.ts
@@ -1,0 +1,3 @@
+export function loadViteDynamicImport() {
+  return Function('return import("vite")')() as Promise<typeof import('vite')>;
+}

--- a/packages/vite/src/generators/init/init.spec.ts
+++ b/packages/vite/src/generators/init/init.spec.ts
@@ -83,6 +83,7 @@ describe('@nx/vite:init', () => {
                 "serveStaticTargetName": "serve-static",
                 "serveTargetName": "serve",
                 "testTargetName": "test",
+                "typecheckTargetName": "typecheck",
               },
               "plugin": "@nx/vite/plugin",
             },

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -76,6 +76,7 @@ export async function initGeneratorInternal(
           'vite:serve-static',
           'vite-serve-static',
         ],
+        typecheckTargetName: ['typecheck', 'vite:typecheck', 'vite-typecheck'],
       },
       schema.updatePackageScripts
     );


### PR DESCRIPTION
- feat(remix): add createnodesv2
- feat(remix): support vite in the plugin
- feat(remix): support remix vite in plugin
- fix(remix): init should ues addPlugin v2

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx does not currently infer targets when someone is using remix w/ vite


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx should infer targets for remix vite apps

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
