### PR TITLE
fix(core): take nx-release-publish target defaults into account for implicit target

### DIFF
--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -177,7 +177,7 @@ export function buildProjectConfigurationFromPackageJson(
     sourceRoot: projectRoot,
     name,
     ...packageJson.nx,
-    targets: readTargetsFromPackageJson(packageJson),
+    targets: readTargetsFromPackageJson(packageJson, nxJson),
     tags: getTagsFromPackageJson(packageJson),
     metadata: getMetadataFromPackageJson(packageJson),
   };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

We to not take targetDefaults into account when creating the implicit target for `nx-release-publish`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We take targetDefaults into account when creating the implicit target for `nx-release-publish`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27749
