### PR TITLE
cleanup(react-native): replace `fs-extra` with `node:fs`

### DIFF
--- a/packages/react-native/.eslintrc.json
+++ b/packages/react-native/.eslintrc.json
@@ -43,6 +43,18 @@
           }
         ]
       }
+    },
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "name": "fs-extra",
+            "message": "Please use equivalent utilities from `node:fs` instead."
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -29,7 +29,6 @@
     "ajv": "^8.12.0",
     "chalk": "^4.1.0",
     "enhanced-resolve": "^5.8.3",
-    "fs-extra": "^11.1.0",
     "glob": "7.1.4",
     "ignore": "^5.0.4",
     "metro-config": "~0.80.4",

--- a/packages/react-native/plugins/with-nx-metro.ts
+++ b/packages/react-native/plugins/with-nx-metro.ts
@@ -1,7 +1,7 @@
 import { workspaceRoot } from '@nx/devkit';
 import { mergeConfig } from 'metro-config';
 import type { MetroConfig } from 'metro-config';
-import { existsSync, readdirSync, statSync } from 'fs-extra';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'path';
 
 import { getResolveRequest } from './metro-resolver';

--- a/packages/react-native/src/executors/storybook/storybook.impl.ts
+++ b/packages/react-native/src/executors/storybook/storybook.impl.ts
@@ -1,3 +1,4 @@
+import { writeFileSync } from 'node:fs';
 import { join, relative, resolve, dirname } from 'path';
 import { ExecutorContext, logger, readJsonFile } from '@nx/devkit';
 import { fileExists } from '@nx/workspace/src/utilities/fileutils';
@@ -9,7 +10,6 @@ import {
   displayNewlyAddedDepsMessage,
   syncDeps,
 } from '../sync-deps/sync-deps.impl';
-import { writeFileSync } from 'fs-extra';
 import { PackageJson } from 'nx/src/utils/package-json';
 
 /**

--- a/packages/react-native/src/migrations/update-18-0-0/remove-symlink-target.ts
+++ b/packages/react-native/src/migrations/update-18-0-0/remove-symlink-target.ts
@@ -4,7 +4,7 @@ import {
   getProjects,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { removeSync } from 'fs-extra';
+import { rmSync } from 'node:fs';
 
 /**
  * Remove ensure-symlink target.
@@ -20,7 +20,7 @@ export default async function update(tree: Tree) {
     ) {
       removeTargets(config.targets, 'ensure-symlink');
       updateProjectConfiguration(tree, projectName, config);
-      removeSync(`${config.root}/node_modules`);
+      rmSync(`${config.root}/node_modules`, { recursive: true, force: true });
     }
   }
 }

--- a/packages/react-native/src/utils/ensure-node-modules-symlink.spec.ts
+++ b/packages/react-native/src/utils/ensure-node-modules-symlink.spec.ts
@@ -1,6 +1,6 @@
+import * as fs from 'node:fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import * as fs from 'fs-extra';
 import { ensureNodeModulesSymlink } from './ensure-node-modules-symlink';
 
 const workspaceDir = join(tmpdir(), 'nx-react-native-test');
@@ -9,8 +9,9 @@ const appDirAbsolutePath = join(workspaceDir, appDir);
 
 describe('ensureNodeModulesSymlink', () => {
   beforeEach(() => {
-    if (fs.existsSync(workspaceDir)) fs.removeSync(workspaceDir);
-    fs.mkdirSync(workspaceDir);
+    if (fs.existsSync(workspaceDir))
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.mkdirSync(workspaceDir, { recursive: true });
     fs.mkdirSync(appDirAbsolutePath, { recursive: true });
     fs.mkdirSync(appDirAbsolutePath, { recursive: true });
     fs.writeFileSync(
@@ -35,7 +36,8 @@ describe('ensureNodeModulesSymlink', () => {
   });
 
   afterEach(() => {
-    if (fs.existsSync(workspaceDir)) fs.removeSync(workspaceDir);
+    if (fs.existsSync(workspaceDir))
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
   });
 
   it('should create symlinks', () => {

--- a/packages/react-native/src/utils/ensure-node-modules-symlink.ts
+++ b/packages/react-native/src/utils/ensure-node-modules-symlink.ts
@@ -1,6 +1,6 @@
-import { join } from 'path';
+import { existsSync, rmSync, symlinkSync } from 'node:fs';
 import { platform } from 'os';
-import { removeSync, existsSync, symlinkSync } from 'fs-extra';
+import { join } from 'path';
 
 /**
  * This function symlink workspace node_modules folder with app project's node_mdules folder.
@@ -24,7 +24,7 @@ export function ensureNodeModulesSymlink(
   const symlinkType = platform() === 'win32' ? 'junction' : 'dir';
 
   if (existsSync(appNodeModulesPath)) {
-    removeSync(appNodeModulesPath);
+    rmSync(appNodeModulesPath, { recursive: true, force: true });
   }
   symlinkSync(worksapceNodeModulesPath, appNodeModulesPath, symlinkType);
 }

--- a/packages/react-native/src/utils/pod-install-task.ts
+++ b/packages/react-native/src/utils/pod-install-task.ts
@@ -1,9 +1,9 @@
 import { execSync } from 'child_process';
+import { existsSync } from 'node:fs';
 import { platform } from 'os';
+import { join } from 'path';
 import * as chalk from 'chalk';
 import { GeneratorCallback, logger } from '@nx/devkit';
-import { existsSync } from 'fs-extra';
-import { join } from 'path';
 
 const podInstallErrorMessage = `
 Running ${chalk.bold('pod install')} failed, see above.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

See: https://github.com/nrwl/nx/pull/27932. `fs-extra` is mostly unnecessary in projects that only support modern Node versions, and can be replaced with native APIs.

## Current Behavior
`fs-extra` is used.

## Expected Behavior
`node:fs` is used.

## Related Issue(s)
N/A
