### PR TITLE
feat(core): allow disabling of tsconfig path sorting in format:write and formatFiles()

### DIFF
--- a/docs/generated/cli/format-check.md
+++ b/docs/generated/cli/format-check.md
@@ -17,16 +17,17 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
-| Option            | Type    | Description                                                                                                                             |
-| ----------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all`           | boolean | Format all projects.                                                                                                                    |
-| `--base`          | string  | Base of the current branch (usually main).                                                                                              |
-| `--exclude`       | string  | Exclude certain projects from being processed.                                                                                          |
-| `--files`         | string  | Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces. |
-| `--head`          | string  | Latest commit of the current branch (usually HEAD).                                                                                     |
-| `--help`          | boolean | Show help.                                                                                                                              |
-| `--libs-and-apps` | boolean | Format only libraries and applications files.                                                                                           |
-| `--projects`      | string  | Projects to format (comma/space delimited).                                                                                             |
-| `--uncommitted`   | boolean | Uncommitted changes.                                                                                                                    |
-| `--untracked`     | boolean | Untracked changes.                                                                                                                      |
-| `--version`       | boolean | Show version number.                                                                                                                    |
+| Option                       | Type    | Description                                                                                                                                       |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all`                      | boolean | Format all projects.                                                                                                                              |
+| `--base`                     | string  | Base of the current branch (usually main).                                                                                                        |
+| `--exclude`                  | string  | Exclude certain projects from being processed.                                                                                                    |
+| `--files`                    | string  | Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces.           |
+| `--head`                     | string  | Latest commit of the current branch (usually HEAD).                                                                                               |
+| `--help`                     | boolean | Show help.                                                                                                                                        |
+| `--libs-and-apps`            | boolean | Format only libraries and applications files.                                                                                                     |
+| `--projects`                 | string  | Projects to format (comma/space delimited).                                                                                                       |
+| `--sort-root-tsconfig-paths` | boolean | Ensure the workspace's tsconfig compilerOptions.paths are sorted. Warning: This will cause comments in the tsconfig to be lost. (Default: `true`) |
+| `--uncommitted`              | boolean | Uncommitted changes.                                                                                                                              |
+| `--untracked`                | boolean | Untracked changes.                                                                                                                                |
+| `--version`                  | boolean | Show version number.                                                                                                                              |

--- a/docs/generated/cli/format-write.md
+++ b/docs/generated/cli/format-write.md
@@ -17,16 +17,17 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
-| Option            | Type    | Description                                                                                                                             |
-| ----------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all`           | boolean | Format all projects.                                                                                                                    |
-| `--base`          | string  | Base of the current branch (usually main).                                                                                              |
-| `--exclude`       | string  | Exclude certain projects from being processed.                                                                                          |
-| `--files`         | string  | Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces. |
-| `--head`          | string  | Latest commit of the current branch (usually HEAD).                                                                                     |
-| `--help`          | boolean | Show help.                                                                                                                              |
-| `--libs-and-apps` | boolean | Format only libraries and applications files.                                                                                           |
-| `--projects`      | string  | Projects to format (comma/space delimited).                                                                                             |
-| `--uncommitted`   | boolean | Uncommitted changes.                                                                                                                    |
-| `--untracked`     | boolean | Untracked changes.                                                                                                                      |
-| `--version`       | boolean | Show version number.                                                                                                                    |
+| Option                       | Type    | Description                                                                                                                                       |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all`                      | boolean | Format all projects.                                                                                                                              |
+| `--base`                     | string  | Base of the current branch (usually main).                                                                                                        |
+| `--exclude`                  | string  | Exclude certain projects from being processed.                                                                                                    |
+| `--files`                    | string  | Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces.           |
+| `--head`                     | string  | Latest commit of the current branch (usually HEAD).                                                                                               |
+| `--help`                     | boolean | Show help.                                                                                                                                        |
+| `--libs-and-apps`            | boolean | Format only libraries and applications files.                                                                                                     |
+| `--projects`                 | string  | Projects to format (comma/space delimited).                                                                                                       |
+| `--sort-root-tsconfig-paths` | boolean | Ensure the workspace's tsconfig compilerOptions.paths are sorted. Warning: This will cause comments in the tsconfig to be lost. (Default: `true`) |
+| `--uncommitted`              | boolean | Uncommitted changes.                                                                                                                              |
+| `--untracked`                | boolean | Untracked changes.                                                                                                                                |
+| `--version`                  | boolean | Show version number.                                                                                                                              |

