### PR TITLE
fix(rspack): set NODE_ENV to production correctly #28584

### DIFF
--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -118,7 +118,7 @@ export function withWeb(opts: WithWebOptions = {}) {
             : path.join(projectRoot, 'src/index.html'),
         }),
         new rspack.EnvironmentPlugin({
-          NODE_ENV: 'development',
+          NODE_ENV: isProd ? 'production' : 'development',
         }),
       ],
     };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The switch from `DefinPlugin` to `EnvironmentPlugin` did not account for `production`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure `production` is accounted for and set as expected

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28584
