### PR TITLE
fix(core): Remove nameAndDirectoryFormat option from generators

### DIFF
--- a/docs/generated/packages/angular/generators/component.json
+++ b/docs/generated/packages/angular/generators/component.json
@@ -10,22 +10,16 @@
     "description": "Creates a new Angular component.",
     "additionalProperties": false,
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "The path at which to create the component file, relative to the workspace root. By default, it is set to the root of the project.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where to create the component?"
+      },
       "name": {
         "type": "string",
         "description": "The name of the component.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the component?"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "aliases": ["dir", "path"],
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       },
       "prefix": {
         "type": "string",
@@ -118,7 +112,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "examplesFile": "## Examples\n\n{% tabs %}\n{% tab label=\"Simple Component\" %}\n\nCreate a component named `my-component`:\n\n```bash\nnx g @nx/angular:component apps/my-app/src/lib/my-component/my-component\n```\n\n{% /tab %}\n\n{% tab label=\"Single File Component\" %}\n\nCreate a component named `my-component` with inline styles and inline template:\n\n```bash\nnx g @nx/angular:component apps/my-app/src/lib/my-component/my-component --inlineStyle --inlineTemplate\n```\n\n{% /tab %}\n\n{% tab label=\"Component with OnPush Change Detection Strategy\" %}\n\nCreate a component named `my-component` with OnPush Change Detection Strategy:\n\n```bash\nnx g @nx/angular:component apps/my-app/src/lib/my-component/my-component --changeDetection=OnPush\n```\n\n{% /tab %}\n",
     "presets": []
   },

--- a/docs/generated/packages/angular/generators/directive.json
+++ b/docs/generated/packages/angular/generators/directive.json
@@ -10,22 +10,16 @@
     "description": "Creates a new Angular directive.",
     "additionalProperties": false,
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "The path at which to create the directive file.",
+        "x-prompt": "Where to put the directive?",
+        "$default": { "$source": "argv", "index": 0 }
+      },
       "name": {
         "type": "string",
         "description": "The name of the new directive.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the directive?"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the directive file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "aliases": ["dir", "path"],
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the directive in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       },
       "prefix": {
         "type": "string",
@@ -72,7 +66,7 @@
         "description": "Skip formatting of files."
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "aliases": ["d"],

--- a/docs/generated/packages/angular/generators/pipe.json
+++ b/docs/generated/packages/angular/generators/pipe.json
@@ -10,29 +10,16 @@
     "additionalProperties": false,
     "description": "Creates an Angular pipe.",
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "The path at which to create the pipe file, relative to the workspace root.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "What is the path of the new pipe?"
+      },
       "name": {
         "type": "string",
         "description": "The name of the pipe.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the pipe?"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the pipe file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "aliases": ["dir", "path"],
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the pipe in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "project": {
-        "type": "string",
-        "description": "The name of the project.",
-        "$default": { "$source": "projectName" },
-        "x-dropdown": "projects",
-        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
       },
       "skipTests": {
         "type": "boolean",
@@ -65,7 +52,7 @@
         "description": "Skip formatting of files."
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Generate an Angular Pipe",

--- a/docs/generated/packages/angular/generators/scam-directive.json
+++ b/docs/generated/packages/angular/generators/scam-directive.json
@@ -16,10 +16,15 @@
     "description": "Creates a new, generic Angular directive definition in the given or default project.",
     "additionalProperties": false,
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "The path at which to create the SCAM Directive files, relative to the workspace root.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "What is the path of the new directive?"
+      },
       "name": {
         "type": "string",
         "description": "The name of the directive.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the directive?",
         "x-priority": "important"
       },
@@ -85,7 +90,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Generate a directive with an accompanying Single Component Angular Module (SCAM).",

--- a/docs/generated/packages/angular/generators/scam-pipe.json
+++ b/docs/generated/packages/angular/generators/scam-pipe.json
@@ -9,37 +9,24 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nx/angular:scam-pipe --project=my-lib --flat=false my-transformation",
+        "command": "nx g @nx/angular:scam-pipe mylib/src/lib/my-transformation/my-transformation",
         "description": "Generates a `MyTransformationPipe` in a `my-transformation` folder in the `my-lib` project"
       }
     ],
     "description": "Creates a new, generic Angular pipe definition in the given or default project.",
     "additionalProperties": false,
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "The path at which to create the pipe file, relative to the workspace root.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "What is the path of the new pipe?"
+      },
       "name": {
         "type": "string",
         "description": "The name of the pipe.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the pipe?",
         "x-priority": "important"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "aliases": ["dir", "path"],
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "project": {
-        "type": "string",
-        "description": "The name of the project.",
-        "$default": { "$source": "projectName" },
-        "x-dropdown": "projects",
-        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
       },
       "skipTests": {
         "type": "boolean",
@@ -71,7 +58,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Generate a pipe with an accompanying Single Component Angular Module (SCAM).",

--- a/docs/generated/packages/angular/generators/scam.json
+++ b/docs/generated/packages/angular/generators/scam.json
@@ -9,36 +9,23 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nx/angular:scam my-sample --directory=my-lib/src/lib/my-sample",
+        "command": "nx g @nx/angular:scam my-lib/src/lib/my-sample/my-sample",
         "description": "Generate a `MySampleComponent` component in the `my-lib` library."
       }
     ],
     "description": "Creates a new Angular SCAM.",
     "additionalProperties": false,
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "The path at which to create the SCAM file, relative to the workspace root.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "What is the path of the new SCAM?"
+      },
       "name": {
         "type": "string",
         "description": "The name of the component.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the component?"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the SCAM files. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "aliases": ["dir", "path"],
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the SCAM in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "project": {
-        "type": "string",
-        "description": "The name of the project.",
-        "$default": { "$source": "projectName" },
-        "x-dropdown": "projects",
-        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
       },
       "displayBlock": {
         "description": "Specifies if the style will contain `:host { display: block; }`.",
@@ -125,7 +112,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Generate a component with an accompanying Single Component Angular Module (SCAM).",

--- a/docs/generated/packages/expo/generators/component.json
+++ b/docs/generated/packages/expo/generators/component.json
@@ -9,19 +9,25 @@
     "type": "object",
     "examples": [
       {
-        "command": "g @nx/expo:component my-component --directory=mylib/my-component",
+        "command": "g @nx/expo:component mylib/my-component --name my-component",
         "description": "Generate a component in the mylib library"
       },
       {
-        "command": "g @nx/expo:component my-component --directory=mylib/my-component --classComponent",
+        "command": "g @nx/expo:component mylib/my-component --name my-component --classComponent",
         "description": "Generate a class component in the mylib library"
       }
     ],
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the component will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the component be generated?",
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "The name of the component.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the component?"
       },
       "js": {
@@ -40,16 +46,6 @@
         "description": "When true, does not create \"spec.ts\" test files for the new component.",
         "default": false
       },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
       "export": {
         "type": "boolean",
         "description": "When true, the component is exported from the project index.ts (if it exists).",
@@ -64,7 +60,7 @@
         "default": false
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Create a component",

--- a/docs/generated/packages/nest/generators/class.json
+++ b/docs/generated/packages/nest/generators/class.json
@@ -9,28 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the class will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the class be generated?"
+      },
       "name": {
         "description": "The name of the class.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "project": {
-        "description": "The Nest project to target.",
-        "type": "string",
-        "$default": { "$source": "projectName" },
-        "alias": "p",
-        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -57,7 +45,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `class` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/controller.json
+++ b/docs/generated/packages/nest/generators/controller.json
@@ -18,7 +18,6 @@
       "name": {
         "description": "The name of the controller.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
       },
       "skipFormat": {

--- a/docs/generated/packages/nest/generators/controller.json
+++ b/docs/generated/packages/nest/generators/controller.json
@@ -9,21 +9,17 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the controller will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the controller be generated?"
+      },
       "name": {
         "description": "The name of the controller.",
         "type": "string",
         "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -53,7 +49,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `controller` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/decorator.json
+++ b/docs/generated/packages/nest/generators/decorator.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the decorator will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the decorator be generated?"
+      },
       "name": {
         "description": "The name of the decorator.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -38,7 +33,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `decorator` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/filter.json
+++ b/docs/generated/packages/nest/generators/filter.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the filter will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the filter be generated?"
+      },
       "name": {
         "description": "The name of the filter.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "type": "boolean",
@@ -44,7 +39,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `filter` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/gateway.json
+++ b/docs/generated/packages/nest/generators/gateway.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the gateway will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the gateway be generated?"
+      },
       "name": {
         "description": "The name of the gateway.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -44,7 +39,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `gateway` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/guard.json
+++ b/docs/generated/packages/nest/generators/guard.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the guard will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the guard be generated?"
+      },
       "name": {
         "description": "The name of the guard.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",

--- a/docs/generated/packages/nest/generators/interceptor.json
+++ b/docs/generated/packages/nest/generators/interceptor.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the interceptor will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the interceptor be generated?"
+      },
       "name": {
         "description": "The name of the interceptor.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",

--- a/docs/generated/packages/nest/generators/interface.json
+++ b/docs/generated/packages/nest/generators/interface.json
@@ -9,28 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the interface will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the interface be generated?"
+      },
       "name": {
         "description": "The name of the interface.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "project": {
-        "description": "The Nest project to target.",
-        "type": "string",
-        "$default": { "$source": "projectName" },
-        "alias": "p",
-        "x-deprecated": "Provide The `directory` option instead and use the `as-provided` format. the project will be determined from the directory provided. It will be removed in Nx v20."
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -46,7 +34,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `interface` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/middleware.json
+++ b/docs/generated/packages/nest/generators/middleware.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the middleware will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the middleware be generated?"
+      },
       "name": {
         "description": "The name of the middleware.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -44,7 +39,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `middleware` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/module.json
+++ b/docs/generated/packages/nest/generators/module.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the module will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the module be generated?"
+      },
       "name": {
         "description": "The name of the module.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -48,7 +43,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `module` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/pipe.json
+++ b/docs/generated/packages/nest/generators/pipe.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the pipe will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the pipe be generated?"
+      },
       "name": {
         "description": "The name of the pipe.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -44,7 +39,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `pipe` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/provider.json
+++ b/docs/generated/packages/nest/generators/provider.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the provider will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the provider be generated?"
+      },
       "name": {
         "description": "The name of the provider.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -44,7 +39,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `provider` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/resolver.json
+++ b/docs/generated/packages/nest/generators/resolver.json
@@ -9,21 +9,16 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "description": "Path where the resolver will be generated.",
+        "type": "string",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the resolver be generated?"
+      },
       "name": {
         "description": "The name of the resolver.",
         "type": "string",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -44,7 +39,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `resolver` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/resource.json
+++ b/docs/generated/packages/nest/generators/resource.json
@@ -18,7 +18,6 @@
       "name": {
         "type": "string",
         "description": "The name of the resource.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for this resource (plural, e.g., `users`)?"
       },
       "skipFormat": {
@@ -80,7 +79,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `resource` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/resource.json
+++ b/docs/generated/packages/nest/generators/resource.json
@@ -9,21 +9,17 @@
     "cli": "nx",
     "type": "object",
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the resource will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the resource be generated?"
+      },
       "name": {
         "type": "string",
         "description": "The name of the resource.",
         "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for this resource (plural, e.g., `users`)?"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",

--- a/docs/generated/packages/nest/generators/service.json
+++ b/docs/generated/packages/nest/generators/service.json
@@ -15,16 +15,6 @@
         "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use?"
       },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
-      "directory": {
-        "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-        "type": "string",
-        "aliases": ["dir", "path"]
-      },
       "skipFormat": {
         "description": "Skip formatting files.",
         "type": "boolean",

--- a/docs/generated/packages/next/generators/component.json
+++ b/docs/generated/packages/next/generators/component.json
@@ -9,10 +9,16 @@
     "description": "Create a React Component for Next.",
     "type": "object",
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the component will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the component be generated?",
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "The name of the component.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the component?",
         "x-priority": "important"
       },
@@ -56,17 +62,6 @@
         "default": false,
         "x-priority": "internal"
       },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-        "alias": "dir",
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
       "export": {
         "type": "boolean",
         "description": "When true, the component is exported from the project index.ts (if it exists).",
@@ -85,7 +80,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "examplesFile": "## Examples\n\n{% tabs %}\n{% tab label=\"Create an app component\" %}\n\n```shell\nnx g component apps/my-app/src/lib/my-cmp/my-cmp\n```\n\n{% /tab %}\n{% tab label=\"Create a component without its own folder\" %}\n\nRunning the following will create a component under `apps/my-app/components/my-cmp.tsx` rather than `apps/my-app/components/my-cmp/my-cmp.tsx`.\n\n```shell\nnx g component apps/my-app/src/lib/my-cmp\n```\n\n{% /tab %}\n{% tab label=\"Create component in a custom directory\" %}\n\nRunning the following will create a component under `apps/my-app/foo/my-cmp.tsx` rather than `apps/my-app/my-cmp/my-cmp.tsx`.\n\n```shell\nnx g component apps/my-app/foo/my-cmp\n```\n\n{% /tab %}\n{% /tabs %}\n",
     "presets": []
   },

--- a/docs/generated/packages/next/generators/page.json
+++ b/docs/generated/packages/next/generators/page.json
@@ -9,30 +9,18 @@
     "description": "Create a Page for Next.",
     "type": "object",
     "properties": {
-      "project": {
+      "path": {
         "type": "string",
-        "description": "The name of the project.",
-        "alias": "p",
-        "$default": { "$source": "projectName" },
-        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
+        "description": "Path where the page will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the page be generated?",
+        "x-priority": "important"
       },
       "name": {
         "type": "string",
-        "description": "The name of the component.",
-        "$default": { "$source": "argv", "index": 0 },
-        "x-prompt": "What name would you like to use for the component?",
+        "description": "The name of the page.",
+        "x-prompt": "What name would you like to use for the page?",
         "x-priority": "important"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the page file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-        "alias": "dir",
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       },
       "style": {
         "description": "The file extension to be used for style files.",

--- a/docs/generated/packages/next/generators/page.json
+++ b/docs/generated/packages/next/generators/page.json
@@ -86,7 +86,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "examplesFile": "## Examples\n\n{% tabs %}\n{% tab label=\"Create static page in an app\" %}\n\n```shell\nnx g page apps/my-app/pages/my-page\n```\n\n{% /tab %}\n{% tab label=\"Create dynamic page in an app\" %}\n\nThe following creates a page under `apps/my-app/pages/products/[id].tsx`.\n\n```shell\nnx g page \"apps/my-app/pages/products/[id]\"\n```\n\n{% /tab %}\n\n{% /tabs %}\n",
     "presets": []
   },

--- a/docs/generated/packages/plugin/generators/executor.json
+++ b/docs/generated/packages/plugin/generators/executor.json
@@ -16,17 +16,17 @@
       }
     ],
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path at which to generate the executor file.",
+        "x-prompt": "What path would you like to use for the executor?",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "Executor name.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the executor?",
-        "x-priority": "important"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the executor file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "aliases": ["dir"],
         "x-priority": "important"
       },
       "description": {
@@ -50,11 +50,6 @@
         "default": false,
         "description": "Do not add an eslint configuration for plugin json files."
       },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the executor in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
       "skipFormat": {
         "type": "boolean",
         "description": "Skip formatting files.",
@@ -62,7 +57,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "additionalProperties": false,
     "presets": []
   },

--- a/docs/generated/packages/plugin/generators/generator.json
+++ b/docs/generated/packages/plugin/generators/generator.json
@@ -10,22 +10,22 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g generator my-generator --project=my-plugin",
+        "command": "nx g generator libs/my-plugin/src/generators//my-generator",
         "description": "Generate `libs/my-plugin/src/generators/my-generator`"
       }
     ],
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the generator will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the generator be generated?",
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "Generator name.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the generator?",
-        "x-priority": "important"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the generator file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "aliases": ["dir"],
         "x-priority": "important"
       },
       "description": {
@@ -49,14 +49,9 @@
         "default": false,
         "description": "Do not format files with prettier.",
         "x-priority": "internal"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the generator in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "additionalProperties": false,
     "presets": []
   },

--- a/docs/generated/packages/plugin/generators/migration.json
+++ b/docs/generated/packages/plugin/generators/migration.json
@@ -10,21 +10,22 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g migration my-migration --project=my-plugin --version=1.0.0",
-        "description": "Adds a new migration to the project `my-plugin`, which will be triggered when migrating to version 1.0.0 or above from a previous version."
+        "command": "nx g migration my-plugin/my-migration --version=1.0.0",
+        "description": "Adds a new migration inside `my-plugin`, which will be triggered when migrating to version 1.0.0 or above from a previous version."
       }
     ],
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the migration will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the migration be generated?",
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "Migration name.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-priority": "important"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the migration file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "aliases": ["dir"]
       },
       "description": {
         "type": "string",
@@ -47,14 +48,9 @@
         "type": "boolean",
         "default": false,
         "description": "Do not eslint configuration for plugin json files."
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the migration in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       }
     },
-    "required": ["packageVersion"],
+    "required": ["packageVersion", "path"],
     "additionalProperties": false,
     "presets": []
   },

--- a/docs/generated/packages/react-native/generators/component.json
+++ b/docs/generated/packages/react-native/generators/component.json
@@ -10,19 +10,24 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nx/react-native:component my-component --directory=mylib/src/lib/my-component",
+        "command": "nx g @nx/react-native:component mylib/src/lib/my-component/my-component ",
         "description": "Generate a component in the `mylib` library"
       },
       {
-        "command": "nx g @nx/react-native:component my-component --directory=mylib/src/lib/my-component --classComponent",
+        "command": "nx g @nx/react-native:component mylib/src/lib/my-component/my-component --classComponent",
         "description": "Generate a class component in the `mylib` library"
       }
     ],
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "The path at which to create the component file.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "What path would you like to use for the component?"
+      },
       "name": {
         "type": "string",
         "description": "The name of the component.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the component?"
       },
       "js": {
@@ -34,16 +39,6 @@
         "type": "boolean",
         "description": "When true, does not create `spec.ts` test files for the new component.",
         "default": false
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       },
       "export": {
         "type": "boolean",
@@ -59,7 +54,7 @@
         "default": false
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Create a React Native component.",

--- a/docs/generated/packages/react/generators/component.json
+++ b/docs/generated/packages/react/generators/component.json
@@ -9,10 +9,16 @@
     "description": "Create a React Component for Nx.",
     "type": "object",
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the component will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the component be generated?",
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "The name of the component.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the component?",
         "x-priority": "important"
       },
@@ -61,17 +67,6 @@
         "default": false,
         "x-priority": "internal"
       },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-        "alias": "dir",
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
       "export": {
         "type": "boolean",
         "description": "When true, the component is exported from the project `index.ts` (if it exists).",
@@ -110,7 +105,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "examplesFile": "## Examples\n\n{% tabs %}\n{% tab label=\"Simple Component\" %}\n\nCreate a component named `my-component` under the `libs/ui` project:\n\n```shell\nnx g @nx/react:component libs/ui/src/my-component\n```\n\n{% /tab %}\n\n{% tab label=\"Standalone Component\" %}\n\nCreate a class component named `my-component` under the `libs/ui` project:\n\n```shell\nnx g @nx/react:component libs/ui/src/my-component --classComponent\n```\n\n{% /tab %}\n",
     "presets": []
   },

--- a/docs/generated/packages/react/generators/hook.json
+++ b/docs/generated/packages/react/generators/hook.json
@@ -10,15 +10,21 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g hook my-hook --project=mylib",
-        "description": "Generate a hook in the `mylib` library"
+        "command": "nx g hook mylib/my-hook",
+        "description": "Generate a hook `my-hook` in the `mylib` library"
       }
     ],
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the hook will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the hook be generated?",
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "The name of the hook.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the hook?",
         "x-priority": "important"
       },

--- a/docs/generated/packages/react/generators/redux.json
+++ b/docs/generated/packages/react/generators/redux.json
@@ -9,23 +9,17 @@
     "description": "Create a Redux state slice for a React project.",
     "type": "object",
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the Redux slice will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the Redux slice be generated?",
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "Redux slice name.",
-        "$default": { "$source": "argv", "index": 0 },
         "x-priority": "important"
-      },
-      "directory": {
-        "type": "string",
-        "alias": "dir",
-        "default": "",
-        "description": "The directory at which to create the Redux files. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       },
       "appProject": {
         "type": "string",
@@ -38,7 +32,7 @@
         "default": false
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Create a Redux slice for a project.",

--- a/docs/generated/packages/remix/generators/resource-route.json
+++ b/docs/generated/packages/remix/generators/resource-route.json
@@ -20,11 +20,6 @@
         "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar')"
       },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the styles in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
-      },
       "action": {
         "type": "boolean",
         "description": "Generate an action function",

--- a/docs/generated/packages/remix/generators/route.json
+++ b/docs/generated/packages/remix/generators/route.json
@@ -16,14 +16,9 @@
     "properties": {
       "path": {
         "type": "string",
-        "description": "The route path or path to the filename of the route. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
+        "description": "The route path or path to the filename of the route.",
         "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar')"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the route in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and path relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       },
       "style": {
         "type": "string",

--- a/docs/generated/packages/remix/generators/style.json
+++ b/docs/generated/packages/remix/generators/style.json
@@ -19,11 +19,6 @@
         "description": "Route path",
         "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar.tsx')"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the styles in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
       }
     },
     "required": ["path"],

--- a/docs/generated/packages/vue/generators/component.json
+++ b/docs/generated/packages/vue/generators/component.json
@@ -10,22 +10,26 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nx/vue:component --directory=my-app/src/app/one --name=one --nameAndDirectoryFormat=as-provided --unitTestRunner=vitest",
-        "description": "Generate a component in the `my-app` application"
+        "command": "nx g @nx/vue:component my-app/src/app/one --name=one --unitTestRunner=vitest",
+        "description": "Generate a component `one` in the `my-app` application at my-app/src/app/one"
+      },
+      {
+        "command": "nx g @nx/vue:component my-app/src/app/one",
+        "description": "Generate a component `one` in the `my-app` application at my-app/src/app/one"
       }
     ],
     "properties": {
+      "path": {
+        "type": "string",
+        "description": "Path where the component will be generated.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Where should the component be generated?",
+        "x-priority": "important"
+      },
       "name": {
         "type": "string",
         "description": "The name of the component.",
-        "$default": { "$source": "argv", "index": 0 },
-        "x-prompt": "What name would you like to use for the component?",
-        "x-priority": "important"
-      },
-      "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-        "type": "string",
-        "enum": ["as-provided", "derived"]
+        "x-prompt": "What name would you like to use for the component?"
       },
       "js": {
         "type": "boolean",
@@ -37,12 +41,6 @@
         "description": "When true, does not create `spec.ts` test files for the new component.",
         "default": false,
         "x-priority": "internal"
-      },
-      "directory": {
-        "type": "string",
-        "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-        "alias": "dir",
-        "x-priority": "important"
       },
       "export": {
         "type": "boolean",
@@ -71,7 +69,7 @@
         "x-priority": "internal"
       }
     },
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "aliases": ["c"],

--- a/e2e/angular/src/cypress-component-tests.test.ts
+++ b/e2e/angular/src/cypress-component-tests.test.ts
@@ -136,7 +136,7 @@ function createApp(appName: string) {
     `generate @nx/angular:app ${appName} --bundler=webpack --project-name-and-root-format=as-provided --no-interactive`
   );
   runCLI(
-    `generate @nx/angular:component fancy-component --directory=${appName}/src/lib/fancy-component --no-interactive`
+    `generate @nx/angular:component ${appName}/src/lib/fancy-component/fancy-component --no-interactive`
   );
 }
 
