### PR TITLE
chore(rspack): update resource query to reduce confusion

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-react-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-react-config.ts
@@ -25,12 +25,12 @@ export function applyReactConfig(
       {
         test: /\.svg$/i,
         type: 'asset',
-        resourceQuery: /react/, // *.svg?react
+        resourceQuery: /url/, // *.svg?url
       },
       {
         test: /\.svg$/i,
         issuer: /\.[jt]sx?$/,
-        resourceQuery: { not: [/react/] }, // exclude react component if *.svg?react
+        resourceQuery: { not: [/url/] }, // exclude react component if not *.svg?url
         use: [{ loader: '@svgr/webpack', options: svgrOptions }],
       }
     );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`withReact` in `rspack` adds svg rules to support svgs as assets/urls and React components.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Svgr docs use `url` as resourceQuery value, https://react-svgr.com/docs/webpack/#use-svgr-and-asset-svg-in-the-same-project Having resource query match on `react` is confusing because you would want the inverse, treat the url as a resource if it has the query and as a React component otherwise.

