### PR TITLE
fix(react): ensure rspack react app is added to exclude on rspack plugin #28464

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1239,4 +1239,85 @@ describe('app', () => {
       }
     `);
   });
+
+  it('should add project to excludes when @nx/rspack/plugin is setup as object and --bundler=rspack', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    let nxJson = readNxJson(tree);
+    delete nxJson.targetDefaults;
+    nxJson.plugins ??= [];
+    nxJson.plugins.push({
+      plugin: '@nx/rspack/plugin',
+      options: {
+        buildTargetName: 'build-base',
+      },
+    });
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    await applicationGenerator(tree, {
+      directory: 'myapp',
+      addPlugin: true,
+      linter: Linter.None,
+      style: 'none',
+      bundler: 'rspack',
+      e2eTestRunner: 'none',
+    });
+
+    // ASSERT
+    nxJson = readNxJson(tree);
+    expect(
+      nxJson.plugins.find((p) =>
+        typeof p === 'string'
+          ? p === '@nx/rspack/plugin'
+          : p.plugin === '@nx/rspack/plugin'
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "exclude": [
+          "myapp/**",
+        ],
+        "options": {
+          "buildTargetName": "build-base",
+        },
+        "plugin": "@nx/rspack/plugin",
+      }
+    `);
+  });
+  it('should add project to excludes when @nx/rspack/plugin is setup as string and --bundler=rspack', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    let nxJson = readNxJson(tree);
+    delete nxJson.targetDefaults;
+    nxJson.plugins ??= [];
+    nxJson.plugins.push('@nx/rspack/plugin');
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    await applicationGenerator(tree, {
+      directory: 'myapp',
+      addPlugin: true,
+      linter: Linter.None,
+      style: 'none',
+      bundler: 'rspack',
+      e2eTestRunner: 'none',
+    });
+
+    // ASSERT
+    nxJson = readNxJson(tree);
+    expect(
+      nxJson.plugins.find((p) =>
+        typeof p === 'string'
+          ? p === '@nx/rspack/plugin'
+          : p.plugin === '@nx/rspack/plugin'
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "exclude": [
+          "myapp/**",
+        ],
+        "plugin": "@nx/rspack/plugin",
+      }
+    `);
+  });
 });

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -47,6 +47,7 @@ import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-com
 import { setupTailwindGenerator } from '../setup-tailwind/setup-tailwind';
 import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { addProjectRootToRspackPluginExcludesIfExists } from './lib/add-project-root-to-rspack-plugin-excludes';
 
 async function addLinting(host: Tree, options: NormalizedSchema) {
   const tasks: GeneratorCallback[] = [];
@@ -248,6 +249,7 @@ export async function applicationGeneratorInternal(
       framework: 'react',
     });
     tasks.push(rspackTask);
+    addProjectRootToRspackPluginExcludesIfExists(host, options.appProjectRoot);
   }
 
   if (options.bundler !== 'vite' && options.unitTestRunner === 'vitest') {

--- a/packages/react/src/generators/application/lib/add-project-root-to-rspack-plugin-excludes.ts
+++ b/packages/react/src/generators/application/lib/add-project-root-to-rspack-plugin-excludes.ts
@@ -1,0 +1,32 @@
+import { joinPathFragments, Tree, updateNxJson } from '@nx/devkit';
+import { readNxJson } from '@nx/devkit';
+
+export function addProjectRootToRspackPluginExcludesIfExists(
+  tree: Tree,
+  projectRoot: string
+) {
+  const excludeProjectGlob = joinPathFragments(projectRoot, '/**');
+  const nxJson = readNxJson(tree);
+  if (!nxJson.plugins?.length) {
+    return;
+  }
+  for (let i = 0; i < nxJson.plugins.length; i++) {
+    let plugin = nxJson.plugins[i];
+    const isRspackPlugin =
+      typeof plugin === 'string'
+        ? plugin === '@nx/rspack/plugin'
+        : plugin.plugin === '@nx/rspack/plugin';
+    if (isRspackPlugin) {
+      if (typeof plugin === 'string') {
+        plugin = {
+          plugin: plugin,
+          exclude: [excludeProjectGlob],
+        };
+      } else {
+        plugin.exclude = [...(plugin.exclude ?? []), excludeProjectGlob];
+      }
+      nxJson.plugins[i] = plugin;
+    }
+  }
+  updateNxJson(tree, nxJson);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When you create a react rspack app when there is a `@nx/rspack/plugin` definition in the nx.json, it causes the project graph to fail to create nodes.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the projects created via @nx/react:app --bundler=rspack are added to exclude array if the plugin exists

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28464
