### PR TITLE
feat(module-federation): move withModuleFederation for rspack to new package

### DIFF
--- a/packages/module-federation/rspack.ts
+++ b/packages/module-federation/rspack.ts
@@ -1,0 +1,2 @@
+export * from './src/with-module-federation/rspack/with-module-federation';
+export * from './src/with-module-federation/rspack/with-module-federation-ssr';

--- a/packages/module-federation/src/with-module-federation/rspack/utils.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/utils.ts
@@ -13,7 +13,7 @@ import {
   mapRemotes,
   mapRemotesForSSR,
   getDependentPackagesForProject,
-} from '@nx/module-federation';
+} from '../../utils';
 
 export function getFunctionDeterminateRemoteUrl(isServer = false) {
   const target = 'serve';

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
@@ -2,9 +2,8 @@ import { DefinePlugin } from '@rspack/core';
 import {
   ModuleFederationConfig,
   NxModuleFederationConfigOverride,
-} from '@nx/module-federation';
+} from '../../utils';
 import { getModuleFederationConfig } from './utils';
-import { NxRspackExecutionContext } from '../../config';
 
 export async function withModuleFederationForSSR(
   options: ModuleFederationConfig,
@@ -19,7 +18,7 @@ export async function withModuleFederationForSSR(
       isServer: true,
     });
 
