### PR TITLE
fix(core): nx import detects plugins synchronously

### DIFF
--- a/e2e/gradle/src/gradle-import.test.ts
+++ b/e2e/gradle/src/gradle-import.test.ts
@@ -8,6 +8,7 @@ import {
   updateFile,
   e2eCwd,
   readJson,
+  runCommand,
 } from '@nx/e2e/utils';
 import { mkdirSync, rmdirSync, writeFileSync } from 'fs';
 import { execSync } from 'node:child_process';
@@ -42,7 +43,11 @@ describe('Nx Import Gradle', () => {
       rmdirSync(tempImportE2ERoot);
     } catch {}
     mkdirSync(tempImportE2ERoot, { recursive: true });
+
+    runCommand(`git add .`);
+    runCommand(`git commit -am "update"`);
   });
+
   afterAll(() => cleanupProject());
 
   it('should be able to import a kotlin gradle app', () => {
@@ -78,9 +83,14 @@ describe('Nx Import Gradle', () => {
     execSync(`git commit -am "initial commit"`, {
       cwd: tempGraldeProjectPath,
     });
-    execSync(`git checkout -b main`, {
-      cwd: tempGraldeProjectPath,
-    });
+
+    try {
+      execSync(`git checkout -b main`, {
+        cwd: tempGraldeProjectPath,
+      });
+    } catch {
+      // This fails if git is already configured to have `main` branch, but that's OK
+    }
 
     const remote = tempGraldeProjectPath;
     const ref = 'main';
@@ -109,6 +119,9 @@ describe('Nx Import Gradle', () => {
       runCLI(`show projects`);
       runCLI('build kotlin-app');
     }).not.toThrow();
+
+    runCommand(`git add .`);
+    runCommand(`git commit -am 'import kotlin project'`);
   });
 
   it('should be able to import a groovy gradle app', () => {
@@ -144,9 +157,14 @@ describe('Nx Import Gradle', () => {
     execSync(`git commit -am "initial commit"`, {
       cwd: tempGraldeProjectPath,
     });
-    execSync(`git checkout -b main`, {
-      cwd: tempGraldeProjectPath,
-    });
+
+    try {
+      execSync(`git checkout -b main`, {
+        cwd: tempGraldeProjectPath,
+      });
+    } catch {
+      // This fails if git is already configured to have `main` branch, but that's OK
+    }
 
     const remote = tempGraldeProjectPath;
     const ref = 'main';
@@ -171,5 +189,8 @@ describe('Nx Import Gradle', () => {
       runCLI(`show projects`);
       runCLI('build groovy-app');
     }).not.toThrow();
+
+    runCommand(`git add .`);
+    runCommand(`git commit -am 'import groovy project'`);
   });
 });

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -22,7 +22,7 @@ import {
 import { prompt } from 'enquirer';
 import { execSync } from 'child_process';
 import { addNxToAngularCliRepo } from './implementation/angular';
-import { globWithWorkspaceContext } from '../../utils/workspace-context';
+import { globWithWorkspaceContextSync } from '../../utils/workspace-context';
 import { connectExistingRepoToNxCloudPrompt } from '../connect/connect-to-nx-cloud';
 import { addNxToNpmRepo } from './implementation/add-nx-to-npm-repo';
 import { addNxToMonorepo } from './implementation/add-nx-to-monorepo';
@@ -188,7 +188,7 @@ export async function detectPlugins(
   updatePackageScripts: boolean;
 }> {
   let files = ['package.json'].concat(
-    await globWithWorkspaceContext(process.cwd(), ['**/*/package.json'])
+    globWithWorkspaceContextSync(process.cwd(), ['**/*/package.json'])
   );
 
   const currentPlugins = new Set(
@@ -229,7 +229,7 @@ export async function detectPlugins(
   }
 
   let gradlewFiles = ['gradlew', 'gradlew.bat'].concat(
-    await globWithWorkspaceContext(process.cwd(), [
+    globWithWorkspaceContextSync(process.cwd(), [
       '**/gradlew',
       '**/gradlew.bat',
     ])


### PR DESCRIPTION
This PR switches `globWithWorkspaceContext` with `globWithWorkspaceContextSync` for `nx init` and `nx import`, since the latter isn't guaranteed to have updated file map during the init/import process.

Note: Also updates Gradle import test to ensure the destination repo does not have uncommitted changes.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Sometimes plugins are not detected.

## Expected Behavior
Always detect plugins.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
