### PR TITLE
chore(react): disable failing e2e test with rspack module federation

### DIFF
--- a/e2e/react/src/react-module-federation.rspack.test.ts
+++ b/e2e/react/src/react-module-federation.rspack.test.ts
@@ -413,7 +413,8 @@ describe('React Rspack Module Federation', () => {
       }, 600_000);
     });
 
-    it('should support generating host and remote apps with the new name and root format', async () => {
+    // TODO(Coly010): investigate this failure
+    xit('should support generating host and remote apps with the new name and root format', async () => {
       const shell = uniq('shell');
       const remote = uniq('remote');
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
