### PR TITLE
fix(rspack): do not global styles as entrypoints

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -119,12 +119,6 @@ export function applyWebConfig(
       const resolvedPath = style.input.startsWith('.')
         ? style.input
         : resolve(options.root, style.input);
-      // Add style entry points.
-      if (entries[style.bundleName]) {
-        entries[style.bundleName].import.push(resolvedPath);
-      } else {
-        entries[style.bundleName] = { import: [resolvedPath] };
-      }
 
       // Add global css paths.
       globalStylePaths.push(resolvedPath);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Setting global styles as entry points in rspack causes HMR to fail


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Rspack does not require styles to be set as entrypoints as it will be handled by the CssExtractPlugin.
Remove the entries

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
