### PR TITLE
fix(core): calculate project dependencies upfront in the schedule

### DIFF
--- a/packages/nx/src/tasks-runner/tasks-schedule.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.ts
@@ -28,6 +28,7 @@ export class TasksSchedule {
   private completedTasks = new Set<string>();
   private scheduleRequestsExecutionChain = Promise.resolve();
   private estimatedTaskTimings: Record<string, number> = {};
+  private projectDependencies: Record<string, number> = {};
 
   constructor(
     private readonly projectGraph: ProjectGraph,
@@ -41,6 +42,15 @@ export class TasksSchedule {
         await this.taskHistory.getEstimatedTaskTimings(
           Object.values(this.taskGraph.tasks).map((t) => t.target)
         );
+    }
+
+    for (const project of Object.values(this.taskGraph.tasks).map(
+      (t) => t.target.project
+    )) {
+      this.projectDependencies[project] ??= findAllProjectNodeDependencies(
+        project,
+        this.reverseProjectGraph
+      ).length;
     }
   }
 
@@ -125,14 +135,8 @@ export class TasksSchedule {
         const project1 = this.taskGraph.tasks[taskId1].target.project;
         const project2 = this.taskGraph.tasks[taskId2].target.project;
 
-        const project1NodeDependencies = findAllProjectNodeDependencies(
-          project1,
-          this.reverseProjectGraph
-        ).length;
-        const project2NodeDependencies = findAllProjectNodeDependencies(
-          project2,
-          this.reverseProjectGraph
-        ).length;
+        const project1NodeDependencies = this.projectDependencies[project1];
+        const project2NodeDependencies = this.projectDependencies[project2];
 
         const dependenciesDiff =
           project2NodeDependencies - project1NodeDependencies;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Counting project dependencies during the sort resulted in a lot of duplicate work.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Count project dependencies for all tasks up front.. so that this information can be easily accessed during the sort.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
