### PR TITLE
feat(core): forward string array arguments

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -54,6 +54,7 @@ const propKeys = [
   'parallel',
   'no-parallel',
   'readyWhen',
+  'readyWhenStatus',
   'cwd',
   'args',
   'envFile',
@@ -238,7 +239,10 @@ function normalizeOptions(
 }
 
 function isArrayOfStrings(arg: unknown): arg is Array<string> {
-  return Array.isArray(arg) && arg.every((item) => typeof item === 'string');
+  if (Array.isArray(arg)) {
+    return arg.every((item) => typeof item === 'string');
+  }
+  return false;
 }
 
 export function interpolateArgsIntoCommand(

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -237,6 +237,10 @@ function normalizeOptions(
   return options as NormalizedRunCommandsOptions;
 }
 
+function isArrayOfStrings(arg: unknown): arg is Array<string> {
+  return Array.isArray(arg) && arg.every((item) => typeof item === 'string');
+}
+
 export function interpolateArgsIntoCommand(
   command: string,
   opts: Pick<
@@ -303,7 +307,8 @@ function unknownOptionsToArgsArray(
   return Object.keys(opts.unknownOptions ?? {})
     .filter(
       (k) =>
-        typeof opts.unknownOptions[k] !== 'object' &&
+        (typeof opts.unknownOptions[k] !== 'object' ||
+          isArrayOfStrings(opts.unknownOptions[k])) &&
         opts.parsedArgs[k] === opts.unknownOptions[k]
     )
     .map((k) => `--${k}=${opts.unknownOptions[k]}`)


### PR DESCRIPTION
Original discussion:
https://github.com/nrwl/nx/discussions/27760

## Current Behavior
Currently if I create a task like:
```
{
  "targets": {
    "build-cds": {
      "options": {
        "schema": "SCHEMA_NAME ",
        "filter": [
          "TABLE1",
          "TABLE1"
        ]
      }
    } 
  }
}
```

it will still call my command like: `mycommand --schema SCHEMA_NAME`

## Expected Behavior

After my change it would run `mycommand --schema SCHEMA_NAME --filter=TABLE1,TABLE2,TABLE3`
