### PR TITLE
docs(nx-cloud): patch details about nxCloudId and access levels

### DIFF
--- a/docs/blog/2024-09-10-personal-access-tokens.md
+++ b/docs/blog/2024-09-10-personal-access-tokens.md
@@ -57,10 +57,10 @@ read from the cache, but limit read/write access to core contributors.
 ![Personal access token settings in Nx Cloud workspace](/blog/images/2024-09-10/workspace-settings.avif)
 
 By default, a workspace that opts in to personal access tokens will allow anonymous users (users without a personal
-access token defined) read-only access. This can be changed to disallow access to the cache for anonymous users
+access token defined) read-write access. This can be changed to disallow access to the cache for anonymous users
 in your workspace settings.
 
-Users with personal access tokens will have read-only access to the cache. This can be changed to enable read-write
+Users with personal access tokens will also have read-write access to the cache. This can be changed to enable read-only
 access in the workspace settings.
 
 ## Converting existing workspaces to use personal access tokens
@@ -79,9 +79,9 @@ can [find more details in our docs](/ci/recipes/security/personal-access-tokens)
    `nx.json`,
    you'll need to provide that CI access token via the
    `NX_CLOUD_ACCESS_TOKEN` [environment variable](/ci/reference/env-vars#nxcloudaccesstoken).
-4. **_Optional_ Disable anonymous access** - By default, anyone without a personal access token will have read-only
+4. **_Recommended_ Disable anonymous access** - By default, anyone without a personal access token will have read-write
    access
-   to your cached artifacts. Once everyone has a personal access token defined, you can disable this anonymous access in
+   to your cached artifacts. You can disable this anonymous access in
    your Nx Cloud workspace settings.
 
 [Learn more about using personal access tokens](/ci/recipes/security/personal-access-tokens)

--- a/docs/nx-cloud/concepts/cache-security.md
+++ b/docs/nx-cloud/concepts/cache-security.md
@@ -26,7 +26,7 @@ In order to keep your cache secure, there are a few steps we recommend you take:
 
 When you use a [personal access token](/ci/recipes/security/personal-access-tokens) to connect to Nx Cloud, you can control the level of access that your developers have to the cache after they authenticate by logging in. By default, all personal access tokens have read-write access to the cache. If you need to give a developer write access to the cache, you can do so in the workspace settings of the Nx Cloud UI.
 
-You can strengthen your workspace security further by revoking all access to the cache for unauthenticated users. This is done by changing the ID Access Level in your workspace settings. By default this is set to `read-write`, but you can change it to `none` to prevent all access.
+You can strengthen your workspace security further by revoking all access to the cache for unauthenticated users. This is done by changing the ID Access Level in your workspace settings. By default this is set to `read-write`, but you can change it to `read-only` to limit access or `none` to prevent all access.
 
 ### Avoid using CI Access Tokens in `nx.json`
 

--- a/docs/nx-cloud/concepts/cache-security.md
+++ b/docs/nx-cloud/concepts/cache-security.md
@@ -24,9 +24,9 @@ In order to keep your cache secure, there are a few steps we recommend you take:
 
 ### Use Personal Access Tokens to Provide Fine-Grained Access Control for Local Development
 
-When you use a [personal access token](/ci/recipes/security/personal-access-tokens) to connect to Nx Cloud, you can control the level of access that your developers have to the cache after they authenticate by logging in. By default, all personal access tokens have read-only access to the cache. If you need to give a developer write access to the cache, you can do so in the workspace settings of the Nx Cloud UI.
+When you use a [personal access token](/ci/recipes/security/personal-access-tokens) to connect to Nx Cloud, you can control the level of access that your developers have to the cache after they authenticate by logging in. By default, all personal access tokens have read-write access to the cache. If you need to give a developer write access to the cache, you can do so in the workspace settings of the Nx Cloud UI.
 
-You can strengthen your workspace security further by revoking all access to the cache for unauthenticated users. This is done by changing the ID Access Level in your workspace settings. By default this is set to `read-only`, but you can change it to `none` to prevent all access.
+You can strengthen your workspace security further by revoking all access to the cache for unauthenticated users. This is done by changing the ID Access Level in your workspace settings. By default this is set to `read-write`, but you can change it to `none` to prevent all access.
 
 ### Avoid using CI Access Tokens in `nx.json`
 

--- a/docs/nx-cloud/recipes/personal-access-tokens.md
+++ b/docs/nx-cloud/recipes/personal-access-tokens.md
@@ -1,6 +1,6 @@
 # Nx Cloud and Personal Access Tokens
 
-From Nx 19.7 repositories are connected to Nx Cloud via a property in `nx.json` called `nxCloudId`. By default this value allows anyone who clones the repository `read-only` access to Nx Cloud features for that workspace. These permissions can be updated in the workspace settings. To disallow access to anonymous users or allow `read-write` access to known users it is required that all users provision their own personal access token. To do that they need to use [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
+From Nx 19.7 repositories are connected to Nx Cloud via a property in `nx.json` called `nxCloudId`. By default this value allows anyone who clones the repository `read-write` access to Nx Cloud features for that workspace. These permissions can be updated in the workspace settings. To disallow access to anonymous users or allow `read-write` access to known users it is required that all users provision their own personal access token. To do that they need to use [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
 
 {% callout type="warning" title="Personal Access Tokens require the `nxCloudId` field in `nx.json`" %}
 Ensure that you have the `nxCloudId` property in your `nx.json` file to connect to Nx Cloud with a Personal Access Token. If you have been using `nxCloudAccessToken`, you can convert it to `nxCloudId` by running [`npx nx-cloud convert-to-nx-cloud-id`](/ci/reference/nx-cloud-cli#npx-nxcloud-converttonxcloudid).
@@ -48,7 +48,17 @@ When you run [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login
 
 ## Permissions
 
-By default all personal access tokens have `read-only` local access to Nx Cloud features for the workspace in which that user is a member. This can be updated to `read-write` in the workspace settings if required, although it is typical for local access to be restricted to `read-only`.
+There are two types of permissions that can be granted to users.
+
+### Workspace ID access level
+
+These are the permissions granted to users who clone your workspace, but have not authenticated with a personal access token via [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
+By default, all users have `read-write` access to the workspace. This can be updated in the workspace settings to `read-only` or `none`.
+
+### Personal Access Token access level
+
+When a workspace member logs in with a personal access token after running [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login) they are granted access to Nx Cloud features.
+By default all personal access tokens have `read-write` access to the remote cache. This can be updated to `read-only` in the workspace settings if required.
 
 ## Better Security
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Default access level of workspace ID setting is read-only

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Default access level of workspace ID setting is read-write

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
