### PR TITLE
fix(angular): ensure @typescript-eslint/utils is used with eslint flat config

### DIFF
--- a/packages/angular/src/generators/add-linting/add-linting.spec.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.spec.ts
@@ -9,24 +9,6 @@ import {
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import * as linter from '@nx/eslint';
 import { addLintingGenerator } from './add-linting';
-import { eslint9__eslintVersion } from '@nx/eslint/src/utils/versions';
-
-jest.mock('nx/src/devkit-internals', () => ({
-  ...jest.requireActual<any>('nx/src/devkit-internals'),
-  readModulePackageJson: jest.fn().mockImplementation((module, extras) => {
-    if (module === 'eslint') {
-      return {
-        packageJson: {
-          version: '9.8.0',
-        },
-      };
-    } else {
-      return jest
-        .requireActual<any>('nx/src/devkit-internals')
-        .readModulePackageJson(module, extras);
-    }
-  }),
-}));
 
 describe('addLinting generator', () => {
   let tree: Tree;
@@ -74,11 +56,7 @@ describe('addLinting generator', () => {
   });
 
   it('should use flat config and install correct dependencies when using it', async () => {
-    updateJson(tree, 'package.json', (json) => {
-      json.devDependencies['eslint'] = eslint9__eslintVersion;
-      return json;
-    });
-
+    process.env.ESLINT_USE_FLAT_CONFIG = 'true';
     await addLintingGenerator(tree, {
       prefix: 'myOrg',
       projectName: appProjectName,
@@ -90,6 +68,7 @@ describe('addLinting generator', () => {
     expect(devDependencies['@typescript-eslint/utils']).toMatchInlineSnapshot(
       `"^8.0.0"`
     );
+    delete process.env.ESLINT_USE_FLAT_CONFIG;
   });
 
   it('should correctly generate the .eslintrc.json file', async () => {

--- a/packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts
+++ b/packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts
@@ -3,15 +3,10 @@ import {
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
+import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
+import { eslint9__typescriptESLintVersion } from '@nx/eslint/src/utils/versions';
 import { versions } from '../../utils/version-utils';
 import { isBuildableLibraryProject } from './buildable-project';
-import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
-import {
-  eslint9__eslintVersion,
-  eslint9__typescriptESLintVersion,
-} from '@nx/eslint/src/utils/versions';
-import { getInstalledEslintVersion } from '@nx/eslint/src/utils/version-utils';
-import { gte } from 'semver';
 
 export function addAngularEsLintDependencies(
   tree: Tree,
@@ -19,7 +14,8 @@ export function addAngularEsLintDependencies(
 ): GeneratorCallback {
   const compatVersions = versions(tree);
   const angularEslintVersionToInstall = compatVersions.angularEslintVersion;
-  const devDependencies = useFlatConfig(tree)
+  const usesEslintFlatConfig = useFlatConfig(tree);
+  const devDependencies = usesEslintFlatConfig
     ? {
         'angular-eslint': angularEslintVersionToInstall,
       }
@@ -30,12 +26,7 @@ export function addAngularEsLintDependencies(
       };
 
   if ('typescriptEslintVersion' in compatVersions) {
-    const installedEslintVersion = getInstalledEslintVersion(tree);
-    const usingEslintV9 = gte(
-      installedEslintVersion ?? eslint9__eslintVersion,
-      '9.0.0'
-    );
-    devDependencies['@typescript-eslint/utils'] = usingEslintV9
+    devDependencies['@typescript-eslint/utils'] = usesEslintFlatConfig
       ? eslint9__typescriptESLintVersion
       : compatVersions.typescriptEslintVersion;
   }

--- a/packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts
+++ b/packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts
@@ -6,6 +6,12 @@ import {
 import { versions } from '../../utils/version-utils';
 import { isBuildableLibraryProject } from './buildable-project';
 import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
+import {
+  eslint9__eslintVersion,
+  eslint9__typescriptESLintVersion,
+} from '@nx/eslint/src/utils/versions';
+import { getInstalledEslintVersion } from '@nx/eslint/src/utils/version-utils';
+import { gte } from 'semver';
 
 export function addAngularEsLintDependencies(
   tree: Tree,
@@ -24,8 +30,14 @@ export function addAngularEsLintDependencies(
       };
 
   if ('typescriptEslintVersion' in compatVersions) {
-    devDependencies['@typescript-eslint/utils'] =
-      compatVersions.typescriptEslintVersion;
+    const installedEslintVersion = getInstalledEslintVersion(tree);
+    const usingEslintV9 = gte(
+      installedEslintVersion ?? eslint9__eslintVersion,
+      '9.0.0'
+    );
+    devDependencies['@typescript-eslint/utils'] = usingEslintV9
+      ? eslint9__typescriptESLintVersion
+      : compatVersions.typescriptEslintVersion;
   }
 
   if (isBuildableLibraryProject(tree, projectName)) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Eslint 9 is installed for new angular workspace but v7 of @typescript-eslint/utils package is being installed and is incompatible 


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Esnure v8 of @typescript-eslint/utils is installed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
