### PR TITLE
fix(misc): createNodesV2 plugins should show inference capabilities

### DIFF
--- a/packages/nx/src/utils/plugins/plugin-capabilities.ts
+++ b/packages/nx/src/utils/plugins/plugin-capabilities.ts
@@ -89,11 +89,14 @@ export async function getPluginCapabilities(
         pluginModule &&
         ('processProjectGraph' in pluginModule ||
           'createNodes' in pluginModule ||
+          'createNodesV2' in pluginModule ||
+          'createMetadata' in pluginModule ||
           'createDependencies' in pluginModule),
       projectInference:
         pluginModule &&
         ('projectFilePatterns' in pluginModule ||
-          'createNodes' in pluginModule),
+          'createNodes' in pluginModule ||
+          'createNodesV2' in pluginModule),
     };
   } catch {
     return null;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Plugins that export `createNodesV2` are not considered as having inference capabilities

## Expected Behavior
`createNodesV2` is the future API replacing `createNodes`, so it should show the same capability

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
