### PR TITLE
fix(expo): pnpm+workspace build

### DIFF
--- a/packages/expo/src/executors/build/build.impl.ts
+++ b/packages/expo/src/executors/build/build.impl.ts
@@ -114,7 +114,7 @@ function copyPackageJsonAndLock(
   packageManager: PackageManager,
   workspaceRoot: string,
   projectRoot: string
-) {
+): () => void {
   const packageJson = pathResolve(workspaceRoot, 'package.json');
   const rootPackageJson = readJsonFile<PackageJson>(packageJson);
   // do not copy package.json and lock file if workspaces are enabled
@@ -123,7 +123,8 @@ function copyPackageJsonAndLock(
       existsSync(pathResolve(workspaceRoot, 'pnpm-workspace.yaml'))) ||
     rootPackageJson.workspaces
   ) {
-    return;
+    // no resource taken, no resource cleaned up
+    return () => {};
   }
 
   const packageJsonProject = pathResolve(projectRoot, 'package.json');


### PR DESCRIPTION
## Current Behavior

build executors for expo crash when package manager pnpm and workspaces are used

## Expected Behavior

no crashies

## Related Issue(s)

https://github.com/nrwl/nx/issues/28208

Fixes #28208

## FAQ

- why not handle the `undefined` by the calling code instead

The less the calling code knows about inner workings, the better: in this case, doing this would add the implicit dependency on "pnpm and workspaces" to the calling code

- but it's an empty function, my performance

We call it once per user interaction.

- but still, it's an empty function

We return an `empty array` when there are no elements; we don't return `undefined` when the array is empty and `array` when array is non-empty. Hopefully so.

- but,

The doc also says that this function returns a function.