### PR TITLE
chore(nx-cloud): remove env variable for login

### DIFF
--- a/docs/generated/cli/login.md
+++ b/docs/generated/cli/login.md
@@ -1,0 +1,25 @@
+---
+title: 'login - CLI command'
+description: 'Login to Nx Cloud.'
+---
+
+# login
+
+Login to Nx Cloud.
+
+## Usage
+
+```shell
+nx login [nxCloudUrl]
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+| Option         | Type    | Description                                                                                                                                              |
+| -------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--help`       | boolean | Show help.                                                                                                                                               |
+| `--nxCloudUrl` | string  | The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to https://cloud.nx.app. |
+| `--verbose`    | boolean | Prints additional information about the commands (e.g., stack traces).                                                                                   |
+| `--version`    | boolean | Show version number.                                                                                                                                     |

--- a/docs/generated/cli/logout.md
+++ b/docs/generated/cli/logout.md
@@ -1,0 +1,24 @@
+---
+title: 'logout - CLI command'
+description: 'Logout from Nx Cloud.'
+---
+
+# logout
+
+Logout from Nx Cloud.
+
+## Usage
+
+```shell
+nx logout
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+| Option      | Type    | Description                                                            |
+| ----------- | ------- | ---------------------------------------------------------------------- |
+| `--help`    | boolean | Show help.                                                             |
+| `--verbose` | boolean | Prints additional information about the commands (e.g., stack traces). |
+| `--version` | boolean | Show version number.                                                   |

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -8712,6 +8712,22 @@
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
+              },
+              {
+                "name": "login",
+                "path": "/nx-api/nx/documents/login",
+                "id": "login",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
+              },
+              {
+                "name": "logout",
+                "path": "/nx-api/nx/documents/logout",
+                "id": "logout",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -1967,6 +1967,28 @@
         "path": "/nx-api/nx/documents/add",
         "tags": [],
         "originalFilePath": "generated/cli/add"
+      },
+      "/nx-api/nx/documents/login": {
+        "id": "login",
+        "name": "login",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/login",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/nx-api/nx/documents/login",
+        "tags": [],
+        "originalFilePath": "generated/cli/login"
+      },
+      "/nx-api/nx/documents/logout": {
+        "id": "logout",
+        "name": "logout",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/logout",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/nx-api/nx/documents/logout",
+        "tags": [],
+        "originalFilePath": "generated/cli/logout"
       }
     },
     "root": "/packages/nx",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1946,6 +1946,28 @@
         "path": "nx/documents/add",
         "tags": [],
         "originalFilePath": "generated/cli/add"
+      },
+      {
+        "id": "login",
+        "name": "login",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/login",
+        "itemList": [],
+        "isExternal": false,
+        "path": "nx/documents/login",
+        "tags": [],
+        "originalFilePath": "generated/cli/login"
+      },
+      {
+        "id": "logout",
+        "name": "logout",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/logout",
+        "itemList": [],
+        "isExternal": false,
+        "path": "nx/documents/logout",
+        "tags": [],
+        "originalFilePath": "generated/cli/logout"
       }
     ],
     "executors": [

--- a/docs/generated/packages/nx/documents/login.md
+++ b/docs/generated/packages/nx/documents/login.md
@@ -1,0 +1,25 @@
+---
+title: 'login - CLI command'
+description: 'Login to Nx Cloud.'
+---
+
+# login
+
+Login to Nx Cloud.
+
+## Usage
+
+```shell
+nx login [nxCloudUrl]
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+| Option         | Type    | Description                                                                                                                                              |
+| -------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--help`       | boolean | Show help.                                                                                                                                               |
+| `--nxCloudUrl` | string  | The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to https://cloud.nx.app. |
+| `--verbose`    | boolean | Prints additional information about the commands (e.g., stack traces).                                                                                   |
+| `--version`    | boolean | Show version number.                                                                                                                                     |

--- a/docs/generated/packages/nx/documents/logout.md
+++ b/docs/generated/packages/nx/documents/logout.md
@@ -1,0 +1,24 @@
+---
+title: 'logout - CLI command'
+description: 'Logout from Nx Cloud.'
+---
+
+# logout
+
+Logout from Nx Cloud.
+
+## Usage
+
+```shell
+nx logout
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+| Option      | Type    | Description                                                            |
+| ----------- | ------- | ---------------------------------------------------------------------- |
+| `--help`    | boolean | Show help.                                                             |
+| `--verbose` | boolean | Prints additional information about the commands (e.g., stack traces). |
+| `--version` | boolean | Show version number.                                                   |

--- a/docs/map.json
+++ b/docs/map.json
@@ -2110,6 +2110,16 @@
               "name": "add",
               "id": "add",
               "file": "generated/cli/add"
+            },
+            {
+              "name": "login",
+              "id": "login",
+              "file": "generated/cli/login"
+            },
+            {
+              "name": "logout",
+              "id": "logout",
+              "file": "generated/cli/logout"
             }
           ]
         },

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -559,6 +559,8 @@
       - [view-logs](/nx-api/nx/documents/view-logs)
       - [release](/nx-api/nx/documents/release)
       - [add](/nx-api/nx/documents/add)
