### PR TITLE
fix(nx-cloud): include nxCloudId when generating connect urls

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -15,9 +15,9 @@ export function readNxCloudToken(directory: string) {
     // nx-ignore-next-line
   )) as typeof import('nx/src/nx-cloud/utilities/get-cloud-options');
 
-  const { accessToken } = getCloudOptions(directory);
+  const { accessToken, nxCloudId } = getCloudOptions(directory);
   nxCloudSpinner.succeed('Nx Cloud has been set up successfully');
-  return accessToken;
+  return accessToken || nxCloudId;
 }
 
 export async function getOnboardingInfo(

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -140,12 +140,6 @@ export async function connectToNxCloud(
   const isGitHubDetected =
     schema.github ?? (await repoUsesGithub(schema.github));
 
-  let responseFromCreateNxCloudWorkspaceV1:
-    | {
-        token: string;
-      }
-    | undefined;
-
   let responseFromCreateNxCloudWorkspaceV2:
     | {
         nxCloudId: string;

--- a/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
+++ b/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
@@ -21,3 +21,7 @@ export function getCloudUrl() {
 export function removeTrailingSlash(apiUrl: string) {
   return apiUrl[apiUrl.length - 1] === '/' ? apiUrl.slice(0, -1) : apiUrl;
 }
+
+export function isNxCloudId(token: string): boolean {
+  return token.length === 24;
+}

--- a/packages/nx/src/nx-cloud/utilities/is-workspace-claimed.ts
+++ b/packages/nx/src/nx-cloud/utilities/is-workspace-claimed.ts
@@ -1,15 +1,16 @@
-import { getCloudUrl } from './get-cloud-options';
+import { getCloudUrl, isNxCloudId } from './get-cloud-options';
 
-export async function isWorkspaceClaimed(nxCloudAccessToken) {
-  if (!nxCloudAccessToken) return false;
+export async function isWorkspaceClaimed(accessToken: string) {
+  if (!accessToken) return false;
 
   const apiUrl = getCloudUrl();
   try {
+    const requestData = isNxCloudId(accessToken)
+      ? { nxCloudId: accessToken }
+      : { nxCloudAccessToken: accessToken };
     const response = await require('axios').post(
       `${apiUrl}/nx-cloud/is-workspace-claimed`,
-      {
-        nxCloudAccessToken,
-      }
+      requestData
     );
 
     if (response.data.message) {

--- a/packages/nx/src/nx-cloud/utilities/onboarding.ts
+++ b/packages/nx/src/nx-cloud/utilities/onboarding.ts
@@ -29,6 +29,11 @@ export async function getNxCloudAppOnBoardingUrl(token: string) {
 
 export function readNxCloudToken(tree: Tree) {
   const nxJson = readNxJson(tree);
-  const { accessToken } = getRunnerOptions('default', nxJson, {}, true);
-  return accessToken;
+  const { accessToken, nxCloudId } = getRunnerOptions(
+    'default',
+    nxJson,
+    {},
+    true
+  );
+  return accessToken || nxCloudId;
 }

--- a/packages/nx/src/utils/nx-cloud-utils.ts
+++ b/packages/nx/src/utils/nx-cloud-utils.ts
@@ -23,21 +23,3 @@ export function getNxCloudUrl(nxJson: NxJsonConfiguration): string {
     throw new Error('nx-cloud runner not found in nx.json');
   return cloudRunner?.options?.url ?? nxJson.nxCloudUrl ?? 'https://nx.app';
 }
-
-export function getNxCloudToken(nxJson: NxJsonConfiguration): string {
-  const cloudRunner = Object.values(nxJson.tasksRunnerOptions ?? {}).find(
-    (r) => r.runner == '@nrwl/nx-cloud' || r.runner == 'nx-cloud'
-  );
-
-  if (
-    !cloudRunner &&
-    !(nxJson.nxCloudAccessToken || process.env.NX_CLOUD_ACCESS_TOKEN)
-  )
-    throw new Error('nx-cloud runner not found in nx.json');
-
-  return (
-    process.env.NX_CLOUD_ACCESS_TOKEN ??
-    cloudRunner?.options.accessToken ??
-    nxJson.nxCloudAccessToken
-  );
-}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

NxCloudId should be part of the URL that is created when connecting a new workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
