### PR TITLE
docs(core): embed videos for powerpack features

### DIFF
--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -441,7 +441,7 @@
       {
         "id": "powerpack",
         "name": "Powerpack Features",
-        "description": "Features of Nx that are available with a powerpack license.",
+        "description": "Nx Powerpack is a suite of paid extensions for the Nx CLI specifically designed for enterprises.",
         "mediaImage": "",
         "file": "",
         "itemList": [
@@ -646,7 +646,7 @@
   "/features/powerpack": {
     "id": "powerpack",
     "name": "Powerpack Features",
-    "description": "Features of Nx that are available with a powerpack license.",
+    "description": "Nx Powerpack is a suite of paid extensions for the Nx CLI specifically designed for enterprises.",
     "mediaImage": "",
     "file": "",
     "itemList": [

--- a/docs/map.json
+++ b/docs/map.json
@@ -134,7 +134,7 @@
             {
               "name": "Powerpack Features",
               "id": "powerpack",
-              "description": "Features of Nx that are available with a powerpack license.",
+              "description": "Nx Powerpack is a suite of paid extensions for the Nx CLI specifically designed for enterprises.",
               "itemList": [
                 {
                   "name": "Run Language-Agnostic Conformance Rules",

--- a/docs/shared/features/powerpack/conformance.md
+++ b/docs/shared/features/powerpack/conformance.md
@@ -1,5 +1,7 @@
 # Run Language-Agnostic Conformance Rules
 
+{% youtube src="https://youtu.be/6wg23sLveTQ" title="Nx Powerpack workspace conformance" /%}
+
 The [`@nx/powerpack-conformance`](/nx-api/powerpack-conformance) plugin allows [Nx Powerpack]() users to write and apply rules for your entire workspace that help with **consistency**, **maintainability**, **reliability** and **security**.
 
 The conformance plugin allows you to **encode your own organization's standards** so that they can be enforced automatically. Conformance rules can also **complement linting tools** by enforcing that those tools are configured in the recommended way. The rules are written in TypeScript but can be **applied to any language in the codebase** or focus entirely on configuration files.

--- a/docs/shared/features/powerpack/custom-caching.md
+++ b/docs/shared/features/powerpack/custom-caching.md
@@ -1,10 +1,12 @@
 # Self-Host the Remote Cache
 
+{% youtube src="https://youtu.be/vRGAa5SuiTM" title="Nx Powerpack self-hosted cache storage" /%}
+
 The recommended way to enable the [remote cache](/ci/features/remote-cache) is to use Nx Replay and have Nx Cloud share the task cache across your organization. For those organizations that are unable to use Nx Cloud, Nx offers official plugins that are enabled by [Nx Powerpack]() to self-host the remote cache in a fast and secure manner. The recommended ways to host the remote cache are, in order of preference:
 
 1. [Nx Replay](/ci/features/remote-cache): Cache is hosted on Nx Cloud servers or on-premise with an [Nx Enterprise](/enterprise) contract
 2. [@nx/powerpack-s3-cache](/nx-api/powerpack-s3-cache): Cache is on a self-hosted, fully secure AWS S3 bucket
-3. [@nx/powerpack-shared-fs-cache](/nx-api/powerpack-s3-cache): Cache is self-hosted and self-secured on a shared file system location
+3. [@nx/powerpack-shared-fs-cache](/nx-api/powerpack-shared-fs-cache): Cache is self-hosted and self-secured on a shared file system location
 
 The options range from fully opting in to Nx's management of the remote cache to fully managing the configuration and security of your own remote cache.
 

--- a/docs/shared/features/powerpack/owners.md
+++ b/docs/shared/features/powerpack/owners.md
@@ -1,5 +1,7 @@
 # Define Code Ownership at the Project Level
 
+{% youtube src="https://youtu.be/mor6urvw-L0" title="Nx Powerpack Codeowners" /%}
+
 This plugin provides the ability to configure and maintain code owners for projects in an Nx workspace.
 
 The atomic unit of code in an Nx workspace is a project. Tasks, module boundaries and the Nx graph all train us to conceptualize the workspace as a collection of projects. The CODEOWNERS file, however, requires you to switch from a project mental model to a more low-level definition based on the folder structure of your workspace. The `@nx/powerpack-owners` plugin enables you to stay in the mental model that your workspace is a collection of projects as you define the ownership rules for your workspace. Nx will take care of compiling the project ownership rules into file-based ownership rules that [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-use-code-owners/) or [GitLab](https://docs.gitlab.com/ee/user/project/codeowners/) can understand in the CODEOWNERS file.


### PR DESCRIPTION
Updates

- https://nx-dev-git-docs-powerpack-videos-nrwl.vercel.app/features/powerpack
- fixes wrong link in https://nx-dev-git-docs-powerpack-videos-nrwl.vercel.app/features/powerpack/custom-caching
- embeds videos in all Powerpack feature pages