### PR TITLE
fix(vite): add vite temp files to gitignore #28371

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,14 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`app generated files content - as-provided - my-app general application should add nuxt entries in .gitignore 1`] = `
-"
-# Nuxt dev/build outputs
+"# Nuxt dev/build outputs
 .output
 .data
 .nuxt
 .nitro
 .cache
-    **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
+**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
 `;
 
 exports[`app generated files content - as-provided - my-app general application should add the nuxt and vitest plugins 1`] = `
@@ -365,14 +364,13 @@ export default defineNuxtConfig({
 `;
 
 exports[`app generated files content - as-provided - myApp general application should add nuxt entries in .gitignore 1`] = `
-"
-# Nuxt dev/build outputs
+"# Nuxt dev/build outputs
 .output
 .data
 .nuxt
 .nitro
 .cache
-    **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
+**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
 `;
 
 exports[`app generated files content - as-provided - myApp general application should add the nuxt and vitest plugins 1`] = `

--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -7,7 +7,8 @@ exports[`app generated files content - as-provided - my-app general application 
 .data
 .nuxt
 .nitro
-.cache"
+.cache
+    **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
 `;
 
 exports[`app generated files content - as-provided - my-app general application should add the nuxt and vitest plugins 1`] = `
@@ -370,7 +371,8 @@ exports[`app generated files content - as-provided - myApp general application s
 .data
 .nuxt
 .nitro
-.cache"
+.cache
+    **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
 `;
 
 exports[`app generated files content - as-provided - myApp general application should add the nuxt and vitest plugins 1`] = `

--- a/packages/vite/src/generators/init/init.spec.ts
+++ b/packages/vite/src/generators/init/init.spec.ts
@@ -127,4 +127,20 @@ describe('@nx/vite:init', () => {
       "
     `);
   });
+
+  it(`should not add multiple instances of the same vite temp file glob to gitignore`, async () => {
+    // ARRANGE
+    tree.write(
+      '.gitignore',
+      '**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*'
+    );
+
+    // ACT
+    await initGenerator(tree, {});
+
+    // ASSERT
+    expect(tree.read('.gitignore', 'utf-8')).toMatchInlineSnapshot(
+      `"**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"`
+    );
+  });
 });

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -13,6 +13,7 @@ import { setupPathsPlugin } from '../setup-paths-plugin/setup-paths-plugin';
 import { createNodesV2 } from '../../plugins/plugin';
 import { InitGeneratorSchema } from './schema';
 import { checkDependenciesInstalled, moveToDevDependencies } from './lib/utils';
+import { addViteTempFilesToGitIgnore } from '../../utils/add-vite-temp-files-to-gitignore';
 
 export function updateNxJsonSettings(tree: Tree) {
   const nxJson = readNxJson(tree);
@@ -83,6 +84,7 @@ export async function initGeneratorInternal(
   }
 
   updateNxJsonSettings(tree);
+  addViteTempFilesToGitIgnore(tree);
 
   if (schema.setupPathsPlugin) {
     await setupPathsPlugin(tree, { skipFormat: true });

--- a/packages/vite/src/migrations/update-20-0-2/add-vite-temp-files-to-git-ignore.spec.ts
+++ b/packages/vite/src/migrations/update-20-0-2/add-vite-temp-files-to-git-ignore.spec.ts
@@ -1,0 +1,33 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import addViteTempFilesToGitIgnore from './add-vite-temp-files-to-git-ignore';
+
+describe('addViteTempFilesToGitIgnore', () => {
+  it('should update an existing .gitignore file to add the glob correctly', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write('.gitignore', '.idea');
+
+    // ACT
+    addViteTempFilesToGitIgnore(tree);
+
+    // ASSERT
+    expect(tree.read('.gitignore', 'utf-8')).toMatchInlineSnapshot(`
+      ".idea
+          **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
+    `);
+  });
+
+  it('should write a new .gitignore file to add the glob correctly', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.delete('.gitignore');
+
+    // ACT
+    addViteTempFilesToGitIgnore(tree);
+
+    // ASSERT
+    expect(tree.read('.gitignore', 'utf-8')).toMatchInlineSnapshot(
+      `"**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"`
+    );
+  });
+});

--- a/packages/vite/src/migrations/update-20-0-2/add-vite-temp-files-to-git-ignore.spec.ts
+++ b/packages/vite/src/migrations/update-20-0-2/add-vite-temp-files-to-git-ignore.spec.ts
@@ -13,7 +13,7 @@ describe('addViteTempFilesToGitIgnore', () => {
     // ASSERT
     expect(tree.read('.gitignore', 'utf-8')).toMatchInlineSnapshot(`
       ".idea
-          **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
+      **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*"
     `);
   });
 

--- a/packages/vite/src/migrations/update-20-0-2/add-vite-temp-files-to-git-ignore.ts
+++ b/packages/vite/src/migrations/update-20-0-2/add-vite-temp-files-to-git-ignore.ts
@@ -1,0 +1,6 @@
+import { Tree } from '@nx/devkit';
+import { addViteTempFilesToGitIgnore as _addViteTempFilesToGitIgnore } from '../../utils/add-vite-temp-files-to-gitignore';
+
+export default function addViteTempFilesToGitIgnore(tree: Tree) {
+  _addViteTempFilesToGitIgnore(tree);
+}

--- a/packages/vite/src/utils/add-vite-temp-files-to-gitignore.ts
+++ b/packages/vite/src/utils/add-vite-temp-files-to-gitignore.ts
@@ -1,11 +1,16 @@
-import type { Tree } from '@nx/devkit';
+import { stripIndents, Tree } from '@nx/devkit';
 
 export function addViteTempFilesToGitIgnore(tree: Tree) {
-  let gitIgnoreContents = `**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*`;
+  let newGitIgnoreContents = `**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*`;
   if (tree.exists('.gitignore')) {
-    gitIgnoreContents = `${tree.read('.gitignore', 'utf-8')}
-    ${gitIgnoreContents}`;
-  }
+    const gitIgnoreContents = tree.read('.gitignore', 'utf-8');
+    if (!gitIgnoreContents.includes(newGitIgnoreContents)) {
+      newGitIgnoreContents = stripIndents`${gitIgnoreContents}
+        ${newGitIgnoreContents}`;
 
-  tree.write('.gitignore', gitIgnoreContents);
+      tree.write('.gitignore', newGitIgnoreContents);
+    }
+  } else {
+    tree.write('.gitignore', newGitIgnoreContents);
+  }
 }

--- a/packages/vite/src/utils/add-vite-temp-files-to-gitignore.ts
+++ b/packages/vite/src/utils/add-vite-temp-files-to-gitignore.ts
@@ -1,0 +1,11 @@
+import type { Tree } from '@nx/devkit';
+
+export function addViteTempFilesToGitIgnore(tree: Tree) {
+  let gitIgnoreContents = `**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*`;
+  if (tree.exists('.gitignore')) {
+    gitIgnoreContents = `${tree.read('.gitignore', 'utf-8')}
+    ${gitIgnoreContents}`;
+  }
+
+  tree.write('.gitignore', gitIgnoreContents);
+}

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -346,6 +346,7 @@ exports[`application generator should set up project correctly with given option
 [
   ".eslintignore",
   ".eslintrc.json",
+  ".gitignore",
   ".prettierignore",
   ".prettierrc",
   ".vscode/extensions.json",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When Vite's tries to handle a `.ts` config file it builds it to JS with a `.timestamp-` suffix. These files are still picked up by Nx when they shouldn't as it's a temp file (https://github.com/vitejs/vite/issues/13267).



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add these temp files to gitignore to prevent processing.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28371
