### PR TITLE
fix(rspack): withModuleFederationForSSR should use commonjs-module as library

### DIFF
--- a/packages/rspack/src/utils/module-federation/with-module-federation/with-module-federation-ssr.ts
+++ b/packages/rspack/src/utils/module-federation/with-module-federation/with-module-federation-ssr.ts
@@ -22,6 +22,9 @@ export async function withModuleFederationForSSR(
   return (config, { context }: NxRspackExecutionContext) => {
     config.target = 'async-node';
     config.output.uniqueName = options.name;
+    config.output.library = {
+      type: 'commonjs-module',
+    };
     config.optimization = {
       ...(config.optimization ?? {}),
       runtimeChunk: false,
@@ -39,6 +42,10 @@ export async function withModuleFederationForSSR(
             ...sharedDependencies,
           },
           isServer: true,
+          library: {
+            type: 'commonjs-module',
+          },
+          remoteType: 'script',
           /**
            * Apply user-defined config overrides
            */


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When navigating directly to a route that renders a portion of a remote app, SSR was not correctly server rendering the remote portion.
This was because of the output type provided to rspack and MFP

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure commonjs-module is set as output type for MF with SSR

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
