### PR TITLE
feat(core): support rollup.config.ts

### DIFF
--- a/packages/rollup/.eslintrc.json
+++ b/packages/rollup/.eslintrc.json
@@ -41,7 +41,8 @@
               "nx",
               "typescript",
               "@swc/core", // Installed to workspace and only used in swc() plugin
-              "postcss"
+              "postcss",
+              "@rollup/plugin-typescript"
             ]
           }
         ]

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -29,11 +29,14 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
+    "@nx/devkit": "file:../devkit",
+    "@nx/js": "file:../js",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-image": "^3.0.3",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^12.1.0",
     "autoprefixer": "^10.4.9",
     "minimatch": "9.0.3",
     "picocolors": "^1.1.0",
@@ -42,9 +45,7 @@
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-typescript2": "^0.36.0",
-    "tslib": "^2.3.0",
-    "@nx/devkit": "file:../devkit",
-    "@nx/js": "file:../js"
+    "tslib": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -55,6 +55,61 @@ exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
 ]
 `;
 
+exports[`@nx/rollup/plugin non-root project should create nodes 2`] = `
+[
+  [
+    "mylib/rollup.config.cts",
+    {
+      "projects": {
+        "mylib": {
+          "root": "mylib",
+          "targets": {
+            "build": {
+              "cache": true,
+              "command": "rollup -c rollup.config.cts --configPlugin @rollup/plugin-typescript",
+              "dependsOn": [
+                "^build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "rollup",
+                  ],
+                },
+              ],
+              "metadata": {
+                "description": "Run Rollup",
+                "help": {
+                  "command": "npx rollup --help",
+                  "example": {
+                    "options": {
+                      "sourcemap": true,
+                      "watch": true,
+                    },
+                  },
+                },
+                "technologies": [
+                  "rollup",
+                ],
+              },
+              "options": {
+                "cwd": "mylib",
+              },
+              "outputs": [
+                "{workspaceRoot}/mylib/build",
+                "{workspaceRoot}/mylib/dist",
+              ],
+            },
+          },
+        },
+      },
+    },
+  ],
+]
+`;
+
 exports[`@nx/rollup/plugin root project should create nodes 1`] = `
 [
   [
@@ -67,6 +122,60 @@ exports[`@nx/rollup/plugin root project should create nodes 1`] = `
             "build": {
               "cache": true,
               "command": "rollup -c rollup.config.cjs --configPlugin @rollup/plugin-typescript",
+              "dependsOn": [
+                "^build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "rollup",
+                  ],
+                },
+              ],
+              "metadata": {
+                "description": "Run Rollup",
+                "help": {
+                  "command": "npx rollup --help",
+                  "example": {
+                    "options": {
+                      "sourcemap": true,
+                      "watch": true,
+                    },
+                  },
+                },
+                "technologies": [
+                  "rollup",
+                ],
+              },
+              "options": {
+                "cwd": ".",
+              },
+              "outputs": [
+                "{workspaceRoot}/dist",
+              ],
+            },
+          },
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`@nx/rollup/plugin root project should create nodes 2`] = `
+[
+  [
+    "rollup.config.cts",
+    {
+      "projects": {
+        ".": {
+          "root": ".",
+          "targets": {
+            "build": {
+              "cache": true,
+              "command": "rollup -c rollup.config.cts --configPlugin @rollup/plugin-typescript",
               "dependsOn": [
                 "^build",
               ],

--- a/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
           "targets": {
             "build": {
               "cache": true,
-              "command": "rollup -c rollup.config.cjs --configPlugin @rollup/plugin-typescript",
+              "command": "rollup -c rollup.config.cjs",
               "dependsOn": [
                 "^build",
               ],
@@ -121,7 +121,7 @@ exports[`@nx/rollup/plugin root project should create nodes 1`] = `
           "targets": {
             "build": {
               "cache": true,
-              "command": "rollup -c rollup.config.cjs --configPlugin @rollup/plugin-typescript",
+              "command": "rollup -c rollup.config.cjs",
               "dependsOn": [
                 "^build",
               ],

--- a/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
           "targets": {
             "build": {
               "cache": true,
-              "command": "rollup -c rollup.config.cjs",
+              "command": "rollup -c rollup.config.cjs --configPlugin @rollup/plugin-typescript",
               "dependsOn": [
                 "^build",
               ],
@@ -66,7 +66,7 @@ exports[`@nx/rollup/plugin root project should create nodes 1`] = `
           "targets": {
             "build": {
               "cache": true,
-              "command": "rollup -c rollup.config.cjs",
+              "command": "rollup -c rollup.config.cjs --configPlugin @rollup/plugin-typescript",
               "dependsOn": [
                 "^build",
               ],

--- a/packages/rollup/src/plugins/plugin.spec.ts
+++ b/packages/rollup/src/plugins/plugin.spec.ts
@@ -15,7 +15,7 @@ describe('@nx/rollup/plugin', () => {
   let context: CreateNodesContext;
   let cwd = process.cwd();
 
-  describe('root project', () => {
+  describe.each(['js', 'ts'])('root project', (extname) => {
     const tempFs = new TempFs('test');
 
     beforeEach(() => {
@@ -51,7 +51,7 @@ describe('@nx/rollup/plugin', () => {
       // is that the hash is different after updating the
       // config file. The actual config read is mocked below.
       tempFs.createFileSync(
-        'rollup.config.cjs',
+        `rollup.config.c${extname}`,
         JSON.stringify(rollupConfigOptions)
       );
       tempFs.createFileSync('package.json', JSON.stringify({ name: 'mylib' }));
@@ -77,7 +77,7 @@ describe('@nx/rollup/plugin', () => {
     it('should create nodes', async () => {
       // ACT
       const nodes = await createNodesFunction(
-        ['rollup.config.cjs'],
+        [`rollup.config.c${extname}`],
         {
           buildTargetName: 'build',
         },
@@ -89,7 +89,7 @@ describe('@nx/rollup/plugin', () => {
     });
   });
 
-  describe('non-root project', () => {
+  describe.each(['js', 'ts'])('non-root project', (extname) => {
     const tempFs = new TempFs('test');
 
     beforeEach(() => {
@@ -125,7 +125,7 @@ describe('@nx/rollup/plugin', () => {
       // is that the hash is different after updating the
       // config file. The actual config read is mocked below.
       tempFs.createFileSync(
-        'mylib/rollup.config.cjs',
+        `mylib/rollup.config.c${extname}`,
         JSON.stringify(rollupConfigOptions)
       );
       tempFs.createFileSync(
@@ -154,7 +154,7 @@ describe('@nx/rollup/plugin', () => {
     it('should create nodes', async () => {
       // ACT
       const nodes = await createNodesFunction(
-        ['mylib/rollup.config.cjs'],
+        [`mylib/rollup.config.c${extname}`],
         {
           buildTargetName: 'build',
         },

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -182,9 +182,11 @@ async function buildRollupTarget(
 
   const targets: Record<string, TargetConfiguration> = {};
   targets[options.buildTargetName] = {
-    command: `rollup -c ${basename(
-      configFilePath
-    )} --configPlugin @rollup/plugin-typescript`,
+    command: `rollup -c ${basename(configFilePath)}${
+      configFilePath.endsWith('ts')
+        ? ' --configPlugin @rollup/plugin-typescript'
+        : ''
+    }`,
     options: { cwd: projectRoot },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -48,7 +48,7 @@ export interface RollupPluginOptions {
   buildTargetName?: string;
 }
 
-const rollupConfigGlob = '**/rollup.config.{js,cjs,mjs}';
+const rollupConfigGlob = '**/rollup.config.{js,cjs,mjs,ts,cts,mts}';
 
 export const createNodes: CreateNodes<RollupPluginOptions> = [
   rollupConfigGlob,
@@ -182,7 +182,9 @@ async function buildRollupTarget(
 
   const targets: Record<string, TargetConfiguration> = {};
   targets[options.buildTargetName] = {
-    command: `rollup -c ${basename(configFilePath)}`,
+    command: `rollup -c ${basename(
+      configFilePath
+    )} --configPlugin @rollup/plugin-typescript`,
     options: { cwd: projectRoot },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],


### PR DESCRIPTION
I would like to be able to use rollup.config.ts. Same way it's used by rollup and vite teams too.

## Current Behavior

Currently nx plugin does not reconize project containing rollup.config.ts. It expects only {c|m}js files

## Expected Behavior
When project has rollup.config.ts rollup plugin infers build target automatically. This build target should be able to find the rollup.config.ts. For that purpose a special [configPlugin ](https://rollupjs.org/command-line-interface/#configplugin-plugin)CLI parameter should be used 

## Related Issue(s)

Feature request [#28226](https://github.com/nrwl/nx/discussions/28226)
