### PR TITLE
fix(core): not to cache entire workspace root

### DIFF
--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -52,7 +52,12 @@ where
         .filter_map(move |entry| {
             entry
                 .ok()
-                .and_then(|e| e.path().strip_prefix(&base_dir).ok().map(|p| p.to_owned()))
+                .and_then(|e|
+                    e.path()
+                    .strip_prefix(&base_dir).ok()
+                    .filter(|p| !p.to_string_lossy().is_empty())
+                    .map(|p| p.to_owned())
+                )
         })
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
- if directory is workspace root, when walking through the directory, it will include the directory root path, then will strip prefix, it will be empty string. it will return "*" as a found path.
- When copying "*", it will run into a recursive loop because it will try to copy the walkspace root with node_modules into node_modules/.cache/nx

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/28393
