### PR TITLE
fix(expo): check if option is not undefined closes #28488

### DIFF
--- a/packages/expo/src/executors/install/install.impl.ts
+++ b/packages/expo/src/executors/install/install.impl.ts
@@ -84,7 +84,7 @@ function createInstallOptions(options: ExpoInstallOptions) {
         // when true, does not need to pass the value true, just need to pass the flag in kebob case
         acc.push(`--${names(k).fileName}`);
       }
-    } else {
+    } else if (v !== undefined) {
       acc.push(`--${names(k).fileName}`, v);
     }
 


### PR DESCRIPTION
## Current Behavior
NX Cannot read properties of undefined (reading 'trim')

TypeError: Cannot read properties of undefined (reading 'trim')
at /path/node_modules/@expo/package-manager/build/node/NpmPackageManager.js:80:22
at Array.map ()
at NpmPackageManager.parsePackageSpecs (/path/node_modules/@expo/package-manager/build/node/NpmPackageManager.js:79:14)
at NpmPackageManager.addAsync (/path/node_modules/@expo/package-manager/build/node/NpmPackageManager.js:34:56)
at installPackagesAsync (/path/node_modules/@expo/cli/build/src/install/installAsync.js:178:30)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
at async installAndUpdatePackageJson (/path/node_modules/@nx/expo/src/executors/install/install.impl.js:33:5)
at async buildExecutor (/path/node_modules/@nx/expo/src/executors/update/update.impl.js:13:9)
at async getLastValueFromAsyncIterableIterator (/path/node_modules/nx/src/utils/async-iterator.js:15:19)
at async iteratorToProcessStatusCode (/path/node_modules/nx/src/command-line/run/run.js:39:25)

## Expected Behavior
› Installing 1 SDK 51.0.0 compatible native module using npm
npm install

## Related Issue(s)
Fixes #28488
