### PR TITLE
fix(angular): when unit test runner is set to none library component should not generate spec file

### DIFF
--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -67,6 +67,7 @@ export async function normalizeOptions(
     fileName,
     importPath,
     ngCliSchematicLibRoot,
+    skipTests: options.unitTestRunner === 'none' ? true : options.skipTests,
     standaloneComponentName: `${
       names(projectNames.projectSimpleName).className
     }Component`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When unitTestRunner is set to none, spec files are still generated


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
SkipTests when unit test runner set to none

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
