### PR TITLE
fix(rspack): move main validation to implementation

### DIFF
--- a/docs/generated/packages/rspack/executors/rspack.json
+++ b/docs/generated/packages/rspack/executors/rspack.json
@@ -155,7 +155,7 @@
         "description": "Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated."
       }
     },
-    "required": ["main", "outputPath", "tsConfig", "rspackConfig"],
+    "required": ["outputPath", "tsConfig", "rspackConfig"],
     "definitions": {
       "assetPattern": {
         "oneOf": [

--- a/packages/rspack/src/executors/rspack/schema.d.ts
+++ b/packages/rspack/src/executors/rspack/schema.d.ts
@@ -2,7 +2,7 @@ import type { Mode } from '@rspack/core';
 
 export interface RspackExecutorSchema {
   target?: 'web' | 'node';
-  main: string;
+  main?: string;
   index?: string;
   tsConfig: string;
   typeCheck?: boolean;

--- a/packages/rspack/src/executors/rspack/schema.json
+++ b/packages/rspack/src/executors/rspack/schema.json
@@ -133,7 +133,7 @@
       "description": "Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated."
     }
   },
-  "required": ["main", "outputPath", "tsConfig", "rspackConfig"],
+  "required": ["outputPath", "tsConfig", "rspackConfig"],
   "definitions": {
     "assetPattern": {
       "oneOf": [

--- a/packages/rspack/src/utils/create-compiler.ts
+++ b/packages/rspack/src/utils/create-compiler.ts
@@ -41,6 +41,8 @@ export async function createCompiler(
     config.devServer ??= options.devServer;
   }
 
+  validateConfig(config);
+
   return rspack(config);
 }
 
@@ -48,4 +50,17 @@ export function isMultiCompiler(
   compiler: Compiler | MultiCompiler
 ): compiler is MultiCompiler {
   return 'compilers' in compiler;
+}
+
+function validateConfig(config: Configuration) {
+  if (!config.entry) {
+    throw new Error(
+      'Entry is required. Please set the `main` option in the executor or the `entry` property in the rspack config.'
+    );
+  }
+  if (!config.output) {
+    throw new Error(
+      'Output is required. Please set the `outputPath` option in the executor or the `output` property in the rspack config.'
+    );
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
We currently have validation for the `main` property in the `executor` schema, however, this value could be defined in the `rspack.config` file.
This can cause an inaccurate schema validation error

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
After loading the config file and applying the executor options, run validation over the config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
