### PR TITLE
fix(angular): install the correct version of @typescript-eslint/utils

### DIFF
--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -18,7 +18,7 @@ export const moduleFederationNodeVersion = '~2.5.0';
 export const moduleFederationEnhancedVersion = '0.6.9';
 
 export const angularEslintVersion = '^18.3.0';
-export const typescriptEslintVersion = '^7.16.0';
+export const typescriptEslintVersion = '^8.0.0';
 export const tailwindVersion = '^3.0.2';
 export const postcssVersion = '^8.4.5';
 export const postcssUrlVersion = '~10.1.3';

--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
@@ -16,8 +16,13 @@ import {
 import { getRelativePathToRootTsConfig } from '@nx/js';
 import { addSwcRegisterDependencies } from '@nx/js/src/utils/swc/add-swc-dependencies';
 import { join } from 'path';
-import { nxVersion, typescriptESLintVersion } from '../../utils/versions';
+import {
+  eslint9__typescriptESLintVersion,
+  nxVersion,
+  typescriptESLintVersion,
+} from '../../utils/versions';
 import { workspaceLintPluginDir } from '../../utils/workspace-lint-rules';
+import { useFlatConfig } from '../../utils/flat-config';
 
 export const WORKSPACE_RULES_PROJECT_NAME = 'eslint-rules';
 
@@ -119,7 +124,9 @@ export async function lintWorkspaceRulesProjectGenerator(
       tree,
       {},
       {
-        '@typescript-eslint/utils': typescriptESLintVersion,
+        '@typescript-eslint/utils': useFlatConfig(tree)
+          ? eslint9__typescriptESLintVersion
+          : typescriptESLintVersion,
       }
     )
   );


### PR DESCRIPTION
This PR updates `@typescript-eslint/utils` to the latest version so that it is compat with v8.57 and v9 of ESLint, and removes the peer dep conflict.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28071 
