### PR TITLE
docs(core): changes to login docs

### DIFF
--- a/docs/blog/2024-09-10-personal-access-tokens.md
+++ b/docs/blog/2024-09-10-personal-access-tokens.md
@@ -71,7 +71,7 @@ can [find more details in our docs](/ci/recipes/security/personal-access-tokens)
    CI
    access token defined in the `nxCloudAccessToken` property. This command will replace that with `nxCloudId`, a generic
    id that references your workspace but no longer provides access to the cache.
-2. **Generate a personal access token by running `npx nx-cloud login`** - Follow the directions in your terminal to log
+2. **Generate a personal access token by running `npx nx login`** - Follow the directions in your terminal to log
    in
    to Nx Cloud. Each contributor with access to the workspace will need to complete this step.
 3. **Move CI access tokens to environment variables** - Now that the access token is no longer committed to your

--- a/docs/nx-cloud/recipes/access-tokens.md
+++ b/docs/nx-cloud/recipes/access-tokens.md
@@ -56,7 +56,7 @@ We do not recommend that you commit an access token to your repository but older
 {% /tabs %}
 
 {% callout type="warning" title="Nx Cloud authentication is changing" %}
-From Nx 19.7 new workspaces are connected to Nx Cloud with a property called `nxCloudId` instead, and we recommend developers use [`nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login) to provision their own local [personal access tokens](/ci/recipes/security/personal-access-tokens).
+From Nx 19.7 new workspaces are connected to Nx Cloud with a property called `nxCloudId` instead, and we recommend developers use [`nx login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login) to provision their own local [personal access tokens](/ci/recipes/security/personal-access-tokens).
 {% /callout %}
 
 ## Using `nx-cloud.env`

--- a/docs/nx-cloud/recipes/personal-access-tokens.md
+++ b/docs/nx-cloud/recipes/personal-access-tokens.md
@@ -1,6 +1,6 @@
 # Nx Cloud and Personal Access Tokens
 
-From Nx 19.7 repositories are connected to Nx Cloud via a property in `nx.json` called `nxCloudId`. By default this value allows anyone who clones the repository `read-write` access to Nx Cloud features for that workspace. These permissions can be updated in the workspace settings. To disallow access to anonymous users or allow `read-write` access to known users it is required that all users provision their own personal access token. To do that they need to use [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
+From Nx 19.7 repositories are connected to Nx Cloud via a property in `nx.json` called `nxCloudId`. By default this value allows anyone who clones the repository `read-write` access to Nx Cloud features for that workspace. These permissions can be updated in the workspace settings. To disallow access to anonymous users or allow `read-write` access to known users it is required that all users provision their own personal access token. To do that they need to use [`npx nx login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
 
 {% callout type="warning" title="Personal Access Tokens require the `nxCloudId` field in `nx.json`" %}
 Ensure that you have the `nxCloudId` property in your `nx.json` file to connect to Nx Cloud with a Personal Access Token. If you have been using `nxCloudAccessToken`, you can convert it to `nxCloudId` by running [`npx nx-cloud convert-to-nx-cloud-id`](/ci/reference/nx-cloud-cli#npx-nxcloud-converttonxcloudid).
@@ -44,7 +44,7 @@ To utilize personal access tokens and Nx Cloud ID with Nx <= 19.6, the nx-cloud 
 
 ## Personal Access Tokens (PATs)
 
-When you run [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login) you will be directed to the Nx Cloud app where you will be required to create an account and login. A new personal access token will be provisioned and saved in a local configuration file in your home folder (the location of this will be displayed when login is complete and varies depending on OS).
+When you run [`npx nx login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login) you will be directed to the Nx Cloud app where you will be required to create an account and login. A new personal access token will be provisioned and saved in a local configuration file in your home folder (the location of this will be displayed when login is complete and varies depending on OS).
 
 ## Permissions
 
@@ -52,12 +52,13 @@ There are two types of permissions that can be granted to users.
 
 ### Workspace ID access level
 
-These are the permissions granted to users who clone your workspace, but have not authenticated with a personal access token via [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
-By default, all users have `read-write` access to the workspace. This can be updated in the workspace settings to `read-only` or `none`.
+These are the permissions granted to users who are not [logged in](/ci/reference/nx-cloud-cli#npx-nxcloud-login) or are not members of the Nx Cloud organization for this workspace. By default, all users have `read-write` access to the workspace. This can be updated in the workspace settings to `read-only` or `none`.
+
+While the initial setting for workspace ID access level is `read-write`, we recommend that you change this setting to `read-only` or `none` for any repository that is visible to people that do not have permission to edit the repository (i.e. open source repositories or repositories that are visible across an organization, but only editable by a specific team).
 
 ### Personal Access Token access level
 
-When a workspace member logs in with a personal access token after running [`npx nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login) they are granted access to Nx Cloud features.
+When a workspace member logs in with a personal access token after running [`npx nx login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login) they are granted access to Nx Cloud features.
 By default all personal access tokens have `read-write` access to the remote cache. This can be updated to `read-only` in the workspace settings if required.
 
 ## Better Security

--- a/docs/nx-cloud/reference/nx-cloud-cli.md
+++ b/docs/nx-cloud/reference/nx-cloud-cli.md
@@ -4,6 +4,8 @@
 
 To provision a local personal access token to access Nx Cloud features run `npx nx-cloud login`. This will open your browser to the Nx Cloud application and after signing in will generate a personal access token and save it in a configuration file locally called `nxcloud.ini`.
 
+This command is the same as running `npx nx login`
+
 {% tabs %}
 {% tab label="macOS & Linux" %}
 

--- a/docs/shared/reference/commands.md
+++ b/docs/shared/reference/commands.md
@@ -297,7 +297,7 @@ nx connect
 
 ### login
 
-Connect an Nx workspace to Nx Cloud
+Login to Nx Cloud. This command is an alias for [`nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
 
 ```shell
 nx login
@@ -310,7 +310,7 @@ nx login
 
 ### logout
 
-Connect an Nx workspace to Nx Cloud
+Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).
 
 ```shell
 nx logout


### PR DESCRIPTION
- Fixes typo for login/logout on commands landing page
- Mention that `nx-cloud login` is the same as `nx login`
- Update references to `npx nx-cloud login` to use `nx login` by default instead
- Updates Workspace ID access level wording in the "Nx CLI and CI Access Tokens" page