### PR TITLE
fix(graph): enable action on the ViewOnGraph button regardless of the…

### DIFF
--- a/graph/ui-project-details/src/lib/target-configuration-details-header/target-configuration-details-header.tsx
+++ b/graph/ui-project-details/src/lib/target-configuration-details-header/target-configuration-details-header.tsx
@@ -166,9 +166,6 @@ export const TargetConfigurationDetailsHeader = ({
               data-tooltip={isCollasped ? false : 'View in Task Graph'}
               data-tooltip-align-right
               onClick={(e) => {
-                if (isCollasped) {
-                  return;
-                }
                 e.stopPropagation();
                 onViewInTaskGraph({ projectName, targetName });
               }}


### PR DESCRIPTION
## Current Behavior
ViewOnGraph button doesn't work until you open the accordion

## Expected Behavior
ViewOnGraph button should direct to graph without the need to open the accordion first.

I believe it's better from the UX prespective that user shouldn't click twice on the same button to fire its action.

