### PR TITLE
docs(js): add a note to JS plugin overview that --preset=ts changed in Nx 20, and that --preset=app can still be used

### DIFF
--- a/docs/generated/packages/js/documents/overview.md
+++ b/docs/generated/packages/js/documents/overview.md
@@ -57,6 +57,12 @@ yarn create nx-workspace my-org --preset=ts
 {% /tab %}
 {% /tabs %}
 
+{% callout type="note" title="Modernized monorepo setup" %}
+Nx 20 updates the TS monorepo setup when using `--preset=ts`. The workspace is set up with [TypeScript Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) along with the Workspaces feature from [npm](https://docs.npmjs.com/cli/using-npm/workspaces), [yarn](https://yarnpkg.com/features/workspaces), [pnpm](https://pnpm.io/workspaces), and [bun](https://bun.sh/docs/install/workspaces).
+
+To create with the older setup for TS monorepo with `compilerOptions.paths`, use `create-nx-workspace --preset=apps`.
+{% /callout %}
+
 ## Create Libraries
 
 You can add a new JS/TS library with the following command:

--- a/docs/shared/packages/js/js-plugin.md
+++ b/docs/shared/packages/js/js-plugin.md
@@ -57,6 +57,12 @@ yarn create nx-workspace my-org --preset=ts
 {% /tab %}
 {% /tabs %}
 
+{% callout type="note" title="Modernized monorepo setup" %}
+Nx 20 updates the TS monorepo setup when using `--preset=ts`. The workspace is set up with [TypeScript Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) along with the Workspaces feature from [npm](https://docs.npmjs.com/cli/using-npm/workspaces), [yarn](https://yarnpkg.com/features/workspaces), [pnpm](https://pnpm.io/workspaces), and [bun](https://bun.sh/docs/install/workspaces).
+
+To create with the older setup for TS monorepo with `compilerOptions.paths`, use `create-nx-workspace --preset=apps`.
+{% /callout %}
+
 ## Create Libraries
 
 You can add a new JS/TS library with the following command:


### PR DESCRIPTION
Since `--preset=ts` has changed, we want to provide users with a way to generate the older, integrated setup if they need to.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
