### PR TITLE
cleanup(nextjs): migrate to node FS

### DIFF
--- a/packages/next/.eslintrc.json
+++ b/packages/next/.eslintrc.json
@@ -10,6 +10,10 @@
           {
             "name": "chalk",
             "message": "Please use `picocolors` in place of `chalk` for rendering terminal colors"
+          },
+          {
+            "name": "fs-extra",
+            "message": "Please use native functionality in place of `fs-extra` for file-system interaction"
           }
         ]
       }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -50,7 +50,6 @@
     "@nx/react": "file:../react",
     "@nx/web": "file:../web",
     "@nx/webpack": "file:../webpack",
-    "@nx/workspace": "file:../workspace",
     "@phenomnomnominal/tsquery": "~5.0.1"
   },
   "publishConfig": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -40,7 +40,6 @@
     "@svgr/webpack": "^8.0.1",
     "copy-webpack-plugin": "^10.2.4",
     "file-loader": "^6.2.0",
-    "fs-extra": "^11.1.0",
     "ignore": "^5.0.4",
     "picocolors": "^1.1.0",
     "semver": "^7.5.3",

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -71,7 +71,7 @@ export default async function buildExecutor(
   }
 
   if (!directoryExists(options.outputPath)) {
-    mkdirSync(options.outputPath);
+    await mkdir(options.outputPath, { recursive; true });
   }
 
   const builtPackageJson = createPackageJson(

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -8,7 +8,7 @@ import {
 } from '@nx/devkit';
 import { createLockFile, createPackageJson, getLockFileName } from '@nx/js';
 import { join, resolve as pathResolve } from 'path';
-import { copySync, existsSync, mkdir, writeFileSync } from 'fs-extra';
+import { cpSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { gte } from 'semver';
 import { directoryExists } from '@nx/workspace/src/utilities/fileutils';
 import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
@@ -71,7 +71,7 @@ export default async function buildExecutor(
   }
 
   if (!directoryExists(options.outputPath)) {
-    mkdir(options.outputPath);
+    mkdirSync(options.outputPath);
   }
 
   const builtPackageJson = createPackageJson(
@@ -114,8 +114,9 @@ export default async function buildExecutor(
   // This is the default behavior when running `nx build <app>`.
   if (options.outputPath.replace(/\/$/, '') !== projectRoot) {
     createNextConfigFile(options, context);
-    copySync(join(projectRoot, 'public'), join(options.outputPath, 'public'), {
+    cpSync(join(projectRoot, 'public'), join(options.outputPath, 'public'), {
       dereference: true,
+      recursive: true,
     });
   }
   return { success: true };

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -8,9 +8,9 @@ import {
 } from '@nx/devkit';
 import { createLockFile, createPackageJson, getLockFileName } from '@nx/js';
 import { join, resolve as pathResolve } from 'path';
-import { cpSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { gte } from 'semver';
-import { directoryExists } from '@nx/workspace/src/utilities/fileutils';
 import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
 
 import { updatePackageJson } from './lib/update-package-json';
@@ -70,9 +70,7 @@ export default async function buildExecutor(
     }
   }
 
-  if (!directoryExists(options.outputPath)) {
-    await mkdir(options.outputPath, { recursive; true });
-  }
+  await mkdir(options.outputPath, { recursive: true });
 
   const builtPackageJson = createPackageJson(
     context.projectName,

--- a/packages/next/src/executors/build/lib/check-project.ts
+++ b/packages/next/src/executors/build/lib/check-project.ts
@@ -1,5 +1,5 @@
 import { logger } from '@nx/devkit';
-import { readdirSync } from 'fs-extra';
+import { readdirSync } from 'node:fs';
 import { join } from 'path';
 
 export function checkPublicDirectory(root: string) {

--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -80,7 +80,7 @@ export function createNextConfigFile(
     );
 
     if (!existsSync(moduleFileDir)) {
-      mkdirSync(moduleFileDir);
+      mkdirSync(moduleFileDir, { recursive: true });
     }
 
     // We already generate a build version of package.json in the dist folder.

--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -79,9 +79,7 @@ export function createNextConfigFile(
       join(context.root, options.outputPath, moduleFile)
     );
 
-    if (!existsSync(moduleFileDir)) {
-      mkdirSync(moduleFileDir, { recursive: true });
-    }
+    mkdirSync(moduleFileDir, { recursive: true });
 
     // We already generate a build version of package.json in the dist folder.
     if (moduleFile !== 'package.json') {

--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -9,12 +9,11 @@ import {
 import * as ts from 'typescript';
 import {
   copyFileSync,
-  ensureDirSync,
   existsSync,
   mkdirSync,
   readFileSync,
   writeFileSync,
-} from 'fs-extra';
+} from 'node:fs';
 import { dirname, extname, join, relative } from 'path';
 import { findNodes } from '@nx/js';
 
@@ -76,7 +75,14 @@ export function createNextConfigFile(
     projectRoot
   );
   for (const moduleFile of moduleFilesToCopy) {
-    ensureDirSync(dirname(join(context.root, options.outputPath, moduleFile)));
+    const moduleFileDir = dirname(
+      join(context.root, options.outputPath, moduleFile)
+    );
+
+    if (!existsSync(moduleFileDir)) {
+      mkdirSync(moduleFileDir);
+    }
+
     // We already generate a build version of package.json in the dist folder.
     if (moduleFile !== 'package.json') {
       copyFileSync(


### PR DESCRIPTION
Switches from `fs-extra` to using node built in functions instead.

Behaviour should all be the same, though this may bump node requirements to 16.x.

We can probably make this change in a few of the packages if this one ends up passing review. if one of you can let me know what the situation is with node versions we support, that'll be super helpful 🙏 