### PR TITLE
fix(core): use fork to execute nx generate workspace:preset

### DIFF
--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -14,6 +14,7 @@ import { NormalizedSchema } from './new';
 import { join } from 'path';
 import * as yargsParser from 'yargs-parser';
 import { fork, ForkOptions } from 'child_process';
+import { getNxRequirePaths } from 'nx/src/utils/installation-directory';
 
 export function addPresetDependencies(host: Tree, options: NormalizedSchema) {
   const { dependencies, dev } = getPresetDependencies(options);
@@ -39,8 +40,9 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
     cwd: newWorkspaceRoot,
   };
   const pmc = getPackageManagerCommand();
+  const nxInstallationPaths = getNxRequirePaths(newWorkspaceRoot);
   const nxBinForNewWorkspaceRoot = require.resolve('nx/bin/nx', {
-    paths: [join(newWorkspaceRoot, 'node_modules')],
+    paths: nxInstallationPaths,
   });
   const args = getPresetArgs(opts);
 

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -34,7 +34,7 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
   });
 
   const newWorkspaceRoot = join(host.root, opts.directory);
-  const spawnOptions: ForkOptions = {
+  const forkOptions: ForkOptions = {
     stdio: 'inherit',
     cwd: newWorkspaceRoot,
   };
@@ -48,7 +48,7 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
     // This needs to be `fork` instead of `spawn` because `spawn` is failing on Windows with pnpm + yarn
     // The root cause is unclear. Spawn causes the `@nx/workspace:preset` generator to be called twice
     // and the second time it fails with `Project {projectName} already exists.`
-    fork(nxBinForNewWorkspaceRoot, args, spawnOptions).on(
+    fork(nxBinForNewWorkspaceRoot, args, forkOptions).on(
       'close',
       (code: number) => {
         if (code === 0) {


### PR DESCRIPTION
## Current Behavior
On Windows, when packageManager=pnpm, `create-nx-workspace` fails due to an issue with `child_process.spawn`.
Using `spawn`, the `@nx/workspace:preset` generator is executed twice when `packageManager=pnpm`, causing the overall create-nx-workspace flow to fail, even though most things have been set up correctly to that point.

Using `fork` has shown success.

## Expected Behavior
Running `create-nx-workspace --packageManager=pnpm` should work on Windows

## Fixes
Fixes #20222 
Fixes #27270 
Fixes #22917 
Fixes #22312 
Fixes #28710 
Fixes #28289 
Fixes #28235 
Fixes #22383 
Fixes #21742 
Fixes #20270 

