### PR TITLE
cleanup(webpack): migrate to picocolors

### DIFF
--- a/packages/webpack/.eslintrc.json
+++ b/packages/webpack/.eslintrc.json
@@ -4,7 +4,15 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "name": "chalk",
+            "message": "Please use `picocolors` in place of `chalk` for rendering terminal colors"
+          }
+        ]
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -38,7 +38,7 @@
     "autoprefixer": "^10.4.9",
     "babel-loader": "^9.1.2",
     "browserslist": "^4.21.4",
-    "chalk": "^4.1.0",
+    "picocolors": "^1.1.0",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "^6.4.0",
     "css-minimizer-webpack-plugin": "^5.0.0",

--- a/packages/webpack/src/executors/ssr-dev-server/ssr-dev-server.impl.ts
+++ b/packages/webpack/src/executors/ssr-dev-server/ssr-dev-server.impl.ts
@@ -4,7 +4,7 @@ import {
   readTargetOptions,
   runExecutor,
 } from '@nx/devkit';
-import * as chalk from 'chalk';
+import * as pc from 'picocolors';
 import { combineAsyncIterables } from '@nx/devkit/src/utils/async-iterable';
 
 import { WebpackExecutorOptions } from '../webpack/schema';
@@ -62,7 +62,7 @@ export async function* ssrDevServerExecutor(
     if (nodeStarted && browserBuilt) {
       await waitUntilServerIsListening(options.port);
       console.log(
-        `[ ${chalk.green('ready')} ] on http://localhost:${options.port}`
+        `[ ${pc.green('ready')} ] on http://localhost:${options.port}`
       );
       yield {
         ...output,

--- a/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
+++ b/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
@@ -1,7 +1,7 @@
 import { logger, type ProjectGraph } from '@nx/devkit';
 import { registerTsProject } from '@nx/js/src/internal';
 import { findMatchingProjects } from 'nx/src/utils/find-matching-projects';
-import * as chalk from 'chalk';
+import * as pc from 'picocolors';
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { ModuleFederationConfig } from './models/index';
@@ -107,7 +107,7 @@ export function getRemotes(
   );
 
   logger.info(
-    `NX Starting module federation dev-server for ${chalk.bold(
+    `NX Starting module federation dev-server for ${pc.bold(
       context.projectName
     )} with ${[...knownRemotes, ...knownDynamicRemotes].length} remotes`
   );


### PR DESCRIPTION
Migrates from `chalk` to `picocolors`.

Think there's only a couple left after this one! 🙏 
