### PR TITLE
fix(react): setup-ssr generator should infer bundler based on the executor for build #28128

### DIFF
--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -124,6 +124,12 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
     );
   }
 
+  if (projectConfig.targets.build.executor === '@nx/rspack:rspack') {
+    options.bundler = 'rspack';
+  } else if (projectConfig.targets.build.executor === '@nx/webpack:webpack') {
+    options.bundler = 'webpack';
+  }
+
   projectConfig.targets = {
     ...projectConfig.targets,
     server: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nx/react:setup-ssr` defaults to webpack which causes issues when the `react` app is already using rspack.



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Infer bundler based on the `build` target

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28128
