### PR TITLE
feat(js): update the setup-build generator to support the new ts setup

### DIFF
--- a/docs/generated/packages/esbuild/generators/configuration.json
+++ b/docs/generated/packages/esbuild/generators/configuration.json
@@ -61,6 +61,12 @@
         "description": "The build target to add.",
         "type": "string",
         "default": "build"
+      },
+      "format": {
+        "description": "The format to build the library (esm or cjs).",
+        "type": "array",
+        "items": { "type": "string", "enum": ["esm", "cjs"] },
+        "default": ["esm"]
       }
     },
     "required": [],

--- a/docs/generated/packages/js/executors/swc.json
+++ b/docs/generated/packages/js/executors/swc.json
@@ -130,12 +130,12 @@
         "description": "Generate a lockfile (e.g. package-lock.json) that matches the workspace lockfile to ensure package versions match.",
         "default": false,
         "x-priority": "internal"
+      },
+      "stripLeadingPaths": {
+        "type": "boolean",
+        "description": "Remove leading directory from output (e.g. src). See: https://swc.rs/docs/usage/cli#--strip-leading-paths",
+        "default": false
       }
-    },
-    "stripLeadingPaths": {
-      "type": "boolean",
-      "description": "Remove leading directory from output (e.g. src). See: https://swc.rs/docs/usage/cli#--strip-leading-paths",
-      "default": false
     },
     "required": ["main", "outputPath", "tsConfig"],
     "definitions": {

--- a/docs/generated/packages/rollup/generators/configuration.json
+++ b/docs/generated/packages/rollup/generators/configuration.json
@@ -26,13 +26,13 @@
       },
       "main": {
         "type": "string",
-        "description": "Path relative to the workspace root for the main entry file. Defaults to '<projectRoot>/src/main.ts'.",
+        "description": "Path relative to the workspace root for the main entry file. Defaults to '<projectRoot>/src/index.ts'.",
         "alias": "entryFile",
         "x-priority": "important"
       },
       "tsConfig": {
         "type": "string",
-        "description": "Path relative to the workspace root for the tsconfig file to build with. Defaults to '<projectRoot>/tsconfig.app.json'.",
+        "description": "Path relative to the workspace root for the tsconfig file to build with. Defaults to '<projectRoot>/tsconfig.lib.json'.",
         "x-priority": "important"
       },
       "skipFormat": {

--- a/e2e/js/src/js-packaging.test.ts
+++ b/e2e/js/src/js-packaging.test.ts
@@ -214,14 +214,20 @@ describe('packaging libs', () => {
 
     expect(readJson(`dist/libs/${tscLib}/package.json`).exports).toEqual({
       './package.json': './package.json',
-      '.': './src/index.js',
+      '.': {
+        default: './src/index.js',
+        types: './src/index.d.ts',
+      },
       './foo/bar': './src/foo/bar.js',
       './foo/faz': './src/foo/faz.js',
     });
 
     expect(readJson(`dist/libs/${swcLib}/package.json`).exports).toEqual({
       './package.json': './package.json',
-      '.': './src/index.js',
+      '.': {
+        default: './src/index.js',
+        types: './src/index.d.ts',
+      },
       './foo/bar': './src/foo/bar.js',
       './foo/faz': './src/foo/faz.js',
     });

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -18,7 +18,10 @@ import {
 import * as esbuild from 'esbuild';
 import { normalizeOptions } from './lib/normalize';
 
-import { EsBuildExecutorOptions } from './schema';
+import {
+  EsBuildExecutorOptions,
+  NormalizedEsBuildExecutorOptions,
+} from './schema';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
 import {
   buildEsbuildOptions,
@@ -213,7 +216,7 @@ export async function* esbuildExecutor(
 }
 
 function getTypeCheckOptions(
-  options: EsBuildExecutorOptions,
+  options: NormalizedEsBuildExecutorOptions,
   context: ExecutorContext
 ) {
   const { watch, tsConfig, outputPath } = options;
@@ -243,7 +246,7 @@ function getTypeCheckOptions(
 }
 
 async function runTypeCheck(
-  options: EsBuildExecutorOptions,
+  options: NormalizedEsBuildExecutorOptions,
   context: ExecutorContext
 ) {
   const { errors, warnings } = await _runTypeCheck(

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -125,7 +125,7 @@ export function buildEsbuildOptions(
 
 export function getOutExtension(
   format: 'cjs' | 'esm',
-  options: NormalizedEsBuildExecutorOptions
+  options: Pick<NormalizedEsBuildExecutorOptions, 'userDefinedBuildOptions'>
 ): '.cjs' | '.mjs' | '.js' {
   const userDefinedExt = options.userDefinedBuildOptions?.outExtension?.['.js'];
   // Allow users to change the output extensions from default CJS and ESM extensions.

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.ts
@@ -17,7 +17,7 @@ export function normalizeOptions(
   const isTsSolutionSetup = isUsingTsSolutionSetup();
   if (isTsSolutionSetup && options.generatePackageJson) {
     throw new Error(
-      `Setting 'generatePackageJson: true' is not allowed with the current TypeScript setup. Please update the 'package.json' file at the project root as needed and don't set the 'generatePackageJson' option.`
+      `Setting 'generatePackageJson: true' is not supported with the current TypeScript setup. Update the 'package.json' file at the project root as needed and unset the 'generatePackageJson' option.`
     );
   }
 
@@ -26,7 +26,7 @@ export function normalizeOptions(
   // If we're not generating package.json file, then copy it as-is as an asset when not using ts solution setup.
   const assets =
     options.generatePackageJson || isTsSolutionSetup
-      ? options.assets
+      ? options.assets ?? []
       : [
           ...options.assets,
           joinPathFragments(

--- a/packages/esbuild/src/executors/esbuild/schema.d.ts
+++ b/packages/esbuild/src/executors/esbuild/schema.d.ts
@@ -35,5 +35,5 @@ export interface NormalizedEsBuildExecutorOptions
   assets: (AssetGlob | string)[];
   singleEntry: boolean;
   external: string[];
-  userDefinedBuildOptions: esbuild.BuildOptions;
+  userDefinedBuildOptions: esbuild.BuildOptions | undefined;
 }

--- a/packages/esbuild/src/executors/esbuild/schema.d.ts
+++ b/packages/esbuild/src/executors/esbuild/schema.d.ts
@@ -5,7 +5,7 @@ type Compiler = 'babel' | 'swc';
 
 export interface EsBuildExecutorOptions {
   additionalEntryPoints?: string[];
-  assets: (AssetGlob | string)[];
+  assets?: (AssetGlob | string)[];
   bundle?: boolean;
   declaration?: boolean;
   declarationRootDir?: string;
@@ -32,6 +32,7 @@ export interface EsBuildExecutorOptions {
 
 export interface NormalizedEsBuildExecutorOptions
   extends Omit<EsBuildExecutorOptions, 'esbuildOptions' | 'esbuildConfig'> {
+  assets: (AssetGlob | string)[];
   singleEntry: boolean;
   external: string[];
   userDefinedBuildOptions: esbuild.BuildOptions;

--- a/packages/esbuild/src/generators/configuration/schema.d.ts
+++ b/packages/esbuild/src/generators/configuration/schema.d.ts
@@ -1,3 +1,5 @@
+import type { SupportedFormat } from '@nx/js';
+
 export interface EsBuildProjectSchema {
   project: string;
   main?: string;
@@ -10,4 +12,5 @@ export interface EsBuildProjectSchema {
   esbuildConfig?: string;
   platform?: 'node' | 'browser' | 'neutral';
   buildTarget?: string;
+  format?: SupportedFormat[];
 }

--- a/packages/esbuild/src/generators/configuration/schema.json
+++ b/packages/esbuild/src/generators/configuration/schema.json
@@ -60,6 +60,15 @@
       "description": "The build target to add.",
       "type": "string",
       "default": "build"
+    },
+    "format": {
+      "description": "The format to build the library (esm or cjs).",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["esm", "cjs"]
+      },
+      "default": ["esm"]
     }
   },
   "required": [],

--- a/packages/esbuild/src/generators/init/init.ts
+++ b/packages/esbuild/src/generators/init/init.ts
@@ -4,14 +4,11 @@ import {
   GeneratorCallback,
   Tree,
 } from '@nx/devkit';
-import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { esbuildVersion } from '@nx/js/src/utils/versions';
 import { nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
 export async function esbuildInitGenerator(tree: Tree, schema: Schema) {
-  assertNotUsingTsSolutionSetup(tree, 'esbuild', 'init');
-
   let installTask: GeneratorCallback = () => {};
   if (!schema.skipPackageJson) {
     installTask = addDependenciesToPackageJson(

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -73,12 +73,12 @@ export async function expoLibraryGeneratorInternal(
   }
   initRootBabelConfig(host);
 
+  createFiles(host, options);
+
   const addProjectTask = await addProject(host, options);
   if (addProjectTask) {
     tasks.push(addProjectTask);
   }
-
-  createFiles(host, options);
 
   const lintTask = await addLinting(host, {
     ...options,

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -113,12 +113,12 @@
       "description": "Generate a lockfile (e.g. package-lock.json) that matches the workspace lockfile to ensure package versions match.",
       "default": false,
       "x-priority": "internal"
+    },
+    "stripLeadingPaths": {
+      "type": "boolean",
+      "description": "Remove leading directory from output (e.g. src). See: https://swc.rs/docs/usage/cli#--strip-leading-paths",
+      "default": false
     }
-  },
-  "stripLeadingPaths": {
-    "type": "boolean",
-    "description": "Remove leading directory from output (e.g. src). See: https://swc.rs/docs/usage/cli#--strip-leading-paths",
-    "default": false
   },
   "required": ["main", "outputPath", "tsConfig"],
   "definitions": {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -67,7 +67,7 @@ import { getProjectPackageManagerWorkspaceStateWarningTask } from './utils/packa
 import {
   ensureProjectIsExcludedFromPluginRegistrations,
   ensureProjectIsIncludedInPluginRegistrations,
-} from './utils/plugin-registrations';
+} from '../../utils/typescript/plugin';
 
 const defaultOutputDirectory = 'dist';
 

--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -156,7 +156,10 @@ describe('getUpdatedPackageJsonContent', () => {
         types: './src/index.d.ts',
         version: '0.0.1',
         exports: {
-          '.': './src/index.js',
+          '.': {
+            import: './src/index.js',
+            types: './src/index.d.ts',
+          },
           './package.json': './package.json',
         },
       });
@@ -185,7 +188,10 @@ describe('getUpdatedPackageJsonContent', () => {
         version: '0.0.1',
         type: 'commonjs',
         exports: {
-          '.': './src/index.cjs',
+          '.': {
+            default: './src/index.cjs',
+            types: './src/index.d.ts',
+          },
           './package.json': './package.json',
         },
       });
@@ -220,7 +226,10 @@ describe('getUpdatedPackageJsonContent', () => {
         types: './src/index.d.ts',
         version: '0.0.1',
         exports: {
-          '.': './src/index.js',
+          '.': {
+            default: './src/index.js',
+            types: './src/index.d.ts',
+          },
           './foo': './src/foo.js',
           './bar': './src/bar.js',
           './package.json': './package.json',
@@ -258,7 +267,10 @@ describe('getUpdatedPackageJsonContent', () => {
         types: './src/index.d.ts',
         version: '0.0.1',
         exports: {
-          '.': './src/index.js',
+          '.': {
+            import: './src/index.js',
+            types: './src/index.d.ts',
+          },
           './foo': './src/foo.js',
           './bar': './src/bar.js',
           './package.json': './package.json',
@@ -298,6 +310,7 @@ describe('getUpdatedPackageJsonContent', () => {
           '.': {
             import: './src/index.js',
             default: './src/index.cjs',
+            types: './src/index.d.ts',
           },
           './foo': {
             import: './src/foo.js',
@@ -351,6 +364,7 @@ describe('getUpdatedPackageJsonContent', () => {
         '.': {
           import: './src/index.js',
           default: './src/index.cjs',
+          types: './src/index.d.ts',
         },
         './package.json': './package.json',
         './custom': './custom.js',
@@ -383,7 +397,10 @@ describe('getUpdatedPackageJsonContent', () => {
       version: '0.0.1',
       type: 'module',
       exports: {
-        '.': './src/index.cjs',
+        '.': {
+          default: './src/index.cjs',
+          types: './src/index.d.ts',
+        },
         './package.json': './package.json',
       },
     });

--- a/packages/js/src/utils/typescript/plugin.ts
+++ b/packages/js/src/utils/typescript/plugin.ts
@@ -21,7 +21,7 @@ export function ensureProjectIsIncludedInPluginRegistrations(
 
     if (typeof registration === 'string') {
       // if it's a string all projects are included but the are no user-specified options
-      // and the `build` task is not inferred by default, so we need to exclude it
+      // and the build task is not inferred by default, so we need to exclude it
       nxJson.plugins[index] = {
         plugin: '@nx/js/typescript',
         exclude: [`${projectRoot}/*`],
@@ -38,19 +38,20 @@ export function ensureProjectIsIncludedInPluginRegistrations(
         // it's included by the plugin registration, check if the user-specified options would result
         // in the appropriate build task being inferred, if not, we need to exclude it
         if (
-          registration.options?.typecheck &&
+          registration.options?.typecheck !== false &&
           matchesBuildTarget(registration.options?.build, buildTargetName)
         ) {
-          // it has the desired options, do nothing
+          // it has the desired options, do nothing, but continue processing
+          // other registrations to exclude as needed
           isIncluded = true;
         } else {
-          // it would not have the `build` task inferred, so we need to exclude it
+          // it would not have the typecheck or build task inferred, so we need to exclude it
           registration.exclude ??= [];
           registration.exclude.push(`${projectRoot}/*`);
         }
       } else if (
         !isIncluded &&
-        registration.options?.typecheck &&
+        registration.options?.typecheck !== false &&
         matchesBuildTarget(registration.options?.build, buildTargetName)
       ) {
         if (!registration.exclude?.length) {
@@ -67,6 +68,10 @@ export function ensureProjectIsIncludedInPluginRegistrations(
           registration.exclude = registration.exclude.filter(
             (e) => e !== `${projectRoot}/*`
           );
+          if (!registration.exclude.length) {
+            // if there's no `exclude` option left, we can remove the exclude option
+            delete registration.exclude;
+          }
         }
       }
     }

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -1,22 +1,25 @@
 import { offsetFromRoot, Tree, updateJson, workspaceRoot } from '@nx/devkit';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
-import * as ts from 'typescript';
+import type * as ts from 'typescript';
 import { ensureTypescript } from './ensure-typescript';
 
 let tsModule: typeof import('typescript');
 
-export function readTsConfig(tsConfigPath: string): ts.ParsedCommandLine {
+export function readTsConfig(
+  tsConfigPath: string,
+  sys?: ts.System
+): ts.ParsedCommandLine {
   if (!tsModule) {
     tsModule = require('typescript');
   }
-  const readResult = tsModule.readConfigFile(
-    tsConfigPath,
-    tsModule.sys.readFile
-  );
+
+  sys ??= tsModule.sys;
+
+  const readResult = tsModule.readConfigFile(tsConfigPath, sys.readFile);
   return tsModule.parseJsonConfigFileContent(
     readResult.config,
-    tsModule.sys,
+    sys,
     dirname(tsConfigPath)
   );
 }

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -71,12 +71,12 @@ export async function reactNativeLibraryGeneratorInternal(
     tasks.push(ensureDependencies(host));
   }
 
+  createFiles(host, options);
+
   const addProjectTask = await addProject(host, options);
   if (addProjectTask) {
     tasks.push(addProjectTask);
   }
-
-  createFiles(host, options);
 
   const lintTask = await addLinting(host, {
     ...options,

--- a/packages/rollup/src/generators/configuration/configuration.spec.ts
+++ b/packages/rollup/src/generators/configuration/configuration.spec.ts
@@ -56,7 +56,7 @@ describe('configurationGenerator', () => {
   it('should support --main option', async () => {
     await configurationGenerator(tree, {
       project: 'mypkg',
-      main: './src/index.ts',
+      main: './libs/mypkg/src/index.ts',
     });
 
     const rollupConfig = tree.read('libs/mypkg/rollup.config.js', 'utf-8');
@@ -85,7 +85,7 @@ module.exports = withNx(
   it('should support --tsConfig option', async () => {
     await configurationGenerator(tree, {
       project: 'mypkg',
-      tsConfig: './tsconfig.custom.json',
+      tsConfig: 'libs/mypkg/tsconfig.custom.json',
     });
 
     const rollupConfig = tree.read('libs/mypkg/rollup.config.js', 'utf-8');

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -6,21 +6,26 @@ import {
   readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
-  stripIndents,
   Tree,
+  updateJson,
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
-import { getImportPath } from '@nx/js/src/utils/get-import-path';
-import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
-
-import { rollupInitGenerator } from '../init/init';
-import { RollupExecutorOptions } from '../../executors/rollup/schema';
-import { RollupProjectSchema } from './schema';
 import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
+import { readTsConfig } from '@nx/js';
+import { getImportPath } from '@nx/js/src/utils/get-import-path';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import * as posix from 'node:path/posix';
+import type { PackageJson } from 'nx/src/utils/package-json';
+import { RollupExecutorOptions } from '../../executors/rollup/schema';
+import { RollupWithNxPluginOptions } from '../../plugins/with-nx/with-nx-options';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { hasPlugin } from '../../utils/has-plugin';
-import { RollupWithNxPluginOptions } from '../../plugins/with-nx/with-nx-options';
+import { rollupInitGenerator } from '../init/init';
+import { RollupProjectSchema } from './schema';
+
+let ts: typeof import('typescript');
 
 export async function configurationGenerator(
   tree: Tree,
@@ -39,15 +44,20 @@ export async function configurationGenerator(
     tasks.push(ensureDependencies(tree, options));
   }
 
+  const isTsSolutionSetup = isUsingTsSolutionSetup(tree);
+  let outputConfig: OutputConfig;
   if (hasPlugin(tree)) {
-    createRollupConfig(tree, options);
+    outputConfig = createRollupConfig(tree, options, isTsSolutionSetup);
   } else {
     options.buildTarget ??= 'build';
     checkForTargetConflicts(tree, options);
-    addBuildTarget(tree, options);
+    outputConfig = addBuildTarget(tree, options);
   }
 
-  addPackageJson(tree, options);
+  updatePackageJson(tree, options, outputConfig, isTsSolutionSetup);
+  if (isTsSolutionSetup) {
+    updateTsConfig(tree, options);
+  }
 
   if (!options.skipFormat) {
     await formatFiles(tree);
@@ -56,20 +66,34 @@ export async function configurationGenerator(
   return runTasksInSerial(...tasks);
 }
 
-function createRollupConfig(tree: Tree, options: RollupProjectSchema) {
-  const isUsingTsPlugin = isUsingTsSolutionSetup(tree);
+type OutputConfig = {
+  main: string;
+  outputPath: string;
+};
+function createRollupConfig(
+  tree: Tree,
+  options: RollupProjectSchema,
+  isTsSolutionSetup: boolean
+): OutputConfig {
   const project = readProjectConfiguration(tree, options.project);
+  const main = options.main
+    ? `./${posix.relative(project.root, options.main)}`
+    : './src/index.ts';
+  const outputPath = isTsSolutionSetup
+    ? './dist'
+    : joinPathFragments(
+        offsetFromRoot(project.root),
+        'dist',
+        project.root === '.' ? project.name : project.root
+      );
+
   const buildOptions: RollupWithNxPluginOptions = {
-    outputPath: isUsingTsPlugin
-      ? './dist'
-      : joinPathFragments(
-          offsetFromRoot(project.root),
-          'dist',
-          project.root === '.' ? project.name : project.root
-        ),
+    outputPath,
     compiler: options.compiler ?? 'babel',
-    main: options.main ?? './src/index.ts',
-    tsConfig: options.tsConfig ?? './tsconfig.lib.json',
+    main,
+    tsConfig: options.tsConfig
+      ? `./${posix.relative(project.root, options.tsConfig)}`
+      : './tsconfig.lib.json',
   };
 
   tree.write(
@@ -82,8 +106,12 @@ module.exports = withNx(
     outputPath: '${buildOptions.outputPath}',
     tsConfig: '${buildOptions.tsConfig}',
     compiler: '${buildOptions.compiler}',
-    format: ${JSON.stringify(options.format ?? ['esm'])},
-    assets: [{ input: '.', output: '.', glob:'*.md' }],
+    format: ${JSON.stringify(options.format ?? ['esm'])},${
+      !isTsSolutionSetup
+        ? `
+    assets: [{ input: '.', output: '.', glob:'*.md' }],`
+        : ''
+    }
   },
   {
     // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
@@ -93,6 +121,11 @@ module.exports = withNx(
 );
 `
   );
+
+  return {
+    main: joinPathFragments(project.root, main),
+    outputPath: joinPathFragments(project.root, outputPath),
+  };
 }
 
 function checkForTargetConflicts(tree: Tree, options: RollupProjectSchema) {
@@ -105,40 +138,73 @@ function checkForTargetConflicts(tree: Tree, options: RollupProjectSchema) {
   }
 }
 
-function addPackageJson(tree: Tree, options: RollupProjectSchema) {
+function updatePackageJson(
+  tree: Tree,
+  options: RollupProjectSchema,
+  outputConfig: OutputConfig,
+  isTsSolutionSetup: boolean
+) {
   const project = readProjectConfiguration(tree, options.project);
-  const packageJsonPath = joinPathFragments(project.root, 'package.json');
 
-  if (!tree.exists(packageJsonPath)) {
+  const { main, outputPath } = outputConfig;
+  const mainName = posix.basename(main).replace(/\.[tj]s$/, '');
+  const relativeOutputPath = posix.relative(
+    posix.join(tree.root, project.root),
+    posix.join(tree.root, outputPath)
+  );
+  const outputDir = `./${posix.normalize(relativeOutputPath)}`;
+  const formats = options.format ?? ['esm'];
+
+  const packageJsonPath = joinPathFragments(project.root, 'package.json');
+  if (tree.exists(packageJsonPath) && isTsSolutionSetup) {
+    if (!relativeOutputPath.startsWith('../')) {
+      updateJson(tree, packageJsonPath, (json) => {
+        // the output is contained within the project root
+        updatePackageJsonFields(json, outputDir, mainName, formats);
+        return json;
+      });
+    }
+  } else if (!tree.exists(packageJsonPath)) {
     const importPath =
       options.importPath || getImportPath(tree, options.project);
-    writeJson(tree, packageJsonPath, {
+    const packageJson: PackageJson = {
       name: importPath,
       version: '0.0.1',
-    });
+    };
+    if (isTsSolutionSetup && !relativeOutputPath.startsWith('../')) {
+      // fully matches the new setup
+      updatePackageJsonFields(packageJson, outputDir, mainName, formats);
+    }
+    writeJson(tree, packageJsonPath, packageJson);
   }
 }
 
-function addBuildTarget(tree: Tree, options: RollupProjectSchema) {
+function addBuildTarget(
+  tree: Tree,
+  options: RollupProjectSchema
+): OutputConfig {
   addBuildTargetDefaults(tree, '@nx/rollup:rollup', options.buildTarget);
   const project = readProjectConfiguration(tree, options.project);
   const prevBuildOptions = project.targets?.[options.buildTarget]?.options;
 
+  options.tsConfig ??=
+    prevBuildOptions?.tsConfig ??
+    joinPathFragments(project.root, 'tsconfig.lib.json');
+  const main =
+    options.main ??
+    prevBuildOptions?.main ??
+    joinPathFragments(project.root, 'src/index.ts');
+  const outputPath =
+    prevBuildOptions?.outputPath ??
+    joinPathFragments(
+      'dist',
+      project.root === '.' ? project.name : project.root
+    );
+
   const buildOptions: RollupExecutorOptions = {
-    main:
-      options.main ??
-      prevBuildOptions?.main ??
-      joinPathFragments(project.root, 'src/index.ts'),
-    outputPath:
-      prevBuildOptions?.outputPath ??
-      joinPathFragments(
-        'dist',
-        project.root === '.' ? project.name : project.root
-      ),
-    tsConfig:
-      options.tsConfig ??
-      prevBuildOptions?.tsConfig ??
-      joinPathFragments(project.root, 'tsconfig.lib.json'),
+    main,
+    outputPath,
+    tsConfig: options.tsConfig,
     additionalEntryPoints: prevBuildOptions?.additionalEntryPoints,
     generateExportsField: prevBuildOptions?.generateExportsField,
     compiler: options.compiler ?? 'babel',
@@ -172,6 +238,57 @@ function addBuildTarget(tree: Tree, options: RollupProjectSchema) {
       },
     },
   });
+
+  return { main, outputPath };
+}
+
+function updateTsConfig(tree: Tree, options: RollupProjectSchema): void {
+  const project = readProjectConfiguration(tree, options.project);
+  const tsconfigPath =
+    options.tsConfig ?? joinPathFragments(project.root, 'tsconfig.lib.json');
+  if (!tree.exists(tsconfigPath)) {
+    throw new Error(
+      `The '${tsconfigPath}' file doesn't exist. Provide the 'tsConfig' option with the correct path pointing to the tsconfig file to use for builds.`
+    );
+  }
+
+  if (!ts) {
+    ts = ensureTypescript();
+  }
+
+  const parsedTsConfig = readTsConfig(tsconfigPath, {
+    ...ts.sys,
+    readFile: (p) => tree.read(p, 'utf-8'),
+    fileExists: (p) => tree.exists(p),
+  });
+
+  updateJson(tree, tsconfigPath, (json) => {
+    if (parsedTsConfig.options.module === ts.ModuleKind.NodeNext) {
+      json.compilerOptions ??= {};
+      json.compilerOptions.module = 'esnext';
+      json.compilerOptions.moduleResolution = 'bundler';
+    }
+
+    return json;
+  });
+}
+
+function updatePackageJsonFields(
+  packageJson: PackageJson,
+  outputDir: string,
+  mainName: string,
+  formats: RollupProjectSchema['format']
+) {
+  if (formats.includes('cjs')) {
+    packageJson.main = `${outputDir}/${mainName}.cjs.js`;
+    packageJson.types = `${outputDir}/${mainName}.cjs.d.ts`;
+  } else if (formats.includes('esm')) {
+    packageJson.main = `${outputDir}/${mainName}.esm.js`;
+    packageJson.types = `${outputDir}/${mainName}.esm.d.ts`;
+  }
+  if (formats.includes('esm')) {
+    packageJson.module = `${outputDir}/${mainName}.esm.js`;
+  }
 }
 
 export default configurationGenerator;

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -309,22 +309,4 @@ function updateTsConfig(tree: Tree, options: RollupProjectSchema): void {
   });
 }
 
-function updatePackageJsonFields(
-  packageJson: PackageJson,
-  outputDir: string,
-  mainName: string,
-  formats: RollupProjectSchema['format']
-) {
-  if (formats.includes('cjs')) {
-    packageJson.main = `${outputDir}/${mainName}.cjs.js`;
-    packageJson.types = `${outputDir}/${mainName}.cjs.d.ts`;
-  } else if (formats.includes('esm')) {
-    packageJson.main = `${outputDir}/${mainName}.esm.js`;
-    packageJson.types = `${outputDir}/${mainName}.esm.d.ts`;
-  }
-  if (formats.includes('esm')) {
-    packageJson.module = `${outputDir}/${mainName}.esm.js`;
-  }
-}
-
 export default configurationGenerator;

--- a/packages/rollup/src/generators/configuration/schema.json
+++ b/packages/rollup/src/generators/configuration/schema.json
@@ -25,13 +25,13 @@
     },
     "main": {
       "type": "string",
-      "description": "Path relative to the workspace root for the main entry file. Defaults to '<projectRoot>/src/main.ts'.",
+      "description": "Path relative to the workspace root for the main entry file. Defaults to '<projectRoot>/src/index.ts'.",
       "alias": "entryFile",
       "x-priority": "important"
     },
     "tsConfig": {
       "type": "string",
-      "description": "Path relative to the workspace root for the tsconfig file to build with. Defaults to '<projectRoot>/tsconfig.app.json'.",
+      "description": "Path relative to the workspace root for the tsconfig file to build with. Defaults to '<projectRoot>/tsconfig.lib.json'.",
       "x-priority": "important"
     },
     "skipFormat": {

--- a/packages/rollup/src/plugins/with-nx/with-nx-options.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx-options.ts
@@ -76,6 +76,12 @@ export interface RollupWithNxPluginOptions {
    * The path to tsconfig file.
    */
   tsConfig: string;
+  /**
+   * Whether to generate a package.json file in the output path. It's not supported when the workspace is
+   * set up with TypeScript Project References along with the package managers' Workspaces feature. Otherwise,
+   * it defaults to `true`.
+   */
+  generatePackageJson?: boolean;
 }
 
 export interface AssetGlobPattern {

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -285,6 +285,7 @@ export default defineConfig({
 exports[`@nx/vite:configuration library mode should set up non buildable library which already has vite.config.ts correctly 1`] = `
 "import dts from 'vite-plugin-dts';
 import * as path from 'path';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
@@ -395,7 +396,6 @@ exports[`@nx/vite:configuration transform React app to use Vite should move inde
 exports[`@nx/vite:configuration transform Web app to use Vite should create vite.config file at the root of the app 1`] = `
 "/// <reference types='vitest' />
 import { defineConfig } from 'vite';
-
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -110,20 +110,10 @@ export async function viteConfigurationGeneratorInternal(
       tree,
       joinPathFragments(projectRoot, 'tsconfig.lib.json'),
       (json) => {
-        if (!json.compilerOptions) {
-          json.compilerOptions = {};
-        }
-        if (!json.compilerOptions.types) {
-          json.compilerOptions.types = [];
-        }
+        json.compilerOptions ??= {};
+        json.compilerOptions.types ??= [];
         if (!json.compilerOptions.types.includes('vite/client')) {
-          return {
-            ...json,
-            compilerOptions: {
-              ...json.compilerOptions,
-              types: [...json.compilerOptions.types, 'vite/client'],
-            },
-          };
+          json.compilerOptions.types.push('vite/client');
         }
         return json;
       }

--- a/packages/vite/src/utils/generator-utils.spec.ts
+++ b/packages/vite/src/utils/generator-utils.spec.ts
@@ -215,7 +215,6 @@ describe('generator utils', () => {
         .toMatchInlineSnapshot(`
         "/// <reference types='vitest' />
         import { defineConfig } from 'vite';
-
         import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
         import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -232,7 +232,15 @@ export function editTsConfig(
 ) {
   const projectConfig = readProjectConfiguration(tree, options.project);
 
-  const config = readJson(tree, `${projectConfig.root}/tsconfig.json`);
+  let tsconfigPath = joinPathFragments(projectConfig.root, 'tsconfig.json');
+  const isTsSolutionSetup = isUsingTsSolutionSetup(tree);
+  if (isTsSolutionSetup) {
+    tsconfigPath = [
+      joinPathFragments(projectConfig.root, 'tsconfig.app.json'),
+      joinPathFragments(projectConfig.root, 'tsconfig.lib.json'),
+    ].find((p) => tree.exists(p));
+  }
+  const config = readJson(tree, tsconfigPath);
 
   switch (options.uiFramework) {
     case 'react':
@@ -245,21 +253,23 @@ export function editTsConfig(
       };
       break;
     case 'none':
-      config.compilerOptions = {
-        module: 'commonjs',
-        forceConsistentCasingInFileNames: true,
-        strict: true,
-        noImplicitOverride: true,
-        noPropertyAccessFromIndexSignature: true,
-        noImplicitReturns: true,
-        noFallthroughCasesInSwitch: true,
-      };
+      if (!isTsSolutionSetup) {
+        config.compilerOptions = {
+          module: 'commonjs',
+          forceConsistentCasingInFileNames: true,
+          strict: true,
+          noImplicitOverride: true,
+          noPropertyAccessFromIndexSignature: true,
+          noImplicitReturns: true,
+          noFallthroughCasesInSwitch: true,
+        };
+      }
       break;
     default:
       break;
   }
 
-  writeJson(tree, `${projectConfig.root}/tsconfig.json`, config);
+  writeJson(tree, tsconfigPath, config);
 }
 
 export function deleteWebpackConfig(


### PR DESCRIPTION
Update the `@nx/js:setup-build` and the generators it depends on to support the new TS setup with project references.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
