### PR TITLE
fix(module-federation): exports could be objects and not strings #28129

### DIFF
--- a/packages/webpack/src/utils/module-federation/secondary-entry-points.ts
+++ b/packages/webpack/src/utils/module-federation/secondary-entry-points.ts
@@ -115,7 +115,12 @@ function collectPackagesFromExports(
   }[]
 ): void {
   for (const [relativeEntryPoint, exportOptions] of Object.entries(exports)) {
-    if (exportOptions?.['default']?.search(/\.(js|mjs|cjs)$/)) {
+    const defaultExportOptions =
+      typeof exportOptions?.['default'] === 'string'
+        ? exportOptions?.['default']
+        : exportOptions?.['default']?.['default'];
+
+    if (defaultExportOptions?.search(/\.(js|mjs|cjs)$/)) {
       let entryPointName = joinPathFragments(pkgName, relativeEntryPoint);
       if (entryPointName.endsWith('.json')) {
         entryPointName = dirname(entryPointName);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Exports defined in `package.json` of packages could be objects rather than strings such that we could see both:

```json
{
  "exports": {
    ".": {
       "default": "./src/index.js"
    },
    "index": {
       "default": {
           "default": "./src/index.js"
        }
    }
  }
}
```


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The logic currently assumes it can only be a string.
Ensure it checks if an object exists first


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28129
