### PR TITLE
fix(module-federation): normalize hypen names for runtime library control plugin #28497

### DIFF
--- a/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -128,10 +128,12 @@ export async function* moduleFederationDevServerExecutor(
 
   // Set NX_MF_DEV_REMOTES for the Nx Runtime Library Control Plugin
   process.env.NX_MF_DEV_REMOTES = JSON.stringify([
-    ...(remotes.devRemotes.map((r) =>
-      typeof r === 'string' ? r : r.remoteName
-    ) ?? []),
-    project.name,
+    ...(
+      remotes.devRemotes.map((r) =>
+        typeof r === 'string' ? r : r.remoteName
+      ) ?? []
+    ).map((r) => r.replace(/-/g, '_')),
+    project.name.replace(/-/g, '_'),
   ]);
 
   const staticRemotesConfig = parseStaticRemotesConfig(

--- a/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -124,8 +124,12 @@ export async function* moduleFederationSsrDevServerExecutor(
 
   // Set NX_MF_DEV_REMOTES for the Nx Runtime Library Control Plugin
   process.env.NX_MF_DEV_REMOTES = JSON.stringify([
-    ...(options.devRemotes ?? []),
-    project.name,
+    ...(
+      options.devRemotes.map((r) =>
+        typeof r === 'string' ? r : r.remoteName
+      ) ?? []
+    ).map((r) => r.replace(/-/g, '_')),
+    project.name.replace(/-/g, '_'),
   ]);
 
   const devRemotes = await startRemotes(

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -229,10 +229,12 @@ export default async function* moduleFederationDevServer(
 
   // Set NX_MF_DEV_REMOTES for the Nx Runtime Library Control Plugin
   process.env.NX_MF_DEV_REMOTES = JSON.stringify([
-    ...(remotes.devRemotes.map((r) =>
-      typeof r === 'string' ? r : r.remoteName
-    ) ?? []),
-    p.name,
+    ...(
+      remotes.devRemotes.map((r) =>
+        typeof r === 'string' ? r : r.remoteName
+      ) ?? []
+    ).map((r) => r.replace(/-/g, '_')),
+    p.name.replace(/-/g, '_'),
   ]);
 
   const staticRemotesConfig = parseStaticRemotesConfig(

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -314,10 +314,12 @@ export default async function* moduleFederationSsrDevServer(
   options.staticRemotesPort ??= remotes.staticRemotePort;
 
   process.env.NX_MF_DEV_REMOTES = JSON.stringify([
-    ...(remotes.devRemotes.map((r) =>
-      typeof r === 'string' ? r : r.remoteName
-    ) ?? []),
-    projectConfig.name,
+    ...(
+      remotes.devRemotes.map((r) =>
+        typeof r === 'string' ? r : r.remoteName
+      ) ?? []
+    ).map((r) => r.replace(/-/g, '_')),
+    projectConfig.name.replace(/-/g, '_'),
   ]);
 
   const staticRemotesConfig = parseStaticSsrRemotesConfig(

--- a/packages/rspack/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -229,10 +229,12 @@ export default async function* moduleFederationDevServer(
 
   // Set NX_MF_DEV_REMOTES for the Nx Runtime Library Control Plugin
   process.env.NX_MF_DEV_REMOTES = JSON.stringify([
-    ...(remotes.devRemotes.map((r) =>
-      typeof r === 'string' ? r : r.remoteName
-    ) ?? []),
-    p.name,
+    ...(
+      remotes.devRemotes.map((r) =>
+        typeof r === 'string' ? r : r.remoteName
+      ) ?? []
+    ).map((r) => r.replace(/-/g, '_')),
+    p.name.replace(/-/g, '_'),
   ]);
 
   const staticRemotesConfig = parseStaticRemotesConfig(

--- a/packages/rspack/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -313,10 +313,12 @@ export default async function* moduleFederationSsrDevServer(
   options.staticRemotesPort ??= remotes.staticRemotePort;
 
   process.env.NX_MF_DEV_REMOTES = JSON.stringify([
-    ...(remotes.devRemotes.map((r) =>
-      typeof r === 'string' ? r : r.remoteName
-    ) ?? []),
-    projectConfig.name,
+    ...(
+      remotes.devRemotes.map((r) =>
+        typeof r === 'string' ? r : r.remoteName
+      ) ?? []
+    ).map((r) => r.replace(/-/g, '_')),
+    projectConfig.name.replace(/-/g, '_'),
   ]);
 
   const staticRemotesConfig = parseStaticSsrRemotesConfig(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
As part of the work to normalize `-` in MF project names for Federation, setting the NX_MF_DEV_REMOTES env var was missed.
This causes issues with the RuntimeLibraryControlPlugin


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Remote names should be normalized correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28497
