### PR TITLE
fix(react): depends on migration should ignore configs that point to …

### DIFF
--- a/packages/react/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
+++ b/packages/react/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
@@ -9,7 +9,7 @@ export default async function (tree: Tree) {
     '@nx/webpack:webpack',
     (options, projectName, targetName) => {
       const webpackConfig: string = options.webpackConfig;
-      if (!webpackConfig) {
+      if (!webpackConfig || webpackConfig === '@nx/react/plugins/webpack') {
         return;
       }
 


### PR DESCRIPTION
…@nx/react #28377 (#28382)

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!--
https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Some executors using `@nx/webpack:webpack` point to a webpack config that is exported from the `@nx/react plugin.

We do not want to try modify this.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Skip the migration if the webpack config points to the exported plugin from @nx/react.
