### PR TITLE
fix(core): remove wasi compatibility while db is unsupported in wasi

### DIFF
--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -55,7 +55,7 @@ mio = "0.8"
 portable-pty = { git = "https://github.com/cammisuli/wezterm", rev = "b538ee29e1e89eeb4832fb35ae095564dce34c29" }
 crossterm = "0.27.0"
 ignore-files = "2.1.0"
-rusqlite = { version = "0.32.1", features = ["bundled", "array", "vtab", "wasm32-wasi-vfs"] }
+rusqlite = { version = "0.32.1", features = ["bundled", "array", "vtab"] }
 watchexec = "3.0.1"
 watchexec-events = "2.0.1"
 watchexec-filterer-ignore = "3.0.0"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Users get a `disk i/o` error from connecting to SQL because of a vfs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Not really sure but this might address those errors. Might not. We don't need this at the moment though because the SQL database is not compiled for wasi.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
