### PR TITLE
fix(nextjs): Add deprecation message for svgr

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -21,6 +21,11 @@ export interface SvgrOptions {
 
 export interface WithNxOptions extends NextConfig {
   nx?: {
+    /**
+     * @deprecated Next.js via turbo conflicts with how webpack handles the import of SVGs.
+     * It is best to configure SVGR manually with the `@svgr/webpack` loader.
+     * We will remove this option in Nx 21.
+     * */
     svgr?: boolean | SvgrOptions;
     babelUpwardRootMode?: boolean;
     fileReplacements?: { replace: string; with: string }[];
@@ -355,6 +360,12 @@ export function getNextConfig(
 
       // Default SVGR support to be on for projects.
       if (nx?.svgr !== false || typeof nx?.svgr === 'object') {
+        forNextVersion('>=15.0.0', () => {
+          // Since Next.js 15, turbopack could be enabled by default.
+          console.warn(
+            `NX: Next.js SVGR support is deprecated. If used with turbopack, it may not work as expected and is not recommended. Please configure SVGR manually.`
+          );
+        });
         const defaultSvgrOptions = {
           svgo: false,
           titleProp: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, if you are using Next.js 15 have SVGR enabled via `WithNx` and are using turbopack. You could potentially have issues loading your svg. This happens because of how webpack imports svg and not having an additional configuration for turbopack (currently it is under the experimental option). 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Moving forward, we can call this out and deprecate the option to be removed in Nx 21. As such should you need to use SVGs it is recommended to do so manually. Something similar to [this comment](https://github.com/vercel/turborepo/issues/4832#issuecomment-1751407444).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
