### PR TITLE
Fixing target groups not merging

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -965,6 +965,47 @@ describe('project-configuration-utils', () => {
           sourceMap['libs/lib-a']['metadata.targetGroups.group1.1']
         ).toEqual(['dummy', 'dummy.ts']);
       });
+
+      it('should not clobber targetGroups', () => {
+        const rootMap = new RootMapBuilder()
+          .addProject({
+            root: 'libs/lib-a',
+            name: 'lib-a',
+            metadata: {
+              targetGroups: {
+                group2: ['target3'],
+              },
+            },
+          })
+          .getRootMap();
+        const sourceMap: ConfigurationSourceMaps = {
+          'libs/lib-a': {},
+        };
+
+        mergeProjectConfigurationIntoRootMap(
+          rootMap,
+          {
+            root: 'libs/lib-a',
+            name: 'lib-a',
+            metadata: {
+              technologies: ['technology'],
+              targetGroups: {
+                group1: ['target1', 'target2'],
+              },
+            },
+          },
+          sourceMap,
+          ['dummy', 'dummy.ts']
+        );
+
+        expect(rootMap['libs/lib-a'].metadata).toEqual({
+          technologies: ['technology'],
+          targetGroups: {
+            group1: ['target1', 'target2'],
+            group2: ['target3'],
+          },
+        });
+      });
     });
 
     describe('source map', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -252,7 +252,7 @@ export function mergeMetadata<T = ProjectMetadata | TargetMetadata>(
             }
           }
         } else {
-          result[metadataKey] = value;
+          result[metadataKey][key] = value[key];
           if (sourceMap) {
             sourceMap[`${baseSourceMapPath}.${metadataKey}`] =
               sourceInformation;

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -73,8 +73,6 @@ export function findAllProjectNodeDependencies(
   return Array.from(dependencyNodeNames);
 }
 
-const cache = {};
-
 // Recursively get all the dependencies of the node
 function collectDependentProjectNodesNames(
   nxDeps: ProjectGraph,

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -82,7 +82,6 @@ function collectDependentProjectNodesNames(
   parentNodeName: string,
   includeExternalDependencies: boolean
 ) {
-  const tokenizedInputs = JSON.stringify(nxDeps, dependencyNodeNames);
   const dependencies = nxDeps.dependencies[parentNodeName];
   if (!dependencies) {
     // no dependencies for the given node, so silently return,

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -73,6 +73,8 @@ export function findAllProjectNodeDependencies(
   return Array.from(dependencyNodeNames);
 }
 
+const cache = {};
+
 // Recursively get all the dependencies of the node
 function collectDependentProjectNodesNames(
   nxDeps: ProjectGraph,
@@ -80,6 +82,7 @@ function collectDependentProjectNodesNames(
   parentNodeName: string,
   includeExternalDependencies: boolean
 ) {
+  const tokenizedInputs = JSON.stringify(nxDeps, dependencyNodeNames);
   const dependencies = nxDeps.dependencies[parentNodeName];
   if (!dependencies) {
     // no dependencies for the given node, so silently return,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When multiple plugins touch the `project > metadata` (note NOT `project > target > metadata`), only the last plugin to run has their `metadata.targetGroups` data present, meaning currently `targetGroups` is clobbering instead of merging.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When multiple plugins write to `metadata.targetGroups`, that data is merged together, so data written by all plugins is present.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
