### PR TITLE
fix(release): show version plan deletion log in dry-run

### DIFF
--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -946,7 +946,7 @@ async function applyChangesAndExit(
   const changedFiles: string[] = changes.map((f) => f.path);
 
   let deletedFiles: string[] = [];
-  if (args.deleteVersionPlans && !args.dryRun) {
+  if (args.deleteVersionPlans) {
     const planFiles = new Set<string>();
     releaseGroups.forEach((group) => {
       if (group.resolvedVersionPlans) {

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -193,7 +193,7 @@ export async function gitAdd({
       if (isFileIgnored) {
         ignoredFiles.push(f);
         // git add will fail if trying to add an untracked file that doesn't exist
-      } else if (changedTrackedFiles.has(f)) {
+      } else if (changedTrackedFiles.has(f) || dryRun) {
         filesToAdd.push(f);
       }
     }


### PR DESCRIPTION
In #27737 I mostly fixed an issue where the version plan deletion logs wouldn't show in dry run, but I forgot to remove the outer `args.dryRun` check after adding the inner one.

Additionally, dry-run would not be taken into account in the `gitAdd` logging for deleted files, so that is fixed here.

After (with verbose logging enabled):

![image](https://github.com/user-attachments/assets/72acc272-e77a-4c63-8675-a4550cc47142)
