### PR TITLE
fix(js): resolve VerdaccioWarning on the "logs" configuration property 

### DIFF
--- a/packages/js/src/generators/setup-verdaccio/files/config.yml
+++ b/packages/js/src/generators/setup-verdaccio/files/config.yml
@@ -19,7 +19,7 @@ packages:
     proxy: npmjs
 
 # log settings
-logs:
+log:
   type: stdout
   format: pretty
   level: warn


### PR DESCRIPTION
fix(js): resolve VerdaccioWarning: The configuration property "logs" has been deprecated; Replaced with "log"

Currently, the Verdaccio configuration generated by running `nx generate setup-verdaccio` contains the deprecated `logs` property. I have updated this property to `log`, thereby removing the VerdaccioWarning that is displayed when running `nx local-registry`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Currently, the Verdaccio configuration generated by running `nx generate setup-verdaccio` includes the deprecated 'logs' property. When you run `nx local-registry` Verdaccio displays the following warning:
<img width="1453" alt="image" src="https://github.com/user-attachments/assets/ccd95587-ec1b-458c-8717-8173a95c1e5d">

## Expected Behavior
Run `nx local-registry` without the warning after using the `setup-verdaccio` generator.
