### PR TITLE
cleanup(web): migrate to picocolors

### DIFF
--- a/packages/web/.eslintrc.json
+++ b/packages/web/.eslintrc.json
@@ -4,7 +4,15 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "name": "chalk",
+            "message": "Please use `picocolors` in place of `chalk` for rendering terminal colors"
+          }
+        ]
+      }
     },
     {
       "files": ["**/*.ts"],

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,9 +31,9 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "chalk": "^4.1.0",
     "detect-port": "^1.5.1",
     "http-server": "^14.1.0",
+    "picocolors": "^1.1.0",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js"

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -1,5 +1,5 @@
 import { execFileSync, fork } from 'child_process';
-import * as chalk from 'chalk';
+import * as pc from 'picocolors';
 import {
   ExecutorContext,
   output,
@@ -176,7 +176,7 @@ export default async function* fileServerExecutor(
           });
         } catch {
           throw new Error(
-            `Build target failed: ${chalk.bold(options.buildTarget)}`
+            `Build target failed: ${pc.bold(options.buildTarget)}`
           );
         } finally {
           process.env.NX_SERVE_STATIC_BUILD_RUNNING = undefined;


### PR DESCRIPTION
Migrate from `chalk` to `picocolors`.