@@ -145,10 +145,10 @@ function createLib(projectName: string, appName: string, libName: string) {
     `generate @nx/angular:lib ${libName} --project-name-and-root-format=as-provided --no-interactive`
   );
   runCLI(
-    `generate @nx/angular:component btn --directory=${libName}/src/lib/btn --inlineTemplate --inlineStyle --export --no-interactive`
+    `generate @nx/angular:component ${libName}/src/lib/btn/btn --inlineTemplate --inlineStyle --export --no-interactive`
   );
   runCLI(
-    `generate @nx/angular:component btn-standalone --directory=${libName}/src/lib/btn-standalone --inlineTemplate --inlineStyle --export --standalone --no-interactive`
+    `generate @nx/angular:component ${libName}/src/lib/btn-standalone/btn-standalone --inlineTemplate --inlineStyle --export --standalone --no-interactive`
   );
   updateFile(
     `${libName}/src/lib/btn/btn.component.ts`,
@@ -191,11 +191,11 @@ function createBuildableLib(projectName: string, libName: string) {
   );
   // create cmp for lib
   runCLI(
-    `generate @nx/angular:component input --directory=${libName}/src/lib/input --inlineTemplate --inlineStyle --export --no-interactive`
+    `generate @nx/angular:component ${libName}/src/lib/input/input --inlineTemplate --inlineStyle --export --no-interactive`
   );
   // create standlone cmp for lib
   runCLI(
-    `generate @nx/angular:component input-standalone --directory=${libName}/src/lib/input-standalone --inlineTemplate --inlineStyle --export --standalone --no-interactive`
+    `generate @nx/angular:component ${libName}/src/lib/input-standalone/input-standalone --inlineTemplate --inlineStyle --export --standalone --no-interactive`
   );
   // update cmp implmentation to use tailwind clasasserting in tests
   updateFile(

--- a/e2e/cypress/src/cypress-legacy.test.ts
+++ b/e2e/cypress/src/cypress-legacy.test.ts
@@ -49,7 +49,7 @@ describe('Cypress E2E Test runner (legacy)', () => {
         { env: { NX_ADD_PLUGINS: 'false' } }
       );
       runCLI(
-        `generate @nx/react:component btn --directory=${appName}/src/app/btn --no-interactive`,
+        `generate @nx/react:component ${appName}/src/app/btn/btn --no-interactive`,
         { env: { NX_ADD_PLUGINS: 'false' } }
       );
       runCLI(

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -158,7 +158,7 @@ export default defineConfig({
         `generate @nx/next:app ${appName} --directory=apps/${appName} --e2eTestRunner=none --no-interactive  --projectNameAndRootFormat=as-provided`
       );
       runCLI(
-        `generate @nx/next:component btn --project=${appName} --directory=apps/${appName}/components --nameAndDirectoryFormat=as-provided --no-interactive`
+        `generate @nx/next:component apps/${appName}/components/btn --no-interactive`
       );
       runCLI(
         `generate @nx/next:cypress-component-configuration --project=${appName} --generate-tests --no-interactive`
@@ -186,7 +186,7 @@ export default defineConfig({
         `generate @nx/angular:app ${appName} --directory=apps/${appName} --e2eTestRunner=none --no-interactive --bundler=webpack`
       );
       runCLI(
-        `generate @nx/angular:component btn --directory=apps/${appName}/src/app/btn --no-interactive`
+        `generate @nx/angular:component apps/${appName}/src/app/btn/btn --no-interactive`
       );
       runCLI(
         `generate @nx/angular:cypress-component-configuration --project=${appName} --generate-tests --no-interactive`

--- a/e2e/expo/src/expo-legacy.test.ts
+++ b/e2e/expo/src/expo-legacy.test.ts
@@ -55,7 +55,7 @@ describe('@nx/expo (legacy)', () => {
     const componentName = uniq('Component');
 
     runCLI(
-      `generate @nx/expo:component ${componentName} --directory=libs/${libName}/src/${componentName} --export --no-interactive`
+      `generate @nx/expo:component libs/${libName}/src/${componentName} --name ${componentName} --export --no-interactive`
     );
 
     updateFile(`apps/${appName}/src/app/App.tsx`, (content) => {

--- a/e2e/next/src/next-component-tests.test.ts
+++ b/e2e/next/src/next-component-tests.test.ts
@@ -121,7 +121,7 @@ function createAppWithCt(appName: string) {
     `generate @nx/next:app ${appName} --directory=apps/${appName} --no-interactive --appDir=false --src=false --projectNameAndRootFormat=as-provided`
   );
   runCLI(
-    `generate @nx/next:component button --project=${appName} --directory=apps/${appName}/components --nameAndDirectoryFormat=as-provided --no-interactive`
+    `generate @nx/next:component apps/${appName}/components/button --no-interactive`
   );
   createFile(
     `apps/${appName}/public/data.json`,
@@ -191,7 +191,7 @@ function createLibWithCt(libName: string, buildable: boolean) {
   );
 
   runCLI(
-    `generate @nx/next:component button --directory=libs/${libName}/src/lib --export --no-interactive`
+    `generate @nx/next:component libs/${libName}/src/lib/button --export --no-interactive`
   );
   updateFile(`libs/${libName}/src/lib/button.tsx`, (content) => {
     return `import { useEffect, useState } from 'react';

--- a/e2e/next/src/next-storybook.test.ts
+++ b/e2e/next/src/next-storybook.test.ts
@@ -18,7 +18,7 @@ describe('Next.js Storybook', () => {
       `generate @nx/next:app ${appName} --e2eTestRunner=none --project-name-and-root-format=as-provided --no-interactive`
     );
     runCLI(
-      `generate @nx/next:component foo --directory=${appName}/components/foo --nameAndDirectoryFormat=as-provided --no-interactive`
+      `generate @nx/next:component ${appName}/components/foo/foo --no-interactive`
     );
   });
 

--- a/e2e/nuxt/src/nuxt.test.ts
+++ b/e2e/nuxt/src/nuxt.test.ts
@@ -20,7 +20,7 @@ describe('Nuxt Plugin', () => {
       `generate @nx/nuxt:app ${app} --unitTestRunner=vitest --projectNameAndRootFormat=as-provided --e2eTestRunner=cypress`
     );
     runCLI(
-      `generate @nx/nuxt:component --directory=${app}/src/components/one --name=one --nameAndDirectoryFormat=as-provided --unitTestRunner=vitest`
+      `generate @nx/nuxt:component ${app}/src/components/one/one --name=one --unitTestRunner=vitest`
     );
   });
 

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -60,7 +60,7 @@ describe('Nx Plugin', () => {
 
     runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
     runCLI(
-      `generate @nx/plugin:migration --directory=${plugin}/src/migrations/update-${version} --packageVersion=${version} --packageJsonUpdates=false`
+      `generate @nx/plugin:migration --path=${plugin}/src/migrations/update-${version} --packageVersion=${version} --packageJsonUpdates=false`
     );
 
     const lintResults = runCLI(`lint ${plugin}`);
@@ -92,7 +92,7 @@ describe('Nx Plugin', () => {
 
     runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
     runCLI(
-      `generate @nx/plugin:generator ${generator} --directory=${plugin}/src/generators/${generator}`
+      `generate @nx/plugin:generator ${plugin}/src/generators/${generator} --name ${generator}`
     );
 
     const lintResults = runCLI(`lint ${plugin}`);
@@ -129,7 +129,7 @@ describe('Nx Plugin', () => {
 
     runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
     runCLI(
-      `generate @nx/plugin:executor ${executor} --directory=${plugin}/src/executors/${executor} --includeHasher`
+      `generate @nx/plugin:executor --name ${executor} --path=${plugin}/src/executors/${executor} --includeHasher`
     );
 
     const lintResults = runCLI(`lint ${plugin}`);
@@ -178,31 +178,31 @@ describe('Nx Plugin', () => {
     runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
 
     runCLI(
-      `generate @nx/plugin:generator ${goodGenerator} --directory=${plugin}/src/generators/${goodGenerator}`
+      `generate @nx/plugin:generator --name=${goodGenerator} --path=${plugin}/src/generators/${goodGenerator}`
     );
 
     runCLI(
-      `generate @nx/plugin:generator ${badFactoryPath} --directory=${plugin}/src/generators/${badFactoryPath}`
+      `generate @nx/plugin:generator --name=${badFactoryPath} --path=${plugin}/src/generators/${badFactoryPath}`
     );
 
     runCLI(
-      `generate @nx/plugin:executor ${goodExecutor} --directory=${plugin}/src/executors/${goodExecutor}`
+      `generate @nx/plugin:executor --name=${goodExecutor} --path=${plugin}/src/executors/${goodExecutor}`
     );
 
     runCLI(
-      `generate @nx/plugin:executor ${badExecutorBadImplPath} --directory=${plugin}/src/executors/${badExecutorBadImplPath}`
+      `generate @nx/plugin:executor --name=${badExecutorBadImplPath} --path=${plugin}/src/executors/${badExecutorBadImplPath}`
     );
 
     runCLI(
-      `generate @nx/plugin:migration ${badMigrationVersion} --directory=${plugin} --packageVersion="invalid"`
+      `generate @nx/plugin:migration --name=${badMigrationVersion} --path=${plugin}/src/migrations --packageVersion="invalid"`
     );
 
     runCLI(
-      `generate @nx/plugin:migration ${missingMigrationVersion} --directory=${plugin}/migrations/0.1.0 --packageVersion="0.1.0"`
+      `generate @nx/plugin:migration --name=${missingMigrationVersion} --path=${plugin}/migrations/0.1.0 --packageVersion="0.1.0"`
     );
 
     runCLI(
-      `generate @nx/plugin:migration ${goodMigration} --directory=${plugin}/migrations/0.1.0  --packageVersion="0.1.0"`
+      `generate @nx/plugin:migration --name=${goodMigration} --path=${plugin}/migrations/0.1.0  --packageVersion="0.1.0"`
     );
 
     updateFile(`${plugin}/generators.json`, (f) => {
@@ -348,11 +348,11 @@ describe('Nx Plugin', () => {
       const generatedProject = uniq('project');
 
       runCLI(
-        `generate @nx/plugin:generator ${generator} --directory=${plugin}/src/generators/${generator}`
+        `generate @nx/plugin:generator --name ${generator} --path ${plugin}/src/generators/${generator}`
       );
 
       runCLI(
-        `generate @nx/plugin:executor ${executor} --directory=${plugin}/src/executors/${executor}`
+        `generate @nx/plugin:executor --name ${executor} --path ${plugin}/src/executors/${executor}`
       );
 
       updateFile(
@@ -389,7 +389,7 @@ describe('Nx Plugin', () => {
 
       expect(() => {
         runCLI(
-          `generate @nx/plugin:generator ${generator} --directory=${plugin}/src/generators/${generator}`
+          `generate @nx/plugin:generator ${plugin}/src/generators/${generator} --name ${generator}`
         );
 
         runCLI(

--- a/e2e/react-native/src/react-native-legacy.test.ts
+++ b/e2e/react-native/src/react-native-legacy.test.ts
@@ -57,7 +57,7 @@ describe('@nx/react-native (legacy)', () => {
   it('should test and lint', async () => {
     const componentName = uniq('Component');
     runCLI(
-      `generate @nx/react-native:component ${componentName} --directory=libs/${libName}/src/lib/${componentName} --export --no-interactive`
+      `generate @nx/react-native:component libs/${libName}/src/lib/${componentName}/${componentName} --export --no-interactive`
     );
 
     updateFile(`apps/${appName}/src/app/App.tsx`, (content) => {

--- a/e2e/react-native/src/react-native-legacy.test.ts
+++ b/e2e/react-native/src/react-native-legacy.test.ts
@@ -189,7 +189,7 @@ describe('@nx/react-native (legacy)', () => {
     const componentName = uniq('Component');
 
     runCLI(
-      `generate @nx/react-native:component ${componentName} --directory=libs/${libName}/src/lib/${componentName} --export`
+      `generate @nx/react-native:component libs/${libName}/src/lib/${componentName}/${componentName} --export`
     );
     expect(() => {
       runCLI(`build ${libName}`);

--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -43,13 +43,13 @@ describe('React Cypress Component Tests', () => {
     }));
 
     runCLI(
-      `generate @nx/react:component fancy-cmp --directory=apps/${appName}/src/app/fancy-cmp --no-interactive`
+      `generate @nx/react:component apps/${appName}/src/app/fancy-cmp/fancy-cmp --no-interactive`
     );
     runCLI(
       `generate @nx/react:lib ${usedInAppLibName} --directory=libs/${usedInAppLibName} --no-interactive --unitTestRunner=jest`
     );
     runCLI(
-      `generate @nx/react:component btn --directory=libs/${usedInAppLibName}/src/lib/btn --export --no-interactive`
+      `generate @nx/react:component libs/${usedInAppLibName}/src/lib/btn/btn --export --no-interactive`
     );
     // makes sure custom webpack is loading
     createFile(

--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -111,7 +111,7 @@ export default App;`
       `generate @nx/react:lib ${buildableLibName} --directory=libs/${buildableLibName} --buildable --no-interactive --unitTestRunner=jest`
     );
     runCLI(
-      `generate @nx/react:component input --directory=libs/${buildableLibName}/src/lib/input --export --no-interactive`
+      `generate @nx/react:component libs/${buildableLibName}/src/lib/input/input --export --no-interactive`
     );
 
     checkFilesExist(`libs/${buildableLibName}/src/lib/input/input.tsx`);

--- a/e2e/react/src/react-vite.test.ts
+++ b/e2e/react/src/react-vite.test.ts
@@ -92,14 +92,14 @@ describe('Build React applications and libraries with Vite', () => {
     }).toThrow();
 
     runCLI(
-      `generate @nx/react:component comp1 --inSourceTests --export --directory=libs/${viteLib}/src/lib/comp1 --no-interactive`
+      `generate @nx/react:component libs/${viteLib}/src/lib/comp1/comp1 --inSourceTests --export --no-interactive`
     );
     expect(() => {
       checkFilesExist(`libs/${viteLib}/src/lib/comp1/comp1.spec.tsx`);
     }).toThrow();
 
     runCLI(
-      `generate @nx/react:component comp2 --export --directory=libs/${viteLib}/src/lib/comp2 --no-interactive`
+      `generate @nx/react:component libs/${viteLib}/src/lib/comp2/comp2 --export --no-interactive`
     );
     checkFilesExist(`libs/${viteLib}/src/lib/comp2/comp2.spec.tsx`);
 

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -113,7 +113,7 @@ describe('React Applications', () => {
         `generate @nx/react:lib ${libName} --directory=libs${libName} --style=css --no-interactive --unit-test-runner=jest --skipFormat`
       );
       runCLI(
-        `generate @nx/react:lib ${libWithNoComponents} --directory=libs${libWithNoComponents} --no-interactive --no-component --unit-test-runner=jest --skipFormat`
+        `generate @nx/react:lib ${libWithNoComponents} --directory=libs/${libWithNoComponents} --no-interactive --no-component --unit-test-runner=jest --skipFormat`
       );
 
       // Libs should not include package.json by default
@@ -219,13 +219,13 @@ describe('React Applications', () => {
         `g @nx/react:app ${appName} --directory=apps/${appName} --bundler=webpack --no-interactive --skipFormat`
       );
       runCLI(
-        `g @nx/react:redux lemon --directory=apps/${appName}/src/app/lemon --skipFormat`
+        `g @nx/react:redux apps/${appName}/src/app/lemon/lemon --skipFormat`
       );
       runCLI(
         `g @nx/react:lib ${libName} --directory=libs/${libName} --unit-test-runner=jest --no-interactive --skipFormat`
       );
       runCLI(
-        `g @nx/react:redux orange --directory=libs/${libName}/src/lib/orange --skipFormat`
+        `g @nx/react:redux libs/${libName}/src/lib/orange/orange --skipFormat`
       );
 
       let lintResults = runCLI(`lint ${appName}`);

--- a/e2e/workspace-create/src/create-nx-plugin.test.ts
+++ b/e2e/workspace-create/src/create-nx-plugin.test.ts
@@ -37,10 +37,10 @@ describe('create-nx-plugin', () => {
     );
 
     runCLI(
-      `generate @nx/plugin:generator ${generatorName} --directory=${pluginName}/src/generators/${generatorName}`
+      `generate @nx/plugin:generator ${pluginName}/src/generators/${generatorName} --name ${generatorName}`
     );
     runCLI(
-      `generate @nx/plugin:executor ${executorName} --directory=${pluginName}/src/executors/${executorName}`
+      `generate @nx/plugin:executor ${pluginName}/src/executors/${executorName} --name ${executorName}`
     );
 
     runCLI(`build ${pluginName}`);

--- a/packages/angular/src/generators/component-story/component-story.spec.ts
+++ b/packages/angular/src/generators/component-story/component-story.spec.ts
@@ -19,7 +19,7 @@ describe('componentStory generator', () => {
     await generateTestLibrary(tree, { name: libName, skipFormat: true });
     await componentGenerator(tree, {
       name: 'test-button',
-      directory: `${libName}/src/lib/test-button`,
+      path: `${libName}/src/lib/test-button`,
       skipFormat: true,
     });
 

--- a/packages/angular/src/generators/component-test/component-test.spec.ts
+++ b/packages/angular/src/generators/component-test/component-test.spec.ts
@@ -31,7 +31,7 @@ describe('Angular Cypress Component Test Generator', () => {
       skipFormat: true,
     });
     await componentGenerator(tree, {
-      directory: 'my-lib/src/lib/my-lib',
+      path: 'my-lib/src/lib/my-lib/my-lib',
       name: 'my-lib',
       skipFormat: true,
     });
@@ -55,7 +55,7 @@ describe('Angular Cypress Component Test Generator', () => {
       skipFormat: true,
     });
     await componentGenerator(tree, {
-      directory: 'my-lib/src/lib/my-lib',
+      path: 'my-lib/src/lib/my-lib/',
       name: 'my-lib',
       skipFormat: true,
     });
@@ -109,7 +109,7 @@ export class MyLibComponent implements OnInit {
       skipFormat: true,
     });
     await componentGenerator(tree, {
-      directory: 'my-lib/src/lib/my-lib',
+      path: 'my-lib/src/lib/my-lib',
       name: 'my-lib',
       standalone: true,
       skipFormat: true,
@@ -164,7 +164,7 @@ export class MyLibComponent implements OnInit {
 
     await componentGenerator(tree, {
       name: 'my-lib',
-      directory: 'my-lib/src/lib/my-lib',
+      path: 'my-lib/src/lib/my-lib',
       skipFormat: true,
     });
     tree.write(
@@ -195,7 +195,7 @@ export class MyLibComponent implements OnInit {
 
     await componentGenerator(tree, {
       name: 'my-lib',
-      directory: 'my-lib/src/lib/my-lib',
+      path: 'my-lib/src/lib/my-lib/my-lib',
       skipFormat: true,
     });
 

--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -33,8 +33,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       standalone: false,
     });
 
@@ -79,8 +78,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       skipTests: true,
       standalone: false,
       skipFormat: true,
@@ -115,8 +113,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       inlineTemplate: true,
       standalone: false,
       skipFormat: true,
@@ -154,8 +151,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       inlineStyle: true,
       standalone: false,
       skipFormat: true,
@@ -193,8 +189,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       style: 'none',
       standalone: false,
       skipFormat: true,
@@ -240,8 +235,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       export: true,
       standalone: false,
       skipFormat: true,
@@ -281,8 +275,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       export: true,
       skipFormat: true,
     });
@@ -323,8 +316,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       export: false,
       standalone: false,
       skipFormat: true,
@@ -366,8 +358,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       export: false,
       skipFormat: true,
     });
@@ -408,8 +399,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       skipImport: true,
       standalone: false,
       skipFormat: true,
@@ -450,8 +440,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       export: true,
       standalone: false,
       skipFormat: true,
@@ -491,8 +480,7 @@ describe('component Generator', () => {
 
     // ACT
     await componentGenerator(tree, {
-      name: 'example',
-      directory: 'libs/lib1/src/lib/example',
+      path: 'libs/lib1/src/lib/example/example',
       export: true,
       standalone: false,
       skipFormat: true,
@@ -539,8 +527,7 @@ describe('component Generator', () => {
 
         // ACT
         await componentGenerator(tree, {
-          name: 'example',
-          directory: 'libs/lib1/src/lib/example',
+          path: 'libs/lib1/src/lib/example/example',
           module,
           export: true,
           standalone: false,
@@ -582,8 +569,7 @@ export class LibModule {}
 
       // ACT
       await componentGenerator(tree, {
-        name: 'example',
-        directory: 'libs/shared/ui/src/lib/example',
+        path: 'libs/shared/ui/src/lib/example/example',
         export: true,
         standalone: false,
         skipFormat: true,
@@ -631,8 +617,7 @@ export class LibModule {}
 
       // ACT
       await componentGenerator(tree, {
-        name: 'example',
-        directory: 'libs/lib1/src/lib/example',
+        path: 'libs/lib1/src/lib/example/example',
         module: 'not-exported',
         export: true,
         standalone: false,
@@ -669,8 +654,7 @@ export class LibModule {}
       // ACT & ASSERT
       await expect(
         componentGenerator(tree, {
-          name: 'example',
-          directory: 'libs/lib1/src/lib/example',
+          path: 'libs/lib1/src/lib/example/example',
           module: 'not-found',
           standalone: false,
           skipFormat: true,
@@ -712,8 +696,7 @@ export class LibModule {}
       // ACT & ASSERT
       await expect(
         componentGenerator(tree, {
-          name: 'example',
-          directory: 'libs/lib1/src/lib/example',
+          path: 'libs/lib1/src/lib/example/example',
           standalone: false,
           skipFormat: true,
         })
@@ -734,9 +717,8 @@ export class LibModule {}
 
     it('should use the prefix', async () => {
       await componentGenerator(tree, {
-        name: 'lib1/src/lib/example/example',
+        path: 'lib1/src/lib/example/example',
         prefix: 'foo',
-        nameAndDirectoryFormat: 'as-provided',
       });
 
       const content = tree.read(
@@ -749,18 +731,16 @@ export class LibModule {}
     it('should error when name starts with a digit', async () => {
       await expect(
         componentGenerator(tree, {
-          name: 'lib1/src/lib/1-one/1-one',
+          path: 'lib1/src/lib/1-one/1-one',
           prefix: 'foo',
-          nameAndDirectoryFormat: 'as-provided',
         })
       ).rejects.toThrow('The selector "foo-1-one" is invalid.');
     });
 
     it('should allow dash in selector before a number', async () => {
       await componentGenerator(tree, {
-        name: 'lib1/src/lib/one-1/one-1',
+        path: 'lib1/src/lib/one-1/one-1',
         prefix: 'foo',
-        nameAndDirectoryFormat: 'as-provided',
       });
 
       const content = tree.read(
@@ -772,9 +752,8 @@ export class LibModule {}
 
     it('should allow dash in selector before a number and without a prefix', async () => {
       await componentGenerator(tree, {
-        name: 'lib1/src/lib/example/example',
+        path: 'lib1/src/lib/example/example',
         selector: 'one-1',
-        nameAndDirectoryFormat: 'as-provided',
       });
 
       const content = tree.read(
@@ -792,8 +771,7 @@ export class LibModule {}
       } as AngularProjectConfiguration);
 
       await componentGenerator(tree, {
-        name: 'lib1/src/lib/example/example',
-        nameAndDirectoryFormat: 'as-provided',
+        path: 'lib1/src/lib/example/example',
       });
 
       const content = tree.read(
@@ -811,8 +789,7 @@ export class LibModule {}
       } as AngularProjectConfiguration);
 
       await componentGenerator(tree, {
-        name: 'lib1/src/lib/example/example',
-        nameAndDirectoryFormat: 'as-provided',
+        path: 'lib1/src/lib/example/example',
       });
 
       const content = tree.read(
@@ -867,8 +844,7 @@ export class LibModule {}
 
       // ACT
       await componentGenerator(tree, {
-        name: 'example',
-        directory: 'libs/lib1/secondary/src/lib/example',
+        path: 'libs/lib1/secondary/src/lib/example/example',
         export: true,
         standalone: false,
         skipFormat: true,
@@ -928,8 +904,7 @@ export class LibModule {}
 
       // ACT
       await componentGenerator(tree, {
-        name: 'example',
-        directory: 'libs/lib1/secondary/src/lib/example',
+        path: 'libs/lib1/secondary/src/lib/example',
         export: true,
         standalone: false,
         skipFormat: true,
@@ -966,8 +941,7 @@ export class LibModule {}
       tree.write('libs/lib1/src/index.ts', '');
 
       await componentGenerator(tree, {
-        name: 'example',
-        directory: 'libs/lib1/src/lib/example',
+        path: 'libs/lib1/src/lib/example/example',
         inlineStyle: true,
         standalone: false,
         skipFormat: true,

--- a/packages/angular/src/generators/component/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/lib/normalize-options.ts
@@ -18,8 +18,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.directory,
     suffix: options.type ?? 'component',
   });
 

--- a/packages/angular/src/generators/component/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/lib/normalize-options.ts
@@ -18,7 +18,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    path: options.directory,
+    path: options.path,
     suffix: options.type ?? 'component',
   });
 

--- a/packages/angular/src/generators/component/schema.d.ts
+++ b/packages/angular/src/generators/component/schema.d.ts
@@ -1,8 +1,6 @@
-import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-
 export interface Schema {
-  name: string;
-  directory?: string;
+  path: string;
+  name?: string;
   nameAndDirectoryFormat?: NameAndDirectoryFormat;
   displayBlock?: boolean;
   inlineStyle?: boolean;

--- a/packages/angular/src/generators/component/schema.d.ts
+++ b/packages/angular/src/generators/component/schema.d.ts
@@ -1,7 +1,6 @@
 export interface Schema {
   path: string;
   name?: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   displayBlock?: boolean;
   inlineStyle?: boolean;
   inlineTemplate?: boolean;

--- a/packages/angular/src/generators/component/schema.json
+++ b/packages/angular/src/generators/component/schema.json
@@ -7,25 +7,19 @@
   "description": "Creates a new Angular component.",
   "additionalProperties": false,
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the component.",
+      "description": "The path at which to create the component file, relative to the workspace root. By default, it is set to the root of the project.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where to create the component?"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the component.",
       "x-prompt": "What name would you like to use for the component?"
-    },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "aliases": ["dir", "path"],
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     },
     "prefix": {
       "type": "string",
@@ -118,6 +112,6 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"],
+  "required": ["path"],
   "examplesFile": "../../../docs/component-examples.md"
 }

--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -64,7 +64,7 @@ describe('Cypress Component Testing Configuration', () => {
       });
       await componentGenerator(tree, {
         name: 'fancy-cmp',
-        directory: 'fancy-lib/src/lib/fancy-cmp',
+        path: 'fancy-lib/src/lib/fancy-cmp/fancy-cmp',
         export: true,
         skipFormat: true,
       });
@@ -130,7 +130,7 @@ describe('Cypress Component Testing Configuration', () => {
       });
       await componentGenerator(tree, {
         name: 'fancy-cmp',
-        directory: 'fancy-lib/src/lib/fancy-cmp/',
+        path: 'fancy-lib/src/lib/fancy-cmp/fancy-cmp',
         export: true,
         skipFormat: true,
       });
@@ -196,7 +196,7 @@ describe('Cypress Component Testing Configuration', () => {
       });
       await componentGenerator(tree, {
         name: 'fancy-cmp',
-        directory: 'fancy-lib/src/lib/fancy-cmp/',
+        path: 'fancy-lib/src/lib/fancy-cmp/fancy-cmp/',
         export: true,
         skipFormat: true,
       });
@@ -252,7 +252,7 @@ describe('Cypress Component Testing Configuration', () => {
       });
       await componentGenerator(tree, {
         name: 'fancy-cmp',
-        directory: 'fancy-app/src/lib/fancy-cmp',
+        path: 'fancy-app/src/lib/fancy-cmp/fancy-cmp',
         export: true,
         skipFormat: true,
       });
@@ -300,7 +300,7 @@ describe('Cypress Component Testing Configuration', () => {
       });
       await componentGenerator(tree, {
         name: 'fancy-cmp',
-        directory: 'fancy-app/src/app/fancy-lib',
+        path: 'fancy-app/src/app/fancy-lib/fancy-lib',
         export: true,
         skipFormat: true,
       });
@@ -424,7 +424,7 @@ describe('Cypress Component Testing Configuration', () => {
     });
     await componentGenerator(tree, {
       name: 'fancy-cmp',
-      directory: 'fancy-app/src/app/fancy-cmp',
+      path: 'fancy-app/src/app/fancy-cmp/fancy-cmp',
       export: true,
       skipFormat: true,
     });
@@ -695,12 +695,12 @@ describe('Cypress Component Testing Configuration', () => {
     });
     await componentGenerator(tree, {
       name: 'fancy-button',
-      directory: 'secondary/src/lib/button/',
+      path: 'secondary/src/lib/button/fancy-button',
       skipFormat: true,
     });
     await componentGenerator(tree, {
       name: 'standalone-fancy-button',
-      directory: 'secondary/src/lib/button',
+      path: 'secondary/src/lib/button/standalone-fancy-button',
       standalone: true,
       skipFormat: true,
     });
@@ -815,12 +815,12 @@ describe('Cypress Component Testing Configuration', () => {
     });
     await componentGenerator(tree, {
       name: 'cmp-one',
-      directory: 'multiple-components/src/lib',
+      path: 'multiple-components/src/lib/cmp-one',
       skipFormat: true,
     });
     await componentGenerator(tree, {
       name: 'cmp-two',
-      directory: 'multiple-components/src/lib',
+      path: 'multiple-components/src/lib/cmp-two',
       skipFormat: true,
     });
     tree.write(
@@ -908,7 +908,7 @@ async function setup(
     `${options.name}-three`,
   ]) {
     await componentGenerator(tree, {
-      directory: `${options.project}/src/lib/${name}`,
+      path: `${options.project}/src/lib/${name}/${name}`,
       name,
       skipFormat: true,
     });

--- a/packages/angular/src/generators/directive/directive.spec.ts
+++ b/packages/angular/src/generators/directive/directive.spec.ts
@@ -53,7 +53,7 @@ describe('directive generator', () => {
 
     // ACT
     await generateDirectiveWithDefaultOptions(tree, {
-      directory: 'test/src/app/my-directives/test',
+      path: 'test/src/app/my-directives/test',
       skipTests: true,
     });
 
@@ -114,7 +114,7 @@ describe('directive generator', () => {
 
       // ACT
       await generateDirectiveWithDefaultOptions(tree, {
-        directory: 'test/src/app/my-directives/test',
+        path: 'test/src/app/my-directives/test/test',
         standalone: false,
       });
 
@@ -138,7 +138,7 @@ describe('directive generator', () => {
 
       // ACT
       await generateDirectiveWithDefaultOptions(tree, {
-        directory: 'test/src/app/my-directives/test',
+        path: 'test/src/app/my-directives/test/test',
         export: true,
         standalone: false,
       });
@@ -154,7 +154,7 @@ describe('directive generator', () => {
 
       // ACT
       await generateDirectiveWithDefaultOptions(tree, {
-        directory: 'test/src/app/my-directives',
+        path: 'test/src/app/my-directives',
         skipImport: true,
         standalone: false,
       });
@@ -169,9 +169,9 @@ describe('directive generator', () => {
   describe('prefix & selector', () => {
     it('should use the prefix', async () => {
       await directiveGenerator(tree, {
-        name: 'test/src/app/example/example',
+        path: 'test/src/app/example/example',
+        name: 'example',
         prefix: 'foo',
-        nameAndDirectoryFormat: 'as-provided',
       });
 
       const content = tree.read(
@@ -189,8 +189,8 @@ describe('directive generator', () => {
       } as AngularProjectConfiguration);
 
       await directiveGenerator(tree, {
-        name: 'test/src/app/example/example',
-        nameAndDirectoryFormat: 'as-provided',
+        path: 'test/src/app/example/example',
+        name: 'example',
       });
 
       const content = tree.read(
@@ -208,8 +208,8 @@ describe('directive generator', () => {
       } as AngularProjectConfiguration);
 
       await directiveGenerator(tree, {
-        name: 'test/src/app/example/example',
-        nameAndDirectoryFormat: 'as-provided',
+        path: 'test/src/app/example/example',
+        name: 'example',
       });
 
       const content = tree.read(
@@ -221,9 +221,9 @@ describe('directive generator', () => {
 
     it('should use provided selector as is', async () => {
       await directiveGenerator(tree, {
-        name: 'test/src/app/example/example',
+        path: 'test/src/app/example/example',
+        name: 'example',
         selector: 'mySelector',
-        nameAndDirectoryFormat: 'as-provided',
       });
 
       const content = tree.read(
@@ -255,7 +255,7 @@ async function generateDirectiveWithDefaultOptions(
 ) {
   await directiveGenerator(tree, {
     name: 'test',
-    directory: 'test/src/app',
+    path: 'test/src/app/test',
     skipFormat: true,
     ...overrides,
   });

--- a/packages/angular/src/generators/directive/lib/normalize-options.ts
+++ b/packages/angular/src/generators/directive/lib/normalize-options.ts
@@ -17,7 +17,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    path: options.directory,
+    path: options.path,
     suffix: 'directive',
   });
 

--- a/packages/angular/src/generators/directive/lib/normalize-options.ts
+++ b/packages/angular/src/generators/directive/lib/normalize-options.ts
@@ -17,8 +17,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.directory,
     suffix: 'directive',
   });
 

--- a/packages/angular/src/generators/directive/schema.d.ts
+++ b/packages/angular/src/generators/directive/schema.d.ts
@@ -1,9 +1,8 @@
 import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
-  name: string;
-  directory?: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  path: string;
+  name?: string;
   prefix?: string;
   skipTests?: boolean;
   skipImport?: boolean;

--- a/packages/angular/src/generators/directive/schema.json
+++ b/packages/angular/src/generators/directive/schema.json
@@ -7,25 +7,19 @@
   "description": "Creates a new Angular directive.",
   "additionalProperties": false,
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the new directive.",
+      "description": "The path at which to create the directive file.",
+      "x-prompt": "Where to put the directive?",
       "$default": {
         "$source": "argv",
         "index": 0
-      },
+      }
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the new directive.",
       "x-prompt": "What name would you like to use for the directive?"
-    },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the directive file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "aliases": ["dir", "path"],
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the directive in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     },
     "prefix": {
       "type": "string",
@@ -77,5 +71,5 @@
       "description": "Skip formatting of files."
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/angular/src/generators/library/lib/add-standalone-component.ts
+++ b/packages/angular/src/generators/library/lib/add-standalone-component.ts
@@ -11,13 +11,14 @@ export async function addStandaloneComponent(
   await componentGenerator(tree, {
     ...componentOptions,
     name: componentOptions.name,
-    directory: joinPathFragments(
+    path: joinPathFragments(
       libraryOptions.projectRoot,
       'src',
       'lib',
-      componentOptions.flat ? '' : componentOptions.name
+      componentOptions.flat
+        ? `${componentOptions.name}`
+        : `${componentOptions.name}/${componentOptions.name}`
     ),
-    nameAndDirectoryFormat: 'as-provided',
     standalone: true,
     export: true,
     skipFormat: true,

--- a/packages/angular/src/generators/pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/pipe/lib/normalize-options.ts
@@ -15,8 +15,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.directory,
     suffix: 'pipe',
   });
 

--- a/packages/angular/src/generators/pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/pipe/lib/normalize-options.ts
@@ -15,7 +15,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    path: options.directory,
+    path: options.path,
     suffix: 'pipe',
   });
 

--- a/packages/angular/src/generators/pipe/pipe.spec.ts
+++ b/packages/angular/src/generators/pipe/pipe.spec.ts
@@ -43,7 +43,7 @@ describe('pipe generator', () => {
   it('should not generate test file when skipTests=true', async () => {
     // ACT
     await generatePipeWithDefaultOptions(tree, {
-      directory: 'test/src/app/my-pipes/test',
+      path: 'test/src/app/my-pipes/test',
       skipTests: true,
     });
 
@@ -82,7 +82,7 @@ describe('pipe generator', () => {
 
       // ACT
       await generatePipeWithDefaultOptions(tree, {
-        directory: 'test/src/app/test',
+        path: 'test/src/app/test/test',
         standalone: false,
       });
 
@@ -103,7 +103,7 @@ describe('pipe generator', () => {
 
       // ACT
       await generatePipeWithDefaultOptions(tree, {
-        directory: 'test/src/app/my-pipes/test',
+        path: 'test/src/app/my-pipes/test/test',
         standalone: false,
       });
 
@@ -124,7 +124,7 @@ describe('pipe generator', () => {
 
       // ACT
       await generatePipeWithDefaultOptions(tree, {
-        directory: 'test/src/app/my-pipes/test',
+        path: 'test/src/app/my-pipes/test/test',
         export: true,
         standalone: false,
       });
@@ -140,7 +140,7 @@ describe('pipe generator', () => {
 
       // ACT
       await generatePipeWithDefaultOptions(tree, {
-        directory: 'test/src/app/my-pipes/test',
+        path: 'test/src/app/my-pipes/test/test',
         skipImport: true,
         standalone: false,
       });
@@ -173,7 +173,7 @@ async function generatePipeWithDefaultOptions(
 ) {
   await pipeGenerator(tree, {
     name: 'test',
-    directory: 'test/src/app',
+    path: 'test/src/app/test',
     skipFormat: true,
     ...overrides,
   });

--- a/packages/angular/src/generators/pipe/schema.d.ts
+++ b/packages/angular/src/generators/pipe/schema.d.ts
@@ -1,9 +1,8 @@
 import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
-  name: string;
-  directory?: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  path: string;
+  name?: string;
   skipTests?: boolean;
   skipImport?: boolean;
   standalone?: boolean;

--- a/packages/angular/src/generators/pipe/schema.json
+++ b/packages/angular/src/generators/pipe/schema.json
@@ -7,34 +7,19 @@
   "additionalProperties": false,
   "description": "Creates an Angular pipe.",
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the pipe.",
+      "description": "The path at which to create the pipe file, relative to the workspace root.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "What is the path of the new pipe?"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the pipe.",
       "x-prompt": "What name would you like to use for the pipe?"
-    },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the pipe file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "aliases": ["dir", "path"],
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the pipe in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "project": {
-      "type": "string",
-      "description": "The name of the project.",
-      "$default": {
-        "$source": "projectName"
-      },
-      "x-dropdown": "projects",
-      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
     },
     "skipTests": {
       "type": "boolean",
@@ -67,5 +52,5 @@
       "description": "Skip formatting of files."
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
@@ -15,7 +15,7 @@ describe('convertDirectiveToScam', () => {
 
     await directiveGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       skipImport: true,
       export: false,
       standalone: false,
@@ -24,6 +24,7 @@ describe('convertDirectiveToScam', () => {
 
     // ACT
     convertDirectiveToScam(tree, {
+      path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
       fileName: 'example.directive',
       filePath: 'apps/app1/src/app/example/example.directive.ts',
@@ -71,7 +72,7 @@ describe('convertDirectiveToScam', () => {
 
     await directiveGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       skipImport: true,
       export: false,
       standalone: false,
@@ -80,6 +81,7 @@ describe('convertDirectiveToScam', () => {
 
     // ACT
     convertDirectiveToScam(tree, {
+      path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
       fileName: 'example.directive',
       filePath: 'apps/app1/src/app/example/example.directive.ts',

--- a/packages/angular/src/generators/scam-directive/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam-directive/lib/normalize-options.ts
@@ -15,8 +15,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.directory,
     suffix: 'directive',
   });
 

--- a/packages/angular/src/generators/scam-directive/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam-directive/lib/normalize-options.ts
@@ -15,7 +15,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    path: options.directory,
+    path: options.path,
     suffix: 'directive',
   });
 

--- a/packages/angular/src/generators/scam-directive/scam-directive.spec.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.spec.ts
@@ -15,7 +15,7 @@ describe('SCAM Directive Generator', () => {
     // ACT
     await scamDirectiveGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app',
+      path: 'apps/app1/src/app/example',
       inlineScam: true,
       skipFormat: true,
     });
@@ -58,7 +58,7 @@ describe('SCAM Directive Generator', () => {
     // ACT
     await scamDirectiveGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app',
+      path: 'apps/app1/src/app/example',
       inlineScam: false,
       skipFormat: true,
     });
@@ -99,7 +99,7 @@ describe('SCAM Directive Generator', () => {
     // ACT
     await scamDirectiveGenerator(tree, {
       name: 'example',
-      directory: 'libs/lib1/feature/src/lib/example',
+      path: 'libs/lib1/feature/src/lib/example/example',
       inlineScam: false,
       export: true,
       skipFormat: true,
@@ -146,7 +146,7 @@ describe('SCAM Directive Generator', () => {
       // ACT
       await scamDirectiveGenerator(tree, {
         name: 'example',
-        directory: 'apps/app1/src/app/random/example',
+        path: 'apps/app1/src/app/random/example/example',
         inlineScam: true,
         skipFormat: true,
       });
@@ -189,7 +189,7 @@ describe('SCAM Directive Generator', () => {
       // ACT
       await scamDirectiveGenerator(tree, {
         name: 'example',
-        directory: '/apps/app1/src/app/random/example',
+        path: '/apps/app1/src/app/random/example/example',
         inlineScam: true,
         skipFormat: true,
       });
@@ -233,7 +233,7 @@ describe('SCAM Directive Generator', () => {
       expect(
         scamDirectiveGenerator(tree, {
           name: 'example',
-          directory: 'libs/proj/src/lib/random/example',
+          path: 'libs/proj/src/lib/random/example/example',
           inlineScam: true,
           skipFormat: true,
         })

--- a/packages/angular/src/generators/scam-directive/scam-directive.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.ts
@@ -13,8 +13,6 @@ export async function scamDirectiveGenerator(tree: Tree, rawOptions: Schema) {
     export: false,
     standalone: false,
     skipFormat: true,
-    // options are already normalize, use them as is
-    nameAndDirectoryFormat: 'as-provided',
   });
 
   convertDirectiveToScam(tree, options);

--- a/packages/angular/src/generators/scam-directive/schema.d.ts
+++ b/packages/angular/src/generators/scam-directive/schema.d.ts
@@ -1,9 +1,8 @@
 import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
-  name: string;
-  directory?: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  path: string;
+  name?: string;
   skipTests?: boolean;
   inlineScam?: boolean;
   prefix?: string;
@@ -13,6 +12,7 @@ export interface Schema {
 }
 
 export interface NormalizedSchema extends Schema {
+  name: string;
   directory: string;
   export: boolean;
   fileName: string;

--- a/packages/angular/src/generators/scam-directive/schema.json
+++ b/packages/angular/src/generators/scam-directive/schema.json
@@ -13,13 +13,18 @@
   "description": "Creates a new, generic Angular directive definition in the given or default project.",
   "additionalProperties": false,
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the directive.",
+      "description": "The path at which to create the SCAM Directive files, relative to the workspace root.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "What is the path of the new directive?"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the directive.",
       "x-prompt": "What name would you like to use for the directive?",
       "x-priority": "important"
     },
@@ -92,5 +97,5 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
@@ -15,7 +15,7 @@ describe('convertPipeToScam', () => {
 
     await pipeGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       skipImport: true,
       export: false,
       standalone: false,
@@ -24,6 +24,7 @@ describe('convertPipeToScam', () => {
 
     // ACT
     convertPipeToScam(tree, {
+      path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
       fileName: 'example.pipe',
       filePath: 'apps/app1/src/app/example/example.pipe.ts',
@@ -73,7 +74,7 @@ describe('convertPipeToScam', () => {
 
     await pipeGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       skipImport: true,
       export: false,
       skipFormat: true,
@@ -81,6 +82,7 @@ describe('convertPipeToScam', () => {
 
     // ACT
     convertPipeToScam(tree, {
+      path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
       fileName: 'example.pipe',
       filePath: 'apps/app1/src/app/example/example.pipe.ts',

--- a/packages/angular/src/generators/scam-pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/normalize-options.ts
@@ -15,8 +15,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.directory,
     suffix: 'pipe',
   });
 

--- a/packages/angular/src/generators/scam-pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/normalize-options.ts
@@ -15,7 +15,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    path: options.directory,
+    path: options.path,
     suffix: 'pipe',
   });
 

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.spec.ts
@@ -15,7 +15,7 @@ describe('SCAM Pipe Generator', () => {
     // ACT
     await scamPipeGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       inlineScam: true,
       skipFormat: true,
     });
@@ -60,7 +60,7 @@ describe('SCAM Pipe Generator', () => {
     // ACT
     await scamPipeGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       inlineScam: false,
       skipFormat: true,
     });
@@ -101,7 +101,7 @@ describe('SCAM Pipe Generator', () => {
     // ACT
     await scamPipeGenerator(tree, {
       name: 'example',
-      directory: 'libs/lib1/feature/src/lib/example',
+      path: 'libs/lib1/feature/src/lib/example/example',
       inlineScam: false,
       export: true,
       skipFormat: true,
@@ -148,7 +148,7 @@ describe('SCAM Pipe Generator', () => {
       // ACT
       await scamPipeGenerator(tree, {
         name: 'example',
-        directory: 'apps/app1/src/app/random/example',
+        path: 'apps/app1/src/app/random/example/example',
         inlineScam: true,
         skipFormat: true,
       });
@@ -193,7 +193,7 @@ describe('SCAM Pipe Generator', () => {
       // ACT
       await scamPipeGenerator(tree, {
         name: 'example',
-        directory: '/apps/app1/src/app/random/example',
+        path: '/apps/app1/src/app/random/example/example',
         inlineScam: true,
         skipFormat: true,
       });
@@ -239,7 +239,7 @@ describe('SCAM Pipe Generator', () => {
       expect(
         scamPipeGenerator(tree, {
           name: 'example',
-          directory: 'libs/proj/src/lib/random/example',
+          path: 'libs/proj/src/lib/random/example/example',
           inlineScam: true,
           skipFormat: true,
         })

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.ts
@@ -13,8 +13,6 @@ export async function scamPipeGenerator(tree: Tree, rawOptions: Schema) {
     export: false,
     standalone: false,
     skipFormat: true,
-    // options are already normalize, use them as is
-    nameAndDirectoryFormat: 'as-provided',
   });
 
   convertPipeToScam(tree, options);

--- a/packages/angular/src/generators/scam-pipe/schema.d.ts
+++ b/packages/angular/src/generators/scam-pipe/schema.d.ts
@@ -1,9 +1,8 @@
 import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
-  name: string;
-  directory?: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  path: string;
+  name?: string;
   skipTests?: boolean;
   inlineScam?: boolean;
   export?: boolean;
@@ -11,6 +10,7 @@ export interface Schema {
 }
 
 export interface NormalizedSchema extends Schema {
+  name: string;
   directory: string;
   export: boolean;
   fileName: string;

--- a/packages/angular/src/generators/scam-pipe/schema.json
+++ b/packages/angular/src/generators/scam-pipe/schema.json
@@ -6,42 +6,27 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nx/angular:scam-pipe --project=my-lib --flat=false my-transformation",
+      "command": "nx g @nx/angular:scam-pipe mylib/src/lib/my-transformation/my-transformation",
       "description": "Generates a `MyTransformationPipe` in a `my-transformation` folder in the `my-lib` project"
     }
   ],
   "description": "Creates a new, generic Angular pipe definition in the given or default project.",
   "additionalProperties": false,
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the pipe.",
+      "description": "The path at which to create the pipe file, relative to the workspace root.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "What is the path of the new pipe?"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the pipe.",
       "x-prompt": "What name would you like to use for the pipe?",
       "x-priority": "important"
-    },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "aliases": ["dir", "path"],
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "project": {
-      "type": "string",
-      "description": "The name of the project.",
-      "$default": {
-        "$source": "projectName"
-      },
-      "x-dropdown": "projects",
-      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
     },
     "skipTests": {
       "type": "boolean",
@@ -73,5 +58,5 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
+++ b/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
@@ -11,7 +11,7 @@ describe('scam-to-standalone', () => {
     await generateTestApplication(tree, { name: 'foo', skipFormat: true });
     await scamGenerator(tree, {
       name: 'bar',
-      directory: 'foo/src/app/bar',
+      path: 'foo/src/app/bar/bar',
       skipFormat: true,
     });
 

--- a/packages/angular/src/generators/scam/lib/convert-component-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam/lib/convert-component-to-scam.spec.ts
@@ -15,7 +15,7 @@ describe('convertComponentToScam', () => {
 
     await componentGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       skipImport: true,
       export: false,
       standalone: false,
@@ -24,6 +24,7 @@ describe('convertComponentToScam', () => {
 
     // ACT
     convertComponentToScam(tree, {
+      path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
       fileName: 'example.component',
       filePath: 'apps/app1/src/app/example/example.component.ts',
@@ -71,7 +72,7 @@ describe('convertComponentToScam', () => {
 
     await componentGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       skipImport: true,
       export: false,
       standalone: false,
@@ -80,6 +81,7 @@ describe('convertComponentToScam', () => {
 
     // ACT
     convertComponentToScam(tree, {
+      path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
       fileName: 'example.component',
       filePath: 'apps/app1/src/app/example/example.component.ts',
@@ -121,7 +123,7 @@ describe('convertComponentToScam', () => {
 
     await componentGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app',
+      path: 'apps/app1/src/app/example',
       skipImport: true,
       export: false,
       type: 'random',
@@ -131,6 +133,7 @@ describe('convertComponentToScam', () => {
 
     // ACT
     convertComponentToScam(tree, {
+      path: 'apps/app1/src/app/example',
       directory: 'apps/app1/src/app',
       fileName: 'example.random',
       filePath: 'apps/app1/src/app/example.random.ts',
@@ -179,7 +182,7 @@ describe('convertComponentToScam', () => {
 
     await componentGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app',
+      path: 'apps/app1/src/app/example',
       skipImport: true,
       export: false,
       type: 'random',
@@ -189,6 +192,7 @@ describe('convertComponentToScam', () => {
 
     // ACT
     convertComponentToScam(tree, {
+      path: 'apps/app1/src/app/example',
       directory: 'apps/app1/src/app',
       fileName: 'example.random',
       filePath: 'apps/app1/src/app/example.random.ts',

--- a/packages/angular/src/generators/scam/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam/lib/normalize-options.ts
@@ -16,8 +16,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.directory,
     suffix: options.type ?? 'component',
   });
 

--- a/packages/angular/src/generators/scam/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam/lib/normalize-options.ts
@@ -16,7 +16,7 @@ export async function normalizeOptions(
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
-    path: options.directory,
+    path: options.path,
     suffix: options.type ?? 'component',
   });
 

--- a/packages/angular/src/generators/scam/scam.spec.ts
+++ b/packages/angular/src/generators/scam/scam.spec.ts
@@ -15,7 +15,7 @@ describe('SCAM Generator', () => {
     // ACT
     await scamGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       inlineScam: true,
       skipFormat: true,
     });
@@ -58,7 +58,7 @@ describe('SCAM Generator', () => {
     // ACT
     await scamGenerator(tree, {
       name: 'example',
-      directory: 'apps/app1/src/app/example',
+      path: 'apps/app1/src/app/example/example',
       inlineScam: false,
       skipFormat: true,
     });
@@ -99,7 +99,7 @@ describe('SCAM Generator', () => {
     // ACT
     await scamGenerator(tree, {
       name: 'example',
-      directory: 'libs/lib1/feature/src/lib/example',
+      path: 'libs/lib1/feature/src/lib/example/example',
       inlineScam: false,
       export: true,
       skipFormat: true,
@@ -146,7 +146,7 @@ describe('SCAM Generator', () => {
       // ACT
       await scamGenerator(tree, {
         name: 'example',
-        directory: 'apps/app1/src/app/random/example',
+        path: 'apps/app1/src/app/random/example/example',
         inlineScam: true,
         skipFormat: true,
       });
@@ -189,7 +189,7 @@ describe('SCAM Generator', () => {
       // ACT
       await scamGenerator(tree, {
         name: 'example',
-        directory: '/apps/app1/src/app/random/example',
+        path: '/apps/app1/src/app/random/example/example',
         inlineScam: true,
         skipFormat: true,
       });
@@ -233,7 +233,7 @@ describe('SCAM Generator', () => {
       expect(
         scamGenerator(tree, {
           name: 'example',
-          directory: 'libs/proj/src/lib/random/example',
+          path: 'libs/proj/src/lib/random/example/example',
           inlineScam: true,
           skipFormat: true,
         })

--- a/packages/angular/src/generators/scam/scam.ts
+++ b/packages/angular/src/generators/scam/scam.ts
@@ -13,8 +13,6 @@ export async function scamGenerator(tree: Tree, rawOptions: Schema) {
     export: false,
     standalone: false,
     skipFormat: true,
-    // options are already normalize, use them as is
-    nameAndDirectoryFormat: 'as-provided',
   });
 
   convertComponentToScam(tree, options);

--- a/packages/angular/src/generators/scam/schema.d.ts
+++ b/packages/angular/src/generators/scam/schema.d.ts
@@ -1,9 +1,8 @@
 import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
-  name: string;
-  directory?: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  path: string;
+  name?: string;
   displayBlock?: boolean;
   inlineStyle?: boolean;
   inlineTemplate?: boolean;
@@ -21,6 +20,7 @@ export interface Schema {
 }
 
 export interface NormalizedSchema extends Schema {
+  name: string;
   directory: string;
   projectName: string;
   fileName: string;

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -6,41 +6,26 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nx/angular:scam my-sample --directory=my-lib/src/lib/my-sample",
+      "command": "nx g @nx/angular:scam my-lib/src/lib/my-sample/my-sample",
       "description": "Generate a `MySampleComponent` component in the `my-lib` library."
     }
   ],
   "description": "Creates a new Angular SCAM.",
   "additionalProperties": false,
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the component.",
+      "description": "The path at which to create the SCAM file, relative to the workspace root.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "What is the path of the new SCAM?"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the component.",
       "x-prompt": "What name would you like to use for the component?"
-    },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the SCAM files. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "aliases": ["dir", "path"],
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the SCAM in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "project": {
-      "type": "string",
-      "description": "The name of the project.",
-      "$default": {
-        "$source": "projectName"
-      },
-      "x-dropdown": "projects",
-      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
     },
     "displayBlock": {
       "description": "Specifies if the style will contain `:host { display: block; }`.",
@@ -132,5 +117,5 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -31,7 +31,7 @@ describe('angularStories generator: applications', () => {
   it('should generate stories file for scam component', async () => {
     await scamGenerator(tree, {
       name: 'my-scam',
-      directory: `${appName}/src/app/my-scam`,
+      path: `${appName}/src/app/my-scam/my-scam`,
       skipFormat: true,
     });
 
@@ -45,7 +45,7 @@ describe('angularStories generator: applications', () => {
   it('should ignore paths', async () => {
     await scamGenerator(tree, {
       name: 'my-scam',
-      directory: `${appName}/src/app/my-scam`,
+      path: `${appName}/src/app/my-scam/my-scam`,
       skipFormat: true,
     });
 
@@ -63,7 +63,7 @@ describe('angularStories generator: applications', () => {
   it('should ignore paths when full path to component is provided', async () => {
     await scamGenerator(tree, {
       name: 'my-scam',
-      directory: `${appName}/src/app/my-scam`,
+      path: `${appName}/src/app/my-scam/my-scam`,
       skipFormat: true,
     });
 
@@ -81,12 +81,12 @@ describe('angularStories generator: applications', () => {
   it('should ignore a path that has a nested component, but still generate nested component stories', async () => {
     await componentGenerator(tree, {
       name: 'component-a',
-      directory: `${appName}/src/app/component-a`,
+      path: `${appName}/src/app/component-a/component-a`,
       skipFormat: true,
     });
     await componentGenerator(tree, {
       name: 'component-b',
-      directory: `${appName}/src/app/component-a/component-b`,
+      path: `${appName}/src/app/component-a/component-b/component-b`,
       skipFormat: true,
     });
 
@@ -136,7 +136,7 @@ describe('angularStories generator: applications', () => {
     );
     await componentGenerator(tree, {
       name: 'component',
-      directory: `${appName}/src/app/component`,
+      path: `${appName}/src/app/component/component`,
       skipFormat: true,
     });
 
@@ -160,7 +160,7 @@ describe('angularStories generator: applications', () => {
   it('should generate stories file for inline scam component', async () => {
     await scamGenerator(tree, {
       name: 'my-scam',
-      directory: `${appName}/src/app/my-scam`,
+      path: `${appName}/src/app/my-scam/my-scam`,
       inlineScam: true,
       skipFormat: true,
     });

--- a/packages/angular/src/generators/stories/stories-lib.spec.ts
+++ b/packages/angular/src/generators/stories/stories-lib.spec.ts
@@ -51,7 +51,7 @@ describe('angularStories generator: libraries', () => {
       // add a standalone component to the secondary entrypoint
       await componentGenerator(tree, {
         name: 'secondary-button',
-        directory: `${libName}/secondary-entry-point/src/lib/secondary-button`,
+        path: `${libName}/secondary-entry-point/src/lib/secondary-button/secondary-button`,
         skipFormat: true,
       });
 
@@ -167,7 +167,7 @@ describe('angularStories generator: libraries', () => {
     it('should generate stories file for scam component', async () => {
       await scamGenerator(tree, {
         name: 'my-scam',
-        directory: `${libName}/src/lib/my-scam`,
+        path: `${libName}/src/lib/my-scam/my-scam`,
         skipFormat: true,
       });
 
@@ -181,7 +181,7 @@ describe('angularStories generator: libraries', () => {
     it('should generate stories file for inline scam component', async () => {
       await scamGenerator(tree, {
         name: 'my-scam',
-        directory: `${libName}/src/lib/my-scam`,
+        path: `${libName}/src/lib/my-scam/my-scam`,
         inlineScam: true,
         skipFormat: true,
       });
@@ -197,7 +197,7 @@ describe('angularStories generator: libraries', () => {
       // add standalone component
       await componentGenerator(tree, {
         name: 'standalone',
-        directory: `${libName}/src/lib/standalone`,
+        path: `${libName}/src/lib/standalone/standalone`,
         standalone: true,
         skipFormat: true,
       });
@@ -211,7 +211,7 @@ describe('angularStories generator: libraries', () => {
       // add a standalone component to the secondary entrypoint
       await componentGenerator(tree, {
         name: 'secondary-standalone',
-        directory: `${libName}/secondary-entry-point/src/lib/secondary-standalone`,
+        path: `${libName}/secondary-entry-point/src/lib/secondary-standalone/secondary-standalone`,
         standalone: true,
         skipFormat: true,
       });
@@ -253,7 +253,7 @@ describe('angularStories generator: libraries', () => {
       // add a standalone component to the secondary entrypoint
       await componentGenerator(tree, {
         name: 'secondary-button',
-        directory: `${libName}/secondary-entry-point/src/lib/secondary-button`,
+        path: `${libName}/secondary-entry-point/src/lib/secondary-button/seconday-button`,
         skipFormat: true,
       });
 

--- a/packages/angular/src/generators/storybook-configuration/storybook-configuration.spec.ts
+++ b/packages/angular/src/generators/storybook-configuration/storybook-configuration.spec.ts
@@ -109,7 +109,7 @@ describe('StorybookConfiguration generator', () => {
     // add standalone component
     await componentGenerator(tree, {
       name: 'standalone',
-      directory: `${libName}/src/lib/standalone`,
+      path: `${libName}/src/lib/standalone/standalone`,
       standalone: true,
       skipFormat: true,
     });
@@ -123,14 +123,14 @@ describe('StorybookConfiguration generator', () => {
     // add a regular component to the secondary entrypoint
     await componentGenerator(tree, {
       name: 'secondary-button',
-      directory: `${libName}/secondary-entry-point/src/lib/secondary-button`,
+      path: `${libName}/secondary-entry-point/src/lib/secondary-button/secondary-button`,
       export: true,
       skipFormat: true,
     });
     // add a standalone component to the secondary entrypoint
     await componentGenerator(tree, {
       name: 'secondary-standalone',
-      directory: `${libName}/secondary-entry-point/src/lib/secondary-standalone`,
+      path: `${libName}/secondary-entry-point/src/lib/secondary-standalone/secondary-standalone`,
       standalone: true,
       export: true,
       skipFormat: true,
@@ -149,7 +149,7 @@ describe('StorybookConfiguration generator', () => {
     // add standalone component
     await componentGenerator(tree, {
       name: 'standalone',
-      directory: `${libName}/src/lib/standalone`,
+      path: `${libName}/src/lib/standalone/standalone`,
       standalone: true,
       skipFormat: true,
     });
@@ -163,14 +163,14 @@ describe('StorybookConfiguration generator', () => {
     // add a regular component to the secondary entrypoint
     await componentGenerator(tree, {
       name: 'secondary-button',
-      directory: `${libName}/secondary-entry-point/src/lib/secondary-button`,
+      path: `${libName}/secondary-entry-point/src/lib/secondary-button/secondary-button`,
       export: true,
       skipFormat: true,
     });
     // add a standalone component to the secondary entrypoint
     await componentGenerator(tree, {
       name: 'secondary-standalone',
-      directory: `${libName}/secondary-entry-point/src/lib/secondary-standalone`,
+      path: `${libName}/secondary-entry-point/src/lib/secondary-standalone/secondary-standalone`,
       standalone: true,
       export: true,
       skipFormat: true,

--- a/packages/angular/src/generators/utils/testing.ts
+++ b/packages/angular/src/generators/utils/testing.ts
@@ -71,7 +71,7 @@ export async function createStorybookTestWorkspaceForLib(
 
   await componentGenerator(tree, {
     name: 'test-button',
-    directory: `${libName}/src/lib/test-button`,
+    path: `${libName}/src/lib/test-button/test-button`,
     standalone: false,
     skipFormat: true,
   });
@@ -115,7 +115,7 @@ export class TestButtonComponent {
 
   await componentGenerator(tree, {
     name: 'barrel-button',
-    directory: `${libName}/src/lib/barrel/barrel-button`,
+    path: `${libName}/src/lib/barrel/barrel-button/barrel-button`,
     module: 'barrel',
     standalone: false,
     skipFormat: true,
@@ -147,7 +147,7 @@ export class BarrelModule {}`
 
   await componentGenerator(tree, {
     name: 'variable-declare-button',
-    directory: `${libName}/src/lib/variable-declare/variable-declare-button`,
+    path: `${libName}/src/lib/variable-declare/variable-declare-button/variable-declare-button`,
     module: 'variable-declare',
     standalone: false,
     skipFormat: true,
@@ -155,7 +155,7 @@ export class BarrelModule {}`
 
   await componentGenerator(tree, {
     name: 'variable-declare-view',
-    directory: `${libName}/src/lib/variable-declare/variable-declare-view`,
+    path: `${libName}/src/lib/variable-declare/variable-declare-view/variable-declare-view`,
     module: 'variable-declare',
     standalone: false,
     skipFormat: true,
@@ -189,7 +189,7 @@ export class VariableDeclareModule {}`
 
   await componentGenerator(tree, {
     name: 'variable-spread-declare-button',
-    directory: `${libName}/src/lib/variable-spread-declare/variable-spread-declare-button`,
+    path: `${libName}/src/lib/variable-spread-declare/variable-spread-declare-button/variable-spread-declare-button`,
     module: 'variable-spread-declare',
     standalone: false,
     skipFormat: true,
@@ -197,7 +197,7 @@ export class VariableDeclareModule {}`
 
   await componentGenerator(tree, {
     name: 'variable-spread-declare-view',
-    directory: `${libName}/src/lib/variable-spread-declare/variable-spread-declare-view`,
+    path: `${libName}/src/lib/variable-spread-declare/variable-spread-declare-view/variable-spread-declare-view`,
     module: 'variable-spread-declare',
     standalone: false,
     skipFormat: true,
@@ -205,7 +205,7 @@ export class VariableDeclareModule {}`
 
   await componentGenerator(tree, {
     name: 'variable-spread-declare-anotherview',
-    directory: `${libName}/src/lib/variable-spread-declare/variable-spread-declare-anotherview`,
+    path: `${libName}/src/lib/variable-spread-declare/variable-spread-declare-anotherview/variable-spread-declare-anotherview`,
     module: 'variable-spread-declare',
     standalone: false,
     skipFormat: true,
@@ -239,7 +239,7 @@ export class VariableSpreadDeclareModule {}`
 
   await componentGenerator(tree, {
     name: 'cmp1',
-    directory: `${libName}/src/lib/static-member-declarations/cmp1`,
+    path: `${libName}/src/lib/static-member-declarations/cmp1/cmp1`,
     module: 'static-member-declarations',
     standalone: false,
     skipFormat: true,
@@ -247,7 +247,7 @@ export class VariableSpreadDeclareModule {}`
 
   await componentGenerator(tree, {
     name: 'cmp2',
-    directory: `${libName}/src/lib/static-member-declarations/cmp2`,
+    path: `${libName}/src/lib/static-member-declarations/cmp2/cmp2`,
     module: 'static-member-declarations',
     standalone: false,
     skipFormat: true,
@@ -280,14 +280,14 @@ export class StaticMemberDeclarationsModule {
   await componentGenerator(tree, {
     name: 'nested-button',
     module: 'nested',
-    directory: `${libName}/src/lib/nested/nested-button`,
+    path: `${libName}/src/lib/nested/nested-button/nested-button`,
     standalone: false,
     skipFormat: true,
   });
 
   await componentGenerator(tree, {
     name: 'test-other',
-    directory: `${libName}/src/lib/test-other`,
+    path: `${libName}/src/lib/test-other/test-other`,
     standalone: false,
     skipFormat: true,
   });

--- a/packages/devkit/src/generators/artifact-name-and-directory-utils.spec.ts
+++ b/packages/devkit/src/generators/artifact-name-and-directory-utils.spec.ts
@@ -35,213 +35,173 @@ describe('determineArtifactNameAndDirectoryOptions', () => {
 
     await expect(
       determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'myComponent',
+        path: 'myComponent',
       })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"The current working directory "some/path" does not exist under any project root. Please make sure to navigate to a location or provide a directory that exists under a project root."`
+      `"The provided directory resolved relative to the current working directory "some/path" does not exist under any project root. Please make sure to navigate to a location or provide a directory that exists under a project root."`
     );
 
     restoreCwd();
   });
 
-  it('should throw when receiving a path as the name and a directory', async () => {
+  it('should return options as provided when there is a project at the cwd', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+    });
+    setCwd('apps/app1');
+
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      path: 'apps/app1/myComponent',
+    });
+
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1',
+      fileName: 'myComponent',
+      filePath: 'apps/app1/myComponent.ts',
+      project: 'app1',
+    });
+
+    restoreCwd();
+  });
+
+  it('should not duplicate the cwd when the provided directory starts with the cwd and format is "as-provided"', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+    });
+    setCwd('apps/app1');
+
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      path: 'apps/app1/myComponent',
+    });
+
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1',
+      fileName: 'myComponent',
+      filePath: 'apps/app1/myComponent.ts',
+      project: 'app1',
+    });
+
+    restoreCwd();
+  });
+
+  it('should return the options as provided when directory is provided', async () => {
     addProjectConfiguration(tree, 'app1', {
       root: 'apps/app1',
       projectType: 'application',
     });
 
-    await expect(
-      determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'apps/app1/foo/bar/myComponent',
-        directory: 'foo/bar',
-      })
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"You can't specify both a directory (foo/bar) and a name with a directory path (apps/app1/foo/bar/myComponent). Please specify either a directory or a name with a directory path."`
-    );
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      path: 'apps/app1/myComponent',
+    });
+
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1',
+      fileName: 'myComponent',
+      filePath: 'apps/app1/myComponent.ts',
+      project: 'app1',
+    });
   });
 
-  describe('as-provided', () => {
-    it('should return options as provided when there is a project at the cwd', async () => {
-      addProjectConfiguration(tree, 'app1', {
-        root: 'apps/app1',
-        projectType: 'application',
-      });
-      setCwd('apps/app1');
-
-      const result = await determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'myComponent',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      expect(result).toStrictEqual({
-        artifactName: 'myComponent',
-        directory: 'apps/app1',
-        fileName: 'myComponent',
-        filePath: 'apps/app1/myComponent.ts',
-        project: 'app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      restoreCwd();
+  it(`should handle window's style paths correctly`, async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
     });
 
-    it('should not duplicate the cwd when the provided directory starts with the cwd and format is "as-provided"', async () => {
-      addProjectConfiguration(tree, 'app1', {
-        root: 'apps/app1',
-        projectType: 'application',
-      });
-      setCwd('apps/app1');
-
-      const result = await determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'myComponent',
-        directory: 'apps/app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      expect(result).toStrictEqual({
-        artifactName: 'myComponent',
-        directory: 'apps/app1',
-        fileName: 'myComponent',
-        filePath: 'apps/app1/myComponent.ts',
-        project: 'app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      restoreCwd();
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      path: 'apps\\app1\\myComponent',
     });
 
-    it('should return the options as provided when directory is provided', async () => {
-      addProjectConfiguration(tree, 'app1', {
-        root: 'apps/app1',
-        projectType: 'application',
-      });
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1',
+      fileName: 'myComponent',
+      filePath: 'apps/app1/myComponent.ts',
+      project: 'app1',
+    });
+  });
 
-      const result = await determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'myComponent',
-        directory: 'apps/app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      expect(result).toStrictEqual({
-        artifactName: 'myComponent',
-        directory: 'apps/app1',
-        fileName: 'myComponent',
-        filePath: 'apps/app1/myComponent.ts',
-        project: 'app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
+  it('should support receiving a path as the name', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
     });
 
-    it(`should handle window's style paths correctly`, async () => {
-      addProjectConfiguration(tree, 'app1', {
-        root: 'apps/app1',
-        projectType: 'application',
-      });
-
-      const result = await determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'myComponent',
-        directory: 'apps\\app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      expect(result).toStrictEqual({
-        artifactName: 'myComponent',
-        directory: 'apps/app1',
-        fileName: 'myComponent',
-        filePath: 'apps/app1/myComponent.ts',
-        project: 'app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      path: 'apps/app1/foo/bar/myComponent',
     });
 
-    it('should support receiving a path as the name', async () => {
-      addProjectConfiguration(tree, 'app1', {
-        root: 'apps/app1',
-        projectType: 'application',
-      });
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1/foo/bar',
+      fileName: 'myComponent',
+      filePath: 'apps/app1/foo/bar/myComponent.ts',
+      project: 'app1',
+    });
+  });
 
-      const result = await determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'apps/app1/foo/bar/myComponent',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      expect(result).toStrictEqual({
-        artifactName: 'myComponent',
-        directory: 'apps/app1/foo/bar',
-        fileName: 'myComponent',
-        filePath: 'apps/app1/foo/bar/myComponent.ts',
-        project: 'app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
+  it('should support receiving a suffix', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
     });
 
-    it('should support receiving a suffix', async () => {
-      addProjectConfiguration(tree, 'app1', {
-        root: 'apps/app1',
-        projectType: 'application',
-      });
-
-      const result = await determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'myComponent',
-        suffix: 'component',
-        directory: 'apps/app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      expect(result).toStrictEqual({
-        artifactName: 'myComponent',
-        directory: 'apps/app1',
-        fileName: 'myComponent.component',
-        filePath: 'apps/app1/myComponent.component.ts',
-        project: 'app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      suffix: 'component',
+      path: 'apps/app1/myComponent',
     });
 
-    it('should support receiving a fileName', async () => {
-      addProjectConfiguration(tree, 'app1', {
-        root: 'apps/app1',
-        projectType: 'application',
-      });
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1',
+      fileName: 'myComponent.component',
+      filePath: 'apps/app1/myComponent.component.ts',
+      project: 'app1',
+    });
+  });
 
-      const result = await determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'myComponent',
-        fileName: 'myComponent.component',
-        directory: 'apps/app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
-
-      expect(result).toStrictEqual({
-        artifactName: 'myComponent',
-        directory: 'apps/app1',
-        fileName: 'myComponent.component',
-        filePath: 'apps/app1/myComponent.component.ts',
-        project: 'app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
+  it('should support receiving a fileName', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
     });
 
-    it('should support receiving a different file extension', async () => {
-      addProjectConfiguration(tree, 'app1', {
-        root: 'apps/app1',
-        projectType: 'application',
-      });
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      fileName: 'myComponent.component',
+      path: 'apps/app1/myComponent',
+    });
 
-      const result = await determineArtifactNameAndDirectoryOptions(tree, {
-        name: 'myComponent',
-        fileExtension: 'tsx',
-        directory: 'apps/app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1',
+      fileName: 'myComponent.component',
+      filePath: 'apps/app1/myComponent.component.ts',
+      project: 'app1',
+    });
+  });
 
-      expect(result).toStrictEqual({
-        artifactName: 'myComponent',
-        directory: 'apps/app1',
-        fileName: 'myComponent',
-        filePath: 'apps/app1/myComponent.tsx',
-        project: 'app1',
-        nameAndDirectoryFormat: 'as-provided',
-      });
+  it('should support receiving a different file extension', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+    });
+
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      fileExtension: 'tsx',
+      path: 'apps/app1/myComponent',
+    });
+
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1',
+      fileName: 'myComponent',
+      filePath: 'apps/app1/myComponent.tsx',
+      project: 'app1',
     });
   });
 });

--- a/packages/devkit/src/generators/artifact-name-and-directory-utils.ts
+++ b/packages/devkit/src/generators/artifact-name-and-directory-utils.ts
@@ -57,7 +57,6 @@ export async function determineArtifactNameAndDirectoryOptions(
   return normalizedOptions;
 }
 
-// TODO(nicholas): Rename to `getArtifactNameAndDirectoryOptions` after testing
 function getNameAndDirectoryOptions(
   tree: Tree,
   options: ArtifactGenerationOptions
@@ -76,7 +75,6 @@ function getNameAndDirectoryOptions(
   }
 
   const project = findProjectFromPath(tree, directory);
-
   const name =
     options.fileName ??
     (options.suffix ? `${extractedName}.${options.suffix}` : extractedName);
@@ -138,6 +136,9 @@ function extractNameAndDirectoryFromPath(path: string): {
   name: string;
   directory: string;
 } {
+  // Remove trailing slash
+  path = path.replace(/\/$/, '');
+
   const parsedPath = normalizePath(path).split('/');
   const name = parsedPath.pop();
   const directory = parsedPath.join('/');

--- a/packages/expo/src/generators/component/component.spec.ts
+++ b/packages/expo/src/generators/component/component.spec.ts
@@ -20,7 +20,7 @@ describe('component', () => {
     appTree.write('.gitignore', '');
     defaultSchema = {
       name: 'hello',
-      path: 'my-lib/src/lib/hello',
+      path: 'my-lib/src/lib/hello/hello',
       skipTests: false,
       export: false,
       classComponent: false,
@@ -35,7 +35,6 @@ describe('component', () => {
       skipFormat: false,
       js: true,
       unitTestRunner: 'jest',
-      projectNameAndRootFormat: 'as-provided',
     });
     await expoLibraryGenerator(appTree, {
       name: projectName,
@@ -45,7 +44,6 @@ describe('component', () => {
       unitTestRunner: 'jest',
       strict: true,
       js: false,
-      projectNameAndRootFormat: 'as-provided',
     });
     jest.spyOn(logger, 'warn').mockImplementation(() => {});
     jest.spyOn(logger, 'debug').mockImplementation(() => {});
@@ -65,7 +63,7 @@ describe('component', () => {
   it('should generate files for an app', async () => {
     await expoComponentGenerator(appTree, {
       ...defaultSchema,
-      path: 'my-app/src/app/hello',
+      path: 'my-app/src/app/hello/hello',
     });
 
     expect(appTree.exists('my-app/src/app/hello/hello.tsx')).toBeTruthy();

--- a/packages/expo/src/generators/component/component.spec.ts
+++ b/packages/expo/src/generators/component/component.spec.ts
@@ -20,7 +20,7 @@ describe('component', () => {
     appTree.write('.gitignore', '');
     defaultSchema = {
       name: 'hello',
-      directory: 'my-lib/src/lib/hello',
+      path: 'my-lib/src/lib/hello',
       skipTests: false,
       export: false,
       classComponent: false,
@@ -65,7 +65,7 @@ describe('component', () => {
   it('should generate files for an app', async () => {
     await expoComponentGenerator(appTree, {
       ...defaultSchema,
-      directory: 'my-app/src/app/hello',
+      path: 'my-app/src/app/hello',
     });
 
     expect(appTree.exists('my-app/src/app/hello/hello.tsx')).toBeTruthy();
@@ -87,7 +87,7 @@ describe('component', () => {
     it('should not export from an app', async () => {
       await expoComponentGenerator(appTree, {
         ...defaultSchema,
-        directory: 'my-lib/src/app/my-app',
+        path: 'my-lib/src/app/my-app',
         export: true,
       });
 
@@ -101,7 +101,7 @@ describe('component', () => {
     it('should create component under the directory', async () => {
       await expoComponentGenerator(appTree, {
         ...defaultSchema,
-        directory: 'my-lib/src/components/hello',
+        path: 'my-lib/src/components/hello',
       });
 
       expect(appTree.exists('my-lib/src/components/hello/hello.tsx'));
@@ -111,7 +111,7 @@ describe('component', () => {
       await expoComponentGenerator(appTree, {
         ...defaultSchema,
         name: 'helloWorld',
-        directory: 'my-lib/src/lib/foo/hello-world',
+        path: 'my-lib/src/lib/foo/hello-world',
       });
 
       expect(appTree.exists('my-lib/src/lib/foo/hello-world/hello-world.tsx'));

--- a/packages/expo/src/generators/component/component.ts
+++ b/packages/expo/src/generators/component/component.ts
@@ -25,7 +25,7 @@ export async function expoComponentGenerator(host: Tree, schema: Schema) {
 }
 
 function createComponentFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(host, join(__dirname, './files'), options.path, {
+  generateFiles(host, join(__dirname, './files'), options.directory, {
     ...options,
     tmpl: '',
   });

--- a/packages/expo/src/generators/component/component.ts
+++ b/packages/expo/src/generators/component/component.ts
@@ -25,7 +25,7 @@ export async function expoComponentGenerator(host: Tree, schema: Schema) {
 }
 
 function createComponentFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(host, join(__dirname, './files'), options.directory, {
+  generateFiles(host, join(__dirname, './files'), options.path, {
     ...options,
     tmpl: '',
   });

--- a/packages/expo/src/generators/component/lib/normalize-options.ts
+++ b/packages/expo/src/generators/component/lib/normalize-options.ts
@@ -3,6 +3,7 @@ import { Schema } from '../schema';
 import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface NormalizedSchema extends Schema {
+  directory: string;
   projectSourceRoot: string;
   fileName: string;
   className: string;
@@ -20,6 +21,7 @@ export async function normalizeOptions(
     artifactName: name,
     fileName,
     filePath,
+    directory,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(host, {
     name: options.name,
@@ -43,6 +45,7 @@ export async function normalizeOptions(
 
   return {
     ...options,
+    directory,
     className,
     fileName,
     filePath,

--- a/packages/expo/src/generators/component/lib/normalize-options.ts
+++ b/packages/expo/src/generators/component/lib/normalize-options.ts
@@ -18,14 +18,12 @@ export async function normalizeOptions(
 
   const {
     artifactName: name,
-    directory,
     fileName,
     filePath,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(host, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.path,
     fileExtension: 'tsx',
   });
 
@@ -45,7 +43,6 @@ export async function normalizeOptions(
 
   return {
     ...options,
-    directory,
     className,
     fileName,
     filePath,
@@ -60,8 +57,8 @@ function assertValidOptions(options: Schema) {
     if (options.name.indexOf(s) !== -1) {
       const [name, ...rest] = options.name.split(s).reverse();
       let suggestion = rest.map((x) => x.toLowerCase()).join(s);
-      if (options.directory) {
-        suggestion = `${options.directory}${s}${suggestion}`;
+      if (options.path) {
+        suggestion = `${options.path}${s}${suggestion}`;
       }
       throw new Error(
         `Found "${s}" in the component name. Did you mean to use the --directory option (e.g. \`nx g c ${name} --directory ${suggestion}\`)?`

--- a/packages/expo/src/generators/component/schema.d.ts
+++ b/packages/expo/src/generators/component/schema.d.ts
@@ -1,5 +1,3 @@
-import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-
 /**
  * Same as the @nx/react library schema, except it removes keys: style, routing, globalCss
  */

--- a/packages/expo/src/generators/component/schema.d.ts
+++ b/packages/expo/src/generators/component/schema.d.ts
@@ -4,8 +4,8 @@ import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-
  * Same as the @nx/react library schema, except it removes keys: style, routing, globalCss
  */
 export interface Schema {
-  name: string;
-  directory?: string;
+  path: string;
+  name?: string;
   skipFormat: boolean; // default is false
   skipTests: boolean; // default is false
   export: boolean; // default is false

--- a/packages/expo/src/generators/component/schema.json
+++ b/packages/expo/src/generators/component/schema.json
@@ -6,22 +6,28 @@
   "type": "object",
   "examples": [
     {
-      "command": "g @nx/expo:component my-component --directory=mylib/my-component",
+      "command": "g @nx/expo:component mylib/my-component --name my-component",
       "description": "Generate a component in the mylib library"
     },
     {
-      "command": "g @nx/expo:component my-component --directory=mylib/my-component --classComponent",
+      "command": "g @nx/expo:component mylib/my-component --name my-component --classComponent",
       "description": "Generate a class component in the mylib library"
     }
   ],
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the component.",
+      "description": "Path where the component will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the component be generated?",
+      "x-priority": "important"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the component.",
       "x-prompt": "What name would you like to use for the component?"
     },
     "js": {
@@ -40,16 +46,6 @@
       "description": "When true, does not create \"spec.ts\" test files for the new component.",
       "default": false
     },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
     "export": {
       "type": "boolean",
       "description": "When true, the component is exported from the project index.ts (if it exists).",
@@ -64,5 +60,5 @@
       "default": false
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/class/class.spec.ts
+++ b/packages/nest/src/generators/class/class.spec.ts
@@ -5,15 +5,15 @@ import { classGenerator } from './class';
 
 describe('class generator', () => {
   let tree: Tree;
-  const project = 'api';
+  const path = 'api';
   const options: ClassGeneratorOptions = {
     name: 'test',
-    directory: project,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(project);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/class/class.spec.ts
+++ b/packages/nest/src/generators/class/class.spec.ts
@@ -18,6 +18,8 @@ describe('class generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(classGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      classGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/class/schema.json
+++ b/packages/nest/src/generators/class/schema.json
@@ -6,33 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the class.",
+    "path": {
+      "description": "Path where the class will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the class be generated?"
+    },
+    "name": {
+      "description": "The name of the class.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "project": {
-      "description": "The Nest project to target.",
-      "type": "string",
-      "$default": {
-        "$source": "projectName"
-      },
-      "alias": "p",
-      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -59,5 +45,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/controller/controller.spec.ts
+++ b/packages/nest/src/generators/controller/controller.spec.ts
@@ -5,15 +5,15 @@ import { controllerGenerator } from './controller';
 
 describe('controller generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: ControllerGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/controller/controller.spec.ts
+++ b/packages/nest/src/generators/controller/controller.spec.ts
@@ -18,6 +18,8 @@ describe('controller generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(controllerGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      controllerGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/controller/schema.json
+++ b/packages/nest/src/generators/controller/schema.json
@@ -18,10 +18,6 @@
     "name": {
       "description": "The name of the controller.",
       "type": "string",
-      "$default": {
-        "$source": "argv",
-        "index": 0
-      },
       "x-prompt": "What name would you like to use?"
     },
     "skipFormat": {

--- a/packages/nest/src/generators/controller/schema.json
+++ b/packages/nest/src/generators/controller/schema.json
@@ -6,6 +6,15 @@
   "cli": "nx",
   "type": "object",
   "properties": {
+    "path": {
+      "description": "Path where the controller will be generated.",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "Where should the controller be generated?"
+    },
     "name": {
       "description": "The name of the controller.",
       "type": "string",
@@ -14,16 +23,6 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -53,5 +52,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/decorator/decorator.spec.ts
+++ b/packages/nest/src/generators/decorator/decorator.spec.ts
@@ -5,14 +5,14 @@ import { decoratorGenerator } from './decorator';
 
 describe('decorator generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: DecoratorGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/decorator/decorator.spec.ts
+++ b/packages/nest/src/generators/decorator/decorator.spec.ts
@@ -17,6 +17,8 @@ describe('decorator generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(decoratorGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      decoratorGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/decorator/schema.json
+++ b/packages/nest/src/generators/decorator/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the decorator.",
+    "path": {
+      "description": "Path where the decorator will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the decorator be generated?"
+    },
+    "name": {
+      "description": "The name of the decorator.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -38,5 +33,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/filter/filter.spec.ts
+++ b/packages/nest/src/generators/filter/filter.spec.ts
@@ -5,15 +5,15 @@ import { filterGenerator } from './filter';
 
 describe('filter generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: FilterGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/filter/filter.spec.ts
+++ b/packages/nest/src/generators/filter/filter.spec.ts
@@ -18,6 +18,8 @@ describe('filter generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(filterGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      filterGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/filter/schema.json
+++ b/packages/nest/src/generators/filter/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the filter.",
+    "path": {
+      "description": "Path where the filter will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the filter be generated?"
+    },
+    "name": {
+      "description": "The name of the filter.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "type": "boolean",
@@ -44,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/gateway/gateway.spec.ts
+++ b/packages/nest/src/generators/gateway/gateway.spec.ts
@@ -18,6 +18,8 @@ describe('gateway generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(gatewayGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      gatewayGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/gateway/gateway.spec.ts
+++ b/packages/nest/src/generators/gateway/gateway.spec.ts
@@ -5,15 +5,15 @@ import { gatewayGenerator } from './gateway';
 
 describe('gateway generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: GatewayGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/gateway/schema.json
+++ b/packages/nest/src/generators/gateway/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the gateway.",
+    "path": {
+      "description": "Path where the gateway will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the gateway be generated?"
+    },
+    "name": {
+      "description": "The name of the gateway.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -44,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/guard/guard.spec.ts
+++ b/packages/nest/src/generators/guard/guard.spec.ts
@@ -18,6 +18,8 @@ describe('guard generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(guardGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      guardGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/guard/guard.spec.ts
+++ b/packages/nest/src/generators/guard/guard.spec.ts
@@ -5,15 +5,15 @@ import { guardGenerator } from './guard';
 
 describe('guard generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: GuardGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/guard/schema.json
+++ b/packages/nest/src/generators/guard/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the guard.",
+    "path": {
+      "description": "Path where the guard will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the guard be generated?"
+    },
+    "name": {
+      "description": "The name of the guard.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",

--- a/packages/nest/src/generators/interceptor/interceptor.spec.ts
+++ b/packages/nest/src/generators/interceptor/interceptor.spec.ts
@@ -18,6 +18,8 @@ describe('interceptor generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(interceptorGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      interceptorGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/interceptor/interceptor.spec.ts
+++ b/packages/nest/src/generators/interceptor/interceptor.spec.ts
@@ -5,15 +5,15 @@ import { interceptorGenerator } from './interceptor';
 
 describe('interceptor generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: InterceptorGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/interceptor/schema.json
+++ b/packages/nest/src/generators/interceptor/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the interceptor.",
+    "path": {
+      "description": "Path where the interceptor will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the interceptor be generated?"
+    },
+    "name": {
+      "description": "The name of the interceptor.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",

--- a/packages/nest/src/generators/interface/interface.spec.ts
+++ b/packages/nest/src/generators/interface/interface.spec.ts
@@ -17,6 +17,8 @@ describe('interface generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(interfaceGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      interfaceGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/interface/interface.spec.ts
+++ b/packages/nest/src/generators/interface/interface.spec.ts
@@ -5,14 +5,14 @@ import { interfaceGenerator } from './interface';
 
 describe('interface generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: InterfaceGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/interface/schema.json
+++ b/packages/nest/src/generators/interface/schema.json
@@ -6,33 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the interface.",
+    "path": {
+      "description": "Path where the interface will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the interface be generated?"
+    },
+    "name": {
+      "description": "The name of the interface.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "project": {
-      "description": "The Nest project to target.",
-      "type": "string",
-      "$default": {
-        "$source": "projectName"
-      },
-      "alias": "p",
-      "x-deprecated": "Provide The `directory` option instead and use the `as-provided` format. the project will be determined from the directory provided. It will be removed in Nx v20."
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -48,5 +34,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/middleware/middleware.spec.ts
+++ b/packages/nest/src/generators/middleware/middleware.spec.ts
@@ -5,15 +5,15 @@ import { middlewareGenerator } from './middleware';
 
 describe('middleware generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: MiddlewareGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/middleware/middleware.spec.ts
+++ b/packages/nest/src/generators/middleware/middleware.spec.ts
@@ -18,6 +18,8 @@ describe('middleware generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(middlewareGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      middlewareGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/middleware/schema.json
+++ b/packages/nest/src/generators/middleware/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the middleware.",
+    "path": {
+      "description": "Path where the middleware will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the middleware be generated?"
+    },
+    "name": {
+      "description": "The name of the middleware.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -44,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/module/module.spec.ts
+++ b/packages/nest/src/generators/module/module.spec.ts
@@ -5,14 +5,14 @@ import { moduleGenerator } from './module';
 
 describe('module generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: ModuleGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/module/module.spec.ts
+++ b/packages/nest/src/generators/module/module.spec.ts
@@ -17,6 +17,8 @@ describe('module generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(moduleGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      moduleGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/module/schema.json
+++ b/packages/nest/src/generators/module/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the module.",
+    "path": {
+      "description": "Path where the module will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the module be generated?"
+    },
+    "name": {
+      "description": "The name of the module.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -48,5 +43,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/pipe/pipe.spec.ts
+++ b/packages/nest/src/generators/pipe/pipe.spec.ts
@@ -18,6 +18,8 @@ describe('pipe generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(pipeGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      pipeGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/pipe/pipe.spec.ts
+++ b/packages/nest/src/generators/pipe/pipe.spec.ts
@@ -5,15 +5,15 @@ import { pipeGenerator } from './pipe';
 
 describe('pipe generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: PipeGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/pipe/schema.json
+++ b/packages/nest/src/generators/pipe/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the pipe.",
+    "path": {
+      "description": "Path where the pipe will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the pipe be generated?"
+    },
+    "name": {
+      "description": "The name of the pipe.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -44,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/provider/provider.spec.ts
+++ b/packages/nest/src/generators/provider/provider.spec.ts
@@ -5,15 +5,15 @@ import { providerGenerator } from './provider';
 
 describe('provider generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: ProviderGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/provider/provider.spec.ts
+++ b/packages/nest/src/generators/provider/provider.spec.ts
@@ -18,6 +18,8 @@ describe('provider generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(providerGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      providerGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/provider/schema.json
+++ b/packages/nest/src/generators/provider/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the provider.",
+    "path": {
+      "description": "Path where the provider will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the provider be generated?"
+    },
+    "name": {
+      "description": "The name of the provider.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -44,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/resolver/resolver.spec.ts
+++ b/packages/nest/src/generators/resolver/resolver.spec.ts
@@ -18,6 +18,8 @@ describe('resolver generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(resolverGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      resolverGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/resolver/resolver.spec.ts
+++ b/packages/nest/src/generators/resolver/resolver.spec.ts
@@ -5,15 +5,15 @@ import { resolverGenerator } from './resolver';
 
 describe('resolver generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: ResolverGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/resolver/schema.json
+++ b/packages/nest/src/generators/resolver/schema.json
@@ -6,24 +6,19 @@
   "cli": "nx",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "The name of the resolver.",
+    "path": {
+      "description": "Path where the resolver will be generated.",
       "type": "string",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the resolver be generated?"
+    },
+    "name": {
+      "description": "The name of the resolver.",
+      "type": "string",
       "x-prompt": "What name would you like to use?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",
@@ -44,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/resource/resource.spec.ts
+++ b/packages/nest/src/generators/resource/resource.spec.ts
@@ -6,15 +6,15 @@ import { resourceGenerator } from './resource';
 // TODO (nicolas) fix the tests current fails with Error: spawn /bin/sh ENOENT)... Also fails on master from utils/run-nest-schematic.spec.ts
 xdescribe('resource generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: ResourceGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/resource/resource.spec.ts
+++ b/packages/nest/src/generators/resource/resource.spec.ts
@@ -19,6 +19,8 @@ xdescribe('resource generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(resourceGenerator(tree, options)).resolves.not.toThrow();
+    await expect(
+      resourceGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/nest/src/generators/resource/schema.json
+++ b/packages/nest/src/generators/resource/schema.json
@@ -18,10 +18,6 @@
     "name": {
       "type": "string",
       "description": "The name of the resource.",
-      "$default": {
-        "$source": "argv",
-        "index": 0
-      },
       "x-prompt": "What name would you like to use for this resource (plural, e.g., `users`)?"
     },
     "skipFormat": {
@@ -92,5 +88,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/resource/schema.json
+++ b/packages/nest/src/generators/resource/schema.json
@@ -6,6 +6,15 @@
   "cli": "nx",
   "type": "object",
   "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path where the resource will be generated.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "Where should the resource be generated?"
+    },
     "name": {
       "type": "string",
       "description": "The name of the resource.",
@@ -14,16 +23,6 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for this resource (plural, e.g., `users`)?"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",

--- a/packages/nest/src/generators/service/schema.json
+++ b/packages/nest/src/generators/service/schema.json
@@ -15,16 +15,6 @@
       },
       "x-prompt": "What name would you like to use?"
     },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
-    "directory": {
-      "description": "Directory where the generated files are placed. when `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. otherwise, it will be relative to the workspace root.",
-      "type": "string",
-      "aliases": ["dir", "path"]
-    },
     "skipFormat": {
       "description": "Skip formatting files.",
       "type": "boolean",

--- a/packages/nest/src/generators/service/service.spec.ts
+++ b/packages/nest/src/generators/service/service.spec.ts
@@ -5,15 +5,15 @@ import { serviceGenerator } from './service';
 
 describe('service generator', () => {
   let tree: Tree;
-  const directory = 'api';
+  const path = 'api';
   const options: ServiceGeneratorOptions = {
     name: 'test',
-    directory,
+    path,
     unitTestRunner: 'jest',
   };
 
   beforeEach(() => {
-    tree = createTreeWithNestApplication(directory);
+    tree = createTreeWithNestApplication(path);
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/service/service.spec.ts
+++ b/packages/nest/src/generators/service/service.spec.ts
@@ -18,6 +18,8 @@ describe('service generator', () => {
   });
 
   it('should run successfully', async () => {
-    await expect(serviceGenerator(tree, options)).resolves.not.toThrowError();
+    await expect(
+      serviceGenerator(tree, { ...options, path: 'api/test' })
+    ).resolves.not.toThrowError();
   });
 });

--- a/packages/nest/src/generators/utils/normalize-options.ts
+++ b/packages/nest/src/generators/utils/normalize-options.ts
@@ -13,8 +13,7 @@ export async function normalizeOptions(
   const { directory, fileName } =
     await determineArtifactNameAndDirectoryOptions(tree, {
       name: options.name,
-      directory: options.directory,
-      nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+      path: options.path,
     });
 
   return {

--- a/packages/nest/src/generators/utils/types.ts
+++ b/packages/nest/src/generators/utils/types.ts
@@ -26,10 +26,9 @@ export type TransportLayer =
   | 'ws';
 
 export type NestGeneratorOptions = {
-  name: string;
-  directory?: string;
+  path: string;
+  name?: string;
   skipFormat?: boolean;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
 };
 
 export type NestGeneratorWithLanguageOption = NestGeneratorOptions & {

--- a/packages/nest/src/generators/utils/types.ts
+++ b/packages/nest/src/generators/utils/types.ts
@@ -1,5 +1,3 @@
-import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-
 export type Language = 'js' | 'ts';
 export type UnitTestRunner = 'jest' | 'none';
 export type NestSchematic =

--- a/packages/next/src/generators/component/component.spec.ts
+++ b/packages/next/src/generators/component/component.spec.ts
@@ -31,7 +31,7 @@ describe('component', () => {
   it('should generate component in components directory for application', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      directory: `${appName}/components/hello`,
+      path: `${appName}/components/hello`,
       style: 'css',
     });
 
@@ -45,7 +45,7 @@ describe('component', () => {
   it('should generate component in default directory for library', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      directory: `${libName}/src/lib/hello`,
+      path: `${libName}/src/lib/hello`,
       style: 'css',
     });
 
@@ -57,12 +57,12 @@ describe('component', () => {
   it('should allow directory override', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      directory: `${appName}/foo/hello`,
+      path: `${appName}/foo/hello`,
       style: 'css',
     });
     await componentGenerator(tree, {
       name: 'world',
-      directory: `${libName}/src/bar/world`,
+      path: `${libName}/src/bar/world`,
       style: 'css',
     });
 
@@ -77,8 +77,7 @@ describe('component', () => {
   it('should work with path as-provided', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      directory: 'my-lib/src/foo',
-      nameAndDirectoryFormat: 'as-provided',
+      path: 'my-lib/src/foo',
       style: 'css',
     });
 
@@ -87,11 +86,10 @@ describe('component', () => {
     expect(tree.exists('my-lib/src/foo/hello.module.css')).toBeTruthy();
   });
 
-  it('should work with directory as a part of the component name', async () => {
+  it('should work with path as a part of the component name', async () => {
     await componentGenerator(tree, {
-      name: `${libName}/src/btn/btn`,
+      path: `${libName}/src/btn`,
       style: 'css',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     expect(tree.exists(`${libName}/src/btn/btn.tsx`)).toBeTruthy();

--- a/packages/next/src/generators/component/component.spec.ts
+++ b/packages/next/src/generators/component/component.spec.ts
@@ -31,7 +31,7 @@ describe('component', () => {
   it('should generate component in components directory for application', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      path: `${appName}/components/hello`,
+      path: `${appName}/components/hello/hello`,
       style: 'css',
     });
 
@@ -45,7 +45,7 @@ describe('component', () => {
   it('should generate component in default directory for library', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      path: `${libName}/src/lib/hello`,
+      path: `${libName}/src/lib/hello/hello`,
       style: 'css',
     });
 
@@ -57,12 +57,12 @@ describe('component', () => {
   it('should allow directory override', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      path: `${appName}/foo/hello`,
+      path: `${appName}/foo/hello/hello`,
       style: 'css',
     });
     await componentGenerator(tree, {
       name: 'world',
-      path: `${libName}/src/bar/world`,
+      path: `${libName}/src/bar/world/world`,
       style: 'css',
     });
 
@@ -77,7 +77,7 @@ describe('component', () => {
   it('should work with path as-provided', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      path: 'my-lib/src/foo',
+      path: 'my-lib/src/foo/hello',
       style: 'css',
     });
 
@@ -88,7 +88,7 @@ describe('component', () => {
 
   it('should work with path as a part of the component name', async () => {
     await componentGenerator(tree, {
-      path: `${libName}/src/btn`,
+      path: `${libName}/src/btn/btn`,
       style: 'css',
     });
 

--- a/packages/next/src/generators/component/component.ts
+++ b/packages/next/src/generators/component/component.ts
@@ -10,16 +10,12 @@ import type { SupportedStyles } from '@nx/react';
 import { componentGenerator as reactComponentGenerator } from '@nx/react';
 
 import { addStyleDependencies } from '../../utils/styles';
-import {
-  determineArtifactNameAndDirectoryOptions,
-  type NameAndDirectoryFormat,
-} from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 interface Schema {
-  name: string;
+  path: string;
+  name?: string;
   style: SupportedStyles;
-  directory?: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   skipFormat?: boolean;
 }
 
@@ -34,16 +30,13 @@ export async function componentGenerator(host: Tree, options: Schema) {
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(host, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.path,
     fileExtension: 'tsx',
   });
 
   const componentInstall = await reactComponentGenerator(host, {
     ...options,
     name,
-    nameAndDirectoryFormat: 'as-provided', // already determined the directory so use as is
-    directory,
     classComponent: false,
     routing: false,
     skipFormat: true,

--- a/packages/next/src/generators/component/schema.json
+++ b/packages/next/src/generators/component/schema.json
@@ -6,13 +6,19 @@
   "description": "Create a React Component for Next.",
   "type": "object",
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the component.",
+      "description": "Path where the component will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the component be generated?",
+      "x-priority": "important"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the component.",
       "x-prompt": "What name would you like to use for the component?",
       "x-priority": "important"
     },
@@ -62,17 +68,6 @@
       "default": false,
       "x-priority": "internal"
     },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-      "alias": "dir",
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
     "export": {
       "type": "boolean",
       "description": "When true, the component is exported from the project index.ts (if it exists).",
@@ -91,6 +86,6 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"],
+  "required": ["path"],
   "examplesFile": "../../../docs/component-examples.md"
 }

--- a/packages/next/src/generators/page/page.spec.ts
+++ b/packages/next/src/generators/page/page.spec.ts
@@ -30,7 +30,7 @@ describe('component', () => {
     it('should generate component in pages directory', async () => {
       await pageGenerator(tree, {
         name: 'hello',
-        path: 'my-app/pages/hello',
+        path: 'my-app/pages/hello/index',
         style: 'css',
       });
 
@@ -41,7 +41,7 @@ describe('component', () => {
     it('should support dynamic routes and directories', async () => {
       await pageGenerator(tree, {
         name: '[dynamic]',
-        path: 'my-app/pages/posts/[dynamic]',
+        path: 'my-app/pages/posts/[dynamic]/index',
         style: 'css',
       });
 
@@ -58,7 +58,7 @@ describe('component', () => {
     it('should generate component in app directory', async () => {
       await pageGenerator(tree, {
         name: 'about',
-        path: `${appRouterProjectName}/app/about`,
+        path: `${appRouterProjectName}/app/about/about`,
         style: 'css',
       });
 
@@ -73,7 +73,7 @@ describe('component', () => {
     it('should support dynamic routes and directories', async () => {
       await pageGenerator(tree, {
         name: '[dynamic]',
-        path: `${appRouterProjectName}/app/posts/[dynamic]`,
+        path: `${appRouterProjectName}/app/posts/[dynamic]/page`,
         style: 'css',
       });
 

--- a/packages/next/src/generators/page/page.spec.ts
+++ b/packages/next/src/generators/page/page.spec.ts
@@ -30,7 +30,7 @@ describe('component', () => {
     it('should generate component in pages directory', async () => {
       await pageGenerator(tree, {
         name: 'hello',
-        directory: 'my-app/pages/hello',
+        path: 'my-app/pages/hello',
         style: 'css',
       });
 
@@ -41,7 +41,7 @@ describe('component', () => {
     it('should support dynamic routes and directories', async () => {
       await pageGenerator(tree, {
         name: '[dynamic]',
-        directory: 'my-app/pages/posts/[dynamic]',
+        path: 'my-app/pages/posts/[dynamic]',
         style: 'css',
       });
 
@@ -51,10 +51,6 @@ describe('component', () => {
       expect(
         tree.exists('my-app/pages/posts/[dynamic]/index.module.css')
       ).toBeTruthy();
-
-      const content = tree
-        .read('my-app/pages/posts/[dynamic]/index.tsx')
-        .toString();
     });
   });
 
@@ -62,9 +58,8 @@ describe('component', () => {
     it('should generate component in app directory', async () => {
       await pageGenerator(tree, {
         name: 'about',
-        directory: `${appRouterProjectName}/app/about`,
+        path: `${appRouterProjectName}/app/about`,
         style: 'css',
-        nameAndDirectoryFormat: 'as-provided',
       });
 
       expect(
@@ -78,7 +73,7 @@ describe('component', () => {
     it('should support dynamic routes and directories', async () => {
       await pageGenerator(tree, {
         name: '[dynamic]',
-        directory: `${appRouterProjectName}/app/posts/[dynamic]`,
+        path: `${appRouterProjectName}/app/posts/[dynamic]`,
         style: 'css',
       });
 

--- a/packages/next/src/generators/page/page.ts
+++ b/packages/next/src/generators/page/page.ts
@@ -21,7 +21,6 @@ export async function pageGenerator(host: Tree, schema: Schema) {
   const componentTask = await reactComponentGenerator(host, {
     ...options,
     isNextPage: true,
-    nameAndDirectoryFormat: 'as-provided', // already determined the directory so use as is
     export: false,
     classComponent: false,
     routing: false,
@@ -47,7 +46,7 @@ async function normalizeOptions(host: Tree, options: Schema) {
   const { project: determinedProjectName } =
     await determineArtifactNameAndDirectoryOptions(host, {
       name: options.name,
-      directory: options.directory,
+      path: options.path,
     });
 
   const project = readProjectConfiguration(host, determinedProjectName);
@@ -57,20 +56,15 @@ async function normalizeOptions(host: Tree, options: Schema) {
     host.exists(`${project.root}/app`) ||
     host.exists(`${project.root}/src/app`);
 
-  const {
-    project: projectName,
-    fileName,
-    directory,
-  } = await determineArtifactNameAndDirectoryOptions(host, {
-    name: options.name,
-    fileName: isAppRouter ? 'page' : 'index',
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
-    fileExtension: 'tsx',
-  });
+  const { project: projectName, fileName } =
+    await determineArtifactNameAndDirectoryOptions(host, {
+      name: options.name,
+      fileName: isAppRouter ? 'page' : 'index',
+      path: options.path,
+      fileExtension: 'tsx',
+    });
   return {
     ...options,
-    directory,
     fileName,
     projectName,
   };

--- a/packages/next/src/generators/page/schema.d.ts
+++ b/packages/next/src/generators/page/schema.d.ts
@@ -2,12 +2,11 @@ import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-
 import { SupportedStyles } from '@nx/react';
 
 export interface Schema {
-  name: string;
+  path: string;
+  name?: string;
   style: SupportedStyles;
-  directory?: string;
   fileName?: string;
   withTests?: boolean;
   js?: boolean;
   skipFormat?: boolean;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
 }

--- a/packages/next/src/generators/page/schema.json
+++ b/packages/next/src/generators/page/schema.json
@@ -6,35 +6,21 @@
   "description": "Create a Page for Next.",
   "type": "object",
   "properties": {
-    "project": {
+    "path": {
       "type": "string",
-      "description": "The name of the project.",
-      "alias": "p",
-      "$default": {
-        "$source": "projectName"
-      },
-      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v20."
-    },
-    "name": {
-      "type": "string",
-      "description": "The name of the component.",
+      "description": "Path where the page will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use for the component?",
+      "x-prompt": "Where should the page be generated?",
       "x-priority": "important"
     },
-    "directory": {
+    "name": {
       "type": "string",
-      "description": "The directory at which to create the page file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-      "alias": "dir",
+      "description": "The name of the page.",
+      "x-prompt": "What name would you like to use for the page?",
       "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     },
     "style": {
       "description": "The file extension to be used for style files.",

--- a/packages/next/src/generators/page/schema.json
+++ b/packages/next/src/generators/page/schema.json
@@ -92,6 +92,6 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"],
+  "required": ["path"],
   "examplesFile": "../../../docs/page-examples.md"
 }

--- a/packages/nuxt/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/nuxt/src/generators/storybook-configuration/configuration.spec.ts
@@ -95,7 +95,7 @@ export async function createTestApp(
 
   await componentGenerator(appTree, {
     name: 'my-component',
-    directory: `${appName}/src/components`,
+    path: `${appName}/src/components/my-component`,
   });
 
   return appTree;

--- a/packages/plugin/src/generators/create-package/create-package.ts
+++ b/packages/plugin/src/generators/create-package/create-package.ts
@@ -70,10 +70,9 @@ async function addPresetGenerator(
   if (!hasGenerator(host, schema.project, 'preset')) {
     await generatorGenerator(host, {
       name: 'preset',
-      directory: join(projectRoot, 'src/generators/preset'),
+      path: join(projectRoot, 'src/generators/preset'),
       unitTestRunner: schema.unitTestRunner,
       skipFormat: true,
-      nameAndDirectoryFormat: 'as-provided',
     });
   }
 

--- a/packages/plugin/src/generators/executor/executor.spec.ts
+++ b/packages/plugin/src/generators/executor/executor.spec.ts
@@ -29,10 +29,9 @@ describe('NxPlugin Executor Generator', () => {
   it('should generate files', async () => {
     await executorGenerator(tree, {
       name: 'my-executor',
-      directory: 'my-plugin/src/executors/my-executor',
+      path: 'my-plugin/src/executors/my-executor',
       unitTestRunner: 'jest',
       includeHasher: false,
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     expect(
@@ -54,9 +53,8 @@ describe('NxPlugin Executor Generator', () => {
     await executorGenerator(tree, {
       name: 'my-executor',
       unitTestRunner: 'jest',
-      directory: 'my-plugin/src/executors/my-executor',
+      path: 'my-plugin/src/executors/my-executor',
       includeHasher: false,
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     expect(
@@ -76,29 +74,7 @@ describe('NxPlugin Executor Generator', () => {
   it('should update executors.json', async () => {
     await executorGenerator(tree, {
       name: 'my-executor',
-      directory: 'my-plugin/src/executors/my-executor',
-      unitTestRunner: 'jest',
-      includeHasher: false,
-      nameAndDirectoryFormat: 'as-provided',
-    });
-
-    const executorJson = readJson(tree, 'my-plugin/executors.json');
-
-    expect(executorJson.executors['my-executor'].implementation).toEqual(
-      './src/executors/my-executor/executor'
-    );
-    expect(executorJson.executors['my-executor'].schema).toEqual(
-      './src/executors/my-executor/schema.json'
-    );
-    expect(executorJson.executors['my-executor'].description).toEqual(
-      'my-executor executor'
-    );
-  });
-
-  it('should update executors.json for derived', async () => {
-    await executorGenerator(tree, {
-      name: 'my-executor',
-      directory: 'my-plugin/src/executors/my-executor',
+      path: 'my-plugin/src/executors/my-executor',
       unitTestRunner: 'jest',
       includeHasher: false,
     });
@@ -119,11 +95,10 @@ describe('NxPlugin Executor Generator', () => {
   it('should generate custom description', async () => {
     await executorGenerator(tree, {
       name: 'my-executor',
-      directory: 'my-plugin/src/executors/my-executor',
+      path: 'my-plugin/src/executors/my-executor',
       description: 'my-executor custom description',
       unitTestRunner: 'jest',
       includeHasher: false,
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     const executorsJson = readJson(tree, 'my-plugin/executors.json');
@@ -143,10 +118,9 @@ describe('NxPlugin Executor Generator', () => {
 
     await executorGenerator(tree, {
       name: 'test-executor',
-      directory: 'test-js-lib/src/executors/my-executor',
+      path: 'test-js-lib/src/executors/my-executor',
       unitTestRunner: 'jest',
       includeHasher: false,
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     expect(() => tree.exists(`${libConfig.root}/executors.json`)).not.toThrow();
@@ -160,10 +134,9 @@ describe('NxPlugin Executor Generator', () => {
       it('should not generate unit test files', async () => {
         await executorGenerator(tree, {
           name: 'my-executor',
-          directory: 'my-plugin/src/executors/my-executor',
+          path: 'my-plugin/src/executors/my-executor',
           unitTestRunner: 'none',
           includeHasher: false,
-          nameAndDirectoryFormat: 'as-provided',
         });
 
         expect(
@@ -180,10 +153,9 @@ describe('NxPlugin Executor Generator', () => {
     it('should generate hasher files', async () => {
       await executorGenerator(tree, {
         name: 'my-executor',
-        directory: 'my-plugin/src/executors/my-executor',
+        path: 'my-plugin/src/executors/my-executor',
         unitTestRunner: 'jest',
         includeHasher: true,
-        nameAndDirectoryFormat: 'as-provided',
       });
       expect(
         tree.exists('my-plugin/src/executors/my-executor/hasher.spec.ts')
@@ -210,10 +182,9 @@ describe('NxPlugin Executor Generator', () => {
     it('should update executors.json', async () => {
       await executorGenerator(tree, {
         name: 'my-executor',
-        directory: 'my-plugin/src/executors/my-executor',
+        path: 'my-plugin/src/executors/my-executor',
         unitTestRunner: 'jest',
         includeHasher: true,
-        nameAndDirectoryFormat: 'as-provided',
       });
 
       const executorsJson = readJson(tree, 'my-plugin/executors.json');

--- a/packages/plugin/src/generators/executor/executor.ts
+++ b/packages/plugin/src/generators/executor/executor.ts
@@ -153,8 +153,7 @@ async function normalizeOptions(
   const { project, artifactName, filePath, directory } =
     await determineArtifactNameAndDirectoryOptions(tree, {
       name: options.name,
-      nameAndDirectoryFormat: options.nameAndDirectoryFormat,
-      directory: options.directory,
+      path: options.directory,
       fileName: 'executor',
     });
 

--- a/packages/plugin/src/generators/executor/executor.ts
+++ b/packages/plugin/src/generators/executor/executor.ts
@@ -28,32 +28,22 @@ interface NormalizedSchema extends Schema {
 }
 
 function addFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(
-    host,
-    path.join(__dirname, './files/executor'),
-    options.directory,
-    {
-      ...options,
-    }
-  );
+  generateFiles(host, path.join(__dirname, './files/executor'), options.path, {
+    ...options,
+  });
 
   if (options.unitTestRunner === 'none') {
-    host.delete(joinPathFragments(options.directory, `executor.spec.ts`));
+    host.delete(joinPathFragments(options.path, `executor.spec.ts`));
   }
 }
 
 function addHasherFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(
-    host,
-    path.join(__dirname, './files/hasher'),
-    options.directory,
-    {
-      ...options,
-    }
-  );
+  generateFiles(host, path.join(__dirname, './files/hasher'), options.path, {
+    ...options,
+  });
 
   if (options.unitTestRunner === 'none') {
-    host.delete(joinPathFragments(options.directory, 'hasher.spec.ts'));
+    host.delete(joinPathFragments(options.path, 'hasher.spec.ts'));
   }
 }
 
@@ -125,18 +115,18 @@ async function updateExecutorJson(host: Tree, options: NormalizedSchema) {
     executors ||= {};
     executors[options.name] = {
       implementation: `./${joinPathFragments(
-        relative(options.projectRoot, options.directory),
+        relative(options.projectRoot, options.path),
         'executor'
       )}`,
       schema: `./${joinPathFragments(
-        relative(options.projectRoot, options.directory),
+        relative(options.projectRoot, options.path),
         'schema.json'
       )}`,
       description: options.description,
     };
     if (options.includeHasher) {
       executors[options.name].hasher = `./${joinPathFragments(
-        relative(options.projectRoot, options.directory),
+        relative(options.projectRoot, options.path),
         'hasher'
       )}`;
     }
@@ -153,7 +143,7 @@ async function normalizeOptions(
   const { project, artifactName, filePath, directory } =
     await determineArtifactNameAndDirectoryOptions(tree, {
       name: options.name,
-      path: options.directory,
+      path: options.path,
       fileName: 'executor',
     });
 

--- a/packages/plugin/src/generators/executor/schema.d.ts
+++ b/packages/plugin/src/generators/executor/schema.d.ts
@@ -1,5 +1,3 @@
-import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-
 export interface Schema {
   name: string;
   directory?: string;

--- a/packages/plugin/src/generators/executor/schema.d.ts
+++ b/packages/plugin/src/generators/executor/schema.d.ts
@@ -1,10 +1,9 @@
 export interface Schema {
-  name: string;
-  directory?: string;
+  path: string;
+  name?: string;
   description?: string;
   unitTestRunner: 'jest' | 'none';
   includeHasher: boolean;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   skipLintChecks?: boolean;
   skipFormat?: boolean;
 }

--- a/packages/plugin/src/generators/executor/schema.json
+++ b/packages/plugin/src/generators/executor/schema.json
@@ -13,20 +13,20 @@
     }
   ],
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "Executor name.",
+      "description": "Path at which to generate the executor file.",
+      "x-prompt": "What path would you like to use for the executor?",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use for the executor?",
       "x-priority": "important"
     },
-    "directory": {
+    "name": {
       "type": "string",
-      "description": "The directory at which to create the executor file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "aliases": ["dir"],
+      "description": "Executor name.",
+      "x-prompt": "What name would you like to use for the executor?",
       "x-priority": "important"
     },
     "description": {
@@ -50,11 +50,6 @@
       "default": false,
       "description": "Do not add an eslint configuration for plugin json files."
     },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the executor in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
     "skipFormat": {
       "type": "boolean",
       "description": "Skip formatting files.",
@@ -62,6 +57,6 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"],
+  "required": ["path"],
   "additionalProperties": false
 }

--- a/packages/plugin/src/generators/generator/generator.spec.ts
+++ b/packages/plugin/src/generators/generator/generator.spec.ts
@@ -33,9 +33,8 @@ describe('NxPlugin Generator Generator', () => {
   it('should generate files', async () => {
     await generatorGenerator(tree, {
       name: 'my-generator',
-      directory: 'my-plugin/src/generators/my-generator',
+      path: 'my-plugin/src/generators/my-generator',
       unitTestRunner: 'jest',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     expect(
@@ -56,8 +55,8 @@ describe('NxPlugin Generator Generator', () => {
     setCwd('my-plugin/src/nx-integrations/generators/my-generator');
     await generatorGenerator(tree, {
       name: 'my-generator',
+      path: 'my-plugin/src/nx-integrations/generators/my-generator',
       unitTestRunner: 'jest',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     expect(
@@ -84,7 +83,7 @@ describe('NxPlugin Generator Generator', () => {
 
   it('should generate files for derived', async () => {
     await generatorGenerator(tree, {
-      directory: `${projectName}/src/generators/my-generator`,
+      path: `${projectName}/src/generators/my-generator`,
       name: 'my-generator',
       unitTestRunner: 'jest',
     });
@@ -106,9 +105,8 @@ describe('NxPlugin Generator Generator', () => {
   it('should update generators.json', async () => {
     await generatorGenerator(tree, {
       name: 'my-generator',
-      directory: 'my-plugin/src/generators/my-generator',
+      path: 'my-plugin/src/generators/my-generator',
       unitTestRunner: 'jest',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     const generatorJson = readJson(tree, 'my-plugin/generators.json');
@@ -126,7 +124,7 @@ describe('NxPlugin Generator Generator', () => {
 
   it('should update generators.json for derived', async () => {
     await generatorGenerator(tree, {
-      directory: 'my-plugin/src/generators/my-generator',
+      path: 'my-plugin/src/generators/my-generator',
       name: 'my-generator',
       unitTestRunner: 'jest',
     });
@@ -147,13 +145,12 @@ describe('NxPlugin Generator Generator', () => {
   it('should throw if recreating an existing generator', async () => {
     await generatorGenerator(tree, {
       name: 'my-generator',
-      directory: 'my-plugin/src/generators/my-generator',
+      path: 'my-plugin/src/generators/my-generator',
       unitTestRunner: 'jest',
-      nameAndDirectoryFormat: 'as-provided',
     });
     expect(
       generatorGenerator(tree, {
-        directory: 'my-plugin/src/generators/my-generator',
+        path: 'my-plugin/src/generators/my-generator',
         name: 'my-generator',
         unitTestRunner: 'jest',
       })
@@ -166,10 +163,9 @@ describe('NxPlugin Generator Generator', () => {
 
     await generatorGenerator(tree, {
       name: generatorName,
-      directory: 'my-plugin/src/generators/my-generator',
+      path: 'my-plugin/src/generators/my-generator',
       unitTestRunner: 'jest',
       description: 'my-generator description',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     const generatorJson = readJson(tree, 'my-plugin/generators.json');
@@ -198,9 +194,8 @@ describe('NxPlugin Generator Generator', () => {
     const libConfig = readProjectConfiguration(tree, 'test-js-lib');
     await generatorGenerator(tree, {
       name: 'test-generator',
-      directory: 'test-js-lib/src/generators/test-generator',
+      path: 'test-js-lib/src/generators/test-generator',
       unitTestRunner: 'jest',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     expect(() =>
@@ -214,10 +209,9 @@ describe('NxPlugin Generator Generator', () => {
   it('should generate custom description', async () => {
     await generatorGenerator(tree, {
       name: 'my-generator',
-      directory: 'my-plugin/src/generators/my-generator',
+      path: 'my-plugin/src/generators/my-generator',
       description: 'my-generator custom description',
       unitTestRunner: 'jest',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     const generatorJson = readJson(tree, 'my-plugin/generators.json');
@@ -232,9 +226,8 @@ describe('NxPlugin Generator Generator', () => {
       it('should not generate files', async () => {
         await generatorGenerator(tree, {
           name: 'my-generator',
-          directory: 'my-plugin/src/generators/my-generator',
+          path: 'my-plugin/src/generators/my-generator',
           unitTestRunner: 'none',
-          nameAndDirectoryFormat: 'as-provided',
         });
 
         expect(
@@ -250,7 +243,7 @@ describe('NxPlugin Generator Generator', () => {
   describe('preset generator', () => {
     it('should default to standalone layout: true', async () => {
       await generatorGenerator(tree, {
-        directory: 'my-plugin/src/generators/preset',
+        path: 'my-plugin/src/generators/preset',
         name: 'preset',
         unitTestRunner: 'none',
       });

--- a/packages/plugin/src/generators/generator/generator.ts
+++ b/packages/plugin/src/generators/generator/generator.ts
@@ -19,6 +19,7 @@ import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generat
 import { join, relative } from 'path';
 
 type NormalizedSchema = Schema & {
+  directory: string;
   fileName: string;
   className: string;
   propertyName: string;
@@ -52,6 +53,7 @@ async function normalizeOptions(
 
   return {
     ...options,
+    directory,
     project,
     fileName,
     className,

--- a/packages/plugin/src/generators/generator/generator.ts
+++ b/packages/plugin/src/generators/generator/generator.ts
@@ -34,8 +34,7 @@ async function normalizeOptions(
   const { project, fileName, artifactName, filePath, directory } =
     await determineArtifactNameAndDirectoryOptions(tree, {
       name: options.name,
-      nameAndDirectoryFormat: options.nameAndDirectoryFormat,
-      directory: options.directory,
+      path: options.path,
       fileName: 'generator',
     });
 
@@ -54,7 +53,6 @@ async function normalizeOptions(
   return {
     ...options,
     project,
-    directory,
     fileName,
     className,
     propertyName,
@@ -65,20 +63,20 @@ async function normalizeOptions(
 }
 
 function addFiles(host: Tree, options: NormalizedSchema) {
-  const indexPath = join(options.directory, 'files/src/index.ts.template');
+  const indexPath = join(options.path, 'files/src/index.ts.template');
 
   if (!host.exists(indexPath)) {
     host.write(indexPath, 'const variable = "<%= name %>";');
   }
 
-  generateFiles(host, join(__dirname, './files/generator'), options.directory, {
+  generateFiles(host, join(__dirname, './files/generator'), options.path, {
     ...options,
     generatorFnName: `${options.propertyName}Generator`,
     schemaInterfaceName: `${options.className}GeneratorSchema`,
   });
 
   if (options.unitTestRunner === 'none') {
-    host.delete(join(options.directory, `generator.spec.ts`));
+    host.delete(join(options.path, `generator.spec.ts`));
   }
 }
 
@@ -153,11 +151,11 @@ async function updateGeneratorJson(host: Tree, options: NormalizedSchema) {
     generators = generators || {};
     generators[options.name] = {
       factory: `./${joinPathFragments(
-        relative(options.projectRoot, options.directory),
+        relative(options.projectRoot, options.path),
         'generator'
       )}`,
       schema: `./${joinPathFragments(
-        relative(options.projectRoot, options.directory),
+        relative(options.projectRoot, options.path),
         'schema.json'
       )}`,
       description: options.description,

--- a/packages/plugin/src/generators/generator/schema.d.ts
+++ b/packages/plugin/src/generators/generator/schema.d.ts
@@ -1,11 +1,10 @@
 import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
-  directory?: string;
-  name: string;
+  path: string;
+  name?: string;
   description?: string;
   unitTestRunner: 'jest' | 'none';
   skipLintChecks?: boolean;
   skipFormat?: boolean;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
 }

--- a/packages/plugin/src/generators/generator/schema.json
+++ b/packages/plugin/src/generators/generator/schema.json
@@ -7,25 +7,25 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g generator my-generator --project=my-plugin",
+      "command": "nx g generator libs/my-plugin/src/generators//my-generator",
       "description": "Generate `libs/my-plugin/src/generators/my-generator`"
     }
   ],
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "Generator name.",
+      "description": "Path where the generator will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use for the generator?",
+      "x-prompt": "Where should the generator be generated?",
       "x-priority": "important"
     },
-    "directory": {
+    "name": {
       "type": "string",
-      "description": "The directory at which to create the generator file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "aliases": ["dir"],
+      "description": "Generator name.",
+      "x-prompt": "What name would you like to use for the generator?",
       "x-priority": "important"
     },
     "description": {
@@ -49,13 +49,8 @@
       "default": false,
       "description": "Do not format files with prettier.",
       "x-priority": "internal"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the generator in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     }
   },
-  "required": ["name"],
+  "required": ["path"],
   "additionalProperties": false
 }

--- a/packages/plugin/src/generators/lint-checks/generator.spec.ts
+++ b/packages/plugin/src/generators/lint-checks/generator.spec.ts
@@ -37,13 +37,13 @@ describe('lint-checks generator', () => {
     });
     await generatorGenerator(tree, {
       name: 'my-generator',
-      directory: 'plugin/src/generators/my-generator',
+      path: 'plugin/src/generators/my-generator',
       unitTestRunner: 'jest',
       skipLintChecks: true,
     });
     await executorGenerator(tree, {
       name: 'my-executor',
-      directory: 'plugin/src/executors/my-executor',
+      path: 'plugin/src/executors/my-executor',
       unitTestRunner: 'jest',
       includeHasher: false,
       skipLintChecks: true,

--- a/packages/plugin/src/generators/migration/migration.spec.ts
+++ b/packages/plugin/src/generators/migration/migration.spec.ts
@@ -28,7 +28,7 @@ describe('NxPlugin migration generator', () => {
 
   it('should update the workspace.json file', async () => {
     await migrationGenerator(tree, {
-      directory: 'packages/my-plugin',
+      path: 'packages/my-plugin',
       packageVersion: '1.0.0',
     });
 
@@ -44,9 +44,8 @@ describe('NxPlugin migration generator', () => {
   it('should generate files', async () => {
     await migrationGenerator(tree, {
       name: 'my-migration',
-      directory: 'packages/my-plugin/migrations/1.0.0',
+      path: 'packages/my-plugin/migrations/1.0.0',
       packageVersion: '1.0.0',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     const migrationsJson = readJson(tree, 'packages/my-plugin/migrations.json');
@@ -73,9 +72,8 @@ describe('NxPlugin migration generator', () => {
   it('should generate files with default name', async () => {
     await migrationGenerator(tree, {
       description: 'my-migration description',
-      directory: 'packages/my-plugin/src/migrations/update-1.0.0',
+      path: 'packages/my-plugin/src/migrations/update-1.0.0',
       packageVersion: '1.0.0',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     const migrationsJson = readJson(tree, 'packages/my-plugin/migrations.json');
@@ -94,9 +92,8 @@ describe('NxPlugin migration generator', () => {
   it('should generate files with default description', async () => {
     await migrationGenerator(tree, {
       name: 'my-migration',
-      directory: 'packages/my-plugin/src/migrations/update-1.0.0',
+      path: 'packages/my-plugin/src/migrations/update-1.0.0',
       packageVersion: '1.0.0',
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     const migrationsJson = readJson(tree, 'packages/my-plugin/migrations.json');
@@ -109,10 +106,9 @@ describe('NxPlugin migration generator', () => {
   it('should generate files with package.json updates', async () => {
     await migrationGenerator(tree, {
       name: 'my-migration',
-      directory: 'packages/my-plugin/src/migrations/update-1.0.0',
+      path: 'packages/my-plugin/src/migrations/update-1.0.0',
       packageVersion: '1.0.0',
       packageJsonUpdates: true,
-      nameAndDirectoryFormat: 'as-provided',
     });
 
     const migrationsJson = readJson(tree, 'packages/my-plugin/migrations.json');

--- a/packages/plugin/src/generators/migration/migration.spec.ts
+++ b/packages/plugin/src/generators/migration/migration.spec.ts
@@ -28,7 +28,7 @@ describe('NxPlugin migration generator', () => {
 
   it('should update the workspace.json file', async () => {
     await migrationGenerator(tree, {
-      path: 'packages/my-plugin',
+      path: `packages/my-plugin/${projectName}`,
       packageVersion: '1.0.0',
     });
 

--- a/packages/plugin/src/generators/migration/migration.ts
+++ b/packages/plugin/src/generators/migration/migration.ts
@@ -38,8 +38,7 @@ async function normalizeOptions(
   const { project, fileName, artifactName, filePath, directory } =
     await determineArtifactNameAndDirectoryOptions(tree, {
       name: name,
-      nameAndDirectoryFormat: options.nameAndDirectoryFormat,
-      directory: options.directory,
+      path: options.path,
       fileName: name,
     });
 
@@ -56,7 +55,6 @@ async function normalizeOptions(
     ...options,
     project,
     name: artifactName,
-    directory,
     description,
     projectRoot,
     projectSourceRoot,
@@ -66,12 +64,10 @@ async function normalizeOptions(
 }
 
 function addFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(
-    host,
-    path.join(__dirname, 'files/migration'),
-    options.directory,
-    { ...options, tmpl: '' }
-  );
+  generateFiles(host, path.join(__dirname, 'files/migration'), options.path, {
+    ...options,
+    tmpl: '',
+  });
 }
 
 function updateMigrationsJson(host: Tree, options: NormalizedSchema) {
@@ -94,7 +90,7 @@ function updateMigrationsJson(host: Tree, options: NormalizedSchema) {
     version: options.packageVersion,
     description: options.description,
     implementation: `./${joinPathFragments(
-      relative(options.projectRoot, options.directory),
+      relative(options.projectRoot, options.path),
       options.name
     )}`,
   };

--- a/packages/plugin/src/generators/migration/migration.ts
+++ b/packages/plugin/src/generators/migration/migration.ts
@@ -19,6 +19,7 @@ import { nxVersion } from '../../utils/versions';
 import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 interface NormalizedSchema extends Schema {
+  directory: string;
   projectRoot: string;
   projectSourceRoot: string;
   project: string;
@@ -53,6 +54,7 @@ async function normalizeOptions(
 
   const normalized: NormalizedSchema = {
     ...options,
+    directory,
     project,
     name: artifactName,
     description,

--- a/packages/plugin/src/generators/migration/schema.d.ts
+++ b/packages/plugin/src/generators/migration/schema.d.ts
@@ -1,11 +1,10 @@
 import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
+  path: string;
   name?: string;
-  directory?: string;
   description?: string;
   packageVersion: string;
   packageJsonUpdates?: boolean;
   skipFormat?: boolean;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
 }

--- a/packages/plugin/src/generators/migration/schema.json
+++ b/packages/plugin/src/generators/migration/schema.json
@@ -7,24 +7,25 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g migration my-migration --project=my-plugin --version=1.0.0",
-      "description": "Adds a new migration to the project `my-plugin`, which will be triggered when migrating to version 1.0.0 or above from a previous version."
+      "command": "nx g migration my-plugin/my-migration --version=1.0.0",
+      "description": "Adds a new migration inside `my-plugin`, which will be triggered when migrating to version 1.0.0 or above from a previous version."
     }
   ],
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "Migration name.",
+      "description": "Path where the migration will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the migration be generated?",
       "x-priority": "important"
     },
-    "directory": {
+    "name": {
       "type": "string",
-      "description": "The directory at which to create the migration file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "aliases": ["dir"]
+      "description": "Migration name.",
+      "x-priority": "important"
     },
     "description": {
       "type": "string",
@@ -47,13 +48,8 @@
       "type": "boolean",
       "default": false,
       "description": "Do not eslint configuration for plugin json files."
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the migration in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     }
   },
-  "required": ["packageVersion"],
+  "required": ["packageVersion", "path"],
   "additionalProperties": false
 }

--- a/packages/plugin/src/migrations/update-16-0-0/cli-in-schema-json.spec.ts
+++ b/packages/plugin/src/migrations/update-16-0-0/cli-in-schema-json.spec.ts
@@ -149,7 +149,7 @@ describe('updateCliPropsForPlugins', () => {
     const { root, name } = await createPlugin(tree);
     await executorGenerator(tree, {
       name: 'my-executor',
-      directory: `${name}/src/executors/my-executor`,
+      path: `${name}/src/executors/my-executor`,
       unitTestRunner: 'jest',
       includeHasher: false,
     });
@@ -171,7 +171,7 @@ describe('updateCliPropsForPlugins', () => {
     const { root, name } = await createPlugin(tree);
     await executorGenerator(tree, {
       name: 'my-executor',
-      directory: `${name}/src/executors/my-executor`,
+      path: `${name}/src/executors/my-executor`,
       unitTestRunner: 'jest',
       includeHasher: false,
     });
@@ -202,7 +202,7 @@ describe('updateCliPropsForPlugins', () => {
     const { root, name } = await createPlugin(tree);
     await generatorGenerator(tree, {
       name: 'my-generator',
-      directory: `${name}/src/generators/my-generator`,
+      path: `${name}/src/generators/my-generator`,
       unitTestRunner: 'jest',
     });
     const schemaPath = joinPathFragments(
@@ -223,7 +223,7 @@ describe('updateCliPropsForPlugins', () => {
     const { root, name } = await createPlugin(tree);
     await generatorGenerator(tree, {
       name: 'my-schematic',
-      directory: `${name}/src/generators/my-schematic`,
+      path: `${name}/src/generators/my-schematic`,
       unitTestRunner: 'jest',
     });
     updateJson<GeneratorsJson>(

--- a/packages/react-native/src/generators/component/component.spec.ts
+++ b/packages/react-native/src/generators/component/component.spec.ts
@@ -26,7 +26,7 @@ describe('component', () => {
   it('should generate component files', async () => {
     await reactNativeComponentGenerator(appTree, {
       name: 'hello',
-      path: `${projectName}/src/lib/hello`,
+      path: `${projectName}/src/lib/hello/hello`,
     });
 
     expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
@@ -36,7 +36,7 @@ describe('component', () => {
   it('should generate files for an app', async () => {
     await reactNativeComponentGenerator(appTree, {
       name: 'hello',
-      path: 'my-app/src/app/hello',
+      path: 'my-app/src/app/hello/hello',
     });
 
     expect(appTree.exists('my-app/src/app/hello/hello.tsx')).toBeTruthy();
@@ -47,7 +47,7 @@ describe('component', () => {
     it('should add to index.ts barrel', async () => {
       await reactNativeComponentGenerator(appTree, {
         name: 'hello',
-        path: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello/hello`,
         export: true,
       });
 
@@ -59,7 +59,7 @@ describe('component', () => {
     it('should not export from an app', async () => {
       await reactNativeComponentGenerator(appTree, {
         name: 'hello',
-        path: 'my-app/src/app/hello',
+        path: 'my-app/src/app/hello/hello',
         export: true,
       });
 
@@ -73,7 +73,7 @@ describe('component', () => {
     it('should create component under the directory', async () => {
       await reactNativeComponentGenerator(appTree, {
         name: 'hello',
-        path: 'my-lib/src/components/hello',
+        path: 'my-lib/src/components/hello/hello',
       });
 
       expect(appTree.exists('my-lib/src/components/hello/hello.tsx'));
@@ -82,7 +82,7 @@ describe('component', () => {
     it('should create with nested directories', async () => {
       await reactNativeComponentGenerator(appTree, {
         name: 'helloWorld',
-        path: 'my-lib/src/lib/foo/hello-world',
+        path: 'my-lib/src/lib/foo/hello-world/hello-world',
       });
 
       expect(appTree.exists('my-lib/src/lib/foo/hello-world/hello-world.tsx'));

--- a/packages/react-native/src/generators/component/component.spec.ts
+++ b/packages/react-native/src/generators/component/component.spec.ts
@@ -26,7 +26,7 @@ describe('component', () => {
   it('should generate component files', async () => {
     await reactNativeComponentGenerator(appTree, {
       name: 'hello',
-      directory: `${projectName}/src/lib/hello`,
+      path: `${projectName}/src/lib/hello`,
     });
 
     expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
@@ -36,7 +36,7 @@ describe('component', () => {
   it('should generate files for an app', async () => {
     await reactNativeComponentGenerator(appTree, {
       name: 'hello',
-      directory: 'my-app/src/app/hello',
+      path: 'my-app/src/app/hello',
     });
 
     expect(appTree.exists('my-app/src/app/hello/hello.tsx')).toBeTruthy();
@@ -47,7 +47,7 @@ describe('component', () => {
     it('should add to index.ts barrel', async () => {
       await reactNativeComponentGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         export: true,
       });
 
@@ -59,7 +59,7 @@ describe('component', () => {
     it('should not export from an app', async () => {
       await reactNativeComponentGenerator(appTree, {
         name: 'hello',
-        directory: 'my-app/src/app/hello',
+        path: 'my-app/src/app/hello',
         export: true,
       });
 
@@ -73,7 +73,7 @@ describe('component', () => {
     it('should create component under the directory', async () => {
       await reactNativeComponentGenerator(appTree, {
         name: 'hello',
-        directory: 'my-lib/src/components/hello',
+        path: 'my-lib/src/components/hello',
       });
 
       expect(appTree.exists('my-lib/src/components/hello/hello.tsx'));
@@ -82,7 +82,7 @@ describe('component', () => {
     it('should create with nested directories', async () => {
       await reactNativeComponentGenerator(appTree, {
         name: 'helloWorld',
-        directory: 'my-lib/src/lib/foo/hello-world',
+        path: 'my-lib/src/lib/foo/hello-world',
       });
 
       expect(appTree.exists('my-lib/src/lib/foo/hello-world/hello-world.tsx'));

--- a/packages/react-native/src/generators/component/lib/normalize-options.ts
+++ b/packages/react-native/src/generators/component/lib/normalize-options.ts
@@ -23,9 +23,8 @@ export async function normalizeOptions(
     filePath,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(host, {
+    path: options.path,
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
     fileExtension: 'tsx',
   });
 

--- a/packages/react-native/src/generators/component/lib/normalize-options.ts
+++ b/packages/react-native/src/generators/component/lib/normalize-options.ts
@@ -3,6 +3,7 @@ import { Schema } from '../schema';
 import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface NormalizedSchema extends Schema {
+  directory: string;
   projectSourceRoot: string;
   fileName: string;
   className: string;
@@ -14,8 +15,6 @@ export async function normalizeOptions(
   host: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
-  assertValidOptions(options);
-
   const {
     artifactName: name,
     directory,
@@ -27,6 +26,8 @@ export async function normalizeOptions(
     name: options.name,
     fileExtension: 'tsx',
   });
+
+  assertValidOptions({ name, directory });
 
   const project = getProjects(host).get(projectName);
 
@@ -44,6 +45,7 @@ export async function normalizeOptions(
 
   return {
     ...options,
+    name,
     directory,
     className,
     fileName,
@@ -53,7 +55,7 @@ export async function normalizeOptions(
   };
 }
 
-function assertValidOptions(options: Schema) {
+function assertValidOptions(options: { name: string; directory: string }) {
   const slashes = ['/', '\\'];
   slashes.forEach((s) => {
     if (options.name.indexOf(s) !== -1) {
@@ -63,7 +65,7 @@ function assertValidOptions(options: Schema) {
         suggestion = `${options.directory}${s}${suggestion}`;
       }
       throw new Error(
-        `Found "${s}" in the component name. Did you mean to use the --directory option (e.g. \`nx g c ${name} --directory ${suggestion}\`)?`
+        `Found "${s}" in the component name. Did you mean to use the --path option (e.g. \`nx g c ${suggestion}/${name} \`)?`
       );
     }
   });

--- a/packages/react-native/src/generators/component/schema.d.ts
+++ b/packages/react-native/src/generators/component/schema.d.ts
@@ -4,11 +4,11 @@ import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-
  * Same as the @nx/react library schema, except it removes keys: style, routing, globalCss
  */
 export interface Schema {
-  name: string;
+  path: string;
+  name?: string;
   skipTests?: boolean;
   directory?: string;
   export?: boolean;
   classComponent?: boolean;
   js?: boolean;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
 }

--- a/packages/react-native/src/generators/component/schema.d.ts
+++ b/packages/react-native/src/generators/component/schema.d.ts
@@ -1,5 +1,3 @@
-import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-
 /**
  * Same as the @nx/react library schema, except it removes keys: style, routing, globalCss
  */

--- a/packages/react-native/src/generators/component/schema.d.ts
+++ b/packages/react-native/src/generators/component/schema.d.ts
@@ -5,7 +5,6 @@ export interface Schema {
   path: string;
   name?: string;
   skipTests?: boolean;
-  directory?: string;
   export?: boolean;
   classComponent?: boolean;
   js?: boolean;

--- a/packages/react-native/src/generators/component/schema.json
+++ b/packages/react-native/src/generators/component/schema.json
@@ -7,22 +7,27 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nx/react-native:component my-component --directory=mylib/src/lib/my-component",
+      "command": "nx g @nx/react-native:component mylib/src/lib/my-component/my-component ",
       "description": "Generate a component in the `mylib` library"
     },
     {
-      "command": "nx g @nx/react-native:component my-component --directory=mylib/src/lib/my-component --classComponent",
+      "command": "nx g @nx/react-native:component mylib/src/lib/my-component/my-component --classComponent",
       "description": "Generate a class component in the `mylib` library"
     }
   ],
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the component.",
+      "description": "The path at which to create the component file.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "What path would you like to use for the component?"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the component.",
       "x-prompt": "What name would you like to use for the component?"
     },
     "js": {
@@ -34,16 +39,6 @@
       "type": "boolean",
       "description": "When true, does not create `spec.ts` test files for the new component.",
       "default": false
-    },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     },
     "export": {
       "type": "boolean",
@@ -59,5 +54,5 @@
       "default": false
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -41,7 +41,7 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       style: 'css',
-      path: `${projectName}/src/lib/hello`,
+      path: `${projectName}/src/lib/hello/hello`,
     });
 
     expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
@@ -61,7 +61,7 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       style: 'css',
-      path: `${projectName}/src/lib/hello`,
+      path: `${projectName}/src/lib/hello/hello`,
       globalCss: true,
     });
 
@@ -81,7 +81,7 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       style: 'css',
-      path: 'my-app/src/app/hello',
+      path: 'my-app/src/app/hello/hello',
     });
 
     expect(appTree.exists('my-app/src/app/hello/hello.tsx')).toBeTruthy();
@@ -95,7 +95,7 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       style: 'css',
-      path: 'my-app/src/app/hello',
+      path: 'my-app/src/app/hello/hello',
       globalCss: true,
     });
 
@@ -110,7 +110,7 @@ describe('component', () => {
       await componentGenerator(appTree, {
         name: 'hello',
         style: 'css',
-        path: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello/hello`,
         classComponent: true,
       });
 
@@ -170,7 +170,7 @@ describe('component', () => {
     it('should generate component files without styles', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        path: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello/hello`,
         style: 'none',
       });
       expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
@@ -204,7 +204,7 @@ describe('component', () => {
     it('should use styled-components as the styled API library', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        path: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello/hello`,
         style: 'styled-components',
       });
 
@@ -234,7 +234,7 @@ describe('component', () => {
     it('should use @emotion/styled as the styled API library', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        path: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello/hello`,
         style: '@emotion/styled',
       });
 
@@ -265,7 +265,7 @@ describe('component', () => {
     it('should use styled-jsx as the styled API library', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        path: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello/hello`,
         style: 'styled-jsx',
       });
 
@@ -296,7 +296,7 @@ describe('component', () => {
       await componentGenerator(appTree, {
         name: 'hello',
         style: 'css',
-        path: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello/hello`,
         routing: true,
       });
 

--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -41,7 +41,7 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       style: 'css',
-      directory: `${projectName}/src/lib/hello`,
+      path: `${projectName}/src/lib/hello`,
     });
 
     expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
@@ -61,7 +61,7 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       style: 'css',
-      directory: `${projectName}/src/lib/hello`,
+      path: `${projectName}/src/lib/hello`,
       globalCss: true,
     });
 
@@ -81,7 +81,7 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       style: 'css',
-      directory: 'my-app/src/app/hello',
+      path: 'my-app/src/app/hello',
     });
 
     expect(appTree.exists('my-app/src/app/hello/hello.tsx')).toBeTruthy();
@@ -95,7 +95,7 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       style: 'css',
-      directory: 'my-app/src/app/hello',
+      path: 'my-app/src/app/hello',
       globalCss: true,
     });
 
@@ -110,7 +110,7 @@ describe('component', () => {
       await componentGenerator(appTree, {
         name: 'hello',
         style: 'css',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         classComponent: true,
       });
 
@@ -127,7 +127,7 @@ describe('component', () => {
       await componentGenerator(appTree, {
         name: 'hello',
         style: 'css',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         export: true,
       });
 
@@ -140,7 +140,7 @@ describe('component', () => {
       await componentGenerator(appTree, {
         name: 'hello',
         style: 'css',
-        directory: 'my-lib/src/app/hello',
+        path: 'my-lib/src/app/hello',
         export: true,
       });
 
@@ -155,7 +155,7 @@ describe('component', () => {
       updateProjectConfiguration(appTree, 'my-lib', projectConfig);
 
       await componentGenerator(appTree, {
-        name: 'my-lib/src/lib/hello',
+        path: 'my-lib/src/lib/hello',
         style: 'css',
         export: true,
       });
@@ -170,7 +170,7 @@ describe('component', () => {
     it('should generate component files without styles', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         style: 'none',
       });
       expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
@@ -204,7 +204,7 @@ describe('component', () => {
     it('should use styled-components as the styled API library', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         style: 'styled-components',
       });
 
@@ -221,7 +221,7 @@ describe('component', () => {
     it('should add dependencies to package.json', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         style: 'styled-components',
       });
 
@@ -234,7 +234,7 @@ describe('component', () => {
     it('should use @emotion/styled as the styled API library', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         style: '@emotion/styled',
       });
 
@@ -251,7 +251,7 @@ describe('component', () => {
     it('should add dependencies to package.json', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         style: '@emotion/styled',
       });
 
@@ -265,7 +265,7 @@ describe('component', () => {
     it('should use styled-jsx as the styled API library', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         style: 'styled-jsx',
       });
 
@@ -282,7 +282,7 @@ describe('component', () => {
     it('should add dependencies to package.json', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         style: 'styled-jsx',
       });
 
@@ -296,7 +296,7 @@ describe('component', () => {
       await componentGenerator(appTree, {
         name: 'hello',
         style: 'css',
-        directory: `${projectName}/src/lib/hello`,
+        path: `${projectName}/src/lib/hello`,
         routing: true,
       });
 
@@ -310,12 +310,12 @@ describe('component', () => {
     });
   });
 
-  describe('--directory', () => {
-    it('should create component under the directory', async () => {
+  describe('--path', () => {
+    it('should create component under the path', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
         style: 'css',
-        directory: `${projectName}/src/components/hello`,
+        path: `${projectName}/src/components/hello`,
       });
 
       expect(appTree.exists('/my-lib/src/components/hello/hello.tsx'));
@@ -325,17 +325,16 @@ describe('component', () => {
       await componentGenerator(appTree, {
         name: 'helloWorld',
         style: 'css',
-        directory: `${projectName}/src/lib/foo/hello-world`,
+        path: `${projectName}/src/lib/foo/hello-world`,
       });
 
       expect(appTree.exists('/my-lib/src/lib/foo/hello-world/helloWorld.tsx'));
     });
 
-    it('should create directory when the path is provided as the component name', async () => {
+    it('should create directory when the path is provided', async () => {
       await componentGenerator(appTree, {
-        name: `my-lib/src/btn/btn`,
+        path: `my-lib/src/btn/btn`,
         style: 'css',
-        nameAndDirectoryFormat: 'as-provided',
       });
 
       expect(appTree.exists('my-lib/src/btn/btn.tsx')).toBeTruthy();

--- a/packages/react/src/generators/component/component.ts
+++ b/packages/react/src/generators/component/component.ts
@@ -50,7 +50,7 @@ export async function componentGenerator(host: Tree, schema: Schema) {
 
 function createComponentFiles(host: Tree, options: NormalizedSchema) {
   const componentTests = getComponentTests(options);
-  generateFiles(host, join(__dirname, './files'), options.directory, {
+  generateFiles(host, join(__dirname, './files'), options.path, {
     ...options,
     componentTests,
     inSourceVitestTests: getInSourceVitestTestsTemplate(componentTests),

--- a/packages/react/src/generators/component/component.ts
+++ b/packages/react/src/generators/component/component.ts
@@ -50,7 +50,7 @@ export async function componentGenerator(host: Tree, schema: Schema) {
 
 function createComponentFiles(host: Tree, options: NormalizedSchema) {
   const componentTests = getComponentTests(options);
-  generateFiles(host, join(__dirname, './files'), options.path, {
+  generateFiles(host, join(__dirname, './files'), options.directory, {
     ...options,
     componentTests,
     inSourceVitestTests: getInSourceVitestTestsTemplate(componentTests),

--- a/packages/react/src/generators/component/lib/normalize-options.ts
+++ b/packages/react/src/generators/component/lib/normalize-options.ts
@@ -18,9 +18,8 @@ export async function normalizeOptions(
     filePath,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
+    path: options.path,
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
     fileExtension: 'tsx',
     fileName: options.fileName,
   });
@@ -56,7 +55,6 @@ export async function normalizeOptions(
   return {
     ...options,
     projectName,
-    directory,
     styledModule,
     hasStyles: options.style !== 'none',
     className,

--- a/packages/react/src/generators/component/lib/normalize-options.ts
+++ b/packages/react/src/generators/component/lib/normalize-options.ts
@@ -54,6 +54,7 @@ export async function normalizeOptions(
 
   return {
     ...options,
+    directory,
     projectName,
     styledModule,
     hasStyles: options.style !== 'none',

--- a/packages/react/src/generators/component/schema.d.ts
+++ b/packages/react/src/generators/component/schema.d.ts
@@ -2,10 +2,10 @@ import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-
 import { SupportedStyles } from '../../../typings/style';
 
 export interface Schema {
-  name: string;
+  path: string;
+  name?: string;
   style: SupportedStyles;
   skipTests?: boolean;
-  directory?: string;
   export?: boolean;
   classComponent?: boolean;
   routing?: boolean;
@@ -14,7 +14,6 @@ export interface Schema {
   fileName?: string;
   inSourceTests?: boolean;
   skipFormat?: boolean;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   // Used by Next.js to determine how React should generate the page
   isNextPage?: boolean;
 }

--- a/packages/react/src/generators/component/schema.d.ts
+++ b/packages/react/src/generators/component/schema.d.ts
@@ -19,6 +19,7 @@ export interface Schema {
 }
 
 export interface NormalizedSchema extends Schema {
+  directory: string;
   projectSourceRoot: string;
   projectName: string;
   fileName: string;

--- a/packages/react/src/generators/component/schema.json
+++ b/packages/react/src/generators/component/schema.json
@@ -6,13 +6,19 @@
   "description": "Create a React Component for Nx.",
   "type": "object",
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the component.",
+      "description": "Path where the component will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the component be generated?",
+      "x-priority": "important"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the component.",
       "x-prompt": "What name would you like to use for the component?",
       "x-priority": "important"
     },
@@ -67,17 +73,6 @@
       "default": false,
       "x-priority": "internal"
     },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
-      "alias": "dir",
-      "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
     "export": {
       "type": "boolean",
       "description": "When true, the component is exported from the project `index.ts` (if it exists).",
@@ -116,6 +111,6 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"],
+  "required": ["path"],
   "examplesFile": "../../../docs/component-examples.md"
 }

--- a/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -346,7 +346,7 @@ describe('React:CypressComponentTestConfiguration', () => {
     });
     await componentGenerator(tree, {
       name: 'another-cmp',
-      directory: 'some-lib/src/lib/another-cmp',
+      path: 'some-lib/src/lib/another-cmp/another-cmp',
       style: 'scss',
     });
 
@@ -393,13 +393,13 @@ describe('React:CypressComponentTestConfiguration', () => {
     });
     await componentGenerator(tree, {
       name: 'some-cmp',
-      directory: 'some-lib/src/lib',
+      path: 'some-lib/src/lib/some-cmp',
       style: 'scss',
       js: true,
     });
     await componentGenerator(tree, {
       name: 'another-cmp',
-      directory: 'some-lib/src/lib/another-cmp',
+      path: 'some-lib/src/lib/another-cmp/another-cmp',
       style: 'scss',
       js: true,
     });

--- a/packages/react/src/generators/hook/hook.spec.ts
+++ b/packages/react/src/generators/hook/hook.spec.ts
@@ -25,7 +25,7 @@ describe('hook', () => {
   it('should generate files', async () => {
     await hookGenerator(appTree, {
       name: 'use-form',
-      path: `${projectName}/src/lib/use-form`,
+      path: `${projectName}/src/lib/use-form/use-form`,
     });
 
     expect(appTree.exists('my-lib/src/lib/use-form/use-form.ts')).toBeTruthy();
@@ -37,7 +37,7 @@ describe('hook', () => {
   it('should generate files for an app', async () => {
     await hookGenerator(appTree, {
       name: 'use-form',
-      path: 'my-app/src/app/use-form',
+      path: 'my-app/src/app/use-form/use-form',
     });
 
     expect(appTree.exists('my-app/src/app/use-form/use-form.ts')).toBeTruthy();
@@ -49,7 +49,7 @@ describe('hook', () => {
   it('handles "use" in the name', async () => {
     await hookGenerator(appTree, {
       name: 'use-hello',
-      path: `${projectName}/src/lib/use-hello`,
+      path: `${projectName}/src/lib/use-hello/use-hello`,
       skipTests: true,
     });
 
@@ -64,7 +64,7 @@ describe('hook', () => {
   it('handles "use-" in the name', async () => {
     await hookGenerator(appTree, {
       name: 'use-hello',
-      path: `${projectName}/src/lib/use-hello`,
+      path: `${projectName}/src/lib/use-hello/use-hello`,
       skipTests: true,
     });
     expect(
@@ -79,7 +79,7 @@ describe('hook', () => {
     it('should add to index.ts barrel', async () => {
       await hookGenerator(appTree, {
         name: 'hello',
-        path: `${projectName}/src/lib/use-hello`,
+        path: `${projectName}/src/lib/use-hello/use-hello`,
         export: true,
       });
 
@@ -91,7 +91,7 @@ describe('hook', () => {
     it('should not export from an app', async () => {
       await hookGenerator(appTree, {
         name: 'hello',
-        path: 'my-lib/src/app/use-hello',
+        path: 'my-lib/src/app/use-hello/use-hello',
         export: true,
       });
 
@@ -105,7 +105,7 @@ describe('hook', () => {
     it('should not generate tests', async () => {
       await hookGenerator(appTree, {
         name: 'use-hello',
-        path: `${projectName}/src/lib/use-hello`,
+        path: `${projectName}/src/lib/use-hello/use-hello`,
         skipTests: true,
       });
       expect(
@@ -121,7 +121,7 @@ describe('hook', () => {
     it('should create component under the directory', async () => {
       await hookGenerator(appTree, {
         name: 'use-hello',
-        path: 'my-lib/src/hooks/use-hello',
+        path: 'my-lib/src/hooks/use-hello/use-hello',
         skipTests: true,
       });
 
@@ -131,7 +131,7 @@ describe('hook', () => {
     it('should create with nested directories', async () => {
       await hookGenerator(appTree, {
         name: 'use-hello-world',
-        path: `${projectName}/src/lib/foo/use-hello-world`,
+        path: `${projectName}/src/lib/foo/use-hello-world/use-hello-world`,
         skipTests: true,
       });
 

--- a/packages/react/src/generators/hook/hook.spec.ts
+++ b/packages/react/src/generators/hook/hook.spec.ts
@@ -25,7 +25,7 @@ describe('hook', () => {
   it('should generate files', async () => {
     await hookGenerator(appTree, {
       name: 'use-form',
-      directory: `${projectName}/src/lib/use-form`,
+      path: `${projectName}/src/lib/use-form`,
     });
 
     expect(appTree.exists('my-lib/src/lib/use-form/use-form.ts')).toBeTruthy();
@@ -37,7 +37,7 @@ describe('hook', () => {
   it('should generate files for an app', async () => {
     await hookGenerator(appTree, {
       name: 'use-form',
-      directory: 'my-app/src/app/use-form',
+      path: 'my-app/src/app/use-form',
     });
 
     expect(appTree.exists('my-app/src/app/use-form/use-form.ts')).toBeTruthy();
@@ -49,7 +49,7 @@ describe('hook', () => {
   it('handles "use" in the name', async () => {
     await hookGenerator(appTree, {
       name: 'use-hello',
-      directory: `${projectName}/src/lib/use-hello`,
+      path: `${projectName}/src/lib/use-hello`,
       skipTests: true,
     });
 
@@ -64,7 +64,7 @@ describe('hook', () => {
   it('handles "use-" in the name', async () => {
     await hookGenerator(appTree, {
       name: 'use-hello',
-      directory: `${projectName}/src/lib/use-hello`,
+      path: `${projectName}/src/lib/use-hello`,
       skipTests: true,
     });
     expect(
@@ -79,7 +79,7 @@ describe('hook', () => {
     it('should add to index.ts barrel', async () => {
       await hookGenerator(appTree, {
         name: 'hello',
-        directory: `${projectName}/src/lib/use-hello`,
+        path: `${projectName}/src/lib/use-hello`,
         export: true,
       });
 
@@ -91,7 +91,7 @@ describe('hook', () => {
     it('should not export from an app', async () => {
       await hookGenerator(appTree, {
         name: 'hello',
-        directory: 'my-lib/src/app/use-hello',
+        path: 'my-lib/src/app/use-hello',
         export: true,
       });
 
@@ -105,7 +105,7 @@ describe('hook', () => {
     it('should not generate tests', async () => {
       await hookGenerator(appTree, {
         name: 'use-hello',
-        directory: `${projectName}/src/lib/use-hello`,
+        path: `${projectName}/src/lib/use-hello`,
         skipTests: true,
       });
       expect(
@@ -121,7 +121,7 @@ describe('hook', () => {
     it('should create component under the directory', async () => {
       await hookGenerator(appTree, {
         name: 'use-hello',
-        directory: 'my-lib/src/hooks/use-hello',
+        path: 'my-lib/src/hooks/use-hello',
         skipTests: true,
       });
 
@@ -131,7 +131,7 @@ describe('hook', () => {
     it('should create with nested directories', async () => {
       await hookGenerator(appTree, {
         name: 'use-hello-world',
-        directory: `${projectName}/src/lib/foo/use-hello-world`,
+        path: `${projectName}/src/lib/foo/use-hello-world`,
         skipTests: true,
       });
 

--- a/packages/react/src/generators/hook/hook.ts
+++ b/packages/react/src/generators/hook/hook.ts
@@ -103,9 +103,8 @@ async function normalizeOptions(
     fileName: _fileName,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(host, {
+    path: options.path,
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
     fileExtension: 'tsx',
   });
 

--- a/packages/react/src/generators/hook/schema.d.ts
+++ b/packages/react/src/generators/hook/schema.d.ts
@@ -1,5 +1,3 @@
-import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-
 export interface Schema {
   path: string;
   name?: string;

--- a/packages/react/src/generators/hook/schema.d.ts
+++ b/packages/react/src/generators/hook/schema.d.ts
@@ -1,7 +1,8 @@
 import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
-  name: string;
+  path: string;
+  name?: string;
   skipTests?: boolean;
   directory?: string;
   export?: boolean;

--- a/packages/react/src/generators/hook/schema.json
+++ b/packages/react/src/generators/hook/schema.json
@@ -7,18 +7,24 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g hook my-hook --project=mylib",
-      "description": "Generate a hook in the `mylib` library"
+      "command": "nx g hook mylib/my-hook",
+      "description": "Generate a hook `my-hook` in the `mylib` library"
     }
   ],
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the hook.",
+      "description": "Path where the hook will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the hook be generated?",
+      "x-priority": "important"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the hook.",
       "x-prompt": "What name would you like to use for the hook?",
       "x-priority": "important"
     },

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -186,14 +186,13 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
 
   if (options.component) {
     const relativeCwd = getRelativeCwd();
-    const name = joinPathFragments(
+    const path = joinPathFragments(
       options.projectRoot,
       'src/lib',
       options.fileName
     );
     const componentTask = await componentGenerator(host, {
-      nameAndDirectoryFormat: 'as-provided',
-      name: relativeCwd ? relative(relativeCwd, name) : name,
+      path: relativeCwd ? relative(relativeCwd, path) : path,
       style: options.style,
       skipTests:
         options.unitTestRunner === 'none' ||

--- a/packages/react/src/generators/redux/redux.spec.ts
+++ b/packages/react/src/generators/redux/redux.spec.ts
@@ -26,7 +26,7 @@ describe('redux', () => {
   it('should add dependencies', async () => {
     await reduxGenerator(appTree, {
       name: 'my-slice',
-      directory: 'my-lib/src/lib/my-slice',
+      path: 'my-lib/src/lib/my-slice',
     });
 
     const packageJson = readJson(appTree, '/package.json');
@@ -37,7 +37,7 @@ describe('redux', () => {
   it('should add slice and spec files', async () => {
     await reduxGenerator(appTree, {
       name: 'my-slice',
-      directory: 'my-lib/src/lib',
+      path: 'my-lib/src/lib',
     });
 
     expect(appTree.exists('/my-lib/src/lib/my-slice.slice.ts')).toBeTruthy();
@@ -59,17 +59,17 @@ describe('redux', () => {
       });
       await reduxGenerator(appTree, {
         name: 'my-slice',
-        directory: 'my-lib/src/lib/my-slice',
+        path: 'my-lib/src/lib/my-slice',
         appProject: 'my-app',
       });
       await reduxGenerator(appTree, {
         name: 'another-slice',
-        directory: 'my-lib/src/lib/another-slice',
+        path: 'my-lib/src/lib/another-slice',
         appProject: 'my-app',
       });
       await reduxGenerator(appTree, {
         name: 'third-slice',
-        directory: 'my-lib/src/lib/third-slice',
+        path: 'my-lib/src/lib/third-slice',
         appProject: 'my-app',
       });
 
@@ -88,7 +88,7 @@ describe('redux', () => {
       await expect(
         reduxGenerator(appTree, {
           name: 'my-slice',
-          directory: 'my-lib/src/lib/my-slice',
+          path: 'my-lib/src/lib/my-slice',
           appProject: 'my-lib',
         })
       ).rejects.toThrow(/Expected m/);

--- a/packages/react/src/generators/redux/redux.spec.ts
+++ b/packages/react/src/generators/redux/redux.spec.ts
@@ -26,7 +26,7 @@ describe('redux', () => {
   it('should add dependencies', async () => {
     await reduxGenerator(appTree, {
       name: 'my-slice',
-      path: 'my-lib/src/lib/my-slice',
+      path: 'my-lib/src/lib/my-slice/my-slice',
     });
 
     const packageJson = readJson(appTree, '/package.json');
@@ -37,7 +37,7 @@ describe('redux', () => {
   it('should add slice and spec files', async () => {
     await reduxGenerator(appTree, {
       name: 'my-slice',
-      path: 'my-lib/src/lib',
+      path: 'my-lib/src/lib/my-slice/',
     });
 
     expect(appTree.exists('/my-lib/src/lib/my-slice.slice.ts')).toBeTruthy();
@@ -59,17 +59,17 @@ describe('redux', () => {
       });
       await reduxGenerator(appTree, {
         name: 'my-slice',
-        path: 'my-lib/src/lib/my-slice',
+        path: 'my-lib/src/lib/my-slice/my-slice',
         appProject: 'my-app',
       });
       await reduxGenerator(appTree, {
         name: 'another-slice',
-        path: 'my-lib/src/lib/another-slice',
+        path: 'my-lib/src/lib/another-slice/another-slice',
         appProject: 'my-app',
       });
       await reduxGenerator(appTree, {
         name: 'third-slice',
-        path: 'my-lib/src/lib/third-slice',
+        path: 'my-lib/src/lib/third-slice/third-slice',
         appProject: 'my-app',
       });
 
@@ -88,7 +88,7 @@ describe('redux', () => {
       await expect(
         reduxGenerator(appTree, {
           name: 'my-slice',
-          path: 'my-lib/src/lib/my-slice',
+          path: 'my-lib/src/lib/my-slice/my-slice',
           appProject: 'my-lib',
         })
       ).rejects.toThrow(/Expected m/);

--- a/packages/react/src/generators/redux/redux.ts
+++ b/packages/react/src/generators/redux/redux.ts
@@ -38,15 +38,10 @@ export async function reduxGenerator(host: Tree, schema: Schema) {
 }
 
 function generateReduxFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(
-    host,
-    joinPathFragments(__dirname, './files'),
-    options.directory,
-    {
-      ...options,
-      tmpl: '',
-    }
-  );
+  generateFiles(host, joinPathFragments(__dirname, './files'), options.path, {
+    ...options,
+    tmpl: '',
+  });
 
   if (options.js) {
     toJS(host);
@@ -83,8 +78,8 @@ function addExportsToBarrel(host: Tree, options: NormalizedSchema) {
       true
     );
 
-    const statePath = options.directory
-      ? `./lib/${options.directory}/${options.fileName}`
+    const statePath = options.path
+      ? `./lib/${options.path}/${options.fileName}`
       : `./lib/${options.fileName}`;
     const changes = applyChangesToString(
       indexSource,
@@ -152,9 +147,8 @@ async function normalizeOptions(
     fileName,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(host, {
+    path: options.path,
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
     fileExtension: 'tsx',
   });
 
@@ -171,8 +165,8 @@ async function normalizeOptions(
     : {};
   const modulePath =
     projectType === 'application'
-      ? options.directory
-        ? `./app/${options.directory}/${extraNames.fileName}.slice`
+      ? options.path
+        ? `./app/${options.path}/${extraNames.fileName}.slice`
         : `./app/${extraNames.fileName}.slice`
       : Object.keys(tsPaths).find((k) =>
           tsPaths[k].some((s) => s.includes(sourceRoot))
@@ -206,7 +200,7 @@ async function normalizeOptions(
     ...extraNames,
     fileName,
     constantName: names(options.name).constantName.toUpperCase(),
-    directory,
+    projectDirectory: directory,
     projectType,
     projectSourcePath: sourceRoot,
     projectModulePath: modulePath,

--- a/packages/react/src/generators/redux/redux.ts
+++ b/packages/react/src/generators/redux/redux.ts
@@ -38,10 +38,15 @@ export async function reduxGenerator(host: Tree, schema: Schema) {
 }
 
 function generateReduxFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(host, joinPathFragments(__dirname, './files'), options.path, {
-    ...options,
-    tmpl: '',
-  });
+  generateFiles(
+    host,
+    joinPathFragments(__dirname, './files'),
+    options.projectDirectory,
+    {
+      ...options,
+      tmpl: '',
+    }
+  );
 
   if (options.js) {
     toJS(host);
@@ -155,6 +160,7 @@ async function normalizeOptions(
   let appProjectSourcePath: string;
   let appMainFilePath: string;
   const extraNames = names(name);
+
   const projects = getProjects(host);
   const project = projects.get(projectName);
   const { sourceRoot, projectType } = project;
@@ -195,6 +201,7 @@ async function normalizeOptions(
       );
     }
   }
+
   return {
     ...options,
     ...extraNames,

--- a/packages/react/src/generators/redux/redux.ts
+++ b/packages/react/src/generators/redux/redux.ts
@@ -206,7 +206,7 @@ async function normalizeOptions(
     ...options,
     ...extraNames,
     fileName,
-    constantName: names(options.name).constantName.toUpperCase(),
+    constantName: names(name).constantName.toUpperCase(),
     projectDirectory: directory,
     projectType,
     projectSourcePath: sourceRoot,

--- a/packages/react/src/generators/redux/schema.d.ts
+++ b/packages/react/src/generators/redux/schema.d.ts
@@ -1,5 +1,3 @@
-import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-
 export interface Schema {
   path: string;
   name?: string;

--- a/packages/react/src/generators/redux/schema.d.ts
+++ b/packages/react/src/generators/redux/schema.d.ts
@@ -1,15 +1,15 @@
 import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface Schema {
-  name: string;
-  directory?: string;
+  path: string;
+  name?: string;
   appProject?: string;
   js?: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
 }
 
 interface NormalizedSchema extends Schema {
   projectType: string;
+  projectDirectory: string;
   projectSourcePath: string;
   projectModulePath: string;
   appProjectSourcePath: string;

--- a/packages/react/src/generators/redux/schema.json
+++ b/packages/react/src/generators/redux/schema.json
@@ -6,26 +6,20 @@
   "description": "Create a Redux state slice for a React project.",
   "type": "object",
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "Redux slice name.",
+      "description": "Path where the Redux slice will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "Where should the Redux slice be generated?",
       "x-priority": "important"
     },
-    "directory": {
+    "name": {
       "type": "string",
-      "alias": "dir",
-      "default": "",
-      "description": "The directory at which to create the Redux files. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the project root.",
+      "description": "Redux slice name.",
       "x-priority": "important"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     },
     "appProject": {
       "type": "string",
@@ -38,5 +32,5 @@
       "default": false
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/react/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.spec.ts
@@ -166,7 +166,7 @@ export async function createTestAppLib(
 
   await componentGenerator(appTree, {
     name: 'my-component',
-    directory: `${libName}/src/app/my-component`,
+    path: `${libName}/src/app/my-component/my-component`,
     style: 'css',
   });
 

--- a/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
+++ b/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
@@ -49,7 +49,6 @@ describe('resource route', () => {
           action: false,
           loader: true,
           skipChecks: false,
-          nameAndDirectoryFormat,
         });
 
         expect(tree.exists('apps/demo/app/routes/example.ts')).toBeTruthy();
@@ -63,7 +62,6 @@ describe('resource route', () => {
           loader: true,
           action: true,
           skipChecks: false,
-          nameAndDirectoryFormat,
         }).catch((e) => expect(e).toMatchSnapshot());
 
         await resourceRouteGenerator(tree, {
@@ -71,7 +69,6 @@ describe('resource route', () => {
           loader: true,
           action: true,
           skipChecks: false,
-          nameAndDirectoryFormat,
         }).catch((e) =>
           expect(e).toMatchInlineSnapshot(
             `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
@@ -83,7 +80,6 @@ describe('resource route', () => {
           loader: true,
           action: true,
           skipChecks: false,
-          nameAndDirectoryFormat,
         }).catch((e) => expect(e).toMatchSnapshot());
       });
 
@@ -100,7 +96,6 @@ describe('resource route', () => {
           loader: true,
           action: true,
           skipChecks: true,
-          nameAndDirectoryFormat,
         });
 
         expect(tree.exists(`${basePath}/${normalizedPath}route1/..ts`)).toBe(
@@ -112,7 +107,6 @@ describe('resource route', () => {
           loader: true,
           action: true,
           skipChecks: true,
-          nameAndDirectoryFormat,
         });
 
         expect(
@@ -124,7 +118,6 @@ describe('resource route', () => {
           loader: true,
           action: true,
           skipChecks: true,
-          nameAndDirectoryFormat,
         });
 
         expect(tree.exists(`${basePath}/${normalizedPath}route3/.ts`)).toBe(

--- a/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
+++ b/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
@@ -4,7 +4,6 @@ jest.mock('../../utils/remix-config');
 import * as remixConfigUtils from '../../utils/remix-config';
 
 import { Tree } from '@nx/devkit';
-import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { dirname } from 'path';
 import applicationGenerator from '../application/application.impl';
@@ -42,7 +41,7 @@ describe('resource route', () => {
 
   describe.each([['as-provided', 'apps/demo/app/routes/example.ts', '']])(
     '--nameAndDirectoryFormat=%s',
-    (nameAndDirectoryFormat: NameAndDirectoryFormat, path: string) => {
+    (nameAndDirectoryFormat, path: string) => {
       it(`should create correct file for path ${path}`, async () => {
         await resourceRouteGenerator(tree, {
           path,

--- a/packages/remix/src/generators/resource-route/resource-route.impl.ts
+++ b/packages/remix/src/generators/resource-route/resource-route.impl.ts
@@ -11,8 +11,7 @@ import { RemixRouteSchema } from './schema';
 export default async function (tree: Tree, options: RemixRouteSchema) {
   const { artifactName: name, directory } =
     await determineArtifactNameAndDirectoryOptions(tree, {
-      name: options.path.replace(/^\//, '').replace(/\/$/, ''),
-      nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+      path: options.path.replace(/^\//, '').replace(/\/$/, ''),
     });
 
   if (!options.skipChecks && checkRoutePathForErrors(options.path)) {

--- a/packages/remix/src/generators/resource-route/schema.d.ts
+++ b/packages/remix/src/generators/resource-route/schema.d.ts
@@ -2,7 +2,6 @@ import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-
 
 export interface RemixRouteSchema {
   path: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   action: boolean;
   loader: boolean;
   skipChecks: boolean;

--- a/packages/remix/src/generators/resource-route/schema.json
+++ b/packages/remix/src/generators/resource-route/schema.json
@@ -20,11 +20,6 @@
       },
       "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar')"
     },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the styles in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
-    },
     "action": {
       "type": "boolean",
       "description": "Generate an action function",

--- a/packages/remix/src/generators/route/__snapshots__/route.impl.spec.ts.snap
+++ b/packages/remix/src/generators/route/__snapshots__/route.impl.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`route --nameAndDirectoryFormat=as-provided should add route component 1`] = `
+exports[`route --nameAndDirectoryFormat=apps/demo/app/routes/path/to/example should add route component 1`] = `
 "import { useLoaderData, useActionData } from '@remix-run/react';
 import { json } from '@remix-run/node';
 import type {
@@ -41,8 +41,8 @@ export default function Example() {
 "
 `;
 
-exports[`route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 1`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+exports[`route --nameAndDirectoryFormat=apps/demo/app/routes/path/to/example should error if it detects a possible missing route param because of un-escaped dollar sign 1`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
 
-exports[`route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 2`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+exports[`route --nameAndDirectoryFormat=apps/demo/app/routes/path/to/example should error if it detects a possible missing route param because of un-escaped dollar sign 2`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
 
-exports[`route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 3`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+exports[`route --nameAndDirectoryFormat=apps/demo/app/routes/path/to/example should error if it detects a possible missing route param because of un-escaped dollar sign 3`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -50,7 +50,6 @@ describe('route', () => {
         });
         await routeGenerator(tree, {
           path,
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -72,7 +71,6 @@ describe('route', () => {
         });
         await routeGenerator(tree, {
           path,
-          nameAndDirectoryFormat,
           style: 'none',
           loader: true,
           action: true,
@@ -92,7 +90,6 @@ describe('route', () => {
         });
         await routeGenerator(tree, {
           path: `/${path}/`,
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -111,7 +108,6 @@ describe('route', () => {
         });
         await routeGenerator(tree, {
           path: `${path}.tsx`,
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -134,7 +130,6 @@ describe('route', () => {
         });
         await routeGenerator(tree, {
           path: `/${path}/$withParam.tsx`,
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -158,7 +153,6 @@ describe('route', () => {
 
         await routeGenerator(tree, {
           path: `${path}/route1/.tsx`, // route.$withParams.tsx => route..tsx
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -168,7 +162,6 @@ describe('route', () => {
 
         await routeGenerator(tree, {
           path: `${path}/route2//index.tsx`, // route/$withParams/index.tsx => route//index.tsx
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -178,7 +171,6 @@ describe('route', () => {
 
         await routeGenerator(tree, {
           path: `${path}/route3/.tsx`, // route/$withParams.tsx => route/.tsx
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -195,7 +187,6 @@ describe('route', () => {
 
         await routeGenerator(tree, {
           path: `${path}/route1/..tsx`, // route.$withParams.tsx => route..tsx
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -209,7 +200,6 @@ describe('route', () => {
 
         await routeGenerator(tree, {
           path: `${path}/route2//index.tsx`, // route/$withParams/index.tsx => route//index.tsx
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -223,7 +213,6 @@ describe('route', () => {
 
         await routeGenerator(tree, {
           path: `${path}/route3/.tsx`, // route/$withParams.tsx => route/.tsx
-          nameAndDirectoryFormat,
           style: 'css',
           loader: true,
           action: true,
@@ -240,7 +229,6 @@ describe('route', () => {
 
         await routeGenerator(tree, {
           path: `${standalonePath}/route.tsx`,
-          nameAndDirectoryFormat,
           style: 'none',
           loader: true,
           action: true,

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -3,7 +3,6 @@ import 'nx/src/internal-testing-utils/mock-project-graph';
 jest.mock('../../utils/remix-config');
 import * as remixConfigUtils from '../../utils/remix-config';
 import { Tree } from '@nx/devkit';
-import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import presetGenerator from '../preset/preset.impl';
@@ -24,7 +23,6 @@ describe('route', () => {
   });
   describe.each([
     [
-      'as-provided',
       'apps/demo/app/routes/path/to/example',
       'app/routes',
       'apps/demo/app/routes/path/to/example.tsx',
@@ -35,13 +33,11 @@ describe('route', () => {
   ])(
     `--nameAndDirectoryFormat=%s`,
     (
-      nameAndDirectoryFormat: NameAndDirectoryFormat,
       path,
       standalonePath,
       expectedRoutePath,
       expectedStylePath,
-      expectedComponentName,
-      project: string
+      expectedComponentName
     ) => {
       it('should add route component', async () => {
         await applicationGenerator(tree, {
@@ -120,10 +116,8 @@ describe('route', () => {
       });
 
       it('should handle routes that have a param', async () => {
-        const componentName =
-          nameAndDirectoryFormat === 'as-provided'
-            ? 'WithParam'
-            : `${expectedComponentName}WithParam`;
+        const componentName = 'WithParam';
+
         await applicationGenerator(tree, {
           name: 'demo',
           directory: 'apps/demo',

--- a/packages/remix/src/generators/route/route.impl.ts
+++ b/packages/remix/src/generators/route/route.impl.ts
@@ -24,8 +24,7 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
     directory,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
-    name: options.path.replace(/^\//, '').replace(/\/$/, ''),
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.path.replace(/^\//, '').replace(/\/$/, ''),
   });
 
   const project = readProjectConfiguration(tree, projectName);
@@ -99,7 +98,6 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
   if (options.style === 'css') {
     await StyleGenerator(tree, {
       path: routeFilePath,
-      nameAndDirectoryFormat: 'as-provided',
     });
   }
 

--- a/packages/remix/src/generators/route/schema.d.ts
+++ b/packages/remix/src/generators/route/schema.d.ts
@@ -2,7 +2,6 @@ import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-
 
 export interface RemixRouteSchema {
   path: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   style: 'css' | 'none';
   action: boolean;
   meta: boolean;

--- a/packages/remix/src/generators/route/schema.json
+++ b/packages/remix/src/generators/route/schema.json
@@ -13,17 +13,12 @@
   "properties": {
     "path": {
       "type": "string",
-      "description": "The route path or path to the filename of the route. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
+      "description": "The route path or path to the filename of the route.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
       "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar')"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the route in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and path relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     },
     "style": {
       "type": "string",

--- a/packages/remix/src/generators/style/schema.d.ts
+++ b/packages/remix/src/generators/style/schema.d.ts
@@ -2,5 +2,4 @@ import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-
 
 export interface RemixStyleSchema {
   path: string;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
 }

--- a/packages/remix/src/generators/style/schema.json
+++ b/packages/remix/src/generators/style/schema.json
@@ -19,11 +19,6 @@
         "index": 0
       },
       "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar.tsx')"
-    },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the styles in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
-      "type": "string",
-      "enum": ["as-provided", "derived"]
     }
   },
   "required": ["path"]

--- a/packages/remix/src/generators/style/style.impl.spec.ts
+++ b/packages/remix/src/generators/style/style.impl.spec.ts
@@ -145,7 +145,6 @@ describe('route', () => {
     await applicationGenerator(tree, { name: 'demo', directory: 'apps/demo' });
     await routeGenerator(tree, {
       path: 'apps/demo/app/routes/example/$withParam.tsx',
-      nameAndDirectoryFormat: 'as-provided',
       style: 'none',
       loader: false,
       action: false,
@@ -154,7 +153,6 @@ describe('route', () => {
     });
     await styleGenerator(tree, {
       path: 'apps/demo/app/routes/example/$withParam.tsx',
-      nameAndDirectoryFormat: 'as-provided',
     });
     const content = tree.read(
       'apps/demo/app/routes/example/$withParam.tsx',

--- a/packages/remix/src/generators/style/style.impl.ts
+++ b/packages/remix/src/generators/style/style.impl.ts
@@ -19,8 +19,7 @@ import {
 export default async function (tree: Tree, options: RemixStyleSchema) {
   const { project: projectName, artifactName: name } =
     await determineArtifactNameAndDirectoryOptions(tree, {
-      name: options.path,
-      nameAndDirectoryFormat: options.nameAndDirectoryFormat ?? 'as-provided',
+      path: options.path,
     });
   const project = readProjectConfiguration(tree, projectName);
   if (!project) throw new Error(`Project does not exist: ${projectName}`);

--- a/packages/vue/src/generators/component/component.spec.ts
+++ b/packages/vue/src/generators/component/component.spec.ts
@@ -25,7 +25,7 @@ describe('component', () => {
   it('should generate files with vitest', async () => {
     await componentGenerator(appTree, {
       name: 'hello',
-      directory: `${libName}/src/lib/hello`,
+      path: `${libName}/src/lib/hello`,
     });
 
     expect(appTree.read(`${libName}/src/lib/hello/hello.vue`, 'utf-8'))
@@ -59,7 +59,7 @@ describe('component', () => {
   it('should have correct component name based on directory', async () => {
     await componentGenerator(appTree, {
       name: 'hello-world',
-      directory: `${libName}/src/foo/bar/hello-world`,
+      path: `${libName}/src/foo/bar/hello-world`,
     });
 
     expect(
@@ -73,7 +73,7 @@ describe('component', () => {
   it('should generate files for an app', async () => {
     await componentGenerator(appTree, {
       name: 'hello',
-      directory: `${appName}/src/app/hello`,
+      path: `${appName}/src/app/hello`,
     });
 
     expect(
@@ -88,7 +88,7 @@ describe('component', () => {
     it('should add to index.ts barrel', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${libName}/src/lib/hello`,
+        path: `${libName}/src/lib/hello`,
         export: true,
       });
       expect(appTree.read(`${libName}/src/index.ts`, 'utf-8'))
@@ -101,7 +101,7 @@ describe('component', () => {
     it('should not export from an app', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        directory: `${appName}/src/app/hello`,
+        path: `${appName}/src/app/hello`,
         export: true,
       });
 

--- a/packages/vue/src/generators/component/component.spec.ts
+++ b/packages/vue/src/generators/component/component.spec.ts
@@ -25,7 +25,7 @@ describe('component', () => {
   it('should generate files with vitest', async () => {
     await componentGenerator(appTree, {
       name: 'hello',
-      path: `${libName}/src/lib/hello`,
+      path: `${libName}/src/lib/hello/hello`,
     });
 
     expect(appTree.read(`${libName}/src/lib/hello/hello.vue`, 'utf-8'))
@@ -59,7 +59,7 @@ describe('component', () => {
   it('should have correct component name based on directory', async () => {
     await componentGenerator(appTree, {
       name: 'hello-world',
-      path: `${libName}/src/foo/bar/hello-world`,
+      path: `${libName}/src/foo/bar/hello-world/hello-world`,
     });
 
     expect(
@@ -73,7 +73,7 @@ describe('component', () => {
   it('should generate files for an app', async () => {
     await componentGenerator(appTree, {
       name: 'hello',
-      path: `${appName}/src/app/hello`,
+      path: `${appName}/src/app/hello/hello`,
     });
 
     expect(
@@ -88,7 +88,7 @@ describe('component', () => {
     it('should add to index.ts barrel', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        path: `${libName}/src/lib/hello`,
+        path: `${libName}/src/lib/hello/hello`,
         export: true,
       });
       expect(appTree.read(`${libName}/src/index.ts`, 'utf-8'))
@@ -101,7 +101,7 @@ describe('component', () => {
     it('should not export from an app', async () => {
       await componentGenerator(appTree, {
         name: 'hello',
-        path: `${appName}/src/app/hello`,
+        path: `${appName}/src/app/hello/hello`,
         export: true,
       });
 

--- a/packages/vue/src/generators/component/component.ts
+++ b/packages/vue/src/generators/component/component.ts
@@ -18,7 +18,7 @@ export async function componentGenerator(
 }
 
 function createComponentFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(host, join(__dirname, './files'), options.path, {
+  generateFiles(host, join(__dirname, './files'), options.directory, {
     ...options,
     tmpl: '',
   });

--- a/packages/vue/src/generators/component/component.ts
+++ b/packages/vue/src/generators/component/component.ts
@@ -18,7 +18,7 @@ export async function componentGenerator(
 }
 
 function createComponentFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(host, join(__dirname, './files'), options.directory, {
+  generateFiles(host, join(__dirname, './files'), options.path, {
     ...options,
     tmpl: '',
   });

--- a/packages/vue/src/generators/component/lib/utils.ts
+++ b/packages/vue/src/generators/component/lib/utils.ts
@@ -21,14 +21,12 @@ export async function normalizeOptions(
 ): Promise<NormalizedSchema> {
   const {
     artifactName: name,
-    directory,
     fileName,
     filePath,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(host, {
     name: options.name,
-    directory: options.directory,
-    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    path: options.path,
     fileExtension: 'vue',
   });
 
@@ -49,7 +47,6 @@ export async function normalizeOptions(
   return {
     ...options,
     filePath,
-    directory,
     className,
     fileName: componentFileName,
     projectSourceRoot,

--- a/packages/vue/src/generators/component/lib/utils.ts
+++ b/packages/vue/src/generators/component/lib/utils.ts
@@ -23,6 +23,7 @@ export async function normalizeOptions(
     artifactName: name,
     fileName,
     filePath,
+    directory,
     project: projectName,
   } = await determineArtifactNameAndDirectoryOptions(host, {
     name: options.name,
@@ -46,6 +47,7 @@ export async function normalizeOptions(
 
   return {
     ...options,
+    directory,
     filePath,
     className,
     fileName: componentFileName,

--- a/packages/vue/src/generators/component/schema.d.ts
+++ b/packages/vue/src/generators/component/schema.d.ts
@@ -1,16 +1,15 @@
 import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 
 export interface ComponentGeneratorSchema {
-  name: string;
+  path: string;
+  name?: string;
   skipTests?: boolean;
-  directory?: string;
   export?: boolean;
   routing?: boolean;
   js?: boolean;
   fileName?: string;
   inSourceTests?: boolean;
   skipFormat?: boolean;
-  nameAndDirectoryFormat?: NameAndDirectoryFormat;
 }
 
 export interface NormalizedSchema extends ComponentGeneratorSchema {

--- a/packages/vue/src/generators/component/schema.d.ts
+++ b/packages/vue/src/generators/component/schema.d.ts
@@ -1,5 +1,3 @@
-import type { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-
 export interface ComponentGeneratorSchema {
   path: string;
   name?: string;
@@ -13,6 +11,7 @@ export interface ComponentGeneratorSchema {
 }
 
 export interface NormalizedSchema extends ComponentGeneratorSchema {
+  directory: string;
   projectName: string;
   projectSourceRoot: string;
   fileName: string;

--- a/packages/vue/src/generators/component/schema.json
+++ b/packages/vue/src/generators/component/schema.json
@@ -7,25 +7,29 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nx/vue:component --directory=my-app/src/app/one --name=one --nameAndDirectoryFormat=as-provided --unitTestRunner=vitest",
-      "description": "Generate a component in the `my-app` application"
+      "command": "nx g @nx/vue:component my-app/src/app/one --name=one --unitTestRunner=vitest",
+      "description": "Generate a component `one` in the `my-app` application at my-app/src/app/one"
+    },
+    {
+      "command": "nx g @nx/vue:component my-app/src/app/one",
+      "description": "Generate a component `one` in the `my-app` application at my-app/src/app/one"
     }
   ],
   "properties": {
-    "name": {
+    "path": {
       "type": "string",
-      "description": "The name of the component.",
+      "description": "Path where the component will be generated.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use for the component?",
+      "x-prompt": "Where should the component be generated?",
       "x-priority": "important"
     },
-    "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+    "name": {
       "type": "string",
-      "enum": ["as-provided", "derived"]
+      "description": "The name of the component.",
+      "x-prompt": "What name would you like to use for the component?"
     },
     "js": {
       "type": "boolean",
@@ -37,12 +41,6 @@
       "description": "When true, does not create `spec.ts` test files for the new component.",
       "default": false,
       "x-priority": "internal"
-    },
-    "directory": {
-      "type": "string",
-      "description": "The directory at which to create the component file. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
-      "alias": "dir",
-      "x-priority": "important"
     },
     "export": {
       "type": "boolean",
@@ -71,5 +69,5 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/vue/src/generators/library/library.ts
+++ b/packages/vue/src/generators/library/library.ts
@@ -65,14 +65,13 @@ export async function libraryGeneratorInternal(tree: Tree, schema: Schema) {
 
   if (options.component) {
     const relativeCwd = getRelativeCwd();
-    const name = joinPathFragments(
+    const path = joinPathFragments(
       options.projectRoot,
       'src/lib',
       options.fileName
     );
     await componentGenerator(tree, {
-      name: relativeCwd ? relative(relativeCwd, name) : name,
-      nameAndDirectoryFormat: 'as-provided',
+      path: relativeCwd ? relative(relativeCwd, path) : path,
       skipTests:
         options.unitTestRunner === 'none' ||
         (options.unitTestRunner === 'vitest' && options.inSourceTests == true),

--- a/packages/vue/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/vue/src/generators/storybook-configuration/configuration.spec.ts
@@ -171,7 +171,7 @@ export async function createTestAppLib(
 
   await componentGenerator(appTree, {
     name: 'my-component',
-    directory: `${libName}/src/app/my-component`,
+    path: `${libName}/src/app/my-component/my-component`,
   });
 
   return appTree;

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/generator.ts
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/generator.ts
@@ -17,8 +17,7 @@ export async function generatorGenerator(tree: Tree) {
     name: `add-${basename(cwd)}-plugin`,
     packageVersion: '17.2.0-beta.0',
     description: `Add @nx/${basename(cwd)}/plugin`,
-    nameAndDirectoryFormat: 'as-provided',
-    directory: `src/migrations/update-17-2-0`,
+    path: `src/migrations/update-17-2-0`,
     skipFormat: true,
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently, when we use generator's via the CLI passing the `name` arg has more than one responsibility:
1.  it can be used as a path
2. it can be used as the generator's name (e.g. Component name)

This is not intuitive as if we use via Nx Console because it creates some ambiguity around the `--name` property which is normally described as only 2.
![image](https://github.com/user-attachments/assets/b05fa2a7-36e7-44a1-af82-6f55f53d6c43)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

What is expected is that the `name` property should only have the responsibility of determining the name of the generated module (Component, Directive etc...). 

The new property `path` replaces the `directory` property but fulfils the same purpose as determining where the module should be created. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
