### PR TITLE
fix(core): add busy handler for sqlite

### DIFF
--- a/packages/nx/src/native/db/mod.rs
+++ b/packages/nx/src/native/db/mod.rs
@@ -1,6 +1,7 @@
 use rusqlite::OpenFlags;
 use std::fs::{create_dir_all, remove_file};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::native::machine_id::get_machine_id;
 use napi::bindgen_prelude::External;
@@ -79,6 +80,9 @@ fn create_connection(db_path: &PathBuf) -> anyhow::Result<Connection> {
 
     // This makes things less synchronous than default
     c.pragma_update(None, "synchronous", "NORMAL")?;
+
+    c.busy_timeout(Duration::from_millis(25))?;
+    c.busy_handler(Some(|tries| tries < 6))?;
 
     Ok(c)
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When the sql database throws a busy signal, there is no handler in nx to try the operation again.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
There is a handler to tell sqlite to handle the operation again, and try up to N times.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
