### PR TITLE
fix(core): createTaskGraph should accept extraTargetDependencies

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -44,13 +44,9 @@ import {
   createProjectGraphAsync,
   handleProjectGraphError,
 } from '../../project-graph/project-graph';
-import {
-  createTaskGraph,
-  mapTargetDefaultsToDependencies,
-} from '../../tasks-runner/create-task-graph';
+import { createTaskGraph } from '../../tasks-runner/create-task-graph';
 import { allFileData } from '../../utils/all-file-data';
 import { splitArgsIntoNxArgsAndOverrides } from '../../utils/command-line-utils';
-import { NxJsonConfiguration } from '../../config/nx-json';
 import { HashPlanner, transferProjectGraph } from '../../native';
 import { transformProjectGraphForRust } from '../../native/transform-objects';
 import { getAffectedGraphNodes } from '../affected/affected';
@@ -887,7 +883,7 @@ async function createTaskGraphClientResponse(
   const nxJson = readNxJson();
 
   performance.mark('task graph generation:start');
-  const taskGraphs = getAllTaskGraphsForWorkspace(nxJson, graph);
+  const taskGraphs = getAllTaskGraphsForWorkspace(graph);
   performance.mark('task graph generation:end');
 
   const planner = new HashPlanner(
@@ -957,17 +953,10 @@ async function createExpandedTaskInputResponse(
   return response;
 }
 
-function getAllTaskGraphsForWorkspace(
-  nxJson: NxJsonConfiguration,
-  projectGraph: ProjectGraph
-): {
+function getAllTaskGraphsForWorkspace(projectGraph: ProjectGraph): {
   taskGraphs: Record<string, TaskGraph>;
   errors: Record<string, string>;
 } {
-  const defaultDependencyConfigs = mapTargetDefaultsToDependencies(
-    nxJson.targetDefaults
-  );
-
   const taskGraphs: Record<string, TaskGraph> = {};
   const taskGraphErrors: Record<string, string> = {};
 
@@ -981,7 +970,7 @@ function getAllTaskGraphsForWorkspace(
       try {
         taskGraphs[taskId] = createTaskGraph(
           projectGraph,
-          defaultDependencyConfigs,
+          {},
           [projectName],
           [target],
           undefined,
@@ -1007,7 +996,7 @@ function getAllTaskGraphsForWorkspace(
           try {
             taskGraphs[taskId] = createTaskGraph(
               projectGraph,
-              defaultDependencyConfigs,
+              {},
               [projectName],
               [target],
               configuration,
@@ -1221,15 +1210,9 @@ async function createJsonOutput(
   };
 
   if (targets?.length) {
-    const nxJson = readNxJson();
-
-    const defaultDependencyConfigs = mapTargetDefaultsToDependencies(
-      nxJson.targetDefaults
-    );
-
     const taskGraph = createTaskGraph(
       rawGraph,
-      defaultDependencyConfigs,
+      {},
       projects,
       targets,
       undefined,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

this pr is a follow up to https://github.com/nrwl/nx/pull/26033.
for function `createTaskGraph`, it should not accept `defaultDependencyConfigs`, it should be `extraTargetDependencies`.

## Current Behavior
<!-- This is the behavior we have today -->
this caused an issue where the task graph shows that 2 tasks depend on each other; however, when actually running, it does not.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/26929
