### PR TITLE
fix(angular): dynamic module federation should not reset remoteUrlDefinitions #27793

### DIFF
--- a/packages/angular/mf/mf.ts
+++ b/packages/angular/mf/mf.ts
@@ -6,23 +6,27 @@ declare const __webpack_init_sharing__: (scope: 'default') => Promise<void>;
 declare const __webpack_share_scopes__: { default: unknown };
 
 let resolveRemoteUrl: ResolveRemoteUrlFunction;
+
 export function setRemoteUrlResolver(
   _resolveRemoteUrl: ResolveRemoteUrlFunction
 ) {
   resolveRemoteUrl = _resolveRemoteUrl;
 }
 
-let remoteUrlDefinitions: Record<string, string> = {};
+let remoteUrlDefinitions: Record<string, string>;
+
 export function setRemoteDefinitions(definitions: Record<string, string>) {
   remoteUrlDefinitions = definitions;
 }
 
 export function setRemoteDefinition(remoteName: string, remoteUrl: string) {
+  remoteUrlDefinitions ??= {};
   remoteUrlDefinitions[remoteName] = remoteUrl;
 }
 
 let remoteModuleMap = new Map<string, unknown>();
 let remoteContainerMap = new Map<string, unknown>();
+
 export async function loadRemoteModule(remoteName: string, moduleName: string) {
   const remoteModuleKey = `${remoteName}:${moduleName}`;
   if (remoteModuleMap.has(remoteModuleKey)) {
@@ -46,6 +50,7 @@ function loadModule(url: string) {
 }
 
 let initialSharingScopeCreated = false;
+
 async function loadRemoteContainer(remoteName: string) {
   if (!resolveRemoteUrl && !remoteUrlDefinitions) {
     throw new Error(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When the `@nx/angular/mf` file is loaded, it sets `remoteUrlDefinitions = {}`.
As this is a global, this can lead to erroneous behaviour by resetting existing definitions. It is also always truthy, breaking logic on whether urls need to be set or not.



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The object should be conditionally set if undefined when calling `setRemoteDefinition`


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27793, #27842
