### PR TITLE
fix(rspack): ensure baseHref is set when provided #28455

### DIFF
--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -116,6 +116,7 @@ export function withWeb(opts: WithWebOptions = {}) {
           template: options.indexHtml
             ? path.join(context.root, options.indexHtml)
             : path.join(projectRoot, 'src/index.html'),
+          ...(options.baseHref ? { base: { href: options.baseHref } } : {}),
         }),
         new rspack.EnvironmentPlugin({
           NODE_ENV: 'development',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/rspack:rspack` executor supports `baseHref` as an option, but we do not set it in the `rspack.HtmlRspackPlugin`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure if `baseHref` is set, we pass it to `rspack.HtmlRspackPlugin`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28455
