### PR TITLE
fix(misc): fix the URL of the @naxodev/nx-cloudflare plugin

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -457,7 +457,7 @@
   {
     "name": "@naxodev/nx-cloudflare",
     "description": "Nx plugin for Cloudflare, in particular Cloudflare workers. It allows to generate build and run Cloudflare workers in your Nx workspace.",
-    "url": "https://github.com/naxodev/oss/tree/main/packages/plugins/nx-cloudflare"
+    "url": "https://github.com/naxodev/oss/tree/main/packages/nx-cloudflare"
   },
   {
     "name": "@ziacik/azure-func",


### PR DESCRIPTION
The former URL returns a 404
