### PR TITLE
chore(repo): disable parallelism for nx-dev:build-base and separate it from `test` tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - checkout
       - nx/set-shas:
           main-branch-name: 'master'
-      - run: npx nx-cloud@next start-ci-run --distribute-on="auto linux-medium" --stop-agents-after="e2e"
+      - run: npx nx-cloud@next start-ci-run --distribute-on="./.nx/workflows/dynamic-changesets.yaml" --stop-agents-after="e2e"
       - run:
           command: |
             sudo apt-get update

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -56,3 +56,60 @@ launch-templates:
 
       - name: Install zip and unzip
         script: sudo apt-get -yqq install zip unzip
+  linux-large:
+    resource-class: 'docker_linux_amd64/large'
+    image: 'ubuntu22.04-node20.11-v10'
+    env:
+      GIT_AUTHOR_EMAIL: test@test.com
+      GIT_AUTHOR_NAME: Test
+      GIT_COMMITTER_EMAIL: test@test.com
+      GIT_COMMITTER_NAME: Test
+      SELECTED_PM: 'pnpm'
+      NPM_CONFIG_PREFIX: '/home/workflows/.npm-global'
+      NX_NATIVE_LOGGING: 'nx::native::db'
+    init-steps:
+      - name: Checkout
+        uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/checkout/main.yaml'
+      - name: Cache restore
+        uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/cache/main.yaml'
+        inputs:
+          key: 'pnpm-lock.yaml'
+          paths: |
+            node_modules
+            ~/.cache/Cypress
+            ~/.cache/ms-playwright
+            ~/.pnpm-store
+          base_branch: 'master'
+      - name: Install e2e deps
+        script: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev
+      - name: Install Pnpm
+        script: |
+          npm install -g pnpm@9.8.0
+
+      - name: Pnpm Install
+        script: |
+          pnpm install --frozen-lockfile
+
+      - name: Install Browsers
+        script: |
+          pnpm exec cypress install
+          pnpm exec playwright install
+
+      - name: Install Rust
+        script: |
+          curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
+          source "$HOME/.cargo/env"
+          rustup toolchain install 1.70.0
+
+      - name: Configure git metadata (needed for lerna smoke tests)
+        script: |
+          git config --global user.email test@test.com
+          git config --global user.name "Test Test"
+
+      - name: Load Cargo Env
+        script: echo "PATH=$HOME/.cargo/bin:$PATH" >> $NX_CLOUD_ENV
+
+      - name: Install zip and unzip
+        script: sudo apt-get -yqq install zip unzip

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,7 +1,5 @@
 distribute-on:
-  small-changeset: 8 linux-medium, 1 linux-large
-  medium-changeset: 12 linux-medium, 1 linux-large
-  large-changeset: 20 linux-medium, 1 linux-large
+  default: auto linux-medium, 1 linux-large
 assignment-rules:
   - project: nx-dev
     target: build-base

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,4 +1,12 @@
 distribute-on:
-  small-changeset: 8 linux-medium
-  medium-changeset: 10 linux-medium
-  large-changeset: 12 linux-medium
+  small-changeset: 8 linux-medium, 1 linux-large
+  medium-changeset: 12 linux-medium, 1 linux-large
+  large-changeset: 20 linux-medium, 1 linux-large
+assignment-rules:
+  - project: nx-dev
+    target: build-base
+    runs-on:
+      - linux-large
+  - target: test
+    runs-on:
+      - linux-medium

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -41,6 +41,7 @@
       }
     },
     "build-base": {
+      "parallelism": false,
       "executor": "@nx/next:build",
       "dependsOn": ["copy-docs"],
       "outputs": ["{options.outputPath}"],

--- a/nx.json
+++ b/nx.json
@@ -246,7 +246,7 @@
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
   "cacheDirectory": "/tmp/nx-cache",
-  "bust": 8,
+  "bust": 1,
   "defaultBase": "master",
   "generators": {
     "@nx/react": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx-dev:build-base` takes a lot of memory and particularly if it is run after `test` tasks, it will cause agents to run out of memory. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

I don't have a fix for the task taking up a lot of memory... but I do have a fix which will alleviate the issue. I've split up `test` tasks and `nx-dev:build-base` to run on different agents.

We should still look into how to make this task not take up so much memory. What I've learned is that prerendering pages for `nx-dev` has a memory leak so we should investigate what during prerendering a page is not cleaned up properly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
