### PR TITLE
fix(js): @nx/js:init ensures tslib is installed if importHelpers is true

### DIFF
--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -506,7 +506,9 @@ describe('Linter', () => {
       it('should report dependency check issues', () => {
         const rootPackageJson = readJson('package.json');
         const nxVersion = rootPackageJson.devDependencies.nx;
-        const tslibVersion = rootPackageJson.dependencies['tslib'];
+        const tslibVersion =
+          rootPackageJson.dependencies['tslib'] ||
+          rootPackageJson.devDependencies['tslib'];
 
         let out = runCLI(`lint ${mylib}`, {
           silenceError: true,
@@ -547,20 +549,18 @@ describe('Linter', () => {
           `Successfully ran target lint for project ${mylib}`
         );
         const packageJson = readJson(`libs/${mylib}/package.json`);
-        expect(packageJson).toMatchInlineSnapshot(`
-          {
-            "dependencies": {
-              "@nx/devkit": "${nxVersion}",
-              "tslib": "${tslibVersion}",
-            },
-            "main": "./src/index.js",
-            "name": "@proj/${mylib}",
-            "private": true,
-            "type": "commonjs",
-            "typings": "./src/index.d.ts",
-            "version": "0.0.1",
-          }
-        `);
+        expect(packageJson).toMatchObject({
+          dependencies: {
+            '@nx/devkit': nxVersion,
+            tslib: tslibVersion,
+          },
+          main: './src/index.js',
+          name: `@proj/${mylib}`,
+          private: true,
+          type: 'commonjs',
+          typings: './src/index.d.ts',
+          version: '0.0.1',
+        });
 
         // intentionally set the invalid version
         updateJson(`libs/${mylib}/package.json`, (json) => {

--- a/packages/js/src/generators/init/init.spec.ts
+++ b/packages/js/src/generators/init/init.spec.ts
@@ -139,4 +139,31 @@ describe('js init generator', () => {
     expect(tree.exists('.prettierignore')).toBeFalsy();
     expect(tree.exists('.prettierrc')).toBeFalsy();
   });
+
+  it.each`
+    fileName                | importHelpers | shouldAdd
+    ${'tsconfig.json'}      | ${true}       | ${true}
+    ${'tsconfig.base.json'} | ${true}       | ${true}
+    ${'tsconfig.json'}      | ${false}      | ${false}
+    ${'tsconfig.base.json'} | ${false}      | ${false}
+    ${null}                 | ${false}      | ${false}
+  `(
+    'should add tslib if importHelpers is true in base tsconfig',
+    async ({ fileName, importHelpers, shouldAdd }) => {
+      if (fileName) {
+        writeJson(tree, fileName, {
+          compilerOptions: {
+            importHelpers,
+          },
+        });
+      }
+
+      await init(tree, {
+        addTsConfigBase: false,
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(!!packageJson.devDependencies?.['tslib']).toBe(shouldAdd);
+    }
+  );
 });

--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -21,6 +21,7 @@ import {
   swcCoreVersion,
   swcHelpersVersion,
   swcNodeVersion,
+  tsLibVersion,
   typescriptVersion,
 } from '../../utils/versions';
 import { InitSchema } from './schema';
@@ -108,6 +109,16 @@ export async function initGeneratorInternal(
       skipPackageJson: schema.skipPackageJson,
     });
     tasks.push(prettierTask);
+  }
+
+  const rootTsConfigFileName = getRootTsConfigFileName(tree);
+  // If the root tsconfig file uses `importHelpers` then we must install tslib
+  // in order to run tsc for build and typecheck.
+  if (rootTsConfigFileName) {
+    const rootTsConfig = readJson(tree, rootTsConfigFileName);
+    if (rootTsConfig.compilerOptions?.importHelpers) {
+      devDependencies['tslib'] = tsLibVersion;
+    }
   }
 
   const installTask = !schema.skipPackageJson

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -170,10 +170,6 @@ export async function libraryGeneratorInternal(
     ]);
   }
 
-  if (options.bundler !== 'none') {
-    addBundlerDependencies(tree, options);
-  }
-
   if (!options.skipFormat) {
     await formatFiles(tree);
   }
@@ -409,23 +405,6 @@ export async function addLint(
     );
   }
   return task;
-}
-
-function addBundlerDependencies(tree: Tree, options: NormalizedSchema) {
-  updateJson(tree, `${options.projectRoot}/package.json`, (json) => {
-    if (options.bundler === 'tsc') {
-      json.dependencies = {
-        ...json.dependencies,
-        tslib: tsLibVersion,
-      };
-    } else if (options.bundler === 'swc') {
-      json.dependencies = {
-        ...json.dependencies,
-        '@swc/helpers': swcHelpersVersion,
-      };
-    }
-    return json;
-  });
 }
 
 function updateTsConfig(tree: Tree, options: NormalizedSchema) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Sometimes tslib is missing even though it is needed for typechecks.

## Expected Behavior
tslib is installed when needed. i.e. `importHelpers: true`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27656
