### PR TITLE
chore(angular): remove superfluous test

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -509,68 +509,6 @@ export default defineConfig({
 "
 `;
 
-exports[`app --unit-test-runner vitest should generate vite.config.mts if package type is module 1`] = `
-"/// <reference types='vitest' />
-import { defineConfig } from 'vite';
-import angular from '@analogjs/vite-plugin-angular';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
-
-export default defineConfig({
-  root: __dirname,
-  cacheDir: '../node_modules/.vite/my-app',
-  plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
-  // Uncomment this if you are using workers.
-  // worker: {
-  //  plugins: [ nxViteTsPaths() ],
-  // },
-  test: {
-    watch: false,
-    globals: true,
-    environment: 'jsdom',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    setupFiles: ['src/test-setup.ts'],
-    reporters: ['default'],
-    coverage: {
-      reportsDirectory: '../coverage/my-app',
-      provider: 'v8',
-    },
-  },
-});
-"
-`;
-
-exports[`app --unit-test-runner vitest should generate vite.config.mts if workspace package type is module 1`] = `
-"/// <reference types='vitest' />
-import { defineConfig } from 'vite';
-import angular from '@analogjs/vite-plugin-angular';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
-
-export default defineConfig({
-  root: __dirname,
-  cacheDir: '../node_modules/.vite/my-app',
-  plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
-  // Uncomment this if you are using workers.
-  // worker: {
-  //  plugins: [ nxViteTsPaths() ],
-  // },
-  test: {
-    watch: false,
-    globals: true,
-    environment: 'jsdom',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    setupFiles: ['src/test-setup.ts'],
-    reporters: ['default'],
-    coverage: {
-      reportsDirectory: '../coverage/my-app',
-      provider: 'v8',
-    },
-  },
-});
-"
-`;
-
 exports[`app angular compat support should import "ApplicationConfig" from "@angular/platform-browser" 1`] = `
 "import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -768,58 +768,6 @@ describe('app', () => {
         expect(devDependencies['@analogjs/vite-plugin-angular']).toBeDefined();
         expect(devDependencies['@analogjs/vitest-angular']).toBeDefined();
       });
-
-      it('should generate vite.config.mts if package type is module', async () => {
-        writeJson(appTree, 'my-app/package.json', {
-          name: 'my-app',
-          type: 'module',
-        });
-
-        await generateApp(appTree, 'my-app', {
-          skipFormat: false,
-          unitTestRunner: UnitTestRunner.Vitest,
-        });
-
-        expect(
-          appTree.read('my-app/vite.config.mts', 'utf-8')
-        ).toMatchSnapshot();
-      });
-
-      it('should generate vite.config.mts if workspace package type is module', async () => {
-        updateJson(appTree, 'package.json', (json) => ({
-          ...json,
-          type: 'module',
-        }));
-
-        await generateApp(appTree, 'my-app', {
-          skipFormat: false,
-          unitTestRunner: UnitTestRunner.Vitest,
-        });
-
-        expect(
-          appTree.read('my-app/vite.config.mts', 'utf-8')
-        ).toMatchSnapshot();
-      });
-
-      it('should not override build configuration when using vitest as a test runner', async () => {
-        await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
-        });
-        const { targets } = readProjectConfiguration(appTree, 'my-app');
-        expect(targets.build.executor).toBe(
-          '@angular-devkit/build-angular:application'
-        );
-      });
-
-      it('should not override serve configuration when using vitest as a test runner', async () => {
-        await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
-        });
-        const { targets } = readProjectConfiguration(appTree, 'my-app');
-        expect(targets.serve.executor).toBe(
-          '@angular-devkit/build-angular:dev-server'
-        );
-      });
     });
 
     describe('none', () => {


### PR DESCRIPTION
We always use .mts extension. It is not conditional anymore.
