### PR TITLE
fix(core): skip eslint custom hasher when hashing tasks during running commands

### DIFF
--- a/packages/eslint/src/executors/lint/hasher.ts
+++ b/packages/eslint/src/executors/lint/hasher.ts
@@ -50,13 +50,15 @@ export default async function run(
       hashes.push(res.details.nodes[d]);
     }
   }
-  return {
+  const hashResult = {
     value: hashArray([command, selfSource, ...hashes, tags]),
     details: {
       command,
       nodes: { [task.target.project]: selfSource, tags, ...nodes },
     },
   };
+  hashResult['name'] = 'eslint-hasher';
+  return hashResult;
 }
 
 function allDeps(

--- a/packages/nx/src/hasher/hash-task.ts
+++ b/packages/nx/src/hasher/hash-task.ts
@@ -41,7 +41,7 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
   const tasksToHash = tasksWithHashers
     .filter(({ task, customHasher }) => {
       // If a task has a custom hasher, it might depend on the outputs of other tasks
-      if (customHasher) {
+      if (customHasher && customHasher.name !== 'eslint-hasher') {
         return false;
       }
 


### PR DESCRIPTION
This PR changes run commands such that the custom eslint hasher is skipped. This prevents Nx Cloud from spending time orchestrating cache hits for lint.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
