### PR TITLE
fix(rspack): do not select char from string when mapping remotes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -79,12 +79,14 @@ rust-toolchain @nrwl/nx-native-reviewers
 /docs/generated/packages/js/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/generated/packages/web/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/generated/packages/webpack/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
+/docs/generated/packages/rspack/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/generated/packages/esbuild/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/generated/packages/rollup/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/generated/packages/vite/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/shared/packages/js/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/shared/packages/web/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/shared/packages/webpack/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
+/docs/shared/packages/rspack/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/shared/packages/esbuild/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /docs/shared/packages/vite/** @nrwl/nx-js-reviewers @nrwl/nx-docs-reviewers
 /packages/js/** @nrwl/nx-js-reviewers
@@ -94,6 +96,9 @@ rust-toolchain @nrwl/nx-native-reviewers
 /packages/webpack/** @nrwl/nx-js-reviewers
 /packages/webpack/src/utils/module-federation @jaysoo @Coly010
 /e2e/webpack/** @nrwl/nx-js-reviewers
+/packages/rspack/** @nrwl/nx-js-reviewers
+/packages/rspack/src/utils/module-federation @jaysoo @Coly010
+/e2e/rspack/** @nrwl/nx-js-reviewers
 /packages/esbuild/** @nrwl/nx-js-reviewers
 /e2e/esbuild/** @nrwl/nx-js-reviewers
 /packages/rollup/** @nrwl/nx-js-reviewers

--- a/packages/rspack/src/utils/module-federation/remotes.ts
+++ b/packages/rspack/src/utils/module-federation/remotes.ts
@@ -24,7 +24,7 @@ export function mapRemotes(
         remoteEntryExt
       );
     } else if (typeof nxRemoteProjectName === 'string') {
-      const mfRemoteName = normalizeRemoteName(nxRemoteProjectName[0]);
+      const mfRemoteName = normalizeRemoteName(nxRemoteProjectName);
       mappedRemotes[mfRemoteName] = handleStringRemote(
         nxRemoteProjectName,
         determineRemoteUrl


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When global prefix is used, there is an issue with the mapping of string remote usage. 
It selects a single character from the string rather than using the full string


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the full string as remote name when mapping remotes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
