### PR TITLE
fix(js): generated tsconfig extends path

### DIFF
--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -69,7 +69,7 @@ export async function* tscExecutor(
 
   const { projectRoot, tmpTsConfig, target, dependencies } = checkDependencies(
     context,
-    options.tsConfig
+    _options.tsConfig
   );
 
   if (tmpTsConfig) {


### PR DESCRIPTION
## Current Behavior

The generated `extends` path in tsconfig is incorrectly generated, causing the build to succeed even if it does nothing

## Expected Behavior

The paths should either both be absolute, or both be relative.

The easiest way to do this was to pass in the relative path into the `checkDependencies` function (since the `tsConfig` variable is not accessed anywhere except to calculate `generatedTsConfig.extends`), but changing `dirnameTsConfig` to always be absolute would also be okay

## Related Issue(s)

Fixes #28316