### PR TITLE
fix(js): throw an error when generating a publishable lib with `--bundler=none`

### DIFF
--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -839,7 +839,9 @@ async function normalizeOptions(
     }
 
     if (options.bundler === 'none') {
-      options.bundler = 'tsc';
+      throw new Error(
+        `Publishable libraries can't be generated with "--bundler=none". Please select a valid bundler.`
+      );
     }
   }
 

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -61,7 +61,7 @@ export function toJsLibraryGeneratorOptions(
 ): JsLibraryGeneratorSchema {
   return {
     name: options.name,
-    bundler: options?.buildable ? 'tsc' : 'none',
+    bundler: options.buildable || options.publishable ? 'tsc' : 'none',
     directory: options.directory,
     importPath: options.importPath,
     linter: options.linter,

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -56,7 +56,7 @@ export async function libraryGeneratorInternal(tree: Tree, schema: Schema) {
 
   const libraryInstall = await jsLibraryGenerator(tree, {
     ...options,
-    bundler: schema.buildable ? 'tsc' : 'none',
+    bundler: schema.buildable || schema.publishable ? 'tsc' : 'none',
     includeBabelRc: schema.babelJest,
     importPath: options.importPath,
     testEnvironment: 'node',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Generating a JS publishable library with `--bundler=none` results in the generator silently switching the `bundler` to `tsc` and generating a `build` target.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Trying to generate a JS publishable library with `--bundler=none` should throw an error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
<!-- Fixes NXC-1075 -->

Fixes #
