### PR TITLE
feat(core): add spinners when graph compute takes long time

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -200,7 +200,7 @@ export class DaemonClient {
       // If the graph takes a while to load, we want to show a spinner.
       timeout = setTimeout(() => {
         spinner = ora('Getting project graph from the Nx Daemon').start();
-      }, 300);
+      }, 500).unref();
     }
     try {
       const response = await this.sendToDaemonViaQueue({

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -33,7 +33,6 @@ import {
   DaemonProjectGraphError,
   ProjectGraphError,
 } from '../../project-graph/error-types';
-import * as ora from 'ora';
 import { IS_WASM, NxWorkspaceFiles, TaskRun, TaskTarget } from '../../native';
 import { HandleGlobMessage } from '../message-types/glob';
 import {
@@ -78,6 +77,10 @@ import {
   FLUSH_SYNC_GENERATOR_CHANGES_TO_DISK,
   type HandleFlushSyncGeneratorChangesToDiskMessage,
 } from '../message-types/flush-sync-generator-changes-to-disk';
+import {
+  DelayedSpinner,
+  SHOULD_SHOW_SPINNERS,
+} from '../../utils/delayed-spinner';
 
 const DAEMON_ENV_SETTINGS = {
   NX_PROJECT_GLOB_CACHE: 'false',
@@ -195,12 +198,16 @@ export class DaemonClient {
     projectGraph: ProjectGraph;
     sourceMaps: ConfigurationSourceMaps;
   }> {
-    let spinner: ReturnType<typeof ora>, timeout: NodeJS.Timeout;
-    if (process.stdout.isTTY) {
+    let spinner: DelayedSpinner;
+    if (SHOULD_SHOW_SPINNERS) {
       // If the graph takes a while to load, we want to show a spinner.
-      timeout = setTimeout(() => {
-        spinner = ora('Getting project graph from the Nx Daemon').start();
-      }, 500).unref();
+      spinner = new DelayedSpinner(
+        'Calculating the project graph on the Nx Daemon',
+        500
+      ).scheduleMessageUpdate(
+        'Calculating the project graph on the Nx Daemon is taking longer than expected. Re-run with NX_DAEMON=false to see more details.',
+        30_000
+      );
     }
     try {
       const response = await this.sendToDaemonViaQueue({
@@ -217,12 +224,7 @@ export class DaemonClient {
         throw e;
       }
     } finally {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-      if (spinner) {
-        spinner.stop();
-      }
+      spinner?.cleanup();
     }
   }
 

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -338,7 +338,7 @@ async function updateProjectGraphWithPlugins(
             ? `${inProgressPlugins.size} plugins`
             : inProgressPlugins.keys()[0]);
       }, 50);
-    }, 300);
+    }, 500).unref();
   }
 
   await Promise.all(
@@ -459,7 +459,7 @@ export async function applyProjectMetadata(
             ? `${inProgressPlugins.size} plugins`
             : inProgressPlugins.keys()[0]);
       }, 50);
-    }, 300);
+    }, 500).unref();
   }
 
   const promises = plugins.map(async (plugin) => {

--- a/packages/nx/src/project-graph/plugins/internal-api.ts
+++ b/packages/nx/src/project-graph/plugins/internal-api.ts
@@ -15,6 +15,7 @@ import {
   CreateNodesContextV2,
   CreateNodesResult,
   NxPluginV2,
+  ProjectsMetadata,
 } from './public-api';
 import { ProjectGraph } from '../../config/project-graph';
 import { loadNxPluginInIsolation } from './isolation';
@@ -25,6 +26,7 @@ import {
   isAggregateCreateNodesError,
 } from '../error-types';
 import { IS_WASM } from '../../native';
+import { RawProjectGraphDependency } from '../project-graph-builder';
 
 export class LoadedNxPlugin {
   readonly name: string;
@@ -41,11 +43,11 @@ export class LoadedNxPlugin {
   ];
   readonly createDependencies?: (
     context: CreateDependenciesContext
-  ) => ReturnType<CreateDependencies>;
+  ) => Promise<RawProjectGraphDependency[]>;
   readonly createMetadata?: (
     graph: ProjectGraph,
     context: CreateMetadataContext
-  ) => ReturnType<CreateMetadata>;
+  ) => Promise<ProjectsMetadata>;
 
   readonly options?: unknown;
   readonly include?: string[];
@@ -110,12 +112,12 @@ export class LoadedNxPlugin {
     }
 
     if (plugin.createDependencies) {
-      this.createDependencies = (context) =>
+      this.createDependencies = async (context) =>
         plugin.createDependencies(this.options, context);
     }
 
     if (plugin.createMetadata) {
-      this.createMetadata = (graph, context) =>
+      this.createMetadata = async (graph, context) =>
         plugin.createMetadata(graph, this.options, context);
     }
   }

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -84,7 +84,7 @@ export interface PluginCreateDependenciesResult {
   type: 'createDependenciesResult';
   payload:
     | {
-        dependencies: ReturnType<LoadedNxPlugin['createDependencies']>;
+        dependencies: Awaited<ReturnType<LoadedNxPlugin['createDependencies']>>;
         success: true;
         tx: string;
       }
@@ -99,7 +99,7 @@ export interface PluginCreateMetadataResult {
   type: 'createMetadataResult';
   payload:
     | {
-        metadata: ReturnType<LoadedNxPlugin['createMetadata']>;
+        metadata: Awaited<ReturnType<LoadedNxPlugin['createMetadata']>>;
         success: true;
         tx: string;
       }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -348,7 +348,7 @@ export async function createProjectConfigurations(
             ? `${inProgressPlugins.size} plugins`
             : inProgressPlugins.values().next().value);
       }, 50);
