### PR TITLE
feat(core): allow prompts from init generators during nx init

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -55,7 +55,7 @@ export function installPlugins(
     execSync(
       `${pmc.exec} nx g ${plugin}:init --keepExistingVersions ${
         updatePackageScripts ? '--updatePackageScripts' : ''
-      } --no-interactive`,
+      }`,
       {
         stdio: [0, 1, 2],
         cwd: repoRoot,


### PR DESCRIPTION
This PR allows init generators to prompt during `nx init`.

Demo (temporarily adds prompt to vite init): https://www.loom.com/share/ad40e6f02186478596ea6e1f08dba7a4

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
