### PR TITLE
fix(rspack): log compilation errors #28179

### DIFF
--- a/packages/rspack/src/utils/with-nx.ts
+++ b/packages/rspack/src/utils/with-nx.ts
@@ -158,6 +158,10 @@ export function withNx(_opts = {}) {
         ...(config.devServer ?? {}),
         port: config.devServer?.port ?? 4200,
         hot: config.devServer?.hot ?? true,
+        devMiddleware: {
+          ...(config.devServer?.devMiddleware ?? {}),
+          stats: true,
+        },
       } as any,
       module: {
         rules: [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When running serve with Rspack, `stats: false` is being added to `devMiddleware` preventing logs from being output to the terminal.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure logs are logged to the devServer

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28179
