### PR TITLE
fix(core): filter out task dependencies on itself

### DIFF
--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -85,10 +85,12 @@ export class ProcessTasks {
 
     this.filterDummyTasks();
 
-    for (const projectName of Object.keys(this.dependencies)) {
-      if (this.dependencies[projectName].length > 1) {
-        this.dependencies[projectName] = [
-          ...new Set(this.dependencies[projectName]).values(),
+    for (const taskId of Object.keys(this.dependencies)) {
+      if (this.dependencies[taskId].length > 0) {
+        this.dependencies[taskId] = [
+          ...new Set(
+            this.dependencies[taskId].filter((d) => d !== taskId)
+          ).values(),
         ];
       }
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Tasks can end up depending on themselves if they depend on a dummy task which ends up depending back on itself. This throws a weird error like:

```
 NX   Could not execute command because the task graph has a circular dependency

devkit:build --> devkit:build-base --> nx:build-base --> nx:build-base
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Tasks cannot depend on themselves. No errors are thrown in those cases.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
