### PR TITLE
docs(linter): mention that eslint.config.cjs is supported

### DIFF
--- a/docs/generated/packages/eslint/documents/overview.md
+++ b/docs/generated/packages/eslint/documents/overview.md
@@ -30,6 +30,7 @@ The `@nx/eslint` plugin will create a task for any project that has an ESLint co
 - `.eslintrc.yml`
 - `.eslintrc.json`
 - `eslint.config.js`
+- `eslint.config.cjs`
 
 Because ESLint applies configuration files to all subdirectories, the `@nx/eslint` plugin will also infer tasks for projects in subdirectories. So, if there is an ESLint configuration file in the root of the repository, every project will have an inferred ESLint task.
 

--- a/docs/shared/packages/eslint/eslint.md
+++ b/docs/shared/packages/eslint/eslint.md
@@ -30,6 +30,7 @@ The `@nx/eslint` plugin will create a task for any project that has an ESLint co
 - `.eslintrc.yml`
 - `.eslintrc.json`
 - `eslint.config.js`
+- `eslint.config.cjs`
 
 Because ESLint applies configuration files to all subdirectories, the `@nx/eslint` plugin will also infer tasks for projects in subdirectories. So, if there is an ESLint configuration file in the root of the repository, every project will have an inferred ESLint task.
 


### PR DESCRIPTION
## Current Behavior
Currently it is already possible to use `eslint.config.cjs` because of this [line](https://github.com/nrwl/nx/blob/c655b6cf4f8c65a03edde1ff3c79a7ba093b5c48/packages/eslint/src/utils/flat-config.ts#L7):

However docs section doesn't mention it

## Expected Behavior
This commit is supposed to mention this feature in the plugin documentation
