### PR TITLE
fix(js): generate nx release config correctly for js libraries in new ts setup and set tags

### DIFF
--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -267,14 +267,26 @@ async function configureProject(
   }
 
   if (!options.useProjectJson) {
+    // we create a cleaner project configuration for the package.json file
+    const projectConfiguration: ProjectConfiguration = {
+      root: options.projectRoot,
+    };
+
     if (options.name !== options.importPath) {
       // if the name is different than the package.json name, we need to set
       // the proper name in the configuration
-      updateProjectConfiguration(tree, options.name, {
-        name: options.name,
-        root: options.projectRoot,
-      });
+      projectConfiguration.name = options.name;
     }
+
+    if (options.parsedTags?.length) {
+      projectConfiguration.tags = options.parsedTags;
+    }
+
+    if (options.publishable) {
+      await addProjectToNxReleaseConfig(tree, options, projectConfiguration);
+    }
+
+    updateProjectConfiguration(tree, options.name, projectConfiguration);
 
     return;
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When setting the Nx configuration for a JS library in the `package.json` file, the provided tags is not set and the relevant `nx release` configuration in `nx.json` is not set either.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When setting the Nx configuration for a JS library in the `package.json` file, the provided tags should be set and the relevant `nx release` configuration in `nx.json` should be configured.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
<!-- Fixes NXC-1074 -->

Fixes #
