### PR TITLE
fix(rspack): removed webpack-sources import

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -41,8 +41,7 @@
     "@rspack/plugin-react-refresh": "^1.0.0",
     "chalk": "~4.1.0",
     "tsconfig-paths": "^4.1.2",
-    "tslib": "^2.3.0",
-    "webpack-sources": "^3.2.3"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@module-federation/enhanced": "~0.6.0",

--- a/packages/rspack/src/plugins/generate-package-json-plugin.ts
+++ b/packages/rspack/src/plugins/generate-package-json-plugin.ts
@@ -12,8 +12,11 @@ import {
   getLockFileName,
   readTsConfig,
 } from '@nx/js';
-import { type Compiler, type RspackPluginInstance } from '@rspack/core';
-import { RawSource } from 'webpack-sources';
+import {
+  type Compiler,
+  type RspackPluginInstance,
+  sources,
+} from '@rspack/core';
 
 const pluginName = 'GeneratePackageJsonPlugin';
 
@@ -71,12 +74,12 @@ export class GeneratePackageJsonPlugin implements RspackPluginInstance {
 
           compilation.emitAsset(
             'package.json',
-            new RawSource(serializeJson(packageJson))
+            new sources.RawSource(serializeJson(packageJson))
           );
           const packageManager = detectPackageManager(this.context.root);
           compilation.emitAsset(
             getLockFileName(packageManager),
-            new RawSource(
+            new sources.RawSource(
               createLockFile(packageJson, this.projectGraph, packageManager)
             )
           );


### PR DESCRIPTION
removed the webpack-sources import and replaced it with the sources export from rspack

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nx/rspack` uses `webpack-sources` which is not listed as dependency. The issue originated in PR #27676 but i decided to split it out. I also opened #28225 to add the dependency-check rule for rspack. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@nx/rspack` uses the reexport from `@rspack/core` 

https://rspack.dev/api/javascript-api/#sources-object

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#28225 #27676
