### PR TITLE
chore(nx-dev): ignore anchors on changelog page

### DIFF
--- a/docs/blog/2024-10-03-nx-20-release.md
+++ b/docs/blog/2024-10-03-nx-20-release.md
@@ -76,7 +76,7 @@ This is where the concept of derived directories comes in. It will try to inspec
 
 There's a lot more in Nx 20, so be sure to check the full changelog for all the details on everything in this major release.
 
-- [Nx 20 Changelog](/changelog)
+- [Nx 20 Changelog](/changelog#20.0.0)
 
 [rspack]: https://rspack.dev
 [rescope]: /deprecated/rescope

--- a/scripts/documentation/internal-link-checker.ts
+++ b/scripts/documentation/internal-link-checker.ts
@@ -148,6 +148,7 @@ const ignoreAnchorUrls = [
   '/blog',
   '/pricing',
   '/ci/reference',
+  '/changelog',
   '/conf',
 ];
 


### PR DESCRIPTION
Do not check anchor links pointing to the changelog page