### PR TITLE
fix(linter): remove legacy dependencies during convert to flat config

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -47,6 +47,32 @@ describe('convert-to-flat-config generator', () => {
     });
   });
 
+  it('should update dependencies', async () => {
+    await lintProjectGenerator(tree, {
+      skipFormat: false,
+      linter: Linter.EsLint,
+      project: 'test-lib',
+      setParserOptionsProject: false,
+    });
+    await convertToFlatConfigGenerator(tree, options);
+
+    expect(tree.read('package.json', 'utf-8')).toMatchInlineSnapshot(`
+      "{
+        "name": "@proj/source",
+        "dependencies": {},
+        "devDependencies": {
+          "@eslint/eslintrc": "^2.1.1",
+          "@nx/eslint": "0.0.1",
+          "@nx/eslint-plugin": "0.0.1",
+          "eslint": "^9.8.0",
+          "eslint-config-prettier": "^9.0.0",
+          "typescript-eslint": "^8.0.0"
+        }
+      }
+      "
+    `);
+  });
+
   it('should convert json successfully', async () => {
     await lintProjectGenerator(tree, {
       skipFormat: false,

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -8,6 +8,7 @@ import {
   ProjectConfiguration,
   readJson,
   readNxJson,
+  removeDependenciesFromPackageJson,
   Tree,
   updateJson,
   updateProjectConfiguration,
@@ -240,4 +241,10 @@ function processConvertedConfig(
   }
 
   addDependenciesToPackageJson(tree, {}, devDependencies);
+
+  removeDependenciesFromPackageJson(
+    tree,
+    ['@typescript-eslint/eslint-plugin', '@typescript-eslint/parser'],
+    ['@typescript-eslint/eslint-plugin', '@typescript-eslint/parser']
+  );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` are left at old versions after converting to flat config.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` are removed when converting to flat config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
