### PR TITLE
fix(remix): vite plugin should be less strict on inference #27884

### DIFF
--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -34,6 +34,7 @@ export interface RemixPluginOptions {
   staticServeTargetName?: string;
   serveStaticTargetName?: string;
 }
+
 type RemixTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
 function readTargetsCache(
@@ -56,7 +57,7 @@ export const createDependencies: CreateDependencies = () => {
   return [];
 };
 
-const remixConfigGlob = '**/{remix,vite}.config.{js,cjs,mjs}';
+const remixConfigGlob = '**/{remix,vite}.config.{js,cjs,mjs,ts,cts,mts}';
 
 export const createNodesV2: CreateNodesV2<RemixPluginOptions> = [
   remixConfigGlob,
@@ -371,13 +372,17 @@ function determineIsRemixVite(configFilePath: string, workspaceRoot: string) {
     return RemixCompiler.IsClassic;
   }
 
+  const VITE_PLUGIN_REGEX = /vitePlugin\(\s*(.|\n)*?\s*\)/;
+  const REMIX_PLUGIN_REGEX = /remix\(\s*(.|\n)*?\s*\)/;
+
   const fileContents = readFileSync(
     join(workspaceRoot, configFilePath),
     'utf8'
   );
   if (
     fileContents.includes('@remix-run/dev') &&
-    (fileContents.includes('vitePlugin()') || fileContents.includes('remix()'))
+    (VITE_PLUGIN_REGEX.test(fileContents) ||
+      REMIX_PLUGIN_REGEX.test(fileContents))
   ) {
     return RemixCompiler.IsVte;
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The Remix plugin is too strict when finding Remix Vite projects


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The Remix plugin should be more permissive in finding Remix Vite projects

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27884
