### PR TITLE
fix(testing): add exports config for cypress plugin

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -23,6 +23,18 @@
   ],
   "main": "./index",
   "typings": "./index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json",
+    "./migrations.json": "./migrations.json",
+    "./generators.json": "./generators.json",
+    "./generators/*/schema.json": "./src/generators/*/schema.json",
+    "./executors.json": "./executors.json",
+    "./executors/*/schema.json": "./src/executors/*/schema.json",
+    "./plugin": "./plugin.js",
+    "./src/utils/*": "./src/utils/*.js",
+    "./plugins/cypress-preset": "./plugins/cypress-preset.js"
+  },
   "author": "Victor Savkin",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
unable to import the cypress preset with mjs cypress configs and yarn PnP

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
able to import the cypress preset when using mjs cypress configs and yarn PnP

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


BREAKING CHANGE: export configuration change for @nx/cypress plugin
technically shouldn't be breaking since it re-exports all existing imports, but honestly you never know with exports 😅