### PR TITLE
fix(core): make sure sharedGlobals is referenced in default namedInputs

### DIFF
--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -244,4 +244,34 @@ describe('CI Workflow generator', () => {
       '{workspaceRoot}/.gitlab-ci.yml',
     ]);
   });
+
+  it('should add workflow files to namedInputs.sharedGlobals and update default', async () => {
+    await ciWorkflowGenerator(tree, { ci: 'github', name: 'CI' });
+
+    const nxJson = readJson(tree, 'nx.json');
+    expect(nxJson.namedInputs.sharedGlobals).toEqual([
+      '{workspaceRoot}/.github/workflows/ci.yml',
+    ]);
+    expect(nxJson.namedInputs.default).toEqual(['sharedGlobals']);
+  });
+
+  it('should append sharedGlobals to existing default namedInput', async () => {
+    // Set up initial nx.json with existing default namedInput
+    const initialNxJson = readJson(tree, 'nx.json');
+    initialNxJson.namedInputs = {
+      default: ['existing'],
+    };
+    writeJson(tree, 'nx.json', initialNxJson);
+
+    await ciWorkflowGenerator(tree, { ci: 'github', name: 'CI' });
+
+    const updatedNxJson = readJson(tree, 'nx.json');
+    expect(updatedNxJson.namedInputs.sharedGlobals).toEqual([
+      '{workspaceRoot}/.github/workflows/ci.yml',
+    ]);
+    expect(updatedNxJson.namedInputs.default).toEqual([
+      'existing',
+      'sharedGlobals',
+    ]);
+  });
 });

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
@@ -125,4 +125,14 @@ function addWorkflowFileToSharedGlobals(
   nxJson.namedInputs ??= {};
   nxJson.namedInputs.sharedGlobals ??= [];
   nxJson.namedInputs.sharedGlobals.push(input);
+
+  // Ensure 'default' named input exists and includes 'sharedGlobals'
+  if (!nxJson.namedInputs.default) {
+    nxJson.namedInputs.default = ['sharedGlobals'];
+  } else if (
+    Array.isArray(nxJson.namedInputs.default) &&
+    !nxJson.namedInputs.default.includes('sharedGlobals')
+  ) {
+    nxJson.namedInputs.default.push('sharedGlobals');
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior and Expected Behavior
<!-- This is the behavior we have today -->

Right now when running the `ci-workflow` generator, it only adds a `sharedGlobals` to the `nx.json`. That's not enough though to have caching be invalidated. The `sharedGlobals` also needs to be referenced by a `default` entry in the `namedInputs` section.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
