### PR TITLE
Revert "fix(core): lower socket path by 10 chars to reduce chances of…

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -579,6 +579,12 @@ export class DaemonClient {
   }
 
   async startInBackground(): Promise<ChildProcess['pid']> {
+    if (global.NX_PLUGIN_WORKER) {
+      throw new Error(
+        'Fatal Error: Something unexpected has occurred. Plugin Workers should not start a new daemon process. Please report this issue.'
+      );
+    }
+
     mkdirSync(DAEMON_DIR_FOR_CURRENT_WORKSPACE, { recursive: true });
     if (!existsSync(DAEMON_OUTPUT_LOG_FILE)) {
       writeFileSync(DAEMON_OUTPUT_LOG_FILE, '');

--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -49,7 +49,7 @@ export function isDaemonDisabled() {
 function socketDirName() {
   const hasher = createHash('sha256');
   hasher.update(workspaceRoot.toLowerCase());
-  const unique = hasher.digest('hex').substring(0, 10);
+  const unique = hasher.digest('hex').substring(0, 20);
   return join(tmpdir, unique);
 }
 

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -12,12 +12,23 @@ if (process.env.NX_PERF_LOGGING === 'true') {
 }
 
 global.NX_GRAPH_CREATION = true;
-
+global.NX_PLUGIN_WORKER = true;
+let connected = false;
 let plugin: LoadedNxPlugin;
 
 const socketPath = process.argv[2];
 
 const server = createServer((socket) => {
+  connected = true;
+  // This handles cases where the host process was killed
+  // after the worker connected but before the worker was
+  // instructed to load the plugin.
+  const loadTimeout = setTimeout(() => {
+    console.error(
+      `Plugin Worker exited because no plugin was loaded within 10 seconds of starting up.`
+    );
+    process.exit(1);
+  }, 10000).unref();
   socket.on(
     'data',
     consumeMessagesFromSocket((raw) => {
@@ -27,6 +38,7 @@ const server = createServer((socket) => {
       }
       return consumeMessage(socket, message, {
         load: async ({ plugin: pluginConfiguration, root }) => {
+          if (loadTimeout) clearTimeout(loadTimeout);
           process.chdir(root);
           try {
             const [promise] = loadNxPlugin(pluginConfiguration, root);
@@ -120,6 +132,8 @@ const server = createServer((socket) => {
   // since the worker is spawned per host process. As such,
   // we can safely close the worker when the host disconnects.
   socket.on('end', () => {
+    // Destroys the socket once it's fully closed.
+    socket.destroySoon();
     // Stops accepting new connections, but existing connections are
     // not closed immediately.
     server.close(() => {
@@ -128,12 +142,19 @@ const server = createServer((socket) => {
       } catch (e) {}
       process.exit(0);
     });
-    // Destroys the socket once it's fully closed.
-    socket.destroySoon();
   });
 });
 
 server.listen(socketPath);
+
+setTimeout(() => {
+  if (!connected) {
+    console.error(
+      'The plugin worker is exiting as it was not connected to within 5 seconds.'
+    );
+    process.exit(1);
+  }
+}, 5000).unref();
 
 const exitHandler = (exitCode: number) => () => {
   server.close();


### PR DESCRIPTION
… too-long paths (#28920)"

This reverts commit be8029d5dda7fe3b7823a8257c3dd343704b46e2.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

#28920 changes makes older versions of Nx unable detect newer servers. But then they start old servers.. and the new servers self destruct... But the cycle loops around when newer versions of Nx cannot connect to older servers.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The change is reverted.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
