### PR TITLE
fix(react): normalizing project names for module federation correctly #27901

### DIFF
--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -67,6 +67,7 @@ export async function hostGeneratorInternal(
 
   const initTask = await applicationGenerator(host, {
     ...options,
+    name: options.projectName,
     // The target use-case is loading remotes as child routes, thus always enable routing.
     routing: true,
     skipFormat: true,

--- a/packages/react/src/generators/host/lib/add-module-federation-files.ts
+++ b/packages/react/src/generators/host/lib/add-module-federation-files.ts
@@ -14,7 +14,7 @@ export function addModuleFederationFiles(
   defaultRemoteManifest: { name: string; port: number }[]
 ) {
   const templateVariables = {
-    ...names(options.name),
+    ...names(options.projectName),
     ...options,
     static: !options?.dynamic,
     tmpl: '',
@@ -26,7 +26,7 @@ export function addModuleFederationFiles(
     }),
   };
 
-  const projectConfig = readProjectConfiguration(host, options.name);
+  const projectConfig = readProjectConfiguration(host, options.projectName);
   const pathToMFManifest = joinPathFragments(
     projectConfig.sourceRoot,
     'assets/module-federation.manifest.json'

--- a/packages/react/src/generators/remote/lib/setup-tspath-for-remote.ts
+++ b/packages/react/src/generators/remote/lib/setup-tspath-for-remote.ts
@@ -2,16 +2,16 @@ import type { Tree } from '@nx/devkit';
 import { joinPathFragments, readProjectConfiguration } from '@nx/devkit';
 import { addTsConfigPath } from '@nx/js';
 import { maybeJs } from '../../../utils/maybe-js';
-import type { Schema } from '../schema';
+import { NormalizedSchema } from '../../application/schema';
 
-export function setupTspathForRemote(tree: Tree, options: Schema) {
-  const project = readProjectConfiguration(tree, options.name);
+export function setupTspathForRemote(tree: Tree, options: NormalizedSchema) {
+  const project = readProjectConfiguration(tree, options.projectName);
 
   const exportPath = maybeJs(options, './src/remote-entry.ts');
 
   const exportName = 'Module';
 
-  addTsConfigPath(tree, `${options.name}/${exportName}`, [
+  addTsConfigPath(tree, `${options.projectName}/${exportName}`, [
     joinPathFragments(project.root, exportPath),
   ]);
 }

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -32,7 +32,7 @@ export function addModuleFederationFiles(
   options: NormalizedSchema<Schema>
 ) {
   const templateVariables = {
-    ...names(options.name),
+    ...names(options.projectName),
     ...options,
     tmpl: '',
   };
@@ -113,16 +113,17 @@ export async function remoteGeneratorInternal(host: Tree, schema: Schema) {
   if (options.dynamic) {
     // Dynamic remotes generate with library { type: 'var' } by default.
     // We need to ensure that the remote name is a valid variable name.
-    const isValidRemote = isValidVariable(options.name);
+    const isValidRemote = isValidVariable(options.projectName);
     if (!isValidRemote.isValid) {
       throw new Error(
-        `Invalid remote name provided: ${options.name}. ${isValidRemote.message}`
+        `Invalid remote name provided: ${options.projectName}. ${isValidRemote.message}`
       );
     }
   }
 
   const initAppTask = await applicationGenerator(host, {
     ...options,
+    name: options.projectName,
     skipFormat: true,
   });
   tasks.push(initAppTask);
@@ -201,7 +202,7 @@ export async function remoteGeneratorInternal(host: Tree, schema: Schema) {
     );
     addRemoteToDynamicHost(
       host,
-      options.name,
+      options.projectName,
       options.devServerPort,
       pathToMFManifest
     );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
React Module Federation generators were normalizing names and using them incorrectly


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The host and remote generators should always use the name provided by the determineProjectNameAndRootOpitons

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27901
