### PR TITLE
Allow default dependsOn for release

### DIFF
--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -187,8 +187,8 @@ export function readTargetsFromPackageJson(packageJson: PackageJson) {
    * package based repos.
    */
   if (!isPrivate && !res['nx-release-publish']) {
-    res['nx-release-publish'] = {
-      dependsOn: ['^nx-release-publish'],
+    res['nx-release-publish'] = {      
+      // dependsOn: ['^nx-release-publish'],
       executor: '@nx/js:release-publish',
       options: {},
     };


### PR DESCRIPTION
## Current Behavior
Described in #27749 

## Expected Behavior
Described in #27749 

## Related Issue(s)
#27749 

Fixes #
- Commented static dependsOn for nx-release-publish
