### PR TITLE
fix(module-federation): migration does not handle external nodes and errors

### DIFF
--- a/packages/angular/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.spec.ts
+++ b/packages/angular/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.spec.ts
@@ -22,6 +22,13 @@ jest.mock('@nx/devkit', () => {
               type: 'static',
             },
           ],
+          'npm:@nx/playwright': [
+            {
+              source: 'npm:@nx/playwright',
+              target: 'npm:@nx/webpack',
+              type: 'static',
+            },
+          ],
         },
         nodes: {
           shell: {
@@ -40,6 +47,17 @@ jest.mock('@nx/devkit', () => {
               root: 'apps/remote',
               sourceRoot: 'remote/src',
               targets: {},
+            },
+          },
+        },
+        externalNodes: {
+          'npm:@nx/playwright': {
+            type: 'npm',
+            name: 'npm:@nx/playwright',
+            data: {
+              version: '20.2.0-beta.3',
+              packageName: '@nx/playwright',
+              hash: 'sha512-8rzIZ8ljVfWsOqmSUSRPo0lT19oAhTR2nAI25V3wbFwhlErQ7kpgKd45W36Tja1aka729cO3mAH5ACKSujU6wQ==',
             },
           },
         },

--- a/packages/angular/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
+++ b/packages/angular/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
@@ -17,6 +17,9 @@ export default async function migrateMfImportsToNewPackage(tree: Tree) {
       (dep) => dep.target === 'npm:@nx/webpack'
     );
     if (usesNxWebpack) {
+      if (graph.externalNodes[project]) {
+        continue;
+      }
       const root = graph.nodes[project].data.root;
       rootsToCheck.add(root);
     }

--- a/packages/angular/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
+++ b/packages/angular/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
@@ -13,13 +13,13 @@ export default async function migrateMfImportsToNewPackage(tree: Tree) {
 
   const graph = await createProjectGraphAsync();
   for (const [project, dependencies] of Object.entries(graph.dependencies)) {
+    if (!graph.nodes[project]) {
+      continue;
+    }
     const usesNxWebpack = dependencies.some(
       (dep) => dep.target === 'npm:@nx/webpack'
     );
     if (usesNxWebpack) {
-      if (graph.externalNodes[project]) {
-        continue;
-      }
       const root = graph.nodes[project].data.root;
       rootsToCheck.add(root);
     }

--- a/packages/react/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.spec.ts
+++ b/packages/react/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.spec.ts
@@ -27,6 +27,13 @@ jest.mock('@nx/devkit', () => {
               type: 'static',
             },
           ],
+          'npm:@nx/playwright': [
+            {
+              source: 'npm:@nx/playwright',
+              target: 'npm:@nx/webpack',
+              type: 'static',
+            },
+          ],
         },
         nodes: {
           shell: {
@@ -45,6 +52,17 @@ jest.mock('@nx/devkit', () => {
               root: 'apps/remote',
               sourceRoot: 'remote/src',
               targets: {},
+            },
+          },
+        },
+        externalNodes: {
+          'npm:@nx/playwright': {
+            type: 'npm',
+            name: 'npm:@nx/playwright',
+            data: {
+              version: '20.2.0-beta.3',
+              packageName: '@nx/playwright',
+              hash: 'sha512-8rzIZ8ljVfWsOqmSUSRPo0lT19oAhTR2nAI25V3wbFwhlErQ7kpgKd45W36Tja1aka729cO3mAH5ACKSujU6wQ==',
             },
           },
         },

--- a/packages/react/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
+++ b/packages/react/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
@@ -14,14 +14,14 @@ export default async function migrateMfImportsToNewPackage(tree: Tree) {
 
   const graph = await createProjectGraphAsync();
   for (const [project, dependencies] of Object.entries(graph.dependencies)) {
+    if (!graph.nodes[project]) {
+      continue;
+    }
     const usesNxWebpackOrRspack = dependencies.some(
       (dep) =>
         dep.target === 'npm:@nx/webpack' || dep.target === 'npm:@nx/rspack'
     );
     if (usesNxWebpackOrRspack) {
-      if (graph.externalNodes[project]) {
-        continue;
-      }
       const root = graph.nodes[project].data.root;
       rootsToCheck.add(root);
     }

--- a/packages/react/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
+++ b/packages/react/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
@@ -19,6 +19,9 @@ export default async function migrateMfImportsToNewPackage(tree: Tree) {
         dep.target === 'npm:@nx/webpack' || dep.target === 'npm:@nx/rspack'
     );
     if (usesNxWebpackOrRspack) {
+      if (graph.externalNodes[project]) {
+        continue;
+      }
       const root = graph.nodes[project].data.root;
       rootsToCheck.add(root);
     }


### PR DESCRIPTION
## Current Behavior
The React + Angular migrations intended to update the path for the `ModuleFederationConfig` imports in webpack and rspack config files will fail on externalNodes in the project graph that have `@nx/webpack` or `@nx/rspack` listed as a dependency.

## Expected Behavior
If the dependency is discovered in an `externalNode` we should skip that node, instead of continuing with the migration.

