### PR TITLE
feat(core): allow optional configuration in infix run command

### DIFF
--- a/packages/nx/src/command-line/run/command-object.ts
+++ b/packages/nx/src/command-line/run/command-object.ts
@@ -37,6 +37,12 @@ export const yargsNxInfixCommand: CommandModule = {
   command: '$0 <target> [project] [_..]',
   describe: 'Run a target for a project.',
   handler: async (args) => {
+    // divide <target> into target:configuration if possible
+    const firstColonIdx = (args.target as string).indexOf(':');
+    if (firstColonIdx !== -1) {
+      args.target = (args.target as string).substring(0, firstColonIdx);
+      args.configuration = (args.target as string).substring(firstColonIdx + 1);
+    }
     const exitCode = await handleErrors(
       (args.verbose as boolean) ?? process.env.NX_VERBOSE_LOGGING === 'true',
       async () => {


### PR DESCRIPTION
It looks as if the current shape of `args.target` that is parsed by the `run` infix version and passed to the command handler **makes the `configuration` unrecognizable**. It's probably because the "regular" `run` invocation parses `target` and `configuration` separately, and passes them as 2 distinct properties, while the infix version of the command contains the concatenated `target:configuration` in the `target` argument.

As explained in the linked issue, I couldn't leverage `yargs` positional arguments syntax in the command template, because the configuration is an _optional_ argument _in the middle_ of the invocation. Custom parsing in the handler must be used. Thankfully it's just about splitting the argument on the first `:`.

I do not know if it won't break any existing behaviours, for example the ability to run NPM scripts that contain colons in their names.

## Current Behavior

Infix notation does not allow passing target configuration.


## Expected Behavior

Infix notation allows passing target configuration.


## Related Issue(s)

Duplicate of #28348 that got closed by mistake.
Fixes #28335.