-    }, 300);
+    }, 500).unref();
   }
 
   const results: Array<ReturnType<LoadedNxPlugin['createNodes'][1]>> = [];

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -338,7 +338,7 @@ export async function createProjectConfigurations(
         'Waiting on project information from ' +
           (inProgressPlugins.size > 1
             ? `${inProgressPlugins.size} plugins`
-            : inProgressPlugins.keys()[0])
+            : inProgressPlugins.values().next().value)
       ).start();
 
       spinnerUpdateInterval = setInterval(() => {
@@ -346,7 +346,7 @@ export async function createProjectConfigurations(
           'Waiting on project information from ' +
           (inProgressPlugins.size > 1
             ? `${inProgressPlugins.size} plugins`
-            : inProgressPlugins.keys()[0]);
+            : inProgressPlugins.values().next().value);
       }, 50);
     }, 300);
   }

--- a/packages/nx/src/utils/delayed-spinner.ts
+++ b/packages/nx/src/utils/delayed-spinner.ts
@@ -1,0 +1,65 @@
+import * as ora from 'ora';
+
+/**
+ * A class that allows to delay the creation of a spinner, as well
+ * as schedule updates to the message of the spinner. Useful for
+ * scenarios where one wants to only show a spinner if an operation
+ * takes longer than a certain amount of time.
+ */
+export class DelayedSpinner {
+  spinner: ora.Ora;
+  timeouts: NodeJS.Timeout[] = [];
+  initial: number = Date.now();
+
+  /**
+   * Constructs a new {@link DelayedSpinner} instance.
+   *
+   * @param message The message to display in the spinner
+   * @param ms The number of milliseconds to wait before creating the spinner
+   */
+  constructor(message: string, ms: number = 500) {
+    this.timeouts.push(
+      setTimeout(() => {
+        this.spinner = ora(message);
+      }, ms).unref()
+    );
+  }
+
+  /**
+   * Sets the message to display in the spinner.
+   *
+   * @param message The message to display in the spinner
+   * @returns The {@link DelayedSpinner} instance
+   */
+  setMessage(message: string) {
+    this.spinner.text = message;
+    return this;
+  }
+
+  /**
+   * Schedules an update to the message of the spinner. Useful for
+   * changing the message after a certain amount of time has passed.
+   *
+   * @param message The message to display in the spinner
+   * @param delay How long to wait before updating the message
+   * @returns The {@link DelayedSpinner} instance
+   */
+  scheduleMessageUpdate(message: string, delay: number) {
+    this.timeouts.push(
+      setTimeout(() => {
+        this.spinner.text = message;
+      }, delay).unref()
+    );
+    return this;
+  }
+
+  /**
+   * Stops the spinner and cleans up any scheduled timeouts.
+   */
+  cleanup() {
+    this.spinner?.stop();
+    this.timeouts.forEach((t) => clearTimeout(t));
+  }
+}
+
+export const SHOULD_SHOW_SPINNERS = process.stdout.isTTY;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

Sometimes graph computation can take longer than may be expected. In these cases we can show a spinner, and if only one plugin is still running **and the daemon is disabled** also show the plugin names.
