### PR TITLE
feat(core): update github action pnpm version

### DIFF
--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -916,7 +916,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -962,7 +962,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -2208,7 +2208,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -2255,7 +2255,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -20,7 +20,7 @@ jobs:
       <% if(packageManager == 'pnpm'){ %>
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
       <% } %>
       <% if(packageManager == 'bun'){ %>
       - uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
After creating a nx workspace using pnpm (v9.9.0) and github actions the CI fails due to: `WARN  Ignoring not compatible lockfile`. The reason why it fails is because the pnpm version in the workflow is set to 8 and does not support the pnpm v9 lockfile.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The CI workflow should support pnpm latest version lockfile.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27814
