### PR TITLE
fix(misc): update generators to use autocomplete instead of select when possible

### DIFF
--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -698,7 +698,7 @@ async function normalizeOptions(
       linter: 'none' | 'eslint';
     }>(
       {
-        type: 'select',
+        type: 'autocomplete',
         name: 'linter',
         message: `Which linter would you like to use?`,
         choices: [{ name: 'none' }, { name: 'eslint' }],
@@ -711,7 +711,7 @@ async function normalizeOptions(
       unitTestRunner: 'none' | 'jest' | 'vitest';
     }>(
       {
-        type: 'select',
+        type: 'autocomplete',
         name: 'unitTestRunner',
         message: `Which unit test runner would you like to use?`,
         choices: [{ name: 'none' }, { name: 'vitest' }, { name: 'jest' }],
@@ -724,7 +724,7 @@ async function normalizeOptions(
       linter: 'none' | 'eslint';
     }>(
       {
-        type: 'select',
+        type: 'autocomplete',
         name: 'linter',
         message: `Which linter would you like to use?`,
         choices: [{ name: 'eslint' }, { name: 'none' }],
@@ -737,7 +737,7 @@ async function normalizeOptions(
       unitTestRunner: 'none' | 'jest' | 'vitest';
     }>(
       {
-        type: 'select',
+        type: 'autocomplete',
         name: 'unitTestRunner',
         message: `Which unit test runner would you like to use?`,
         choices: [{ name: 'jest' }, { name: 'vitest' }, { name: 'none' }],

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -492,7 +492,7 @@ async function promptForApplyingSyncGeneratorChanges(): Promise<boolean> {
   try {
     const promptConfig = {
       name: 'applyChanges',
-      type: 'select',
+      type: 'autocomplete',
       message:
         'Would you like to sync the identified changes to get your workspace up to date?',
       choices: [
@@ -523,7 +523,7 @@ async function confirmRunningTasksWithSyncFailures(): Promise<void> {
   try {
     const promptConfig = {
       name: 'runTasks',
-      type: 'select',
+      type: 'autocomplete',
       message:
         'Would you like to ignore the sync failures and continue running the tasks?',
       choices: [

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -224,7 +224,7 @@ async function normalizeOptions(
       linter: 'none' | 'eslint';
     }>(
       {
-        type: 'select',
+        type: 'autocomplete',
         name: 'linter',
         message: `Which linter would you like to use?`,
         choices: [{ name: 'none' }, { name: 'eslint' }],
@@ -237,7 +237,7 @@ async function normalizeOptions(
       linter: 'none' | 'eslint';
     }>(
       {
-        type: 'select',
+        type: 'autocomplete',
         name: 'linter',
         message: `Which linter would you like to use?`,
         choices: [{ name: 'eslint' }, { name: 'none' }],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
A few prompts that are written in generator code use a `select` instead of `autocomplete`

## Expected Behavior
All prompts are autocompletes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
