### PR TITLE
fix(rspack): buildLibsFromSource option

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -8,7 +8,6 @@ import {
   SwcJsMinimizerRspackPlugin,
   CopyRspackPlugin,
   RspackOptionsNormalized,
-  type DevTool,
 } from '@rspack/core';
 import { getRootTsConfigPath } from '@nx/js';
 

--- a/packages/rspack/src/plugins/utils/plugins/nx-tsconfig-paths-rspack-plugin.ts
+++ b/packages/rspack/src/plugins/utils/plugins/nx-tsconfig-paths-rspack-plugin.ts
@@ -26,7 +26,7 @@ export class NxTsconfigPathsRspackPlugin {
   apply(compiler: Compiler): void {
     // TODO(Colum): Investigate the best way to handle this, currently it is not working and affecting HMR
     // // If we are not building libs from source, we need to remap paths so tsconfig may be updated.
-    // this.handleBuildLibsFromSource(compiler.options, this.options);
+    this.handleBuildLibsFromSource(compiler.options, this.options);
 
     const pathToTsconfig = !path.isAbsolute(this.options.tsConfig)
       ? path.join(workspaceRoot, this.options.tsConfig)
@@ -75,7 +75,8 @@ export class NxTsconfigPathsRspackPlugin {
         options.tsConfig,
         options.root,
         target.data.root,
-        dependencies
+        dependencies,
+        true // There is an issue with Rspack that requires the baseUrl to be set in the generated tsconfig
       );
       this.tmpTsConfigPath = options.tsConfig;
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, the `buildLibsFromSource` option is not being used. So even if the user sets it to `'buildLibsFromSource': false` it will not be updated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `buildLibsFromSource` should be supported.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
There is an issue with Rspack that requires the baseUrl to be set in the generated tsconfig.

Fixes #
