### PR TITLE
feat(release)!: version.generatorOptions.updateDependents is "auto" by default

### DIFF
--- a/e2e/release/src/circular-dependencies.test.ts
+++ b/e2e/release/src/circular-dependencies.test.ts
@@ -684,7 +684,7 @@ describe('nx release circular dependencies', () => {
         {project-name} 📄 Using the provided version specifier "major".
         {project-name} ⚠️  Warning, the following packages depend on "{project-name}" but have been filtered out via --projects, and therefore will not be updated:
         - {project-name}
-        => You can adjust this behavior by setting \`version.generatorOptions.updateDependents\` to "auto"
+        => You can adjust this behavior by removing the usage of \`version.generatorOptions.updateDependents\` with "never"
         {project-name} ✍️  New version 2.0.0 written to {project-name}/package.json
 
 

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -190,9 +190,6 @@ describe('nx release - independent projects', () => {
         {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
         {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
         {project-name} 📄 Using the provided version specifier "999.9.9-package.3".
-        {project-name} ⚠️  Warning, the following packages depend on "{project-name}" but have been filtered out via --projects, and therefore will not be updated:
-        - {project-name}
-        => You can adjust this behavior by removing the usage of \`version.generatorOptions.updateDependents\` with "never"
         {project-name} ✍️  New version 999.9.9-package.3 written to {project-name}/package.json
 
 
@@ -200,6 +197,17 @@ describe('nx release - independent projects', () => {
         -   "version": "0.0.0",
         +   "version": "999.9.9-package.3",
         "scripts": {
+
+
+        "name": "@proj/{project-name}",
+        -   "version": "999.9.9-package.2",
+        +   "version": "999.9.9",
+        "scripts": {
+
+        "dependencies": {
+        -     "@proj/{project-name}": "0.0.0"
+        +     "@proj/{project-name}": "999.9.9-package.3"
+        }
 
 
         NX   Staging changed files with git
@@ -316,7 +324,7 @@ describe('nx release - independent projects', () => {
         NX   Running release version for project: {project-name}
 
         {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
-        {project-name} 📄 Resolved the current version as 999.9.9-package.2 from {project-name}/package.json
+        {project-name} 📄 Resolved the current version as 999.9.9 from {project-name}/package.json
         {project-name} 📄 Using the provided version specifier "999.9.9-version-git-operations-test.3".
         {project-name} ✍️  New version 999.9.9-version-git-operations-test.3 written to {project-name}/package.json
 
@@ -335,7 +343,7 @@ describe('nx release - independent projects', () => {
 
 
         "name": "@proj/{project-name}",
-        -   "version": "999.9.9-package.2",
+        -   "version": "999.9.9",
         +   "version": "999.9.9-version-git-operations-test.3",
         "scripts": {
 

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -192,7 +192,7 @@ describe('nx release - independent projects', () => {
         {project-name} 📄 Using the provided version specifier "999.9.9-package.3".
         {project-name} ⚠️  Warning, the following packages depend on "{project-name}" but have been filtered out via --projects, and therefore will not be updated:
         - {project-name}
-        => You can adjust this behavior by setting \`version.generatorOptions.updateDependents\` to "auto"
+        => You can adjust this behavior by removing the usage of \`version.generatorOptions.updateDependents\` with "never"
         {project-name} ✍️  New version 999.9.9-package.3 written to {project-name}/package.json
 
 

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -1,4 +1,4 @@
-import { NxJsonConfiguration } from '@nx/devkit';
+import type { NxJsonConfiguration } from '@nx/devkit';
 import {
   cleanupProject,
   createFile,
@@ -6,7 +6,6 @@ import {
   killProcessAndPorts,
   newProject,
   readFile,
-  readJson,
   runCLI,
   runCommandAsync,
   runCommandUntil,
@@ -92,9 +91,6 @@ describe('nx release', () => {
       `git remote add origin https://github.com/nrwl/fake-repo.git`
     );
 
-    const pkg1ContentsBeforeVersioning = readFile(`${pkg1}/package.json`);
-    const pkg2ContentsBeforeVersioning = readFile(`${pkg2}/package.json`);
-
     const versionOutput = runCLI(`release version 999.9.9`);
 
     /**
@@ -121,50 +117,6 @@ describe('nx release', () => {
         /New version 999.9.9 written to my-pkg-\d*\/package.json/g
       ).length
     ).toEqual(3);
-
-    // Only one dependency relationship exists, so this log should only match once
-    const dependencyRelationshipLogMatch = versionOutput.match(
-      /Applying new version 999.9.9 to 1 package which depends on my-pkg-\d*/g
-    );
-    if (
-      !dependencyRelationshipLogMatch ||
-      dependencyRelationshipLogMatch.length !== 1
-    ) {
-      const projectGraphDependencies = readJson(
-        '.nx/cache/project-graph.json'
-      ).dependencies;
-      const firstPartyProjectGraphDependencies = JSON.stringify(
-        Object.fromEntries(
-          Object.entries(projectGraphDependencies).filter(
-            ([key]) => !key.startsWith('npm:')
-          )
-        )
-      );
-
-      // From JamesHenry: explicit warning to assist troubleshooting NXC-143.
-      console.warn(
-        `
-WARNING: Expected to find exactly one dependency relationship log line.
-
-If you are seeing this message then you have been impacted by some flakiness in the test.
-
-${JSON.stringify(
-  {
-    versionOutput,
-    pkg1Name: pkg1,
-    pkg2Name: pkg2,
-    pkg1ContentsBeforeVersioning,
-    pkg2ContentsBeforeVersioning,
-    pkg2ContentsAfterVersioning: readFile(`${pkg2}/package.json`),
-    firstPartyProjectGraphDependencies,
-  },
-  null,
-  2
-)}`
-      );
-    }
-    // TODO: re-enable this assertion once the flakiness documented in NXC-143 is resolved
-    // expect(dependencyRelationshipLogMatch.length).toEqual(1);
 
     // Generate a changelog for the new version
     expect(exists('CHANGELOG.md')).toEqual(false);
