### PR TITLE
feat(graph): expose functions to render pdv & error page

### DIFF
--- a/graph/client/src/app/console-project-details/project-details.app.tsx
+++ b/graph/client/src/app/console-project-details/project-details.app.tsx
@@ -1,0 +1,94 @@
+import { useCallback } from 'react';
+import {
+  ErrorToastUI,
+  ExpandedTargetsProvider,
+  getExternalApiService,
+} from '@nx/graph/shared';
+import { useMachine, useSelector } from '@xstate/react';
+import { ProjectDetails } from '@nx/graph-internal/ui-project-details';
+import {
+  ProjectDetailsEvents,
+  ProjectDetailsState,
+} from './project-details.machine';
+import { Interpreter } from 'xstate';
+
+export function ProjectDetailsApp({
+  service,
+}: {
+  service: Interpreter<ProjectDetailsState, any, ProjectDetailsEvents>;
+}) {
+  const externalApiService = getExternalApiService();
+
+  const project = useSelector(service, (state) => state.context.project);
+  const sourceMap = useSelector(service, (state) => state.context.sourceMap);
+  const errors = useSelector(service, (state) => state.context.errors);
+  const connectedToCloud = useSelector(
+    service,
+    (state) => state.context.connectedToCloud
+  );
+
+  const handleViewInProjectGraph = useCallback(
+    (data: { projectName: string }) => {
+      externalApiService.postEvent({
+        type: 'open-project-graph',
+        payload: {
+          projectName: data.projectName,
+        },
+      });
+    },
+    [externalApiService]
+  );
+
+  const handleViewInTaskGraph = useCallback(
+    (data: { projectName: string; targetName: string }) => {
+      externalApiService.postEvent({
+        type: 'open-task-graph',
+        payload: {
+          projectName: data.projectName,
+          targetName: data.targetName,
+        },
+      });
+    },
+    [externalApiService]
+  );
+
+  const handleRunTarget = useCallback(
+    (data: { projectName: string; targetName: string }) => {
+      externalApiService.postEvent({
+        type: 'run-task',
+        payload: { taskId: `${data.projectName}:${data.targetName}` },
+      });
+    },
+    [externalApiService]
+  );
+
+  const handleNxConnect = useCallback(
+    () =>
+      externalApiService.postEvent({
+        type: 'nx-connect',
+      }),
+    [externalApiService]
+  );
+
+  if (project && sourceMap) {
+    return (
+      <>
+        <ExpandedTargetsProvider>
+          <ProjectDetails
+            project={project}
+            sourceMap={sourceMap}
+            onViewInProjectGraph={handleViewInProjectGraph}
+            onViewInTaskGraph={handleViewInTaskGraph}
+            onRunTarget={handleRunTarget}
+            viewInProjectGraphPosition="bottom"
+            connectedToCloud={connectedToCloud}
+            onNxConnect={handleNxConnect}
+          />
+        </ExpandedTargetsProvider>
+        <ErrorToastUI errors={errors} />
+      </>
+    );
+  } else {
+    return null;
+  }
+}

