### PR TITLE
fix(module-federation): additionalShared should check node_modules when applying to support transitive deps #28137

### DIFF
--- a/packages/webpack/src/utils/module-federation/share.ts
+++ b/packages/webpack/src/utils/module-federation/share.ts
@@ -306,10 +306,14 @@ function addStringDependencyToSharedConfig(
 
     sharedConfig[dependency] = config;
   } else {
-    throw new Error(
-      `The specified dependency "${dependency}" in the additionalShared configuration does not exist in the project graph. ` +
-        `Please check your additionalShared configuration and make sure you are including valid workspace projects or npm packages.`
-    );
+    const pkgJsonPath = require.resolve(`${dependency}/package.json`);
+    if (!pkgJsonPath) {
+      throw new Error(
+        `Could not find package ${dependency} when applying it as a shared package. Are you sure it has been installed?`
+      );
+    }
+    const pkgJson = readJsonFile(pkgJsonPath);
+    const config = getNpmPackageSharedConfig(dependency, pkgJson.version);
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Transitive deps may not exist on the project graph or be installed in the root package.json file.
They could require the singleton pattern and should use the `additionalShared` functionality.

However, the additionalShared will check project graph and root package.json, erroring if the package cannot be found.

The last resort should be to use `require.resolve` to check the node_modules folder to find the package.json of the package and select a version from it.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28137
