### PR TITLE
fix(core): do not depend on ci info crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,15 +291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "ci_info"
-version = "0.14.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b"
-dependencies = [
- "envmnt",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,16 +461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
-name = "envmnt"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73999a2b8871e74c8b8bc23759ee9f3d85011b24fafc91a4b3b5c8cc8185501"
-dependencies = [
- "fsio",
- "indexmap",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,15 +568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "fsio"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad0ce30be0cc441b325c5d705c8b613a0ca0d92b6a8953d41bd236dc09a36d0"
-dependencies = [
- "dunce",
 ]
 
 [[package]]
@@ -1069,16 +1041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,7 +1477,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_fs",
- "ci_info",
  "colored",
  "crossbeam-channel",
  "crossterm",

--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -167,8 +167,17 @@ describe('Linter', () => {
         const newRuleName = 'e2e-test-rule-name';
         runCLI(`generate @nx/eslint:workspace-rule ${newRuleName}`);
 
+        // TODO(@AgentEnder): This reset gets rid of a lockfile changed error... we should fix this in another way
+        runCLI(`reset`, {
+          env: { CI: 'false' },
+        });
+
         // Ensure that the unit tests for the new rule are runnable
-        expect(() => runCLI(`test eslint-rules`)).not.toThrow();
+        expect(() =>
+          runCLI(`test eslint-rules`, {
+            env: { CI: 'false' },
+          })
+        ).not.toThrow();
 
         // Update the rule for the e2e test so that we can assert that it produces the expected lint failure when used
         const knownLintErrorMessage = 'e2e test known error message';
@@ -603,8 +612,16 @@ describe('Linter', () => {
         );
 
         // validate that the new projects are linted successfully
-        expect(() => runCLI(`lint ${reactLib}`)).not.toThrow();
-        expect(() => runCLI(`lint ${jsLib}`)).not.toThrow();
+        expect(() =>
+          runCLI(`lint ${reactLib}`, {
+            env: { CI: 'false' },
+          })
+        ).not.toThrow();
+        expect(() =>
+          runCLI(`lint ${jsLib}`, {
+            env: { CI: 'false' },
+          })
+        ).not.toThrow();
       });
     });
   });

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -13,7 +13,6 @@ strip = "none"
 
 [dependencies]
 anyhow = "1.0.71"
-ci_info = "0.14.14"
 colored = "2"
 crossbeam-channel = '0.5'
 dashmap = { version = "5.5.3", features = ["rayon"] }

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -4,6 +4,7 @@ use rusqlite::{Connection, OpenFlags};
 use std::fs::{remove_file, File};
 use std::path::{Path, PathBuf};
 use tracing::{debug, trace};
+use crate::native::utils::ci::is_ci;
 
 pub(super) struct LockFile {
     file: File,
@@ -99,7 +100,7 @@ fn create_metadata_table(c: &mut NxDbConnection, nx_version: &str) -> anyhow::Re
 }
 
 fn open_database_connection(db_path: &Path) -> anyhow::Result<NxDbConnection> {
-    let conn = if cfg!(target_family = "unix") && ci_info::is_ci() {
+    let conn = if cfg!(target_family = "unix") && is_ci() {
         trace!("Opening connection with unix-dotfile");
         Connection::open_with_flags_and_vfs(
             db_path,

--- a/packages/nx/src/native/utils/ci.rs
+++ b/packages/nx/src/native/utils/ci.rs
@@ -1,0 +1,19 @@
+use std::env;
+
+pub fn is_ci() -> bool {
+    env::var("CI").is_ok_and(|s| s != "false")
+        || env::var("TF_BUILD").is_ok_and(|s| s == "true")
+        || env::var("GITHUB_ACTIONS").is_ok_and(|s| s == "true")
+        || env::var("BUILDKITE").is_ok_and(|s| s == "true")
+        || env::var("CIRCLECI").is_ok_and(|s| s == "true")
+        || env::var("CIRRUS_CI").is_ok_and(|s| s == "true")
+        || env::var("TRAVIS").is_ok_and(|s| s == "true")
+        || env::var("bamboo.buildKey").is_ok()
+        || env::var("bamboo_buildKey").is_ok()
+        || env::var("CODEBUILD_BUILD_ID").is_ok()
+        || env::var("GITLAB_CI").is_ok()
+        || env::var("HEROKU_TEST_RUN_ID").is_ok()
+        || env::var("BUILD_ID").is_ok()
+        || env::var("BUILD_BUILDID").is_ok()
+        || env::var("TEAMCITY_VERSION").is_ok()
+}

--- a/packages/nx/src/native/utils/mod.rs
+++ b/packages/nx/src/native/utils/mod.rs
@@ -10,5 +10,6 @@ pub use normalize_trait::Normalize;
 #[cfg_attr(not(target_arch = "wasm32"), path = "atomics/default.rs")]
 #[cfg_attr(target_arch = "wasm32", path = "atomics/wasm.rs")]
 pub mod atomics;
+pub mod ci;
 
 pub use atomics::*;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The way VS Code / Nx Console starts the daemon makes the ci info rust crate believe that the daemon process is running in CI. This starts the database using the unix dotfile... which causes issues

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The ci info rust crate is not used, we have our own logic which is identical to the JS logic we have.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
