### PR TITLE
fix(rspack): remove unnecessary required properties in schema validation

### DIFF
--- a/docs/generated/packages/rspack/executors/rspack.json
+++ b/docs/generated/packages/rspack/executors/rspack.json
@@ -155,7 +155,7 @@
         "description": "Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated."
       }
     },
-    "required": ["outputPath", "tsConfig", "rspackConfig"],
+    "required": ["rspackConfig"],
     "definitions": {
       "assetPattern": {
         "oneOf": [

--- a/packages/rspack/src/executors/rspack/schema.d.ts
+++ b/packages/rspack/src/executors/rspack/schema.d.ts
@@ -4,9 +4,9 @@ export interface RspackExecutorSchema {
   target?: 'web' | 'node';
   main?: string;
   index?: string;
-  tsConfig: string;
+  tsConfig?: string;
   typeCheck?: boolean;
-  outputPath: string;
+  outputPath?: string;
   outputFileName?: string;
   indexHtml?: string;
   mode?: Mode;

--- a/packages/rspack/src/executors/rspack/schema.json
+++ b/packages/rspack/src/executors/rspack/schema.json
@@ -133,7 +133,7 @@
       "description": "Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated."
     }
   },
-  "required": ["outputPath", "tsConfig", "rspackConfig"],
+  "required": ["rspackConfig"],
   "definitions": {
     "assetPattern": {
       "oneOf": [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/rspack:rspack` executor had listed other properties as required in the schema that could have been set by the rspack config.



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Make those properties optional and add validation after config is resolved

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
