### PR TITLE
fix(webpack): handle relative paths for additionalEntryPath

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join, relative, resolve } from 'path';
+import { basename, dirname, join, parse, relative, resolve } from 'path';
 import { statSync } from 'fs';
 import {
   normalizePath,
@@ -204,6 +204,18 @@ function normalizeRelativePaths(
   for (const [fieldName, fieldValue] of Object.entries(options)) {
     if (isRelativePath(fieldValue)) {
       options[fieldName] = join(projectRoot, fieldValue);
+    } else if (fieldName === 'additionalEntryPoints') {
+      for (let i = 0; i < fieldValue.length; i++) {
+        const v = fieldValue[i];
+        if (isRelativePath(v)) {
+          fieldValue[i] = {
+            entryName: parse(v).name,
+            entryPath: join(projectRoot, v),
+          };
+        } else if (isRelativePath(v.entryPath)) {
+          v.entryPath = join(projectRoot, v.entryPath);
+        }
+      }
     } else if (Array.isArray(fieldValue)) {
       for (let i = 0; i < fieldValue.length; i++) {
         if (isRelativePath(fieldValue[i])) {


### PR DESCRIPTION
The `NxAppWebpackPlugin` does not support relative paths in `additionalEntryPoints`.

So this will fail:

```js
new NxAppWebpackPlugin({
  ...
  additionalEntryPoints: ['.src/foo.ts']
```

The resolved path is relative to workspace root when it should be project root.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Build will fail.
## Expected Behavior
Build should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
