### PR TITLE
dbName was null trying to connect. fixes issue #28424

### DIFF
--- a/packages/nx/src/utils/db-connection.ts
+++ b/packages/nx/src/utils/db-connection.ts
@@ -11,7 +11,8 @@ export function getDbConnection(
   } = {}
 ) {
   opts.directory ??= workspaceDataDirectory;
-  const key = `${opts.directory}:${opts.dbName ?? 'default'}`;
+  opts.dbName ??= 'default';
+  const key = `${opts.directory}:${opts.dbName}`;
   const connection = getEntryOrSet(dbConnectionMap, key, () =>
     connectToNxDb(opts.directory, NX_VERSION, opts.dbName)
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
If you try to run a 2nd process in parallel you get ...

NX disk I/O error

Error: disk I/O error
at /home/ken/dev/animalus/animalus/node_modules/nx/src/utils/db-connection.js:11:93
at getEntryOrSet (/home/ken/dev/animalus/animalus/node_modules/nx/src/utils/db-connection.js:19:17)
at getDbConnection (/home/ken/dev/animalus/animalus/node_modules/nx/src/utils/db-connection.js:11:24)
at getTaskDetails (/home/ken/dev/animalus/animalus/node_modules/nx/src/hasher/hash-task.js:19:84)
at invokeTasksRunner (/home/ken/dev/animalus/animalus/node_modules/nx/src/tasks-runner/run-command.js:367:56)
at runCommandForTasks (/home/ken/dev/animalus/animalus/node_modules/nx/src/tasks-runner/run-command.js:117:31)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async /home/ken/dev/animalus/animalus/node_modules/nx/src/tasks-runner/run-command.js:105:29
at async handleErrors (/home/ken/dev/animalus/animalus/node_modules/nx/src/utils/handle-errors.js:9:24)
at async runCommand (/home/ken/dev/animalus/animalus/node_modules/nx/src/tasks-runner/run-command.js:104:20)

## Expected Behavior
Ability to run a 2nd process in parallel

## Related Issue(s)
#28424 

Fixes #
