### PR TITLE
fix(core): lower socket path by 10 chars to reduce chances of too-long paths

### DIFF
--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -49,7 +49,7 @@ export function isDaemonDisabled() {
 function socketDirName() {
   const hasher = createHash('sha256');
   hasher.update(workspaceRoot.toLowerCase());
-  const unique = hasher.digest('hex').substring(0, 20);
+  const unique = hasher.digest('hex').substring(0, 10);
   return join(tmpdir, unique);
 }
 


### PR DESCRIPTION

## Current Behavior
Socket paths have quite a short allowed length. It's easy to hit the maximum.

## Expected Behavior
We should exceed the maximum as rarely as possible. By lowering the workspacePath hash portion, we reduce the chances of exceeding the path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/27725