@@ -376,14 +328,6 @@ ${JSON.stringify(
         /New version 1000.0.0-next.0 written to my-pkg-\d*\/package.json/g
       ).length
     ).toEqual(3);
-
-    // TODO: Also impacted by NXC-143
-    // Only one dependency relationship exists, so this log should only match once
-    // expect(
-    //   versionOutput2.match(
-    //     /Applying new version 1000.0.0-next.0 to 1 package which depends on my-pkg-\d*/g
-    //   ).length
-    // ).toEqual(1);
 
     // Perform an initial dry-run of the publish to the custom registry (not e2e registry), and a custom dist tag of "next"
     const publishToNext = `release publish --registry=${customRegistryUrl} --tag=next`;
@@ -846,14 +790,6 @@ ${JSON.stringify(
         /New version 1100.1.0 written to my-pkg-\d*\/package.json/g
       ).length
     ).toEqual(3);
-
-    // TODO: Also impacted by NXC-143
-    // Only one dependency relationship exists, so this log should only match once
-    // expect(
-    //   versionOutput3.match(
-    //     /Applying new version 1100.1.0 to 1 package which depends on my-pkg-\d*/g
-    //   ).length
-    // ).toEqual(1);
 
     createFile(
       `${pkg1}/my-file.txt`,

--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -454,7 +454,7 @@ To fix this you will either need to add a package.json file at that location, or
       });
 
       describe('updateDependentsOptions', () => {
-        it(`should not update dependents when filtering to a subset of projects by default`, async () => {
+        it(`should update dependents even when filtering to a subset of projects which do not include those dependents, by default`, async () => {
           expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
             '0.0.1'
           );
@@ -494,6 +494,7 @@ To fix this you will either need to add a package.json file at that location, or
             currentVersionResolver: 'disk',
             specifierSource: 'prompt',
             releaseGroup: createReleaseGroup('independent'),
+            updateDependents: 'auto',
           });
 
           expect(readJson(tree, 'libs/my-lib/package.json'))
@@ -512,10 +513,10 @@ To fix this you will either need to add a package.json file at that location, or
           ).toMatchInlineSnapshot(`
             {
               "dependencies": {
-                "my-lib": "0.0.1",
+                "my-lib": "9.9.9",
               },
               "name": "project-with-dependency-on-my-pkg",
-              "version": "0.0.1",
+              "version": "0.0.2",
             }
           `);
           expect(
@@ -526,10 +527,10 @@ To fix this you will either need to add a package.json file at that location, or
           ).toMatchInlineSnapshot(`
             {
               "devDependencies": {
-                "my-lib": "0.0.1",
+                "my-lib": "9.9.9",
               },
               "name": "project-with-devDependency-on-my-pkg",
-              "version": "0.0.1",
+              "version": "0.0.2",
             }
           `);
         });

