### PR TITLE
fix(core): replace red in console with blue

### DIFF
--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
@@ -113,8 +113,8 @@ function addPrefixTransformer(prefix?: string) {
 const colors = [
   chalk.green,
   chalk.greenBright,
-  chalk.red,
-  chalk.redBright,
+  chalk.blue,
+  chalk.blueBright,
   chalk.cyan,
   chalk.cyanBright,
   chalk.yellow,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Red is used as a colour when running multiple processes in the command line.  This causes confusion as red is universally the colour for danger/errors.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Red should not be a colour in the console and blue should be used instead.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19901
