### PR TITLE
chore(core): refactor nxCloudToken to nxCloudId

### DIFF
--- a/packages/angular/src/generators/application/lib/create-files.ts
+++ b/packages/angular/src/generators/application/lib/create-files.ts
@@ -30,12 +30,12 @@ export async function createFiles(
 
   const onBoardingStatus = await createNxCloudOnboardingURLForWelcomeApp(
     tree,
-    options.nxCloudToken
+    options.nxCloudId
   );
 
   const connectCloudUrl =
     onBoardingStatus === 'unclaimed' &&
-    (await getNxCloudAppOnBoardingUrl(options.nxCloudToken));
+    (await getNxCloudAppOnBoardingUrl(options.nxCloudId));
 
   const substitutions = {
     rootSelector,

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -31,5 +31,5 @@ export interface Schema {
   minimal?: boolean;
   bundler?: 'webpack' | 'esbuild';
   ssr?: boolean;
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }

--- a/packages/expo/src/generators/application/lib/create-application-files.ts
+++ b/packages/expo/src/generators/application/lib/create-application-files.ts
@@ -28,12 +28,12 @@ export async function createApplicationFiles(
 
   const onBoardingStatus = await createNxCloudOnboardingURLForWelcomeApp(
     host,
-    options.nxCloudToken
+    options.nxCloudId
   );
 
   const connectCloudUrl =
     onBoardingStatus === 'unclaimed' &&
-    (await getNxCloudAppOnBoardingUrl(options.nxCloudToken));
+    (await getNxCloudAppOnBoardingUrl(options.nxCloudId));
 
   generateFiles(
     host,

--- a/packages/expo/src/generators/application/schema.d.ts
+++ b/packages/expo/src/generators/application/schema.d.ts
@@ -19,5 +19,5 @@ export interface Schema {
   standaloneConfig?: boolean;
   skipPackageJson?: boolean; // default is false
   addPlugin?: boolean;
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -41,12 +41,12 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 
   const onBoardingStatus = await createNxCloudOnboardingURLForWelcomeApp(
     tree,
-    options.nxCloudToken
+    options.nxCloudId
   );
 
   const connectCloudUrl =
     onBoardingStatus === 'unclaimed' &&
-    (await getNxCloudAppOnBoardingUrl(options.nxCloudToken));
+    (await getNxCloudAppOnBoardingUrl(options.nxCloudId));
 
   const jsInitTask = await jsInitGenerator(tree, {
     ...schema,

--- a/packages/nuxt/src/generators/application/schema.d.ts
+++ b/packages/nuxt/src/generators/application/schema.d.ts
@@ -15,7 +15,7 @@ export interface Schema {
   rootProject?: boolean;
   setParserOptionsProject?: boolean;
   style?: 'css' | 'scss' | 'less' | 'none';
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
+++ b/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
@@ -21,7 +21,3 @@ export function getCloudUrl() {
 export function removeTrailingSlash(apiUrl: string) {
   return apiUrl[apiUrl.length - 1] === '/' ? apiUrl.slice(0, -1) : apiUrl;
 }
-
-export function isNxCloudId(token: string): boolean {
-  return token.length === 24;
-}

--- a/packages/nx/src/nx-cloud/utilities/is-workspace-claimed.ts
+++ b/packages/nx/src/nx-cloud/utilities/is-workspace-claimed.ts
@@ -1,13 +1,17 @@
-import { getCloudUrl, isNxCloudId } from './get-cloud-options';
+import { getCloudUrl } from './get-cloud-options';
 
-export async function isWorkspaceClaimed(accessToken: string) {
-  if (!accessToken) return false;
+export async function isWorkspaceClaimed(
+  token: string,
+  tokenType: 'ciAccessToken' | 'nxCloudId'
+) {
+  if (!token) return false;
 
   const apiUrl = getCloudUrl();
   try {
-    const requestData = isNxCloudId(accessToken)
-      ? { nxCloudId: accessToken }
-      : { nxCloudAccessToken: accessToken };
+    const requestData =
+      tokenType === 'ciAccessToken'
+        ? { nxCloudAccessToken: token }
+        : { nxCloudId: token };
     const response = await require('axios').post(
       `${apiUrl}/nx-cloud/is-workspace-claimed`,
       requestData

--- a/packages/react-native/src/generators/application/lib/create-application-files.ts
+++ b/packages/react-native/src/generators/application/lib/create-application-files.ts
@@ -13,12 +13,12 @@ export async function createApplicationFiles(
 ) {
   const onBoardingStatus = await createNxCloudOnboardingURLForWelcomeApp(
     host,
-    options.nxCloudToken
+    options.nxCloudId
   );
 
   const connectCloudUrl =
     onBoardingStatus === 'unclaimed' &&
-    (await getNxCloudAppOnBoardingUrl(options.nxCloudToken));
+    (await getNxCloudAppOnBoardingUrl(options.nxCloudId));
 
   generateFiles(host, join(__dirname, '../files/app'), options.appProjectRoot, {
     ...options,

--- a/packages/react-native/src/generators/application/schema.d.ts
+++ b/packages/react-native/src/generators/application/schema.d.ts
@@ -20,5 +20,5 @@ export interface Schema {
   install: boolean; // default is true
   skipPackageJson?: boolean; //default is false
   addPlugin?: boolean;
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -43,12 +43,12 @@ export async function createApplicationFiles(
 
   const onBoardingStatus = await createNxCloudOnboardingURLForWelcomeApp(
     host,
-    options.nxCloudToken
+    options.nxCloudId
   );
 
   const connectCloudUrl =
     onBoardingStatus === 'unclaimed' &&
-    (await getNxCloudAppOnBoardingUrl(options.nxCloudToken));
+    (await getNxCloudAppOnBoardingUrl(options.nxCloudId));
 
   const relativePathToRootTsConfig = getRelativePathToRootTsConfig(
     host,

--- a/packages/react/src/generators/application/schema.d.ts
+++ b/packages/react/src/generators/application/schema.d.ts
@@ -29,7 +29,7 @@ export interface Schema {
   bundler?: 'webpack' | 'vite' | 'rspack';
   minimal?: boolean;
   addPlugin?: boolean;
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }
 
 export interface NormalizedSchema<T extends Schema = Schema> extends T {

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -120,12 +120,12 @@ export async function remixApplicationGeneratorInternal(
 
   const onBoardingStatus = await createNxCloudOnboardingURLForWelcomeApp(
     tree,
-    options.nxCloudToken
+    options.nxCloudId
   );
 
   const connectCloudUrl =
     onBoardingStatus === 'unclaimed' &&
-    (await getNxCloudAppOnBoardingUrl(options.nxCloudToken));
+    (await getNxCloudAppOnBoardingUrl(options.nxCloudId));
 
   const vars = {
     ...options,

--- a/packages/remix/src/generators/application/schema.d.ts
+++ b/packages/remix/src/generators/application/schema.d.ts
@@ -13,5 +13,5 @@ export interface NxRemixGeneratorSchema {
   skipFormat?: boolean;
   rootProject?: boolean;
   addPlugin?: boolean;
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }

--- a/packages/vue/src/generators/application/lib/create-application-files.ts
+++ b/packages/vue/src/generators/application/lib/create-application-files.ts
@@ -15,12 +15,12 @@ export async function createApplicationFiles(
 ) {
   const onBoardingStatus = await createNxCloudOnboardingURLForWelcomeApp(
     tree,
-    options.nxCloudToken
+    options.nxCloudId
   );
 
   const connectCloudUrl =
     onBoardingStatus === 'unclaimed' &&
-    (await getNxCloudAppOnBoardingUrl(options.nxCloudToken));
+    (await getNxCloudAppOnBoardingUrl(options.nxCloudId));
 
   generateFiles(
     tree,

--- a/packages/vue/src/generators/application/schema.d.ts
+++ b/packages/vue/src/generators/application/schema.d.ts
@@ -19,7 +19,7 @@ export interface Schema {
   skipPackageJson?: boolean;
   rootProject?: boolean;
   addPlugin?: boolean;
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -82,7 +82,7 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
         : null,
       opts.ssr ? `--ssr` : null,
       opts.prefix !== undefined ? `--prefix=${opts.prefix}` : null,
-      opts.nxCloudToken ? `--nxCloudToken=${opts.nxCloudToken}` : null,
+      opts.nxCloudId ? `--nxCloudId=${opts.nxCloudId}` : null,
     ].filter((e) => !!e);
   }
 }

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -292,7 +292,7 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
 async function createReadme(
   tree: Tree,
   { name, appName, directory, preset, nxCloud }: NormalizedSchema,
-  nxCloudToken?: string
+  nxCloudId?: string
 ) {
   const formattedNames = names(name);
 
@@ -302,8 +302,8 @@ async function createReadme(
     generateLibCmd: null,
   };
 
-  const nxCloudOnboardingUrl = nxCloudToken
-    ? await createNxCloudOnboardingURL('readme', nxCloudToken)
+  const nxCloudOnboardingUrl = nxCloudId
+    ? await createNxCloudOnboardingURL('readme', nxCloudId)
     : null;
 
   generateFiles(tree, join(__dirname, './files-readme'), directory, {

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -42,14 +42,14 @@ interface Schema {
 export interface NormalizedSchema extends Schema {
   presetVersion?: string;
   isCustomPreset: boolean;
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }
 
 export async function newGenerator(tree: Tree, opts: Schema) {
   const options = normalizeOptions(opts);
   validateOptions(options, tree);
 
-  options.nxCloudToken = await generateWorkspaceFiles(tree, options);
+  options.nxCloudId = await generateWorkspaceFiles(tree, options);
 
   addPresetDependencies(tree, options);
 

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -38,7 +38,7 @@ async function createPreset(tree: Tree, options: Schema) {
       bundler: options.bundler,
       ssr: options.ssr,
       prefix: options.prefix,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.AngularStandalone) {
     const {
@@ -58,7 +58,7 @@ async function createPreset(tree: Tree, options: Schema) {
       bundler: options.bundler,
       ssr: options.ssr,
       prefix: options.prefix,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.ReactMonorepo) {
     const { applicationGenerator: reactApplicationGenerator } = require('@nx' +
@@ -73,7 +73,7 @@ async function createPreset(tree: Tree, options: Schema) {
       bundler: options.bundler ?? 'webpack',
       e2eTestRunner: options.e2eTestRunner ?? 'playwright',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.ReactStandalone) {
     const { applicationGenerator: reactApplicationGenerator } = require('@nx' +
@@ -90,7 +90,7 @@ async function createPreset(tree: Tree, options: Schema) {
       e2eTestRunner: options.e2eTestRunner ?? 'playwright',
       unitTestRunner: options.bundler === 'vite' ? 'vitest' : 'jest',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.RemixMonorepo) {
     const { applicationGenerator: remixApplicationGenerator } = require('@nx' +
@@ -104,7 +104,7 @@ async function createPreset(tree: Tree, options: Schema) {
       e2eTestRunner: options.e2eTestRunner ?? 'playwright',
       unitTestRunner: 'vitest',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.RemixStandalone) {
     const { applicationGenerator: remixApplicationGenerator } = require('@nx' +
@@ -119,7 +119,7 @@ async function createPreset(tree: Tree, options: Schema) {
       rootProject: true,
       unitTestRunner: 'vitest',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.VueMonorepo) {
     const { applicationGenerator: vueApplicationGenerator } = require('@nx' +
@@ -133,7 +133,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       e2eTestRunner: options.e2eTestRunner ?? 'playwright',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.VueStandalone) {
     const { applicationGenerator: vueApplicationGenerator } = require('@nx' +
@@ -149,7 +149,7 @@ async function createPreset(tree: Tree, options: Schema) {
       e2eTestRunner: options.e2eTestRunner ?? 'playwright',
       unitTestRunner: 'vitest',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.Nuxt) {
     const { applicationGenerator: nuxtApplicationGenerator } = require('@nx' +
@@ -163,7 +163,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       e2eTestRunner: options.e2eTestRunner ?? 'playwright',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.NuxtStandalone) {
     const { applicationGenerator: nuxtApplicationGenerator } = require('@nx' +
@@ -179,7 +179,7 @@ async function createPreset(tree: Tree, options: Schema) {
       e2eTestRunner: options.e2eTestRunner ?? 'playwright',
       unitTestRunner: 'vitest',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.NextJs) {
     const { applicationGenerator: nextApplicationGenerator } = require('@nx' +
@@ -224,7 +224,7 @@ async function createPreset(tree: Tree, options: Schema) {
       bundler: 'vite',
       e2eTestRunner: options.e2eTestRunner ?? 'playwright',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.Nest) {
     const { applicationGenerator: nestApplicationGenerator } = require('@nx' +
@@ -260,7 +260,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       e2eTestRunner: options.e2eTestRunner ?? 'detox',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.Expo) {
     const { expoApplicationGenerator } = require('@nx' + '/expo');
@@ -271,7 +271,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       e2eTestRunner: options.e2eTestRunner ?? 'detox',
       addPlugin,
-      nxCloudToken: options.nxCloudToken,
+      nxCloudId: options.nxCloudId,
     });
   } else if (options.preset === Preset.TS) {
     const { initGenerator } = require('@nx' + '/js');

--- a/packages/workspace/src/generators/preset/schema.d.ts
+++ b/packages/workspace/src/generators/preset/schema.d.ts
@@ -19,5 +19,5 @@ export interface Schema {
   js?: boolean;
   ssr?: boolean;
   prefix?: string;
-  nxCloudToken?: string;
+  nxCloudId?: string;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Generators all had an ambiguous `nxCloudToken` field. This is outdated since workspaces automatically connect via `nxCloudId`. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generators now explicitly pass `nxCloudId`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
