### PR TITLE
fix(angular): ngrx-root-store generator check ngModule path

### DIFF
--- a/packages/angular/src/generators/ngrx-root-store/lib/normalize-options.ts
+++ b/packages/angular/src/generators/ngrx-root-store/lib/normalize-options.ts
@@ -45,11 +45,16 @@ export function normalizeOptions(
    * --> If so, use that
    * --> If not, use main.ts
    */
-  const parent = !isStandalone
-    ? joinPathFragments(project.sourceRoot, 'app/app.module.ts')
-    : tree.exists(appConfigPath)
-    ? appConfigPath
-    : appMainPath;
+  const ngModulePath = joinPathFragments(
+    project.sourceRoot,
+    'app/app.module.ts'
+  );
+  const parent =
+    !isStandalone && tree.exists(ngModulePath)
+      ? ngModulePath
+      : tree.exists(appConfigPath)
+      ? appConfigPath
+      : appMainPath;
 
   options.directory = options.directory ?? '+state';
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When we run the ngrx-root-store generator on a MFe host app it assumes `app.module.ts` is created.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should check if `app.module.ts` exists first, then fall back if not.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28970
