### PR TITLE
fix(core): repair SIGINT signals on windows

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -273,7 +273,7 @@ export function runCommandUntil(
       ...opts.env,
       FORCE_COLOR: 'false',
     },
-    windowsHide: true,
+    windowsHide: false,
   });
   return new Promise((res, rej) => {
     let output = '';

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -65,7 +65,7 @@ function getPublishedVersion(): Promise<string | undefined> {
     exec(
       'npm view nx@latest version',
       {
-        windowsHide: true,
+        windowsHide: false,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/packages/create-nx-workspace/src/utils/child-process-utils.ts
+++ b/packages/create-nx-workspace/src/utils/child-process-utils.ts
@@ -19,7 +19,7 @@ export function spawnAndWait(command: string, args: string[], cwd: string) {
         ESLINT_USE_FLAT_CONFIG: process.env.ESLINT_USE_FLAT_CONFIG ?? 'true',
       },
       shell: true,
-      windowsHide: true,
+      windowsHide: false,
     });
 
     childProcess.on('exit', (code) => {
@@ -36,7 +36,7 @@ export function execAndWait(command: string, cwd: string) {
   return new Promise<{ code: number; stdout: string }>((res, rej) => {
     exec(
       command,
-      { cwd, env: { ...process.env, NX_DAEMON: 'false' }, windowsHide: true },
+      { cwd, env: { ...process.env, NX_DAEMON: 'false' }, windowsHide: false },
       (error, stdout, stderr) => {
         if (error) {
           const logFile = join(cwd, 'error.log');

--- a/packages/create-nx-workspace/src/utils/git/default-base.ts
+++ b/packages/create-nx-workspace/src/utils/git/default-base.ts
@@ -8,7 +8,7 @@ export function deduceDefaultBase(): string {
   const nxDefaultBase = 'main';
   try {
     return (
-      execSync('git config --get init.defaultBranch', { windowsHide: true })
+      execSync('git config --get init.defaultBranch', { windowsHide: false })
         .toString()
         .trim() || nxDefaultBase
     );

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -4,7 +4,7 @@ import { output } from '../output';
 
 export function checkGitVersion(): string | null | undefined {
   try {
-    let gitVersionOutput = execSync('git --version', { windowsHide: true })
+    let gitVersionOutput = execSync('git --version', { windowsHide: false })
       .toString()
       .trim();
     return gitVersionOutput.match(/[0-9]+\.[0-9]+\.+[0-9]+/)?.[0];
@@ -43,7 +43,7 @@ export async function initializeGitRepo(
             }
           : {}),
       },
-      windowsHide: true,
+      windowsHide: false,
     };
     return new Promise<void>((resolve, reject) => {
       spawn('git', args, spawnOptions).on('close', (code) => {

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -139,7 +139,7 @@ function shouldRecordStats(): boolean {
   try {
     const stdout = execSync(pmc.getRegistryUrl, {
       encoding: 'utf-8',
-      windowsHide: true,
+      windowsHide: false,
     });
     const url = new URL(stdout.trim());
 

--- a/packages/create-nx-workspace/src/utils/nx/show-nx-warning.ts
+++ b/packages/create-nx-workspace/src/utils/nx/show-nx-warning.ts
@@ -9,7 +9,7 @@ export function showNxWarning(workspaceName: string) {
     execSync('nx --version', {
       cwd: pathToRunNxCommand,
       stdio: ['ignore', 'ignore', 'ignore'],
-      windowsHide: true,
+      windowsHide: false,
     });
   } catch (e) {
     // no nx found

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -123,7 +123,7 @@ export function getPackageManagerVersion(
   const version = execSync(`${packageManager} --version`, {
     cwd,
     encoding: 'utf-8',
-    windowsHide: true,
+    windowsHide: false,
   }).trim();
   pmVersionCache.set(packageManager, version);
   return version;

--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -78,14 +78,14 @@ function startWebServer(webServerCommand: string) {
     // Windows is fine so we leave it attached to this process
     detached: process.platform !== 'win32',
     stdio: 'inherit',
-    windowsHide: true,
+    windowsHide: false,
   });
 
   return () => {
     if (process.platform === 'win32') {
       try {
         execSync('taskkill /pid ' + serverProcess.pid + ' /T /F', {
-          windowsHide: true,
+          windowsHide: false,
         });
       } catch (e) {
         if (process.env.NX_VERBOSE_LOGGING === 'true') {

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -43,7 +43,7 @@ export function installPackagesTask(
     const execSyncOptions: ExecSyncOptions = {
       cwd: join(tree.root, cwd),
       stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
-      windowsHide: true,
+      windowsHide: false,
     };
     // ensure local registry from process is not interfering with the install
     // when we start the process from temp folder the local registry would override the custom registry

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -497,7 +497,7 @@ export function ensurePackage<T extends any = any>(
     execSync(preInstallCommand, {
       cwd: tempDir,
       stdio: isVerbose ? 'inherit' : 'ignore',
-      windowsHide: true,
+      windowsHide: false,
     });
   }
   let addCommand = getPackageManagerCommand(packageManager).addDev;
@@ -508,7 +508,7 @@ export function ensurePackage<T extends any = any>(
   execSync(`${addCommand} ${pkg}@${requiredVersion}`, {
     cwd: tempDir,
     stdio: isVerbose ? 'inherit' : 'ignore',
-    windowsHide: true,
+    windowsHide: false,
   });
 
   addToNodePath(join(workspaceRoot, 'node_modules'));

--- a/packages/expo/src/utils/pod-install-task.ts
+++ b/packages/expo/src/utils/pod-install-task.ts
@@ -68,7 +68,7 @@ export function podInstall(
       execSync('touch .xcode.env', {
         cwd: iosDirectory,
         stdio: 'inherit',
-        windowsHide: true,
+        windowsHide: false,
       });
     }
     execSync(
@@ -78,7 +78,7 @@ export function podInstall(
       {
         cwd: iosDirectory,
         stdio: 'inherit',
-        windowsHide: true,
+        windowsHide: false,
       }
     );
   } catch (e) {

--- a/packages/expo/src/utils/resolve-eas.ts
+++ b/packages/expo/src/utils/resolve-eas.ts
@@ -11,13 +11,13 @@ export function resolveEas(workspaceRoot: string): string {
 
   let npmGlobalPath: string, yarnGlobalPath: string;
   try {
-    npmGlobalPath = execSync('npm root -g', { windowsHide: true })
+    npmGlobalPath = execSync('npm root -g', { windowsHide: false })
       ?.toString()
       ?.trim()
       ?.replace('\u001b[2K\u001b[1G', ''); // strip out ansi codes
   } catch {}
   try {
-    yarnGlobalPath = execSync('yarn global dir', { windowsHide: true })
+    yarnGlobalPath = execSync('yarn global dir', { windowsHide: false })
       ?.toString()
       ?.trim()
       ?.replace('\u001b[2K\u001b[1G', ''); // strip out ansi codes

--- a/packages/gradle/src/utils/exec-gradle.ts
+++ b/packages/gradle/src/utils/exec-gradle.ts
@@ -27,7 +27,7 @@ export function execGradleAsync(
     const cp = execFile(gradleBinaryPath, args, {
       cwd: dirname(gradleBinaryPath),
       shell: true,
-      windowsHide: true,
+      windowsHide: false,
       env: process.env,
       ...execOptions,
     });

--- a/packages/gradle/src/utils/exec-gradle.ts
+++ b/packages/gradle/src/utils/exec-gradle.ts
@@ -27,7 +27,7 @@ export function execGradleAsync(
     const cp = execFile(gradleBinaryPath, args, {
       cwd: dirname(gradleBinaryPath),
       shell: true,
-      windowsHide: false,
+      windowsHide: true,
       env: process.env,
       ...execOptions,
     });

--- a/packages/js/src/executors/node/lib/kill-tree.ts
+++ b/packages/js/src/executors/node/lib/kill-tree.ts
@@ -21,7 +21,7 @@ export async function killTree(pid: number, signal: NodeJS.Signals) {
         exec(
           'taskkill /pid ' + pid + ' /T /F',
           {
-            windowsHide: true,
+            windowsHide: false,
           },
           (error) => {
             // Ignore Fatal errors (128) because it might be due to the process already being killed.
@@ -37,7 +37,7 @@ export async function killTree(pid: number, signal: NodeJS.Signals) {
           pidsToProcess,
           function (parentPid) {
             return spawn('pgrep', ['-P', parentPid], {
-              windowsHide: true,
+              windowsHide: false,
             });
           },
           function () {
@@ -55,7 +55,7 @@ export async function killTree(pid: number, signal: NodeJS.Signals) {
               'ps',
               ['-o', 'pid', '--no-headers', '--ppid', parentPid],
               {
-                windowsHide: true,
+                windowsHide: false,
               }
             );
           },

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -128,7 +128,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
         env: processEnv(true),
         cwd: context.root,
         stdio: ['ignore', 'pipe', 'pipe'],
-        windowsHide: true,
+        windowsHide: false,
       });
 
       const resultJson = JSON.parse(result.toString());
@@ -154,7 +154,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
               env: processEnv(true),
               cwd: context.root,
               stdio: 'ignore',
-              windowsHide: true,
+              windowsHide: false,
             });
             console.log(
               `Added the dist-tag ${tag} to v${currentVersion} for registry ${registry}.\n`
@@ -269,7 +269,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
       env: processEnv(true),
       cwd: context.root,
       stdio: ['ignore', 'pipe', 'pipe'],
-      windowsHide: true,
+      windowsHide: false,
     });
 
     /**

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -136,7 +136,7 @@ function createVerdaccioOptions(
 
 function setupNpm(options: VerdaccioExecutorSchema) {
   try {
-    execSync('npm --version', { env, windowsHide: true });
+    execSync('npm --version', { env, windowsHide: false });
   } catch (e) {
     return () => {};
   }
@@ -151,7 +151,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
         npmRegistryPaths.push(
           execSync(
             `npm config get ${registryName} --location ${options.location}`,
-            { env, windowsHide: true }
+            { env, windowsHide: false }
           )
             ?.toString()
             ?.trim()
@@ -159,12 +159,12 @@ function setupNpm(options: VerdaccioExecutorSchema) {
         );
         execSync(
           `npm config set ${registryName} http://localhost:${options.port}/ --location ${options.location}`,
-          { env, windowsHide: true }
+          { env, windowsHide: false }
         );
 
         execSync(
           `npm config set //localhost:${options.port}/:_authToken="secretVerdaccioToken" --location ${options.location}`,
-          { env, windowsHide: true }
+          { env, windowsHide: false }
         );
 
         logger.info(
@@ -181,7 +181,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
       try {
         const currentNpmRegistryPath = execSync(
           `npm config get registry --location ${options.location}`,
-          { env, windowsHide: true }
+          { env, windowsHide: false }
         )
           ?.toString()
           ?.trim()
@@ -194,7 +194,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
           ) {
             execSync(
               `npm config set ${registryName} ${npmRegistryPaths[index]} --location ${options.location}`,
-              { env, windowsHide: true }
+              { env, windowsHide: false }
             );
             logger.info(
               `Reset npm ${registryName} to ${npmRegistryPaths[index]}`
@@ -204,7 +204,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
               `npm config delete ${registryName} --location ${options.location}`,
               {
                 env,
-                windowsHide: true,
+                windowsHide: false,
               }
             );
             logger.info('Cleared custom npm registry');
@@ -212,7 +212,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
         });
         execSync(
           `npm config delete //localhost:${options.port}/:_authToken  --location ${options.location}`,
-          { env, windowsHide: true }
+          { env, windowsHide: false }
         );
       } catch (e) {
         throw new Error(`Failed to reset npm registry: ${e.message}`);
@@ -231,7 +231,7 @@ function getYarnUnsafeHttpWhitelist(isYarnV1: boolean) {
         JSON.parse(
           execSync(`yarn config get unsafeHttpWhitelist --json`, {
             env,
-            windowsHide: true,
+            windowsHide: false,
           }).toString()
         )
       )
@@ -247,13 +247,13 @@ function setYarnUnsafeHttpWhitelist(
       `yarn config set unsafeHttpWhitelist --json '${JSON.stringify(
         Array.from(currentWhitelist)
       )}'` + (options.location === 'user' ? ' --home' : ''),
-      { env, windowsHide: true }
+      { env, windowsHide: false }
     );
   } else {
     execSync(
       `yarn config unset unsafeHttpWhitelist` +
         (options.location === 'user' ? ' --home' : ''),
-      { env, windowsHide: true }
+      { env, windowsHide: false }
     );
   }
 }
@@ -266,7 +266,9 @@ function setupYarn(options: VerdaccioExecutorSchema) {
   try {
     isYarnV1 =
       major(
-        execSync('yarn --version', { env, windowsHide: true }).toString().trim()
+        execSync('yarn --version', { env, windowsHide: false })
+          .toString()
+          .trim()
       ) === 1;
   } catch {
     // This would fail if yarn is not installed which is okay
@@ -281,7 +283,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
       yarnRegistryPaths.push(
         execSync(`yarn config get ${scopeName}${registryConfigName}`, {
           env,
-          windowsHide: true,
+          windowsHide: false,
         })
           ?.toString()
           ?.trim()
@@ -291,7 +293,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
       execSync(
         `yarn config set ${scopeName}${registryConfigName} http://localhost:${options.port}/` +
           (options.location === 'user' ? ' --home' : ''),
-        { env, windowsHide: true }
+        { env, windowsHide: false }
       );
 
       logger.info(
@@ -318,7 +320,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
       try {
         const currentYarnRegistryPath = execSync(
           `yarn config get ${registryConfigName}`,
-          { env, windowsHide: true }
+          { env, windowsHide: false }
         )
           ?.toString()
           ?.trim()
@@ -339,7 +341,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
               {
                 env,
 
-                windowsHide: true,
+                windowsHide: false,
               }
             );
             logger.info(
@@ -349,7 +351,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
             execSync(
               `yarn config ${isYarnV1 ? 'delete' : 'unset'} ${registryName}` +
                 (options.location === 'user' ? ' --home' : ''),
-              { env, windowsHide: true }
+              { env, windowsHide: false }
             );
             logger.info(`Cleared custom yarn ${registryConfigName}`);
           }

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -213,7 +213,7 @@ To fix this you will either need to add a package.json file at that location, or
                 exec(
                   `npm view ${packageName} version --"${registryConfigKey}=${registry}" --tag=${tag}`,
                   {
-                    windowsHide: true,
+                    windowsHide: false,
                   },
                   (error, stdout, stderr) => {
                     if (error) {

--- a/packages/js/src/generators/release-version/utils/update-lock-file.ts
+++ b/packages/js/src/generators/release-version/utils/update-lock-file.ts
@@ -133,7 +133,7 @@ function execLockFileUpdate(
         ...process.env,
         ...env,
       },
-      windowsHide: true,
+      windowsHide: false,
     });
   } catch (e) {
     output.error({

--- a/packages/js/src/generators/setup-verdaccio/generator.ts
+++ b/packages/js/src/generators/setup-verdaccio/generator.ts
@@ -23,7 +23,7 @@ export async function setupVerdaccio(
     generateFiles(tree, path.join(__dirname, 'files'), '.verdaccio', {
       npmUplinkRegistry:
         execSync('npm config get registry', {
-          windowsHide: true,
+          windowsHide: false,
         })
           ?.toString()
           ?.trim() ?? 'https://registry.npmjs.org',

--- a/packages/js/src/plugins/jest/start-local-registry.ts
+++ b/packages/js/src/plugins/jest/start-local-registry.ts
@@ -48,7 +48,7 @@ export function startLocalRegistry({
         execSync(
           `npm config set //localhost:${port}/:_authToken "secretVerdaccioToken"`,
           {
-            windowsHide: true,
+            windowsHide: false,
           }
         );
 
@@ -63,7 +63,7 @@ export function startLocalRegistry({
         resolve(() => {
           childProcess.kill();
           execSync(`npm config delete //localhost:${port}/:_authToken`, {
-            windowsHide: true,
+            windowsHide: false,
           });
         });
         childProcess?.stdout?.off('data', listener);

--- a/packages/js/src/utils/npm-config.ts
+++ b/packages/js/src/utils/npm-config.ts
@@ -108,7 +108,7 @@ async function getNpmConfigValue(key: string, cwd: string): Promise<string> {
 async function execAsync(command: string, cwd: string): Promise<string> {
   // Must be non-blocking async to allow spinner to render
   return new Promise<string>((resolve, reject) => {
-    exec(command, { cwd, windowsHide: true }, (error, stdout, stderr) => {
+    exec(command, { cwd, windowsHide: false }, (error, stdout, stderr) => {
       if (error) {
         return reject(error);
       }

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -85,7 +85,7 @@ export async function compileSwc(
   const swcCmdLog = execSync(getSwcCmd(normalizedOptions), {
     encoding: 'utf8',
     cwd: normalizedOptions.swcCliOptions.swcCwd,
-    windowsHide: true,
+    windowsHide: false,
   });
   logger.log(swcCmdLog.replace(/\n/, ''));
   const isCompileSuccess = swcCmdLog.includes('Successfully compiled');
@@ -138,7 +138,7 @@ export async function* compileSwcWatch(
 
       const swcWatcher = exec(getSwcCmd(normalizedOptions, true), {
         cwd: normalizedOptions.swcCliOptions.swcCwd,
-        windowsHide: true,
+        windowsHide: false,
       });
 
       processOnExit = () => {

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -159,7 +159,7 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
       execSync(`npx -y nuxi prepare`, {
         cwd: options.appProjectRoot,
 
-        windowsHide: true,
+        windowsHide: false,
       });
     } catch (e) {
       console.error(

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -252,14 +252,14 @@ function getLocalNxVersion(workspace: WorkspaceTypeAndRoot): string | null {
 function _getLatestVersionOfNx(): string {
   try {
     return execSync('npm view nx@latest version', {
-      windowsHide: true,
+      windowsHide: false,
     })
       .toString()
       .trim();
   } catch {
     try {
       return execSync('pnpm view nx@latest version', {
-        windowsHide: true,
+        windowsHide: false,
       })
         .toString()
         .trim();

--- a/packages/nx/src/command-line/activate-powerpack/activate-powerpack.ts
+++ b/packages/nx/src/command-line/activate-powerpack/activate-powerpack.ts
@@ -26,7 +26,7 @@ async function requirePowerpack(): Promise<any> {
         execSync(
           `${getPackageManagerCommand().addDev} @nx/powerpack-license@latest`,
           {
-            windowsHide: true,
+            windowsHide: false,
           }
         );
 

--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -46,7 +46,7 @@ async function installPackage(
       exec(
         `${pmc.addDev} ${pkgName}@${version}`,
         {
-          windowsHide: true,
+          windowsHide: false,
         },
         (error, stdout) => {
           if (error) {

--- a/packages/nx/src/command-line/connect/view-logs.ts
+++ b/packages/nx/src/command-line/connect/view-logs.ts
@@ -50,7 +50,7 @@ export async function viewLogs(): Promise<number> {
   const pmc = getPackageManagerCommand();
   execSync(`${pmc.exec} nx-cloud upload-and-show-run-details`, {
     stdio: [0, 1, 2],
-    windowsHide: true,
+    windowsHide: false,
   });
 
   if (!cloudUsed) {

--- a/packages/nx/src/command-line/exec/exec.ts
+++ b/packages/nx/src/command-line/exec/exec.ts
@@ -54,7 +54,7 @@ export async function nxExecCommand(
         NX_PROJECT_ROOT_PATH:
           projectGraph.nodes?.[process.env.NX_TASK_TARGET_PROJECT]?.data?.root,
       },
-      windowsHide: true,
+      windowsHide: false,
     });
   } else {
     // nx exec is being ran inside of Nx's context
@@ -105,7 +105,7 @@ async function runScriptAsNxTarget(
             projectGraph.nodes?.[projectName]?.data?.root
           )
         : workspaceRoot,
-      windowsHide: true,
+      windowsHide: false,
     });
   });
 }
@@ -132,7 +132,7 @@ function runTargetOnProject(
   execSync(command, {
     stdio: 'inherit',
 
-    windowsHide: true,
+    windowsHide: false,
   });
 }
 

--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -211,7 +211,7 @@ function write(patterns: string[]) {
       )}`,
       {
         stdio: [0, 1, 2],
-        windowsHide: true,
+        windowsHide: false,
       }
     );
 
@@ -222,7 +222,7 @@ function write(patterns: string[]) {
         )} --parser json`,
         {
           stdio: [0, 1, 2],
-          windowsHide: true,
+          windowsHide: false,
         }
       );
     }
@@ -239,7 +239,7 @@ async function check(patterns: string[]): Promise<string[]> {
   return new Promise((resolve) => {
     exec(
       `node "${prettierPath}" --list-different ${patterns.join(' ')}`,
-      { encoding: 'utf-8', windowsHide: true },
+      { encoding: 'utf-8', windowsHide: false },
       (error, stdout) => {
         if (error) {
           // The command failed so there are files with different formatting. Prettier writes them to stdout, newline separated.

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -1270,6 +1270,6 @@ function getHelpTextFromTarget(
 
   return execSync(command, {
     cwd: target.options?.cwd ?? workspaceRoot,
-    windowsHide: true,
+    windowsHide: false,
   }).toString();
 }

--- a/packages/nx/src/command-line/init/implementation/angular/integrated-workspace.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/integrated-workspace.ts
@@ -6,6 +6,6 @@ export function setupIntegratedWorkspace(): void {
   execSync(`${pmc.exec} nx g @nx/angular:ng-add`, {
     stdio: [0, 1, 2],
 
-    windowsHide: true,
+    windowsHide: false,
   });
 }

--- a/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
@@ -108,7 +108,7 @@ export async function getLegacyMigrationFunctionIfApplicable(
     output.log({ title: '📝 Setting up workspace' });
     execSync(`${pmc.exec} ${legacyMigrationCommand}`, {
       stdio: [0, 1, 2],
-      windowsHide: true,
+      windowsHide: false,
     });
 
     if (useNxCloud) {
@@ -149,7 +149,7 @@ async function installDependencies(
   }
   writeJsonFile(`package.json`, json);
 
-  execSync(pmc.install, { stdio: [0, 1, 2], windowsHide: true });
+  execSync(pmc.install, { stdio: [0, 1, 2], windowsHide: false });
 }
 
 async function resolvePackageVersion(

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -68,7 +68,7 @@ export function generateDotNxSetup(version?: string) {
 export function normalizeVersionForNxJson(pkg: string, version: string) {
   if (!valid(version)) {
     version = execSync(`npm view ${pkg}@${version} version`, {
-      windowsHide: true,
+      windowsHide: false,
     }).toString();
   }
   return version.trimEnd();

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -90,7 +90,7 @@ function performInstallation(
     cp.execSync('npm i', {
       cwd: path.dirname(installationPath),
       stdio: 'inherit',
-      windowsHide: true,
+      windowsHide: false,
     });
   } catch (e) {
     // revert possible changes to the current installation

--- a/packages/nx/src/command-line/init/implementation/react/check-for-uncommitted-changes.ts
+++ b/packages/nx/src/command-line/init/implementation/react/check-for-uncommitted-changes.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 
 export function checkForUncommittedChanges() {
   const gitResult = execSync('git status --porcelain', {
-    windowsHide: true,
+    windowsHide: false,
   }).toString();
 
   const filteredResults = gitResult

--- a/packages/nx/src/command-line/init/implementation/react/index.ts
+++ b/packages/nx/src/command-line/init/implementation/react/index.ts
@@ -70,7 +70,7 @@ function installDependencies(options: NormalizedOptions) {
 
   execSync(`${options.pmc.addDev} ${dependencies.join(' ')}`, {
     stdio: [0, 1, 2],
-    windowsHide: true,
+    windowsHide: false,
   });
 }
 
@@ -88,7 +88,7 @@ async function normalizeOptions(options: Options): Promise<NormalizedOptions> {
   };
   const isCRA5 = /^[^~]?5/.test(deps['react-scripts']);
   const npmVersion = execSync('npm -v', {
-    windowsHide: true,
+    windowsHide: false,
   }).toString();
   // Should remove this check 04/2023 once Node 14 & npm 6 reach EOL
   const npxYesFlagNeeded = !npmVersion.startsWith('6'); // npm 7 added -y flag to npx
@@ -131,11 +131,11 @@ async function reorgnizeWorkspaceStructure(options: NormalizedOptions) {
 
   execSync(`echo "node_modules" >> .gitignore`, {
     stdio: [0, 1, 2],
-    windowsHide: true,
+    windowsHide: false,
   });
   execSync(`echo "dist" >> .gitignore`, {
     stdio: [0, 1, 2],
-    windowsHide: true,
+    windowsHide: false,
   });
 
   process.chdir('..');
@@ -177,7 +177,7 @@ function createTempWorkspace(options: NormalizedOptions) {
     } ${
       options.addE2e ? '--e2eTestRunner=playwright' : '--e2eTestRunner=none'
     }`,
-    { stdio: [0, 1, 2], windowsHide: true }
+    { stdio: [0, 1, 2], windowsHide: false }
   );
 
   output.log({ title: '👋 Welcome to Nx!' });
@@ -330,7 +330,7 @@ async function addBundler(options: NormalizedOptions) {
 
     execSync(`echo "SKIP_PREFLIGHT_CHECK=true" > .env`, {
       stdio: [0, 1, 2],
-      windowsHide: true,
+      windowsHide: false,
     });
   }
 }

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -68,28 +68,28 @@ function deduceDefaultBase() {
   try {
     execSync(`git rev-parse --verify main`, {
       stdio: ['ignore', 'ignore', 'ignore'],
-      windowsHide: true,
+      windowsHide: false,
     });
     return 'main';
   } catch {
     try {
       execSync(`git rev-parse --verify dev`, {
         stdio: ['ignore', 'ignore', 'ignore'],
-        windowsHide: true,
+        windowsHide: false,
       });
       return 'dev';
     } catch {
       try {
         execSync(`git rev-parse --verify develop`, {
           stdio: ['ignore', 'ignore', 'ignore'],
-          windowsHide: true,
+          windowsHide: false,
         });
         return 'develop';
       } catch {
         try {
           execSync(`git rev-parse --verify next`, {
             stdio: ['ignore', 'ignore', 'ignore'],
-            windowsHide: true,
+            windowsHide: false,
           });
           return 'next';
         } catch {
@@ -144,7 +144,11 @@ export function runInstall(
   repoRoot: string,
   pmc: PackageManagerCommands = getPackageManagerCommand()
 ) {
-  execSync(pmc.install, { stdio: [0, 1, 2], cwd: repoRoot, windowsHide: true });
+  execSync(pmc.install, {
+    stdio: [0, 1, 2],
+    cwd: repoRoot,
+    windowsHide: false,
+  });
 }
 
 export async function initCloud(

--- a/packages/nx/src/command-line/init/init-v1.ts
+++ b/packages/nx/src/command-line/init/init-v1.ts
@@ -95,7 +95,7 @@ export async function initHandler(options: InitArgs) {
     } else {
       execSync(`npx --yes create-nx-workspace@${version} ${args}`, {
         stdio: [0, 1, 2],
-        windowsHide: true,
+        windowsHide: false,
       });
     }
   }

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -59,7 +59,7 @@ export function installPlugins(
       {
         stdio: [0, 1, 2],
         cwd: repoRoot,
-        windowsHide: true,
+        windowsHide: false,
       }
     );
   }

--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -128,7 +128,7 @@ function runMigration() {
       }
       execSync(`${p} _migrate ${process.argv.slice(3).join(' ')}`, {
         stdio: ['inherit', 'inherit', 'inherit'],
-        windowsHide: true,
+        windowsHide: false,
       });
     }
   } else {
@@ -156,14 +156,14 @@ function nxCliPath() {
       execSync(pmc.preInstall, {
         cwd: tmpDir,
         stdio: ['ignore', 'ignore', 'ignore'],
-        windowsHide: true,
+        windowsHide: false,
       });
       // if it's berry ensure we set the node_linker to node-modules
       if (packageManager === 'yarn' && pmc.ciInstall.includes('immutable')) {
         execSync('yarn config set nodeLinker node-modules', {
           cwd: tmpDir,
           stdio: ['ignore', 'ignore', 'ignore'],
-          windowsHide: true,
+          windowsHide: false,
         });
       }
     }
@@ -171,7 +171,7 @@ function nxCliPath() {
     execSync(pmc.install, {
       cwd: tmpDir,
       stdio: ['ignore', 'ignore', 'ignore'],
-      windowsHide: true,
+      windowsHide: false,
     });
 
     // Set NODE_PATH so that these modules can be used for module resolution

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1387,7 +1387,7 @@ function runInstall() {
   output.log({
     title: `Running '${pmCommands.install}' to make sure necessary packages are installed`,
   });
-  execSync(pmCommands.install, { stdio: [0, 1, 2], windowsHide: true });
+  execSync(pmCommands.install, { stdio: [0, 1, 2], windowsHide: false });
 }
 
 export async function executeMigrations(

--- a/packages/nx/src/command-line/release/config/version-plans.ts
+++ b/packages/nx/src/command-line/release/config/version-plans.ts
@@ -323,7 +323,7 @@ async function getCommitForVersionPlanFile(
     exec(
       `git log --diff-filter=A --pretty=format:"%s|%h|%an|%ae|%b" -n 1 -- ${rawVersionPlan.absolutePath}`,
       {
-        windowsHide: true,
+        windowsHide: false,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/packages/nx/src/command-line/release/utils/exec-command.ts
+++ b/packages/nx/src/command-line/release/utils/exec-command.ts
@@ -10,7 +10,7 @@ export async function execCommand(
       ...options,
       stdio: ['pipe', 'pipe', 'pipe'], // stdin, stdout, stderr
       encoding: 'utf-8',
-      windowsHide: true,
+      windowsHide: false,
     });
 
     let stdout = '';

--- a/packages/nx/src/command-line/release/utils/github.ts
+++ b/packages/nx/src/command-line/release/utils/github.ts
@@ -367,7 +367,7 @@ async function resolveGithubToken(hostname: string): Promise<string | null> {
         return execSync(`gh auth token`, {
           encoding: 'utf8',
           stdio: 'pipe',
-          windowsHide: true,
+          windowsHide: false,
         }).trim();
       }
     }

--- a/packages/nx/src/command-line/release/utils/launch-editor.ts
+++ b/packages/nx/src/command-line/release/utils/launch-editor.ts
@@ -14,7 +14,7 @@ export async function launchEditor(filePath: string) {
   return new Promise((resolve, reject) => {
     const editorProcess = spawn(cmd, [...args, filePath], {
       stdio: 'inherit', // This will ensure the editor uses the current terminal
-      windowsHide: true,
+      windowsHide: false,
     });
 
     editorProcess.on('exit', (code) => {
@@ -30,7 +30,7 @@ export async function launchEditor(filePath: string) {
 function getGitConfig(key): string | null {
   try {
     return execSync(`git config --get ${key}`, {
-      windowsHide: true,
+      windowsHide: false,
     })
       .toString()
       .trim();

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -762,7 +762,7 @@ function runPreVersionCommand(
       maxBuffer: LARGE_BUFFER,
       stdio,
       env,
-      windowsHide: true,
+      windowsHide: false,
     });
   } catch (e) {
     const title = verbose

--- a/packages/nx/src/command-line/run/run.ts
+++ b/packages/nx/src/command-line/run/run.ts
@@ -134,7 +134,7 @@ async function printTargetRunHelpInternal(
     } else {
       const cp = exec(helpCommand, {
         env,
-        windowsHide: true,
+        windowsHide: false,
       });
       cp.on('exit', (code) => {
         process.exit(code);

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -132,7 +132,7 @@ class BatchCommandRunner extends BatchFunctionRunner {
               [this.projectNameEnv]: env[this.projectNameEnv],
               [this.fileChangesEnv]: env[this.fileChangesEnv],
             },
-            windowsHide: true,
+            windowsHide: false,
           });
           commandExec.on('close', () => {
             resolve();

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -594,7 +594,7 @@ export class DaemonClient {
         cwd: workspaceRoot,
         stdio: ['ignore', this._out.fd, this._err.fd],
         detached: true,
-        windowsHide: true,
+        windowsHide: false,
         shell: false,
         env: {
           ...process.env,

--- a/packages/nx/src/daemon/client/generate-help-output.ts
+++ b/packages/nx/src/daemon/client/generate-help-output.ts
@@ -9,7 +9,7 @@ export function generateDaemonHelpOutput(): string {
    */
   const res = spawnSync(process.execPath, ['./exec-is-server-available.js'], {
     cwd: __dirname,
-    windowsHide: true,
+    windowsHide: false,
   });
 
   const isServerAvailable = res?.stdout?.toString().trim().indexOf('true') > -1;

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -572,7 +572,7 @@ describe('Run Commands', () => {
           ...process.env,
           ...env(),
         },
-        windowsHide: true,
+        windowsHide: false,
       });
       expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
         maxBuffer: LARGE_BUFFER,
@@ -580,7 +580,7 @@ describe('Run Commands', () => {
           ...process.env,
           ...env(),
         },
-        windowsHide: true,
+        windowsHide: false,
       });
     });
 
@@ -603,7 +603,7 @@ describe('Run Commands', () => {
           ...process.env,
           ...env(),
         },
-        windowsHide: true,
+        windowsHide: false,
       });
       expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
         maxBuffer: LARGE_BUFFER,
@@ -611,7 +611,7 @@ describe('Run Commands', () => {
           ...process.env,
           ...env(),
         },
-        windowsHide: true,
+        windowsHide: false,
       });
     });
 
@@ -631,12 +631,12 @@ describe('Run Commands', () => {
       expect(exec).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, {
         maxBuffer: LARGE_BUFFER,
         env: { ...process.env, FORCE_COLOR: `true`, ...env() },
-        windowsHide: true,
+        windowsHide: false,
       });
       expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
         maxBuffer: LARGE_BUFFER,
         env: { ...process.env, FORCE_COLOR: `true`, ...env() },
-        windowsHide: true,
+        windowsHide: false,
       });
     });
   });

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -392,7 +392,7 @@ function nodeProcess(
       maxBuffer: LARGE_BUFFER,
       env,
       cwd,
-      windowsHide: true,
+      windowsHide: false,
     });
 
     childProcesses.add(childProcess);

--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -54,7 +54,7 @@ function nodeProcess(
     stdio: ['inherit', 'inherit', 'inherit'],
     cwd,
     env,
-    windowsHide: true,
+    windowsHide: false,
   });
 }
 

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -37,7 +37,7 @@ function getNxInitDate(): string | null {
   try {
     const nxInitIso = execSync(
       'git log --diff-filter=A --follow --format=%aI -- nx.json | tail -1',
-      { stdio: 'pipe', windowsHide: true }
+      { stdio: 'pipe', windowsHide: false }
     )
       .toString()
       .trim();

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -56,7 +56,7 @@ export const createNodes: CreateNodes = [
         ? readFileSync(lockFilePath).toString()
         : execSync(`bun ${lockFilePath}`, {
             maxBuffer: 1024 * 1024 * 10,
-            windowsHide: true,
+            windowsHide: false,
           }).toString();
     const lockFileHash = getLockFileHash(lockFileContents);
 
@@ -102,7 +102,7 @@ export const createDependencies: CreateDependencies = (
         ? readFileSync(lockFilePath).toString()
         : execSync(`bun ${lockFilePath}`, {
             maxBuffer: 1024 * 1024 * 10,
-            windowsHide: true,
+            windowsHide: false,
           }).toString();
     const lockFileHash = getLockFileHash(lockFileContents);
 

--- a/packages/nx/src/project-graph/file-utils.ts
+++ b/packages/nx/src/project-graph/file-utils.ts
@@ -125,7 +125,7 @@ function defaultReadFileAtRevision(
       : execSync(`git show ${revision}:${filePathInGitRepository}`, {
           maxBuffer: TEN_MEGABYTES,
           stdio: ['pipe', 'pipe', 'ignore'],
-          windowsHide: true,
+          windowsHide: false,
         })
           .toString()
           .trim();

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -234,7 +234,7 @@ export class Cache {
           stdio: 'ignore',
           detached: true,
           shell: false,
-          windowsHide: true,
+          windowsHide: false,
         });
         p.unref();
       } catch (e) {

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -110,7 +110,7 @@ function shouldRecordStats(): boolean {
   try {
     const stdout = execSync(pmc.getRegistryUrl, {
       encoding: 'utf-8',
-      windowsHide: true,
+      windowsHide: false,
     });
     const url = new URL(stdout.trim());
 

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -299,7 +299,7 @@ function getMergeBase(base: string, head: string = 'HEAD') {
       maxBuffer: TEN_MEGABYTES,
       cwd: workspaceRoot,
       stdio: 'pipe',
-      windowsHide: true,
+      windowsHide: false,
     })
       .toString()
       .trim();
@@ -309,7 +309,7 @@ function getMergeBase(base: string, head: string = 'HEAD') {
         maxBuffer: TEN_MEGABYTES,
         cwd: workspaceRoot,
         stdio: 'pipe',
-        windowsHide: true,
+        windowsHide: false,
       })
         .toString()
         .trim();
@@ -329,7 +329,7 @@ function parseGitOutput(command: string): string[] {
   return execSync(command, {
     maxBuffer: TEN_MEGABYTES,
     cwd: workspaceRoot,
-    windowsHide: true,
+    windowsHide: false,
   })
     .toString('utf-8')
     .split('\n')

--- a/packages/nx/src/utils/default-base.ts
+++ b/packages/nx/src/utils/default-base.ts
@@ -5,7 +5,7 @@ export function deduceDefaultBase(): string {
   try {
     return (
       execSync('git config --get init.defaultBranch', {
-        windowsHide: true,
+        windowsHide: false,
       })
         .toString()
         .trim() || nxDefaultBase

--- a/packages/nx/src/utils/git-utils.index-filter.ts
+++ b/packages/nx/src/utils/git-utils.index-filter.ts
@@ -9,10 +9,10 @@ try {
   const { execSync } = require('child_process');
   // NOTE: Using env vars because Windows PowerShell has its own handling of quotes (") messes up quotes in args, even if escaped.
   const src = process.env.NX_IMPORT_SOURCE;
-  execSync('git read-tree --empty', { stdio: 'inherit', windowsHide: true });
+  execSync('git read-tree --empty', { stdio: 'inherit', windowsHide: false });
   execSync(`git reset ${process.env.GIT_COMMIT} -- "${src}"`, {
     stdio: 'inherit',
-    windowsHide: true,
+    windowsHide: false,
   });
 } catch (error) {
   console.error(`Error executing Git commands: ${error}`);

--- a/packages/nx/src/utils/git-utils.spec.ts
+++ b/packages/nx/src/utils/git-utils.spec.ts
@@ -23,7 +23,7 @@ describe('git utils tests', () => {
       expect(result).toBe('origin-user/repo-name');
       expect(execSync).toHaveBeenCalledWith('git remote -v', {
         stdio: 'pipe',
-        windowsHide: true,
+        windowsHide: false,
       });
     });
 
@@ -35,7 +35,7 @@ describe('git utils tests', () => {
       expect(result).toBe('github');
       expect(execSync).toHaveBeenCalledWith('git remote -v', {
         stdio: 'pipe',
-        windowsHide: true,
+        windowsHide: false,
       });
     });
 
@@ -49,7 +49,7 @@ describe('git utils tests', () => {
       expect(result).toBe('github');
       expect(execSync).toHaveBeenCalledWith('git remote -v', {
         stdio: 'pipe',
-        windowsHide: true,
+        windowsHide: false,
       });
     });
 
@@ -64,7 +64,7 @@ describe('git utils tests', () => {
       expect(result).toBe('upstream-user/repo-name');
       expect(execSync).toHaveBeenCalledWith('git remote -v', {
         stdio: 'pipe',
-        windowsHide: true,
+        windowsHide: false,
       });
     });
 
@@ -79,7 +79,7 @@ describe('git utils tests', () => {
       expect(result).toBeNull();
       expect(execSync).toHaveBeenCalledWith('git remote -v', {
         stdio: 'pipe',
-        windowsHide: true,
+        windowsHide: false,
       });
     });
 
@@ -94,7 +94,7 @@ describe('git utils tests', () => {
       expect(result).toBe('origin-user/repo-name');
       expect(execSync).toHaveBeenCalledWith('git remote -v', {
         stdio: 'pipe',
-        windowsHide: true,
+        windowsHide: false,
       });
     });
   });

--- a/packages/nx/src/utils/git-utils.tree-filter.ts
+++ b/packages/nx/src/utils/git-utils.tree-filter.ts
@@ -15,7 +15,7 @@ try {
   const src = process.env.NX_IMPORT_SOURCE;
   const dest = process.env.NX_IMPORT_DESTINATION;
   const files = execSync(`git ls-files -z ${src}`, {
-    windowsHide: true,
+    windowsHide: false,
   })
     .toString()
     .trim()

--- a/packages/nx/src/utils/git-utils.ts
+++ b/packages/nx/src/utils/git-utils.ts
@@ -40,7 +40,7 @@ export class GitRepository {
   getGitRootPath(cwd: string) {
     return execSync('git rev-parse --show-toplevel', {
       cwd,
-      windowsHide: true,
+      windowsHide: false,
     })
       .toString()
       .trim();
@@ -238,7 +238,7 @@ export function getGithubSlugOrNull(): string | null {
   try {
     const gitRemote = execSync('git remote -v', {
       stdio: 'pipe',
-      windowsHide: true,
+      windowsHide: false,
     }).toString();
     // If there are no remotes, we default to github
     if (!gitRemote || gitRemote.length === 0) {
@@ -304,7 +304,7 @@ export function commitChanges(
       stdio: 'pipe',
       input: commitMessage,
       cwd: directory,
-      windowsHide: true,
+      windowsHide: false,
     });
   } catch (err) {
     if (directory) {
@@ -326,7 +326,7 @@ export function getLatestCommitSha(): string | null {
     return execSync('git rev-parse HEAD', {
       encoding: 'utf8',
       stdio: 'pipe',
-      windowsHide: true,
+      windowsHide: false,
     }).trim();
   } catch {
     return null;

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -203,7 +203,7 @@ export function getPackageManagerVersion(
     version = execSync(`${packageManager} --version`, {
       cwd,
       encoding: 'utf-8',
-      windowsHide: false,
+      windowsHide: true,
     }).trim();
   } catch {
     if (existsSync(join(cwd, 'package.json'))) {
@@ -414,7 +414,7 @@ export async function resolvePackageVersionUsingInstallation(
     const pmc = getPackageManagerCommand();
     await execAsync(`${pmc.add} ${packageName}@${version}`, {
       cwd: dir,
-      windowsHide: false,
+      windowsHide: true,
     });
 
     const { packageJson } = readModulePackageJson(packageName, [dir]);
@@ -446,7 +446,7 @@ export async function packageRegistryView(
   }
 
   const { stdout } = await execAsync(`${pm} view ${pkg}@${version} ${args}`, {
-    windowsHide: false,
+    windowsHide: true,
   });
   return stdout.toString().trim();
 }
@@ -472,7 +472,7 @@ export async function packageRegistryPack(
 
   const { stdout } = await execAsync(`${pm} pack ${pkg}@${version}`, {
     cwd,
-    windowsHide: false,
+    windowsHide: true,
   });
 
   const tarballPath = stdout.trim();

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -203,7 +203,7 @@ export function getPackageManagerVersion(
     version = execSync(`${packageManager} --version`, {
       cwd,
       encoding: 'utf-8',
-      windowsHide: true,
+      windowsHide: false,
     }).trim();
   } catch {
     if (existsSync(join(cwd, 'package.json'))) {
@@ -414,7 +414,7 @@ export async function resolvePackageVersionUsingInstallation(
     const pmc = getPackageManagerCommand();
     await execAsync(`${pmc.add} ${packageName}@${version}`, {
       cwd: dir,
-      windowsHide: true,
+      windowsHide: false,
     });
 
     const { packageJson } = readModulePackageJson(packageName, [dir]);
@@ -446,7 +446,7 @@ export async function packageRegistryView(
   }
 
   const { stdout } = await execAsync(`${pm} view ${pkg}@${version} ${args}`, {
-    windowsHide: true,
+    windowsHide: false,
   });
   return stdout.toString().trim();
 }
@@ -472,7 +472,7 @@ export async function packageRegistryPack(
 
   const { stdout } = await execAsync(`${pm} pack ${pkg}@${version}`, {
     cwd,
-    windowsHide: true,
+    windowsHide: false,
   });
 
   const tarballPath = stdout.trim();

--- a/packages/playwright/src/executors/playwright/playwright.impl.ts
+++ b/packages/playwright/src/executors/playwright/playwright.impl.ts
@@ -81,7 +81,7 @@ export async function playwrightExecutor(
     execSync(`${pmc.exec} playwright install`, {
       cwd: workspaceRoot,
       stdio: 'inherit',
-      windowsHide: true,
+      windowsHide: false,
     });
   }
 

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -166,7 +166,7 @@ function getBrowsersInstallTask() {
     const pmc = getPackageManagerCommand();
     execSync(`${pmc.exec} playwright install`, {
       cwd: workspaceRoot,
-      windowsHide: true,
+      windowsHide: false,
     });
   };
 }

--- a/packages/plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/plugin/src/utils/testing-utils/async-commands.ts
@@ -21,7 +21,7 @@ export function runCommandAsync(
       {
         cwd: opts.cwd ?? tmpProjPath(),
         env: { ...process.env, ...opts.env },
-        windowsHide: true,
+        windowsHide: false,
       },
       (err, stdout, stderr) => {
         if (!opts.silenceError && err) {

--- a/packages/plugin/src/utils/testing-utils/commands.ts
+++ b/packages/plugin/src/utils/testing-utils/commands.ts
@@ -21,7 +21,7 @@ export function runNxCommand(
     const execSyncOptions: ExecOptions = {
       cwd,
       env: { ...process.env, ...opts.env },
-      windowsHide: true,
+      windowsHide: false,
     };
     if (fileExists(tmpProjPath('package.json'))) {
       const pmc = getPackageManagerCommand(detectPackageManager(cwd));

--- a/packages/plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/plugin/src/utils/testing-utils/nx-project.ts
@@ -21,7 +21,7 @@ function runNxNewCommand(args?: string, silent?: boolean) {
     {
       cwd: localTmpDir,
       ...(silent && false ? { stdio: ['ignore', 'ignore', 'ignore'] } : {}),
-      windowsHide: true,
+      windowsHide: false,
     }
   );
 }
@@ -56,7 +56,7 @@ export function runPackageManagerInstall(silent: boolean = true) {
   const install = execSync(pmc.install, {
     cwd,
     ...(silent ? { stdio: ['ignore', 'ignore', 'ignore'] } : {}),
-    windowsHide: true,
+    windowsHide: false,
   });
   return install ? install.toString() : '';
 }

--- a/packages/react-native/src/utils/pod-install-task.ts
+++ b/packages/react-native/src/utils/pod-install-task.ts
@@ -72,7 +72,7 @@ export function podInstall(
       execSync('touch .xcode.env', {
         cwd: iosDirectory,
         stdio: 'inherit',
-        windowsHide: true,
+        windowsHide: false,
       });
     }
     const podCommand = [
@@ -83,7 +83,7 @@ export function podInstall(
     execSync(podCommand, {
       cwd: iosDirectory,
       stdio: 'inherit',
-      windowsHide: true,
+      windowsHide: false,
     });
   } catch (e) {
     logger.error(podInstallErrorMessage);

--- a/packages/storybook/src/generators/migrate-7/calling-storybook-cli.ts
+++ b/packages/storybook/src/generators/migrate-7/calling-storybook-cli.ts
@@ -20,7 +20,7 @@ export function callUpgrade(schema: Schema): 1 | Buffer {
       }`,
       {
         stdio: [0, 1, 2],
-        windowsHide: true,
+        windowsHide: false,
       }
     );
 
@@ -86,7 +86,7 @@ export function callAutomigrate(
           `${commandToRun}  ${schema.autoAcceptAllPrompts ? '--yes' : ''}`,
           {
             stdio: 'inherit',
-            windowsHide: true,
+            windowsHide: false,
           }
         );
 

--- a/packages/storybook/src/generators/migrate-8/calling-storybook-cli.ts
+++ b/packages/storybook/src/generators/migrate-8/calling-storybook-cli.ts
@@ -20,7 +20,7 @@ export function callUpgrade(schema: Schema): 1 | Buffer {
       }`,
       {
         stdio: [0, 1, 2],
-        windowsHide: true,
+        windowsHide: false,
       }
     );
 
@@ -84,7 +84,7 @@ export function callAutomigrate(
           `${commandToRun}  ${schema.autoAcceptAllPrompts ? '--yes' : ''}`,
           {
             stdio: 'inherit',
-            windowsHide: true,
+            windowsHide: false,
           }
         );
 

--- a/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
+++ b/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
@@ -19,7 +19,7 @@ export function nxViteBuildCoordinationPlugin(
   async function buildChangedProjects() {
     await new Promise<void>((res) => {
       activeBuildProcess = exec(options.buildCommand, {
-        windowsHide: true,
+        windowsHide: false,
       });
       activeBuildProcess.stdout.pipe(process.stdout);
       activeBuildProcess.stderr.pipe(process.stderr);

--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -36,7 +36,7 @@ export async function validateTypes(opts: {
       {
         cwd: opts.workspaceRoot,
         stdio: 'inherit',
-        windowsHide: true,
+        windowsHide: false,
       }
     );
   }

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -172,7 +172,7 @@ export default async function* fileServerExecutor(
           execFileSync(pmCmd, args, {
             stdio: [0, 1, 2],
             shell: true,
-            windowsHide: true,
+            windowsHide: false,
           });
         } catch {
           throw new Error(

--- a/packages/webpack/src/plugins/webpack-nx-build-coordination-plugin.ts
+++ b/packages/webpack/src/plugins/webpack-nx-build-coordination-plugin.ts
@@ -53,7 +53,7 @@ export class WebpackNxBuildCoordinationPlugin {
     try {
       return await new Promise<void>((res) => {
         this.buildCmdProcess = exec(this.buildCmd, {
-          windowsHide: true,
+          windowsHide: false,
         });
 
         this.buildCmdProcess.stdout.pipe(process.stdout);

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -36,7 +36,7 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
     stdio: 'inherit',
     shell: true,
     cwd: join(host.root, opts.directory),
-    windowsHide: true,
+    windowsHide: false,
   };
   const pmc = getPackageManagerCommand();
   const executable = `${pmc.exec} nx`;

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -64,7 +64,7 @@ export async function newGenerator(tree: Tree, opts: Schema) {
           cwd: joinPathFragments(tree.root, options.directory),
           stdio:
             process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
-          windowsHide: true,
+          windowsHide: false,
         });
       }
       installPackagesTask(

--- a/packages/workspace/src/generators/utils/get-npm-package-version.ts
+++ b/packages/workspace/src/generators/utils/get-npm-package-version.ts
@@ -10,7 +10,7 @@ export function getNpmPackageVersion(
       {
         stdio: ['pipe', 'pipe', 'ignore'],
 
-        windowsHide: true,
+        windowsHide: false,
       }
     );
 

--- a/packages/workspace/src/utilities/default-base.ts
+++ b/packages/workspace/src/utilities/default-base.ts
@@ -5,7 +5,7 @@ export function deduceDefaultBase(): string {
   try {
     return (
       execSync('git config --get init.defaultBranch', {
-        windowsHide: true,
+        windowsHide: false,
       })
         .toString()
         .trim() || nxDefaultBase

--- a/scripts/angular-support-upgrades/init-upgrade.ts
+++ b/scripts/angular-support-upgrades/init-upgrade.ts
@@ -46,7 +46,7 @@ async function run() {
     stdio: 'inherit',
     encoding: 'utf8',
 
-    windowsHide: true,
+    windowsHide: false,
   });
   console.log('✅ - Finished installing packages!');
 
@@ -54,7 +54,7 @@ async function run() {
   execSync('pnpm nx format', {
     stdio: 'inherit',
     encoding: 'utf8',
-    windowsHide: true,
+    windowsHide: false,
   });
   console.log('✅ - Finished creating migrations!');
 }

--- a/scripts/documentation/generators/generate-devkit-documentation.ts
+++ b/scripts/documentation/generators/generate-devkit-documentation.ts
@@ -10,7 +10,7 @@ export async function generateDevkitDocumentation() {
   const execSyncOptions: ExecSyncOptions = {
     stdio: 'true' === 'true' ? 'inherit' : 'ignore',
     // stdio: process.env.CI === 'true' ? 'inherit' : 'ignore',
-    windowsHide: true,
+    windowsHide: false,
   };
 
   execSync('nx run-many -t build -p devkit,typedoc-theme', execSyncOptions);

--- a/scripts/documentation/generators/main.ts
+++ b/scripts/documentation/generators/main.ts
@@ -44,7 +44,7 @@ async function generate() {
 
 function checkDocumentation() {
   const output = execSync('git status --porcelain ./docs', {
-    windowsHide: true,
+    windowsHide: false,
   }).toString('utf-8');
 
   if (output) {
@@ -59,7 +59,7 @@ function checkDocumentation() {
     console.log('\nChanged Docs:');
     execSync('git status --porcelain ./docs', {
       stdio: 'inherit',
-      windowsHide: true,
+      windowsHide: false,
     });
 
     process.exit(1);

--- a/scripts/generate-graph-environment.ts
+++ b/scripts/generate-graph-environment.ts
@@ -63,7 +63,7 @@ function writeFile() {
   // if no generated projects are found, generate one for nx and try this again
   if (generatedGraphs.length === 0) {
     execSync('nx run graph-client:generate-graph --directory ./ --name nx', {
-      windowsHide: true,
+      windowsHide: false,
     });
     writeFile();
     return;

--- a/scripts/generate-graph.ts
+++ b/scripts/generate-graph.ts
@@ -13,7 +13,7 @@ async function generateGraph(directory: string, name: string) {
   try {
     execSync(
       'npx nx graph --file ./node_modules/.cache/nx-graph-gen/graph.html',
-      { cwd: directory, stdio: 'ignore', windowsHide: true }
+      { cwd: directory, stdio: 'ignore', windowsHide: false }
     );
   } catch {
     console.error(`Could not run graph command in directory ${directory}`);

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -35,7 +35,7 @@ const VALID_AUTHORS_FOR_LATEST = [
   execSync(`pnpm nx copy-native-package-directories nx`, {
     stdio: isVerboseLogging ? [0, 1, 2] : 'ignore',
     maxBuffer: LARGE_BUFFER,
-    windowsHide: true,
+    windowsHide: false,
   });
 
   // Expected to run as part of the Github `publish` workflow
@@ -45,13 +45,13 @@ const VALID_AUTHORS_FOR_LATEST = [
     execSync('find ./build -name "*.node" -delete', {
       stdio: [0, 1, 2],
       maxBuffer: LARGE_BUFFER,
-      windowsHide: true,
+      windowsHide: false,
     });
 
     execSync('pnpm nx run-many --target=artifacts', {
       stdio: [0, 1, 2],
       maxBuffer: LARGE_BUFFER,
-      windowsHide: true,
+      windowsHide: false,
     });
   }
 
@@ -69,7 +69,7 @@ const VALID_AUTHORS_FOR_LATEST = [
     execSync(versionCommand, {
       stdio: isVerboseLogging ? [0, 1, 2] : 'ignore',
       maxBuffer: LARGE_BUFFER,
-      windowsHide: true,
+      windowsHide: false,
     });
   };
 
@@ -79,7 +79,7 @@ const VALID_AUTHORS_FOR_LATEST = [
     isVerboseLogging = true;
 
     execSync('git status --ahead-behind', {
-      windowsHide: true,
+      windowsHide: false,
     });
 
     if (isRelativeVersionKeyword(options.version)) {
@@ -93,7 +93,7 @@ const VALID_AUTHORS_FOR_LATEST = [
     execSync(`pnpm nx run-many -t add-extra-dependencies --parallel 8`, {
       stdio: isVerboseLogging ? [0, 1, 2] : 'ignore',
       maxBuffer: LARGE_BUFFER,
-      windowsHide: true,
+      windowsHide: false,
     });
 
     let changelogCommand = `pnpm nx release changelog ${options.version} --interactive workspace`;
@@ -113,7 +113,7 @@ const VALID_AUTHORS_FOR_LATEST = [
     execSync(changelogCommand, {
       stdio: isVerboseLogging ? [0, 1, 2] : 'ignore',
       maxBuffer: LARGE_BUFFER,
-      windowsHide: true,
+      windowsHide: false,
     });
 
     console.log(
@@ -127,7 +127,7 @@ const VALID_AUTHORS_FOR_LATEST = [
   execSync(`pnpm nx run-many -t add-extra-dependencies --parallel 8`, {
     stdio: isVerboseLogging ? [0, 1, 2] : 'ignore',
     maxBuffer: LARGE_BUFFER,
-    windowsHide: true,
+    windowsHide: false,
   });
 
   const distTag = determineDistTag(options.version);
@@ -183,14 +183,14 @@ const VALID_AUTHORS_FOR_LATEST = [
   execSync(publishCommand, {
     stdio: [0, 1, 2],
     maxBuffer: LARGE_BUFFER,
-    windowsHide: true,
+    windowsHide: false,
   });
 
   if (!options.dryRun) {
     let version;
     if (['minor', 'major', 'patch'].includes(options.version)) {
       version = execSync(`npm view nx@${distTag} version`, {
-        windowsHide: true,
+        windowsHide: false,
       })
         .toString()
         .trim();
@@ -271,12 +271,12 @@ function parseArgs() {
          */
 
         const currentLatestVersion = execSync('npm view nx@latest version', {
-          windowsHide: true,
+          windowsHide: false,
         })
           .toString()
           .trim();
         const currentNextVersion = execSync('npm view nx@next version', {
-          windowsHide: true,
+          windowsHide: false,
         })
           .toString()
           .trim();
@@ -309,7 +309,7 @@ function parseArgs() {
 
         // Get the current short git sha
         const gitSha = execSync('git rev-parse --short HEAD', {
-          windowsHide: true,
+          windowsHide: false,
         })
           .toString()
           .trim();
@@ -382,7 +382,7 @@ function parseArgs() {
 function getRegistry() {
   return new URL(
     execSync('npm config get registry', {
-      windowsHide: true,
+      windowsHide: false,
     })
       .toString()
       .trim()
@@ -421,7 +421,7 @@ function determineDistTag(
   }
 
   const currentLatestVersion = execSync('npm view nx version', {
-    windowsHide: true,
+    windowsHide: false,
   })
     .toString()
     .trim();

--- a/scripts/release-docs.ts
+++ b/scripts/release-docs.ts
@@ -9,7 +9,7 @@ console.log(`Comparing ${currentVersion} to npm versions`);
 const majorVersion = major(currentVersion);
 const releasedVersions: string[] = JSON.parse(
   execSync(`npm show nx@^${majorVersion} version --json`, {
-    windowsHide: true,
+    windowsHide: false,
   }).toString()
 );
 
@@ -26,10 +26,10 @@ if (currentVersion && latestVersion && gte(currentVersion, latestVersion)) {
   );
   // We force recreate the branch in order to always be up to date and avoid merge conflicts within the automated workflow
   execSync(`git branch -f ${branchName}`, {
-    windowsHide: true,
+    windowsHide: false,
   });
   execSync(`git push -f origin ${branchName}`, {
-    windowsHide: true,
+    windowsHide: false,
   });
 } else {
   console.log(`Not publishing docs to ${branchName}`);


### PR DESCRIPTION
using `windowsHide: true` is causing an issue on windows: Ctrl + C handling isn't enabled and no `SIGINT` is sent to the child process when users exit the process. See https://github.com/nodejs/node/issues/29837  and https://github.com/nodejs/node-v0.x-archive/issues/5054 for reference. This will cause leftover processes throughout nx.

This PR sets `windowsHide: false` everywhere except for the plugin workers and some short-lived utils. They `spawn` child processes but have explicit handling to make sure they kill themselves when the parent process dies, so the missing Ctrl + C handling doesn't cause issues.

We will follow up to make sure any other culprits that still cause windows popups (especially when used through Nx Console) are handled. Leaving no leftover processes running is more important for now, though. 

Keep in mind the underlying tooling (like vite) might have some windows popups themselves that Nx will inherit.

