### PR TITLE
fix(angular): use vitest generator instead of vite config generator

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -800,6 +800,26 @@ describe('app', () => {
           appTree.read('my-app/vite.config.mts', 'utf-8')
         ).toMatchSnapshot();
       });
+
+      it('should not override build configuration when using vitest as a test runner', async () => {
+        await generateApp(appTree, 'my-app', {
+          unitTestRunner: UnitTestRunner.Vitest,
+        });
+        const { targets } = readProjectConfiguration(appTree, 'my-app');
+        expect(targets.build.executor).toBe(
+          '@angular-devkit/build-angular:application'
+        );
+      });
+
+      it('should not override serve configuration when using vitest as a test runner', async () => {
+        await generateApp(appTree, 'my-app', {
+          unitTestRunner: UnitTestRunner.Vitest,
+        });
+        const { targets } = readProjectConfiguration(appTree, 'my-app');
+        expect(targets.serve.executor).toBe(
+          '@angular-devkit/build-angular:dev-server'
+        );
+      });
     });
 
     describe('none', () => {

--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -30,7 +30,7 @@ export async function addVitest(
     );
   }
 
-  const { createOrEditViteConfig, viteConfigurationGenerator } = ensurePackage<
+  const { createOrEditViteConfig, vitestGenerator } = ensurePackage<
     typeof import('@nx/vite')
   >('@nx/vite', nxVersion);
 
@@ -58,12 +58,13 @@ getTestBed().initTestEnvironment(
 `
     );
 
-    await viteConfigurationGenerator(tree, {
+    await vitestGenerator(tree, {
       project: options.name,
-      newProject: true,
       uiFramework: 'none',
-      includeVitest: true,
+      skipViteConfig: true,
       testEnvironment: 'jsdom',
+      coverageProvider: 'v8',
+      addPlugin: false,
     });
 
     createOrEditViteConfig(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Using the viteConfigGenerator leads to build and serve targets being overriden


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the `vitestGenerator` to only add the test target

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
