### PR TITLE
fix(core): allow prompts during nx add

### DIFF
--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -4,7 +4,7 @@ import * as ora from 'ora';
 import { isAngularPluginInstalled } from '../../adapter/angular-json';
 import type { GeneratorsJsonEntry } from '../../config/misc-interfaces';
 import { readNxJson, type NxJsonConfiguration } from '../../config/nx-json';
-import { runNxAsync } from '../../utils/child-process';
+import { runNxAsync, runNxSync } from '../../utils/child-process';
 import { writeJsonFile } from '../../utils/fileutils';
 import { logger } from '../../utils/logger';
 import { output } from '../../utils/output';
@@ -135,8 +135,8 @@ async function initializePlugin(
       args.push(...options.__overrides_unparsed__);
     }
 
-    await runNxAsync(`g ${pkgName}:${initGenerator} ${args.join(' ')}`, {
-      silent: !options.verbose,
+    runNxSync(`g ${pkgName}:${initGenerator} ${args.join(' ')}`, {
+      stdio: [0, 1, 2],
     });
   } catch (e) {
     spinner.fail();


### PR DESCRIPTION
This PR allows `nx add` to initialize plugins that have prompts.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
