### PR TITLE
fix(core): fix env for parallel

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -79,7 +79,7 @@ export class TaskOrchestrator {
     await this.forkedProcessTaskRunner.init();
 
     // initial scheduling
-    await this.scheduleNextTasks();
+    await this.tasksSchedule.scheduleNextTasks();
 
     performance.mark('task-execution:start');
 
@@ -115,6 +115,7 @@ export class TaskOrchestrator {
       this.options.skipNxCache === false ||
       this.options.skipNxCache === undefined;
 
+    this.processAllScheduledTasks();
     const batch = this.tasksSchedule.nextBatch();
     if (batch) {
       const groupId = this.closeGroup();
@@ -612,17 +613,11 @@ export class TaskOrchestrator {
       })
     );
 
-    await this.scheduleNextTasks();
+    await this.tasksSchedule.scheduleNextTasks();
 
     // release blocked threads
     this.waitingForTasks.forEach((f) => f(null));
     this.waitingForTasks.length = 0;
-  }
-
-  private async scheduleNextTasks() {
-    await this.tasksSchedule.scheduleNextTasks();
-
-    this.processAllScheduledTasks();
   }
 
   private complete(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
- between this.tasksSchedule.scheduleNextTasks() and this.tasksSchedule.nextTask(), scheduledTasks are different when in parallel, so when calling `processAllScheduledTasks`, it does not process the all scheduled tasks, so it did not populate env.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/27586
