### PR TITLE
fix(core): improve local plugin loading by reading only tsconfig comp

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -293,8 +293,7 @@ export function getTranspiler(
  * @returns cleanup method
  */
 export function registerTranspiler(
-  compilerOptions: CompilerOptions,
-  tsConfigRaw?: unknown
+  compilerOptions: CompilerOptions
 ): () => void {
   // Function to register transpiler that returns cleanup function
   const transpiler = getTranspiler(compilerOptions);

--- a/packages/nx/src/plugins/js/utils/typescript.ts
+++ b/packages/nx/src/plugins/js/utils/typescript.ts
@@ -23,7 +23,7 @@ export function readTsConfig(tsConfigPath: string) {
   );
 }
 
-function readTsConfigOptions(tsConfigPath: string) {
+export function readTsConfigOptions(tsConfigPath: string) {
   if (!tsModule) {
     tsModule = require('typescript');
   }

--- a/packages/nx/src/project-graph/plugins/loader.ts
+++ b/packages/nx/src/project-graph/plugins/loader.ts
@@ -16,8 +16,8 @@ import {
   registerTsConfigPaths,
 } from '../../plugins/js/utils/register';
 import {
-  ProjectRootMappings,
   findProjectForPath,
+  ProjectRootMappings,
 } from '../utils/find-project-for-path';
 import { normalizePath } from '../../utils/path';
 import { logger } from '../../utils/logger';
@@ -29,8 +29,8 @@ import { PluginConfiguration } from '../../config/nx-json';
 import { retrieveProjectConfigurationsWithoutPluginInference } from '../utils/retrieve-workspace-files';
 import { LoadedNxPlugin } from './internal-api';
 import { LoadPluginError } from '../error-types';
+import { readTsConfigOptions } from '../../plugins/js/utils/typescript';
 import path = require('node:path/posix');
-import { readTsConfig } from '../../plugins/js/utils/typescript';
 
 export function readPluginPackageJson(
   pluginName: string,
@@ -92,19 +92,16 @@ export function registerPluginTSTranspiler() {
     return;
   }
 
-  const tsConfig: Partial<ts.ParsedCommandLine> = tsConfigName
-    ? readTsConfig(tsConfigName)
+  const tsConfigOptions: ts.CompilerOptions = tsConfigName
+    ? readTsConfigOptions(tsConfigName)
     : {};
   const cleanupFns = [
     registerTsConfigPaths(tsConfigName),
-    registerTranspiler(
-      {
-        experimentalDecorators: true,
-        emitDecoratorMetadata: true,
-        ...tsConfig.options,
-      },
-      tsConfig.raw
-    ),
+    registerTranspiler({
+      experimentalDecorators: true,
+      emitDecoratorMetadata: true,
+      ...tsConfigOptions,
+    }),
   ];
   unregisterPluginTSTranspiler = () => {
     cleanupFns.forEach((fn) => fn?.());


### PR DESCRIPTION
## Current Behavior

When loading local plugins, Nx compiles TypeScript code on the fly. To achieve this, Nx uses the TypeScript function parseJsonConfigFileContent, which processes the entire configuration.

In large repositories, this process can take more than 10 seconds per plugin. Even though the process is parallelized, it significantly impacts performance when generating the graph.

## Expected Behavior

Loading local plugins should be fast to allow immediate graph generation. Since only the compiler options are needed, we can read the root tsconfig file directly.

With this approach, loading a plugin now takes just 200ms, even for large monorepos.