### PR TITLE
feat(core): add support for community remote cache.

### DIFF
--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -21,6 +21,7 @@ Nx.json configuration
 - [affected](../../devkit/documents/NxJsonConfiguration#affected): NxAffectedConfig
 - [cacheDirectory](../../devkit/documents/NxJsonConfiguration#cachedirectory): string
 - [cli](../../devkit/documents/NxJsonConfiguration#cli): Object
+- [communityCache](../../devkit/documents/NxJsonConfiguration#communitycache): string
 - [defaultBase](../../devkit/documents/NxJsonConfiguration#defaultbase): string
 - [defaultProject](../../devkit/documents/NxJsonConfiguration#defaultproject): string
 - [enableDbCache](../../devkit/documents/NxJsonConfiguration#enabledbcache): boolean
@@ -79,6 +80,14 @@ Default generator collection. It is used when no collection is provided.
 | :-------------------- | :-------------------------------------------------------- |
 | `defaultProjectName?` | `string`                                                  |
 | `packageManager?`     | [`PackageManager`](../../devkit/documents/PackageManager) |
+
+---
+
+### communityCache
+
+• `Optional` **communityCache**: `string`
+
+community support for custom cache
 
 ---
 

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -19,6 +19,7 @@ use ProjectsConfigurations or NxJsonConfiguration
 - [affected](../../devkit/documents/Workspace#affected): NxAffectedConfig
 - [cacheDirectory](../../devkit/documents/Workspace#cachedirectory): string
 - [cli](../../devkit/documents/Workspace#cli): Object
+- [communityCache](../../devkit/documents/Workspace#communitycache): string
 - [defaultBase](../../devkit/documents/Workspace#defaultbase): string
 - [defaultProject](../../devkit/documents/Workspace#defaultproject): string
 - [enableDbCache](../../devkit/documents/Workspace#enabledbcache): boolean
@@ -91,6 +92,18 @@ Default generator collection. It is used when no collection is provided.
 #### Inherited from
 
 [NxJsonConfiguration](../../devkit/documents/NxJsonConfiguration).[cli](../../devkit/documents/NxJsonConfiguration#cli)
+
+---
+
+### communityCache
+
+• `Optional` **communityCache**: `string`
+
+community support for custom cache
+
+#### Inherited from
+
+[NxJsonConfiguration](../../devkit/documents/NxJsonConfiguration).[communityCache](../../devkit/documents/NxJsonConfiguration#communitycache)
 
 ---
 

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -81,6 +81,7 @@ export const allowedWorkspaceExtensions = [
   'neverConnectToCloud',
   'sync',
   'enableDbCache',
+  'communityCache',
 ] as const;
 
 if (!patched) {

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -519,6 +519,11 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    * Enable the new experimental db based cache
    */
   enableDbCache?: boolean;
+
+  /**
+   * community support for custom cache
+   */
+  communityCache?: string;
 }
 
 export type PluginConfiguration = string | ExpandedPluginConfiguration;

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -152,6 +152,7 @@ export class DbCache {
       }
     } else {
       return (
+        (await this.getCustomCache(nxJson.communityCache)) ??
         (await this.getPowerpackS3Cache()) ??
         (await this.getPowerpackSharedCache()) ??
         null
@@ -160,14 +161,14 @@ export class DbCache {
   }
 
   private getPowerpackS3Cache(): Promise<RemoteCacheV2 | null> {
-    return this.getPowerpackCache('@nx/powerpack-s3-cache');
+    return this.getCustomCache('@nx/powerpack-s3-cache');
   }
 
   private getPowerpackSharedCache(): Promise<RemoteCacheV2 | null> {
-    return this.getPowerpackCache('@nx/powerpack-shared-fs-cache');
+    return this.getCustomCache('@nx/powerpack-shared-fs-cache');
   }
 
-  private async getPowerpackCache(pkg: string): Promise<RemoteCacheV2 | null> {
+  private async getCustomCache(pkg: string): Promise<RemoteCacheV2 | null> {
     let getRemoteCache = null;
     try {
       getRemoteCache = (await import(this.resolvePackage(pkg))).getRemoteCache;


### PR DESCRIPTION
## Current Behavior
Before latest NX supported community cache. Now its behind a paywall. See my views here:  https://github.com/nrwl/nx/issues/28150#issuecomment-2379341998

Current solutions is community patch to NX https://gist.github.com/Jordan-Hall/5743969938cefc4fa462c86c96b5c3d0

## Expected Behavior
Community Indy hackers should be able to still provide solutions. Powerpack for new functionality sure. For NX own supported solution great. But not by removing currently supported and much used feature! 
 
## Related Issue(s)
Fixes #28150

