### PR TITLE
fix(release): respect updateDependents being explicitly disabled in conventional commits

### DIFF
--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -383,7 +383,10 @@ To fix this you will either need to add a package.json file at that location, or
             );
 
             if (!specifier) {
-              if (projectToDependencyBumps.has(projectName)) {
+              if (
+                updateDependents !== 'never' &&
+                projectToDependencyBumps.has(projectName)
+              ) {
                 // No applicable changes to the project directly by the user, but one or more dependencies have been bumped and updateDependents is enabled
                 specifier = updateDependentsBump;
                 logger.buffer(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Setting `version.generatorOptions.updateDependents` to `never` when using conventional commits isn't respected.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Setting `version.generatorOptions.updateDependents` to `never` when using conventional commits is respected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
