### PR TITLE
feat(devkit): expose `findMatchingProjects` from @nx/devkit

### DIFF
--- a/docs/generated/devkit/README.md
+++ b/docs/generated/devkit/README.md
@@ -119,6 +119,7 @@ It only uses language primitives and immutable objects
 - [detectPackageManager](../../devkit/documents/detectPackageManager)
 - [ensurePackage](../../devkit/documents/ensurePackage)
 - [extractLayoutDirectory](../../devkit/documents/extractLayoutDirectory)
+- [findMatchingProjects](../../devkit/documents/findMatchingProjects)
 - [formatFiles](../../devkit/documents/formatFiles)
 - [generateFiles](../../devkit/documents/generateFiles)
 - [getOutputsForTargetAndConfiguration](../../devkit/documents/getOutputsForTargetAndConfiguration)

--- a/docs/generated/devkit/findMatchingProjects.md
+++ b/docs/generated/devkit/findMatchingProjects.md
@@ -1,0 +1,16 @@
+# Function: findMatchingProjects
+
+▸ **findMatchingProjects**(`patterns?`, `projects`): `string`[]
+
+Find matching project names given a list of potential project names or globs.
+
+#### Parameters
+
+| Name       | Type                                                                                              | Default value | Description                                                                                         |
+| :--------- | :------------------------------------------------------------------------------------------------ | :------------ | :-------------------------------------------------------------------------------------------------- |
+| `patterns` | `string`[]                                                                                        | `[]`          | A list of project names or globs to match against.                                                  |
+| `projects` | `Record`\<`string`, [`ProjectGraphProjectNode`](../../devkit/documents/ProjectGraphProjectNode)\> | `undefined`   | A map of [ProjectGraphProjectNode](../../devkit/documents/ProjectGraphProjectNode) by project name. |
+
+#### Returns
+
+`string`[]

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -119,6 +119,7 @@ It only uses language primitives and immutable objects
 - [detectPackageManager](../../devkit/documents/detectPackageManager)
 - [ensurePackage](../../devkit/documents/ensurePackage)
 - [extractLayoutDirectory](../../devkit/documents/extractLayoutDirectory)
+- [findMatchingProjects](../../devkit/documents/findMatchingProjects)
 - [formatFiles](../../devkit/documents/formatFiles)
 - [generateFiles](../../devkit/documents/generateFiles)
 - [getOutputsForTargetAndConfiguration](../../devkit/documents/getOutputsForTargetAndConfiguration)

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -248,4 +248,9 @@ export { cacheDir } from './utils/cache-directory';
  */
 export { createProjectFileMapUsingProjectGraph } from './project-graph/file-map-utils';
 
+/**
+ * @category Utils
+ */
+export { findMatchingProjects } from './utils/find-matching-projects';
+
 export { isDaemonEnabled } from './daemon/client/client';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

The `findMatchingProjects` utility can be useful in standalone scripts that consume the project graph.

## Current Behavior
There is no public access to the `findMatchingProjects` utility.

## Expected Behavior
There is public access to the `findMatchingProjects` utility.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to https://github.com/nrwl/nx/discussions/23409
