### PR TITLE
fix(core): nx add should show errors

### DIFF
--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -135,7 +135,7 @@ async function initializePlugin(
   } catch (e) {
     spinner.fail();
     output.addNewline();
-    logger.error(e.message);
+    logger.error(e);
     output.error({
       title: `Failed to initialize ${pkgName}. Please check the error above for more details.`,
     });

--- a/packages/nx/src/utils/child-process.ts
+++ b/packages/nx/src/utils/child-process.ts
@@ -36,7 +36,7 @@ export function runNxSync(
 export async function runNxAsync(
   cmd: string,
   options?: ExecOptions & { cwd?: string; silent?: boolean }
-) {
+): Promise<void> {
   let baseCmd: string;
   if (existsSync(join(workspaceRoot, 'package.json'))) {
     baseCmd = `${getPackageManagerCommand().exec} nx`;
@@ -57,15 +57,15 @@ export async function runNxAsync(
   if (options?.silent) {
     delete options.silent;
   }
-  await new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     const child = exec(
       `${baseCmd} ${cmd}`,
       options,
       (error, stdout, stderr) => {
         if (error) {
-          reject(error);
+          reject(stderr || stdout || error.message);
         } else {
-          resolve(stdout);
+          resolve();
         }
       }
     );


### PR DESCRIPTION
`nx add` errors should be surfaced to users.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Users do not see errors from init generator.

## Expected Behavior
Users see errors from init generator.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
