### PR TITLE
fix: add required minimizer setting to the generated Nest rspack conf…

### DIFF
--- a/packages/rspack/src/utils/generator-utils.ts
+++ b/packages/rspack/src/utils/generator-utils.ts
@@ -277,8 +277,28 @@ function createConfig(
   } else if (options.framework === 'nest') {
     return `
     const { composePlugins, withNx } = require('@nx/rspack');
+    const rspack = require('@rspack/core');
 
     module.exports = composePlugins(withNx(), (config) => {
+      config.optimization = {
+        minimizer: [
+          new rspack.SwcJsMinimizerRspackPlugin({
+            minimizerOptions: {
+              // We need to disable mangling and compression for class names and function names for Nest.js to work properly
+              // The execution context class returns a reference to the class/handler function, which is for example used for applying metadata using decorators
+              // https://docs.nestjs.com/fundamentals/execution-context#executioncontext-class
+              compress: {
+                keep_classnames: true,
+                keep_fnames: true,
+              },
+              mangle: {
+                keep_classnames: true,
+                keep_fnames: true,
+              },
+            },
+          }),
+        ],
+      };
       return config;
     });
     `;


### PR DESCRIPTION
## Current Behavior
When using Nest.js in combination with [decorator metadata](https://docs.nestjs.com/fundamentals/execution-context#reflection-and-metadata), the class names and handlers become mangled/compressed causing them to lose the reference to the correct class/handler name.

## Expected Behavior
The decorator metadata works as intended.

## Approach
This PR implements a custom instance of the `SwcJsMinimizerRspackPlugin`, where the setting is modified to keep original class and function names from the `compress` and `mangle` options.

## Related
I've opened a related PR on the rspack-examples repository: https://github.com/rspack-contrib/rspack-examples/pull/158
