### PR TITLE
fix(core): neverConnectToCloud should disable connecting to nxCloud

### DIFF
--- a/packages/nx/src/utils/nx-cloud-utils.ts
+++ b/packages/nx/src/utils/nx-cloud-utils.ts
@@ -1,12 +1,8 @@
 import { NxJsonConfiguration } from '../config/nx-json';
 
 export function isNxCloudUsed(nxJson: NxJsonConfiguration): boolean {
-  if (process.env.NX_NO_CLOUD === 'true') {
+  if (process.env.NX_NO_CLOUD === 'true' || nxJson.neverConnectToCloud) {
     return false;
-  }
-
-  if (nxJson.neverConnectToCloud) {
-    return true;
   }
 
   return (


### PR DESCRIPTION
closed #28482, #28486

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
If, `neverConnectToCloud` is set to `true`, there are still attempts made to connect to NxCloud.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
if, `neverConnectToCloud` is set to `true`, we should not attempt to connect to NxCloud.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
