### PR TITLE
fix(vite): set NODE_ENV to production correctly #28584

### DIFF
--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -54,14 +54,16 @@ export async function* viteBuildExecutor(
       : relative(context.cwd, joinPathFragments(context.root, projectRoot));
 
   const { buildOptions, otherOptions } = await getBuildExtraArgs(options);
+  const defaultMode = otherOptions?.mode ?? 'production';
 
   const resolved = await resolveConfig(
     {
       configFile: viteConfigPath,
-      mode: otherOptions?.mode ?? 'production',
+      mode: defaultMode,
     },
     'build',
-    otherOptions?.mode ?? 'production'
+    defaultMode,
+    process.env.NODE_ENV ?? defaultMode
   );
 
   const outDir =

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -56,13 +56,16 @@ export async function* viteDevServerExecutor(
     buildOptions,
     otherOptionsFromBuild
   );
+  const defaultMode =
+    otherOptions?.mode ?? buildTargetOptions?.['mode'] ?? 'development';
   const resolved = await resolveConfig(
     {
       configFile: viteConfigPath,
-      mode: otherOptions?.mode ?? buildTargetOptions?.['mode'] ?? 'development',
+      mode: defaultMode,
     },
     'serve',
-    otherOptions?.mode ?? buildTargetOptions?.['mode'] ?? 'development'
+    defaultMode,
+    process.env.NODE_ENV ?? defaultMode
   );
 
   // vite InlineConfig

--- a/packages/vite/src/executors/preview-server/preview-server.impl.ts
+++ b/packages/vite/src/executors/preview-server/preview-server.impl.ts
@@ -60,13 +60,17 @@ export async function* vitePreviewServerExecutor(
     configuration,
     otherOptionsFromBuild
   );
+  const defaultMode =
+    otherOptions?.mode ?? otherOptionsFromBuild?.mode ?? 'production';
+
   const resolved = await resolveConfig(
     {
       configFile: viteConfigPath,
-      mode: otherOptions?.mode ?? otherOptionsFromBuild?.mode ?? 'production',
+      mode: defaultMode,
     },
     'build',
-    otherOptions?.mode ?? otherOptionsFromBuild?.mode ?? 'production'
+    defaultMode,
+    process.env.NODE_ENV ?? defaultMode
   );
 
   const outDir =


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
After the switch to use `resolveConfig` we failed to set the value for `NODE_ENV` which is an argument to the function.
This means it always defaulted to development.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure `NODE_ENV` is set as expected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28584