--- a/docs/generated/devkit/formatFiles.md
+++ b/docs/generated/devkit/formatFiles.md
@@ -1,14 +1,15 @@
 # Function: formatFiles
 
-▸ **formatFiles**(`tree`): `Promise`\<`void`\>
+▸ **formatFiles**(`tree`, `sortRootTsConfigPaths?`): `Promise`\<`void`\>
 
 Formats all the created or updated files using Prettier
 
 #### Parameters
 
-| Name   | Type                                  | Description          |
-| :----- | :------------------------------------ | :------------------- |
-| `tree` | [`Tree`](../../devkit/documents/Tree) | the file system tree |
+| Name                     | Type                                  | Description                                                                                                                                                |
+| :----------------------- | :------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tree`                   | [`Tree`](../../devkit/documents/Tree) | the file system tree                                                                                                                                       |
+| `sortRootTsConfigPaths?` | `boolean`                             | TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important in Nx workspace setups, and the sorting causes comments to be lost. |
 
 #### Returns
 

--- a/docs/generated/devkit/formatFiles.md
+++ b/docs/generated/devkit/formatFiles.md
@@ -1,15 +1,16 @@
 # Function: formatFiles
 
-▸ **formatFiles**(`tree`, `sortRootTsConfigPaths?`): `Promise`\<`void`\>
+▸ **formatFiles**(`tree`, `options?`): `Promise`\<`void`\>
 
 Formats all the created or updated files using Prettier
 
 #### Parameters
 
-| Name                     | Type                                  | Description                                                                                                                                                |
-| :----------------------- | :------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tree`                   | [`Tree`](../../devkit/documents/Tree) | the file system tree                                                                                                                                       |
-| `sortRootTsConfigPaths?` | `boolean`                             | TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important in Nx workspace setups, and the sorting causes comments to be lost. |
+| Name                            | Type                                  | Description                                                                                                                                                |
+| :------------------------------ | :------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tree`                          | [`Tree`](../../devkit/documents/Tree) | the file system tree                                                                                                                                       |
+| `options?`                      | `Object`                              | -                                                                                                                                                          |
+| `options.sortRootTsConfigPaths` | `boolean`                             | TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important in Nx workspace setups, and the sorting causes comments to be lost. |
 
 #### Returns
 

--- a/docs/generated/devkit/formatFiles.md
+++ b/docs/generated/devkit/formatFiles.md
@@ -10,7 +10,7 @@ Formats all the created or updated files using Prettier
 | :------------------------------ | :------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tree`                          | [`Tree`](../../devkit/documents/Tree) | the file system tree                                                                                                                                       |
 | `options?`                      | `Object`                              | -                                                                                                                                                          |
-| `options.sortRootTsConfigPaths` | `boolean`                             | TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important in Nx workspace setups, and the sorting causes comments to be lost. |
+| `options.sortRootTsconfigPaths` | `boolean`                             | TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important in Nx workspace setups, and the sorting causes comments to be lost. |
 
 #### Returns
 

