### PR TITLE
fix(core): change getCache signature to only accept options

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -29,17 +29,14 @@ export type CachedResult = {
 };
 export type TaskWithCachedResult = { task: Task; cachedResult: CachedResult };
 
-export function getCache(
-  nxJson: NxJsonConfiguration,
-  options: DefaultTasksRunnerOptions
-): DbCache | Cache {
+// Do not change the order of these arguments as this function is used by nx cloud
+export function getCache(options: DefaultTasksRunnerOptions): DbCache | Cache {
+  const nxJson = readNxJson();
   return process.env.NX_DISABLE_DB !== 'true' &&
     (nxJson.enableDbCache === true || process.env.NX_DB_CACHE === 'true')
     ? new DbCache({
         // Remove this in Nx 21
-        nxCloudRemoteCache: isNxCloudUsed(readNxJson())
-          ? options.remoteCache
-          : null,
+        nxCloudRemoteCache: isNxCloudUsed(nxJson) ? options.remoteCache : null,
       })
     : new Cache(options);
 }

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -36,7 +36,7 @@ import type { TaskDetails } from '../native';
 
 export class TaskOrchestrator {
   private taskDetails: TaskDetails | null = getTaskDetails();
-  private cache: DbCache | Cache = getCache(this.nxJson, this.options);
+  private cache: DbCache | Cache = getCache(this.options);
   private forkedProcessTaskRunner = new ForkedProcessTaskRunner(this.options);
 
   private tasksSchedule = new TasksSchedule(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`getCache` has an argument for nxjson. This breaks nx cloud when using the db cache.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`getCache` now only has options as an argument, and uses `readNxJson` in the function body

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
