### PR TITLE
chore(repo): fix npm-audit workflow, only run on origin

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -8,24 +8,20 @@ on:
 permissions: {}
 jobs:
   audit:
+    if: ${{ github.repository_owner == 'nrwl' }}
     permissions:
       contents: read  #  to fetch code (actions/checkout)
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install PNPM
-        run: |
-          npm install -g @pnpm/exe@8
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.8.0 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
 
       - name: Run a security audit
         run: pnpm dlx audit-ci --critical --report-type summary
-
-    # - name: Run Dependency confusion supply chain check
-    #  run: npx snync -d .
 
   report:
     if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

We run the workflow on all forks. The workflow is not working because it installs pnpm v8.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We only the workflow on origin, it succeeds.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28445
