### PR TITLE
chore(repo): ensure playwright is installed before running e2e tests

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -38,7 +38,7 @@ launch-templates:
       - name: Install Browsers
         script: |
           pnpm exec cypress install
-          pnpm exec playwright install
+          pnpm exec playwright install --with-deps
 
       - name: Install Rust
         script: |
@@ -95,7 +95,7 @@ launch-templates:
       - name: Install Browsers
         script: |
           pnpm exec cypress install
-          pnpm exec playwright install
+          pnpm exec playwright install --with-deps
 
       - name: Install Rust
         script: |

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -184,7 +184,7 @@ describe('Next.js Applications', () => {
 
     runCLI(`generate @nx/next:app ${appName} --no-interactive --style=css`);
 
-    if (runE2ETests('cypress')) {
+    if (runE2ETests('playwright')) {
       const e2eResults = runCLI(`e2e-ci ${appName}-e2e --verbose`, {
         verbose: true,
         env: {


### PR DESCRIPTION
We're using Playwright by default, but the e2e test is ensuring Cypress installation.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
