### PR TITLE
docs(release): add recipe for preVersionCommand

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -2033,6 +2033,14 @@
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
+              },
+              {
+                "name": "Build Before Versioning",
+                "path": "/recipes/nx-release/build-before-versioning",
+                "id": "build-before-versioning",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
               }
             ],
             "disableCollapsible": false
@@ -3776,6 +3784,14 @@
             "isExternal": false,
             "children": [],
             "disableCollapsible": false
+          },
+          {
+            "name": "Build Before Versioning",
+            "path": "/recipes/nx-release/build-before-versioning",
+            "id": "build-before-versioning",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
           }
         ],
         "disableCollapsible": false
@@ -3872,6 +3888,14 @@
         "name": "Publish a Custom Dist Directory",
         "path": "/recipes/nx-release/publish-custom-dist-directory",
         "id": "publish-custom-dist-directory",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Build Before Versioning",
+        "path": "/recipes/nx-release/build-before-versioning",
+        "id": "build-before-versioning",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -2779,6 +2779,17 @@
             "isExternal": false,
             "path": "/recipes/nx-release/publish-custom-dist-directory",
             "tags": ["nx-release"]
+          },
+          {
+            "id": "build-before-versioning",
+            "name": "Build Before Versioning",
+            "description": "",
+            "mediaImage": "",
+            "file": "shared/recipes/nx-release/build-before-versioning",
+            "itemList": [],
+            "isExternal": false,
+            "path": "/recipes/nx-release/build-before-versioning",
+            "tags": ["nx-release"]
           }
         ],
         "isExternal": false,
@@ -5169,6 +5180,17 @@
         "isExternal": false,
         "path": "/recipes/nx-release/publish-custom-dist-directory",
         "tags": ["nx-release"]
+      },
+      {
+        "id": "build-before-versioning",
+        "name": "Build Before Versioning",
+        "description": "",
+        "mediaImage": "",
+        "file": "shared/recipes/nx-release/build-before-versioning",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/nx-release/build-before-versioning",
+        "tags": ["nx-release"]
       }
     ],
     "isExternal": false,
@@ -5305,6 +5327,17 @@
     "itemList": [],
     "isExternal": false,
     "path": "/recipes/nx-release/publish-custom-dist-directory",
+    "tags": ["nx-release"]
+  },
+  "/recipes/nx-release/build-before-versioning": {
+    "id": "build-before-versioning",
+    "name": "Build Before Versioning",
+    "description": "",
+    "mediaImage": "",
+    "file": "shared/recipes/nx-release/build-before-versioning",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/nx-release/build-before-versioning",
     "tags": ["nx-release"]
   },
   "/recipes/other": {

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -554,6 +554,13 @@
       "path": "/recipes/nx-release/publish-custom-dist-directory"
     },
     {
+      "description": "",
+      "file": "shared/recipes/nx-release/build-before-versioning",
+      "id": "build-before-versioning",
+      "name": "Build Before Versioning",
+      "path": "/recipes/nx-release/build-before-versioning"
+    },
+    {
       "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
       "file": "generated/packages/nx/documents/release",
       "id": "release",

--- a/docs/map.json
+++ b/docs/map.json
@@ -1068,6 +1068,12 @@
                   "id": "publish-custom-dist-directory",
                   "tags": ["nx-release"],
                   "file": "shared/recipes/nx-release/publish-custom-dist-directory"
+                },
+                {
+                  "name": "Build Before Versioning",
+                  "id": "build-before-versioning",
+                  "tags": ["nx-release"],
+                  "file": "shared/recipes/nx-release/build-before-versioning"
                 }
               ]
             },

--- a/docs/shared/recipes/nx-release/build-before-versioning.md
+++ b/docs/shared/recipes/nx-release/build-before-versioning.md
@@ -1,0 +1,15 @@
+# Build Before Versioning
+
+In order to ensure that projects are built before the new version is applied to their package manifest, you can use the `preVersionCommand` property in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "release": {
+    "version": {
+      "preVersionCommand": "npx nx run-many -t build"
+    }
+  }
+}
+```
+
+This command will run the `build` target for all projects before the version step of Nx Release. Any command can be specified, including non-nx commands. This step is often required when [publishing from a custom dist directory](/recipes/nx-release/publish-custom-dist-directory), as the dist directory must be built before the version is applied to the dist directory's package manifest.

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -169,6 +169,7 @@
       - [Update Your Local Registry Setup to use Nx Release](/recipes/nx-release/update-local-registry-setup)
       - [Configure Changelog Format](/recipes/nx-release/configure-changelog-format)
       - [Publish a Custom Dist Directory](/recipes/nx-release/publish-custom-dist-directory)
+      - [Build Before Versioning](/recipes/nx-release/build-before-versioning)
     - [Other](/recipes/other)
       - [Rescope Packages from @nrwl to @nx](/recipes/other/rescope)
       - [Troubleshoot Nx Console Issues](/recipes/nx-console/console-troubleshooting)


### PR DESCRIPTION
Adds a recipe for using `release.preVersionCommand` to ensure packages are built before they are versioned.
