### PR TITLE
feat(rspack): make target property optional

### DIFF
--- a/docs/generated/packages/rspack/executors/rspack.json
+++ b/docs/generated/packages/rspack/executors/rspack.json
@@ -155,7 +155,7 @@
         "description": "Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated."
       }
     },
-    "required": ["target", "main", "outputPath", "tsConfig", "rspackConfig"],
+    "required": ["main", "outputPath", "tsConfig", "rspackConfig"],
     "definitions": {
       "assetPattern": {
         "oneOf": [

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -13,6 +13,7 @@ export default async function* runExecutor(
   context: ExecutorContext
 ) {
   process.env.NODE_ENV ??= options.mode ?? 'production';
+  options.target ??= 'web';
 
   if (isMode(process.env.NODE_ENV)) {
     options.mode = process.env.NODE_ENV;

--- a/packages/rspack/src/executors/rspack/schema.d.ts
+++ b/packages/rspack/src/executors/rspack/schema.d.ts
@@ -1,7 +1,7 @@
 import type { Mode } from '@rspack/core';
 
 export interface RspackExecutorSchema {
-  target: 'web' | 'node';
+  target?: 'web' | 'node';
   main: string;
   index?: string;
   tsConfig: string;

--- a/packages/rspack/src/executors/rspack/schema.json
+++ b/packages/rspack/src/executors/rspack/schema.json
@@ -133,7 +133,7 @@
       "description": "Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated."
     }
   },
-  "required": ["target", "main", "outputPath", "tsConfig", "rspackConfig"],
+  "required": ["main", "outputPath", "tsConfig", "rspackConfig"],
   "definitions": {
     "assetPattern": {
       "oneOf": [

--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -40,6 +40,7 @@ export function withWeb(opts: WithWebOptions = {}) {
 
     return {
       ...config,
+      target: config.target ?? 'web',
       experiments: {
         css: true,
       },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `target` property is currently required by the `@nx/rspack:rspack` executor, but is not by the `@nx/webpack:webpack` executor.
This can make migrating between the two a little more difficult.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Target should be handled by Nx's `withWeb` helper or set intentionally by the user in their `rspack.config` file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