-  return (config, { context }: NxRspackExecutionContext) => {
+  return (config, { context }) => {
     config.target = 'async-node';
     config.output.uniqueName = options.name;
     config.output.library = {

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
@@ -4,9 +4,9 @@ import { DefinePlugin } from '@rspack/core';
 import {
   ModuleFederationConfig,
   NxModuleFederationConfigOverride,
-} from '@nx/module-federation';
+} from '../../utils';
 import { getModuleFederationConfig } from './utils';
-import { NxRspackExecutionContext } from '../../config';
+import { type ExecutorContext } from '@nx/devkit';
 
 const isVarOrWindow = (libType?: string) =>
   libType === 'var' || libType === 'window';
@@ -31,7 +31,7 @@ export async function withModuleFederation(
 
   return function makeConfig(
     config: Configuration,
-    { context }: NxRspackExecutionContext
+    { context }
   ): Configuration {
     config.output.uniqueName = options.name;
     config.output.publicPath = 'auto';

--- a/packages/react/src/generators/host/__snapshots__/host.rspack.spec.ts.snap
+++ b/packages/react/src/generators/host/__snapshots__/host.rspack.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`hostGenerator bundler=rspack should generate host files and configs for SSR 1`] = `
 "const { composePlugins, withNx, withReact } = require('@nx/rspack');
-const { withModuleFederationForSSR } = require('@nx/rspack/module-federation');
+const { withModuleFederationForSSR } = require('@nx/module-federation/rspack');
 
 const baseConfig = require('./module-federation.config');
 
@@ -44,7 +44,7 @@ module.exports = moduleFederationConfig;
 
 exports[`hostGenerator bundler=rspack should generate host files and configs for SSR when --typescriptConfiguration=true 1`] = `
 "import { composePlugins, withNx, withReact } from '@nx/rspack';
-import { withModuleFederationForSSR } from '@nx/rspack/module-federation';
+import { withModuleFederationForSSR } from '@nx/module-federation/rspack';
 
 import baseConfig from './module-federation.config';
 
@@ -83,7 +83,7 @@ export default config;
 
 exports[`hostGenerator bundler=rspack should generate host files and configs when --typescriptConfiguration=false 1`] = `
 "const { composePlugins, withNx, withReact } = require('@nx/rspack');
-const { withModuleFederation } = require('@nx/rspack/module-federation');
+const { withModuleFederation } = require('@nx/module-federation/rspack');
 
 const baseConfig = require('./module-federation.config');
 
@@ -130,7 +130,7 @@ module.exports = {
 
 exports[`hostGenerator bundler=rspack should generate host files and configs when --typescriptConfiguration=true 1`] = `
 "import {composePlugins, withNx, withReact} from '@nx/rspack';
-import { withModuleFederation } from '@nx/rspack/module-federation';
+import { withModuleFederation } from '@nx/module-federation/rspack';
 import { ModuleFederationConfig } from '@nx/module-federation';
 
 import baseConfig from './module-federation.config';

--- a/packages/react/src/generators/host/files/rspack-module-federation-ssr-ts/rspack.server.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation-ssr-ts/rspack.server.config.ts__tmpl__
@@ -1,5 +1,5 @@
 import {composePlugins, withNx, withReact} from '@nx/rspack';
-import {withModuleFederationForSSR} from '@nx/rspack/module-federation';
+import {withModuleFederationForSSR} from '@nx/module-federation/rspack';
 
 import baseConfig from './module-federation.config';
 

--- a/packages/react/src/generators/host/files/rspack-module-federation-ssr/rspack.server.config.js__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation-ssr/rspack.server.config.js__tmpl__
@@ -1,5 +1,5 @@
 const {composePlugins, withNx, withReact} = require('@nx/rspack');
-const {withModuleFederationForSSR} = require('@nx/rspack/module-federation');
+const {withModuleFederationForSSR} = require('@nx/module-federation/rspack');
 
 const baseConfig = require('./module-federation.config');
 

--- a/packages/react/src/generators/host/files/rspack-module-federation-ts/rspack.config.prod.ts__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation-ts/rspack.config.prod.ts__tmpl__
@@ -1,5 +1,5 @@
 import { composePlugins, withNx, withReact } from '@nx/rspack';
-import { withModuleFederation } from '@nx/rspack/module-federation';
+import { withModuleFederation } from '@nx/module-federation/rspack';
 import { ModuleFederationConfig } from '@nx/module-federation';
 
 import baseConfig from './module-federation.config';

--- a/packages/react/src/generators/host/files/rspack-module-federation-ts/rspack.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation-ts/rspack.config.ts__tmpl__
@@ -1,5 +1,5 @@
 import {composePlugins, withNx, withReact} from '@nx/rspack';
-import { withModuleFederation } from '@nx/rspack/module-federation';
+import { withModuleFederation } from '@nx/module-federation/rspack';
 import { ModuleFederationConfig } from '@nx/module-federation';
 
 import baseConfig from './module-federation.config';

--- a/packages/react/src/generators/host/files/rspack-module-federation/rspack.config.js__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation/rspack.config.js__tmpl__
@@ -1,5 +1,5 @@
 const { composePlugins, withNx, withReact } = require('@nx/rspack');
-const { withModuleFederation } = require('@nx/rspack/module-federation');
+const { withModuleFederation } = require('@nx/module-federation/rspack');
 
 const baseConfig = require('./module-federation.config');
 

--- a/packages/react/src/generators/host/files/rspack-module-federation/rspack.config.prod.js__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation/rspack.config.prod.js__tmpl__
@@ -1,5 +1,5 @@
 const { composePlugins, withNx, withReact } = require('@nx/rspack');
-const { withModuleFederation } = require('@nx/rspack/module-federation');
+const { withModuleFederation } = require('@nx/module-federation/rspack');
 
 const baseConfig = require('./module-federation.config');
 

--- a/packages/react/src/generators/remote/__snapshots__/remote.rspack.spec.ts.snap
+++ b/packages/react/src/generators/remote/__snapshots__/remote.rspack.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`remote generator bundler=rspack should create the remote with the correct config files 1`] = `
 "const { composePlugins, withNx, withReact } = require('@nx/rspack');
-const { withModuleFederation } = require('@nx/rspack/module-federation');
+const { withModuleFederation } = require('@nx/module-federation/rspack');
 
 const baseConfig = require('./module-federation.config');
 
@@ -37,7 +37,7 @@ module.exports = {
 
 exports[`remote generator bundler=rspack should create the remote with the correct config files when --js=true 1`] = `
 "const { composePlugins, withNx, withReact } = require('@nx/rspack');
-const { withModuleFederation } = require('@nx/rspack/module-federation');
+const { withModuleFederation } = require('@nx/module-federation/rspack');
 
 const baseConfig = require('./module-federation.config');
 
@@ -72,7 +72,7 @@ module.exports = {
 
 exports[`remote generator bundler=rspack should create the remote with the correct config files when --typescriptConfiguration=true 1`] = `
 "import { composePlugins, withNx, withReact } from '@nx/rspack';
-import { withModuleFederation } from '@nx/rspack/module-federation';
+import { withModuleFederation } from '@nx/module-federation/rspack';
 
 import baseConfig from './module-federation.config';
 
@@ -118,7 +118,7 @@ export default config;
 
 exports[`remote generator bundler=rspack should generate correct remote with config files when using --ssr 1`] = `
 "const {composePlugins, withNx, withReact} = require('@nx/rspack');
-const {withModuleFederationForSSR} = require('@nx/rspack/module-federation');
+const {withModuleFederationForSSR} = require('@nx/module-federation/rspack');
 
 const baseConfig = require("./module-federation.server.config");
 
@@ -151,7 +151,7 @@ module.exports = {
 
 exports[`remote generator bundler=rspack should generate correct remote with config files when using --ssr and --typescriptConfiguration=true 1`] = `
 "import { composePlugins, withNx, withReact } from '@nx/rspack';
-import { withModuleFederationForSSR } from '@nx/rspack/module-federation';
+import { withModuleFederationForSSR } from '@nx/module-federation/rspack';
 
 import baseConfig from './module-federation.server.config';
 

--- a/packages/react/src/generators/remote/files/rspack-module-federation-ssr-ts/rspack.server.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/rspack-module-federation-ssr-ts/rspack.server.config.ts__tmpl__
@@ -1,5 +1,5 @@
 import {composePlugins, withNx, withReact} from '@nx/rspack';
-import {withModuleFederationForSSR} from '@nx/rspack/module-federation';
+import {withModuleFederationForSSR} from '@nx/module-federation/rspack';
 
 import baseConfig from "./module-federation.server.config";
 

--- a/packages/react/src/generators/remote/files/rspack-module-federation-ssr/rspack.server.config.js__tmpl__
+++ b/packages/react/src/generators/remote/files/rspack-module-federation-ssr/rspack.server.config.js__tmpl__
@@ -1,5 +1,5 @@
 const {composePlugins, withNx, withReact} = require('@nx/rspack');
-const {withModuleFederationForSSR} = require('@nx/rspack/module-federation');
+const {withModuleFederationForSSR} = require('@nx/module-federation/rspack');
 
 const baseConfig = require("./module-federation.server.config");
 

--- a/packages/react/src/generators/remote/files/rspack-module-federation-ts/rspack.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/rspack-module-federation-ts/rspack.config.ts__tmpl__
@@ -1,5 +1,5 @@
 import {composePlugins, withNx, withReact} from '@nx/rspack';
-import {withModuleFederation} from '@nx/rspack/module-federation';
+import {withModuleFederation} from '@nx/module-federation/rspack';
 
 import baseConfig from './module-federation.config';
 

--- a/packages/react/src/generators/remote/files/rspack-module-federation/rspack.config.js__tmpl__
+++ b/packages/react/src/generators/remote/files/rspack-module-federation/rspack.config.js__tmpl__
@@ -1,5 +1,5 @@
 const { composePlugins, withNx, withReact } = require('@nx/rspack');
-const { withModuleFederation } = require('@nx/rspack/module-federation');
+const { withModuleFederation } = require('@nx/module-federation/rspack');
 
 const baseConfig = require('./module-federation.config');
 

--- a/packages/rspack/migrations.json
+++ b/packages/rspack/migrations.json
@@ -1,5 +1,12 @@
 {
-  "generators": {},
+  "generators": {
+    "update-20-2-0-update-with-module-federation-import": {
+      "cli": "nx",
+      "version": "20.2.0-beta.3",
+      "description": "Update the withModuleFederation import use @nx/module-federation/rspack.",
+      "factory": "./src/migrations/update-20-2-0/migrate-with-mf-import-to-new-package"
+    }
+  },
   "packageJsonUpdates": {
     "18.1.0": {
       "version": "18.1.0-beta.0",

--- a/packages/rspack/module-federation.ts
+++ b/packages/rspack/module-federation.ts
@@ -1,1 +1,7 @@
-export * from './src/utils/module-federation/public-api';
+/**
+ * @deprecated Use `@nx/module-federation/rspack` instead. This will be removed in Nx v22.
+ */
+export {
+  withModuleFederation,
+  withModuleFederationForSSR,
+} from '@nx/module-federation/rspack';

--- a/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
+++ b/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
@@ -140,7 +140,7 @@ describe('Convert webpack', () => {
 
     expect(tree.exists('demo/rspack.config.ts')).toBeTruthy();
     expect(tree.read('demo/rspack.config.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/rspack/module-federation';
+      "import { withModuleFederation } from '@nx/module-federation/rspack';
       import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';
@@ -242,7 +242,7 @@ describe('Convert webpack', () => {
     expect(tree.exists('remote1/rspack.config.ts')).toBeTruthy();
     expect(tree.read('remote1/rspack.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/rspack/module-federation';
+      "import { withModuleFederation } from '@nx/module-federation/rspack';
       import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';
@@ -348,7 +348,7 @@ describe('Convert webpack', () => {
     expect(tree.exists('remote2/rspack.config.ts')).toBeTruthy();
     expect(tree.read('remote2/rspack.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/rspack/module-federation';
+      "import { withModuleFederation } from '@nx/module-federation/rspack';
       import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';

--- a/packages/rspack/src/generators/convert-webpack/lib/transform-cjs.ts
+++ b/packages/rspack/src/generators/convert-webpack/lib/transform-cjs.ts
@@ -172,7 +172,7 @@ function transformModuleFederationConfig(
     endIndex++;
   }
 
-  const newContents = `const { ModuleFederationConfig } = require('@nx/rspack/module-federation');
+  const newContents = `const { ModuleFederationConfig } = require('@nx/module-federation');
   ${configContents.slice(0, startIndex)}${configContents.slice(endIndex)}`;
 
   tree.write(configPath, newContents);
@@ -205,7 +205,7 @@ function transformWithModuleFederation(
     endIndex++;
   }
 
-  const newContents = `const { withModuleFederation } = require('@nx/rspack/module-federation');
+  const newContents = `const { withModuleFederation } = require('@nx/module-federation/rspack');
   ${configContents.slice(0, startIndex)}${configContents.slice(endIndex)}`;
 
   tree.write(configPath, newContents);
@@ -238,7 +238,7 @@ function transformWithModuleFederationSSR(
     endIndex++;
   }
 
-  const newContents = `const { withModuleFederationForSSR } = require('@nx/rspack/module-federation');
+  const newContents = `const { withModuleFederationForSSR } = require('@nx/module-federation/rspack');
   ${configContents.slice(0, startIndex)}${configContents.slice(endIndex)}`;
 
   tree.write(configPath, newContents);

--- a/packages/rspack/src/generators/convert-webpack/lib/transform-esm.ts
+++ b/packages/rspack/src/generators/convert-webpack/lib/transform-esm.ts
@@ -172,7 +172,7 @@ function transformWithModuleFederation(
     endIndex++;
   }
 
-  const newContents = `import { withModuleFederation } from '@nx/rspack/module-federation';
+  const newContents = `import { withModuleFederation } from '@nx/module-federation/rspack';
   ${configContents.slice(0, startIndex)}${configContents.slice(endIndex)}`;
 
   tree.write(configPath, newContents);
@@ -205,7 +205,7 @@ function transformModuleFederationConfig(
     endIndex++;
   }
 
-  const newContents = `import { ModuleFederationConfig } from '@nx/rspack/module-federation';
+  const newContents = `import { ModuleFederationConfig } from '@nx/module-federation';
   ${configContents.slice(0, startIndex)}${configContents.slice(endIndex)}`;
 
   tree.write(configPath, newContents);
@@ -238,7 +238,7 @@ function transformWithModuleFederationSSR(
     endIndex++;
   }
 
-  const newContents = `import { withModuleFederationForSSR } from '@nx/rspack/module-federation';
+  const newContents = `import { withModuleFederationForSSR } from '@nx/module-federation/rspack';
   ${configContents.slice(0, startIndex)}${configContents.slice(endIndex)}`;
 
   tree.write(configPath, newContents);

--- a/packages/rspack/src/migrations/update-20-2-0/migrate-with-mf-import-to-new-package.spec.ts
+++ b/packages/rspack/src/migrations/update-20-2-0/migrate-with-mf-import-to-new-package.spec.ts
@@ -1,0 +1,138 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migrateWithMfImport from './migrate-with-mf-import-to-new-package';
+
+describe('migrate-with-mf-import-to-new-package', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'apps/shell/project.json',
+      JSON.stringify({
+        name: 'shell',
+        root: 'apps/shell',
+        sourceRoot: 'apps/shell/src',
+        projectType: 'application',
+        targets: {
+          serve: {
+            executor: '@nx/rspack:module-federation-dev-server',
+            options: {},
+          },
+        },
+      })
+    );
+  });
+
+  it('should migrate the import correctly for withMf', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/rspack.config.ts',
+      `import { withModuleFederation } from '@nx/rspack/module-federation';`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/rspack.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { withModuleFederation } from '@nx/module-federation/rspack';
+      "
+    `);
+  });
+
+  it('should migrate the require correctly for withMf', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/rspack.config.js',
+      `const { withModuleFederation } = require('@nx/rspack/module-federation');`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/rspack.config.js', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "const { withModuleFederation } = require('@nx/module-federation/rspack');
+      "
+    `);
+  });
+
+  it('should migrate the import correctly for withMfSSR', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/webpack.config.ts',
+      `import { withModuleFederationForSSR } from '@nx/rspack/module-federation';`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/webpack.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { withModuleFederationForSSR } from '@nx/module-federation/rspack';
+      "
+    `);
+  });
+
+  it('should migrate the require correctly for withMfSSR', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/rspack.config.js',
+      `const { withModuleFederationForSSR } = require('@nx/rspack/module-federation');`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/rspack.config.js', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "const { withModuleFederationForSSR } = require('@nx/module-federation/rspack');
+      "
+    `);
+  });
+
+  describe('idempotent', () => {
+    it('should migrate the import correctly for withMf even when run twice', async () => {
+      // ARRANGE
+      tree.write(
+        'apps/shell/webpack.config.ts',
+        `import { withModuleFederation } from '@nx/rspack/module-federation';`
+      );
+
+      // ACT
+      await migrateWithMfImport(tree);
+      await migrateWithMfImport(tree);
+
+      // ASSERT
+      expect(tree.read('apps/shell/webpack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/module-federation/rspack';
+        "
+      `);
+    });
+
+    it('should migrate the require correctly for withMfSSR even when run twice', async () => {
+      // ARRANGE
+      tree.write(
+        'apps/shell/rspack.config.js',
+        `const { withModuleFederationForSSR } = require('@nx/rspack/module-federation');`
+      );
+
+      // ACT
+      await migrateWithMfImport(tree);
+      await migrateWithMfImport(tree);
+
+      // ASSERT
+      expect(tree.read('apps/shell/rspack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederationForSSR } = require('@nx/module-federation/rspack');
+        "
+      `);
+    });
+  });
+});

--- a/packages/rspack/src/migrations/update-20-2-0/migrate-with-mf-import-to-new-package.ts
+++ b/packages/rspack/src/migrations/update-20-2-0/migrate-with-mf-import-to-new-package.ts
@@ -8,15 +8,15 @@ import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-optio
 import { tsquery } from '@phenomnomnominal/tsquery';
 
 const NX_RSPACK_MODULE_FEDERATION_IMPORT_SELECTOR =
-  'ImportDeclaration > StringLiteral[value=@nx/react/module-federation], VariableStatement CallExpression:has(Identifier[name=require]) > StringLiteral[value=@nx/react/module-federation]';
-const NEW_IMPORT_PATH = `'@nx/module-federation/webpack'`;
+  'ImportDeclaration > StringLiteral[value=@nx/rspack/module-federation], VariableStatement CallExpression:has(Identifier[name=require]) > StringLiteral[value=@nx/rspack/module-federation]';
+const NEW_IMPORT_PATH = `'@nx/module-federation/rspack'`;
 
 export default async function migrateWithMfImport(tree: Tree) {
   const projects = new Set<string>();
 
   forEachExecutorOptions(
     tree,
-    '@nx/react:module-federation-dev-server',
+    '@nx/rspack:module-federation-dev-server',
     (options, project, target) => {
       const projectConfig = readProjectConfiguration(tree, project);
       projects.add(projectConfig.root);
@@ -29,7 +29,7 @@ export default async function migrateWithMfImport(tree: Tree) {
         return;
       }
       let contents = tree.read(filePath, 'utf-8');
-      if (!contents.includes('@nx/react/module-federation')) {
+      if (!contents.includes('@nx/rspack/module-federation')) {
         return;
       }
 

--- a/packages/rspack/src/utils/module-federation/public-api.ts
+++ b/packages/rspack/src/utils/module-federation/public-api.ts
@@ -1,4 +1,0 @@
-import { withModuleFederation } from './with-module-federation/with-module-federation';
-import { withModuleFederationForSSR } from './with-module-federation/with-module-federation-ssr';
-
-export { withModuleFederation, withModuleFederationForSSR };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `withModuleFederation` helper currently lives in the `@nx/rspack` package.
With the goal of consolidating the module federation support into a single package, this introduces a divergence in where module-federation support lies


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Move `withModuleFederation` helper for angular into the `@nx/module-federation` package, exposed via `@nx/module-federation/rspack`.
Adds a migration to migrate existing projects to use the new package

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
