### PR TITLE
docs(nx-dev): fix heading case on GitHub integration page

### DIFF
--- a/docs/nx-cloud/features/github-integration.md
+++ b/docs/nx-cloud/features/github-integration.md
@@ -8,19 +8,19 @@ Any CI tool requires tight integration with your existing version control system
 
 Get started with Nx Cloud in no time with our GitHub connection process. Connect your workspace, and Nx Cloud will create a pull request with everything you need. Select your workspace and organization, and Nx Cloud takes care of the rest. User access is automatically connected to GitHub, and a PR is created to connect your workspace. Your repo now has [distributed caching](/ci/features/remote-cache) in less than 5 minutes.
 
-## Pull Request insights
+## Pull Request Insights
 
 ![Screenshot of Nx Cloud app for GitHub showing pull request insights](/nx-cloud/features/github-pr-bot.avif)
 
 Good CI checks require fast and easy access to results. That's why Nx Cloud will update your PR with the current running status of your tasks and a convenient link to your Nx Cloud results and logs. Take advantage of the enhanced developer experience of structured and searchable logs. Quick insight to PR task progress, so you're not stuck waiting for every task to complete. And with Nx Replay, developers can quickly replay tasks locally to avoid running tasks that CI has already completed.
 
-## Access control
+## Access Control
 
 ![Diagram showing users syncing from GitHub to Nx Cloud](/nx-cloud/features/github-user-management.avif)
 
 Nx Cloud organizations can use their existing GitHub access controls to manage Nx Cloud as well. This allows Nx Cloud to fit in to any existing on-boarding or off-boarding process. There's no need to manually manage users separately. Get your engineers Nx Cloud access right alongside their GitHub access so they can get to work fast. Use [personal access tokens](/ci/recipes/security/personal-access-tokens) to further enhance your security.
 
-## Get started
+## Get Started
 
 First, you'll want to connect your Nx Cloud account to GitHub. You can use your regular username and password or log in via Google or GitHub, connecting to GitHub is a separate step.
 
@@ -28,7 +28,7 @@ First, you'll want to connect your Nx Cloud account to GitHub. You can use your 
 Connect to GitHub
 {% /call-to-action %}
 
-## Connect a new workspace and organization
+## Connect a New Workspace and Organization
 
 1. Visit [Nx Cloud](https://cloud.nx.app) and click **Connect a workspace** at the top.
 2. Select **Connect existing repository** from the dropdown.
@@ -40,7 +40,7 @@ Connect to GitHub
 Connect an Nx workspace in GitHub to Nx Cloud
 {% /call-to-action %}
 
-## Connect an existing organization
+## Connect an Existing Organization
 
 If you've already created an organization in Nx Cloud, and you'd like to use your GitHub organization to manage access to it:
 
@@ -49,6 +49,6 @@ If you've already created an organization in Nx Cloud, and you'd like to use you
 3. Go to **Connect GitHub organization in the sidebar**
 4. Follow the prompts there to connect to GitHub.
 
-## Connect an existing workspace
+## Connect an Existing Workspace
 
 If you already have a workspace connected to Nx Cloud, and you'd like to connect it to a GitHub repo to enable PR insights, [see our recipe for more details.](/ci/recipes/source-control-integration/github)


### PR DESCRIPTION
## Current Behavior
Headings on GitHub integration page are sentence case

## Expected Behavior
Headings on GitHub integration page are title case

