### PR TITLE
feat(expo): upgrade Expo to v52

### DIFF
--- a/packages/expo/migrations.json
+++ b/packages/expo/migrations.json
@@ -247,6 +247,67 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "20.2.0": {
+      "version": "20.2.0-beta.2",
+      "packages": {
+        "expo": {
+          "version": "~52.0.7",
+          "alwaysAddToPackageJson": false
+        },
+        "expo-splash-screen": {
+          "version": "~0.29.9",
+          "alwaysAddToPackageJson": false
+        },
+        "expo-status-bar": {
+          "version": "~2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@expo/cli": {
+          "version": "~0.21.5",
+          "alwaysAddToPackageJson": false
+        },
+        "babel-preset-expo": {
+          "version": "~12.0.1",
+          "alwaysAddToPackageJson": false
+        },
+        "react-native": {
+          "version": "0.76.2",
+          "alwaysAddToPackageJson": false
+        },
+        "react-native-web": {
+          "version": "~0.19.13",
+          "alwaysAddToPackageJson": false
+        },
+        "@expo/metro-config": {
+          "version": "~0.19.4",
+          "alwaysAddToPackageJson": false
+        },
+        "@expo/metro-runtime": {
+          "version": "~4.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "react-native-svg-transformer": {
+          "version": "1.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "react-native-svg": {
+          "version": "15.9.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@testing-library/react-native": {
+          "version": "~12.8.1",
+          "alwaysAddToPackageJson": false
+        },
+        "jest-expo": {
+          "version": "~52.0.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@babel/runtime": {
+          "version": "7.26.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/expo/src/utils/versions.ts
+++ b/packages/expo/src/utils/versions.ts
@@ -1,27 +1,27 @@
 export const nxVersion = require('../../package.json').version;
 
-export const expoVersion = '~51.0.8';
-export const expoSplashScreenVersion = '~0.27.4';
-export const expoStatusBarVersion = '~1.12.1';
-export const expoCliVersion = '~0.18.13'; // @expo/cli
-export const babelPresetExpoVersion = '~11.0.0';
+export const expoVersion = '~52.0.7';
+export const expoSplashScreenVersion = '~0.29.9';
+export const expoStatusBarVersion = '~2.0.0';
+export const expoCliVersion = '~0.21.5'; // @expo/cli
+export const babelPresetExpoVersion = '~12.0.1';
 
-export const reactVersion = '18.2.0';
-export const reactDomVersion = '18.2.0';
-export const reactTestRendererVersion = '18.2.0';
-export const typesReactVersion = '~18.2.45';
+export const reactVersion = '18.3.1';
+export const reactDomVersion = '18.3.1';
+export const reactTestRendererVersion = '18.3.1';
+export const typesReactVersion = '~18.3.12';
 
-export const reactNativeVersion = '0.74.1';
-export const reactNativeWebVersion = '~0.19.11';
+export const reactNativeVersion = '0.76.2';
+export const reactNativeWebVersion = '~0.19.13';
 
-export const expoMetroConfigVersion = '~0.18.1';
-export const expoMetroRuntimeVersion = '~3.2.1';
+export const expoMetroConfigVersion = '~0.19.4';
+export const expoMetroRuntimeVersion = '~4.0.0';
 
-export const reactNativeSvgTransformerVersion = '1.3.0';
-export const reactNativeSvgVersion = '15.2.0';
+export const reactNativeSvgTransformerVersion = '1.5.0';
+export const reactNativeSvgVersion = '15.9.0';
 
-export const testingLibraryReactNativeVersion = '~12.5.0';
+export const testingLibraryReactNativeVersion = '~12.8.1';
 export const testingLibraryJestNativeVersion = '~5.4.3';
-export const jestExpoVersion = '~51.0.2';
+export const jestExpoVersion = '~52.0.2';
 
-export const babelRuntimeVersion = '7.24.5';
+export const babelRuntimeVersion = '7.26.0';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

Used https://github.com/nrwl/nx/pull/26143 as a guide.

## Current Behavior

The current nx plugin scaffolds a project using Expo v51.

<!-- This is the behavior we have today -->

## Expected Behavior

The nx plugin should scaffold a project [using Expo v52](https://expo.dev/changelog/2024/11-12-sdk-52).

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

/cc @xiongemi 
