### PR TITLE
fix(nextjs): update default next-env

### DIFF
--- a/e2e/next/src/__snapshots__/next.test.ts.snap
+++ b/e2e/next/src/__snapshots__/next.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Next.js Applications next-env.d.ts should remain the same after a build 1`] = `
+"/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+"
+`;
+
+exports[`Next.js Applications next-env.d.ts should remain the same after a build 2`] = `
+"/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+"
+`;

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -197,6 +197,34 @@ describe('Next.js Applications', () => {
       );
     }
   }, 600_000);
+
+  it('next-env.d.ts should remain the same after a build', async () => {
+    const appName = uniq('app');
+    const pagesAppName = uniq('pages-app');
+
+    runCLI(`generate @nx/next:app ${appName} --style=css --no-interactive`);
+    runCLI(
+      `generate @nx/next:app ${pagesAppName} --appDir=false --style=css --no-interactive`
+    );
+
+    const appDirNextEnv = `${appName}/next-env.d.ts`;
+    const appDirNextEnvContent = readFile(appDirNextEnv);
+
+    const pagesDirNextEnv = `${pagesAppName}/next-env.d.ts`;
+    const pagesDirNextEnvContent = readFile(pagesDirNextEnv);
+
+    runCLI(`build ${appName}`);
+    runCLI(`build ${pagesAppName}`);
+
+    const postBuildAppContent = readFile(appDirNextEnv);
+    const postBuildPagesContent = readFile(pagesDirNextEnv);
+
+    expect(postBuildAppContent).toEqual(appDirNextEnvContent);
+    expect(postBuildAppContent).toMatchSnapshot();
+
+    expect(postBuildPagesContent).toEqual(pagesDirNextEnvContent);
+    expect(postBuildPagesContent).toMatchSnapshot();
+  });
 });
 
 function getData(port, path = ''): Promise<any> {

--- a/packages/next/src/generators/application/files/common/next-env.d.ts__tmpl__
+++ b/packages/next/src/generators/application/files/common/next-env.d.ts__tmpl__
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/packages/next/src/generators/application/files/common/next-env.d.ts__tmpl__
+++ b/packages/next/src/generators/application/files/common/next-env.d.ts__tmpl__
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/<%- appDirType %>/building-your-application/configuring/typescript for more information.

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -44,6 +44,7 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
     dot: '.',
     tmpl: '',
     offsetFromRoot,
+    appDirType: options.appDir ? 'app' : 'pages',
     layoutTypeSrcPath,
     rootPath,
     layoutTypeDistPath,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The current next-env.d.ts is outdated so when you run `nx build` Next.js would update the `next-env.d.ts` file which would trigger git changes due to the outdated content. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When you run `nx build` the `next-env.d.ts` ideally should not update from what is generated OOTB.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
