### PR TITLE
fix(core): import should be rebasable

### DIFF
--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -348,8 +348,9 @@ export async function importHandler(options: ImportOptions) {
     title: `Merging these changes into ${getBaseRef(nxJson)}`,
     bodyLines: [
       `MERGE these changes when merging these changes.`,
-      `Do NOT squash and do NOT rebase these changes when merging these changes.`,
-      `If you would like to UNDO these changes, run "git reset HEAD~1 --hard"`,
+      `Do NOT squash these commits when merging these changes.`,
+      `If you rebase, make sure to use "--rebase-merges" to preserve merge commits.`,
+      `To UNDO these changes, run "git reset HEAD~1 --hard"`,
     ],
   });
 }

--- a/packages/nx/src/command-line/import/utils/prepare-source-repo.ts
+++ b/packages/nx/src/command-line/import/utils/prepare-source-repo.ts
@@ -19,55 +19,24 @@ export async function prepareSourceRepo(
     join(gitClient.root, source)
   );
 
-  if (relativeSourceDir !== '') {
-    if (await gitClient.hasFilterRepoInstalled()) {
-      spinner.start(
-        `Filtering git history to only include files in ${relativeSourceDir}`
-      );
-      await gitClient.filterRepo(relativeSourceDir);
-    } else {
-      spinner.start(
-        `Filtering git history to only include files in ${relativeSourceDir} (this might take a few minutes -- install git-filter-repo for faster performance)`
-      );
-      await gitClient.filterBranch(relativeSourceDir, tempImportBranch);
-    }
-    spinner.succeed(
-      `Filtered git history to only include files in ${relativeSourceDir}`
-    );
-  }
-
-  const destinationInSource = join(gitClient.root, relativeDestination);
-  spinner.start(`Moving files and git history to ${destinationInSource}`);
-
-  // The result of filter-branch will contain only the files in the subdirectory at its root.
-  const files = await gitClient.getGitFiles('.');
-  try {
-    await rm(destinationInSource, {
-      recursive: true,
-    });
-  } catch {}
-  await mkdir(destinationInSource, { recursive: true });
-  for (const file of files) {
+  if (await gitClient.hasFilterRepoInstalled()) {
     spinner.start(
-      `Moving files and git history to ${destinationInSource}: ${file}`
+      `Filtering git history to only include files in ${relativeSourceDir}`
     );
-
-    const newPath = join(destinationInSource, file);
-
-    await mkdir(dirname(newPath), { recursive: true });
-    try {
-      await gitClient.move(file, newPath);
-    } catch {
-      await wait(100);
-      await gitClient.move(file, newPath);
-    }
+    await gitClient.filterRepo(relativeSourceDir, relativeDestination);
+  } else {
+    spinner.start(
+      `Filtering git history to only include files in ${relativeSourceDir} (this might take a few minutes -- install git-filter-repo for faster performance)`
+    );
+    await gitClient.filterBranch(
+      relativeSourceDir,
+      relativeDestination,
+      tempImportBranch
+    );
   }
-
-  await gitClient.commit(
-    `chore(repo): move ${source} to ${relativeDestination} to prepare to be imported`
+  spinner.succeed(
+    `Filtered git history to only include files in ${relativeSourceDir}`
   );
-
-  await gitClient.amendCommit();
 
   spinner.succeed(
     `${sourceRemoteUrl} has been prepared to be imported into this workspace on a temporary branch: ${tempImportBranch} in ${gitClient.root}`

--- a/packages/nx/src/utils/git-utils.index-filter.ts
+++ b/packages/nx/src/utils/git-utils.index-filter.ts
@@ -1,0 +1,17 @@
+/**
+ * This is meant to be used with `git filter-branch --index-filter` to rewrite
+ * history such that only commits related to the subdirectory is kept.
+ *
+ * Example:
+ * git filter-branch --index-filter 'node git-utils.index-filter.js "packages/foo"' --prune-empty -- --all
+ */
+try {
+  const { execSync } = require('child_process');
+  execSync('git read-tree --empty', { stdio: 'inherit' });
+  execSync(`git reset ${process.env.GIT_COMMIT} -- "${process.argv[2]}"`, {
+    stdio: 'inherit',
+  });
+} catch (error) {
+  console.error(`Error executing Git commands: ${error}`);
+  process.exit(1);
+}

--- a/packages/nx/src/utils/git-utils.tree-filter.ts
+++ b/packages/nx/src/utils/git-utils.tree-filter.ts
@@ -1,0 +1,38 @@
+/**
+ * This is meant to be used with `git filter-branch --tree-filter` to rewrite
+ * history to only include commits related to the source project folder. If the
+ * destination folder is different, this script also moves the files over.
+ *
+ * Example:
+ * git filter-branch --tree-filter 'node git-utils.tree-filter.js <source> <destination>' --prune-empty -- --all
+ */
+const { execSync } = require('child_process');
+const { existsSync, mkdirSync, renameSync, rmSync } = require('fs');
+const { posix } = require('path');
+try {
+  const src = process.argv[2];
+  const dest = process.argv[3];
+  const files = execSync(`git ls-files -z ${src}`)
+    .toString()
+    .trim()
+    .split('\x00')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const srcRegex = new RegExp(`^${src}`);
+  for (const file of files) {
+    if (src === '' || srcRegex.test(file)) {
+      // If source and destination are the same, then keep the file as is.
+      if (src === dest) continue;
+      const destFile = posix.join(dest, file.replace(srcRegex, ''));
+      const dir = posix.dirname(destFile);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      renameSync(file, destFile);
+    } else {
+      // If not matching the source we are filtering, remove it.
+      rmSync(file);
+    }
+  }
+} catch (error) {
+  console.error(`Error executing Git commands: ${error}`);
+  process.exit(1);
+}


### PR DESCRIPTION
When users run `nx import` and open a PR with the imported package, they should be able to use `git rebase --rebase-merges` to update their branch with latest main.

## Why this matters

If the repo requires the PR to be updated with latest main before merge, the user must have a way to do this and avoid having to do the import process all over again.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Rebase results in git error

## Expected Behavior
Rebase works

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
