### PR TITLE
fix(release): add groupPreVersionCommand to schema, improve logging

### DIFF
--- a/e2e/release/src/pre-version-command.test.ts
+++ b/e2e/release/src/pre-version-command.test.ts
@@ -107,7 +107,7 @@ describe('nx release pre-version command', () => {
     const result4 = runCLI(`release patch -d -g ${groupName} --first-release`);
 
     expect(result4).toContain(
-      `NX   Executing release group pre-version command for ${groupName}`
+      `NX   Executing release group pre-version command for "${groupName}"`
     );
 
     updateJson(`nx.json`, (json) => {

--- a/e2e/release/src/pre-version-command.test.ts
+++ b/e2e/release/src/pre-version-command.test.ts
@@ -106,7 +106,9 @@ describe('nx release pre-version command', () => {
     // command should succeed because the pre-version command will build the package
     const result4 = runCLI(`release patch -d -g ${groupName} --first-release`);
 
-    expect(result4).toContain('NX   Executing pre-version command');
+    expect(result4).toContain(
+      `NX   Executing release group pre-version command for ${groupName}`
+    );
 
     updateJson(`nx.json`, (json) => {
       json.release = {

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -152,25 +152,7 @@
                 ]
               },
               "version": {
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/NxReleaseVersionConfiguration"
-                  },
-                  {
-                    "allOf": [
-                      {
-                        "not": {
-                          "required": ["git"]
-                        }
-                      },
-                      {
-                        "not": {
-                          "required": ["preVersionCommand"]
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "$ref": "#/definitions/NxReleaseGroupVersionConfiguration"
               },
               "changelog": {
                 "oneOf": [
@@ -675,9 +657,32 @@
         },
         "preVersionCommand": {
           "type": "string",
-          "description": "A command to run after validation of nx release configuration, but before versioning begins. Used for preparing build artifacts. If --dry-run is passed, the command is still executed, but with the NX_DRY_RUN environment variable set to 'true'."
+          "description": "A command to run after validation of nx release configuration, but before versioning begins. Useful for preparing build artifacts. If --dry-run is passed, the command is still executed, but with the NX_DRY_RUN environment variable set to 'true'."
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    "NxReleaseGroupVersionConfiguration": {
+      "type": "object",
+      "properties": {
+        "conventionalCommits": {
+          "type": "boolean",
+          "description": "Shorthand for enabling the current version of projects to be resolved from git tags, and the next version to be determined by analyzing commit messages according to the Conventional Commits specification.",
+          "default": false
+        },
+        "generator": {
+          "type": "string"
+        },
+        "generatorOptions": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "groupPreVersionCommand": {
+          "type": "string",
+          "description": "A command to run after validation of nx release configuration AND after the release.version.preVersionCommand (if any), but before versioning begins for this specific group. Useful for preparing build artifacts for the group. If --dry-run is passed, the command is still executed, but with the NX_DRY_RUN environment variable set to 'true'."
+        }
+      },
+      "additionalProperties": false
     },
     "NxReleaseChangelogConfiguration": {
       "type": "object",

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -383,10 +383,14 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     for (const releaseGroup of releaseGroups) {
       const releaseGroupName = releaseGroup.name;
 
-      runPreVersionCommand(releaseGroup.version.groupPreVersionCommand, {
-        dryRun: args.dryRun,
-        verbose: args.verbose,
-      });
+      runPreVersionCommand(
+        releaseGroup.version.groupPreVersionCommand,
+        {
+          dryRun: args.dryRun,
+          verbose: args.verbose,
+        },
+        releaseGroup
+      );
 
       const projectBatches = batchProjectsByGeneratorConfig(
         projectGraph,
@@ -727,13 +731,18 @@ function resolveGeneratorData({
 }
 function runPreVersionCommand(
   preVersionCommand: string,
-  { dryRun, verbose }: { dryRun: boolean; verbose: boolean }
+  { dryRun, verbose }: { dryRun: boolean; verbose: boolean },
+  releaseGroup?: ReleaseGroupWithName
 ) {
   if (!preVersionCommand) {
     return;
   }
 
-  output.logSingleLine(`Executing pre-version command`);
+  output.logSingleLine(
+    releaseGroup
+      ? `Executing release group pre-version command for "${releaseGroup.name}"`
+      : `Executing pre-version command`
+  );
   if (verbose) {
     console.log(`Executing the following pre-version command:`);
     console.log(preVersionCommand);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

"groupPreVersionCommand" was not added to nx-schema.json in #27474 and additional properties can be added without feedback, leading to potential confusion. Additionally, the log for pre-version command was not made specific for group pre version command 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

"groupPreVersionCommand" is in the schema and the logging is more clear


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
