### PR TITLE
feat(release): allow local dependency version protocols to be preserved, pnpm publish support

### DIFF
--- a/e2e/release/src/custom-registries.test.ts
+++ b/e2e/release/src/custom-registries.test.ts
@@ -17,14 +17,21 @@ describe('nx release - custom npm registries', () => {
   const verdaccioPort = 7191;
   const customRegistryUrl = `http://localhost:${verdaccioPort}`;
   const scope = 'scope';
+  let previousPackageManager: string;
 
   beforeAll(async () => {
+    previousPackageManager = process.env.SELECTED_PM;
+    // We are testing some more advanced scoped registry features that only npm has within this file
+    process.env.SELECTED_PM = 'npm';
     newProject({
       unsetProjectNameAndRootFormat: false,
       packages: ['@nx/js'],
     });
   }, 60000);
-  afterAll(() => cleanupProject());
+  afterAll(() => {
+    cleanupProject();
+    process.env.SELECTED_PM = previousPackageManager;
+  });
 
   it('should respect registry configuration for each package', async () => {
     updateJson<NxJsonConfiguration>('nx.json', (nxJson) => {

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -1,10 +1,7 @@
 import {
-  PackageManager,
   ProjectGraphProjectNode,
   Tree,
-  detectPackageManager,
   formatFiles,
-  getPackageManagerVersion,
   joinPathFragments,
   output,
   readJson,
@@ -38,7 +35,8 @@ import {
 } from 'nx/src/command-line/release/version';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import * as ora from 'ora';
-import { ReleaseType, gt, inc, lt, prerelease } from 'semver';
+import { ReleaseType, gt, inc, prerelease } from 'semver';
+import { isLocallyLinkedPackageVersion } from '../../utils/is-locally-linked-package-version';
 import { parseRegistryOptions } from '../../utils/npm-config';
 import { ReleaseVersionGeneratorSchema } from './schema';
 import {
@@ -761,10 +759,16 @@ To fix this you will either need to add a package.json file at that location, or
             }
           }
 
-          // Apply the new version of the dependency to the dependent
-          const newDepVersion = `${versionPrefix}${newDependencyVersion}`;
-          json[dependentProject.dependencyCollection][dependencyPackageName] =
-            newDepVersion;
+          // Apply the new version of the dependency to the dependent (if not preserving locally linked package protocols)
+          const shouldUpdateDependency = !(
+            isLocallyLinkedPackageVersion(currentDependencyVersion) &&
+            options.preserveLocalDependencyProtocols
+          );
+          if (shouldUpdateDependency) {
+            const newDepVersion = `${versionPrefix}${newDependencyVersion}`;
+            json[dependentProject.dependencyCollection][dependencyPackageName] =
+              newDepVersion;
+          }
 
           // Bump the dependent's version if applicable and record it in the version data
           if (forceVersionBump) {
@@ -985,43 +989,4 @@ class ProjectLogger {
       console.log(this.color.instance.bold(this.projectName) + ' ' + msg);
     });
   }
-}
-
-let pm: PackageManager | undefined;
-let pmVersion: string | undefined;
-
-const localPackageProtocols = [
-  'file:', // all package managers
-  'workspace:', // not npm
-  'portal:', // modern yarn only
-];
-
-function isLocallyLinkedPackageVersion(version: string): boolean {
-  // Not using a supported local protocol
-  if (!localPackageProtocols.some((protocol) => version.startsWith(protocol))) {
-    return false;
-  }
-  // Supported by all package managers
-  if (version.startsWith('file:')) {
-    return true;
-  }
-  // Determine specific package manager in use
-  if (!pm) {
-    pm = detectPackageManager();
-    pmVersion = getPackageManagerVersion(pm);
-  }
-  if (pm === 'npm' && version.startsWith('workspace:')) {
-    throw new Error(
-      `The "workspace:" protocol is not yet supported by npm (https://github.com/npm/rfcs/issues/765). Please ensure you have a valid setup according to your package manager before attempting to release packages.`
-    );
-  }
-  if (
-    version.startsWith('portal:') &&
-    (pm !== 'yarn' || lt(pmVersion, '2.0.0'))
-  ) {
-    throw new Error(
-      `The "portal:" protocol is only supported by yarn@2.0.0 and above. Please ensure you have a valid setup according to your package manager before attempting to release packages.`
-    );
-  }
-  return true;
 }

--- a/packages/js/src/utils/is-locally-linked-package-version.ts
+++ b/packages/js/src/utils/is-locally-linked-package-version.ts
@@ -1,0 +1,47 @@
+import {
+  detectPackageManager,
+  getPackageManagerVersion,
+  PackageManager,
+} from '@nx/devkit';
+// import { lt } from 'semver';
+
+let pm: PackageManager | undefined;
+// let pmVersion: string | undefined;
+
+const localPackageProtocols = [
+  'file:', // all package managers
+  'workspace:', // not npm
+  // TODO: Support portal protocol at the project graph level before enabling here
+  // 'portal:', // modern yarn only
+];
+
+export function isLocallyLinkedPackageVersion(version: string): boolean {
+  // Not using a supported local protocol
+  if (!localPackageProtocols.some((protocol) => version.startsWith(protocol))) {
+    return false;
+  }
+  // Supported by all package managers
+  if (version.startsWith('file:')) {
+    return true;
+  }
+  // Determine specific package manager in use
+  if (!pm) {
+    pm = detectPackageManager();
+    // pmVersion = getPackageManagerVersion(pm);
+  }
+  if (pm === 'npm' && version.startsWith('workspace:')) {
+    throw new Error(
+      `The "workspace:" protocol is not yet supported by npm (https://github.com/npm/rfcs/issues/765). Please ensure you have a valid setup according to your package manager before attempting to release packages.`
+    );
+  }
+  // TODO: Support portal protocol at the project graph level before enabling here
+  // if (
+  //   version.startsWith('portal:') &&
+  //   (pm !== 'yarn' || lt(pmVersion, '2.0.0'))
+  // ) {
+  //   throw new Error(
+  //     `The "portal:" protocol is only supported by yarn@2.0.0 and above. Please ensure you have a valid setup according to your package manager before attempting to release packages.`
+  //   );
+  // }
+  return true;
+}

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -94,6 +94,12 @@ export interface ReleaseVersionGeneratorSchema {
    * large monorepos which have a large number of projects, especially when only a subset are released together.
    */
   logUnchangedProjects?: boolean;
+  /**
+   * Whether or not to keep local dependency protocols (e.g. file:, workspace:) when updating dependencies in
+   * package.json files. This is `false` by default as not all package managers support publishing with these protocols
+   * still present in the package.json.
+   */
+  preserveLocalDependencyProtocols?: boolean;
 }
 
 export interface NxReleaseVersionResult {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

We always update relevant dependency versions to their new semantic version as part of versioning and we only ever publish using `npm publish`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We allow for the user to configure a preference for preserving local dependency protocols (such as `file:` and `workspace:`) when versioning, whilst maintaining all other aspects of the versioning logic.

This would allow them to combine it with `pnpm publish`, which would handle the dynamic replacement of those values during the packing step. Therefore, when the user is using `pnpm`, we now preferentially publish using `pnpm publish` instead of `npm publish`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
