### PR TITLE
fix(core): jest plugin should work with nodenext set in tsconfig

### DIFF
--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -123,39 +123,7 @@ export async function configurationGeneratorInternal(
     await formatFiles(tree);
   }
 
-  tasks.push(getUnsupportedModuleResolutionWarningTask(tree));
-
   return runTasksInSerial(...tasks);
-}
-
-/**
- * For Jest < 30, there is no way to load jest.config.ts file if the tsconfig.json/tsconfig.base.json sets moduleResolution to bundler or nodenext.
- * Jest uses ts-node in a way that is not compatible, so until this is fixed we need to log a warning.
- * See: https://github.com/jestjs/jest/blob/main/packages/jest-config/src/readConfigFileAndSetRootDir.ts#L145-L153
- */
-function getUnsupportedModuleResolutionWarningTask(
-  tree: Tree
-): GeneratorCallback {
-  const tsConfigFileName = getRootTsConfigFileName(tree);
-  if (tsConfigFileName) {
-    const json = readJson(tree, tsConfigFileName);
-    if (
-      json.compilerOptions.moduleResolution !== 'node' &&
-      json.compilerOptions.moduleResolution !== 'node10'
-    ) {
-      return () => {
-        output.warn({
-          title: `Compiler option 'moduleResolution' in ${tsConfigFileName} must be 'node' or 'node10'`,
-          bodyLines: [
-            `Jest requires 'moduleResolution' to be set to 'node' or 'node10' to work properly. It would need to be changed in the "${tsConfigFileName}" file. It's not enough to override the compiler option in the project's tsconfig file.`,
-            `Alternatively, you can use the environment variable \`TS_NODE_COMPILER_OPTIONS='{"moduleResolution": "node10"}'\` to override Jest's usage of ts-node.`,
-          ],
-        });
-      };
-    }
-  }
-
-  return () => {};
 }
 
 export default configurationGenerator;

--- a/packages/jest/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/jest/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -39,6 +39,9 @@ exports[`@nx/jest/plugin should add package as externalDependencies to the input
               },
               "options": {
                 "cwd": "proj",
+                "env": {
+                  "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                },
               },
               "outputs": [
                 "{workspaceRoot}/coverage",
@@ -91,6 +94,9 @@ exports[`@nx/jest/plugin should add package as externalDependencies to the input
               },
               "options": {
                 "cwd": "proj",
+                "env": {
+                  "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                },
               },
               "outputs": [
                 "{workspaceRoot}/coverage",
@@ -143,6 +149,9 @@ exports[`@nx/jest/plugin should add package as externalDependencies to the input
               },
               "options": {
                 "cwd": "proj",
+                "env": {
+                  "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                },
               },
               "outputs": [
                 "{workspaceRoot}/coverage",

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -96,6 +96,9 @@ describe('@nx/jest/plugin', () => {
                     },
                     "options": {
                       "cwd": "proj",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                      },
                     },
                     "outputs": [
                       "{workspaceRoot}/coverage",
@@ -173,6 +176,9 @@ describe('@nx/jest/plugin', () => {
                     },
                     "options": {
                       "cwd": "proj",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                      },
                     },
                     "outputs": [
                       "{workspaceRoot}/coverage",
@@ -306,6 +312,9 @@ describe('@nx/jest/plugin', () => {
                     },
                     "options": {
                       "cwd": "proj",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                      },
                     },
                     "outputs": [
                       "{workspaceRoot}/coverage",
@@ -413,6 +422,9 @@ describe('@nx/jest/plugin', () => {
                     },
                     "options": {
                       "cwd": "proj",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                      },
                     },
                     "outputs": [
                       "{workspaceRoot}/coverage",
@@ -480,6 +492,9 @@ describe('@nx/jest/plugin', () => {
                     },
                     "options": {
                       "cwd": "proj",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                      },
                     },
                     "outputs": [
                       "{workspaceRoot}/coverage",
@@ -593,6 +608,9 @@ describe('@nx/jest/plugin', () => {
                     },
                     "options": {
                       "cwd": "proj",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                      },
                     },
                     "outputs": [
                       "{workspaceRoot}/coverage",
@@ -660,6 +678,9 @@ describe('@nx/jest/plugin', () => {
                     },
                     "options": {
                       "cwd": "proj",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                      },
                     },
                     "outputs": [
                       "{workspaceRoot}/coverage",

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -192,6 +192,9 @@ async function buildJestTargets(
     command: 'jest',
     options: {
       cwd: projectRoot,
+      // Jest registers ts-node with module CJS https://github.com/SimenB/jest/blob/v29.6.4/packages/jest-config/src/readConfigFileAndSetRootDir.ts#L117-L119
+      // We want to support of ESM via 'module':'nodenext', we need to override the resolution until Jest supports it.
+      env: { TS_NODE_COMPILER_OPTIONS: '{"moduleResolution":"node10"}' },
     },
     metadata: {
       technologies: ['jest'],
@@ -269,6 +272,7 @@ async function buildJestTargets(
           outputs,
           options: {
             cwd: projectRoot,
+            env: { TS_NODE_COMPILER_OPTIONS: '{"moduleResolution":"node10"}' },
           },
           metadata: {
             technologies: ['jest'],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When you create a new project using the new ts setup to support ts project references jest does not work out of the box due to incompatibility with the module being set inside tsconfig to `nodenext`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Jest should work out of the box with our current setup

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
