### PR TITLE
fix(rspack): ensure swc provides react runtime automatically

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -404,11 +404,13 @@ function applyNxDependentConfig(
             },
             transform: {
               react: {
+                runtime: 'automatic',
                 pragma: 'React.createElement',
                 pragmaFrag: 'React.Fragment',
                 throwIfNamespace: true,
                 // Config.mode is already set based on options.mode and `process.env.NODE_ENV`
                 development: config.mode === 'development',
+                refresh: config.mode === 'development',
                 useBuiltins: false,
               },
             },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Rspack w/ SWC requires setting `runtime: 'automatic'` to allow React global to be set in browser


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Set `runtime: 'automatic'`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
