### PR TITLE
fix(core): esbuild - honour supplied options.outputPath

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -554,4 +554,44 @@ describe('buildEsbuildOptions', () => {
       },
     });
   });
+
+  it('should respect user defined outputs', () => {
+    expect(
+      buildEsbuildOptions(
+        'esm',
+        {
+          bundle: true,
+          platform: 'node',
+          main: 'apps/myapp/src/index.ts',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          assets: [],
+          singleEntry: true,
+          outputPath: 'user-defined-outputPath',
+          outputFileName: 'user-defined-fileName.js',
+          external: ['foo'],
+          userDefinedBuildOptions: {
+            external: ['bar'],
+          },
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'esm',
+      platform: 'node',
+      outfile: 'user-defined-outputPath/user-defined-fileName.js',
+      tsconfig:
+        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      external: ['bar', 'foo'],
+      outExtension: {
+        '.js': '.js',
+      },
+      metafile: undefined,
+      minify: undefined,
+      target: undefined,
+      sourcemap: false,
+    });
+  });
 });

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -147,7 +147,7 @@ export function getOutfile(
 ) {
   const ext = getOutExtension(format, options);
   const candidate = joinPathFragments(
-    context.target.options.outputPath,
+    options.outputPath,
     options.outputFileName
   );
   const { dir, name } = path.parse(candidate);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
esbuild executor uses `outputPath` from `project.json`, ignoring supplied options and making it impossible to call esbuild from custom executors:

ie
```
// project.json
"custom-build": {
      "executor": "@my-project/build-plugin:build",
      "cache": false
}

// executor.ts
const runExecutor: PromiseExecutor<McaddonExecutorSchema> = async (
  options,
  context,
) => {
  const esbuild = esbuildExecutor(
    {
      outputPath: 'dist/apps/my-app', // this will be ignored and instead esbuild will try to use outputPath from project.json
      ...
    },
    context,
  );

  for await (const result of esbuild) {
    if (!result.success) {
      return result;
    }
  }


  return {
    success: true,
  };
};

``` 

## Expected Behavior
esbuild executor should honour provided options.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
