### PR TITLE
fix(core): Fixed command line expansion of args on generators

### DIFF
--- a/packages/nx/src/command-line/generate/command-object.spec.ts
+++ b/packages/nx/src/command-line/generate/command-object.spec.ts
@@ -1,0 +1,35 @@
+import * as yargs from 'yargs';
+
+import { withGenerateOptions } from './command-object';
+
+const argv = yargs.default([]);
+
+describe('command-object', () => {
+  describe('yargsGenerateCommand', () => {
+    const command = withGenerateOptions(argv);
+
+    it('should parse files to array', () => {
+      const result = command.parseSync([
+        'affected',
+        '--files',
+        'file1',
+        '--files',
+        'file2',
+        '--tag',
+        '81919e4',
+        '--parallel',
+        '3',
+        '--maxParallel',
+        '2',
+      ]);
+      expect(result).toEqual(
+        expect.objectContaining({
+          _: ['affected', '--tag', '81919e4'],
+          files: ['file1', 'file2'],
+          parallel: '3',
+          maxParallel: 2,
+        })
+      );
+    });
+  });
+});

--- a/packages/nx/src/command-line/generate/command-object.ts
+++ b/packages/nx/src/command-line/generate/command-object.ts
@@ -1,7 +1,6 @@
 import { CommandModule, Argv } from 'yargs';
 import { getCwd } from '../../utils/path';
-import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
-import { withVerbose } from '../yargs-utils/shared-options';
+import { defaultYargsParserConfiguration, withVerbose } from '../yargs-utils/shared-options';
 
 export const yargsGenerateCommand: CommandModule = {
   command: 'generate <generator> [_..]',
@@ -17,10 +16,11 @@ export const yargsGenerateCommand: CommandModule = {
   },
 };
 
-function withGenerateOptions(yargs: Argv) {
+export function withGenerateOptions(yargs: Argv) {
   const generatorWillShowHelp =
     process.argv[3] && !process.argv[3].startsWith('-');
   const res = withVerbose(yargs)
+    .parserConfiguration(defaultYargsParserConfiguration)
     .positional('generator', {
       describe: 'Name of the generator (e.g., @nx/js:library, library).',
       type: 'string',


### PR DESCRIPTION
## Current Behavior

Scientific notation, hex and numbers can cause validation problems for generators.

--tag 81919e4 gets expanded to --tag 819190000

And other scenarios where generators take a string, but it happens to be a number it will get coerced which is not intended.

## Expected Behavior

Should be able to pass numbers, hex and scientific notion to generators without it being expanded.

## Related Issue(s)

This PR is just extending the fix in this PR to generators.

https://github.com/nrwl/nx/pull/27515
