### PR TITLE
docs(nx-dev): update link href in trial-callout component

### DIFF
--- a/nx-dev/ui-pricing/src/lib/trial-callout.tsx
+++ b/nx-dev/ui-pricing/src/lib/trial-callout.tsx
@@ -62,7 +62,7 @@ export function TrialCallout({
             <p className="mt-8 text-pretty text-base/8 leading-normal">
               Need a bit more? For larger teams we offer personalized support,{' '}
               <Link
-                href="/contact-us/sales"
+                href="/contact/sales"
                 title="Reach out to us"
                 onClick={() =>
                   sendCustomEvent(


### PR DESCRIPTION
Changed the href attribute for the sales contact link from "/contact-us/sales" to "/contact/sales" to correct the URL path.
