### PR TITLE
docs(core): add missing .DocSearch-VisuallyHiddenForAccessibility style

### DIFF
--- a/nx-dev/feature-search/src/lib/algolia-search.global.css
+++ b/nx-dev/feature-search/src/lib/algolia-search.global.css
@@ -2,6 +2,10 @@
   @apply overflow-hidden !important;
 }
 
+.DocSearch-VisuallyHiddenForAccessibility {
+  visibility: hidden;
+}
+
 body .DocSearch-Container {
   @apply fixed left-0 top-0 z-[50] flex h-screen w-screen cursor-auto flex-col bg-black/10 p-4 backdrop-blur-sm sm:p-6 md:p-[10vh] lg:p-[12vh] dark:bg-white/10;
 }


### PR DESCRIPTION
Same as this https://github.com/nrwl/nx/pull/28020


<img width="2033" alt="Screenshot 2024-09-20 at 3 58 36 PM" src="https://github.com/user-attachments/assets/0a741e04-6467-463f-9e16-058aa495c095">