### PR TITLE
fix(angular): license-webpack-plugin should not scan root package.json #27989

### DIFF
--- a/packages/angular/src/builders/utilities/webpack.ts
+++ b/packages/angular/src/builders/utilities/webpack.ts
@@ -2,6 +2,7 @@ import { merge } from 'webpack-merge';
 import { registerTsProject } from '@nx/js/src/internal';
 import { workspaceRoot } from '@nx/devkit';
 import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
 
 export async function mergeCustomWebpackConfig(
   baseWebpackConfig: any,
@@ -22,11 +23,44 @@ export async function mergeCustomWebpackConfig(
 
   // The extra Webpack configuration file can export a synchronous or asynchronous function,
   // for instance: `module.exports = async config => { ... }`.
+  let newConfig: any;
   if (typeof config === 'function') {
-    return config(baseWebpackConfig, options, target);
+    newConfig = config(baseWebpackConfig, options, target);
   } else {
-    return merge(baseWebpackConfig, config);
+    newConfig = merge(baseWebpackConfig, config);
   }
+
+  // license-webpack-plugin will at times try to scan the monorepo's root package.json
+  // This will result in an error being thrown
+  // Ensure root package.json is excluded
+  const licensePlugin = newConfig.plugins.find(
+    (p) => p.constructor.name === 'LicenseWebpackPlugin'
+  );
+  if (licensePlugin) {
+    let rootPackageJsonName: string;
+    const pathToRootPackageJson = join(
+      newConfig.context.root ?? workspaceRoot,
+      'package.json'
+    );
+    if (existsSync(pathToRootPackageJson)) {
+      try {
+        const rootPackageJson = JSON.parse(
+          readFileSync(pathToRootPackageJson, 'utf-8')
+        );
+        rootPackageJsonName = rootPackageJson.name;
+        licensePlugin.pluginOptions.excludedPackageTest = (pkgName: string) => {
+          if (!rootPackageJsonName) {
+            return false;
+          }
+          return pkgName === rootPackageJsonName;
+        };
+      } catch {
+        // do nothing
+      }
+    }
+  }
+
+  return newConfig;
 }
 
 export function resolveCustomWebpackConfig(path: string, tsConfig: string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `license-webpack-plugin` is trying to scan the root package.json on windows, resulting in an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Patch the `license-webpack-plugin` to prevent it from scanning the root package.json. A similar fix was needed for rspack.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27989
