### PR TITLE
fix(core): respect filenames of inputs when computing task hash

### DIFF
--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -157,17 +157,17 @@ describe('native task hasher', () => {
             "env:TESTENV": "11441948532827618368",
             "parent:ProjectConfiguration": "3608670998275221195",
             "parent:TsConfig": "2264969541778889434",
-            "parent:{projectRoot}/**/*": "15295586939211629225",
+            "parent:{projectRoot}/**/*": "17059468255294227635",
             "runtime:echo runtime123": "29846575039086708",
             "tagged:ProjectConfiguration": "8596726088057301092",
             "tagged:TsConfig": "2264969541778889434",
-            "tagged:{projectRoot}/**/*": "112200405683630828",
+            "tagged:{projectRoot}/**/*": "14666997081331501901",
             "unrelated:ProjectConfiguration": "11133337791644294114",
             "unrelated:TsConfig": "2264969541778889434",
-            "unrelated:{projectRoot}/**/*": "10505120368757496776",
-            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "5219582320960288192",
+            "unrelated:{projectRoot}/**/*": "4127219831408253695",
+            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "18099427347122160586",
           },
-          "value": "13049022000906481001",
+          "value": "14471888706892195399",
         },
       ]
     `);
@@ -226,13 +226,13 @@ describe('native task hasher', () => {
           "AllExternalDependencies": "3244421341483603138",
           "child:ProjectConfiguration": "710102491746666394",
           "child:TsConfig": "2264969541778889434",
-          "child:{projectRoot}/**/*": "7694964870822928111",
+          "child:{projectRoot}/**/*": "3347149359534435991",
           "parent:ProjectConfiguration": "8031122597231773116",
           "parent:TsConfig": "2264969541778889434",
-          "parent:{projectRoot}/**/*": "15295586939211629225",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "5219582320960288192",
+          "parent:{projectRoot}/**/*": "17059468255294227635",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "18099427347122160586",
         },
-        "value": "17442516481637512275",
+        "value": "2877551238604232699",
       }
     `);
   });
@@ -305,13 +305,13 @@ describe('native task hasher', () => {
           "AllExternalDependencies": "3244421341483603138",
           "child:ProjectConfiguration": "13051054958929525761",
           "child:TsConfig": "2264969541778889434",
-          "child:{projectRoot}/**/*": "7694964870822928111",
-          "parent:!{projectRoot}/**/*.spec.ts": "7663204892242899157",
+          "child:{projectRoot}/**/*": "3347149359534435991",
+          "parent:!{projectRoot}/**/*.spec.ts": "8911122541468969799",
           "parent:ProjectConfiguration": "3608670998275221195",
           "parent:TsConfig": "2264969541778889434",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "4641558175996703359",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "11114659294156087056",
         },
-        "value": "3497993078654537309",
+        "value": "5146047476750743843",
       }
     `);
   });
@@ -372,22 +372,22 @@ describe('native task hasher', () => {
         {
           "details": {
             "AllExternalDependencies": "3244421341483603138",
-            "parent:!{projectRoot}/**/*.spec.ts": "7663204892242899157",
+            "parent:!{projectRoot}/**/*.spec.ts": "8911122541468969799",
             "parent:ProjectConfiguration": "16402137858974842465",
             "parent:TsConfig": "2264969541778889434",
-            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "4641558175996703359",
+            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "11114659294156087056",
           },
-          "value": "10775755355957559912",
+          "value": "845448225466199915",
         },
         {
           "details": {
             "AllExternalDependencies": "3244421341483603138",
             "parent:ProjectConfiguration": "16402137858974842465",
             "parent:TsConfig": "2264969541778889434",
-            "parent:{projectRoot}/**/*": "15295586939211629225",
-            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "4641558175996703359",
+            "parent:{projectRoot}/**/*": "17059468255294227635",
+            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "11114659294156087056",
           },
-          "value": "13219368697419749776",
+          "value": "16342992587503026008",
         },
       ]
     `);
@@ -467,18 +467,18 @@ describe('native task hasher', () => {
         {
           "details": {
             "AllExternalDependencies": "3244421341483603138",
-            "child:!{projectRoot}/**/*.spec.ts": "13790135045935437026",
+            "child:!{projectRoot}/**/*.spec.ts": "6212660753359890679",
             "child:ProjectConfiguration": "10085593111011845427",
             "child:TsConfig": "2264969541778889434",
             "env:MY_TEST_HASH_ENV": "17357374746554314488",
             "parent:ProjectConfiguration": "14398811678394411425",
             "parent:TsConfig": "2264969541778889434",
-            "parent:{projectRoot}/**/*": "15295586939211629225",
-            "workspace:[{workspaceRoot}/global1]": "13078141817211771580",
-            "workspace:[{workspaceRoot}/global2]": "13625885481717016690",
-            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "10897751101872977225",
+            "parent:{projectRoot}/**/*": "17059468255294227635",
+            "workspace:[{workspaceRoot}/global1]": "14542405497386871555",
+            "workspace:[{workspaceRoot}/global2]": "12932836274958677781",
+            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "12076281115618125366",
           },
-          "value": "14298810822113951946",
+          "value": "8928030752507058",
         },
       ]
     `);
@@ -529,10 +529,10 @@ describe('native task hasher', () => {
           "AllExternalDependencies": "3244421341483603138",
           "parent:ProjectConfiguration": "3608670998275221195",
           "parent:TsConfig": "8661678577354855152",
-          "parent:{projectRoot}/**/*": "15295586939211629225",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "5219582320960288192",
+          "parent:{projectRoot}/**/*": "17059468255294227635",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "18099427347122160586",
         },
-        "value": "10821775409399212451",
+        "value": "10182005362255577288",
       }
     `);
   });
