### PR TITLE
feat(testing): allow setting `testProject` on playwright executor

### DIFF
--- a/docs/generated/packages/playwright/executors/playwright.json
+++ b/docs/generated/packages/playwright/executors/playwright.json
@@ -56,6 +56,10 @@
         "description": "Test files to run",
         "items": { "type": "string" }
       },
+      "testProject": {
+        "type": "string",
+        "description": "Playwright TestProject to use for running tests"
+      },
       "headed": {
         "type": "boolean",
         "description": "Run tests in headed browsers",

--- a/packages/playwright/src/executors/playwright/playwright.impl.ts
+++ b/packages/playwright/src/executors/playwright/playwright.impl.ts
@@ -22,6 +22,7 @@ export interface PlaywrightExecutorSchema {
   globalTimeout?: number;
   grepInvert?: string;
   testFiles?: string[];
+  testProject?: string[];
   headed?: boolean;
   ignoreSnapshots?: boolean;
   workers?: number | string;
@@ -85,6 +86,10 @@ export async function playwrightExecutor(
     });
   }
 
+  if (options.testProject) {
+    options.project = options.testProject;
+  }
+
   const args = createArgs(options);
   const p = runPlaywright(args, context.root);
   p.stdout.on('data', (message) => {
@@ -103,7 +108,7 @@ export async function playwrightExecutor(
 
 function createArgs(
   opts: PlaywrightExecutorSchema,
-  exclude: string[] = ['skipInstall']
+  exclude: string[] = ['skipInstall', 'testProject']
 ): string[] {
   const args: string[] = [];
 

--- a/packages/playwright/src/executors/playwright/schema.json
+++ b/packages/playwright/src/executors/playwright/schema.json
@@ -55,6 +55,10 @@
         "type": "string"
       }
     },
+    "testProject": {
+      "type": "string",
+      "description": "Playwright TestProject to use for running tests"
+    },
     "headed": {
       "type": "boolean",
       "description": "Run tests in headed browsers",


### PR DESCRIPTION
`testProject` is a workaround that allows setting the --project option of Playwright to run the tests on a specific Playwright project configuration. Naming chosen to align with the Playwright documentation of "TestProject".
As a side effect, this also allows passing the project as a `project.json` or `nx.json` option when running `nx affected`.

closed #28543

## Current Behavior
Current recommendation
`npx nx run appl:e2e --test-files=apps/appl/playwright/e2e --skip-install -- --project=chromium`
Ignores `--test-files` and `--skip-install` option.

## Expected Behavior
`npx nx run appl:e2e --test-files=apps/appl/playwright/e2e --skip-install --test-project=chromium`
does not ignore any option and allows setting a specific Playwright project to run tests on.

## Related Issue(s)
https://github.com/nrwl/nx/issues/28543


Fixes #28543
