### PR TITLE
fix(nest): update project config to enable artifacts to be built as dev

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -15,17 +15,66 @@ describe('application generator', () => {
   it('should generate project configurations', async () => {
     await applicationGenerator(tree, {
       directory: appDirectory,
+      addPlugin: true,
     });
 
     const projectConfigurations = devkit.getProjects(tree);
+    const project = projectConfigurations.get(appDirectory);
 
-    expect(projectConfigurations.get(appDirectory)).toBeTruthy();
     expect(projectConfigurations.get(`${appDirectory}-e2e`)).toBeTruthy();
+    expect(project).toMatchInlineSnapshot(`
+      {
+        "$schema": "../node_modules/nx/schemas/project-schema.json",
+        "name": "my-node-app",
+        "projectType": "application",
+        "root": "my-node-app",
+        "sourceRoot": "my-node-app/src",
+        "tags": [],
+        "targets": {
+          "build": {
+            "configurations": {
+              "development": {
+                "args": [
+                  "node-env=development",
+                ],
+              },
+            },
+            "executor": "nx:run-commands",
+            "options": {
+              "args": [
+                "node-env=production",
+              ],
+              "command": "webpack-cli build",
+            },
+          },
+          "serve": {
+            "configurations": {
+              "development": {
+                "buildTarget": "my-node-app:build:development",
+              },
+              "production": {
+                "buildTarget": "my-node-app:build:production",
+              },
+            },
+            "defaultConfiguration": "development",
+            "dependsOn": [
+              "build",
+            ],
+            "executor": "@nx/js:node",
+            "options": {
+              "buildTarget": "my-node-app:build",
+              "runBuildTargetDependencies": false,
+            },
+          },
+        },
+      }
+    `);
   });
 
   it('should generate files', async () => {
     await applicationGenerator(tree, {
       directory: appDirectory,
+      addPlugin: true,
     });
 
     expect(tree.exists(`${appDirectory}/src/main.ts`)).toBeTruthy();
@@ -45,6 +94,7 @@ describe('application generator', () => {
   it('should configure tsconfig correctly', async () => {
     await applicationGenerator(tree, {
       directory: appDirectory,
+      addPlugin: true,
     });
 
     const tsConfig = devkit.readJson(tree, `${appDirectory}/tsconfig.app.json`);
@@ -61,6 +111,7 @@ describe('application generator', () => {
     await applicationGenerator(tree, {
       directory: appDirectory,
       strict: true,
+      addPlugin: true,
     });
     const tsConfig = devkit.readJson(tree, `${appDirectory}/tsconfig.app.json`);
 
@@ -79,6 +130,7 @@ describe('application generator', () => {
 
       await applicationGenerator(tree, {
         directory: appDirectory,
+        addPlugin: true,
       });
 
       expect(devkit.formatFiles).toHaveBeenCalled();
@@ -90,6 +142,7 @@ describe('application generator', () => {
       await applicationGenerator(tree, {
         directory: appDirectory,
         skipFormat: true,
+        addPlugin: true,
       });
 
       expect(devkit.formatFiles).not.toHaveBeenCalled();
@@ -101,6 +154,7 @@ describe('application generator', () => {
       await applicationGenerator(tree, {
         directory: appDirectory,
         e2eTestRunner: 'none',
+        addPlugin: true,
       });
 
       const projectConfigurations = devkit.getProjects(tree);

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -159,6 +159,21 @@ function getServeConfig(options: NormalizedSchema): TargetConfiguration {
   };
 }
 
+function getNestWebpackBuildConfig(): TargetConfiguration {
+  return {
+    executor: 'nx:run-commands',
+    options: {
+      command: 'webpack-cli build',
+      args: ['node-env=production'],
+    },
+    configurations: {
+      development: {
+        args: ['node-env=development'],
+      },
+    },
+  };
+}
+
 function addProject(tree: Tree, options: NormalizedSchema) {
   const project: ProjectConfiguration = {
     root: options.appProjectRoot,
@@ -175,6 +190,10 @@ function addProject(tree: Tree, options: NormalizedSchema) {
     if (!hasWebpackPlugin(tree)) {
       addBuildTargetDefaults(tree, `@nx/webpack:webpack`);
       project.targets.build = getWebpackBuildConfig(project, options);
+    } else if (options.isNest) {
+      // If we are using Nest that has the webpack plugin we need to override the
+      // build target so that node-env can be set to production or development so the serve target can be run in development mode
+      project.targets.build = getNestWebpackBuildConfig();
     }
   }
   project.targets.serve = getServeConfig(options);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, when we generate a Nest application and run the serve target with development configuration the `node-env` is set to `production`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running the serve target in `development` should build the artifacts as `development` so they can be served correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26761
