### PR TITLE
feat(nx-cloud): configure import paths for light client when running …

### DIFF
--- a/packages/nx/src/command-line/login/login.ts
+++ b/packages/nx/src/command-line/login/login.ts
@@ -1,6 +1,7 @@
 import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
 import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
 import { handleErrors } from '../../utils/handle-errors';
+import { findAncestorNodeModules } from '../../nx-cloud/resolution-helpers';
 
 export interface LoginArgs {
   nxCloudUrl?: string;
@@ -15,6 +16,10 @@ export function loginHandler(args: LoginArgs): Promise<number> {
   return handleErrors(args.verbose, async () => {
     const nxCloudClient = (await verifyOrUpdateNxCloudClient(getCloudOptions()))
       .nxCloudClient;
+
+    const paths = findAncestorNodeModules(__dirname, []);
+    nxCloudClient.configureLightClientRequire()(paths);
+
     await nxCloudClient.commands.login();
   });
 }

--- a/packages/nx/src/command-line/logout/logout.ts
+++ b/packages/nx/src/command-line/logout/logout.ts
@@ -1,6 +1,7 @@
 import { verifyOrUpdateNxCloudClient } from '../../nx-cloud/update-manager';
 import { getCloudOptions } from '../../nx-cloud/utilities/get-cloud-options';
 import { handleErrors } from '../../utils/handle-errors';
+import { findAncestorNodeModules } from '../../nx-cloud/resolution-helpers';
 
 export interface LogoutArgs {
   verbose?: boolean;
@@ -10,6 +11,10 @@ export function logoutHandler(args: LogoutArgs): Promise<number> {
   return handleErrors(args.verbose, async () => {
     const nxCloudClient = (await verifyOrUpdateNxCloudClient(getCloudOptions()))
       .nxCloudClient;
+
+    const paths = findAncestorNodeModules(__dirname, []);
+    nxCloudClient.configureLightClientRequire()(paths);
+
     await nxCloudClient.commands.logout();
   });
 }


### PR DESCRIPTION
…login/logout

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When you call `nx login` and `nx logout`, we did not pass in import paths to node modules so the displayed messages for each command were just raw text. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When you call `login` or `logout`, you get formatting on the command output. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
