### PR TITLE
fix(testing): getJestProjectsAsync no longer duplicates project paths

### DIFF
--- a/packages/jest/src/utils/config/get-jest-projects.spec.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.spec.ts
@@ -462,10 +462,7 @@ describe('getJestProjectsAsync', () => {
         },
       },
     });
-    const expectedResults = [
-      '<rootDir>/projects/test-1',
-      '<rootDir>/projects/test-1/jest1.config.ts',
-    ];
+    const expectedResults = ['<rootDir>/projects/test-1/jest1.config.ts'];
     expect(await getJestProjectsAsync()).toEqual(expectedResults);
   });
 

--- a/packages/jest/src/utils/config/get-jest-projects.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.ts
@@ -4,7 +4,7 @@ import {
   type TargetConfiguration,
 } from '@nx/devkit';
 import { readWorkspaceConfig } from 'nx/src/project-graph/file-utils';
-import { join } from 'path';
+import { join, parse } from 'path';
 import * as yargs from 'yargs-parser';
 
 function getJestConfigProjectPath(projectJestConfigPath: string): string {
@@ -120,7 +120,18 @@ export async function getJestProjectsAsync() {
     }
   }
 
+  removeDuplicates(jestConfigurations);
   return Array.from(jestConfigurations);
+}
+
+// If two paths result in same project, prefer the more specific path.
+// e.g. <rootDir>/demo/jest.config.js over <rootDir>/demo
+function removeDuplicates(configs: Set<string>): void {
+  configs.forEach((config) => {
+    const { dir, ext } = parse(config);
+    // If the directory has been added previously, remove it and keep the current, more specific path.
+    if (ext) configs.delete(dir);
+  });
 }
 
 function collectJestConfigFromJestExecutor(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Using `getJestProjectsAsync` to include both `project.json` and inferred targets can result in errors due to duplcicated paths.

You see an error like this:

```
Error: Whoops! Two projects resolved to the same config path: /Users/jack/projects/ocean/libs/nx-cloud/data-access-organization-dashboard/jest.config.ts:

  Project 1: /Users/jack/projects/ocean/libs/nx-cloud/data-access-organization-dashboard/jest.config.ts
  Project 2: /Users/jack/projects/ocean/libs/nx-cloud/data-access-organization-dashboard

This usually means that your "projects" config includes a directory that doesn't have any configuration recognizable by Jest. Please fix it.

    at ensureNoDuplicateConfigs (/Users/jack/projects/ocean/node_modules/jest-config/build/index.js:325:13)
    at readConfigs (/Users/jack/projects/ocean/node_modules/jest-config/build/index.js:474:5)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async runCLI (/Users/jack/projects/ocean/node_modules/jest-cli/node_modules/@jest/core/build/cli/index.js:151:59)
    at async Object.run (/Users/jack/projects/ocean/node_modules/jest-cli/build/run.js:130:37)
```

## Expected Behavior
Using `getJestProjectsAsync` should work and include all inferred projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