+      - [login](/nx-api/nx/documents/login)
+      - [logout](/nx-api/nx/documents/logout)
     - [executors](/nx-api/nx/executors)
       - [noop](/nx-api/nx/executors/noop)
       - [run-commands](/nx-api/nx/executors/run-commands)

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.spec.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.spec.ts
@@ -21,7 +21,7 @@ describe('connect-to-nx-cloud', () => {
       expect(
         withEnvironmentVariables(
           {
-            NX_ENABLE_LOGIN: null,
+            NX_CLOUD_ACCESS_TOKEN: null,
           },
           () =>
             onlyDefaultRunnerIsUsed({

--- a/packages/nx/src/command-line/login/command-object.ts
+++ b/packages/nx/src/command-line/login/command-object.ts
@@ -3,7 +3,7 @@ import { withVerbose } from '../../command-line/yargs-utils/shared-options';
 
 export const yargsLoginCommand: CommandModule = {
   command: 'login [nxCloudUrl]',
-  describe: false,
+  describe: 'Login to Nx Cloud.',
   builder: (yargs) =>
     withVerbose(
       yargs.positional('nxCloudUrl', {

--- a/packages/nx/src/command-line/logout/command-object.ts
+++ b/packages/nx/src/command-line/logout/command-object.ts
@@ -3,7 +3,7 @@ import { withVerbose } from '../../command-line/yargs-utils/shared-options';
 
 export const yargsLogoutCommand: CommandModule = {
   command: 'logout',
-  describe: false,
+  describe: 'Logout from Nx Cloud.',
   builder: (yargs) => withVerbose(yargs),
   handler: async (args: any) => {
     process.exit(await (await import('./logout')).logoutHandler(args));

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -48,28 +48,6 @@ function getNxInitDate(): string | null {
   }
 }
 
-async function createNxCloudWorkspaceV1(
-  workspaceName: string,
-  installationSource: string,
-  nxInitDate: string | null
-): Promise<{ token: string; url: string }> {
-  const apiUrl = getCloudUrl();
-  const response = await require('axios').post(
-    `${apiUrl}/nx-cloud/create-org-and-workspace`,
-    {
-      workspaceName,
-      installationSource,
-      nxInitDate,
-    }
-  );
-
-  if (response.data.message) {
-    throw new Error(response.data.message);
-  }
-
-  return response.data;
-}
-
 async function createNxCloudWorkspaceV2(
   workspaceName: string,
   installationSource: string,
@@ -123,29 +101,6 @@ export interface ConnectToNxCloudOptions {
   github?: boolean;
   directory?: string;
   generateToken?: boolean;
-}
-
-function addNxCloudOptionsToNxJson(
-  tree: Tree,
-  token: string,
-  directory: string = ''
-) {
-  const nxJsonPath = join(directory, 'nx.json');
-  if (tree.exists(nxJsonPath)) {
-    updateJson<NxJsonConfiguration>(
-      tree,
-      join(directory, 'nx.json'),
-      (nxJson) => {
-        const overrideUrl = process.env.NX_CLOUD_API || process.env.NRWL_API;
-        if (overrideUrl) {
-          nxJson.nxCloudUrl = overrideUrl;
-        }
-        nxJson.nxCloudAccessToken = token;
-
-        return nxJson;
-      }
-    );
-  }
 }
 
 function addNxCloudIdToNxJson(
@@ -208,41 +163,22 @@ export async function connectToNxCloud(
   )
     return null;
 
-  if (process.env.NX_ENABLE_LOGIN === 'true') {
-    responseFromCreateNxCloudWorkspaceV2 = await createNxCloudWorkspaceV2(
-      getRootPackageName(tree),
-      schema.installationSource,
-      getNxInitDate()
-    );
+  responseFromCreateNxCloudWorkspaceV2 = await createNxCloudWorkspaceV2(
+    getRootPackageName(tree),
+    schema.installationSource,
+    getNxInitDate()
+  );
 
-    addNxCloudIdToNxJson(
-      tree,
-      responseFromCreateNxCloudWorkspaceV2?.nxCloudId,
-      schema.directory
-    );
+  addNxCloudIdToNxJson(
+    tree,
+    responseFromCreateNxCloudWorkspaceV2?.nxCloudId,
+    schema.directory
+  );
 
-    await formatChangedFilesWithPrettierIfAvailable(tree, {
-      silent: schema.hideFormatLogs,
-    });
-    return responseFromCreateNxCloudWorkspaceV2.nxCloudId;
-  } else {
-    responseFromCreateNxCloudWorkspaceV1 = await createNxCloudWorkspaceV1(
-      getRootPackageName(tree),
-      schema.installationSource,
-      getNxInitDate()
-    );
-
-    addNxCloudOptionsToNxJson(
-      tree,
-      responseFromCreateNxCloudWorkspaceV1?.token,
-      schema.directory
-    );
-
-    await formatChangedFilesWithPrettierIfAvailable(tree, {
-      silent: schema.hideFormatLogs,
-    });
-    return responseFromCreateNxCloudWorkspaceV1.token;
-  }
+  await formatChangedFilesWithPrettierIfAvailable(tree, {
+    silent: schema.hideFormatLogs,
+  });
+  return responseFromCreateNxCloudWorkspaceV2.nxCloudId;
 }
 
 async function connectToNxCloudGenerator(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

You need to use NX_ENABLE_LOGIN=true to connect to Nx Cloud with nxCloudId. Documentation also is hidden for `nx login` and `nx logout` aliases.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx connect` automatically connects via nxCloudId. Documentation shows up for `nx login` and `nx logout` commands. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
