### PR TITLE
docs(module-federation): remote schema should show updated regex for names #28558

### DIFF
--- a/docs/generated/packages/angular/generators/remote.json
+++ b/docs/generated/packages/angular/generators/remote.json
@@ -24,7 +24,7 @@
       "name": {
         "type": "string",
         "description": "The name to give to the remote Angular app.",
-        "pattern": "^[a-zA-Z][^:]*$",
+        "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
         "x-priority": "important"
       },
       "host": {

--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -19,7 +19,7 @@
       "name": {
         "type": "string",
         "description": "The name of the remote application to generate the Module Federation configuration",
-        "pattern": "^[a-zA-Z][^:]*$",
+        "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
         "x-priority": "important"
       },
       "dynamic": {

--- a/packages/angular/src/generators/remote/schema.json
+++ b/packages/angular/src/generators/remote/schema.json
@@ -24,7 +24,7 @@
     "name": {
       "type": "string",
       "description": "The name to give to the remote Angular app.",
-      "pattern": "^[a-zA-Z][^:]*$",
+      "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
       "x-priority": "important"
     },
     "host": {

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -19,7 +19,7 @@
     "name": {
       "type": "string",
       "description": "The name of the remote application to generate the Module Federation configuration",
-      "pattern": "^[a-zA-Z][^:]*$",
+      "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
       "x-priority": "important"
     },
     "dynamic": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Docs show incorrect regex pattern for valid MF remote names

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Docs show correct regex pattern for valid MF remote names

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28558