--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -494,7 +494,7 @@ To fix this you will either need to add a package.json file at that location, or
             currentVersionResolver: 'disk',
             specifierSource: 'prompt',
             releaseGroup: createReleaseGroup('independent'),
-            updateDependents: 'auto',
+            // No value for updateDependents, should default to 'auto'
           });
 
           expect(readJson(tree, 'libs/my-lib/package.json'))

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -88,7 +88,7 @@ Valid values are: ${validReleaseVersionPrefixes
     }
 
     // Set default for updateDependents
-    const updateDependents = options.updateDependents ?? 'never';
+    const updateDependents = options.updateDependents ?? 'auto';
     const updateDependentsBump = 'patch';
 
     // Sort the projects topologically if update dependents is enabled
@@ -601,7 +601,7 @@ To fix this you will either need to add a package.json file at that location, or
           return localPackageDependency.target === project.name;
         });
 
-      const includeTransitiveDependents = updateDependents === 'auto';
+      const includeTransitiveDependents = updateDependents !== 'never';
       const transitiveLocalPackageDependents: LocalPackageDependency[] = [];
       if (includeTransitiveDependents) {
         for (const directDependent of allDependentProjects) {
@@ -674,7 +674,7 @@ To fix this you will either need to add a package.json file at that location, or
           logMsg += `\n${dependentProjectsOutsideCurrentBatch
             .map((dependentProject) => `${indent}- ${dependentProject.source}`)
             .join('\n')}`;
-          logMsg += `\n${indent}=> You can adjust this behavior by setting \`version.generatorOptions.updateDependents\` to "auto"`;
+          logMsg += `\n${indent}=> You can adjust this behavior by removing the usage of \`version.generatorOptions.updateDependents\` with "never"`;
           logger.buffer(logMsg);
         }
       }

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -86,10 +86,10 @@ export interface ReleaseVersionGeneratorSchema {
   conventionalCommitsConfig?: NxReleaseConfig['conventionalCommits'];
   deleteVersionPlans?: boolean;
   /**
-   * 'auto' allows users to opt into dependents being updated (a patch version bump) when a dependency is versioned.
-   * This is only applicable to independently released projects.
+   * 'auto' is the default and will cause dependents to be updated (a patch version bump) when a dependency is versioned.
+   * This is only applicable to independently released projects. 'never' will cause dependents to not be updated.
    */
-  updateDependents?: 'never' | 'auto';
+  updateDependents?: 'auto' | 'never';
   /**
    * Whether or not to completely omit project logs when that project has no applicable changes. This can be useful for
    * large monorepos which have a large number of projects, especially when only a subset are released together.


### PR DESCRIPTION
BREAKING CHANGE

In Nx v19, `release.version.generatorOptions.updateDependents` is "never" by default, meaning dependents are not automatically patched when their dependencies change (applicable to independent projects).

In Nx v20, `release.version.generatorOptions.updateDependents` is "auto" by default, meaning dependents are automatically patched when their dependencies change (applicable to independent projects).
