### PR TITLE
fix(angular): make scam-to-standalone replace correct module

### DIFF
--- a/packages/angular/src/generators/scam-to-standalone/lib/replace-module-usages-with-component.ts
+++ b/packages/angular/src/generators/scam-to-standalone/lib/replace-module-usages-with-component.ts
@@ -13,7 +13,9 @@ export function replaceModuleUsagesWithComponent(
     }
     const fileContents = tree.read(path, 'utf-8');
     if (fileContents.includes(moduleName)) {
-      const moduleNameRegex = new RegExp(moduleName, 'g');
+      // Word boundary \b ensures that other modules won't be affected.
+      // E.g. "MapIconModule" would not be affected when "IconModule" is being migrated.
+      const moduleNameRegex = new RegExp(`\\b${moduleName}\\b`, 'g');
       const newFileContents = fileContents.replace(
         moduleNameRegex,
         componentName

--- a/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
+++ b/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
@@ -18,9 +18,10 @@ describe('scam-to-standalone', () => {
     tree.write(
       'foo/src/app/mymodule.module.ts',
       `import { BarComponentModule } from './bar/bar.component';
+      import { ExtraBarComponentModule } from './bar/extra-bar.component';
       
       @NgModule({
-        imports: [BarComponentModule]
+        imports: [BarComponentModule, ExtraBarComponentModule]
       })
       export class MyModule {}`
     );
@@ -49,9 +50,10 @@ describe('scam-to-standalone', () => {
     expect(tree.read('foo/src/app/mymodule.module.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
       "import { BarComponent } from './bar/bar.component';
+      import { ExtraBarComponentModule } from './bar/extra-bar.component';
 
       @NgModule({
-        imports: [BarComponent],
+        imports: [BarComponent, ExtraBarComponentModule],
       })
       export class MyModule {}
       "


### PR DESCRIPTION
## Current Behavior
Without this fix, the regular expression would replace other modules that have old module name in their name.  
E.g. `MapIconModule` contains `IconModule` and when migrating `IconModule`, the migration would wrongfully update `MapIconModule` to `MapIconComponent`.

## Expected Behavior
Migration changes only the Module/Component that's being migrated.
