### PR TITLE
fix(angular): ensure async webpack configs are awaited #28200

### DIFF
--- a/packages/angular/src/builders/utilities/webpack.ts
+++ b/packages/angular/src/builders/utilities/webpack.ts
@@ -21,11 +21,11 @@ export async function mergeCustomWebpackConfig(
   // then await will just resolve that object.
   const config = await customWebpackConfiguration;
 
-  // The extra Webpack configuration file can export a synchronous or asynchronous function,
-  // for instance: `module.exports = async config => { ... }`.
   let newConfig: any;
   if (typeof config === 'function') {
-    newConfig = config(baseWebpackConfig, options, target);
+    // The extra Webpack configuration file can export a synchronous or asynchronous function,
+    // for instance: `module.exports = async config => { ... }`.
+    newConfig = await config(baseWebpackConfig, options, target);
   } else {
     newConfig = merge(baseWebpackConfig, config);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Custom webpack functions may return a promise that needs to be awaited before we attempt to do any additional work on it


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure custom webpack functions are awaited. they will no-op for synchronous functions

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28200
