### PR TITLE
fix(module-federation): collect secondary entry points from exports #26878

### DIFF
--- a/packages/webpack/src/utils/module-federation/share.spec.ts
+++ b/packages/webpack/src/utils/module-federation/share.spec.ts
@@ -163,20 +163,110 @@ describe('MF Share Utils', () => {
       ]);
       // ASSERT
       expect(packages).toEqual({
-        '@angular/core': {
-          singleton: true,
-          strictVersion: true,
-          requiredVersion: '~13.2.0',
-        },
         '@angular/common': {
+          requiredVersion: '~13.2.0',
           singleton: true,
           strictVersion: true,
+        },
+        '@angular/common/http': {
           requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/http/testing': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/locales/*': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/locales/global/*': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/testing': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/upgrade': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/event-dispatch-contract.min.js': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/primitives/event-dispatch': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/primitives/signals': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/rxjs-interop': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/schematics/*': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/testing': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
         },
         rxjs: {
+          requiredVersion: '~7.4.0',
           singleton: true,
           strictVersion: true,
+        },
+        'rxjs/ajax': {
           requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/fetch': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/internal/*': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/operators': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/testing': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/webSocket': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
         },
       });
     });
@@ -218,6 +308,36 @@ describe('MF Share Utils', () => {
       // ASSERT
       expect(packages).toEqual({
         '@angular/core': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/event-dispatch-contract.min.js': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/primitives/event-dispatch': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/primitives/signals': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/rxjs-interop': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/schematics/*': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/testing': {
           singleton: true,
           strictVersion: true,
           requiredVersion: '~13.2.0',
@@ -227,12 +347,67 @@ describe('MF Share Utils', () => {
           strictVersion: true,
           requiredVersion: '~13.2.0',
         },
-        '@angular/common/http/testing': {
+        '@angular/common/http': {
+          requiredVersion: '~13.2.0',
           singleton: true,
           strictVersion: true,
+        },
+        '@angular/common/http/testing': {
           requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/locales/*': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/locales/global/*': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/testing': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/common/upgrade': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
         },
         rxjs: {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/ajax': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/fetch': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/internal/*': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/operators': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/testing': {
+          requiredVersion: '~7.4.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        'rxjs/webSocket': {
           singleton: true,
           strictVersion: true,
           requiredVersion: '~7.4.0',
@@ -284,6 +459,31 @@ describe('MF Share Utils', () => {
           singleton: true,
           strictVersion: true,
           requiredVersion: '~13.2.0',
+        },
+        '@angular/core/event-dispatch-contract.min.js': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/primitives/event-dispatch': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/primitives/signals': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/rxjs-interop': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/schematics/*': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
         },
         '@angular/core/testing': {
           singleton: true,
@@ -360,6 +560,31 @@ describe('MF Share Utils', () => {
           singleton: true,
           strictVersion: true,
           requiredVersion: '~13.2.0',
+        },
+        '@angular/core/event-dispatch-contract.min.js': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/primitives/event-dispatch': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/primitives/signals': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/rxjs-interop': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
+        },
+        '@angular/core/schematics/*': {
+          requiredVersion: '~13.2.0',
+          singleton: true,
+          strictVersion: true,
         },
         '@angular/core/testing': {
           singleton: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Some packages that use `exports` in the package.json may point to a directory such as `esm/<entrypoint>`. 
They would still be imported such as `mypackage/secondary-point`.
This needs to be shared still for Module Federation.

However, our current logic for finding secondary entry points for packages looks at the sub dirs of the package and tries to match it with the exports fiels.

Therefore if `mypackage/secondary-point` was set up such that

```
"./secondary-point": {
  default: "esm/secondary-point/index.mjs"
}
```

then it would never be found correctly, causing share problems.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
exports of secondary entrypoints should be shared correctly


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26878
