### PR TITLE
fix(core): handleErrors should display error cause if it exists

### DIFF
--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -9,7 +9,7 @@ import { writeJsonFile } from '../../utils/fileutils';
 import { logger } from '../../utils/logger';
 import { output } from '../../utils/output';
 import { getPackageManagerCommand } from '../../utils/package-manager';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import { getPluginCapabilities } from '../../utils/plugins';
 import { nxVersion } from '../../utils/versions';
 import { workspaceRoot } from '../../utils/workspace-root';

--- a/packages/nx/src/command-line/affected/command-object.ts
+++ b/packages/nx/src/command-line/affected/command-object.ts
@@ -9,7 +9,7 @@ import {
   withRunOptions,
   withTargetAndConfigurationOption,
 } from '../yargs-utils/shared-options';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 
 export const yargsAffectedCommand: CommandModule = {
   command: 'affected',

--- a/packages/nx/src/command-line/deprecated/command-objects.ts
+++ b/packages/nx/src/command-line/deprecated/command-objects.ts
@@ -1,5 +1,5 @@
 import { CommandModule } from 'yargs';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import {
   withAffectedOptions,
   withTargetAndConfigurationOption,

--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -12,14 +12,13 @@ import {
 import { logger, NX_PREFIX } from '../../utils/logger';
 import {
   combineOptionsForGenerator,
-  handleErrors,
   Options,
   Schema,
 } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import { getLocalWorkspacePlugins } from '../../utils/plugins/local-plugins';
 import { printHelp } from '../../utils/print-help';
 import { workspaceRoot } from '../../utils/workspace-root';
-import { NxJsonConfiguration } from '../../config/nx-json';
 import { calculateDefaultProjectName } from '../../config/calculate-default-project-name';
 import { findInstalledPlugins } from '../../utils/plugins/installed-plugins';
 import { getGeneratorInformation } from './generator-utils';

--- a/packages/nx/src/command-line/import/command-object.ts
+++ b/packages/nx/src/command-line/import/command-object.ts
@@ -1,7 +1,7 @@
 import { CommandModule } from 'yargs';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
 import { withVerbose } from '../yargs-utils/shared-options';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 
 export const yargsImportCommand: CommandModule = {
   command: 'import [sourceRepository] [destinationDirectory]',

--- a/packages/nx/src/command-line/login/login.ts
+++ b/packages/nx/src/command-line/login/login.ts
@@ -1,6 +1,6 @@
 import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
 import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 
 export interface LoginArgs {
   nxCloudUrl?: string;

--- a/packages/nx/src/command-line/logout/logout.ts
+++ b/packages/nx/src/command-line/logout/logout.ts
@@ -1,6 +1,6 @@
 import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
 import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 
 export interface LogoutArgs {
   verbose?: boolean;

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -49,7 +49,7 @@ import {
   packageRegistryView,
   resolvePackageVersionUsingRegistry,
 } from '../../utils/package-manager';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import {
   connectToNxCloudWithPrompt,
   onlyDefaultRunnerIsUsed,

--- a/packages/nx/src/command-line/new/new.ts
+++ b/packages/nx/src/command-line/new/new.ts
@@ -1,5 +1,6 @@
 import { flushChanges, FsTree } from '../../generators/tree';
-import { combineOptionsForGenerator, handleErrors } from '../../utils/params';
+import { combineOptionsForGenerator } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import { getGeneratorInformation } from '../generate/generator-utils';
 
 function removeSpecialFlags(generatorOptions: { [p: string]: any }): void {

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -25,7 +25,7 @@ import { createProjectGraphAsync } from '../../project-graph/project-graph';
 import { interpolate } from '../../tasks-runner/utils';
 import { isCI } from '../../utils/is-ci';
 import { output } from '../../utils/output';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import { joinPathFragments } from '../../utils/path';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { ChangelogOptions } from './command-object';

--- a/packages/nx/src/command-line/release/plan-check.ts
+++ b/packages/nx/src/command-line/release/plan-check.ts
@@ -7,7 +7,7 @@ import {
   splitArgsIntoNxArgsAndOverrides,
 } from '../../utils/command-line-utils';
 import { output } from '../../utils/output';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import { PlanCheckOptions, PlanOptions } from './command-object';
 import {
   createNxReleaseConfig,

--- a/packages/nx/src/command-line/release/plan.ts
+++ b/packages/nx/src/command-line/release/plan.ts
@@ -12,7 +12,7 @@ import {
   splitArgsIntoNxArgsAndOverrides,
 } from '../../utils/command-line-utils';
 import { output } from '../../utils/output';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import { PlanOptions } from './command-object';
 import {
   createNxReleaseConfig,

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -15,7 +15,7 @@ import {
   readGraphFileFromGraphArg,
 } from '../../utils/command-line-utils';
 import { output } from '../../utils/output';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import { projectHasTarget } from '../../utils/project-graph-utils';
 import { generateGraph } from '../graph/graph';
 import { PublishOptions } from './command-object';

--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -4,7 +4,7 @@ import { NxReleaseConfiguration, readNxJson } from '../../config/nx-json';
 import { createProjectFileMapUsingProjectGraph } from '../../project-graph/file-map-utils';
 import { createProjectGraphAsync } from '../../project-graph/project-graph';
 import { output } from '../../utils/output';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import {
   createAPI as createReleaseChangelogAPI,
   shouldCreateGitHubRelease,

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -19,7 +19,7 @@ import {
   readProjectsConfigurationFromProjectGraph,
 } from '../../project-graph/project-graph';
 import { output } from '../../utils/output';
-import { combineOptionsForGenerator, handleErrors } from '../../utils/params';
+import { combineOptionsForGenerator } from '../../utils/params';
 import { joinPathFragments } from '../../utils/path';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { parseGeneratorString } from '../generate/generate';
@@ -52,6 +52,7 @@ import {
   createGitTagValues,
   handleDuplicateGitTags,
 } from './utils/shared';
+import { handleErrors } from '../../utils/handle-errors';
 
 const LARGE_BUFFER = 1024 * 1000000;
 

--- a/packages/nx/src/command-line/repair/repair.ts
+++ b/packages/nx/src/command-line/repair/repair.ts
@@ -1,4 +1,4 @@
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import * as migrationsJson from '../../../migrations.json';
 import { executeMigrations } from '../migrate/migrate';
 import { output } from '../../utils/output';

--- a/packages/nx/src/command-line/run-many/command-object.ts
+++ b/packages/nx/src/command-line/run-many/command-object.ts
@@ -7,7 +7,7 @@ import {
   withOverrides,
   withBatch,
 } from '../yargs-utils/shared-options';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 
 export const yargsRunManyCommand: CommandModule = {
   command: 'run-many',

--- a/packages/nx/src/command-line/run/command-object.ts
+++ b/packages/nx/src/command-line/run/command-object.ts
@@ -4,7 +4,7 @@ import {
   withOverrides,
   withRunOneOptions,
 } from '../yargs-utils/shared-options';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 
 export const yargsRunCommand: CommandModule = {
   command: 'run [project][:target][:configuration] [_..]',

--- a/packages/nx/src/command-line/run/run.ts
+++ b/packages/nx/src/command-line/run/run.ts
@@ -1,9 +1,6 @@
 import { env as appendLocalEnv } from 'npm-run-path';
-import {
-  combineOptionsForExecutor,
-  handleErrors,
-  Schema,
-} from '../../utils/params';
+import { combineOptionsForExecutor, Schema } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import { printHelp } from '../../utils/print-help';
 import { NxJsonConfiguration } from '../../config/nx-json';
 import { relative } from 'path';

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -5,7 +5,7 @@ import {
   withAffectedOptions,
   withVerbose,
 } from '../yargs-utils/shared-options';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 
 export interface NxShowArgs {
   json?: boolean;

--- a/packages/nx/src/command-line/sync/sync.ts
+++ b/packages/nx/src/command-line/sync/sync.ts
@@ -2,7 +2,7 @@ import * as ora from 'ora';
 import { readNxJson } from '../../config/nx-json';
 import { createProjectGraphAsync } from '../../project-graph/project-graph';
 import { output } from '../../utils/output';
-import { handleErrors } from '../../utils/params';
+import { handleErrors } from '../../utils/handle-errors';
 import {
   collectAllRegisteredSyncGenerators,
   flushSyncGeneratorChanges,

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -20,7 +20,7 @@ import { isRelativePath } from '../utils/fileutils';
 import { isCI } from '../utils/is-ci';
 import { isNxCloudUsed } from '../utils/nx-cloud-utils';
 import { output } from '../utils/output';
-import { handleErrors } from '../utils/params';
+import { handleErrors } from '../utils/handle-errors';
 import {
   collectEnabledTaskSyncGeneratorsFromTaskGraph,
   flushSyncGeneratorChanges,

--- a/packages/nx/src/utils/handle-errors.spec.ts
+++ b/packages/nx/src/utils/handle-errors.spec.ts
@@ -1,0 +1,70 @@
+import {
+  CreateMetadataError,
+  ProjectGraphError,
+} from '../project-graph/error-types';
+import { handleErrors } from './handle-errors';
+import { output } from './output';
+
+describe('handleErrors', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should display project graph error cause message', async () => {
+    const spy = jest.spyOn(output, 'error').mockImplementation(() => {});
+    await handleErrors(true, async () => {
+      const cause = new Error('cause message');
+      const metadataError = new CreateMetadataError(cause, 'test-plugin');
+      throw new ProjectGraphError(
+        [metadataError],
+        { nodes: {}, dependencies: {} },
+        {}
+      );
+    });
+    const { bodyLines, title } = spy.mock.calls[0][0];
+    const body = bodyLines.join('\n');
+    expect(body).toContain('cause message');
+    expect(body).toContain('test-plugin');
+  });
+
+  it('should only display wrapper error if not verbose', async () => {
+    const spy = jest.spyOn(output, 'error').mockImplementation(() => {});
+    await handleErrors(false, async () => {
+      const cause = new Error('cause message');
+      const metadataError = new CreateMetadataError(cause, 'test-plugin');
+      throw new ProjectGraphError(
+        [metadataError],
+        { nodes: {}, dependencies: {} },
+        {}
+      );
+    });
+
+    const { bodyLines, title } = spy.mock.calls[0][0];
+    const body = bodyLines.join('\n');
+    expect(body).not.toContain('cause message');
+  });
+
+  it('should display misc errors that do not have a cause', async () => {
+    const spy = jest.spyOn(output, 'error').mockImplementation(() => {});
+    await handleErrors(true, async () => {
+      throw new Error('misc error');
+    });
+    const { bodyLines, title } = spy.mock.calls[0][0];
+    const body = bodyLines.join('\n');
+    expect(body).toContain('misc error');
+    expect(body).not.toMatch(/[Cc]ause/);
+  });
+
+  it('should display misc errors that have a cause', async () => {
+    const spy = jest.spyOn(output, 'error').mockImplementation(() => {});
+    await handleErrors(true, async () => {
+      const cause = new Error('cause message');
+      const err = new Error('misc error', { cause });
+      throw err;
+    });
+    const { bodyLines, title } = spy.mock.calls[0][0];
+    const body = bodyLines.join('\n');
+    expect(body).toContain('misc error');
+    expect(body).toContain('cause message');
+  });
+});

--- a/packages/nx/src/utils/handle-errors.ts
+++ b/packages/nx/src/utils/handle-errors.ts
@@ -1,0 +1,74 @@
+import { daemonClient } from '../daemon/client/client';
+import { ProjectGraphError } from '../project-graph/error-types';
+import { logger } from './logger';
+import { output } from './output';
+
+export async function handleErrors(
+  isVerbose: boolean,
+  fn: Function
+): Promise<number> {
+  try {
+    const result = await fn();
+    if (typeof result === 'number') {
+      return result;
+    }
+    return 0;
+  } catch (err) {
+    err ||= new Error('Unknown error caught');
+    if (err.constructor.name === 'UnsuccessfulWorkflowExecution') {
+      logger.error('The generator workflow failed. See above.');
+    } else if (err.name === 'ProjectGraphError') {
+      const projectGraphError = err as ProjectGraphError;
+      let title = projectGraphError.message;
+      if (
+        projectGraphError.cause &&
+        typeof projectGraphError.cause === 'object' &&
+        'message' in projectGraphError.cause
+      ) {
+        title += ' ' + projectGraphError.cause.message + '.';
+      }
+      if (isVerbose) {
+        title += ' See errors below.';
+      }
+
+      const bodyLines = isVerbose
+        ? formatErrorStackAndCause(projectGraphError)
+        : ['Pass --verbose to see the stacktraces.'];
+
+      output.error({
+        title,
+        bodyLines: bodyLines,
+      });
+    } else {
+      const lines = (err.message ? err.message : err.toString()).split('\n');
+      const bodyLines: string[] = lines.slice(1);
+      if (isVerbose) {
+        bodyLines.push(...formatErrorStackAndCause(err));
+      } else if (err.stack) {
+        bodyLines.push('Pass --verbose to see the stacktrace.');
+      }
+      output.error({
+        title: lines[0],
+        bodyLines,
+      });
+    }
+    if (daemonClient.enabled()) {
+      daemonClient.reset();
+    }
+    return 1;
+  }
+}
+
+function formatErrorStackAndCause<T extends Error>(error: T): string[] {
+  return [
+    error.stack || error.message,
+    ...(error.cause && typeof error.cause === 'object'
+      ? [
+          'Caused by:',
+          'stack' in error.cause
+            ? error.cause.stack.toString()
+            : error.cause.toString(),
+        ]
+      : []),
+  ];
+}

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -89,56 +89,6 @@ export type Options = {
   [k: string]: string | number | boolean | string[] | Unmatched[] | undefined;
 };
 
-export async function handleErrors(
-  isVerbose: boolean,
-  fn: Function
-): Promise<number> {
-  try {
-    const result = await fn();
-    if (typeof result === 'number') {
-      return result;
-    }
-    return 0;
-  } catch (err) {
-    err ||= new Error('Unknown error caught');
-    if (err.constructor.name === 'UnsuccessfulWorkflowExecution') {
-      logger.error('The generator workflow failed. See above.');
-    } else if (err.name === 'ProjectGraphError') {
-      const projectGraphError = err as ProjectGraphError;
-      let title = projectGraphError.message;
-      if (isVerbose) {
-        title += ' See errors below.';
-      }
-
-      const bodyLines = isVerbose
-        ? [projectGraphError.stack]
-        : ['Pass --verbose to see the stacktraces.'];
-
-      output.error({
-        title,
-        bodyLines: bodyLines,
-      });
-    } else {
-      const lines = (err.message ? err.message : err.toString()).split('\n');
-      const bodyLines = lines.slice(1);
-      if (err.stack && !isVerbose) {
-        bodyLines.push('Pass --verbose to see the stacktrace.');
-      }
-      output.error({
-        title: lines[0],
-        bodyLines,
-      });
-      if (err.stack && isVerbose) {
-        logger.info(err.stack);
-      }
-    }
-    if (daemonClient.enabled()) {
-      daemonClient.reset();
-    }
-    return 1;
-  }
-}
-
 function camelCase(input: string): string {
   if (input.indexOf('-') > 1) {
     return input


### PR DESCRIPTION
Some error messages are not displaying properly, as they pass their original message as a cause. While `node` supports this, our `handleErrors` function was not displaying error causes.

```
"Failed to process project graph. Run "nx reset" to fix this. Please report the issue if you keep seeing it.
            CreateMetadataError: The "test-plugin" plugin threw an error while creating metadata: cause message
            at /Users/agentender/repos/nx/packages/nx/src/utils/handle-errors.spec.ts:17:29
            at handleErrors (/Users/agentender/repos/nx/packages/nx/src/utils/handle-errors.ts:11:26)
            at Object.<anonymous> (/Users/agentender/repos/nx/packages/nx/src/utils/handle-errors.spec.ts:15:23)
            at Promise.then.completed (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)
            at new Promise (<anonymous>)
            at callAsyncCircusFn (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)
            at _callCircusTest (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)
            at async _runTest (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)
            at async _runTestsForDescribeBlock (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)
            at async _runTestsForDescribeBlock (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)
            at async run (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)
            at async runAndTransformResultsToJestFormat (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
            at async jestAdapter (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
            at async runTestInternal (/Users/agentender/repos/nx/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)
            at async runTest (/Users/agentender/repos/nx/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)
        Caused by: 
            Error: cause message
              at /Users/agentender/repos/nx/packages/nx/src/utils/handle-errors.spec.ts:16:21
              at handleErrors (/Users/agentender/repos/nx/packages/nx/src/utils/handle-errors.ts:11:26)
              at Object.<anonymous> (/Users/agentender/repos/nx/packages/nx/src/utils/handle-errors.spec.ts:15:23)
              at Promise.then.completed (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)
              at new Promise (<anonymous>)
              at callAsyncCircusFn (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)
              at _callCircusTest (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)
              at async _runTest (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)
              at async _runTestsForDescribeBlock (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)
              at async _runTestsForDescribeBlock (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)
              at async run (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)
              at async runAndTransformResultsToJestFormat (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
              at async jestAdapter (/Users/agentender/repos/nx/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
              at async runTestInternal (/Users/agentender/repos/nx/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)
              at async runTest (/Users/agentender/repos/nx/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"
    `
```