### PR TITLE
fix(core): add missing supported CI providers to `NxCloud` type

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -2,7 +2,14 @@ import { CLIOutput } from '../output';
 import { getMessageFactory } from './messages';
 import * as ora from 'ora';
 
-export type NxCloud = 'yes' | 'github' | 'circleci' | 'skip';
+export type NxCloud =
+  | 'yes'
+  | 'github'
+  | 'gitlab'
+  | 'azure'
+  | 'bitbucket-pipelines'
+  | 'circleci'
+  | 'skip';
 
 export function readNxCloudToken(directory: string) {
   const nxCloudSpinner = ora(`Checking Nx Cloud setup`).start();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`CreateWorkspaceOptions` that is exposed via the `create-nx-workspace` package, 
https://github.com/nrwl/nx/blob/a0d760f7902b09eb2cf77f0cd83e2157669c794d/packages/create-nx-workspace/src/create-workspace-options.ts#L7

has a field named `NxCloud` that only contains the  following types:, 
https://github.com/nrwl/nx/blob/1c2ae37b6e7c9e58dbdf10dc8cd614dcb5886178/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts#L5

while more CI providers are in fact supported by the underlying code (see `NxCloudChoices` array  in `ab-testing.ts`): 

https://github.com/nrwl/nx/blob/a0d760f7902b09eb2cf77f0cd83e2157669c794d/packages/create-nx-workspace/src/utils/nx/ab-testing.ts#L5

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Align the type of `NxCloud` to match all supported values from `NxCloudChoices`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
