### PR TITLE
feat(misc): enable new ts minimal setup by default and guard execution of generators with no support for it

### DIFF
--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -7,7 +7,9 @@ import {
   Tree,
   updateNxJson,
 } from '@nx/devkit';
+import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { initGenerator as jsInitGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { angularInitGenerator } from '../init/init';
 import { setupSsr } from '../setup-ssr/setup-ssr';
 import { setupTailwindGenerator } from '../setup-tailwind/setup-tailwind';
@@ -27,12 +29,13 @@ import {
   updateEditorTsConfig,
 } from './lib';
 import type { Schema } from './schema';
-import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 
 export async function applicationGenerator(
   tree: Tree,
   schema: Partial<Schema>
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(tree, 'angular', 'application');
+
   const options = await normalizeOptions(tree, schema);
   const rootOffset = offsetFromRoot(options.appProjectRoot);
 

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -9,16 +9,19 @@ import {
   determineProjectNameAndRootOptions,
   ensureProjectName,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import { isValidVariable } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { E2eTestRunner } from '../../utils/test-runners';
 import applicationGenerator from '../application/application';
 import remoteGenerator from '../remote/remote';
 import { setupMf } from '../setup-mf/setup-mf';
+import { addMfEnvToTargetDefaultInputs } from '../utils/add-mf-env-to-inputs';
 import { updateSsrSetup } from './lib';
 import type { Schema } from './schema';
-import { addMfEnvToTargetDefaultInputs } from '../utils/add-mf-env-to-inputs';
-import { isValidVariable } from '@nx/js';
 
 export async function host(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'angular', 'host');
+
   const { typescriptConfiguration = true, ...options }: Schema = schema;
   options.standalone = options.standalone ?? true;
 

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -9,14 +9,17 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
-import { getInstalledPackageVersion, versions } from '../utils/version-utils';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodesV2 } from '../../plugins/plugin';
+import { getInstalledPackageVersion, versions } from '../utils/version-utils';
 import { Schema } from './schema';
 
 export async function angularInitGenerator(
   tree: Tree,
   options: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(tree, 'angular', 'init');
+
   ignoreAngularCacheDirectory(tree);
   const installTask = installAngularDevkitCoreIfMissing(tree, options);
 

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -30,11 +30,14 @@ import { addJest } from '../utils/add-jest';
 import { setGeneratorDefaults } from './lib/set-generator-defaults';
 import { ensureAngularDependencies } from '../utils/ensure-angular-dependencies';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export async function libraryGenerator(
   tree: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(tree, 'angular', 'library');
+
   // Do some validation checks
   if (!schema.routing && schema.lazy) {
     throw new Error(`To use "--lazy" option, "--routing" must also be set.`);

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -9,15 +9,18 @@ import {
   determineProjectNameAndRootOptions,
   ensureProjectName,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { swcHelpersVersion } from '@nx/js/src/utils/versions';
 import { E2eTestRunner } from '../../utils/test-runners';
 import { applicationGenerator } from '../application/application';
 import { setupMf } from '../setup-mf/setup-mf';
+import { addMfEnvToTargetDefaultInputs } from '../utils/add-mf-env-to-inputs';
 import { findNextAvailablePort, updateSsrSetup } from './lib';
 import type { Schema } from './schema';
-import { swcHelpersVersion } from '@nx/js/src/utils/versions';
-import { addMfEnvToTargetDefaultInputs } from '../utils/add-mf-env-to-inputs';
 
 export async function remote(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'angular', 'remote');
+
   const { typescriptConfiguration = true, ...options }: Schema = schema;
   options.standalone = options.standalone ?? true;
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -397,7 +397,7 @@ async function determineStack(
           name: `none`,
           message:
             process.env.NX_ADD_PLUGINS !== 'false' &&
-            process.env.NX_ADD_TS_PLUGIN === 'true'
+            process.env.NX_ADD_TS_PLUGIN !== 'false'
               ? `None:          Configures a TypeScript/JavaScript monorepo.`
               : `None:          Configures a TypeScript/JavaScript project with minimal structure.`,
         },
@@ -447,8 +447,9 @@ async function determineNoneOptions(
   parsedArgs: yargs.Arguments<NoneArguments>
 ): Promise<Partial<NoneArguments>> {
   if (
+    (!parsedArgs.preset || parsedArgs.preset === Preset.TS) &&
     process.env.NX_ADD_PLUGINS !== 'false' &&
-    process.env.NX_ADD_TS_PLUGIN === 'true'
+    process.env.NX_ADD_TS_PLUGIN !== 'false'
   ) {
     const reply = await enquirer.prompt<{ prettier: 'Yes' | 'No' }>([
       {

--- a/packages/cypress/src/generators/component-configuration/component-configuration.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.ts
@@ -14,6 +14,7 @@ import {
   runTasksInSerial,
   GeneratorCallback,
 } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { installedCypressVersion } from '../../utils/cypress-version';
 
 import {
@@ -42,6 +43,8 @@ export async function componentConfigurationGeneratorInternal(
   tree: Tree,
   options: CypressComponentConfigurationSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'cypress', 'component-configuration');
+
   const tasks: GeneratorCallback[] = [];
   const opts = normalizeOptions(tree, options);
 

--- a/packages/cypress/src/generators/configuration/configuration.ts
+++ b/packages/cypress/src/generators/configuration/configuration.ts
@@ -17,18 +17,19 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { Linter, LinterType } from '@nx/eslint';
 import {
   getRelativePathToRootTsConfig,
   initGenerator as jsInitGenerator,
 } from '@nx/js';
-import { Linter, LinterType } from '@nx/eslint';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { join } from 'path';
 import { addLinterToCyProject } from '../../utils/add-linter';
 import { addDefaultE2EConfig } from '../../utils/config';
 import { installedCypressVersion } from '../../utils/cypress-version';
 import { typesNodeVersion, viteVersion } from '../../utils/versions';
-import cypressInitGenerator, { addPlugin } from '../init/init';
 import { addBaseCypressSetup } from '../base-setup/base-setup';
+import cypressInitGenerator, { addPlugin } from '../init/init';
 
 export interface CypressE2EConfigSchema {
   project: string;
@@ -67,6 +68,8 @@ export async function configurationGeneratorInternal(
   tree: Tree,
   options: CypressE2EConfigSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'cypress', 'configuration');
+
   const opts = normalizeOptions(tree, options);
   opts.addPlugin ??= process.env.NX_ADD_PLUGINS !== 'false';
   const tasks: GeneratorCallback[] = [];

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -11,6 +11,7 @@ import {
   updateNxJson,
 } from '@nx/devkit';
 import { addPlugin as _addPlugin } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodesV2 } from '../../plugins/plugin';
 import { cypressVersion, nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
@@ -105,6 +106,8 @@ export async function cypressInitGeneratorInternal(
   tree: Tree,
   options: Schema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'cypress', 'init');
+
   updateProductionFileset(tree);
 
   const nxJson = readNxJson(tree);

--- a/packages/detox/src/generators/application/application.ts
+++ b/packages/detox/src/generators/application/application.ts
@@ -1,4 +1,5 @@
 import { formatFiles, runTasksInSerial, Tree } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import detoxInitGenerator from '../init/init';
 import { addGitIgnoreEntry } from './lib/add-git-ignore-entry';
@@ -20,6 +21,8 @@ export async function detoxApplicationGeneratorInternal(
   host: Tree,
   schema: Schema
 ) {
+  assertNotUsingTsSolutionSetup(host, 'detox', 'application');
+
   const options = await normalizeOptions(host, schema);
 
   const initTask = await detoxInitGenerator(host, {

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -9,6 +9,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodes } from '../../plugins/plugin';
 import { detoxVersion, nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
@@ -18,6 +19,8 @@ export function detoxInitGenerator(host: Tree, schema: Schema) {
 }
 
 export async function detoxInitGeneratorInternal(host: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'detox', 'init');
+
   const tasks: GeneratorCallback[] = [];
 
   const nxJson = readNxJson(host);

--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -8,6 +8,7 @@ import {
 } from '@nx/devkit';
 
 import { getImportPath } from '@nx/js/src/utils/get-import-path';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import { esbuildInitGenerator } from '../init/init';
 import { EsBuildExecutorOptions } from '../../executors/esbuild/schema';
@@ -18,6 +19,8 @@ export async function configurationGenerator(
   tree: Tree,
   options: EsBuildProjectSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'esbuild', 'configuration');
+
   const task = await esbuildInitGenerator(tree, {
     ...options,
     skipFormat: true,

--- a/packages/esbuild/src/generators/init/init.ts
+++ b/packages/esbuild/src/generators/init/init.ts
@@ -4,11 +4,14 @@ import {
   GeneratorCallback,
   Tree,
 } from '@nx/devkit';
-import { Schema } from './schema';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { esbuildVersion } from '@nx/js/src/utils/versions';
 import { nxVersion } from '../../utils/versions';
+import { Schema } from './schema';
 
 export async function esbuildInitGenerator(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'esbuild', 'init');
+
   let installTask: GeneratorCallback = () => {};
   if (!schema.skipPackageJson) {
     installTask = addDependenciesToPackageJson(

--- a/packages/expo/src/generators/application/application.ts
+++ b/packages/expo/src/generators/application/application.ts
@@ -6,6 +6,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { initGenerator as jsInitGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import { addLinting } from '../../utils/add-linting';
 import { addJest } from '../../utils/add-jest';
@@ -35,6 +36,8 @@ export async function expoApplicationGeneratorInternal(
   host: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(host, 'expo', 'application');
+
   const options = await normalizeOptions(host, schema);
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/expo/src/generators/init/init.ts
+++ b/packages/expo/src/generators/init/init.ts
@@ -9,6 +9,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodes } from '../../../plugins/plugin';
 import {
   expoCliVersion,
@@ -27,6 +28,8 @@ export function expoInitGenerator(tree: Tree, schema: Schema) {
 }
 
 export async function expoInitGeneratorInternal(host: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'expo', 'init');
+
   const nxJson = readNxJson(host);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -20,6 +20,7 @@ import {
   getRelativePathToRootTsConfig,
   initGenerator as jsInitGenerator,
 } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import init from '../init/init';
 import { addLinting } from '../../utils/add-linting';
 import { addJest } from '../../utils/add-jest';
@@ -49,6 +50,8 @@ export async function expoLibraryGeneratorInternal(
   host: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(host, 'expo', 'library');
+
   const options = await normalizeOptions(host, schema);
   if (options.publishable === true && !schema.importPath) {
     throw new Error(

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@nx/devkit": "file:../devkit",
+    "@nx/js": "file:../js",
     "@nx/node": "file:../node",
     "tslib": "^2.3.0"
   },

--- a/packages/express/src/generators/application/application.ts
+++ b/packages/express/src/generators/application/application.ts
@@ -11,6 +11,7 @@ import {
   determineProjectNameAndRootOptions,
   ensureProjectName,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { applicationGenerator as nodeApplicationGenerator } from '@nx/node';
 import { tslibVersion } from '@nx/node/src/utils/versions';
 import { join } from 'path';
@@ -74,6 +75,8 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 }
 
 export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'express', 'application');
+
   const options = await normalizeOptions(tree, schema);
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/express/src/generators/init/init.ts
+++ b/packages/express/src/generators/init/init.ts
@@ -6,6 +6,7 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { expressVersion, nxVersion } from '../../utils/versions';
 import type { Schema } from './schema';
 
@@ -28,6 +29,8 @@ function updateDependencies(tree: Tree, schema: Schema) {
 }
 
 export async function initGenerator(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'express', 'init');
+
   let installTask: GeneratorCallback = () => {};
   if (!schema.skipPackageJson) {
     installTask = updateDependencies(tree, schema);

--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -90,7 +90,7 @@ export async function initGeneratorInternal(
     process.env.NX_ADD_PLUGINS !== 'false' &&
     nxJson.useInferencePlugins !== false;
   schema.addTsPlugin ??=
-    schema.addPlugin && process.env.NX_ADD_TS_PLUGIN === 'true';
+    schema.addPlugin && process.env.NX_ADD_TS_PLUGIN !== 'false';
 
   if (schema.addTsPlugin) {
     await addPlugin(

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -1,4 +1,4 @@
-import { readJson, readNxJson, type Tree } from '@nx/devkit';
+import { output, readJson, readNxJson, type Tree } from '@nx/devkit';
 import { isUsingPackageManagerWorkspaces } from '../package-manager-workspaces';
 
 export function isUsingTypeScriptPlugin(tree: Tree): boolean {
@@ -60,4 +60,30 @@ function isWorkspaceSetupWithTsSolution(tree: Tree): boolean {
   }
 
   return true;
+}
+
+export function assertNotUsingTsSolutionSetup(
+  tree: Tree,
+  pluginName: string,
+  generatorName: string
+): void {
+  if (
+    process.env.NX_IGNORE_UNSUPPORTED_TS_SETUP === 'true' ||
+    !isUsingTsSolutionSetup(tree)
+  ) {
+    return;
+  }
+
+  const artifactString =
+    generatorName === 'init'
+      ? `"@nx/${pluginName}" plugin`
+      : `"@nx/${pluginName}:${generatorName}" generator`;
+  output.error({
+    title: `The ${artifactString} doesn't yet support the existing TypeScript setup`,
+    bodyLines: [
+      `We're working hard to support the existing TypeScript setup with the ${artifactString}. We'll soon release a new version of Nx with support for it.`,
+    ],
+  });
+
+  process.exit(1);
 }

--- a/packages/nest/src/generators/application/application.ts
+++ b/packages/nest/src/generators/application/application.ts
@@ -1,5 +1,6 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { formatFiles, runTasksInSerial } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { applicationGenerator as nodeApplicationGenerator } from '@nx/node';
 
 import { initGenerator } from '../init/init';
@@ -26,6 +27,8 @@ export async function applicationGeneratorInternal(
   tree: Tree,
   rawOptions: ApplicationGeneratorOptions
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(tree, 'nest', 'application');
+
   const options = await normalizeOptions(tree, rawOptions);
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/nest/src/generators/init/init.ts
+++ b/packages/nest/src/generators/init/init.ts
@@ -1,5 +1,6 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { formatFiles } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import { addDependencies } from './lib';
 import type { InitGeneratorOptions } from './schema';
@@ -8,6 +9,8 @@ export async function initGenerator(
   tree: Tree,
   options: InitGeneratorOptions
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(tree, 'nest', 'init');
+
   let installPackagesTask: GeneratorCallback = () => {};
   if (!options.skipPackageJson) {
     installPackagesTask = addDependencies(tree, options);

--- a/packages/nest/src/generators/library/library.ts
+++ b/packages/nest/src/generators/library/library.ts
@@ -1,6 +1,7 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { formatFiles, runTasksInSerial } from '@nx/devkit';
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import {
   addExportsToBarrelFile,
   addProject,
@@ -29,6 +30,8 @@ export async function libraryGeneratorInternal(
   tree: Tree,
   rawOptions: LibraryGeneratorOptions
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(tree, 'nest', 'library');
+
   const options = await normalizeOptions(tree, rawOptions);
   await jsLibraryGenerator(tree, toJsLibraryGeneratorOptions(options));
   const initTask = await initGenerator(tree, rawOptions);

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -7,6 +7,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { initGenerator as jsInitGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { setupTailwindGenerator } from '@nx/react';
 import {
   testingLibraryReactVersion,
@@ -39,6 +40,8 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
 }
 
 export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'next', 'application');
+
   const tasks: GeneratorCallback[] = [];
   const options = await normalizeOptions(host, schema);
 

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -8,6 +8,7 @@ import {
   createProjectGraphAsync,
 } from '@nx/devkit';
 import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { reactDomVersion, reactVersion } from '@nx/react/src/utils/versions';
 import { addGitIgnoreEntry } from '../../utils/add-gitignore-entry';
 import { nextVersion, nxVersion } from '../../utils/versions';
@@ -45,6 +46,8 @@ export async function nextInitGeneratorInternal(
   host: Tree,
   schema: InitSchema
 ) {
+  assertNotUsingTsSolutionSetup(host, 'next', 'init');
+
   const nxJson = readNxJson(host);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -9,6 +9,7 @@ import {
 } from '@nx/devkit';
 import { libraryGenerator as reactLibraryGenerator } from '@nx/react/src/generators/library/library';
 import { addTsConfigPath, initGenerator as jsInitGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { testingLibraryReactVersion } from '@nx/react/src/utils/versions';
 
 import { nextInitGenerator } from '../init/init';
@@ -24,6 +25,8 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
 }
 
 export async function libraryGeneratorInternal(host: Tree, rawOptions: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'next', 'library');
+
   const options = await normalizeOptions(host, rawOptions);
   const tasks: GeneratorCallback[] = [];
 

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -30,6 +30,7 @@ import {
   initGenerator as jsInitGenerator,
   tsConfigBaseOptions,
 } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { esbuildVersion } from '@nx/js/src/utils/versions';
 import { Linter, lintProjectGenerator } from '@nx/eslint';
 import { join } from 'path';
@@ -390,6 +391,8 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 }
 
 export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'node', 'application');
+
   const options = await normalizeOptions(tree, schema);
   const tasks: GeneratorCallback[] = [];
 

--- a/packages/node/src/generators/init/init.ts
+++ b/packages/node/src/generators/init/init.ts
@@ -6,6 +6,7 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -26,6 +27,8 @@ function updateDependencies(tree: Tree, options: Schema) {
 }
 
 export async function initGenerator(tree: Tree, options: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'node', 'init');
+
   let installTask: GeneratorCallback = () => {};
   if (!options.skipPackageJson) {
     installTask = updateDependencies(tree, options);

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -21,6 +21,7 @@ import {
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
 import { addSwcConfig } from '@nx/js/src/utils/swc/add-swc-config';
 import { addSwcDependencies } from '@nx/js/src/utils/swc/add-swc-dependencies';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { join } from 'path';
 import { tslibVersion, typesNodeVersion } from '../../utils/versions';
 import { initGenerator } from '../init/init';
@@ -43,6 +44,8 @@ export async function libraryGenerator(tree: Tree, schema: Schema) {
 }
 
 export async function libraryGeneratorInternal(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'node', 'library');
+
   const options = await normalizeOptions(tree, schema);
   const tasks: GeneratorCallback[] = [
     await initGenerator(tree, {

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -18,6 +18,7 @@ import {
   getRelativePathToRootTsConfig,
   initGenerator as jsInitGenerator,
 } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { updateGitIgnore } from '../../utils/update-gitignore';
 import { Linter } from '@nx/eslint';
 import { addE2e } from './lib/add-e2e';
@@ -33,6 +34,8 @@ import {
 } from 'nx/src/nx-cloud/utilities/onboarding';
 
 export async function applicationGenerator(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'nuxt', 'application');
+
   const tasks: GeneratorCallback[] = [];
 
   const options = await normalizeOptions(tree, schema);

--- a/packages/nuxt/src/generators/init/init.ts
+++ b/packages/nuxt/src/generators/init/init.ts
@@ -1,11 +1,14 @@
 import { createProjectGraphAsync, GeneratorCallback, Tree } from '@nx/devkit';
 import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import { createNodes } from '../../plugins/plugin';
 import { InitSchema } from './schema';
 import { updateDependencies } from './lib/utils';
 
 export async function nuxtInitGenerator(host: Tree, schema: InitSchema) {
+  assertNotUsingTsSolutionSetup(host, 'nuxt', 'init');
+
   await addPluginV1(
     host,
     await createProjectGraphAsync(),

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -20,6 +20,7 @@ import {
   writeJson,
 } from '@nx/devkit';
 import { getRelativePathToRootTsConfig } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { typescriptVersion } from '@nx/js/src/utils/versions';
 import { execSync } from 'child_process';
 import * as path from 'path';
@@ -39,6 +40,8 @@ export async function configurationGeneratorInternal(
   tree: Tree,
   options: ConfigurationGeneratorSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'playwright', 'configuration');
+
   const nxJson = readNxJson(tree);
   options.addPlugin ??=
     process.env.NX_ADD_PLUGINS !== 'false' &&

--- a/packages/playwright/src/generators/init/init.ts
+++ b/packages/playwright/src/generators/init/init.ts
@@ -8,6 +8,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodesV2 } from '../../plugins/plugin';
 import { nxVersion, playwrightVersion } from '../../utils/versions';
 import { InitGeneratorSchema } from './schema';
@@ -20,6 +21,8 @@ export async function initGeneratorInternal(
   tree: Tree,
   options: InitGeneratorSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'playwright', 'init');
+
   const tasks: GeneratorCallback[] = [];
 
   const nxJson = readNxJson(tree);

--- a/packages/plugin/src/generators/create-package/create-package.ts
+++ b/packages/plugin/src/generators/create-package/create-package.ts
@@ -14,6 +14,7 @@ import {
 } from '@nx/devkit';
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
 import { addTsLibDependencies } from '@nx/js/src/utils/typescript/add-tslib-dependencies';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nxVersion } from 'nx/src/utils/versions';
 import generatorGenerator from '../generator/generator';
 import { CreatePackageSchema } from './schema';
@@ -26,6 +27,8 @@ export async function createPackageGenerator(
   host: Tree,
   schema: CreatePackageSchema
 ) {
+  assertNotUsingTsSolutionSetup(host, 'plugin', 'create-package');
+
   const tasks: GeneratorCallback[] = [];
 
   const options = await normalizeSchema(host, schema);

--- a/packages/plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.ts
@@ -21,6 +21,7 @@ import { addPropertyToJestConfig, configurationGenerator } from '@nx/jest';
 import { getRelativePathToRootTsConfig } from '@nx/js';
 import { setupVerdaccio } from '@nx/js/src/generators/setup-verdaccio/generator';
 import { addLocalRegistryScripts } from '@nx/js/src/utils/add-local-registry-scripts';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { Linter, LinterType, lintProjectGenerator } from '@nx/eslint';
 import { join } from 'path';
 import type { Schema } from './schema';
@@ -176,6 +177,8 @@ export async function e2eProjectGenerator(host: Tree, schema: Schema) {
 }
 
 export async function e2eProjectGeneratorInternal(host: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'plugin', 'e2e-project');
+
   const tasks: GeneratorCallback[] = [];
 
   validatePlugin(host, schema.pluginName);

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -12,6 +12,7 @@ import {
 } from '@nx/devkit';
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
 import { addSwcDependencies } from '@nx/js/src/utils/swc/add-swc-dependencies';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { Linter } from '@nx/eslint';
 import * as path from 'path';
 import { e2eProjectGenerator } from '../e2e-project/e2e';
@@ -74,6 +75,8 @@ function updatePluginConfig(host: Tree, options: NormalizedSchema) {
 }
 
 export async function pluginGenerator(host: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'plugin', 'plugin');
+
   const options = await normalizeOptions(host, schema);
   const tasks: GeneratorCallback[] = [];
 

--- a/packages/plugin/src/generators/preset/generator.ts
+++ b/packages/plugin/src/generators/preset/generator.ts
@@ -7,12 +7,15 @@ import {
   updateJson,
 } from '@nx/devkit';
 import { Linter } from '@nx/eslint';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { PackageJson } from 'nx/src/utils/package-json';
 import { pluginGenerator } from '../plugin/plugin';
 import { PresetGeneratorSchema } from './schema';
 import createPackageGenerator from '../create-package/create-package';
 
 export default async function (tree: Tree, options: PresetGeneratorSchema) {
+  assertNotUsingTsSolutionSetup(tree, 'plugin', 'preset');
+
   const tasks: GeneratorCallback[] = [];
   const pluginProjectName = names(
     options.pluginName.includes('/')

--- a/packages/react-native/src/generators/application/application.ts
+++ b/packages/react-native/src/generators/application/application.ts
@@ -9,6 +9,7 @@ import {
 } from '@nx/devkit';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import { addLinting } from '../../utils/add-linting';
 import { addJest } from '../../utils/add-jest';
@@ -40,6 +41,8 @@ export async function reactNativeApplicationGeneratorInternal(
   host: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(host, 'react-native', 'application');
+
   const options = await normalizeOptions(host, schema);
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/react-native/src/generators/init/init.ts
+++ b/packages/react-native/src/generators/init/init.ts
@@ -9,6 +9,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodes } from '../../../plugins/plugin';
 import {
   nxVersion,
@@ -30,6 +31,8 @@ export async function reactNativeInitGeneratorInternal(
   host: Tree,
   schema: Schema
 ) {
+  assertNotUsingTsSolutionSetup(host, 'react-native', 'init');
+
   addGitIgnoreEntry(host);
 
   const nxJson = readNxJson(host);

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -32,6 +32,7 @@ import { NormalizedSchema, normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export async function reactNativeLibraryGenerator(
   host: Tree,
@@ -47,6 +48,8 @@ export async function reactNativeLibraryGeneratorInternal(
   host: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(host, 'react-native', 'library');
+
   const options = await normalizeOptions(host, schema);
   if (options.publishable === true && !schema.importPath) {
     throw new Error(

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -46,6 +46,7 @@ import { initGenerator as jsInitGenerator } from '@nx/js';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { setupTailwindGenerator } from '../setup-tailwind/setup-tailwind';
 import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 async function addLinting(host: Tree, options: NormalizedSchema) {
   const tasks: GeneratorCallback[] = [];
@@ -113,6 +114,8 @@ export async function applicationGeneratorInternal(
   host: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(host, 'react', 'application');
+
   const tasks = [];
 
   const options = await normalizeOptions(host, schema);

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -25,11 +25,14 @@ import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs'
 import { isValidVariable } from '@nx/js';
 import { moduleFederationEnhancedVersion } from '../../utils/versions';
 import { ensureProjectName } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export async function hostGenerator(
   host: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(host, 'react', 'host');
+
   const tasks: GeneratorCallback[] = [];
   const options: NormalizedSchema = {
     ...(await normalizeOptions<Schema>(host, schema)),

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -6,10 +6,13 @@ import {
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nxVersion, reactDomVersion, reactVersion } from '../../utils/versions';
 import { InitSchema } from './schema';
 
 export async function reactInitGenerator(host: Tree, schema: InitSchema) {
+  assertNotUsingTsSolutionSetup(host, 'react', 'init');
+
   const tasks: GeneratorCallback[] = [];
 
   if (!schema.skipPackageJson) {

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -12,6 +12,7 @@ import {
 import { getRelativeCwd } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { addTsConfigPath, initGenerator as jsInitGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import { nxVersion } from '../../utils/versions';
 import { maybeJs } from '../../utils/maybe-js';
@@ -36,6 +37,8 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
 }
 
 export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'react', 'library');
+
   const tasks: GeneratorCallback[] = [];
 
   const options = await normalizeOptions(host, schema);

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -27,6 +27,7 @@ import { maybeJs } from '../../utils/maybe-js';
 import { isValidVariable } from '@nx/js';
 import { moduleFederationEnhancedVersion } from '../../utils/versions';
 import { ensureProjectName } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export function addModuleFederationFiles(
   host: Tree,
@@ -90,6 +91,8 @@ export function addModuleFederationFiles(
 }
 
 export async function remoteGenerator(host: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'react', 'remote');
+
   const tasks: GeneratorCallback[] = [];
   const options: NormalizedSchema<Schema> = {
     ...(await normalizeOptions<Schema>(host, schema)),

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -20,6 +20,7 @@ import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-default
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { extractTsConfigBase } from '@nx/js/src/utils/typescript/create-ts-config';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { dirname } from 'node:path';
 import {
   createNxCloudOnboardingURLForWelcomeApp,
@@ -56,6 +57,8 @@ export async function remixApplicationGeneratorInternal(
   tree: Tree,
   _options: NxRemixGeneratorSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'remix', 'application');
+
   const options = await normalizeOptions(tree, _options);
   const tasks: GeneratorCallback[] = [
     await initGenerator(tree, {

--- a/packages/remix/src/generators/init/init.ts
+++ b/packages/remix/src/generators/init/init.ts
@@ -11,6 +11,7 @@ import {
   addPlugin,
   generateCombinations,
 } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodesV2 } from '../../plugins/plugin';
 import { nxVersion, remixVersion } from '../../utils/versions';
 import { type Schema } from './schema';
@@ -20,6 +21,8 @@ export function remixInitGenerator(tree: Tree, options: Schema) {
 }
 
 export async function remixInitGeneratorInternal(tree: Tree, options: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'remix', 'init');
+
   const tasks: GeneratorCallback[] = [];
 
   if (!options.skipPackageJson) {

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -1,6 +1,7 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles, GeneratorCallback, runTasksInSerial } from '@nx/devkit';
 import { Linter } from '@nx/eslint';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { libraryGenerator } from '@nx/react';
 import {
   addTsconfigEntryPoints,
@@ -21,6 +22,8 @@ export async function remixLibraryGeneratorInternal(
   tree: Tree,
   schema: NxRemixGeneratorSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'remix', 'library');
+
   const tasks: GeneratorCallback[] = [];
   const options = await normalizeOptions(tree, schema);
 

--- a/packages/rspack/src/generators/application/application.ts
+++ b/packages/rspack/src/generators/application/application.ts
@@ -1,4 +1,5 @@
 import { ensurePackage, formatFiles, runTasksInSerial, Tree } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { version as nxVersion } from 'nx/package.json';
 import configurationGenerator from '../configuration/configuration';
 import rspackInitGenerator from '../init/init';
@@ -9,6 +10,8 @@ export default async function (
   tree: Tree,
   _options: ApplicationGeneratorSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'rspack', 'application');
+
   const tasks = [];
   const initTask = await rspackInitGenerator(tree, {
     ..._options,

--- a/packages/rspack/src/generators/configuration/configuration.ts
+++ b/packages/rspack/src/generators/configuration/configuration.ts
@@ -5,6 +5,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import {
   addOrChangeBuildTarget,
   addOrChangeServeTarget,
@@ -25,6 +26,8 @@ export async function configurationGenerator(
   tree: Tree,
   options: ConfigurationSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'rspack', 'configuration');
+
   const task = await rspackInitGenerator(tree, {
     ...options,
     // TODO: Crystalize the default rspack.config.js file.

--- a/packages/rspack/src/generators/init/init.ts
+++ b/packages/rspack/src/generators/init/init.ts
@@ -9,6 +9,7 @@ import {
 } from '@nx/devkit';
 import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
 import { initGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodesV2 } from '../../../plugin';
 import {
   lessLoaderVersion,
@@ -24,6 +25,8 @@ export async function rspackInitGenerator(
   tree: Tree,
   schema: InitGeneratorSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'rspack', 'init');
+
   const tasks: GeneratorCallback[] = [];
 
   const nxJson = readNxJson(tree);

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -9,6 +9,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { initGenerator as jsInitGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import { StorybookConfigureSchema } from './schema';
 import { initGenerator } from '../init/init';
@@ -59,6 +60,8 @@ export async function configurationGeneratorInternal(
   tree: Tree,
   rawSchema: StorybookConfigureSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'storybook', 'configuration');
+
   const storybookMajor = storybookMajorVersion();
   if (storybookMajor > 0 && storybookMajor === 6) {
     throw new Error(pleaseUpgrade());

--- a/packages/storybook/src/generators/cypress-project/cypress-project.ts
+++ b/packages/storybook/src/generators/cypress-project/cypress-project.ts
@@ -15,6 +15,7 @@ import {
 } from '@nx/devkit';
 import { Linter, LinterType } from '@nx/eslint';
 import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { join } from 'path';
 
 import { safeFileDelete } from '../../utils/utilities';
@@ -34,6 +35,8 @@ export async function cypressProjectGenerator(
   tree: Tree,
   schema: CypressConfigureSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'cypress', 'cypress-project');
+
   logger.warn(
     `Use 'interactionTests' instead when running '@nx/storybook:configuration'. This generator will be removed in v21.`
   );

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -11,6 +11,7 @@ import {
   updateNxJson,
 } from '@nx/devkit';
 import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { gte } from 'semver';
 import { createNodes } from '../../plugins/plugin';
 import {
@@ -95,6 +96,8 @@ export function initGenerator(tree: Tree, schema: Schema) {
 }
 
 export async function initGeneratorInternal(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'storybook', 'init');
+
   const nxJson = readNxJson(tree);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&

--- a/packages/vue/src/generators/application/application.ts
+++ b/packages/vue/src/generators/application/application.ts
@@ -9,6 +9,7 @@ import {
 } from '@nx/devkit';
 import { Linter } from '@nx/eslint';
 import { initGenerator as jsInitGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { Schema } from './schema';
 import { normalizeOptions } from './lib/normalize-options';
 import { vueInitGenerator } from '../init/init';
@@ -28,6 +29,8 @@ export async function applicationGeneratorInternal(
   tree: Tree,
   _options: Schema
 ): Promise<GeneratorCallback> {
+  assertNotUsingTsSolutionSetup(tree, 'vue', 'application');
+
   const options = await normalizeOptions(tree, _options);
   const nxJson = readNxJson(tree);
 

--- a/packages/vue/src/generators/init/init.ts
+++ b/packages/vue/src/generators/init/init.ts
@@ -6,6 +6,7 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nxVersion, vueVersion } from '../../utils/versions';
 import { InitSchema } from './schema';
 
@@ -27,6 +28,8 @@ function updateDependencies(host: Tree, schema: InitSchema) {
 }
 
 export async function vueInitGenerator(host: Tree, schema: InitSchema) {
+  assertNotUsingTsSolutionSetup(host, 'vue', 'init');
+
   let installTask: GeneratorCallback = () => {};
   if (!schema.skipPackageJson) {
     installTask = updateDependencies(host, schema);

--- a/packages/vue/src/generators/library/library.ts
+++ b/packages/vue/src/generators/library/library.ts
@@ -9,6 +9,7 @@ import {
   updateJson,
 } from '@nx/devkit';
 import { addTsConfigPath, initGenerator as jsInitGenerator } from '@nx/js';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { vueInitGenerator } from '../init/init';
 import { Schema } from './schema';
 import { normalizeOptions } from './lib/normalize-options';
@@ -27,6 +28,8 @@ export function libraryGenerator(tree: Tree, schema: Schema) {
 }
 
 export async function libraryGeneratorInternal(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'vue', 'library');
+
   const tasks: GeneratorCallback[] = [];
 
   const options = await normalizeOptions(tree, schema);

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -49,6 +49,7 @@ import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-com
 import staticServeConfiguration from '../static-serve/static-serve-configuration';
 import { findPluginForConfigFile } from '@nx/devkit/src/utils/find-plugin-for-config-file';
 import { E2EWebServerDetails } from '@nx/devkit/src/generators/e2e-web-server-info-utils';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 interface NormalizedSchema extends Schema {
   projectName: string;
@@ -257,6 +258,8 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
 }
 
 export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(host, 'web', 'application');
+
   const options = await normalizeOptions(host, schema);
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -6,6 +6,7 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -26,6 +27,8 @@ function updateDependencies(tree: Tree, schema: Schema) {
 }
 
 export async function webInitGenerator(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'web', 'init');
+
   let installTask: GeneratorCallback = () => {};
   if (!schema.skipPackageJson) {
     installTask = updateDependencies(tree, schema);

--- a/packages/webpack/src/generators/configuration/configuration.ts
+++ b/packages/webpack/src/generators/configuration/configuration.ts
@@ -17,6 +17,7 @@ import { WebpackExecutorOptions } from '../../executors/webpack/schema';
 import { hasPlugin } from '../../utils/has-plugin';
 import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export function configurationGenerator(
   tree: Tree,
@@ -29,6 +30,8 @@ export async function configurationGeneratorInternal(
   tree: Tree,
   options: ConfigurationGeneratorSchema
 ) {
+  assertNotUsingTsSolutionSetup(tree, 'webpack', 'configuration');
+
   const tasks: GeneratorCallback[] = [];
   const nxJson = readNxJson(tree);
   const addPluginDefault =

--- a/packages/webpack/src/generators/init/init.ts
+++ b/packages/webpack/src/generators/init/init.ts
@@ -7,6 +7,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
+import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodes } from '../../plugins/plugin';
 import { nxVersion, webpackCliVersion } from '../../utils/versions';
 import { Schema } from './schema';
@@ -16,6 +17,8 @@ export function webpackInitGenerator(tree: Tree, schema: Schema) {
 }
 
 export async function webpackInitGeneratorInternal(tree: Tree, schema: Schema) {
+  assertNotUsingTsSolutionSetup(tree, 'webpack', 'init');
+
   const nxJson = readNxJson(tree);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&

--- a/packages/workspace/src/generators/new/__snapshots__/generate-workspace-files.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/generate-workspace-files.spec.ts.snap
@@ -1563,6 +1563,24 @@ Pass \`--dry-run\` to see what would happen without actually releasing the libra
 
 [Learn more about Nx release &raquo;](hhttps://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
 
+## Keep TypeScript project references up to date
+
+Nx automatically updates TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) in \`tsconfig.json\` files to ensure they remain accurate based on your project dependencies (\`import\` or \`require\` statements). This sync is automatically done when running tasks such as \`build\` or \`typecheck\`, which require updated references to function correctly.
+
+To manually trigger the process to sync the project graph dependencies information to the TypeScript project references, run the following command:
+
+\`\`\`sh
+npx nx sync
+\`\`\`
+
+You can enforce that the TypeScript project references are always in the correct state when running in CI by adding a step to your CI job configuration that runs the following command:
+
+\`\`\`sh
+npx nx sync:check
+\`\`\`
+
+[Learn more about nx sync](https://nx.dev/reference/nx-commands#sync)
+
 [Learn more about Nx on CI](https://nx.dev/ci/intro/ci-with-nx#ready-get-started-with-your-provider?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
 
 ## Install Nx Console
@@ -3832,6 +3850,24 @@ Pass \`--dry-run\` to see what would happen without actually releasing the libra
 
 [Learn more about Nx release &raquo;](hhttps://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
 
+## Keep TypeScript project references up to date
+
+Nx automatically updates TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) in \`tsconfig.json\` files to ensure they remain accurate based on your project dependencies (\`import\` or \`require\` statements). This sync is automatically done when running tasks such as \`build\` or \`typecheck\`, which require updated references to function correctly.
+
+To manually trigger the process to sync the project graph dependencies information to the TypeScript project references, run the following command:
+
+\`\`\`sh
+npx nx sync
+\`\`\`
+
+You can enforce that the TypeScript project references are always in the correct state when running in CI by adding a step to your CI job configuration that runs the following command:
+
+\`\`\`sh
+npx nx sync:check
+\`\`\`
+
+[Learn more about nx sync](https://nx.dev/reference/nx-commands#sync)
+
 ## Set up CI!
 
 ### Step 1
@@ -5835,6 +5871,24 @@ npx nx release
 Pass \`--dry-run\` to see what would happen without actually releasing the library.
 
 [Learn more about Nx release &raquo;](hhttps://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+
+## Keep TypeScript project references up to date
+
+Nx automatically updates TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) in \`tsconfig.json\` files to ensure they remain accurate based on your project dependencies (\`import\` or \`require\` statements). This sync is automatically done when running tasks such as \`build\` or \`typecheck\`, which require updated references to function correctly.
+
+To manually trigger the process to sync the project graph dependencies information to the TypeScript project references, run the following command:
+
+\`\`\`sh
+npx nx sync
+\`\`\`
+
+You can enforce that the TypeScript project references are always in the correct state when running in CI by adding a step to your CI job configuration that runs the following command:
+
+\`\`\`sh
+npx nx sync:check
+\`\`\`
+
+[Learn more about nx sync](https://nx.dev/reference/nx-commands#sync)
 
 [Learn more about Nx on CI](https://nx.dev/ci/intro/ci-with-nx#ready-get-started-with-your-provider?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
 

--- a/packages/workspace/src/generators/new/files-package-based-repo/__dot__vscode/extensions.json__tmpl__
+++ b/packages/workspace/src/generators/new/files-package-based-repo/__dot__vscode/extensions.json__tmpl__
@@ -1,8 +1,6 @@
 {
-  "recommendations": [
-    <% if(cliCommand === 'ng') { %>
-    "angular.ng-template",<% }
-    %>
+  "recommendations": [<% if(cliCommand === 'ng') { %>
+    "angular.ng-template",<% } %>
     "nrwl.angular-console"
   ]
 }

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -276,7 +276,7 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
       ? './files-root-app'
       : (options.preset === Preset.TS &&
           process.env.NX_ADD_PLUGINS !== 'false' &&
-          process.env.NX_ADD_TS_PLUGIN === 'true') ||
+          process.env.NX_ADD_TS_PLUGIN !== 'false') ||
         options.preset === Preset.NPM
       ? './files-package-based-repo'
       : './files-integrated-repo';
@@ -315,7 +315,7 @@ async function createReadme(
     isTsPreset: preset === Preset.TS,
     isUsingNewTsSolutionSetup:
       process.env.NX_ADD_PLUGINS !== 'false' &&
-      process.env.NX_ADD_TS_PLUGIN === 'true',
+      process.env.NX_ADD_TS_PLUGIN !== 'false',
     isEmptyRepo: !appName,
     appName,
     generateAppCmd: presetInfo.generateAppCmd,
@@ -416,7 +416,7 @@ function setUpWorkspacesInPackageJson(tree: Tree, options: NormalizedSchema) {
     options.preset === Preset.NPM ||
     (options.preset === Preset.TS &&
       process.env.NX_ADD_PLUGINS !== 'false' &&
-      process.env.NX_ADD_TS_PLUGIN === 'true')
+      process.env.NX_ADD_TS_PLUGIN !== 'false')
   ) {
     if (options.packageManager === 'pnpm') {
       tree.write(

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -262,7 +262,7 @@ async function createPreset(tree: Tree, options: Schema) {
       formatter: options.formatter,
       addTsPlugin:
         process.env.NX_ADD_PLUGINS !== 'false' &&
-        process.env.NX_ADD_TS_PLUGIN === 'true',
+        process.env.NX_ADD_TS_PLUGIN !== 'false',
     });
   } else if (options.preset === Preset.TsStandalone) {
     const { libraryGenerator } = require('@nx' + '/js');


### PR DESCRIPTION
- Enable generating the new & minimal TS setup by default when generating the `ts` preset with CNW.
The existing `NX_ADD_TS_PLUGIN` environment variable is kept with its default value inverted and set to `true`. It can be used to opt out of the new TS setup by running CNW with `NX_ADD_TS_PLUGIN=false`.
- Throw an error when running generators that don't yet support the new TS setup.
  - We'll add support for those generators incrementally in follow-up PRs.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
<!-- Fixes NXC-1066 -->
<!-- Fixes NXC-1068 -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
