### PR TITLE
fix(remix): remove tooling packages from generated package.json since they are installed in the root

### DIFF
--- a/packages/remix/src/generators/application/files/integrated/package.json__tmpl__
+++ b/packages/remix/src/generators/application/files/integrated/package.json__tmpl__
@@ -14,10 +14,7 @@
   "devDependencies": {
     "@remix-run/dev": "<%= remixVersion %>",
     "@types/react": "<%= typesReactVersion %>",
-    "@types/react-dom": "<%= typesReactDomVersion %>",
-    "eslint": "<%= eslintVersion %>",
-    "typescript": "<%= typescriptVersion %>",
-    "vite": "<%= viteVersion %>",
+    "@types/react-dom": "<%= typesReactDomVersion %>"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
The `eslint` version is causing errors like:

```
Error while loading rule '@typescript-eslint/no-unused-expressions': Cannot read properties of undefined (reading 'allowShortCircuit')
```

This is because we are installing both eslint 8 and 9 to the workspace, which are not compatible. We shouldn't need to add `eslint`, `typescript`, `vite` and other tooling to the app's package.json since they should following single version policy by default and be installed at the root.

Note: This is only an issue when you enable workspaces.
<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
