### PR TITLE
fix(module-federation): use 'hoisted' runtime for node to prevent issues with eager sharing

### DIFF
--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
@@ -47,10 +47,19 @@ export async function withModuleFederationForSSR(
             shared: {
               ...sharedDependencies,
             },
+            remoteType: 'script',
+            library: {
+              type: 'commonjs-module',
+            },
             /**
              * Apply user-defined config override
              */
             ...(configOverride ? configOverride : {}),
+            experiments: {
+              federationRuntime: 'hoisted',
+              // We should allow users to override federationRuntime
+              ...(configOverride?.experiments ?? {}),
+            },
             runtimePlugins:
               process.env.NX_MF_DEV_REMOTES &&
               !options.disableNxRuntimeLibraryControlPlugin

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
@@ -49,6 +49,11 @@ export async function withModuleFederationForSSR(
            * Apply user-defined config overrides
            */
           ...(configOverride ? configOverride : {}),
+          experiments: {
+            federationRuntime: 'hoisted',
+            // We should allow users to override federationRuntime
+            ...(configOverride?.experiments ?? {}),
+          },
           runtimePlugins:
             process.env.NX_MF_DEV_REMOTES &&
             !options.disableNxRuntimeLibraryControlPlugin

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
@@ -36,10 +36,19 @@ export async function withModuleFederationForSSR(
           shared: {
             ...sharedDependencies,
           },
+          remoteType: 'script',
+          library: {
+            type: 'commonjs-module',
+          },
           /**
            * Apply user-defined config overrides
            */
           ...(configOverride ? configOverride : {}),
+          experiments: {
+            federationRuntime: 'hoisted',
+            // We should allow users to override federationRuntime
+            ...(configOverride?.experiments ?? {}),
+          },
           runtimePlugins:
             process.env.NX_MF_DEV_REMOTES &&
             !options.disableNxRuntimeLibraryControlPlugin


### PR DESCRIPTION
## Current Behavior
SSR with Module Federation frequently encounters issues related to the eager resolution of shared packages.
This has resulted in numerous erroneous behaviours including but not limited to:
- Failure to start server
- Failure to resolve remotes
- Failure to server render remotes

## Expected Behavior
Using the `'hoisted'` runtime provided by MF 2.0, we can ensure that SSR for Module Federation runs in an async environment, removing the issues surrounding eager consumption and resolution of shared modules.
In testing, this has fixed the issues outlined above

## Related Issue(s)

Fixes #27000
Fixes #27964
