### PR TITLE
fix(webpack): removing cleanuptranspiler to fix custom webpack builds

### DIFF
--- a/packages/webpack/src/utils/webpack/custom-webpack.ts
+++ b/packages/webpack/src/utils/webpack/custom-webpack.ts
@@ -1,4 +1,4 @@
-import { registerTsProject } from '@nx/js/src/internal';
+import { tsNodeRegister } from '@nx/js/src/utils/typescript/tsnode-register';
 
 export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
   // Don't transpile non-TS files. This prevents workspaces libs from being registered via tsconfig-paths.
@@ -7,10 +7,9 @@ export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
     return require(path);
   }
 
-  const cleanupTranspiler = registerTsProject(tsConfig);
-  const maybeCustomWebpackConfig = require(path);
-  cleanupTranspiler();
+  tsNodeRegister(path, tsConfig);
 
+  const maybeCustomWebpackConfig = require(path);
   // If the user provides a configuration in TS file
   // then there are 3 cases for exporing an object. The first one is:
   // `module.exports = { ... }`. And the second one is:

--- a/packages/webpack/src/utils/webpack/custom-webpack.ts
+++ b/packages/webpack/src/utils/webpack/custom-webpack.ts
@@ -1,4 +1,4 @@
-import { tsNodeRegister } from '@nx/js/src/utils/typescript/tsnode-register';
+import { registerTsProject } from '@nx/js/src/internal';
 
 export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
   // Don't transpile non-TS files. This prevents workspaces libs from being registered via tsconfig-paths.
@@ -7,9 +7,9 @@ export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
     return require(path);
   }
 
-  tsNodeRegister(path, tsConfig);
-
+  registerTsProject(tsConfig);
   const maybeCustomWebpackConfig = require(path);
+
   // If the user provides a configuration in TS file
   // then there are 3 cases for exporing an object. The first one is:
   // `module.exports = { ... }`. And the second one is:


### PR DESCRIPTION
closed #28016, #26329

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Builds that use custom webpack configuration to load ts files fail

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Builds that use custom webpack configurations to load ts files should run successfully

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

#28016, #26329