--- a/graph/client/src/app/console-project-details/project-details.machine.spec.ts
+++ b/graph/client/src/app/console-project-details/project-details.machine.spec.ts
@@ -15,10 +15,10 @@ describe('graphMachine', () => {
   it('should have initial idle state', () => {
     expect(service.state.value).toEqual('idle');
     expect(service.state.context.project).toEqual(null);
-    expect(service.state.context.errors).toEqual(null);
+    expect(service.state.context.errors).toBeUndefined();
   });
 
-  it('should handle setting project and source map', () => {
+  it('should handle setting data', () => {
     service.send({
       type: 'loadData',
       project: {
@@ -29,7 +29,11 @@ describe('graphMachine', () => {
       sourceMap: {
         root: ['project.json', 'nx-core-build-project-json-nodes'],
       },
+      errors: [{ name: 'ERROR' }],
+      connectedToCloud: true,
     });
+
+    expect(service.state.value).toEqual('loaded');
 
     expect(service.state.context.project).toEqual({
       type: 'app',
@@ -39,44 +43,7 @@ describe('graphMachine', () => {
     expect(service.state.context.sourceMap).toEqual({
       root: ['project.json', 'nx-core-build-project-json-nodes'],
     });
-  });
-
-  it('should handle errors', () => {
-    const testError = {
-      message: 'test',
-      stack: 'test',
-      cause: 'test',
-      name: 'test',
-      pluginName: 'test',
-    };
-
-    service.send({
-      type: 'setErrors',
-      errors: [testError],
-    });
-    expect(service.state.value).toEqual('error');
-    expect(service.state.context.errors).toBeDefined();
-
-    service.send({ type: 'clearErrors' });
-    expect(service.state.value).toEqual('idle');
-
-    service.send({
-      type: 'setErrors',
-      errors: [testError],
-    });
-    expect(service.state.value).toEqual('error');
-    service.send({
-      type: 'loadData',
-      project: {
-        type: 'app',
-        name: 'proj',
-        data: {},
-      },
-      sourceMap: {
-        root: ['project.json', 'nx-core-build-project-json-nodes'],
-      },
-    });
-    // Still in error state
-    expect(service.state.value).toEqual('error');
+    expect(service.state.context.errors).toEqual([{ name: 'ERROR' }]);
+    expect(service.state.context.connectedToCloud).toEqual(true);
   });
 });

--- a/graph/client/src/app/console-project-details/project-details.machine.spec.ts
+++ b/graph/client/src/app/console-project-details/project-details.machine.spec.ts
@@ -1,0 +1,82 @@
+import { interpret } from 'xstate';
+import { projectDetailsMachine } from './project-details.machine';
+
+describe('graphMachine', () => {
+  let service;
+
+  beforeEach(() => {
+    service = interpret(projectDetailsMachine).start();
+  });
+
+  afterEach(() => {
+    service.stop();
+  });
+
+  it('should have initial idle state', () => {
+    expect(service.state.value).toEqual('idle');
+    expect(service.state.context.project).toEqual(null);
+    expect(service.state.context.errors).toEqual(null);
+  });
+
+  it('should handle setting project and source map', () => {
+    service.send({
+      type: 'loadData',
+      project: {
+        type: 'app',
+        name: 'proj',
+        data: {},
+      },
+      sourceMap: {
+        root: ['project.json', 'nx-core-build-project-json-nodes'],
+      },
+    });
+
+    expect(service.state.context.project).toEqual({
+      type: 'app',
+      name: 'proj',
+      data: {},
+    });
+    expect(service.state.context.sourceMap).toEqual({
+      root: ['project.json', 'nx-core-build-project-json-nodes'],
+    });
+  });
+
+  it('should handle errors', () => {
+    const testError = {
+      message: 'test',
+      stack: 'test',
+      cause: 'test',
+      name: 'test',
+      pluginName: 'test',
+    };
+
+    service.send({
+      type: 'setErrors',
+      errors: [testError],
+    });
+    expect(service.state.value).toEqual('error');
+    expect(service.state.context.errors).toBeDefined();
+
+    service.send({ type: 'clearErrors' });
+    expect(service.state.value).toEqual('idle');
+
+    service.send({
+      type: 'setErrors',
+      errors: [testError],
+    });
+    expect(service.state.value).toEqual('error');
+    service.send({
+      type: 'loadData',
+      project: {
+        type: 'app',
+        name: 'proj',
+        data: {},
+      },
+      sourceMap: {
+        root: ['project.json', 'nx-core-build-project-json-nodes'],
+      },
+    });
+    // Still in error state
+    expect(service.state.value).toEqual('error');
+  });
+});

--- a/graph/client/src/app/console-project-details/project-details.machine.ts
+++ b/graph/client/src/app/console-project-details/project-details.machine.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @nx/enforce-module-boundaries */
+// nx-ignore-next-line
+import type { ProjectGraphProjectNode } from '@nx/devkit';
+// nx-ignore-next-line
+import { GraphError } from 'nx/src/command-line/graph/graph';
+/* eslint-enable @nx/enforce-module-boundaries */
+import { createMachine } from 'xstate';
+import { assign } from '@xstate/immer';
+
+export interface ProjectDetailsState {
+  project: null | ProjectGraphProjectNode;
+  sourceMap: null | Record<string, string[]>;
+  errors: null | GraphError[];
+  connectedToCloud: boolean;
+}
+
+export type ProjectDetailsEvents =
+  | {
+      type: 'loadData';
+      project: ProjectGraphProjectNode;
+      sourceMap: Record<string, string[]>;
+      connectedToCloud: boolean;
+    }
+  | {
+      type: 'setErrors';
+      errors: GraphError[];
+    }
+  | {
+      type: 'clearErrors';
+    };
+
+const initialContext: ProjectDetailsState = {
+  project: null,
+  sourceMap: null,
+  errors: null,
+  connectedToCloud: false,
+};
+
+export const projectDetailsMachine = createMachine<
+  ProjectDetailsState,
+  ProjectDetailsEvents
+>({
+  predictableActionArguments: true,
+  preserveActionOrder: true,
+  id: 'project-view',
+  initial: 'idle',
+  context: initialContext,
+  states: {
+    idle: {},
+    loaded: {},
+    error: {},
+  },
+  on: {
+    loadData: [
+      {
+        target: 'loaded',
+        cond: (ctx, _event) => ctx.errors === null || ctx.errors.length === 0,
+        actions: [
+          assign((ctx, event) => {
+            ctx.project = event.project;
+            ctx.sourceMap = event.sourceMap;
+            ctx.connectedToCloud = event.connectedToCloud;
+          }),
+        ],
+      },
+      {
+        target: 'error',
+        cond: (ctx, _event) => ctx.errors !== null && ctx.errors.length > 0,
+        actions: [
+          assign((ctx, event) => {
+            ctx.project = event.project;
+            ctx.sourceMap = event.sourceMap;
+            ctx.connectedToCloud = event.connectedToCloud;
+          }),
+        ],
+      },
+    ],
+    setErrors: {
+      target: 'error',
+      actions: assign((ctx, event) => {
+        ctx.errors = event.errors;
+      }),
+    },
+    clearErrors: [
+      {
+        target: 'idle',
+        cond: (ctx, _event) => ctx.project === null,
+        actions: assign((ctx) => {
+          ctx.errors = null;
+        }),
+      },
+      {
+        target: 'loaded',
+        cond: (ctx, _event) => ctx.project !== null,
+        actions: assign((ctx) => {
+          ctx.errors = null;
+        }),
+      },
+    ],
+  },
+});

--- a/graph/client/src/app/console-project-details/project-details.machine.ts
+++ b/graph/client/src/app/console-project-details/project-details.machine.ts
@@ -10,24 +10,17 @@ import { assign } from '@xstate/immer';
 export interface ProjectDetailsState {
   project: null | ProjectGraphProjectNode;
   sourceMap: null | Record<string, string[]>;
-  errors: null | GraphError[];
+  errors?: GraphError[];
   connectedToCloud: boolean;
 }
 
-export type ProjectDetailsEvents =
-  | {
-      type: 'loadData';
-      project: ProjectGraphProjectNode;
-      sourceMap: Record<string, string[]>;
-      connectedToCloud: boolean;
-    }
-  | {
-      type: 'setErrors';
-      errors: GraphError[];
-    }
-  | {
-      type: 'clearErrors';
-    };
+export type ProjectDetailsEvents = {
+  type: 'loadData';
+  project: ProjectGraphProjectNode;
+  sourceMap: Record<string, string[]>;
+  connectedToCloud: boolean;
+  errors?: GraphError[];
+};
 
 const initialContext: ProjectDetailsState = {
   project: null,
@@ -48,53 +41,19 @@ export const projectDetailsMachine = createMachine<
   states: {
     idle: {},
     loaded: {},
-    error: {},
   },
   on: {
     loadData: [
       {
         target: 'loaded',
-        cond: (ctx, _event) => ctx.errors === null || ctx.errors.length === 0,
         actions: [
           assign((ctx, event) => {
             ctx.project = event.project;
             ctx.sourceMap = event.sourceMap;
             ctx.connectedToCloud = event.connectedToCloud;
+            ctx.errors = event.errors;
           }),
         ],
-      },
-      {
-        target: 'error',
-        cond: (ctx, _event) => ctx.errors !== null && ctx.errors.length > 0,
-        actions: [
-          assign((ctx, event) => {
-            ctx.project = event.project;
-            ctx.sourceMap = event.sourceMap;
-            ctx.connectedToCloud = event.connectedToCloud;
-          }),
-        ],
-      },
-    ],
-    setErrors: {
-      target: 'error',
-      actions: assign((ctx, event) => {
-        ctx.errors = event.errors;
-      }),
-    },
-    clearErrors: [
-      {
-        target: 'idle',
-        cond: (ctx, _event) => ctx.project === null,
-        actions: assign((ctx) => {
-          ctx.errors = null;
-        }),
-      },
-      {
-        target: 'loaded',
-        cond: (ctx, _event) => ctx.project !== null,
-        actions: assign((ctx) => {
-          ctx.errors = null;
-        }),
       },
     ],
   },

--- a/graph/client/src/app/console-project-details/project-details.machine.ts
+++ b/graph/client/src/app/console-project-details/project-details.machine.ts
@@ -11,7 +11,7 @@ export interface ProjectDetailsState {
   project: null | ProjectGraphProjectNode;
   sourceMap: null | Record<string, string[]>;
   errors?: GraphError[];
-  connectedToCloud: boolean;
+  connectedToCloud?: boolean;
 }
 
 export type ProjectDetailsEvents = {
@@ -25,8 +25,6 @@ export type ProjectDetailsEvents = {
 const initialContext: ProjectDetailsState = {
   project: null,
   sourceMap: null,
-  errors: null,
-  connectedToCloud: false,
 };
 
 export const projectDetailsMachine = createMachine<

--- a/graph/client/src/app/ui-components/error-boundary.tsx
+++ b/graph/client/src/app/ui-components/error-boundary.tsx
@@ -5,12 +5,12 @@ import {
   useEnvironmentConfig,
   usePoll,
 } from '@nx/graph/shared';
-import { ErrorRenderer } from '@nx/graph/ui-components';
 import {
   isRouteErrorResponse,
   useParams,
   useRouteError,
 } from 'react-router-dom';
+import { ErrorPage } from './error-page';
 
 export function ErrorBoundary() {
   let error = useRouteError();
@@ -63,38 +63,11 @@ export function ErrorBoundary() {
   return (
     <div className="flex h-screen w-full flex-col items-center">
       {environment !== 'nx-console' && <ProjectDetailsHeader />}
-      <div className="mx-auto mb-8 w-full max-w-6xl flex-grow px-8">
-        <h1 className="mb-4 text-4xl dark:text-slate-100">Error</h1>
-        <div>
-          <ErrorWithStack message={message} stack={stack} />
-        </div>
-        {hasErrorData && (
-          <div>
-            <p className="text-md mb-4 dark:text-slate-200">
-              Nx encountered the following issues while processing the project
-              graph:{' '}
-            </p>
-            <div>
-              <ErrorRenderer errors={error.data.errors} />
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function ErrorWithStack({
-  message,
-  stack,
-}: {
-  message: string | JSX.Element;
-  stack?: string;
-}) {
-  return (
-    <div>
-      <p className="mb-4 text-lg dark:text-slate-100">{message}</p>
-      {stack && <p className="text-sm">Error message: {stack}</p>}
+      <ErrorPage
+        message={message}
+        stack={stack}
+        errors={hasErrorData ? error.data.errors : undefined}
+      />
     </div>
   );
 }

--- a/graph/client/src/app/ui-components/error-page.tsx
+++ b/graph/client/src/app/ui-components/error-page.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable @nx/enforce-module-boundaries */
+// nx-ignore-next-line
+import { ErrorRenderer } from '@nx/graph/ui-components';
+import { GraphError } from 'nx/src/command-line/graph/graph';
+/* eslint-enable @nx/enforce-module-boundaries */
+
+export type ErrorPageProps = {
+  message: string | JSX.Element;
+  stack?: string;
+  errors: GraphError[];
+};
+
+export function ErrorPage({ message, stack, errors }: ErrorPageProps) {
+  return (
+    <div className="mx-auto mb-8 w-full max-w-6xl flex-grow px-8">
+      <h1 className="mb-4 text-4xl dark:text-slate-100">Error</h1>
+      <div>
+        <ErrorWithStack message={message} stack={stack} />
+      </div>
+      {errors && (
+        <div>
+          <p className="text-md mb-4 dark:text-slate-200">
+            Nx encountered the following issues while processing the project
+            graph:{' '}
+          </p>
+          <div>
+            <ErrorRenderer errors={errors} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ErrorWithStack({
+  message,
+  stack,
+}: {
+  message: string | JSX.Element;
+  stack?: string;
+}) {
+  return (
+    <div>
+      <p className="mb-4 text-lg dark:text-slate-100">{message}</p>
+      {stack && <p className="text-sm">Error message: {stack}</p>}
+    </div>
+  );
+}

--- a/graph/client/src/app/ui-components/error-page.tsx
+++ b/graph/client/src/app/ui-components/error-page.tsx
@@ -3,6 +3,7 @@
 import { ErrorRenderer } from '@nx/graph/ui-components';
 import { GraphError } from 'nx/src/command-line/graph/graph';
 /* eslint-enable @nx/enforce-module-boundaries */
+import type { JSX } from 'react';
 
 export type ErrorPageProps = {
   message: string | JSX.Element;

--- a/graph/client/src/globals.d.ts
+++ b/graph/client/src/globals.d.ts
@@ -20,6 +20,11 @@ export declare global {
     appConfig: AppConfig;
     useXstateInspect: boolean;
     externalApi?: ExternalApi;
+
+    // using bundled graph components directly from outside the graph app
+    __NX_RENDER_GRAPH__?: boolean;
+    renderPDV?: (data: any) => void;
+    renderError?: (data: any) => void;
   }
 }
 declare module 'cytoscape' {

--- a/graph/client/src/globals.d.ts
+++ b/graph/client/src/globals.d.ts
@@ -6,6 +6,12 @@ import type {
   TaskGraphClientResponse,
 } from 'nx/src/command-line/graph/graph';
 import type { AppConfig, ExternalApi } from '@nx/graph/shared';
+import {
+  ProjectDetailsEvents,
+  projectDetailsMachine,
+  ProjectDetailsState,
+} from './app/console/project-details/project-details.machine';
+import { Interpreter } from 'xstate';
 
 export declare global {
   interface Window {
@@ -23,7 +29,9 @@ export declare global {
 
     // using bundled graph components directly from outside the graph app
     __NX_RENDER_GRAPH__?: boolean;
-    renderPDV?: (data: any) => void;
+    renderPDV?: (
+      data: any
+    ) => Interpreter<ProjectDetailsState, any, ProjectDetailsEvents>;
     renderError?: (data: any) => void;
   }
 }

--- a/graph/client/src/main.tsx
+++ b/graph/client/src/main.tsx
@@ -9,30 +9,58 @@ import { inspect } from '@xstate/inspect';
 import { App } from './app/app';
 import { ExternalApiImpl } from './app/external-api-impl';
 import { render } from 'preact';
+import { ErrorToastUI, ExpandedTargetsProvider } from '@nx/graph/shared';
+import { ProjectDetails } from '@nx/graph-internal/ui-project-details';
+import { ErrorPage } from './app/ui-components/error-page';
 
-if (window.useXstateInspect === true) {
-  inspect({
-    url: 'https://stately.ai/viz?inspect',
-    iframe: false, // open in new window
-  });
-}
+if (window.__NX_RENDER_GRAPH__ === false) {
+  window.renderPDV = (data: any) => {
+    const container = document.getElementById('app');
+    render(
+      <StrictMode>
+        <ExpandedTargetsProvider>
+          <ProjectDetails {...data} />
+        </ExpandedTargetsProvider>
+        <ErrorToastUI errors={data.errors} />
+      </StrictMode>,
+      container
+    );
+  };
 
-window.externalApi = new ExternalApiImpl();
-const container = document.getElementById('app');
-
-if (!window.appConfig) {
-  render(
-    <p>
-      No environment could be found. Please run{' '}
-      <pre>npx nx run graph-client:generate-dev-environment-js</pre>.
-    </p>,
-    container
-  );
+  window.renderError = (data: any) => {
+    const container = document.getElementById('app');
+    render(
+      <StrictMode>
+        <ErrorPage {...data} />
+      </StrictMode>,
+      container
+    );
+  };
 } else {
-  render(
-    <StrictMode>
-      <App />
-    </StrictMode>,
-    container
-  );
+  if (window.useXstateInspect === true) {
+    inspect({
+      url: 'https://stately.ai/viz?inspect',
+      iframe: false, // open in new window
+    });
+  }
+
+  window.externalApi = new ExternalApiImpl();
+  const container = document.getElementById('app');
+
+  if (!window.appConfig) {
+    render(
+      <p>
+        No environment could be found. Please run{' '}
+        <pre>npx nx run graph-client:generate-dev-environment-js</pre>.
+      </p>,
+      container
+    );
+  } else {
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+      container
+    );
+  }
 }

--- a/graph/client/src/main.tsx
+++ b/graph/client/src/main.tsx
@@ -21,10 +21,13 @@ import { ProjectDetailsApp } from './app/console-project-details/project-details
 import { interpret } from 'xstate';
 
 if (window.__NX_RENDER_GRAPH__ === false) {
+  window.externalApi = new ExternalApiImpl();
+
   window.renderPDV = (data: {
     project: ProjectGraphProjectNode;
     sourceMap: Record<string, string[]>;
     connectedToCloud: boolean;
+    errors?: GraphError[];
   }) => {
     const service = interpret(projectDetailsMachine).start();
 

--- a/graph/ui-project-details/src/lib/project-details/project-details.tsx
+++ b/graph/ui-project-details/src/lib/project-details/project-details.tsx
@@ -90,7 +90,7 @@ export const ProjectDetails = ({
           </div>
           {onViewInProjectGraph && viewInProjectGraphPosition === 'top' && (
             <ViewInProjectGraphButton
-              callback={() =>
+              onClick={() =>
                 onViewInProjectGraph({ projectName: project.name })
               }
             />
@@ -125,7 +125,7 @@ export const ProjectDetails = ({
             {onViewInProjectGraph &&
               viewInProjectGraphPosition === 'bottom' && (
                 <ViewInProjectGraphButton
-                  callback={() =>
+                  onClick={() =>
                     onViewInProjectGraph({ projectName: project.name })
                   }
                 />
@@ -162,11 +162,11 @@ export const ProjectDetails = ({
 
 export default ProjectDetails;
 
-function ViewInProjectGraphButton({ callback }: { callback: () => void }) {
+function ViewInProjectGraphButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       className="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-base text-slate-600 ring-2 ring-inset ring-slate-400/40 hover:bg-slate-50 dark:text-slate-300 dark:ring-slate-400/30 dark:hover:bg-slate-800/60"
-      onClick={() => callback()}
+      onClick={() => onClick()}
     >
       <EyeIcon className="h-5 w-5 "></EyeIcon>
       <span>View In Graph</span>

--- a/graph/ui-project-details/src/lib/utils/group-targets.ts
+++ b/graph/ui-project-details/src/lib/utils/group-targets.ts
@@ -12,9 +12,9 @@ export function groupTargets(project: ProjectGraphProjectNode): {
   groups: Record<string, string[]>;
   targets: string[];
 } {
-  const targetGroups = project.data.metadata?.targetGroups ?? {};
+  const targetGroups = { ...(project.data.metadata?.targetGroups ?? {}) };
   Object.entries(targetGroups).forEach(([group, targets]) => {
-    targetGroups[group] = targets.sort(sortNxReleasePublishLast);
+    targetGroups[group] = [...targets].sort(sortNxReleasePublishLast);
   });
   const allTargetsInTargetGroups: string[] = Object.values(targetGroups).flat();
   const targets: string[] = Object.keys(project.data.targets ?? {})

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "@markdoc/markdoc": "0.2.2",
     "@monaco-editor/react": "^4.4.6",
     "@napi-rs/canvas": "^0.1.52",
-    "@nx/graph": "0.0.1-alpha.15",
+    "@nx/graph": "0.0.1-alpha.16",
     "@react-spring/three": "^9.7.3",
     "@react-three/drei": "^9.108.3",
     "@react-three/fiber": "^8.16.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^0.1.52
         version: 0.1.52
       '@nx/graph':
-        specifier: 0.0.1-alpha.15
-        version: 0.0.1-alpha.15(@nx/devkit@19.7.0-beta.6(nx@19.7.0-beta.6(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(nx@19.7.0-beta.6(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.1-alpha.16
+        version: 0.0.1-alpha.16(@nx/devkit@19.7.0-beta.6(nx@19.7.0-beta.6(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(nx@19.7.0-beta.6(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@react-spring/three':
         specifier: ^9.7.3
         version: 9.7.3(@react-three/fiber@8.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(react@18.3.1)(three@0.166.1)
@@ -978,7 +978,7 @@ importers:
         version: 5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)
       webpack-dev-server:
         specifier: 5.0.4
-        version: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
+        version: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0)
       webpack-merge:
         specifier: ^5.8.0
         version: 5.8.0
@@ -5776,8 +5776,8 @@ packages:
       '@zkochan/js-yaml':
         optional: true
 
-  '@nx/graph@0.0.1-alpha.15':
-    resolution: {integrity: sha512-wwotjQcUCz46NknyvZ99Pi0qpvVul6Maa1Y+bvcd6SUgrpmbfW/zyMQejlyq+iKufZCTJv/iiDUIKZEKvvVRjw==}
+  '@nx/graph@0.0.1-alpha.16':
+    resolution: {integrity: sha512-pJVFuTunlRfa8BuO2Vy6wxRtfC2kDT3TKDR6y1KXmMl90xTVT30zU/K9ITXPZzLfo8nLpewIfbv41gGSCY9+Dg==}
     peerDependencies:
       '@nx/devkit': '>= 19 < 20'
       nx: '>= 19 < 20'
@@ -18545,7 +18545,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1802.1(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1802.1(chokidar@3.6.0)(webpack-dev-server@5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))))(webpack@5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)))
+      '@angular-devkit/build-webpack': 0.1802.1(chokidar@3.6.0)(webpack-dev-server@5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0))(webpack@5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)))
       '@angular-devkit/core': 18.2.1(chokidar@3.6.0)
       '@angular/build': 18.2.1(@angular/compiler-cli@18.2.1(@angular/compiler@18.2.1(@angular/core@18.2.1(rxjs@7.8.1)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.8)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.41)(stylus@0.59.0)(tailwindcss@3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.8)(typescript@5.5.3)))(terser@5.31.6)(typescript@5.5.3)
       '@angular/compiler-cli': 18.2.1(@angular/compiler@18.2.1(@angular/core@18.2.1(rxjs@7.8.1)(zone.js@0.14.3)))(typescript@5.5.3)
@@ -18631,12 +18631,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1802.1(chokidar@3.6.0)(webpack-dev-server@5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))))(webpack@5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)))':
+  '@angular-devkit/build-webpack@0.1802.1(chokidar@3.6.0)(webpack-dev-server@5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0))(webpack@5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)))':
     dependencies:
       '@angular-devkit/architect': 0.1802.1(chokidar@3.6.0)
       rxjs: 7.8.1
       webpack: 5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))
-      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)))
+      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0)
     transitivePeerDependencies:
       - chokidar
 
@@ -25471,7 +25471,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/graph@0.0.1-alpha.15(@nx/devkit@19.7.0-beta.6(nx@19.7.0-beta.6(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(nx@19.7.0-beta.6(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@nx/graph@0.0.1-alpha.16(@nx/devkit@19.7.0-beta.6(nx@19.7.0-beta.6(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(nx@19.7.0-beta.6(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react': 0.26.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@headlessui/react': 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -25930,7 +25930,7 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.0.0
       tslib: 2.6.3
       webpack: 5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)
-      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0)
       webpack-node-externals: 3.0.0
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.0(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
     transitivePeerDependencies:
@@ -26320,7 +26320,7 @@ snapshots:
       webpack: 5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)
     optionalDependencies:
       type-fest: 3.13.1
-      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0)
       webpack-hot-middleware: 2.25.3
 
   '@pnpm/lockfile-types@6.0.0':
@@ -28935,7 +28935,7 @@ snapshots:
       webpack: 5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)
     optionalDependencies:
-      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0)
 
   '@widgetbot/embed-api@1.2.15':
     dependencies:
@@ -41322,7 +41322,7 @@ snapshots:
       webpack: 5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0)
 
   webpack-dev-middleware@6.1.3(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)):
     dependencies:
@@ -41367,47 +41367,6 @@ snapshots:
     optionalDependencies:
       webpack: 5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))
 
-  webpack-dev-server@5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.21
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.7
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.10
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.2.1
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.19.2
-      graceful-fs: 4.2.11
-      html-entities: 2.5.2
-      http-proxy-middleware: 2.0.6(@types/express@4.17.21)
-      ipaddr.js: 2.2.0
-      launch-editor: 2.6.1
-      open: 10.1.0
-      p-retry: 6.2.0
-      rimraf: 5.0.7
-      schema-utils: 4.2.0
-      selfsigned: 2.4.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.2.1(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      webpack: 5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
   webpack-dev-server@5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))(webpack@5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))):
     dependencies:
       '@types/bonjour': 3.5.13
@@ -41442,6 +41401,47 @@ snapshots:
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     optionalDependencies:
       webpack: 5.93.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0))
+      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  webpack-dev-server@5.0.4(bufferutil@4.0.7)(utf-8-validate@5.0.10)(webpack-cli@5.1.4)(webpack@5.88.0):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.21
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.7
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.5.10
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.2.1
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      compression: 1.7.4
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.19.2
+      graceful-fs: 4.2.11
+      html-entities: 2.5.2
+      http-proxy-middleware: 2.0.6(@types/express@4.17.21)
+      ipaddr.js: 2.2.0
+      launch-editor: 2.6.1
+      open: 10.1.0
+      p-retry: 6.2.0
+      rimraf: 5.0.7
+      schema-utils: 4.2.0
+      selfsigned: 2.4.1
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 7.2.1(webpack@5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4))
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      webpack: 5.88.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.88.0)
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
we have fully isolated graph & error components with a good api but no way to access them directly from the outside (in console). 

This PR adds two functions to the window object so that we can render the PDV directly instead of needing the entire app with routing and everything.