### PR TITLE
fix(release): ensure plan subcommand works with object config

### DIFF
--- a/packages/nx/src/command-line/release/plan.ts
+++ b/packages/nx/src/command-line/release/plan.ts
@@ -77,7 +77,7 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     }
 
     // If no release groups have version plans enabled, it doesn't make sense to use the plan command only to set yourself up for an error at release time
-    if (!releaseGroups.some((group) => group.versionPlans === true)) {
+    if (!releaseGroups.some((group) => !!group.versionPlans)) {
       if (releaseGroups.length === 1) {
         output.warn({
           title: `Version plans are not enabled in your release configuration`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The plan command explicitly checks for `true`, which might not be the case when version plans are enabled.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The plan command checks for any truthy value for `versionPlans`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28387
