### PR TITLE
cleanup(nx-plugin): replace `fs-extra` with `node:fs`

### DIFF
--- a/packages/plugin/.eslintrc.json
+++ b/packages/plugin/.eslintrc.json
@@ -5,7 +5,15 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "name": "fs-extra",
+            "message": "Please use equivalent utilities from `node:fs` instead."
+          }
+        ]
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -27,7 +27,6 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "fs-extra": "^11.1.0",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",
     "@nx/jest": "file:../jest",

--- a/packages/plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/plugin/src/utils/testing-utils/nx-project.ts
@@ -5,8 +5,8 @@ import {
   writeJsonFile,
 } from '@nx/devkit';
 import { execSync } from 'child_process';
+import { mkdirSync } from 'node:fs';
 import { dirname } from 'path';
-import { ensureDirSync } from 'fs-extra';
 import { tmpProjPath } from './paths';
 import { cleanup } from './utils';
 
@@ -85,6 +85,6 @@ export function ensureNxProject(
   npmPackageName?: string,
   pluginDistPath?: string
 ): void {
-  ensureDirSync(tmpProjPath());
+  mkdirSync(tmpProjPath(), { recursive: true });
   newNxProject(npmPackageName, pluginDistPath);
 }

--- a/packages/plugin/src/utils/testing-utils/utils.ts
+++ b/packages/plugin/src/utils/testing-utils/utils.ts
@@ -1,13 +1,13 @@
 import {
-  copySync,
-  ensureDirSync,
+  cpSync,
+  mkdirSync,
   readdirSync,
   readFileSync,
-  removeSync,
   renameSync,
+  rmSync,
   statSync,
   writeFileSync,
-} from 'fs-extra';
+} from 'node:fs';
 import { dirname, isAbsolute } from 'path';
 import { tmpFolder, tmpProjPath } from './paths';
 import { parseJson } from '@nx/devkit';
@@ -22,10 +22,14 @@ export { directoryExists, fileExists };
  */
 export function copyNodeModules(modules: string[]) {
   modules.forEach((module) => {
-    removeSync(`${tmpProjPath()}/node_modules/${module}`);
-    copySync(
+    rmSync(`${tmpProjPath()}/node_modules/${module}`, {
+      recursive: true,
+      force: true,
+    });
+    cpSync(
       `./node_modules/${module}`,
-      `${tmpProjPath()}/node_modules/${module}`
+      `${tmpProjPath()}/node_modules/${module}`,
+      { recursive: true }
     );
   });
 }
@@ -54,7 +58,7 @@ export function updateFile(
   file: string,
   content: string | ((originalFileContent: string) => string)
 ): void {
-  ensureDirSync(dirname(tmpProjPath(file)));
+  mkdirSync(dirname(tmpProjPath(file)), { recursive: true });
   if (typeof content === 'string') {
     writeFileSync(tmpProjPath(file), content);
   } else {
@@ -71,7 +75,7 @@ export function updateFile(
  * @param newPath New path
  */
 export function renameFile(path: string, newPath: string): void {
-  ensureDirSync(dirname(tmpProjPath(newPath)));
+  mkdirSync(dirname(tmpProjPath(newPath)), { recursive: true });
   renameSync(tmpProjPath(path), tmpProjPath(newPath));
 }
 
@@ -125,18 +129,18 @@ export function readFile(path: string): string {
  * Deletes the e2e directory
  */
 export function cleanup(): void {
-  removeSync(tmpProjPath());
+  rmSync(tmpProjPath(), { recursive: true, force: true });
 }
 
 /**
  * Remove the dist folder from the e2e directory
  */
 export function rmDist(): void {
-  removeSync(`${tmpProjPath()}/dist`);
+  rmSync(`${tmpProjPath()}/dist`, { recursive: true, force: true });
 }
 
 export function removeTmpProject(project: string): void {
-  removeSync(`${tmpFolder()}/${project}`);
+  rmSync(`${tmpFolder()}/${project}`, { recursive: true, force: true });
 }
 
 /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

See: https://github.com/nrwl/nx/pull/27932. `fs-extra` is mostly unnecessary in projects that only support modern Node versions, and can be replaced with native APIs.

## Current Behavior
`fs-extra` is used.

## Expected Behavior
`node:fs` is used.

## Related Issue(s)
N/A
