### PR TITLE
fix(core): allow for non-js libs to be moved without errors or the creation of any unneeded tsconfig files

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -102,16 +102,18 @@ export function updateImports(
       from: mainEntryPointImportPath,
       to: schema.importPath,
     },
-    ...secondaryEntryPointImportPaths.map((p) => ({
-      from: p,
-      // if the import path doesn't start with the main entry point import path,
-      // it's a custom import path we don't know how to update the name, we keep
-      // it as-is, but we'll update the path it points to
-      to:
-        schema.importPath && p.startsWith(mainEntryPointImportPath)
-          ? p.replace(mainEntryPointImportPath, schema.importPath)
-          : null,
-    })),
+    ...(secondaryEntryPointImportPaths
+      ? secondaryEntryPointImportPaths.map((p) => ({
+          from: p,
+          // if the import path doesn't start with the main entry point import path,
+          // it's a custom import path we don't know how to update the name, we keep
+          // it as-is, but we'll update the path it points to
+          to:
+            schema.importPath && p.startsWith(mainEntryPointImportPath)
+              ? p.replace(mainEntryPointImportPath, schema.importPath)
+              : null,
+        }))
+      : []),
   ];
 
   if (

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -129,4 +129,20 @@ describe('move', () => {
       '../../node_modules/nx/schemas/project-schema.json'
     );
   });
+
+  it('should work without tsconfig.base.json (https://github.com/nrwl/nx/issues/28349)', async () => {
+    await libraryGenerator(tree, {
+      directory: 'my-lib',
+    });
+    tree.delete('tsconfig.base.json');
+
+    await moveGenerator(tree, {
+      projectName: 'my-lib',
+      importPath: '@proj/shared-mylib',
+      updateImportPath: true,
+      destination: 'shared/my-lib-new',
+    });
+
+    expect(tree.exists('tsconfig.base.json')).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Current Behavior

I have a project that is utilizing the `@nx-go/nx-go` extension that's used for supporting Go applications.

When I attempt to use the `@nx/workspace:move` generator to move a Go library, it'll produce an error. (Please refer to the _Failure Logs_ section for said error.)

Sadly, there isn't a consistent means to get the bun to start showing up, but once it does, the issue will persist throughout the workspace's life cycle.

I was able to trace this to the compiled Javascript files within Nx's installed project files under the `node_modules` directory, which is where I found a workaround. That being to have the `secondaryEntryPointImportPaths` variable (located within the `updateImports` function) set with an empty array on the same line it's declared.

However, this will produce a `tsconfig.base.json` file at the root of the workspace with the text `undefined` contained within it and with no actual JSON to speak of. 

## Expected Behavior

I have a project that is utilizing the `@nx-go/nx-go` extension that's used for supporting Go applications.

The `@nx/workspace:move` schematic generator should be able to move libraries based in Go and other programming languages without any errors popping up.

It should also do it without generating an empty `tsconfig.base.json` file if one didn't exist previously. This tends to be the case when there is no Typescript to speak of within the Nx workspace. For example, an Nx workspace initiated with the `@nx-go/nx-go` preset.

## Related Issue(s)

- [#28349](https://github.com/nrwl/nx/issues/28349)