### PR TITLE
fix(release): use prepatch version for pre-release dependent package updates

### DIFF
--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -696,6 +696,70 @@ To fix this you will either need to add a package.json file at that location, or
             }
           `);
         });
+
+        it('should update dependents with a prepatch when creating a pre-release version', async () => {
+          expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+            '0.0.1'
+          );
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-dependency-on-my-pkg/package.json'
+            ).version
+          ).toEqual('0.0.1');
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-devDependency-on-my-pkg/package.json'
+            ).version
+          ).toEqual('0.0.1');
+
+          await releaseVersionGenerator(tree, {
+            projects: Object.values(projectGraph.nodes), // version all projects
+            projectGraph,
+            currentVersionResolver: 'disk',
+            specifier: 'prepatch',
+            preid: 'alpha',
+            releaseGroup: createReleaseGroup('independent'),
+          });
+
+          expect(readJson(tree, 'libs/my-lib/package.json'))
+            .toMatchInlineSnapshot(`
+            {
+              "name": "my-lib",
+              "version": "0.0.2-alpha.0",
+            }
+          `);
+
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-dependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "dependencies": {
+                "my-lib": "0.0.2-alpha.0",
+              },
+              "name": "project-with-dependency-on-my-pkg",
+              "version": "0.0.2-alpha.0",
+            }
+          `);
+          expect(
+            readJson(
+              tree,
+              'libs/project-with-devDependency-on-my-pkg/package.json'
+            )
+          ).toMatchInlineSnapshot(`
+            {
+              "devDependencies": {
+                "my-lib": "0.0.2-alpha.0",
+              },
+              "name": "project-with-devDependency-on-my-pkg",
+              "version": "0.0.2-alpha.0",
+            }
+          `);
+        });
       });
     });
   });


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

When creating a pre-release version, if a package only had its dependencies updated, it creates a new `patch` version.

`nx release version --preid=alpha`

```sh
UPDATE packages/XXX/package.json [dry-run]

    "name": "XXX",
-   "version": "7.2.0",
+   "version": "7.2.1",

    "dependencies": {
-     "YYY": "16.0.0",
+     "YYY": "16.1.0-alpha.0",
      "react": "18.2.0",
```

## Expected Behavior
When creating a pre-release version, if a package only had its dependencies updated, it creates a new `prepatch` version.

```sh
UPDATE packages/XXX/package.json [dry-run]

    "name": "XXX",
-   "version": "7.2.0",
+   "version": "7.2.1-alpha.0",

    "dependencies": {
-     "YYY": "16.0.0",
+     "YYY": "16.1.0-alpha.0",
      "react": "18.2.0",
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

<!-- Fixes # -->

Couldn't find any
