### PR TITLE
fix(core): Esbuild copy assets should copy if the assets are a strings

### DIFF
--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -81,14 +81,16 @@ export class CopyAssetsHandler {
     this.assetGlobs = opts.assets.map((f) => {
       let isGlob = false;
       let pattern: string;
+      const defaultGlob = '**/*';
       // Input and output directories are normalized to be relative to root
       let input: string;
       let output: string;
       let ignore: string[] | null = null;
       if (typeof f === 'string') {
-        pattern = f;
-        input = path.relative(opts.rootDir, opts.projectDir);
-        output = path.relative(opts.rootDir, opts.outputDir);
+        // Glob patterns are needed for single string entries
+        pattern = this.isGlobPattern(f) ? f : path.join(f, defaultGlob);
+        input = f;
+        output = path.join(path.relative(opts.rootDir, opts.outputDir), f);
       } else {
         isGlob = true;
         pattern = pathPosix.join(f.input, f.glob);
@@ -108,6 +110,12 @@ export class CopyAssetsHandler {
         output,
       };
     });
+  }
+
+  private isGlobPattern(str) {
+    const globChars = ['*', '?', '[', ']', '(', ')', '{', '}', '!'];
+
+    return globChars.some((char) => str.includes(char));
   }
 
   async processAllAssetsOnce(): Promise<void> {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When we set the assets option as a string the assets end up not being copied over to the output folder after the build has succeded.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The assets which are provided should be copied over after the build has succeded.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21654
