### PR TITLE
fix(nextjs): do not generate spec files if unitTestRunner is not set programmatically

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -444,6 +444,9 @@ describe('app', () => {
     expect(tree.read(`${name}/jest.config.ts`, 'utf-8')).toContain(
       `moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],`
     );
+    expect(
+      readJson(tree, 'package.json').devDependencies['@testing-library/react']
+    ).toBeDefined();
   });
 
   it('should setup jest with SVGR support', async () => {

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -104,7 +104,7 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
       '@types/react-dom': typesReactDomVersion,
     };
 
-    if (schema.unitTestRunner && schema.unitTestRunner !== 'none') {
+    if (options.unitTestRunner && options.unitTestRunner !== 'none') {
       devDependencies['@testing-library/react'] = testingLibraryReactVersion;
     }
 


### PR DESCRIPTION
This PR fixes an issue where `create-nx-workspace` with Next.js preset generates with Jest spec files, but does not install `@testing-library/react` correctly due to not checking the normalized schema file.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