@@ -604,13 +604,13 @@ describe('native task hasher', () => {
           "AllExternalDependencies": "3244421341483603138",
           "child:ProjectConfiguration": "13748859057138736105",
           "child:TsConfig": "2264969541778889434",
-          "child:{projectRoot}/**/*": "7694964870822928111",
+          "child:{projectRoot}/**/*": "3347149359534435991",
           "parent:ProjectConfiguration": "3608670998275221195",
           "parent:TsConfig": "2264969541778889434",
-          "parent:{projectRoot}/**/*": "15295586939211629225",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "5219582320960288192",
+          "parent:{projectRoot}/**/*": "17059468255294227635",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "18099427347122160586",
         },
-        "value": "12197760444984597111",
+        "value": "12868980333884890989",
       }
     `);
 
@@ -626,13 +626,13 @@ describe('native task hasher', () => {
           "AllExternalDependencies": "3244421341483603138",
           "child:ProjectConfiguration": "13748859057138736105",
           "child:TsConfig": "2264969541778889434",
-          "child:{projectRoot}/**/*": "7694964870822928111",
+          "child:{projectRoot}/**/*": "3347149359534435991",
           "parent:ProjectConfiguration": "3608670998275221195",
           "parent:TsConfig": "2264969541778889434",
-          "parent:{projectRoot}/**/*": "15295586939211629225",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "5219582320960288192",
+          "parent:{projectRoot}/**/*": "17059468255294227635",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "18099427347122160586",
         },
-        "value": "12197760444984597111",
+        "value": "12868980333884890989",
       }
     `);
   });

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -18,6 +18,7 @@ pub fn hash_project_files(
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
     for file in collected_files {
         hasher.update(file.hash.as_bytes());
+        hasher.update(file.file.as_bytes());
     }
     Ok(hasher.digest().to_string())
 }
@@ -157,7 +158,12 @@ mod tests {
         let hash_result = hash_project_files(proj_name, proj_root, file_sets, &file_map).unwrap();
         assert_eq!(
             hash_result,
-            hash(&[file_data1.hash.as_bytes(), file_data3.hash.as_bytes()].concat())
+            hash(&[
+                file_data1.hash.as_bytes(),
+                file_data1.file.as_bytes(),
+                file_data3.hash.as_bytes(),
+                file_data3.file.as_bytes()
+            ].concat())
         );
     }
 
@@ -199,7 +205,12 @@ mod tests {
         let hash_result = hash_project_files(proj_name, proj_root, file_sets, &file_map).unwrap();
         assert_eq!(
             hash_result,
-            hash(&[file_data1.hash.as_bytes(), file_data3.hash.as_bytes()].concat())
+            hash(&[
+                file_data1.hash.as_bytes(),
+                file_data1.file.as_bytes(),
+                file_data3.hash.as_bytes(),
+                file_data3.file.as_bytes(),
+            ].concat())
         );
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -53,7 +53,8 @@ pub fn hash_workspace_files(
         .filter(|file| glob.is_match(&file.file))
     {
         trace!("{:?} was found with glob {:?}", file.file, globs);
-        hashes.push(file.hash.clone())
+        hashes.push(file.hash.clone());
+        hashes.push(file.file.clone());
     }
     hasher.update(hashes.join(",").as_bytes());
     let hashed_value = hasher.digest().to_string();
@@ -110,6 +111,9 @@ mod test {
             Arc::new(DashMap::new()),
         )
         .unwrap();
-        assert_eq!(result, hash(gitignore_file.hash.as_bytes()));
+        assert_eq!(result, hash([
+            gitignore_file.hash,
+            gitignore_file.file
+        ].join(",").as_bytes()));
     }
 }


### PR DESCRIPTION
I really don't know if this is the right fix and I'm not a rust programmer. Hoping to get the ball rolling. In our very large scale project, we are hitting invalid cache entries when source files are renamed, which cascades the wrong outputs to dependent targets. 🙏🏻 

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

## Current Behavior
<!-- This is the behavior we have today -->

When a project file is moved/renamed, the task cache is _not_ invalidated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a project file is moved/renamed, the task cache _is_ invalidated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#23106

