### PR TITLE
fix(testing): migration for getJestProjects -> getJestProjectsAsync handles both CJS and ESM

### DIFF
--- a/packages/jest/src/migrations/update-20-0-0/replace-getJestProjects-with-getJestProjectsAsync.spec.ts
+++ b/packages/jest/src/migrations/update-20-0-0/replace-getJestProjects-with-getJestProjectsAsync.spec.ts
@@ -9,13 +9,61 @@ describe('replace-getJestProjects-with-getJestProjectsAsync', () => {
     tree = createTree();
   });
 
-  it('should replace getJestProjects with getJestProjectsAsync', async () => {
+  it('should replace getJestProjects with getJestProjectsAsync using `require`', async () => {
     tree.write(
       'jest.config.ts',
       `
         const { getJestProjects } = require('@nx/jest');
   
         module.exports = {
+          projects: getJestProjects(),
+        };
+          `
+    );
+    await update(tree);
+    const updatedJestConfig = tree.read('jest.config.ts')?.toString();
+    expect(updatedJestConfig).toMatchInlineSnapshot(`
+      "
+              const { getJestProjectsAsync } = require('@nx/jest');
+        
+              module.exports = async () => ({
+                projects: await getJestProjectsAsync(),
+              });
+                "
+    `);
+  });
+
+  it('should replace getJestProjects with getJestProjectsAsync using `import`', async () => {
+    tree.write(
+      'jest.config.ts',
+      `
+        import { getJestProjects } from '@nx/jest';
+  
+        export default {
+          projects: getJestProjects(),
+        };
+          `
+    );
+    await update(tree);
+    const updatedJestConfig = tree.read('jest.config.ts')?.toString();
+    expect(updatedJestConfig).toMatchInlineSnapshot(`
+      "
+              import { getJestProjectsAsync } from '@nx/jest';
+        
+              export default async () => ({
+                projects: await getJestProjectsAsync(),
+              });
+                "
+    `);
+  });
+
+  it('should replace getJestProjects with getJestProjectsAsync using `require` with `export default`', async () => {
+    tree.write(
+      'jest.config.ts',
+      `
+        const { getJestProjects } = require('@nx/jest');
+  
+        export default {
           projects: getJestProjects(),
         };
           `
@@ -33,7 +81,31 @@ describe('replace-getJestProjects-with-getJestProjectsAsync', () => {
     `);
   });
 
-  it('should replace getJestProjects with getJestProjectsAsync with additonal properties', async () => {
+  it('should replace getJestProjects with getJestProjectsAsync using `import` with `module.exports`', async () => {
+    tree.write(
+      'jest.config.ts',
+      `
+        import { getJestProjects } from '@nx/jest';
+  
+        module.exports = {
+          projects: getJestProjects(),
+        };
+          `
+    );
+    await update(tree);
+    const updatedJestConfig = tree.read('jest.config.ts')?.toString();
+    expect(updatedJestConfig).toMatchInlineSnapshot(`
+      "
+              import { getJestProjectsAsync } from '@nx/jest';
+        
+              module.exports = async () => ({
+                projects: await getJestProjectsAsync(),
+              });
+                "
+    `);
+  });
+
+  it('should replace getJestProjects with getJestProjectsAsync with additional properties', async () => {
     tree.write(
       'jest.config.ts',
       `
@@ -53,12 +125,66 @@ describe('replace-getJestProjects-with-getJestProjectsAsync', () => {
       "
               const { getJestProjectsAsync } = require('@nx/jest');
         
-              export default async () => ({
+              module.exports = async () => ({
                 projects: await getJestProjectsAsync(),
               filename: __filename,
               env: process.env,
               dirname: __dirname
               });
+                "
+    `);
+  });
+
+  it('should not update config that are not in supported format', async () => {
+    // Users don't tend to update the root jest config file since it's only meant to be able to run
+    // `jest` command from the root of the repo. If the AST doesn't match what we generate
+    // then bail on the update. Users will still see that `getJestProjects` is deprecated when
+    // viewing the file.
+    tree.write(
+      'jest.config.ts',
+      `
+        import { getJestProjects } from '@nx/jest';
+  
+        const obj = {
+          projects: getJestProjects(),
+        };
+        export default obj
+          `
+    );
+    await update(tree);
+    let updatedJestConfig = tree.read('jest.config.ts')?.toString();
+    expect(updatedJestConfig).toMatchInlineSnapshot(`
+      "
+              import { getJestProjects } from '@nx/jest';
+        
+              const obj = {
+                projects: getJestProjects(),
+              };
+              export default obj
+                "
+    `);
+
+    tree.write(
+      'jest.config.ts',
+      `
+        const { getJestProjects } = require('@nx/jest');
+  
+        const obj = {
+          projects: getJestProjects(),
+        };
+        module.exports = obj;
+          `
+    );
+    await update(tree);
+    updatedJestConfig = tree.read('jest.config.ts')?.toString();
+    expect(updatedJestConfig).toMatchInlineSnapshot(`
+      "
+              const { getJestProjects } = require('@nx/jest');
+        
+              const obj = {
+                projects: getJestProjects(),
+              };
+              module.exports = obj;
                 "
     `);
   });


### PR DESCRIPTION
This PR updates the Jest migration so it handles both CJS and ESM format for Jest config file. We now generate with ESM so those need to be handled. There are four combinations:

1. `require` (CJS) with `module.export` (CJS)
2. `import` (ESM) with `export default` (ESM)
3. `require` (CJS) with `export default` (ESM)
4. `import` (ESM) with `module.export` (CJS)

(1) and (2) should cover almost all cases, and (3) and (4) are there just in case. If the format isn't matching what we generate, then just bail.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
