### PR TITLE
fix(linter): ensure .cjs config file is handled correctly for generators #28214

### DIFF
--- a/packages/eslint/src/generators/lint-project/lint-project.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.ts
@@ -273,7 +273,7 @@ function createEsLintConfiguration(
     });
     const nodeList = createNodeList(importMap, nodes);
     const content = stringifyNodeList(nodeList);
-    const ext = extendedRootConfig.endsWith('.cjs') ? '.cjs' : '.js';
+    const ext = extendedRootConfig?.endsWith('.cjs') ? '.cjs' : '.js';
     tree.write(join(projectConfig.root, `eslint.config${ext}`), content);
   } else {
     writeJson(tree, join(projectConfig.root, `.eslintrc.json`), {

--- a/packages/eslint/src/generators/lint-project/lint-project.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.ts
@@ -273,7 +273,8 @@ function createEsLintConfiguration(
     });
     const nodeList = createNodeList(importMap, nodes);
     const content = stringifyNodeList(nodeList);
-    tree.write(join(projectConfig.root, 'eslint.config.js'), content);
+    const ext = extendedRootConfig.endsWith('.cjs') ? '.cjs' : '.js';
+    tree.write(join(projectConfig.root, `eslint.config${ext}`), content);
   } else {
     writeJson(tree, join(projectConfig.root, `.eslintrc.json`), {
       extends: extendedRootConfig ? [pathToRootConfig] : undefined,

--- a/packages/eslint/src/generators/utils/eslint-file.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.ts
@@ -64,7 +64,11 @@ export function isEslintConfigSupported(tree: Tree, projectRoot = ''): boolean {
   if (!eslintFile) {
     return false;
   }
-  return eslintFile.endsWith('.json') || eslintFile.endsWith('.config.js');
+  return (
+    eslintFile.endsWith('.json') ||
+    eslintFile.endsWith('.config.js') ||
+    eslintFile.endsWith('.config.cjs')
+  );
 }
 
 export function updateRelativePathsInConfig(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When the workspace has `eslint.config.cjs` at the root, generation of new lint projects currently does not check for it correctly 


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure utils continue to work as expected when `eslint.config.cjs` is detected at the workspaceRoot

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28214
