### PR TITLE
fix(nuxt): change tsconfig path on server part

### DIFF
--- a/packages/nuxt/src/generators/application/files/base/src/server/tsconfig.json__tmpl__
+++ b/packages/nuxt/src/generators/application/files/base/src/server/tsconfig.json__tmpl__
@@ -1,3 +1,3 @@
 {
-  "extends": "../.nuxt/tsconfig.server.json"
+  "extends": "../../.nuxt/tsconfig.server.json"
 }


### PR DESCRIPTION
## Current Behavior
On a new workspace with nuxt preset (`npx create-nx-workspace@latest --preset=nuxt`), a `tsconfig.json` file is create on the nuxt server side directory (path: `apps/nuxt-test/src/server/tsconfig.json`). The file extends the building nuxt server tsconfig file (path: `apps/nuxt-test/.nuxt/tsconfig.server.json`) with the following value :
```json
{
  "extends": "../.nuxt/tsconfig.server.json"
}
```

## Expected Behavior
This `tconfig.json` file generate need to extends the `tsconfig.server.json` with the good path

Fixes #

The correct value is 
```json
{
  "extends": "../../.nuxt/tsconfig.server.json"
}
```