### PR TITLE
fix(nextjs): add next.config.ts as valid config file

### DIFF
--- a/docs/shared/packages/next/plugin-overview.md
+++ b/docs/shared/packages/next/plugin-overview.md
@@ -60,6 +60,7 @@ The `@nx/next` plugin will create tasks for any project that has a Next.js confi
 - `next.config.js`
 - `next.config.cjs`
 - `next.config.mjs`
+- `next.config.ts`
 
 ### View Inferred Tasks
 

--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -155,7 +155,12 @@ export function findNextConfigPath(
     );
   }
 
-  const candidates = ['next.config.js', 'next.config.cjs', 'next.config.mjs'];
+  const candidates = [
+    'next.config.js',
+    'next.config.cjs',
+    'next.config.mjs',
+    'next.config.ts',
+  ];
   for (const candidate of candidates) {
     if (existsSync(join(dirname, candidate))) return candidate;
   }

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -29,7 +29,7 @@ export interface NextPluginOptions {
   serveStaticTargetName?: string;
 }
 
-const nextConfigBlob = '**/next.config.{js,cjs,mjs}';
+const nextConfigBlob = '**/next.config.{js,cjs,mjs,ts}';
 
 function readTargetsCache(
   cachePath: string


### PR DESCRIPTION
closed #28572

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Executing an application with a next.config.ts file instead of next.config.{js,mjs,cjs} results in an error:  NX   Cannot find configuration for task template-app:dev. To clarify, not having `.ts` in the list of valid config file extensions renders the `@nx/next plugin` **unusable** from an executor point-of-view.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

As of https://github.com/vercel/next.js/pull/63051#issue-2176289774, Next.js now supports next.config.ts configuration files. See additional information below for resolution.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28572
