### PR TITLE
fix(nextjs): ensure next apps config is correctly checked when using jest

### DIFF
--- a/packages/jest/src/generators/configuration/lib/update-tsconfig.ts
+++ b/packages/jest/src/generators/configuration/lib/update-tsconfig.ts
@@ -42,6 +42,16 @@ export function updateTsConfig(
       root,
       options.runtimeTsconfigFileName
     );
+    // If the app is Next.js it will not have a tsconfig.app.json
+    const extensions = ['js', 'ts', 'mjs', 'cjs'];
+    const hasNextConfig = extensions.some((ext) =>
+      host.exists(joinPathFragments(root, `next.config.${ext}`))
+    );
+
+    if (hasNextConfig && projectType === 'application') {
+      runtimeTsconfigPath = joinPathFragments(root, 'tsconfig.json');
+    }
+
     if (!host.exists(runtimeTsconfigPath)) {
       // the user provided a runtimeTsconfigFileName that doesn't exist, so we throw an error
       throw new Error(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When we create a new Next.js app it checks if `tsconfig.app.json` exists else it throws an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should check for `tsconfig.json` instead of `tsconfig.app.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29035
