### PR TITLE
test(linter): check if package version is bumped correctly

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -1234,7 +1234,7 @@ describe('Dependency checks (eslint)', () => {
       name: '@mycompany/liba',
       dependencies: {
         external1: '~16.0.0',
-        external2: '^1.0.0',
+        external2: '^5.1.0',
       },
     };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

Scenario / setup:

- Using `@nx/dependency-check` eslint rule
- Having a library `libs/lib-a` with its own `package.json` containing `"dependencies": { "external-dep": "^5.1.0" }`
- Having a root `package.json` containing `"dependencies": { "external-dep": "^5.2.0" }`
- Running the dependency-check rule results in dependency `external-dep` in `libs/lib-a/package.json` **not being updated**
- It **is updated**, however if `libs/lib-a/package.json` would contain a lower major version, e.g., `"dependencies": { "external-dep": "^4.5.0" }`

## Expected Behavior

dependency-check rule would update `libs/lib-a/package.json` to contain `"dependencies": { "external-dep": "^5.2.0" }`, i.e., `external-dep` would be identical to the version of the root `package.json`.

Addendum:

If the case were reversed, i.e., the lib's `package.json` mentions a **newer** version than the root `package.json`, I would expect the dependency-check to **not bump the version** in the lib. Rationale: The author of the lib intentionally mentioned a newer version as the lib does not work with an older one.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
