### PR TITLE
fix(expo): change force to be an option for yarn

### DIFF
--- a/docs/generated/packages/expo/executors/install.json
+++ b/docs/generated/packages/expo/executors/install.json
@@ -27,6 +27,11 @@
         "type": "boolean",
         "description": "Automatically update any invalid package versions",
         "default": false
+      },
+      "force": {
+        "type": "boolean",
+        "description": "Force the installation of a package, even if it is already installed",
+        "default": false
       }
     },
     "presets": []

--- a/e2e/expo/src/expo-legacy.test.ts
+++ b/e2e/expo/src/expo-legacy.test.ts
@@ -146,14 +146,14 @@ describe('@nx/expo (legacy)', () => {
   it('should install', async () => {
     // run install command
     let installResults = await runCLIAsync(
-      `install ${appName} --no-interactive`
+      `install ${appName} --no-interactive --force`
     );
     expect(installResults.combinedOutput).toContain(
       'Successfully ran target install'
     );
 
     installResults = await runCLIAsync(
-      `install ${appName} --packages=@react-native-async-storage/async-storage,react-native-image-picker --no-interactive`
+      `install ${appName} --force --packages=@react-native-async-storage/async-storage,react-native-image-picker --no-interactive`
     );
     expect(installResults.combinedOutput).toContain(
       'Successfully ran target install'

--- a/e2e/expo/src/expo.test.ts
+++ b/e2e/expo/src/expo.test.ts
@@ -117,14 +117,14 @@ describe('@nx/expo', () => {
   it('should install', async () => {
     // run install command
     let installResults = await runCLIAsync(
-      `install ${appName} --no-interactive`
+      `install ${appName} --force --no-interactive`
     );
     expect(installResults.combinedOutput).toContain(
       'Successfully ran target install'
     );
 
     installResults = await runCLIAsync(
-      `install ${appName} --packages=@react-native-async-storage/async-storage,react-native-image-picker --no-interactive`
+      `install ${appName} --force --packages=@react-native-async-storage/async-storage,react-native-image-picker --no-interactive`
     );
     expect(installResults.combinedOutput).toContain(
       'Successfully ran target install'

--- a/packages/expo/src/executors/install/install.impl.ts
+++ b/packages/expo/src/executors/install/install.impl.ts
@@ -42,8 +42,14 @@ export async function installAndUpdatePackageJson(
       ? options.packages.split(',')
       : options.packages ?? [];
 
-  // Use force in case there are any unmet peer dependencies.
-  await installAsync(packages, createInstallOptions(options), ['--force']);
+  await installAsync(
+    packages,
+    createInstallOptions({
+      fix: options.fix,
+      check: options.check,
+    }),
+    createInstallOptions({ force: options.force })
+  );
 
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;

--- a/packages/expo/src/executors/install/schema.d.ts
+++ b/packages/expo/src/executors/install/schema.d.ts
@@ -4,4 +4,5 @@ export interface ExpoInstallOptions {
   packages?: string | string[]; // either a string separated by comma or a string array
   check?: boolean; // default is false
   fix?: boolean; // default is false
+  force?: boolean; // default is false
 }

--- a/packages/expo/src/executors/install/schema.json
+++ b/packages/expo/src/executors/install/schema.json
@@ -29,6 +29,11 @@
       "type": "boolean",
       "description": "Automatically update any invalid package versions",
       "default": false
+    },
+    "force": {
+      "type": "boolean",
+      "description": "Force the installation of a package, even if it is already installed",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
- currently --force is passed into every `expo install` command -> then the package install command
- but it is not supported in yarn, change it to an option so it would not get passed in everytime

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/28062
