### PR TITLE
feat(core): add support for bun.lock and generating bun lock file

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -1,6 +1,7 @@
 import {
   checkFilesDoNotExist,
   checkFilesExist,
+  checkOneOfFilesExist,
   cleanupProject,
   createFile,
   detectPackageManager,
@@ -56,12 +57,9 @@ describe('EsBuild Plugin', () => {
 
     expect(runCommand(`node dist/libs/${myPkg}/index.cjs`)).toMatch(/Hello/);
     // main field should be set correctly in package.json
-    checkFilesExist(
-      `dist/libs/${myPkg}/package.json`,
-      `dist/libs/${myPkg}/${
-        packageManagerLockFile[detectPackageManager(tmpProjPath())]
-      }`
-    );
+    const pm = detectPackageManager(tmpProjPath());
+    checkFilesExist(`dist/libs/${myPkg}/package.json`);
+    checkOneOfFilesExist(`dist/libs/${myPkg}/`, ...packageManagerLockFile[pm]);
     expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/Hello/);
 
     expect(runCommand(`node dist/libs/${myPkg}/index.cjs`)).toMatch(/Hello/);

--- a/e2e/js/src/js-executor-tsc.test.ts
+++ b/e2e/js/src/js-executor-tsc.test.ts
@@ -1,6 +1,7 @@
 import {
   checkFilesDoNotExist,
   checkFilesExist,
+  checkOneOfFilesExist,
   cleanupProject,
   createFile,
   detectPackageManager,
@@ -45,12 +46,11 @@ describe('js:tsc executor', () => {
     );
 
     runCLI(`build ${lib} --generateLockfile=true`);
-    checkFilesExist(
-      `dist/libs/${lib}/package.json`,
-      `dist/libs/${lib}/${
-        packageManagerLockFile[detectPackageManager(tmpProjPath())]
-      }`
-    );
+
+    const pm = detectPackageManager(tmpProjPath());
+    checkFilesExist(`dist/libs/${lib}/package.json`);
+
+    checkOneOfFilesExist(`dist/libs/${lib}/`, ...packageManagerLockFile[pm]);
 
     updateJson(`libs/${lib}/project.json`, (json) => {
       json.targets.build.options.assets.push({

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -3,6 +3,7 @@ import { joinPathFragments } from '@nx/devkit';
 import {
   checkFilesDoNotExist,
   checkFilesExist,
+  checkOneOfFilesExist,
   cleanupProject,
   createFile,
   detectPackageManager,
@@ -437,10 +438,9 @@ describe('Build Node apps', () => {
     await runCLIAsync(`build ${nestapp} --generatePackageJson`);
 
     checkFilesExist(`dist/apps/${nestapp}/package.json`);
-    checkFilesExist(
-      `dist/apps/${nestapp}/${getLockFileName(
-        detectPackageManager(tmpProjPath())
-      )}`
+    checkOneOfFilesExist(
+      `dist/apps/${nestapp}/`,
+      ...getLockFileName(detectPackageManager(tmpProjPath()))
     );
     const rootPackageJson = JSON.parse(readFile(`package.json`));
     const packageJson = JSON.parse(
@@ -485,9 +485,11 @@ describe('Build Node apps', () => {
       )
     ).toBeTruthy();
 
-    checkFilesExist(
-      `dist/apps/${nestapp}/${packageManagerLockFile[packageManager]}`
+    checkOneOfFilesExist(
+      `dist/apps/${nestapp}/`,
+      ...packageManagerLockFile[packageManager]
     );
+
     runCommand(`${getPackageManagerCommand().ciInstall}`, {
       cwd: joinPathFragments(tmpProjPath(), 'dist/apps', nestapp),
     });

--- a/e2e/utils/file-utils.ts
+++ b/e2e/utils/file-utils.ts
@@ -116,6 +116,23 @@ export function getSize(filePath: string): number {
   return statSync(filePath).size;
 }
 
+export function checkOneOfFilesExist(
+  basePath: string,
+  ...fileArrays: string[]
+): void {
+  for (const fileArray of fileArrays) {
+    for (const file of fileArray) {
+      const fullPath = file.startsWith('/') ? file : path.join(basePath, file);
+      if (exists(fullPath)) {
+        return;
+      }
+    }
+  }
+  throw new Error(
+    `None of the specified files exist in any of the provided arrays`
+  );
+}
+
 export function tmpBackupProjPath(path?: string) {
   return path ? `${e2eCwd}/proj-backup/${path}` : `${e2eCwd}/proj-backup`;
 }

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -107,10 +107,10 @@ export function getLatestLernaVersion(): string {
 }
 
 export const packageManagerLockFile = {
-  npm: 'package-lock.json',
-  yarn: 'yarn.lock',
-  pnpm: 'pnpm-lock.yaml',
-  bun: 'bun.lockb',
+  npm: ['package-lock.json'],
+  yarn: ['yarn.lock'],
+  pnpm: ['pnpm-lock.yaml'],
+  bun: ['bun.lockb', 'bun.lock'],
 };
 
 export function ensureCypressInstallation() {

--- a/e2e/workspace-create/src/create-nx-plugin.test.ts
+++ b/e2e/workspace-create/src/create-nx-plugin.test.ts
@@ -1,5 +1,6 @@
 import {
   checkFilesExist,
+  checkOneOfFilesExist,
   cleanupProject,
   getSelectedPackageManager,
   packageManagerLockFile,
@@ -23,11 +24,9 @@ describe('create-nx-plugin', () => {
       extraArgs: `--createPackageName=false`,
     });
 
-    checkFilesExist(
-      'package.json',
-      packageManagerLockFile[packageManager],
-      `project.json`
-    );
+    checkFilesExist('package.json', `project.json`);
+
+    checkOneOfFilesExist(``, ...packageManagerLockFile[packageManager]);
 
     runCLI(`build ${pluginName}`);
 

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -1,6 +1,7 @@
 import {
   checkFilesDoNotExist,
   checkFilesExist,
+  checkOneOfFilesExist,
   cleanupProject,
   e2eCwd,
   expectCodeIsFormatted,
@@ -110,7 +111,8 @@ describe('create-nx-workspace', () => {
       packageManager,
     });
 
-    checkFilesExist('package.json', packageManagerLockFile[packageManager]);
+    checkFilesExist('package.json');
+    checkOneOfFilesExist(``, ...packageManagerLockFile[packageManager]);
 
     expectNoAngularDevkit();
   });
@@ -402,11 +404,11 @@ describe('create-nx-workspace', () => {
     if (packageManager === 'npm') {
       it('should use npm when invoked with npx', () => {
         setupProject('npm');
-        checkFilesExist(packageManagerLockFile['npm']);
+        checkOneOfFilesExist(``, ...packageManagerLockFile['npm']);
         checkFilesDoNotExist(
-          packageManagerLockFile['yarn'],
-          packageManagerLockFile['pnpm'],
-          packageManagerLockFile['bun']
+          ...packageManagerLockFile['yarn'],
+          ...packageManagerLockFile['pnpm'],
+          ...packageManagerLockFile['bun']
         );
         process.env.SELECTED_PM = packageManager;
       }, 90000);
@@ -415,11 +417,11 @@ describe('create-nx-workspace', () => {
     if (packageManager === 'pnpm') {
       it('should use pnpm when invoked with pnpx', () => {
         setupProject('pnpm');
-        checkFilesExist(packageManagerLockFile['pnpm']);
+        checkOneOfFilesExist(``, ...packageManagerLockFile['pnpm']);
         checkFilesDoNotExist(
-          packageManagerLockFile['yarn'],
-          packageManagerLockFile['npm'],
-          packageManagerLockFile['bun']
+          ...packageManagerLockFile['yarn'],
+          ...packageManagerLockFile['npm'],
+          ...packageManagerLockFile['bun']
         );
         process.env.SELECTED_PM = packageManager;
       }, 90000);
@@ -428,11 +430,11 @@ describe('create-nx-workspace', () => {
     if (packageManager === 'bun') {
       it('should use bun when invoked with bunx', () => {
         setupProject('bun');
-        checkFilesExist(packageManagerLockFile['bun']);
+        checkOneOfFilesExist(``, ...packageManagerLockFile['bun']);
         checkFilesDoNotExist(
-          packageManagerLockFile['yarn'],
-          packageManagerLockFile['npm'],
-          packageManagerLockFile['pnpm']
+          ...packageManagerLockFile['yarn'],
+          ...packageManagerLockFile['npm'],
+          ...packageManagerLockFile['pnpm']
         );
         process.env.SELECTED_PM = packageManager;
       }, 90000);
@@ -442,11 +444,11 @@ describe('create-nx-workspace', () => {
     if (packageManager === 'yarn') {
       xit('should use yarn when invoked with yarn create', () => {
         setupProject('yarn');
-        checkFilesExist(packageManagerLockFile['yarn']);
+        checkOneOfFilesExist(``, ...packageManagerLockFile['yarn']);
         checkFilesDoNotExist(
-          packageManagerLockFile['pnpm'],
-          packageManagerLockFile['npm'],
-          packageManagerLockFile['bun']
+          ...packageManagerLockFile['pnpm'],
+          ...packageManagerLockFile['npm'],
+          ...packageManagerLockFile['bun']
         );
         process.env.SELECTED_PM = packageManager;
       }, 90000);

--- a/packages/angular/src/plugins/plugin.ts
+++ b/packages/angular/src/plugins/plugin.ts
@@ -119,11 +119,12 @@ async function createNodesInternal(
     return {};
   }
 
+  const pm = detectPackageManager(context.workspaceRoot);
   const hash = await calculateHashForCreateNodes(
     angularWorkspaceRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
   );
 
   projectsCache[hash] ??= await buildAngularProjects(

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -14,6 +14,8 @@ export type PackageManager = (typeof packageManagerList)[number];
 export function detectPackageManager(dir: string = ''): PackageManager {
   return existsSync(join(dir, 'bun.lockb'))
     ? 'bun'
+    : existsSync(join(dir, 'bun.lock'))
+    ? 'bun'
     : existsSync(join(dir, 'yarn.lock'))
     ? 'yarn'
     : existsSync(join(dir, 'pnpm-lock.yaml'))

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -102,11 +102,12 @@ async function createNodesInternal(
     return {};
   }
 
+  const pm = detectPackageManager(context.workspaceRoot);
   const hash = await calculateHashForCreateNodes(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
   );
 
   targetsCache[hash] ??= await buildCypressTargets(

--- a/packages/detox/src/plugins/plugin.ts
+++ b/packages/detox/src/plugins/plugin.ts
@@ -52,11 +52,12 @@ export const createNodes: CreateNodes<DetoxPluginOptions> = [
       return {};
     }
 
+    const pm = detectPackageManager(context.workspaceRoot);
     const hash = await calculateHashForCreateNodes(
       projectRoot,
       options,
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
     );
 
     targetsCache[hash] ??= buildDetoxTargets(projectRoot, options, context);

--- a/packages/devkit/src/utils/replace-package.ts
+++ b/packages/devkit/src/utils/replace-package.ts
@@ -162,6 +162,7 @@ function replaceMentions(
       'package-lock.json',
       'pnpm-lock.yaml',
       'bun.lockb',
+      'bun.lock',
       'CHANGELOG.md',
     ];
     if (ignoredFiles.includes(basename(path))) {

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -72,11 +72,12 @@ export const createNodes: CreateNodes<ExpoPluginOptions> = [
       return {};
     }
 
+    const pm = detectPackageManager(context.workspaceRoot);
     const hash = await calculateHashForCreateNodes(
       projectRoot,
       options,
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
     );
 
     targetsCache[hash] ??= buildExpoTargets(projectRoot, options, context);

--- a/packages/expo/src/executors/build/build.impl.ts
+++ b/packages/expo/src/executors/build/build.impl.ts
@@ -129,7 +129,14 @@ function copyPackageJsonAndLock(
   const packageJsonProject = pathResolve(projectRoot, 'package.json');
   const projectPackageJson = readJsonFile<PackageJson>(packageJsonProject);
 
-  const lockFile = getLockFileName(detectPackageManager(workspaceRoot));
+  const pm = detectPackageManager(workspaceRoot);
+  const lockFiles = getLockFileName(detectPackageManager(workspaceRoot));
+  const lockFile =
+    pm === 'bun'
+      ? existsSync(pathResolve(workspaceRoot, lockFiles[0]))
+        ? lockFiles[0]
+        : lockFiles[1]
+      : lockFiles[0];
   const lockFileProject = pathResolve(projectRoot, lockFile);
 
   const rootPackageJsonDependencies = rootPackageJson.dependencies;

--- a/packages/expo/src/generators/application/lib/create-application-files.ts
+++ b/packages/expo/src/generators/application/lib/create-application-files.ts
@@ -17,11 +17,11 @@ export async function createApplicationFiles(
   host: Tree,
   options: NormalizedSchema
 ) {
-  const packageManagerLockFile: Record<PackageManager, string> = {
-    npm: 'package-lock.json',
-    yarn: 'yarn.lock',
-    pnpm: 'pnpm-lock.yaml',
-    bun: 'bun.lockb',
+  const packageManagerLockFile: Record<PackageManager, string[]> = {
+    npm: ['package-lock.json'],
+    yarn: ['yarn.lock'],
+    pnpm: ['pnpm-lock.yaml'],
+    bun: ['bun.lockb', 'bun.lock'],
   };
   const packageManager = detectPackageManager(host.root);
   const packageLockFile = packageManagerLockFile[packageManager];
@@ -43,7 +43,8 @@ export async function createApplicationFiles(
       ...options,
       offsetFromRoot: offsetFromRoot(options.appProjectRoot),
       packageManager,
-      packageLockFile,
+      packageLockFile:
+        packageManager === 'bun' ? packageLockFile[1] : packageLockFile[0],
     }
   );
 
@@ -56,7 +57,8 @@ export async function createApplicationFiles(
       connectCloudUrl,
       offsetFromRoot: offsetFromRoot(options.appProjectRoot),
       packageManager,
-      packageLockFile,
+      packageLockFile:
+        packageManager === 'bun' ? packageLockFile[1] : packageLockFile[0],
     }
   );
 

--- a/packages/js/src/generators/release-version/utils/update-lock-file.ts
+++ b/packages/js/src/generators/release-version/utils/update-lock-file.ts
@@ -6,6 +6,8 @@ import {
   output,
 } from '@nx/devkit';
 import { execSync } from 'child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { daemonClient } from 'nx/src/daemon/client/client';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getLockFileName } from 'nx/src/plugins/js/lock-file/lock-file';
@@ -80,7 +82,10 @@ export async function updateLockFile(
     }
   }
 
-  const lockFile = getLockFileName(packageManager);
+  const lockFile =
+    packageManager === 'bun' && existsSync(join(cwd, 'bun.lock'))
+      ? getLockFileName(packageManager)[1]
+      : getLockFileName(packageManager)[0];
   const command =
     `${packageManagerCommands.updateLockFile} ${installArgs}`.trim();
 

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -150,11 +150,12 @@ async function createNodesInternal(
     return {};
   }
 
+  const pm = detectPackageManager(context.workspaceRoot);
   const nodeHash = await calculateHashForCreateNodes(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
   );
   // The hash is calculated at the node/project level, so we add the config file path to avoid conflicts when caching
   const cacheKey = `${nodeHash}_${configFilePath}`;

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -119,24 +119,19 @@ export function updatePackageJson(
 
   if (options.generateLockfile) {
     const packageManager = detectPackageManager(context.root);
-    if (packageManager === 'bun') {
-      logger.warn(
-        `Bun lockfile generation is unsupported. Remove "generateLockfile" option or set it to false.`
-      );
-    } else {
-      const lockFile = createLockFile(
-        packageJson,
-        context.projectGraph,
-        packageManager
-      );
-      writeFileSync(
-        `${options.outputPath}/${getLockFileName(packageManager)}`,
-        lockFile,
-        {
-          encoding: 'utf-8',
-        }
-      );
-    }
+    const lockFile = createLockFile(
+      packageJson,
+      context.projectGraph,
+      packageManager
+    );
+    // we force uses to bun.lock files
+    const lockFileName =
+      packageManager === 'bun'
+        ? getLockFileName(packageManager)[1]
+        : getLockFileName(packageManager)[0];
+    writeFileSync(`${options.outputPath}/${lockFileName}`, lockFile, {
+      encoding: 'utf-8',
+    });
   }
 }
 

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -97,17 +97,18 @@ export default async function buildExecutor(
   if (options.generateLockfile) {
     const packageManager = detectPackageManager(context.root);
     const lockFile = createLockFile(
-      builtPackageJson,
+      packageJson,
       context.projectGraph,
       packageManager
     );
-    writeFileSync(
-      `${options.outputPath}/${getLockFileName(packageManager)}`,
-      lockFile,
-      {
-        encoding: 'utf-8',
-      }
-    );
+    // we force uses to bun.lock files
+    const lockFileName =
+      packageManager === 'bun'
+        ? getLockFileName(packageManager)[1]
+        : getLockFileName(packageManager)[0];
+    writeFileSync(`${options.outputPath}/${lockFileName}`, lockFile, {
+      encoding: 'utf-8',
+    });
   }
 
   // If output path is different from source path, then copy over the config and public files.

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -63,11 +63,12 @@ export const createNodes: CreateNodes<NextPluginOptions> = [
     }
     options = normalizeOptions(options);
 
+    const pm = detectPackageManager(context.workspaceRoot);
     const hash = await calculateHashForCreateNodes(
       projectRoot,
       options,
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
     );
 
     targetsCache[hash] ??= await buildNextTargets(

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -61,12 +61,14 @@ export const createNodes: CreateNodes<NuxtPluginOptions> = [
 
     options = normalizeOptions(options);
 
+    const pm = detectPackageManager(context.workspaceRoot);
     const hash = await calculateHashForCreateNodes(
       projectRoot,
       options,
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
     );
+
     targetsCache[hash] ??= await buildNuxtTargets(
       configFilePath,
       projectRoot,

--- a/packages/nx/src/command-line/init/implementation/react/index.ts
+++ b/packages/nx/src/command-line/init/implementation/react/index.ts
@@ -263,10 +263,12 @@ function moveFilesToTempWorkspace(options: NormalizedOptions) {
     options.packageManager === 'yarn' ? 'yarn.lock' : null,
     options.packageManager === 'pnpm' ? 'pnpm-lock.yaml' : null,
     options.packageManager === 'npm' ? 'package-lock.json' : null,
-    options.packageManager === 'bun' ? 'bun.lockb' : null,
   ];
 
-  const optionalCraFiles = ['README.md'];
+  const optionalCraFiles = [
+    'README.md',
+    ...(options.packageManager === 'bun' ? ['bun.lockb', 'bun.lock'] : []),
+  ];
 
   const filesToMove = [...requiredCraFiles, ...optionalCraFiles].filter(
     Boolean

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -383,6 +383,7 @@ function lockFileHashChanged(): boolean {
     join(workspaceRoot, 'yarn.lock'),
     join(workspaceRoot, 'pnpm-lock.yaml'),
     join(workspaceRoot, 'bun.lockb'),
+    join(workspaceRoot, 'bun.lock'),
   ]
     .filter((file) => existsSync(file))
     .map((file) => hashFile(file));

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -46,7 +46,7 @@ export const createNodes: CreateNodes = [
     const packageManager = detectPackageManager(workspaceRoot);
 
     // Only process the correct lockfile
-    if (lockFile !== getLockFileName(packageManager)) {
+    if (getLockFileName(packageManager).includes(lockFile)) {
       return {};
     }
 
@@ -96,9 +96,17 @@ export const createDependencies: CreateDependencies = (
     lockFileExists(packageManager) &&
     parsedLockFile.externalNodes
   ) {
-    const lockFilePath = join(workspaceRoot, getLockFileName(packageManager));
+    const lockFileName = getLockFileName(packageManager);
+    // this referrs to the bun.lock file not the bun.lockb
+    const bunLockFile =
+      packageManager === 'bun'
+        ? existsSync(join(workspaceRoot, lockFileName[1]))
+        : false;
+    const lockFilePath = bunLockFile
+      ? join(workspaceRoot, lockFileName[1])
+      : join(workspaceRoot, lockFileName[0]);
     const lockFileContents =
-      packageManager !== 'bun'
+      packageManager !== 'bun' || bunLockFile
         ? readFileSync(lockFilePath).toString()
         : execSync(`bun ${lockFilePath}`, {
             maxBuffer: 1024 * 1024 * 10,

--- a/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.spec.ts
@@ -42,6 +42,7 @@ describe('getTouchedProjectsFromLockFile', () => {
     'pnpm-lock.yaml',
     'pnpm-lock.yml',
     'bun.lockb',
+    'bun.lock',
   ].forEach((lockFile) => {
     describe(`"${lockFile}"`, () => {
       it(`should not return changes when "${lockFile}" is not touched`, () => {

--- a/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.ts
@@ -26,6 +26,7 @@ export const getTouchedProjectsFromLockFile: TouchedProjectLocator<
     'pnpm-lock.yaml',
     'pnpm-lock.yml',
     'bun.lockb',
+    'bun.lock',
   ];
 
   if (fileChanges.some((f) => lockFiles.includes(f.file))) {

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -38,6 +38,8 @@ describe('package-manager', () => {
             return false;
           case 'bun.lockb':
             return false;
+          case 'bun.lock':
+            return false;
           default:
             return jest.requireActual('fs').existsSync(p);
         }
@@ -79,6 +81,31 @@ describe('package-manager', () => {
           case 'package-lock.json':
             return false;
           case 'bun.lockb':
+            return true;
+          case 'bun.lock':
+            return false;
+          default:
+            return jest.requireActual('fs').existsSync(p);
+        }
+      });
+      const packageManager = detectPackageManager();
+      expect(packageManager).toEqual('bun');
+      expect(fs.existsSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should detect bun package manager from bun.lock', () => {
+      jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+      jest.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        switch (p) {
+          case 'yarn.lock':
+            return false;
+          case 'pnpm-lock.yaml':
+            return false;
+          case 'package-lock.json':
+            return false;
+          case 'bun.lockb':
+            return false;
+          case 'bun.lock':
             return true;
           default:
             return jest.requireActual('fs').existsSync(p);

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -41,6 +41,8 @@ export function detectPackageManager(dir: string = ''): PackageManager {
     nxJson.cli?.packageManager ??
     (existsSync(join(dir, 'bun.lockb'))
       ? 'bun'
+      : existsSync(join(dir, 'bun.lock'))
+      ? 'bun'
       : existsSync(join(dir, 'yarn.lock'))
       ? 'yarn'
       : existsSync(join(dir, 'pnpm-lock.yaml'))

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -111,11 +111,12 @@ async function createNodesInternal(
 
   const normalizedOptions = normalizeOptions(options);
 
+  const pm = detectPackageManager(context.workspaceRoot);
   const hash = await calculateHashForCreateNodes(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
   );
 
   targetsCache[hash] ??= await buildPlaywrightTargets(

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -70,11 +70,12 @@ export const createNodes: CreateNodes<ReactNativePluginOptions> = [
       return {};
     }
 
+    const pm = detectPackageManager(context.workspaceRoot);
     const hash = await calculateHashForCreateNodes(
       projectRoot,
       options,
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
     );
 
     targetsCache[hash] ??= buildReactNativeTargets(

--- a/packages/remix/src/executors/build/build.impl.ts
+++ b/packages/remix/src/executors/build/build.impl.ts
@@ -89,13 +89,14 @@ export default async function buildExecutor(
       context.projectGraph,
       packageManager
     );
-    writeFileSync(
-      `${options.outputPath}/${getLockFileName(packageManager)}`,
-      lockFile,
-      {
-        encoding: 'utf-8',
-      }
-    );
+    // we force uses to bun.lock files
+    const lockFileName =
+      packageManager === 'bun'
+        ? getLockFileName(packageManager)[1]
+        : getLockFileName(packageManager)[0];
+    writeFileSync(`${options.outputPath}/${lockFileName}`, lockFile, {
+      encoding: 'utf-8',
+    });
   }
 
   // If output path is different from source path, then copy over the config and public files.

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -117,10 +117,14 @@ async function createNodesInternal(
     return {};
   }
 
+  const pm = detectPackageManager(context.workspaceRoot);
   const hash =
-    (await calculateHashForCreateNodes(projectRoot, options, context, [
-      getLockFileName(detectPackageManager(context.workspaceRoot)),
-    ])) + configFilePath;
+    (await calculateHashForCreateNodes(
+      projectRoot,
+      options,
+      context,
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
+    )) + configFilePath;
 
   targetsCache[hash] ??= await buildRemixTargets(
     configFilePath,

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -59,11 +59,12 @@ export const createNodes: CreateNodes<RollupPluginOptions> = [
 
     options = normalizeOptions(options);
 
+    const pm = detectPackageManager(context.workspaceRoot);
     const hash = await calculateHashForCreateNodes(
       projectRoot,
       options,
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
     );
 
     targetsCache[hash] ??= await buildRollupTarget(

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -72,11 +72,12 @@ export const createNodes: CreateNodes<StorybookPluginOptions> = [
     }
 
     options = normalizeOptions(options);
+    const pm = detectPackageManager(context.workspaceRoot);
     const hash = await calculateHashForCreateNodes(
       projectRoot,
       options,
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
     );
 
     const projectName = buildProjectName(projectRoot, context.workspaceRoot);

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -138,14 +138,18 @@ export async function* viteBuildExecutor(
       builtPackageJson
     );
     const packageManager = detectPackageManager(context.root);
-
     const lockFile = createLockFile(
       builtPackageJson,
       context.projectGraph,
       packageManager
     );
+    // we force uses to bun.lock files
+    const lockFileName =
+      packageManager === 'bun'
+        ? getLockFileName(packageManager)[1]
+        : getLockFileName(packageManager)[0];
     writeFileSync(
-      `${outDirRelativeToWorkspaceRoot}/${getLockFileName(packageManager)}`,
+      `${outDirRelativeToWorkspaceRoot}/${lockFileName}`,
       lockFile,
       {
         encoding: 'utf-8',

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -106,12 +106,13 @@ async function createNodesInternal(
 
   // We do not want to alter how the hash is calculated, so appending the config file path to the hash
   // to prevent vite/vitest files overwriting the target cache created by the other
+  const pm = detectPackageManager(context.workspaceRoot);
   const hash =
     (await calculateHashForCreateNodes(
       projectRoot,
-      normalizedOptions,
+      options,
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
     )) + configFilePath;
 
   const { isLibrary, ...viteTargets } = await buildViteTargets(

--- a/packages/webpack/src/plugins/generate-package-json-plugin.ts
+++ b/packages/webpack/src/plugins/generate-package-json-plugin.ts
@@ -12,6 +12,8 @@ import {
   type ProjectGraph,
   serializeJson,
 } from '@nx/devkit';
+import { existsSync } from 'fs';
+import { join } from 'path';
 
 const pluginName = 'GeneratePackageJsonPlugin';
 
@@ -76,8 +78,11 @@ export class GeneratePackageJsonPlugin implements WebpackPluginInstance {
             new sources.RawSource(serializeJson(packageJson))
           );
           const packageManager = detectPackageManager(this.options.root);
+          const lockFile = getLockFileName(packageManager).find((lock) =>
+            existsSync(join(this.options.root, lock))
+          );
           compilation.emitAsset(
-            getLockFileName(packageManager),
+            lockFile,
             new sources.RawSource(
               createLockFile(
                 packageJson,

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -107,11 +107,12 @@ async function createNodesInternal(
     return {};
   }
 
+  const pm = detectPackageManager(context.workspaceRoot);
   const hash = await calculateHashForCreateNodes(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    getLockFileName(pm).filter((lock) => siblingFiles.includes(lock))
   );
 
   targetsCache[hash] ??= await createWebpackTargets(

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -38,6 +38,7 @@ jest.mock('fs', () => {
     existsSync: (p) =>
       p.endsWith('yarn.lock') ||
       p.endsWith('pnpm-lock.yaml') ||
+      p.endsWith('bun.lock') ||
       p.endsWith('bun.lockb')
         ? memFs.existsSync(p)
         : actualFs.existsSync(p),

--- a/scripts/check-lock-files.js
+++ b/scripts/check-lock-files.js
@@ -12,6 +12,11 @@ function checkLockFiles() {
       'Invalid occurence of "bun.lockb" file. Please remove it and use only "pnpm-lock.yaml"'
     );
   }
+  if (fs.existsSync('bun.lock')) {
+    errors.push(
+      'Invalid occurence of "bun.lock" file. Please remove it and use only "pnpm-lock.yaml"'
+    );
+  }
   if (fs.existsSync('yarn.lock')) {
     errors.push(
       'Invalid occurence of "yarn.lock" file. Please remove it and use only "pnpm-lock.yaml"'


### PR DESCRIPTION
Fixes: #26640 

This branch made from https://github.com/nrwl/nx/pull/27820 to avoid merge conflicts

This should only be merged once bun added the feature https://x.com/jarredsumner/status/1839056611765268651 tacking https://github.com/oven-sh/bun/issues/11863. - It maybe jsonc so will have to update the generating lock file once it's confirmed

Issue: 
Before `bun.lock` bun only support binary lock files which makes alot of NX flexibility around hashing and creating the lock file impossible  without using bun install.

Solution:
When generating with package lock. We automatically generate `bun.lock` files forcing users to `bun.lock` with a me logged message saying migrated to lock


notes:
This could be deemed as a breaking changes to 3rd party plugins if their relay on any of the package manger detection and lock files