### PR TITLE
fix(detox): fix detox expo generated commands typo from --no-interactive to --non-interactive

### DIFF
--- a/packages/detox/src/generators/application/application.spec.ts
+++ b/packages/detox/src/generators/application/application.spec.ts
@@ -341,7 +341,7 @@ describe('detox application generator', () => {
         'android.local': {
           binaryPath: '../../my-dir/my-app/dist/MyDirMyApp.apk',
           build:
-            'npx nx run my-dir-my-app:build --platform android --profile preview --wait --local --no-interactive --output=../../my-dir/my-app/dist/MyDirMyApp.apk',
+            'npx nx run my-dir-my-app:build --platform android --profile preview --wait --local --non-interactive --output=../../my-dir/my-app/dist/MyDirMyApp.apk',
           type: 'android.apk',
         },
         'android.release': {
@@ -361,7 +361,7 @@ describe('detox application generator', () => {
         'ios.local': {
           binaryPath: '../../my-dir/my-app/dist/MyDirMyApp.app',
           build:
-            'npx nx run my-dir-my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../../my-dir/my-app/dist/MyDirMyApp.tar.gz',
+            'npx nx run my-dir-my-app:build --platform ios --profile preview --wait --local --non-interactive --output=../../my-dir/my-app/dist/MyDirMyApp.tar.gz',
           type: 'ios.app',
         },
         'ios.release': {

--- a/packages/detox/src/generators/application/files/app/.detoxrc.json.template
+++ b/packages/detox/src/generators/application/files/app/.detoxrc.json.template
@@ -22,7 +22,7 @@
 <% if (framework === 'expo') { %>
     "ios.local": {
       "type": "ios.app",
-      "build": "<%= exec %> nx run <%= appFileName %>:build --platform ios --profile preview --wait --local --no-interactive --output=<%= offsetFromRoot %><%= appRoot %>/dist/<%= appExpoName %>.tar.gz",
+      "build": "<%= exec %> nx run <%= appFileName %>:build --platform ios --profile preview --wait --local --non-interactive --output=<%= offsetFromRoot %><%= appRoot %>/dist/<%= appExpoName %>.tar.gz",
       "binaryPath": "<%= offsetFromRoot %><%= appRoot %>/dist/<%= appExpoName %>.app"
     },
 <% } %>
@@ -39,7 +39,7 @@
 <% if (framework === 'expo') { %>
     "android.local": {
       "type": "android.apk",
-      "build": "<%= exec %> nx run <%= appFileName %>:build --platform android --profile preview --wait --local --no-interactive --output=<%= offsetFromRoot %><%= appRoot %>/dist/<%= appExpoName %>.apk",
+      "build": "<%= exec %> nx run <%= appFileName %>:build --platform android --profile preview --wait --local --non-interactive --output=<%= offsetFromRoot %><%= appRoot %>/dist/<%= appExpoName %>.apk",
       "binaryPath": "<%= offsetFromRoot %><%= appRoot %>/dist/<%= appExpoName %>.apk"
     },
 <% } %>

--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -125,7 +125,7 @@ describe('app', () => {
         'android.local': {
           binaryPath: '../my-dir/dist/MyApp.apk',
           build:
-            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../my-dir/dist/MyApp.apk',
+            'npx nx run my-app:build --platform android --profile preview --wait --local --non-interactive --output=../my-dir/dist/MyApp.apk',
           type: 'android.apk',
         },
         'android.release': {
@@ -145,7 +145,7 @@ describe('app', () => {
         'ios.local': {
           binaryPath: '../my-dir/dist/MyApp.app',
           build:
-            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../my-dir/dist/MyApp.tar.gz',
+            'npx nx run my-app:build --platform ios --profile preview --wait --local --non-interactive --output=../my-dir/dist/MyApp.tar.gz',
           type: 'ios.app',
         },
         'ios.release': {
@@ -186,7 +186,7 @@ describe('app', () => {
         'android.local': {
           binaryPath: '../my-app/dist/MyApp.apk',
           build:
-            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../my-app/dist/MyApp.apk',
+            'npx nx run my-app:build --platform android --profile preview --wait --local --non-interactive --output=../my-app/dist/MyApp.apk',
           type: 'android.apk',
         },
         'android.release': {
@@ -206,7 +206,7 @@ describe('app', () => {
         'ios.local': {
           binaryPath: '../my-app/dist/MyApp.app',
           build:
-            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../my-app/dist/MyApp.tar.gz',
+            'npx nx run my-app:build --platform ios --profile preview --wait --local --non-interactive --output=../my-app/dist/MyApp.tar.gz',
           type: 'ios.app',
         },
         'ios.release': {
@@ -250,7 +250,7 @@ describe('app', () => {
         'android.local': {
           binaryPath: '../my-app/dist/myappname.apk',
           build:
-            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../my-app/dist/myappname.apk',
+            'npx nx run my-app:build --platform android --profile preview --wait --local --non-interactive --output=../my-app/dist/myappname.apk',
           type: 'android.apk',
         },
         'android.release': {
@@ -270,7 +270,7 @@ describe('app', () => {
         'ios.local': {
           binaryPath: '../my-app/dist/myappname.app',
           build:
-            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../my-app/dist/myappname.tar.gz',
+            'npx nx run my-app:build --platform ios --profile preview --wait --local --non-interactive --output=../my-app/dist/myappname.tar.gz',
           type: 'ios.app',
         },
         'ios.release': {


### PR DESCRIPTION
## Current Behavior
Trying to execute testing in Expo with Detox fails by `Unexpected argument: --no-interactive`

## Expected Behavior
Expo with Detox should run the command using the argument `--non-interactive` instead.
