### PR TITLE
fix(devkit): do not write back to package.json when adding plugin and there are no changes

### DIFF
--- a/packages/devkit/src/utils/add-plugin.spec.ts
+++ b/packages/devkit/src/utils/add-plugin.spec.ts
@@ -431,6 +431,32 @@ describe('addPlugin', () => {
         'echo "Typechecking..." && nx build -p tsconfig.lib.json && nx build -p tsconfig.spec.json && echo "Done"'
       );
     });
+
+    it('should not touch the package.json when there are no changes to make', async () => {
+      // package.json with mixed/bad indentation and array value in a single line
+      // JSON serialization would have a standard indentation and would expand the array value into multiple lines
+      const packageJsonContent = `{
+  "name": "app1",
+  "scripts": {
+            "build": "tsc --build"
+  },
+  "keywords": ["foo", "bar", "baz"]
+}`;
+      tree.write('app1/package.json', packageJsonContent);
+
+      await addPlugin(
+        tree,
+        graph,
+        '@nx/next/plugin',
+        createNodes,
+        {
+          targetName: ['build'],
+        },
+        true
+      );
+
+      expect(tree.read('app1/package.json', 'utf-8')).toBe(packageJsonContent);
+    });
   });
 });
 

--- a/packages/devkit/src/utils/add-plugin.ts
+++ b/packages/devkit/src/utils/add-plugin.ts
@@ -233,7 +233,7 @@ function processProject(
     return;
   }
 
-  const replacedTargets = new Set<string>();
+  let hasChanges = false;
   for (const targetCommand of targetCommands) {
     const { command, target, configuration } = targetCommand;
     const targetCommandRegex = new RegExp(
@@ -250,7 +250,7 @@ function processProject(
             ? `$1nx ${target} --configuration=${configuration}$3`
             : `$1nx ${target}$3`
         );
-        replacedTargets.add(target);
+        hasChanges = true;
       } else {
         /**
          * Parse script and command to handle the following:
@@ -327,7 +327,7 @@ function processProject(
                   : `$1nx ${target}$4`
               )
             );
-            replacedTargets.add(target);
+            hasChanges = true;
           } else {
             // there are different args or the script has extra args, replace with the command leaving the args
             packageJson.scripts[scriptName] = packageJson.scripts[
@@ -341,14 +341,16 @@ function processProject(
                   : `$1nx ${target}$3`
               )
             );
-            replacedTargets.add(target);
+            hasChanges = true;
           }
         }
       }
     }
   }
 
-  writeJson(tree, packageJsonPath, packageJson);
+  if (hasChanges) {
+    writeJson(tree, packageJsonPath, packageJson);
+  }
 }
 
 function getInferredTargetCommands(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Generators adding plugins to `nx.json` can modify projects' `package.json` files with some JSON serialization changes even though there are no actual changes and prettier is not installed, so they shouldn't be formatted.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generators adding plugins to `nx.json` should not modify projects' `package.json` files with JSON serialization changes when there are no actual changes to make and prettier is not installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
