### PR TITLE
fix(react): selecting tailwind should import correct style file extension

### DIFF
--- a/packages/react/src/generators/application/files/style-tailwind/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/style-tailwind/src/app/__fileName__.tsx__tmpl__
@@ -2,8 +2,6 @@
 import { Component } from 'react';
 <% } if (!minimal) { %>
 import NxWelcome from "./nx-welcome";
-<% } if (bundler === "rspack") { %>
-import '../styles.css';
 <% } %>
 
 <% if (classComponent) { %>

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -63,6 +63,7 @@ export async function createApplicationFiles(
     offsetFromRoot: offsetFromRoot(options.appProjectRoot),
     appTests,
     inSourceVitestTests: getInSourceVitestTestsTemplate(appTests),
+    style: options.style === 'tailwind' ? 'css' : options.style,
   };
 
   if (options.bundler === 'vite') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently we use `<%= style %>` to set the style file extension in the `main.tsx` template file.
This is incorrect when `style=tailwind`


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
If `options.style=tailwind` update the `templateVariables` that are used to set `style=css`


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