--- a/docs/generated/packages/nx/documents/format-check.md
+++ b/docs/generated/packages/nx/documents/format-check.md
@@ -17,16 +17,17 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
-| Option            | Type    | Description                                                                                                                             |
-| ----------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all`           | boolean | Format all projects.                                                                                                                    |
-| `--base`          | string  | Base of the current branch (usually main).                                                                                              |
-| `--exclude`       | string  | Exclude certain projects from being processed.                                                                                          |
-| `--files`         | string  | Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces. |
-| `--head`          | string  | Latest commit of the current branch (usually HEAD).                                                                                     |
-| `--help`          | boolean | Show help.                                                                                                                              |
-| `--libs-and-apps` | boolean | Format only libraries and applications files.                                                                                           |
-| `--projects`      | string  | Projects to format (comma/space delimited).                                                                                             |
-| `--uncommitted`   | boolean | Uncommitted changes.                                                                                                                    |
-| `--untracked`     | boolean | Untracked changes.                                                                                                                      |
-| `--version`       | boolean | Show version number.                                                                                                                    |
+| Option                       | Type    | Description                                                                                                                                       |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all`                      | boolean | Format all projects.                                                                                                                              |
+| `--base`                     | string  | Base of the current branch (usually main).                                                                                                        |
+| `--exclude`                  | string  | Exclude certain projects from being processed.                                                                                                    |
+| `--files`                    | string  | Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces.           |
+| `--head`                     | string  | Latest commit of the current branch (usually HEAD).                                                                                               |
+| `--help`                     | boolean | Show help.                                                                                                                                        |
+| `--libs-and-apps`            | boolean | Format only libraries and applications files.                                                                                                     |
+| `--projects`                 | string  | Projects to format (comma/space delimited).                                                                                                       |
+| `--sort-root-tsconfig-paths` | boolean | Ensure the workspace's tsconfig compilerOptions.paths are sorted. Warning: This will cause comments in the tsconfig to be lost. (Default: `true`) |
+| `--uncommitted`              | boolean | Uncommitted changes.                                                                                                                              |
+| `--untracked`                | boolean | Untracked changes.                                                                                                                                |
+| `--version`                  | boolean | Show version number.                                                                                                                              |

