### PR TITLE
chore(js): update dep `babel-plugin-macros` to ^3.1.0

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -43,7 +43,7 @@
     "@nx/workspace": "file:../workspace",
     "@zkochan/js-yaml": "0.0.7",
     "babel-plugin-const-enum": "^1.0.1",
-    "babel-plugin-macros": "^2.8.0",
+    "babel-plugin-macros": "^3.1.0",
     "babel-plugin-transform-typescript-metadata": "^0.3.1",
     "chalk": "^4.1.0",
     "columnify": "^1.6.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

```bash
@coreproject-moe/monorepo@ /home/moonlitgrace/Projects/coreproject-monorepo
├─┬ @coreproject-moe/icons@0.0.65 -> ./packages/icons
│ └─┬ jest-config@29.7.0
│   └─┬ jest-circus@29.7.0
│     └─┬ dedent@1.5.3
│       └── babel-plugin-macros@2.8.0 deduped invalid: "^3.1.0" from node_modules/dedent
└─┬ @nx/js@20.0.5
  └── babel-plugin-macros@2.8.0
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

No conflicts, without overriding `package.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28620 
