### PR TITLE
fix(angular): generate serve-static only if e2eTestRunner is passed

### DIFF
--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -27,8 +27,11 @@ export async function addE2e(tree: Tree, options: NormalizedSchema) {
     options.name,
     options.port
   );
-  // TODO: This can call `@nx/web:static-config` generator when ready
-  addFileServerTarget(tree, options, 'serve-static', e2eWebServerInfo.e2ePort);
+  
+  if (options.e2eTestRunner) {
+    // TODO: This can call `@nx/web:static-config` generator when ready
+    addFileServerTarget(tree, options, 'serve-static', e2eWebServerInfo.e2ePort);
+  }
 
   if (options.e2eTestRunner === 'cypress') {
     const { configurationGenerator } = ensurePackage<


### PR DESCRIPTION
Newly created app should not generate serve-static target under project.json if e2eTestRunner flag is not passed
