### PR TITLE
feat(core): add eslint vscode extension on eslint init

### DIFF
--- a/packages/eslint/src/generators/init/init.spec.ts
+++ b/packages/eslint/src/generators/init/init.spec.ts
@@ -1,6 +1,12 @@
 import 'nx/src/internal-testing-utils/mock-project-graph';
 
-import { NxJsonConfiguration, readJson, Tree, updateJson } from '@nx/devkit';
+import {
+  NxJsonConfiguration,
+  readJson,
+  Tree,
+  updateJson,
+  writeJson,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { LinterInitOptions, lintInitGenerator } from './init';
 import { setWorkspaceRoot } from 'nx/src/utils/workspace-root';
@@ -70,6 +76,28 @@ describe('@nx/eslint:init', () => {
           "plugin": "@nx/eslint/plugin",
         },
       ]
+    `);
+  });
+
+  it('should add the eslint extension to the recommended property', async () => {
+    writeJson(tree, '.vscode/extensions.json', {
+      recommendations: [
+        'nrwl.angular-console',
+        'angular.ng-template',
+        'esbenp.prettier-vscode',
+      ],
+    });
+
+    await lintInitGenerator(tree, options);
+    expect(readJson(tree, '.vscode/extensions.json')).toMatchInlineSnapshot(`
+      {
+        "recommendations": [
+          "nrwl.angular-console",
+          "angular.ng-template",
+          "esbenp.prettier-vscode",
+          "dbaeumer.vscode-eslint",
+        ],
+      }
     `);
   });
 

--- a/packages/eslint/src/generators/init/init.ts
+++ b/packages/eslint/src/generators/init/init.ts
@@ -6,6 +6,7 @@ import {
   removeDependenciesFromPackageJson,
   runTasksInSerial,
   Tree,
+  updateJson,
   updateNxJson,
 } from '@nx/devkit';
 import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
@@ -47,6 +48,21 @@ function addTargetDefaults(tree: Tree) {
     `{workspaceRoot}/eslint.config.js`,
   ];
   updateNxJson(tree, nxJson);
+}
+
+function updateVsCodeRecommendedExtensions(host: Tree) {
+  if (!host.exists('.vscode/extensions.json')) {
+    return;
+  }
+
+  updateJson(host, '.vscode/extensions.json', (json) => {
+    json.recommendations = json.recommendations || [];
+    const extension = 'dbaeumer.vscode-eslint';
+    if (!json.recommendations.includes(extension)) {
+      json.recommendations.push(extension);
+    }
+    return json;
+  });
 }
 
 export async function initEsLint(
@@ -92,6 +108,8 @@ export async function initEsLint(
   }
 
   updateProductionFileset(tree);
+
+  updateVsCodeRecommendedExtensions(tree);
 
   if (options.addPlugin) {
     await addPlugin(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
when create fresh angular or react integrated project no eslint extension out of the box. Few years ago I fill the issue https://github.com/nrwl/nx/issues/7047 about deprecated tslint extension looks like that has been deleted but without change to eslint extension
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
when I create angular / react  project eslint extension should be added to recommended vscode extensions
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
