### PR TITLE
fix(core): bump plugin pool attempts to work with slow runtimes

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -400,7 +400,7 @@ async function startPluginWorker() {
           worker,
           socket,
         });
-      } else if (attempts > 1000) {
+      } else if (attempts > 10000) {
         // daemon fails to start, the process probably exited
         // we print the logs and exit the client
         reject('Failed to start plugin worker.');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

With plugin isolation turned on, it works on CI but doesn't on slow laptops due to corporate software.


We currently run nx with the following patch to figure out why it happen :

```patch
diff --git a/src/project-graph/plugins/isolation/plugin-pool.js b/src/project-graph/plugins/isolation/plugin-pool.js
index b10ee0d28c994db4e39c4f650dd47496c22cdb60..5a4dfb015906de8a0f9028e09140c6a3f543ca28 100644
--- a/src/project-graph/plugins/isolation/plugin-pool.js
+++ b/src/project-graph/plugins/isolation/plugin-pool.js
@@ -266,6 +266,7 @@ async function startPluginWorker() {
         const id = setInterval(async () => {
             const socket = await isServerAvailable(ipcPath);
             if (socket) {
+                console.log('Managed to start the worker after', attempts, 'attempts.')
                 socket.unref();
                 clearInterval(id);
                 resolve({
@@ -273,10 +274,10 @@ async function startPluginWorker() {
                     socket,
                 });
             }
-            else if (attempts > 1000) {
+            else if (attempts > 10000) {
                 // daemon fails to start, the process probably exited
                 // we print the logs and exit the client
-                reject('Failed to start plugin worker.');
+                reject('Failed to start plugin worker after ' + attempts + ' attempts.');
             }
             else {
                 attempts++;

```

With the added logging, we can see the following:

On ci (nx agents, or circleci)
```
Managed to start the worker after 17 attempts.
Managed to start the worker after 20 attempts.
Managed to start the worker after 23 attempts.
Managed to start the worker after 26 attempts.
Managed to start the worker after 27 attempts.
Managed to start the worker after 27 attempts.
Managed to start the worker after 28 attempts.
Managed to start the worker after 39 attempts.
Managed to start the worker after 47 attempts.
Managed to start the worker after 34 attempts.
Managed to start the worker after 36 attempts.
Managed to start the worker after 40 attempts.
Managed to start the worker after 47 attempts.
Managed to start the worker after 52 attempts.
Managed to start the worker after 54 attempts.
Managed to start the worker after 54 attempts.
Managed to start the worker after 55 attempts.
Managed to start the worker after 41 attempts.
Managed to start the worker after 53 attempts.
Managed to start the worker after 59 attempts.
Managed to start the worker after 46 attempts.
Managed to start the worker after 60 attempts.
Managed to start the worker after 52 attempts.
Managed to start the worker after 67 attempts.
```


On local (Mac, silicon m1)
```
Managed to start the worker after 59 attempts.
Managed to start the worker after 112 attempts.
Managed to start the worker after 166 attempts.
Managed to start the worker after 221 attempts.
Managed to start the worker after 274 attempts.
Managed to start the worker after 160 attempts.
Managed to start the worker after 269 attempts.
Managed to start the worker after 436 attempts.
Managed to start the worker after 390 attempts.
Managed to start the worker after 480 attempts.
Managed to start the worker after 427 attempts.
Managed to start the worker after 655 attempts.
Managed to start the worker after 754 attempts.
Managed to start the worker after 745 attempts.
Managed to start the worker after 200 attempts.
Managed to start the worker after 158 attempts.
Managed to start the worker after 854 attempts.
Managed to start the worker after 852 attempts.
Managed to start the worker after 1011 attempts.
Managed to start the worker after 373 attempts.
Managed to start the worker after 1180 attempts.
Managed to start the worker after 628 attempts.
Managed to start the worker after 789 attempts.
Managed to start the worker after 747 attempts.
```

We even got to numbers as high as 2000 on some laptops.

For the reference, we have the following plugins on our `nx.json`

```json
{
  "plugins": [
    {
      "name": "tsc",
      "plugin": "./tools/nx-tools/src/plugins/tsc.ts",
      "options": {
        "targetName": "type-check"
      }
    },
    {
      "name": "eslint",
      "plugin": "./tools/nx-tools/src/plugins/eslint.ts",
      "options": {
        "targetName": "lint"
      }
    },
    {
      "plugin": "@nx/vite/plugin",
      "options": {
        "buildTargetName": "build",
        "previewTargetName": "preview",
        "testTargetName": "test",
        "serveTargetName": "dev",
        "serveStaticTargetName": "serve-static"
      }
    },
    {
      "plugin": "./tools/nx-tools/src/plugins/jest.ts",
      "options": {
        "targetName": "test"
      }
    },
    {
      "plugin": "./tools/nx-tools/src/plugins/tsup.ts",
      "options": {
        "targetName": "build"
      }
    },
    {
      "plugin": "./tools/nx-tools/src/plugins/storybook.ts",
      "options": {
        "buildStorybookTargetName": "build-storybook",
        "serveStorybookTargetName": "storybook",
        "testStorybookTargetName": "test-storybook",
        "staticStorybookTargetName": "static-storybook"
      }
    }
  ]
}
```

One thing we managed to find out is the more plugin on the project, the bigger the number.

So for now, the current workaround is to bump to 10000 instead of 1000 tries

_Debugged in pair with @AgentEnder_

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Plugin worker should work and nx should be working with plugin isolation