### PR TITLE
docs(nx-dev): update plan references from Pro to Team

### DIFF
--- a/docs/blog/2024-07-29-explain-with-ai.md
+++ b/docs/blog/2024-07-29-explain-with-ai.md
@@ -40,10 +40,6 @@ Note that you'll need to be an organization admin for your Nx Cloud workspace to
 Log in to Nx Cloud
 {% /call-to-action %}
 
-### I want to try this, but I'm on the Hobby plan 🤔
-
-If you're currently on the Hobby plan, you can start a free Pro plan trial for 14 days to try it out on your own workspace. No, we don't ask for credit cards to start a trial, so feel free to experiment!
-
 ## More to come!
 
 This is just the first of a series of AI-powered features that we're going to be rolling out to your workspaces. We've got some cool features in the works already, which we're going to **announce publicly during the [Monorepo World](https://monorepo.world) conference in October**! So stay tuned!

--- a/docs/nx-cloud/concepts/ai-features.md
+++ b/docs/nx-cloud/concepts/ai-features.md
@@ -17,7 +17,7 @@ Ensure that you **accept the AI terms** to start using the AI features.
 
 {% callout type="info" title="AI Features Availability" %}
 
-AI features are available only for the [Nx Cloud Pro plan](/pricing). If you are on the Hobby plan, you can start a free trial to test AI features in your workspace.
+AI features are available only for the [Nx Cloud Team plan](/pricing).
 
 {% /callout %}
 

--- a/docs/nx-cloud/features/explain-with-ai.md
+++ b/docs/nx-cloud/features/explain-with-ai.md
@@ -15,7 +15,7 @@ To use the "Explain with AI" feature, you need to [enable AI features for your o
 
 ![enable ai features](/nx-cloud/features/ai-features.png)
 
-AI features are available only for the [Nx Cloud Pro plan](/pricing). If you are on the Hobby plan, you can start a free trial to test AI features in your workspace.
+AI features are available only for the [Nx Cloud Team plan](/pricing).
 
 ## Using Explain with AI
 

--- a/nx-dev/ui-pricing/src/lib/faq.tsx
+++ b/nx-dev/ui-pricing/src/lib/faq.tsx
@@ -54,7 +54,7 @@ export function Faq(): ReactElement {
       question:
         'What happens if I consume all my credits while on the Hobby plan?',
       answer:
-        'The Hobby plan allows you to configure and run a small project at no cost. If you consume all the credits, your organization will be disabled until you upgrade to Pro or wait for the next billing cycle.',
+        'The Hobby plan allows you to configure and run a small project at no cost. If you consume all the credits, your organization will be disabled until you upgrade to Team or wait for the next billing cycle.',
     },
     {
       question: 'What is a CI Pipeline Execution?',


### PR DESCRIPTION
Replaced mentions of "Pro plan" with "Team plan" across several documentation files to reflect the updated plan structure.
