### PR TITLE
fix(core): fix dependency with multiple dependent packages

### DIFF
--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -8,6 +8,7 @@ import { Task, TaskGraph } from '../config/task-graph';
 import { TargetDefaults, TargetDependencies } from '../config/nx-json';
 import { output } from '../utils/output';
 import { TargetDependencyConfig } from '../config/workspace-json-project-json';
+import { findCycle } from './task-graph-utils';
 
 const DUMMY_TASK_TARGET = '__nx_dummy_task__';
 
@@ -105,7 +106,7 @@ export class ProcessTasks {
     projectUsedToDeriveDependencies: string,
     configuration: string,
     overrides: Object
-  ) {
+  ): void {
     const seenKey = `${task.id}-${projectUsedToDeriveDependencies}`;
     if (this.seen.has(seenKey)) {
       return;
@@ -233,7 +234,7 @@ export class ProcessTasks {
     task: Task,
     taskOverrides: Object | { __overrides_unparsed__: any[] },
     overrides: Object
-  ) {
+  ): void {
     if (
       !this.projectGraph.dependencies.hasOwnProperty(
         projectUsedToDeriveDependencies
@@ -292,7 +293,7 @@ export class ProcessTasks {
           undefined
         );
         this.dependencies[task.id].push(dummyId);
-        this.dependencies[dummyId] = [];
+        this.dependencies[dummyId] ??= [];
         const noopTask = this.createDummyTask(dummyId, task);
         this.processTask(noopTask, depProject.name, configuration, overrides);
       }
@@ -377,22 +378,53 @@ export class ProcessTasks {
     return id;
   }
 
-  private filterDummyTasks() {
-    for (const [key, deps] of Object.entries(this.dependencies)) {
-      const normalizedDeps = [];
-      for (const dep of deps) {
-        if (dep.endsWith(DUMMY_TASK_TARGET)) {
-          normalizedDeps.push(
-            ...this.dependencies[dep].filter(
-              (d) => !d.endsWith(DUMMY_TASK_TARGET)
-            )
-          );
-        } else {
-          normalizedDeps.push(dep);
-        }
+  /**
+   * this function is used to get the non dummy dependencies of a task recursively
+   * For example, when we have the following dependencies:
+   * {
+   *   'app1:compile': [ 'app2:__nx_dummy_task__' ],
+   *   'app2:__nx_dummy_task__': [ 'app3:__nx_dummy_task__' ],
+   *   'app3:__nx_dummy_task__': [ 'app4:precompile' ],
+   *   'app4:precompile': []
+   * }
+   * getNonDummyDeps('app1:compile') will return ['app1:compile']
+   * getNonDummyDeps('app2:__nx_dummy_task__') will return ['app4:precompile']
+   * getNonDummyDeps('app3:__nx_dummy_task__') will return ['app4:precompile']
+   * getNonDummyDeps('app4:precompile') will return ['app4:precompile']
+   */
+  private getNonDummyDeps(
+    currentTask: string,
+    originalTask: string,
+    cycle?: string[]
+  ): string[] {
+    if (currentTask === originalTask) {
+      return [];
+    } else if (currentTask.endsWith(DUMMY_TASK_TARGET)) {
+      if (cycle?.length && cycle?.includes(currentTask)) {
+        return [];
       }
+      // if not a cycle, recursively get the non dummy dependencies
+      return (
+        this.dependencies[currentTask]?.flatMap((dep) =>
+          this.getNonDummyDeps(dep, originalTask, cycle)
+        ) ?? []
+      );
+    } else {
+      return [currentTask];
+    }
+  }
 
-      this.dependencies[key] = normalizedDeps;
+  private filterDummyTasks() {
+    const cycle = findCycle({ dependencies: this.dependencies });
+    for (const [key, deps] of Object.entries(this.dependencies)) {
+      if (!key.endsWith(DUMMY_TASK_TARGET)) {
+        const normalizedDeps = [];
+        for (const dep of deps) {
+          normalizedDeps.push(...this.getNonDummyDeps(dep, key, cycle));
+        }
+
+        this.dependencies[key] = normalizedDeps;
+      }
     }
 
     for (const key of Object.keys(this.dependencies)) {

--- a/packages/nx/src/tasks-runner/task-graph-utils.ts
+++ b/packages/nx/src/tasks-runner/task-graph-utils.ts
@@ -1,10 +1,6 @@
-import { readNxJson } from '../config/configuration';
 import { ProjectGraph } from '../config/project-graph';
-import { Task, TaskGraph } from '../config/task-graph';
-import { isNxCloudUsed } from '../utils/nx-cloud-utils';
+import { TaskGraph } from '../config/task-graph';
 import { output } from '../utils/output';
-import { serializeTarget } from '../utils/serialize-target';
-import chalk = require('chalk');
 
 function _findCycle(
   graph: { dependencies: Record<string, string[]> },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
- we introduce a feature to allow circular project dependencies to execute tasks in pr https://github.com/nrwl/nx/pull/28227/files
- for this feature, we introduce the concept of dummy task as a temporary placeholder so we can still generate a task graph even if dependencies contain circular dependencies
- however, it does not handle a task graph of multiple dummy task deps. for example:
lib1 -> lib2 -> lib3 -> lib4
if we got task graph like:
lib1:build -> lib2:dummy
lib2:dummy -> lib3:dummy
lib3:dummy -> lib4:rebuild
currently, it does not create a dependency between lib1:build->lib4:prebuild

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
it should link the dependency when it contains multiple level of depending on dummy tasks

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/28599 and https://github.com/nrwl/nx/issues/28380
