### PR TITLE
fix(vite): exit from test if no files found

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -57,10 +57,15 @@ export async function* vitestExecutor(
     process.on('exit', processExit);
   }
 
-  for await (const report of nxReporter) {
-    // vitest sets the exitCode = 1 when code coverage isn't met
-    hasErrors =
-      report.hasErrors || (process.exitCode && process.exitCode !== 0);
+  // vitest sets the exitCode in case of exception without notifying reporters
+  if (process.exitCode === undefined) {
+    for await (const report of nxReporter) {
+      // vitest sets the exitCode = 1 when code coverage isn't met
+      hasErrors =
+        report.hasErrors || (process.exitCode && process.exitCode !== 0);
+    }
+  } else {
+    hasErrors = process.exitCode !== 0;
   }
 
   return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
After running `nx test project` or `nx run-many -t test` with no test files with `@nx/vite:test` plugin, vitest process exit directly but nx reporter keep waiting for finish notification which cause to waiting indefinitely.

vitest reference:
https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/node/core.ts#L409-L413
https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/node/cli/cli-api.ts#L102-L116

console log example:
```bash
nx test project

> nx run project:test


 RUN  v2.0.5 /path/to/project

include: src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}
exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*
No test files found, exiting with code 0
```

```bash
nx run-many -t test --no-cache -p project

 NX   Running target test for project project

      With additional flags:
        --cache=false

   →  Executing 1/1 remaining tasks...

   ⠹  nx run project:test
```

## Expected Behavior
`nx test project` should exit directly in case vitest process exit early.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
