### PR TITLE
fix(angular): migrations should use correct namedInputs #27899

### DIFF
--- a/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
+++ b/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
@@ -5,12 +5,15 @@ export function addMfEnvToTargetDefaultInputs(tree: Tree) {
   const webpackExecutor = '@nx/angular:webpack-browser';
   const mfEnvVar = 'NX_MF_DEV_REMOTES';
 
+  const inputs = [
+    ...(nxJson.namedInputs && 'production' in nxJson.namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+  ];
+
   nxJson.targetDefaults ??= {};
   nxJson.targetDefaults[webpackExecutor] ??= {};
-  nxJson.targetDefaults[webpackExecutor].inputs ??= [
-    'production',
-    '^production',
-  ];
+  nxJson.targetDefaults[webpackExecutor].inputs ??= inputs;
   nxJson.targetDefaults[webpackExecutor].dependsOn ??= ['^build'];
 
   let mfEnvVarExists = false;

--- a/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
+++ b/packages/angular/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
@@ -30,8 +30,8 @@ describe('addMfEnvVarToTargetDefaults', () => {
             "^build",
           ],
           "inputs": [
-            "production",
-            "^production",
+            "default",
+            "^default",
             {
               "env": "NX_MF_DEV_REMOTES",
             },

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
@@ -60,8 +60,8 @@ describe('ensure-depends-on-for-mf', () => {
           "^build",
         ],
         "inputs": [
-          "production",
-          "^production",
+          "default",
+          "^default",
           {
             "env": "NX_MF_DEV_REMOTES",
           },

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
@@ -30,6 +30,12 @@ export default async function (tree: Tree) {
 
   const nxJson = readNxJson(tree);
   const nxMFDevRemotesEnvVar = 'NX_MF_DEV_REMOTES';
+  const inputs = [
+    ...(nxJson.namedInputs && 'production' in nxJson.namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    { env: nxMFDevRemotesEnvVar },
+  ];
   if (
     !nxJson.targetDefaults ||
     !nxJson.targetDefaults?.['@nx/angular:webpack-browser']
@@ -37,7 +43,7 @@ export default async function (tree: Tree) {
     nxJson.targetDefaults ??= {};
     nxJson.targetDefaults['@nx/angular:webpack-browser'] = {
       cache: true,
-      inputs: ['production', '^production', { env: nxMFDevRemotesEnvVar }],
+      inputs,
       dependsOn: ['^build'],
     };
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Should use correct namedInputs in the migration instead of assuming 'production' is available.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the correct namedInputs based on what is listed in `nx.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27899
