### PR TITLE
fix(core): move daemon server-process.json watching to outputs watcher

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -524,7 +524,7 @@ export async function startServer(): Promise<Server> {
 
           if (!getOutputWatcherInstance()) {
             storeOutputWatcherInstance(
-              await watchOutputFiles(handleOutputsChanges)
+              await watchOutputFiles(server, handleOutputsChanges)
             );
           }
 

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -27,28 +27,13 @@ export type FileWatcherCallback = (
 export async function watchWorkspace(server: Server, cb: FileWatcherCallback) {
   const { Watcher } = await import('../../native');
 
-  let relativeServerProcess = normalizePath(
-    relative(workspaceRoot, serverProcessJsonPath)
-  );
-
-  let watcher = new Watcher(workspaceRoot, [`!${relativeServerProcess}`]);
+  const watcher = new Watcher(workspaceRoot);
   watcher.watch((err, events) => {
     if (err) {
       return cb(err, null);
     }
 
     for (const event of events) {
-      if (
-        event.path == relativeServerProcess &&
-        getDaemonProcessIdSync() !== process.pid
-      ) {
-        handleServerProcessTermination({
-          server,
-          reason: 'this process is no longer the current daemon (native)',
-          sockets: openSockets,
-        });
-      }
-
       if (event.path.endsWith('.gitignore') || event.path === '.nxignore') {
         // If the ignore files themselves have changed we need to dynamically update our cached ignoreGlobs
         handleServerProcessTermination({
@@ -66,13 +51,36 @@ export async function watchWorkspace(server: Server, cb: FileWatcherCallback) {
   return watcher;
 }
 
-export async function watchOutputFiles(cb: FileWatcherCallback) {
+export async function watchOutputFiles(
+  server: Server,
+  cb: FileWatcherCallback
+) {
   const { Watcher } = await import('../../native');
 
-  let watcher = new Watcher(workspaceRoot, null, false);
+  const relativeServerProcess = normalizePath(
+    relative(workspaceRoot, serverProcessJsonPath)
+  );
+  const watcher = new Watcher(
+    workspaceRoot,
+    [`!${relativeServerProcess}`],
+    false
+  );
   watcher.watch((err, events) => {
     if (err) {
       return cb(err, null);
+    }
+
+    for (const event of events) {
+      if (
+        event.path == relativeServerProcess &&
+        getDaemonProcessIdSync() !== process.pid
+      ) {
+        return handleServerProcessTermination({
+          server,
+          reason: 'this process is no longer the current daemon (native)',
+          sockets: openSockets,
+        });
+      }
     }
 
     if (events.length !== 0) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The `server-process.json` for the daemon gets included in a root project's **/* fileset when it changes after the daemon has started.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `server-process.json` watching is handled in the `outputs` file watcher which will not add it to the workspace files and won't show up in the **/* fileset.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
