### PR TITLE
fix(nuxt): use loadNuxtConfig to load nuxt config for plugin

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -38,7 +38,9 @@
     "@nx/vite": "file:../vite",
     "@phenomnomnominal/tsquery": "~5.0.1"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+    "@nuxt/schema": "^3.10.0"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
We switched to using `loadConfigFile` from `@nx/devkit` to load Nuxt Config files when plugins were not isolated.
However, they are now, so we can use `loadNuxtConfig` again.

The effect of using `loadConfigFile` paired with Nuxt's auto-imports resulted in inconsistent failures.



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use `loadNuxtConfig` when `NX_ISOLATE_PLUGINS=true`


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28506
Fixes #28374
