### PR TITLE
fix(core): fix powerpack license report and add back remote cache

### DIFF
--- a/packages/nx/src/command-line/report/report.ts
+++ b/packages/nx/src/command-line/report/report.ts
@@ -103,7 +103,9 @@ export async function reportHandler() {
         powerpackLicense.workspaceCount
       } workspace${
         powerpackLicense.workspaceCount > 1 ? 's' : ''
-      } until ${new Date(powerpackLicense.expiresAt).toLocaleDateString()}`
+      } until ${new Date(
+        powerpackLicense.expiresAt * 1000
+      ).toLocaleDateString()}`
     );
     bodyLines.push('');
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -75,10 +75,11 @@ export class TaskOrchestrator {
   ) {}
 
   async run() {
-    // Init the ForkedProcessTaskRunner
+    // Init the ForkedProcessTaskRunner, TasksSchedule, and Cache
     await Promise.all([
       this.forkedProcessTaskRunner.init(),
       this.tasksSchedule.init(),
+      'init' in this.cache ? this.cache.init() : null,
     ]);
 
     // initial scheduling


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The remote cache was not being initialized on the new db cache. Powerpack license expiration improperly assumed to be unix timestamp in ms

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The remote cache is being initialized on the new db cache. Powerpack license expiration shows up properly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
