### PR TITLE
fix(js): improve @nx/js/typescript plugin and typescript-sync generator performance

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1,6 +1,8 @@
-import { type CreateNodesContext } from '@nx/devkit';
+import { detectPackageManager, type CreateNodesContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { minimatch } from 'minimatch';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { getLockFileName } from 'nx/src/plugins/js/lock-file/lock-file';
 import { setupWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { PLUGIN_NAME, createNodesV2, type TscPluginOptions } from './plugin';
 
@@ -25,6 +27,10 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     process.chdir(tempFs.tempDir);
     originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
     process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+    const lockFileName = getLockFileName(
+      detectPackageManager(context.workspaceRoot)
+    );
+    applyFilesToTempFsAndContext(tempFs, context, { [lockFileName]: '' });
   });
 
   afterEach(() => {

--- a/packages/nx/src/hasher/file-hasher.ts
+++ b/packages/nx/src/hasher/file-hasher.ts
@@ -15,3 +15,9 @@ export function hashObject(obj: object): string {
 
   return hashArray(parts);
 }
+
+export function hashFile(filePath: string): string {
+  const { hashFile } = require('../native');
+
+  return hashFile(filePath);
+}


### PR DESCRIPTION
- Significantly improve the perf of the `@nx/js/typescript` plugin (see below) by not using the `calculateHashForCreateNodes` function to create the cache key. That function is very generic and always hashes all project files to create the cache key. The `@nx/js/typescript` plugin output is solely influenced by the TS configuration files and installed packages, nothing else. So, this PR replaces the usage of `calculateHashForCreateNodes` with a more surgical hash of what really matters.
- Refactor the cache handling of the `@nx/js:typescript-sync` sync generator. Additionally, cache the checks for file existence.

## Before

The `@nx/js/typescript` plugin execution times out after 10 minutes (on my machine) running in the repo: https://github.com/leosvelperez/huge-ts-monorepo-perf-issue. It's a repo with 2251 libraries, each with about 500 TypeScript files.

```bash
NX_DAEMON=false NX_PERF_LOGGING=true NX_VERBOSE_LOGGING=true pnpm nx graph --no-open
Time for 'loading dotenv files' 0.28191699999996445
Time for 'workspace context init' 1.7878329999999778
Time for 'Load Nx Plugin: /Users/leosvel/code/playground/huge-ts-monorepo/node_modules/.pnpm/nx@20.0.0-canary.20241002-1d10a19_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5._kpa22fllnv36ws73ps6dxoprny/node_modules/nx/src/plugins/project-json/build-nodes/project-json' 0.3739999999999952
Time for 'Load Nx Plugin: /Users/leosvel/code/playground/huge-ts-monorepo/node_modules/.pnpm/nx@20.0.0-canary.20241002-1d10a19_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5._kpa22fllnv36ws73ps6dxoprny/node_modules/nx/src/plugins/package-json' 0.6995000000000005
Time for 'Load Nx Plugin: /Users/leosvel/code/playground/huge-ts-monorepo/node_modules/.pnpm/nx@20.0.0-canary.20241002-1d10a19_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5._kpa22fllnv36ws73ps6dxoprny/node_modules/nx/src/plugins/js' 15.443958999999992
Time for 'Load Nx Plugin: @nx/js/typescript' 433.81937500000004
Time for 'nx/js/dependencies-and-lockfile:createNodes' 72.19974999999977
Time for 'loadNxPlugins' 571.003625
Time for 'nx/core/project-json:createNodes' 0.1109580000047572
Time for 'nx/core/package-json:createNodes' 2415.916250000002
Time for 'build-project-configs' 600072.1975
Time for 'createNodes:merge' 26.039540999918245
Time for 'native-file-deps' 0.0012499999720603228
Time for 'get-workspace-files' 1451.049417000031
Time for 'get-all-workspace-files' 360.20758299995214
Time for 'read cache' 0.1965000000782311
Time for 'build typescript dependencies' 37416.08045799995
Time for 'nx/js/dependencies-and-lockfile:createDependencies' 40340.08241699997

 NX   Failed to create nodes

An error occurred while processing files for the @nx/js/typescript plugin.
  - @nx/js/typescript timed out after 10 minutes during createNodes. As a last resort, you can set NX_PLUGIN_NO_TIMEOUTS=true to bypass this timeout.
    Error: @nx/js/typescript timed out after 10 minutes during createNodes. As a last resort, you can set NX_PLUGIN_NO_TIMEOUTS=true to bypass this timeout.
        at Timeout.<anonymous> (/Users/leosvel/code/playground/huge-ts-monorepo/node_modules/.pnpm/nx@20.0.0-canary.20241002-1d10a19_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5._kpa22fllnv36ws73ps6dxoprny/node_modules/nx/src/project-graph/plugins/isolation/plugin-pool.js:219:21)
        at listOnTimeout (node:internal/timers:573:17)
        at process.processTimers (node:internal/timers:514:7)
...
```

## After

The `@nx/js/typescript` plugin in about 15 seconds in the same repo:

```bash
NX_DAEMON=false NX_PERF_LOGGING=true NX_VERBOSE_LOGGING=true pnpm nx graph --no-open
Time for 'loading dotenv files' 0.2621250000000259
Time for 'workspace context init' 1.7320000000000277
Time for 'Load Nx Plugin: /Users/leosvel/code/playground/huge-ts-monorepo-perf/node_modules/.pnpm/nx@20.0.0-canary.20241002-1d10a19_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5._kpa22fllnv36ws73ps6dxoprny/node_modules/nx/src/plugins/package-json' 0.3127500000000083
Time for 'Load Nx Plugin: /Users/leosvel/code/playground/huge-ts-monorepo-perf/node_modules/.pnpm/nx@20.0.0-canary.20241002-1d10a19_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5._kpa22fllnv36ws73ps6dxoprny/node_modules/nx/src/plugins/project-json/build-nodes/project-json' 0.4220419999999905
Time for 'Load Nx Plugin: /Users/leosvel/code/playground/huge-ts-monorepo-perf/node_modules/.pnpm/nx@20.0.0-canary.20241002-1d10a19_@swc-node+register@1.9.2_@swc+core@1.5.29_@swc+helpers@0.5._kpa22fllnv36ws73ps6dxoprny/node_modules/nx/src/plugins/js' 12.358916999999991
Time for 'Load Nx Plugin: @nx/js/typescript' 463.34191699999997
Time for 'nx/js/dependencies-and-lockfile:createNodes' 71.64483299999847
Time for 'loadNxPlugins' 600.3308750000001
Time for 'nx/core/project-json:createNodes' 0.11258400000224356
Time for 'nx/core/package-json:createNodes' 1325.8219579999932
Time for '@nx/js/typescript:createNodes' 15625.287917000001
```

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
