### PR TITLE
fix(linter): scope js and ts shared configs to js and ts files

### DIFF
--- a/packages/eslint-plugin/src/flat-configs/javascript.ts
+++ b/packages/eslint-plugin/src/flat-configs/javascript.ts
@@ -23,8 +23,10 @@ const isPrettierAvailable =
  * related plugins and rules below.
  */
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
+  },
   ...(isPrettierAvailable ? [require('eslint-config-prettier')] : []),
   {
     languageOptions: {

--- a/packages/eslint-plugin/src/flat-configs/typescript.ts
+++ b/packages/eslint-plugin/src/flat-configs/typescript.ts
@@ -14,8 +14,10 @@ const isPrettierAvailable =
  * to one ecosystem, such as React, Angular, Node etc.
  */
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
+  },
   ...(isPrettierAvailable ? [require('eslint-config-prettier')] : []),
   {
     plugins: { '@typescript-eslint': tseslint.plugin },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The `flat/javascript` and `flat/typescript` shared configurations from the `@nx/eslint-plugin` are not scoped to the respective js and ts files. This causes them to apply to files they shouldn't apply to.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `flat/javascript` and `flat/typescript` shared configurations from the `@nx/eslint-plugin` should be scoped to the respective js and ts files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28347 
