### PR TITLE
fix(vite): typecheck infer plugin should use correct inputs

### DIFF
--- a/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -53,6 +53,11 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               "inputs": [
                 "production",
                 "^production",
+                {
+                  "externalDependencies": [
+                    "typescript",
+                  ],
+                },
               ],
               "metadata": {
                 "description": "Run Typechecking",

--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -53,6 +53,11 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
               "inputs": [
                 "production",
                 "^production",
+                {
+                  "externalDependencies": [
+                    "typescript",
+                  ],
+                },
               ],
               "metadata": {
                 "description": "Run Typechecking",

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -212,7 +212,12 @@ async function buildViteTargets(
       ) ?? tsConfigFiles[0];
     targets[options.typecheckTargetName] = {
       cache: true,
-      inputs: ['production', '^production'],
+      inputs: [
+        ...('production' in namedInputs
+          ? ['production', '^production']
+          : ['default', '^default']),
+        { externalDependencies: ['typescript'] },
+      ],
       command: `tsc --noEmit -p ${tsConfigToUse}`,
       options: { cwd: joinPathFragments(projectRoot) },
       metadata: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Vite typecheck target is not falling back to default if production does not exist.
It also does not have an input on typescript itself

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Inputs should be configured correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
