### PR TITLE
fix(core): add migration to set `useLegacyCache` by default

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -61,7 +61,8 @@
     "use-legacy-cache": {
       "version": "20.0.1",
       "description": "Set `useLegacyCache` to true for migrating workspaces",
-      "implementation": "./src/migrations/update-20-0-1/use-legacy-cache"
+      "implementation": "./src/migrations/update-20-0-1/use-legacy-cache",
+      "x-repair-skip": true
     }
   }
 }

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -57,6 +57,11 @@
       "version": "20.0.0-beta.7",
       "description": "Migration for v20.0.0-beta.7",
       "implementation": "./src/migrations/update-20-0-0/move-use-daemon-process"
+    },
+    "use-legacy-cache": {
+      "version": "20.0.1",
+      "description": "Set `useLegacyCache` to true for migrating workspaces",
+      "implementation": "./src/migrations/update-20-0-1/use-legacy-cache"
     }
   }
 }

--- a/packages/nx/src/migrations/update-20-0-1/use-legacy-cache.spec.ts
+++ b/packages/nx/src/migrations/update-20-0-1/use-legacy-cache.spec.ts
@@ -1,0 +1,59 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { Tree } from '../../generators/tree';
+
+import update from './use-legacy-cache';
+import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
+
+describe('use legacy cache', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add `useLegacyCache` on migrating workspaces that did not have `enableDbCache`', async () => {
+    await update(tree);
+
+    expect(readNxJson(tree)).toMatchInlineSnapshot(`
+      {
+        "affected": {
+          "defaultBase": "main",
+        },
+        "targetDefaults": {
+          "build": {
+            "cache": true,
+          },
+          "lint": {
+            "cache": true,
+          },
+        },
+        "useLegacyCache": true,
+      }
+    `);
+  });
+  it('should not add `useLegacyCache` on migrating workspaces that did have `enableDbCache`', async () => {
+    const nxJson = readNxJson(tree);
+    updateNxJson(tree, {
+      enableDbCache: true,
+      ...nxJson,
+    } as any);
+
+    await update(tree);
+
+    expect(readNxJson(tree)).toMatchInlineSnapshot(`
+      {
+        "affected": {
+          "defaultBase": "main",
+        },
+        "targetDefaults": {
+          "build": {
+            "cache": true,
+          },
+          "lint": {
+            "cache": true,
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/nx/src/migrations/update-20-0-1/use-legacy-cache.ts
+++ b/packages/nx/src/migrations/update-20-0-1/use-legacy-cache.ts
@@ -1,0 +1,19 @@
+import { Tree } from '../../generators/tree';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
+import { NxJsonConfiguration } from '../../config/nx-json';
+
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree) as NxJsonConfiguration;
+
+  // If workspaces  had `enableDbCache` we can just delete the property as the db cache is enabled by default in nx v20
+  if ((nxJson as any).enableDbCache) {
+    delete (nxJson as any).enableDbCache;
+  } else {
+    nxJson.useLegacyCache = true;
+  }
+
+  updateNxJson(tree, nxJson);
+
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}

--- a/packages/nx/src/migrations/update-20-0-1/use-legacy-cache.ts
+++ b/packages/nx/src/migrations/update-20-0-1/use-legacy-cache.ts
@@ -6,6 +6,10 @@ import { NxJsonConfiguration } from '../../config/nx-json';
 export default async function update(tree: Tree) {
   const nxJson = readNxJson(tree) as NxJsonConfiguration;
 
+  if (!nxJson) {
+    return;
+  }
+
   // If workspaces  had `enableDbCache` we can just delete the property as the db cache is enabled by default in nx v20
   if ((nxJson as any).enableDbCache) {
     delete (nxJson as any).enableDbCache;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Existing workspaces that migrate to v20 use the db cache by default. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Existing workspaces that migrate to v20 have `useLegacyCache` set to true. Unless they specifically had `enableDbCache` from previous versions of Nx. All new workspaces will not have `useLegacyCache` set by default. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