--- a/docs/generated/packages/nx/documents/format-write.md
+++ b/docs/generated/packages/nx/documents/format-write.md
@@ -17,16 +17,17 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
-| Option            | Type    | Description                                                                                                                             |
-| ----------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all`           | boolean | Format all projects.                                                                                                                    |
-| `--base`          | string  | Base of the current branch (usually main).                                                                                              |
-| `--exclude`       | string  | Exclude certain projects from being processed.                                                                                          |
-| `--files`         | string  | Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces. |
-| `--head`          | string  | Latest commit of the current branch (usually HEAD).                                                                                     |
-| `--help`          | boolean | Show help.                                                                                                                              |
-| `--libs-and-apps` | boolean | Format only libraries and applications files.                                                                                           |
-| `--projects`      | string  | Projects to format (comma/space delimited).                                                                                             |
-| `--uncommitted`   | boolean | Uncommitted changes.                                                                                                                    |
-| `--untracked`     | boolean | Untracked changes.                                                                                                                      |
-| `--version`       | boolean | Show version number.                                                                                                                    |
+| Option                       | Type    | Description                                                                                                                                       |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all`                      | boolean | Format all projects.                                                                                                                              |
+| `--base`                     | string  | Base of the current branch (usually main).                                                                                                        |
+| `--exclude`                  | string  | Exclude certain projects from being processed.                                                                                                    |
+| `--files`                    | string  | Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces.           |
+| `--head`                     | string  | Latest commit of the current branch (usually HEAD).                                                                                               |
+| `--help`                     | boolean | Show help.                                                                                                                                        |
+| `--libs-and-apps`            | boolean | Format only libraries and applications files.                                                                                                     |
+| `--projects`                 | string  | Projects to format (comma/space delimited).                                                                                                       |
+| `--sort-root-tsconfig-paths` | boolean | Ensure the workspace's tsconfig compilerOptions.paths are sorted. Warning: This will cause comments in the tsconfig to be lost. (Default: `true`) |
+| `--uncommitted`              | boolean | Uncommitted changes.                                                                                                                              |
+| `--untracked`                | boolean | Untracked changes.                                                                                                                                |
+| `--version`                  | boolean | Show version number.                                                                                                                              |

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -10,18 +10,20 @@ import { sortObjectByKeys } from 'nx/src/devkit-internals';
  */
 export async function formatFiles(
   tree: Tree,
-  /**
-   * TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important
-   * in Nx workspace setups, and the sorting causes comments to be lost.
-   */
-  sortRootTsConfigPaths = true
+  options = {
+    /**
+     * TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important
+     * in Nx workspace setups, and the sorting causes comments to be lost.
+     */
+    sortRootTsConfigPaths: true,
+  }
 ): Promise<void> {
   let prettier: typeof Prettier;
   try {
     prettier = await import('prettier');
   } catch {}
 
-  if (sortRootTsConfigPaths) {
+  if (options.sortRootTsConfigPaths) {
     sortTsConfig(tree);
   }
 

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -15,7 +15,7 @@ export async function formatFiles(
      * TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important
      * in Nx workspace setups, and the sorting causes comments to be lost.
      */
-    sortRootTsConfigPaths: true,
+    sortRootTsconfigPaths: true,
   }
 ): Promise<void> {
   let prettier: typeof Prettier;
@@ -23,7 +23,7 @@ export async function formatFiles(
     prettier = await import('prettier');
   } catch {}
 
-  if (options.sortRootTsConfigPaths) {
+  if (options.sortRootTsconfigPaths) {
     sortTsConfig(tree);
   }
 

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -8,13 +8,22 @@ import { sortObjectByKeys } from 'nx/src/devkit-internals';
  * Formats all the created or updated files using Prettier
  * @param tree - the file system tree
  */
-export async function formatFiles(tree: Tree): Promise<void> {
+export async function formatFiles(
+  tree: Tree,
+  /**
+   * TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important
+   * in Nx workspace setups, and the sorting causes comments to be lost.
+   */
+  sortRootTsConfigPaths = true
+): Promise<void> {
   let prettier: typeof Prettier;
   try {
     prettier = await import('prettier');
   } catch {}
 
-  sortTsConfig(tree);
+  if (sortRootTsConfigPaths) {
+    sortTsConfig(tree);
+  }
 
   if (!prettier) return;
 

--- a/packages/nx/src/command-line/format/command-object.ts
+++ b/packages/nx/src/command-line/format/command-object.ts
@@ -39,6 +39,15 @@ function withFormatOptions(yargs: Argv): Argv {
       type: 'string',
       coerce: parseCSV,
     })
+    .option('sort-root-tsconfig-paths', {
+      describe: `Ensure the workspace's tsconfig compilerOptions.paths are sorted. Warning: This will cause comments in the tsconfig to be lost.`,
+      type: 'boolean',
+      /**
+       * TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important
+       * in Nx workspace setups, and the sorting causes comments to be lost.
+       */
+      default: true,
+    })
     .option('all', {
       describe: 'Format all projects.',
       type: 'boolean',

--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -60,7 +60,9 @@ export async function format(
 
   switch (command) {
     case 'write':
-      sortTsConfig();
+      if (nxArgs.sortRootTsConfigPaths) {
+        sortTsConfig();
+      }
       addRootConfigFiles(chunkList, nxArgs);
       chunkList.forEach((chunk) => write(chunk));
       break;

--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -60,7 +60,7 @@ export async function format(
 
   switch (command) {
     case 'write':
-      if (nxArgs.sortRootTsConfigPaths) {
+      if (nxArgs.sortRootTsconfigPaths) {
         sortTsConfig();
       }
       addRootConfigFiles(chunkList, nxArgs);

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -41,6 +41,7 @@ export interface NxArgs {
   batch?: boolean;
   excludeTaskDependencies?: boolean;
   skipSync?: boolean;
+  sortRootTsConfigPaths?: boolean;
 }
 
 export function createOverrides(__overrides_unparsed__: string[] = []) {

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -41,7 +41,7 @@ export interface NxArgs {
   batch?: boolean;
   excludeTaskDependencies?: boolean;
   skipSync?: boolean;
-  sortRootTsConfigPaths?: boolean;
+  sortRootTsconfigPaths?: boolean;
 }
 
 export function createOverrides(__overrides_unparsed__: string[] = []) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

There is no way to prevent `nx format:write` or `formatFiles(...)` from sorting tsconfig compilerOptions.paths.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

You can set `nx format:write --sort-root-tsconfig-paths=false` and `await formatFiles(tree, { sortRootTsconfigPaths: false })` to disable the sorting of tsconfig compilerOptions.paths as part of formatting.

⚠️ NOTE: Because we cannot change the current default behaviour, to be able to get the desired outcome via Nx's own generators that call `formatFiles` behind the scenes, the flow for now should be to call the respective generator (such as `@nx/js:library` with `--skip-format` and then run `nx format:write --sort-root-tsconfig-paths=false`, e.g.

```sh
nx g @nx/js:lib --skip-format
nx format:write --sort-root-tsconfig-paths=false
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28484
