### PR TITLE
fix(vite): tsconfig paths plugin should resolve file with dot in the name

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -251,9 +251,15 @@ There should at least be a tsconfig.base.json or tsconfig.json in the root of th
 
   function findFile(path: string): string {
     for (const ext of options.extensions) {
+      // Support file with "." in the name.
+      let resolvedPath = resolve(path + ext);
+      if (existsSync(resolvedPath)) {
+        return resolvedPath;
+      }
+
       // Support file extensions such as .css and .js in the import path.
       const { dir, name } = parse(path);
-      const resolvedPath = resolve(dir, name + ext);
+      resolvedPath = resolve(dir, name + ext);
       if (existsSync(resolvedPath)) {
         return resolvedPath;
       }


### PR DESCRIPTION

closed #28615

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28615
