### PR TITLE
fix(linter): do not generate docs.recommended property

### DIFF
--- a/packages/eslint/src/generators/workspace-rule/__snapshots__/workspace-rule.spec.ts.snap
+++ b/packages/eslint/src/generators/workspace-rule/__snapshots__/workspace-rule.spec.ts.snap
@@ -28,7 +28,6 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
     type: 'problem',
     docs: {
       description: \`\`,
-      recommended: 'recommended',
     },
     schema: [],
     messages: {},
@@ -84,7 +83,6 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
     type: 'problem',
     docs: {
       description: \`\`,
-      recommended: 'recommended',
     },
     schema: [],
     messages: {},
@@ -140,7 +138,6 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
     type: 'problem',
     docs: {
       description: \`\`,
-      recommended: 'recommended',
     },
     schema: [],
     messages: {},

--- a/packages/eslint/src/generators/workspace-rule/files/__name__.ts__tmpl__
+++ b/packages/eslint/src/generators/workspace-rule/files/__name__.ts__tmpl__
@@ -25,7 +25,6 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
     type: 'problem',
     docs: {
       description: ``,
-      recommended: 'recommended',
     },
     schema: [],
     messages: {},

--- a/packages/eslint/src/migrations/update-17-1-0/__snapshots__/update-typescript-eslint.spec.ts.snap
+++ b/packages/eslint/src/migrations/update-17-1-0/__snapshots__/update-typescript-eslint.spec.ts.snap
@@ -43,7 +43,6 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
     type: 'problem',
     docs: {
       description: \`\`,
-      recommended: 'recommended',
     },
     schema: [],
     messages: {},

--- a/packages/eslint/src/migrations/update-17-1-0/update-typescript-eslint.spec.ts
+++ b/packages/eslint/src/migrations/update-17-1-0/update-typescript-eslint.spec.ts
@@ -84,7 +84,6 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
     type: 'problem',
     docs: {
       description: \`\`,
-      recommended: 'error',
     },
     schema: [],
     messages: {},


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

We still generate `docs.recommended` which is not on the types.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We do not generate `docs.recommended`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
