### PR TITLE
fix(vite): tsconfig paths plugin should resolve file extensions

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -5,7 +5,7 @@ import {
   workspaceRoot,
 } from '@nx/devkit';
 import { copyFileSync, existsSync } from 'node:fs';
-import { relative, join, resolve } from 'node:path';
+import { join, parse, relative, resolve } from 'node:path';
 import {
   loadConfig,
   createMatchPath,
@@ -57,8 +57,13 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
     '.js',
     '.jsx',
     '.json',
+    '.mts',
     '.mjs',
+    '.cts',
     '.cjs',
+    '.css',
+    '.scss',
+    '.less',
   ];
   options.mainFields ??= [['exports', '.', 'import'], 'module', 'main'];
   options.buildLibsFromSource ??= true;
@@ -246,7 +251,9 @@ There should at least be a tsconfig.base.json or tsconfig.json in the root of th
 
   function findFile(path: string): string {
     for (const ext of options.extensions) {
-      const resolvedPath = resolve(path + ext);
+      // Support file extensions such as .css and .js in the import path.
+      const { dir, name } = parse(path);
+      const resolvedPath = resolve(dir, name + ext);
       if (existsSync(resolvedPath)) {
         return resolvedPath;
       }


### PR DESCRIPTION
This PR updates the tsconfig paths plugin for Vite such that it resolves paths with file extensions as well.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22868
