### PR TITLE
feat(release)!: releasePublish always returns status code per project

### DIFF
--- a/packages/nx/src/command-line/release/index.ts
+++ b/packages/nx/src/command-line/release/index.ts
@@ -28,6 +28,10 @@ export const releaseChangelog = defaultClient.releaseChangelog.bind(
 /**
  * @public
  */
+export { PublishProjectsResult } from './publish';
+/**
+ * @public
+ */
 export const releasePublish = defaultClient.releasePublish.bind(
   defaultClient
 ) as typeof defaultClient.releasePublish;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

BREAKING CHANGE

In v19 of nx, the programmatic usage of `await releasePublish({ ... })` would throw in the case that _any_ project failed to publish. It would return the number `0` (to represent the overall exit code) in the case that all projects were successfully published.

Now, in v20, the programmatic usage of `await releasePublish({ ... })` will always return a `PublishProjectsResult` object, which is a mapping of project names to an object of `{ code: number }` for each project. This allows consumers to make informed decisions about which projects failed to publish and decide how to handle it in their release scripts.

For example, where there are projects called "pkg-a" and "pkg-b" and "pkg-a" is successfully published and "pkg-b" fails:

```ts
const result = await releasePublish({
  dryRun: false
});
// result is set to { "pkg-a": { code: 0 }, "pkg-b": { code: 1 } )
```
