### PR TITLE
fix(release): ensure dependents that are both direct and transitive are not bumped twice

### DIFF
--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -1757,6 +1757,139 @@ Valid values are: "auto", "", "~", "^", "="`,
           }
         `);
       });
+
+      it('should not double patch transitive dependents that are already direct dependents', async () => {
+        projectGraph = createWorkspaceWithPackageDependencies(tree, {
+          '@slateui/core': {
+            projectRoot: 'packages/core',
+            packageName: '@slateui/core',
+            version: '1.0.0',
+            packageJsonPath: 'packages/core/package.json',
+            localDependencies: [],
+          },
+          // buttons depends on core
+          '@slateui/buttons': {
+            projectRoot: 'packages/buttons',
+            packageName: '@slateui/buttons',
+            version: '1.0.0',
+            packageJsonPath: 'packages/buttons/package.json',
+            localDependencies: [
+              {
+                projectName: '@slateui/core',
+                dependencyCollection: 'dependencies',
+                version: '1.0.0',
+              },
+            ],
+          },
+          // forms depends on both core and buttons, making it both a direct and transitive dependent of core
+          '@slateui/forms': {
+            projectRoot: 'packages/forms',
+            packageName: '@slateui/forms',
+            version: '1.0.0',
+            packageJsonPath: 'packages/forms/package.json',
+            localDependencies: [
+              {
+                projectName: '@slateui/core',
+                dependencyCollection: 'dependencies',
+                version: '1.0.0',
+              },
+              {
+                projectName: '@slateui/buttons',
+                dependencyCollection: 'dependencies',
+                version: '1.0.0',
+              },
+            ],
+          },
+        });
+
+        expect(
+          await releaseVersionGenerator(tree, {
+            projects: [projectGraph.nodes['@slateui/core']],
+            releaseGroup: createReleaseGroup('independent'),
+            projectGraph,
+            // Bump core to 2.0.0, which will cause buttons and forms to be patched to 1.0.1
+            // This prevents a regression against an issue where forms would end up being patched twice to 1.0.2 in this scenario
+            specifier: '2.0.0',
+            currentVersionResolver: 'disk',
+            specifierSource: 'prompt',
+          })
+        ).toMatchInlineSnapshot(`
+          {
+            "callback": [Function],
+            "data": {
+              "@slateui/buttons": {
+                "currentVersion": "1.0.0",
+                "dependentProjects": [
+                  {
+                    "dependencyCollection": "dependencies",
+                    "rawVersionSpec": "1.0.0",
+                    "source": "@slateui/forms",
+                    "target": "@slateui/buttons",
+                    "type": "static",
+                  },
+                ],
+                "newVersion": "1.0.1",
+              },
+              "@slateui/core": {
+                "currentVersion": "1.0.0",
+                "dependentProjects": [
+                  {
+                    "dependencyCollection": "dependencies",
+                    "rawVersionSpec": "1.0.0",
+                    "source": "@slateui/buttons",
+                    "target": "@slateui/core",
+                    "type": "static",
+                  },
+                  {
+                    "dependencyCollection": "dependencies",
+                    "rawVersionSpec": "1.0.0",
+                    "source": "@slateui/forms",
+                    "target": "@slateui/core",
+                    "type": "static",
+                  },
+                ],
+                "newVersion": "2.0.0",
+              },
+              "@slateui/forms": {
+                "currentVersion": "1.0.0",
+                "dependentProjects": [],
+                "newVersion": "1.0.1",
+              },
+            },
+          }
+        `);
+
+        expect(readJson(tree, 'packages/core/package.json'))
+          .toMatchInlineSnapshot(`
+          {
+            "name": "@slateui/core",
+            "version": "2.0.0",
+          }
+        `);
+
+        expect(readJson(tree, 'packages/buttons/package.json'))
+          .toMatchInlineSnapshot(`
+          {
+            "dependencies": {
+              "@slateui/core": "2.0.0",
+            },
+            "name": "@slateui/buttons",
+            "version": "1.0.1",
+          }
+        `);
+
+        expect(readJson(tree, 'packages/forms/package.json'))
+          .toMatchInlineSnapshot(`
+          {
+            "dependencies": {
+              "@slateui/buttons": "1.0.1",
+              "@slateui/core": "2.0.0",
+            },
+            "name": "@slateui/forms",
+            "version": "1.0.1",
+          }
+        `);
+      });
     });
   });
 

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -609,26 +609,24 @@ To fix this you will either need to add a package.json file at that location, or
         options.releaseGroup.projectsRelationship === 'independent';
       const transitiveLocalPackageDependents: LocalPackageDependency[] = [];
       if (includeTransitiveDependents) {
-        // Create a Set of all direct dependency relationships for O(1) lookups
+        // Precompute a Set of all direct dependency relationships for O(1) lookups
         const directDependentSet = new Set(
           allDependentProjects.map((dep) => `${dep.source}:${dep.target}`)
         );
-        // Get all potential transitive dependencies in a single pass
-        const potentialTransitiveDependents = Object.values(
-          localPackageDependencies
-        )
+        // Precompute a Set of all dependent targets for O(1) lookup
+        const dependentTargetsSet = new Set(
+          allDependentProjects.map((dep) => dep.source)
+        );
+        Object.values(localPackageDependencies)
           .flat()
-          .filter((dependent) => {
-            return (
-              allDependentProjects.some(
-                (direct) => direct.source === dependent.target
-              ) &&
-              // Only include if this exact dependency relationship isn't already covered by a direct dependent
+          .forEach((dependent) => {
+            if (
+              dependentTargetsSet.has(dependent.target) &&
               !directDependentSet.has(`${dependent.source}:${dependent.target}`)
-            );
+            ) {
+              transitiveLocalPackageDependents.push(dependent);
+            }
           });
-
-        transitiveLocalPackageDependents.push(...potentialTransitiveDependents);
       }
 
       const dependentProjectsInCurrentBatch = [];


### PR DESCRIPTION
Before and after is covered by the new unit test added in this PR
