### PR TITLE
feat(expo): build w/package.json overrides/resolutions

### DIFF
--- a/packages/expo/src/executors/build/build.impl.ts
+++ b/packages/expo/src/executors/build/build.impl.ts
@@ -143,6 +143,17 @@ function copyPackageJsonAndLock(
   projectPackageJson.dependencies = rootPackageJsonDependencies;
   projectPackageJson.devDependencies = rootPackageJsonDevDependencies;
 
+  const projectOverrides = projectPackageJson.overrides;
+  const projectResolutions = projectPackageJson.resolutions;
+
+  if (rootPackageJson.overrides) {
+    projectPackageJson.overrides = rootPackageJson.overrides;
+  }
+  // if overrides exists, give precedence to it over resolutions
+  if (!rootPackageJson.overrides && rootPackageJson.resolutions) {
+    projectPackageJson.resolutions = rootPackageJson.resolutions;
+  }
+
   // Copy dependencies from root package.json to project package.json
   writeJsonFile(packageJsonProject, projectPackageJson);
 
@@ -153,6 +164,18 @@ function copyPackageJsonAndLock(
     // Reset project package.json to original state
     projectPackageJson.dependencies = projectPackageJsonDependencies;
     projectPackageJson.devDependencies = projectPackageJsonDevDependencies;
+
+    if (projectOverrides) {
+      projectPackageJson.overrides = projectOverrides;
+    } else {
+      delete projectPackageJson.overrides;
+    }
+    if (projectResolutions) {
+      projectPackageJson.resolutions = projectResolutions;
+    } else {
+      delete projectPackageJson.resolutions;
+    }
+
     writeFileSync(
       packageJsonProject,
       JSON.stringify(projectPackageJson, null, 2)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When running nx build expo-app, the build executor copies dependencies and devDependencies of the workspace package.json (see copyPackageJsonAndLock function).

The build executor does not copy the resolutions object (for yarn) nor the overrides object (for npm).

## Expected Behavior
The build executor copies the overrides object or the resolutions object, if present in the package.json. The original project package.json is restored after the build is completed successfully or after it errors.

## Related Issue(s)
#28249

Fixes #
