### PR TITLE
fix(nest): Fix generators (guard, interceptor etc...) path to not duplicate when provided

### DIFF
--- a/docs/generated/packages/nest/generators/guard.json
+++ b/docs/generated/packages/nest/generators/guard.json
@@ -39,7 +39,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `guard` NestJS generator with Nx project support.",

--- a/docs/generated/packages/nest/generators/interceptor.json
+++ b/docs/generated/packages/nest/generators/interceptor.json
@@ -39,7 +39,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["path"],
     "presets": []
   },
   "description": "Run the `interceptor` NestJS generator with Nx project support.",

--- a/packages/nest/src/generators/guard/schema.json
+++ b/packages/nest/src/generators/guard/schema.json
@@ -39,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/interceptor/schema.json
+++ b/packages/nest/src/generators/interceptor/schema.json
@@ -39,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": ["path"]
 }

--- a/packages/nest/src/generators/utils/normalize-options.ts
+++ b/packages/nest/src/generators/utils/normalize-options.ts
@@ -10,16 +10,18 @@ export async function normalizeOptions(
   tree: Tree,
   options: NestGeneratorOptions
 ): Promise<NormalizedOptions> {
-  const { directory, fileName } =
+  const { directory, artifactName } =
     await determineArtifactNameAndDirectoryOptions(tree, {
       name: options.name,
       path: options.path,
     });
 
+  options.path = undefined; // Now that we have `directory` we don't need `path`
+
   return {
     ...options,
     flat: true,
-    name: fileName,
+    name: artifactName,
     skipFormat: options.skipFormat,
     sourceRoot: directory,
   };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When we run the nest generators (interceptor, resource, guard etc...) it tends to duplicate the path and leads to unexpected folder creations.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should generate in the path provided.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29076
