### PR TITLE
fix(release): remove duplicate space character in changelog thank you header

### DIFF
--- a/docs/blog/2024-02-09-versioning-and-releasing-packages.md
+++ b/docs/blog/2024-02-09-versioning-and-releasing-packages.md
@@ -188,7 +188,7 @@ It also generates a nice `CHANGELOG.md` for us:
 
 - **buttons:** add new background shadow
 
-### ❤️  Thank You
+### ❤️ Thank You
 
 - Juri
 

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -133,7 +133,7 @@ describe('nx release', () => {
       +
       + - an awesome new feature ([{COMMIT_SHA}](https://github.com/nrwl/fake-repo/commit/{COMMIT_SHA}))
       +
-      + ### ❤️  Thank You
+      + ### ❤️ Thank You
       +
       + - Test @{COMMIT_AUTHOR}
 
@@ -153,7 +153,7 @@ describe('nx release', () => {
 
       - an awesome new feature ([{COMMIT_SHA}](https://github.com/nrwl/fake-repo/commit/{COMMIT_SHA}))
 
-      ### ❤️  Thank You
+      ### ❤️ Thank You
 
       - Test @{COMMIT_AUTHOR}
     `);

--- a/e2e/release/src/version-plans.test.ts
+++ b/e2e/release/src/version-plans.test.ts
@@ -178,7 +178,7 @@ Here is another line in the message.
 +
 + - Update the fixed packages with a minor release.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -192,7 +192,7 @@ Here is another line in the message.
 +
 + - Update the fixed packages with a minor release.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -208,7 +208,7 @@ Here is another line in the message.
 +
 +   Here is another line in the message.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -225,7 +225,7 @@ Here is another line in the message.
 +
 +   Here is another line in the message.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -242,7 +242,7 @@ Here is another line in the message.
 +
 +   Here is another line in the message.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -321,7 +321,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #2
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -336,7 +336,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #2
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test
 `
@@ -352,7 +352,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #1
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -368,7 +368,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #2
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -384,7 +384,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #2
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -549,7 +549,7 @@ const yargs = require('yargs');
 +
 + - Update the fixed packages with a minor release.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -563,7 +563,7 @@ const yargs = require('yargs');
 +
 + - Update the fixed packages with a minor release.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -577,7 +577,7 @@ const yargs = require('yargs');
 +
 + - Update the independent packages with a patch, preminor, and prerelease.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -592,7 +592,7 @@ const yargs = require('yargs');
 +
 + - Update the independent packages with a patch, preminor, and prerelease.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -607,7 +607,7 @@ const yargs = require('yargs');
 +
 + - Update the independent packages with a patch, preminor, and prerelease.
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -689,7 +689,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #2
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -704,7 +704,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #2
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test
 `
@@ -720,7 +720,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #1
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -736,7 +736,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #2
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );
@@ -752,7 +752,7 @@ Update packages in both groups with a mix #2
 +
 + - Update packages in both groups with a mix #2
 +
-+ ### ❤️  Thank You
++ ### ❤️ Thank You
 +
 + - Test`
     );

--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -168,7 +168,7 @@ describe('ChangelogRenderer', () => {
                   - all packages fixed
                   - **pkg-a:** squashing bugs
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - James Henry"
               `);
@@ -235,7 +235,7 @@ describe('ChangelogRenderer', () => {
                   - all packages fixed
                   - **pkg-a:** squashing bugs
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - James Henry"
               `);
@@ -279,7 +279,7 @@ describe('ChangelogRenderer', () => {
 
                   - all packages fixed
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - James Henry"
               `);
@@ -427,7 +427,7 @@ describe('ChangelogRenderer', () => {
                   - all packages fixed
                   - **pkg-a:** squashing bugs
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - Author 1
                   - Author 3
@@ -451,7 +451,7 @@ describe('ChangelogRenderer', () => {
 
                   - all packages fixed
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - Author 1
                   - Author 2
@@ -575,7 +575,7 @@ describe('ChangelogRenderer', () => {
 
                   - **release:** Revert "fix(release): do not update dependents when they already use "*" (#20607)"
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - James Henry"
               `);
@@ -699,7 +699,7 @@ describe('ChangelogRenderer', () => {
 
                   - ⚠️  **WebSocketSubject:** no longer extends \`Subject\`.
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - James Henry"
               `);
@@ -752,7 +752,7 @@ describe('ChangelogRenderer', () => {
 
                   - **WebSocketSubject:** \`WebSocketSubject\` is no longer \`instanceof Subject\`. Check for \`instanceof WebSocketSubject\` instead.
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - James Henry"
               `);
@@ -795,7 +795,7 @@ describe('ChangelogRenderer', () => {
 
                   - Updated pkg-b to 2.0.0
 
-                  ### ❤️  Thank You
+                  ### ❤️ Thank You
 
                   - James Henry"
               `);
@@ -867,7 +867,7 @@ describe('ChangelogRenderer', () => {
         - all packages fixed
         - **pkg-a:** squashing bugs
 
-        ### ❤️  Thank You
+        ### ❤️ Thank You
 
         - James Henry"
       `);

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -403,7 +403,7 @@ export default class DefaultChangelogRenderer {
     if (authors.length > 0) {
       markdownLines.push(
         '',
-        '### ' + '❤️  Thank You',
+        '### ' + '❤️ Thank You',
         '',
         ...authors
           .sort((a, b) => a.name.localeCompare(b.name))

--- a/packages/nx/src/command-line/release/utils/markdown.spec.ts
+++ b/packages/nx/src/command-line/release/utils/markdown.spec.ts
@@ -11,7 +11,7 @@ describe('markdown utils', () => {
 
 - **baz:** bugfix for baz
 
-### ❤️  Thank You
+### ❤️ Thank You
 
 - James Henry
 
@@ -26,7 +26,7 @@ describe('markdown utils', () => {
 
 - **bar:** some bugfix in bar
 
-### ❤️  Thank You
+### ❤️ Thank You
 
 - James Henry
     `;
@@ -38,7 +38,7 @@ describe('markdown utils', () => {
 
         - **baz:** bugfix for baz
 
-        ### ❤️  Thank You
+        ### ❤️ Thank You
 
         - James Henry",
               "version": "0.0.3",
@@ -52,7 +52,7 @@ describe('markdown utils', () => {
 
         - **bar:** some bugfix in bar
 
-        ### ❤️  Thank You
+        ### ❤️ Thank You
 
         - James Henry",
               "version": "0.0.2",
@@ -71,7 +71,7 @@ describe('markdown utils', () => {
 
 - **baz:** bugfix for baz
 
-### ❤️  Thank You
+### ❤️ Thank You
 
 - James Henry
 
@@ -86,7 +86,7 @@ describe('markdown utils', () => {
 
 - **bar:** some bugfix in bar
 
-### ❤️  Thank You
+### ❤️ Thank You
 
 - James Henry
     `;
@@ -98,7 +98,7 @@ describe('markdown utils', () => {
 
         - **baz:** bugfix for baz
 
-        ### ❤️  Thank You
+        ### ❤️ Thank You
 
         - James Henry",
               "version": "0.0.3-alpha.1",
@@ -112,7 +112,7 @@ describe('markdown utils', () => {
 
         - **bar:** some bugfix in bar
 
-        ### ❤️  Thank You
+        ### ❤️ Thank You
 
         - James Henry",
               "version": "0.0.2-beta.256",
@@ -131,7 +131,7 @@ describe('markdown utils', () => {
 
 - **baz:** bugfix for baz
 
-### ❤️  Thank You
+### ❤️ Thank You
 
 - James Henry
 
@@ -146,7 +146,7 @@ describe('markdown utils', () => {
 
 - **bar:** some bugfix in bar
 
-### ❤️  Thank You
+### ❤️ Thank You
 
 - James Henry
     `;
@@ -158,7 +158,7 @@ describe('markdown utils', () => {
 
         - **baz:** bugfix for baz
 
-        ### ❤️  Thank You
+        ### ❤️ Thank You
 
         - James Henry",
               "version": "1.0.1",
@@ -172,7 +172,7 @@ describe('markdown utils', () => {
 
         - **bar:** some bugfix in bar
 
-        ### ❤️  Thank You
+        ### ❤️ Thank You
 
         - James Henry",
               "version": "1.0.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

The nx release changelog command currently generates a changelog that is not formatted properly. It contains two spaces in the `Thank you` header .

## Expected Behavior
Only once space should be added.
