### PR TITLE
cleanup(linter): remove unused basePath parameter

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -337,8 +337,7 @@ export default ESLintUtils.RuleCreator(
                   for (const importMember of imports) {
                     const importPath = getRelativeImportPath(
                       importMember,
-                      join(workspaceRoot, entryPointPath.path),
-                      sourceProject.data.sourceRoot
+                      join(workspaceRoot, entryPointPath.path)
                     );
                     // we cannot remap, so leave it as is
                     if (importPath) {
@@ -444,8 +443,7 @@ export default ESLintUtils.RuleCreator(
                   for (const importMember of imports) {
                     const importPath = getRelativeImportPath(
                       importMember,
-                      join(workspaceRoot, entryPointPath),
-                      sourceProject.data.sourceRoot
+                      join(workspaceRoot, entryPointPath)
                     );
                     if (importPath) {
                       // resolve the import path

--- a/packages/eslint-plugin/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin/src/utils/ast-utils.ts
@@ -108,7 +108,7 @@ function hasMemberExport(exportedMember, filePath) {
   );
 }
 
-export function getRelativeImportPath(exportedMember, filePath, basePath) {
+export function getRelativeImportPath(exportedMember, filePath) {
   const status = lstatSync(filePath, {
     throwIfNoEntry: false,
   });
@@ -273,8 +273,7 @@ export function getRelativeImportPath(exportedMember, filePath, basePath) {
       if (hasMemberExport(exportedMember, moduleFilePath)) {
         const foundFilePath = getRelativeImportPath(
           exportedMember,
-          moduleFilePath,
-          basePath
+          moduleFilePath
         );
         if (foundFilePath) {
           return foundFilePath;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

I was looking at the source to understand how `sourceRoot` is used and saw it was referenced in the eslint-plugin but it turns out it isn't actually used

## Current Behavior

This parameter isn't used

## Expected Behavior

The parameter should be removed
