### PR TITLE
fix(misc): repair --print flag for nx graph

### DIFF
--- a/e2e/nx/src/affected-graph.test.ts
+++ b/e2e/nx/src/affected-graph.test.ts
@@ -405,6 +405,65 @@ describe('Nx Affected and Graph Tests', () => {
       );
     }, 1000000);
 
+    it.each(['--print', '--file=stdout'])(
+      'graph should output json to %s',
+      (arg) => {
+        const output = runCLI(`graph ${arg}`);
+
+        const jsonFileContents = JSON.parse(output);
+
+        expect(jsonFileContents.graph.dependencies).toEqual(
+          expect.objectContaining({
+            [myapp3E2e]: [
+              {
+                source: myapp3E2e,
+                target: myapp3,
+                type: 'implicit',
+              },
+            ],
+            [myapp2]: [
+              {
+                source: myapp2,
+                target: mylib,
+                type: 'static',
+              },
+            ],
+            [myapp2E2e]: [
+              {
+                source: myapp2E2e,
+                target: myapp2,
+                type: 'implicit',
+              },
+            ],
+            [mylib]: [
+              {
+                source: mylib,
+                target: mylib2,
+                type: 'static',
+              },
+            ],
+            [mylib2]: [],
+            [myapp]: [
+              {
+                source: myapp,
+                target: mylib,
+                type: 'static',
+              },
+            ],
+            [myappE2e]: [
+              {
+                source: myappE2e,
+                target: myapp,
+                type: 'implicit',
+              },
+            ],
+            [myapp3]: [],
+          })
+        );
+      },
+      1000000
+    );
+
     if (isNotWindows()) {
       it('graph should output json to file by absolute path', () => {
         runCLI(`graph --file=/tmp/project-graph.json`);

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -251,6 +251,7 @@ export async function generateGraph(
     focus?: string;
     exclude?: string[];
     affected?: boolean;
+    print?: boolean;
   },
   affectedProjects: string[]
 ): Promise<void> {
@@ -352,7 +353,7 @@ export async function generateGraph(
         splitArgsIntoNxArgsAndOverrides(
           args,
           'affected',
-          { printWarnings: args.file !== 'stdout' },
+          { printWarnings: args.file !== 'stdout' && !args.print },
           readNxJson()
         ).nxArgs,
         rawGraph
@@ -391,7 +392,7 @@ export async function generateGraph(
 
   if (args.file) {
     // stdout is a magical constant that doesn't actually write a file
-    if (args.file === 'stdout') {
+    if (args.file === 'stdout' || args.print) {
       console.log(
         JSON.stringify(
           await createJsonOutput(


### PR DESCRIPTION
## Current Behavior
`nx graph --print` opens a web browser

## Expected Behavior
`nx graph --print` is equivalent to `nx graph --file=stdout`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27682
Fixes #28688
