### PR TITLE
feat(core): deprecate custom task runners

### DIFF
--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -270,7 +270,10 @@ Dependencies between different target names across all projects
 
 • `Optional` **tasksRunnerOptions**: `Object`
 
-Available Task Runners
+**`Deprecated`**
+
+Custom task runners will no longer be supported in Nx 21. Use Nx Cloud or Nx Powerpack instead.
+Available Task Runners for Nx to use
 
 #### Index signature
 

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -370,7 +370,10 @@ Dependencies between different target names across all projects
 
 • `Optional` **tasksRunnerOptions**: `Object`
 
-Available Task Runners
+**`Deprecated`**
+
+Custom task runners will no longer be supported in Nx 21. Use Nx Cloud or Nx Powerpack instead.
+Available Task Runners for Nx to use
 
 #### Index signature
 

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -393,7 +393,8 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
     appsDir?: string;
   };
   /**
-   * Available Task Runners
+   * @deprecated Custom task runners will no longer be supported in Nx 21. Use Nx Cloud or Nx Powerpack instead.
+   * Available Task Runners for Nx to use
    */
   tasksRunnerOptions?: {
     [tasksRunnerName: string]: {

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -790,7 +790,7 @@ export function getRunner(
   runnerOptions: any;
 } {
   let runner = nxArgs.runner;
-  runner = runner || 'default';
+  runner = runner ?? 'default';
 
   if (runner !== 'default' && !nxJson.tasksRunnerOptions?.[runner]) {
     throw new Error(`Could not find runner configuration for ${runner}`);
@@ -799,6 +799,16 @@ export function getRunner(
   const modulePath: string = getTasksRunnerPath(runner, nxJson);
 
   try {
+    if (isCustomRunnerPath(modulePath)) {
+      output.warn({
+        title: `Custom task runners will no longer be supported in Nx 21.`,
+        bodyLines: [
+          `Use Nx Cloud or the Nx Powerpack caches instead.`,
+          `For more information, see https://nx.dev/features/powerpack/custom-caching`,
+        ],
+      });
+    }
+
     const tasksRunner = loadTasksRunner(modulePath);
 
     return {
@@ -814,6 +824,8 @@ export function getRunner(
     throw new Error(`Could not find runner configuration for ${runner}`);
   }
 }
+
+const defaultTasksRunnerPath = require.resolve('./default-tasks-runner');
 
 function getTasksRunnerPath(
   runner: string,
@@ -838,7 +850,7 @@ function getTasksRunnerPath(
     // Nx Cloud ID specified in nxJson
     nxJson.nxCloudId;
 
-  return isCloudRunner ? 'nx-cloud' : require.resolve('./default-tasks-runner');
+  return isCloudRunner ? 'nx-cloud' : defaultTasksRunnerPath;
 }
 
 export function getRunnerOptions(
@@ -900,4 +912,9 @@ export function getRunnerOptions(
   }
 
   return result;
+}
+function isCustomRunnerPath(modulePath: string) {
+  return !['nx-cloud', '@nrwl/nx-cloud', defaultTasksRunnerPath].includes(
+    modulePath
+  );
 }

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -14,6 +14,9 @@ export interface RawNxArgs extends NxArgs {
 export interface NxArgs {
   targets?: string[];
   configuration?: string;
+  /**
+   * @deprecated Custom task runners will no longer be supported in Nx 21. Use Nx Cloud or Nx Powerpack instead.
+   */
   runner?: string;
   parallel?: number;
   untracked?: boolean;


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Custom task runners are a high level abstraction to customize caching, a relatively low level mechanism, to utilize other methods of remote caching. The abstraction of custom task runners makes it hard for Nx to make guarantees to make it faster. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Custom task runners are now deprecated. They will still work for Nx 20 but a warning will be shown when they are being used. The migration path is to use Nx Cloud (the ideal caching solution) or a Nx Powerpack cache (written by the Nx Core team which we can make guarantees about).  

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
