### PR TITLE
Fix access local registry by localhost:4873 when running in a devcontainer

### DIFF
--- a/project.json
+++ b/project.json
@@ -5,6 +5,7 @@
     "local-registry": {
       "executor": "@nx/js:verdaccio",
       "options": {
+        "listenAddress": "0.0.0.0",
         "port": 4873,
         "config": ".verdaccio/config.yml",
         "storage": "build/local-registry/storage"


### PR DESCRIPTION
## Current Behavior

If repo is opened in a devcontainer on the local machine, verdaccio is not reachable by localhost:4873

## Expected Behavior
Running command like `pnpm local-registry` should start a local registry and this registry must be reachable via localhost

## Related Issue(s)

Fixes #28238 

