### PR TITLE
feat(core): use isBuiltIn function from node:module rather than implement our own

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -1,5 +1,5 @@
-import { builtinModules } from 'node:module';
-import { dirname, join, parse, posix, relative } from 'node:path';
+import { isBuiltin } from 'node:module';
+import { dirname, join, posix, relative } from 'node:path';
 import { clean } from 'semver';
 import {
   ProjectGraphExternalNode,
@@ -31,21 +31,9 @@ type NpmResolutionCache = Map<string, string | null>;
  */
 const defaultNpmResolutionCache: NpmResolutionCache = new Map();
 
-const builtInModuleSet = new Set<string>([
-  ...builtinModules,
-  ...builtinModules.map((x) => `node:${x}`),
-  // These are missing in the builtinModules list
-  // See: https://github.com/nodejs/node/issues/42785
-  // TODO(v20): We should be safe to use `isBuiltin` function instead of keep the set here (https://nodejs.org/api/module.html#moduleisbuiltinmodulename)
-  'test',
-  'node:test',
-  'node:sea',
-  'node:sqlite',
-]);
-
 export function isBuiltinModuleImport(importExpr: string): boolean {
   const packageName = getPackageNameFromImportPath(importExpr);
-  return builtInModuleSet.has(packageName);
+  return isBuiltin(packageName);
 }
 
 export class TargetProjectLocator {


### PR DESCRIPTION
It's the same and is more future-proof + handles cases where experimental Node flags enable additional built-ins.
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
