### PR TITLE
fix(rspack): outputHashing should default to 'all' #29011

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -46,6 +46,7 @@ export function applyBaseConfig(
   options.memoryLimit ??= 2048;
   options.transformers ??= [];
   options.progress ??= true;
+  options.outputHashing ??= 'all';
 
   applyNxIndependentConfig(options, config);
 


### PR DESCRIPTION
## Current Behavior
Current default for outputHashing is set to 'none'.
This means that both executor and plugin usage will output file names that will not bust browser cache.

## Expected Behavior
Set default for `outputHashing` to 'all' to ensure all outputted files are hashed allowing for cache busting.

## Related Issue(s)

Fixes #29011
