### PR TITLE
fix(vite/test): partial support for vitest@2

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -34,11 +34,17 @@ export async function* vitestExecutor(
 
   const cliFilters = options.testFiles ?? [];
 
+  const checkExitCode = process.exitCode === undefined;
+
   const ctx = await startVitest(
     resolvedOptions['mode'] ?? 'test',
     cliFilters,
     resolvedOptions
   );
+
+  if(checkExitCode && process.exitCode) {
+    process.exit();
+  }
 
   let hasErrors = false;
 


### PR DESCRIPTION
When having no tests the process will hang, this is because `onFinished` event is never emitted when no test exists and before version 2, the process was terminated, but not it was not

this is the vitest PR that changed it:
https://github.com/vitest-dev/vitest/pull/5926
