### PR TITLE
cleanup(core): migrate esbuild to use picocolors

### DIFF
--- a/packages/esbuild/.eslintrc.json
+++ b/packages/esbuild/.eslintrc.json
@@ -4,7 +4,15 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "name": "chalk",
+            "message": "Please use `picocolors` in place of `chalk` for rendering terminal colors"
+          }
+        ]
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -31,13 +31,13 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "chalk": "^4.1.0",
+    "@nx/devkit": "file:../devkit",
+    "@nx/js": "file:../js",
     "fast-glob": "3.2.7",
     "fs-extra": "^11.1.0",
-    "tslib": "^2.3.0",
+    "picocolors": "^1.1.0",
     "tsconfig-paths": "^4.1.2",
-    "@nx/devkit": "file:../devkit",
-    "@nx/js": "file:../js"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "esbuild": "~0.19.2"

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import * as pc from 'picocolors';
 import type { ExecutorContext } from '@nx/devkit';
 import { cacheDir, joinPathFragments, logger, stripIndents } from '@nx/devkit';
 import {
@@ -24,10 +24,10 @@ import { getExtraDependencies } from './lib/get-extra-dependencies';
 import { DependentBuildableProjectNode } from '@nx/js/src/utils/buildable-libs-utils';
 import { join, relative } from 'path';
 
-const BUILD_WATCH_FAILED = `[ ${chalk.red(
+const BUILD_WATCH_FAILED = `[ ${pc.red(
   'watch'
 )} ] build finished with errors (see above), watching for changes...`;
-const BUILD_WATCH_SUCCEEDED = `[ ${chalk.green(
+const BUILD_WATCH_SUCCEEDED = `[ ${pc.green(
   'watch'
 )} ] build succeeded, watching for changes...`;
 

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.ts
@@ -5,7 +5,7 @@ import {
   NormalizedEsBuildExecutorOptions,
 } from '../schema';
 import { ExecutorContext, joinPathFragments, logger } from '@nx/devkit';
-import chalk = require('chalk');
+import * as pc from 'picocolors';
 import * as esbuild from 'esbuild';
 import { readTsConfig } from '@nx/js';
 
@@ -28,12 +28,12 @@ export function normalizeOptions(
 
   if (!options.bundle && options.thirdParty) {
     logger.info(
-      chalk.yellow(
-        `Your build has conflicting options, ${chalk.bold(
+      pc.yellow(
+        `Your build has conflicting options, ${pc.bold(
           'bundle:false'
-        )} and ${chalk.bold(
+        )} and ${pc.bold(
           'thirdParty:true'
-        )}. Your package.json depedencies might not be generated correctly so we added an update ${chalk.bold(
+        )}. Your package.json depedencies might not be generated correctly so we added an update ${pc.bold(
           'thirdParty:false'
         )}`
       )
@@ -55,12 +55,12 @@ export function normalizeOptions(
 
   if (options.skipTypeCheck && declaration) {
     logger.info(
-      chalk.yellow(
-        `Your build has conflicting options, ${chalk.bold(
+      pc.yellow(
+        `Your build has conflicting options, ${pc.bold(
           'skipTypeCheck:true'
-        )} and ${chalk.bold(
+        )} and ${pc.bold(
           'declaration:true'
-        )}. Your declarations won't be generated so we added an update ${chalk.bold(
+        )}. Your declarations won't be generated so we added an update ${pc.bold(
           'skipTypeCheck:false'
         )}`
       )


### PR DESCRIPTION
Migrates from `chalk` to `picocolors`.

I used `core` here in the commit since we don't have a scope for the esbuild project
