### PR TITLE
fix(js): include referenced internal config files in plugin cache hash

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -173,18 +173,25 @@ async function createNodesInternal(
    * - hashes of the content of the relevant files that can affect what's inferred by the plugin:
    *   - current config file
    *   - config files extended by the current config file (recursively up to the root config file)
+   *   - referenced config files that are internal to the owning Nx project of the current config file
    *   - lock file
    * - hash of the plugin options
    * - current config file path
    */
-  const extendedConfigFiles = getExtendedConfigFiles(
-    fullConfigPath,
-    readCachedTsConfig(fullConfigPath)
+  const tsConfig = readCachedTsConfig(fullConfigPath);
+  const extendedConfigFiles = getExtendedConfigFiles(fullConfigPath, tsConfig);
+  const internalReferencedFiles = resolveInternalProjectReferences(
+    tsConfig,
+    context.workspaceRoot,
+    projectRoot
   );
   const nodeHash = hashArray([
-    ...[configFilePath, ...extendedConfigFiles.files, lockFileName].map(
-      hashFile
-    ),
+    ...[
+      configFilePath,
+      ...extendedConfigFiles.files,
+      ...Object.keys(internalReferencedFiles),
+      lockFileName,
+    ].map(hashFile),
     hashObject(options),
   ]);
   const cacheKey = `${nodeHash}_${configFilePath}`;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The referenced internal config files are not considered by the `@nx/js/typescript` plugin when building its cache key. This results in changes to those files being ignored and the cache being wrongly reused.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The referenced internal config files should be part of the `@nx/js/typescript` plugin cache key.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
