### PR TITLE
fix(core): remove wrapping double quotes of commit sha of last successful pipeline run

### DIFF
--- a/docs/nx-cloud/enterprise/dte/azure-dte.md
+++ b/docs/nx-cloud/enterprise/dte/azure-dte.md
@@ -46,7 +46,7 @@ jobs:
     steps:
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"

--- a/docs/shared/monorepo-ci-azure.md
+++ b/docs/shared/monorepo-ci-azure.md
@@ -41,7 +41,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -86,7 +86,7 @@ Then we can query the pipelines API (providing the auth token)
 ```yaml
 # Get last successfull commit from Azure Devops CLI
 - bash: |
-    LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"")
+    LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"" | sed 's/"//g')
     if [ -z "$LAST_SHA" ]
     then
       echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -32,7 +32,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -276,7 +276,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -341,7 +341,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -747,7 +747,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -809,7 +809,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -1200,7 +1200,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -1265,7 +1265,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -1694,7 +1694,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -1756,7 +1756,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -2149,7 +2149,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -2394,7 +2394,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -2459,7 +2459,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -2867,7 +2867,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -2929,7 +2929,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -3322,7 +3322,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -3387,7 +3387,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -3818,7 +3818,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
@@ -3880,7 +3880,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -8,8 +8,8 @@ import {
   writeJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { ciWorkflowGenerator } from './ci-workflow';
 import { vol } from 'memfs';
+import { ciWorkflowGenerator } from './ci-workflow';
 
 jest.mock('child_process', () => {
   const cp = jest.requireActual('child_process');
@@ -487,7 +487,7 @@ describe('CI Workflow generator', () => {
                 displayName: 'Set default Azure DevOps organization and project'
               # Get last successfull commit from Azure Devops CLI
               - bash: |
-                  LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+                  LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"" | sed 's/"//g')
                   if [ -z "$LAST_SHA" ]
                   then
                     echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"

--- a/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
@@ -29,7 +29,7 @@ jobs:
         displayName: 'Set default Azure DevOps organization and project'
       # Get last successfull commit from Azure Devops CLI
       - bash: |
-          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"")
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"" | sed 's/"//g')
           if [ -z "$LAST_SHA" ]
           then
             echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"


### PR DESCRIPTION
## Current Behavior
```sh
LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\"ci.sourceSha\"")

echo $LAST_SHA # output: "sha"
```

## Expected Behavior
The value of the variable `LAST_SHA` should not be `"sha"` but rather `sha`. 



This PR changes:

- the docs of 'Get last successfull commit from Azure Devops CLI'
- the 'ci-workflow generator' for azure pipelines