### PR TITLE
test(expo): add breaking E2E test for an Expo module that includes post-installation output

### DIFF
--- a/e2e/expo/src/expo.test.ts
+++ b/e2e/expo/src/expo.test.ts
@@ -137,6 +137,29 @@ describe('@nx/expo', () => {
       },
     });
   });
+  
+  it('should install packages with post-installation output', async () => {
+    // run install command
+    let installResults = await runCLIAsync(
+      `install ${appName} --force --no-interactive`
+    );
+    expect(installResults.combinedOutput).toContain(
+      'Successfully ran target install'
+    );
+
+    installResults = await runCLIAsync(
+      `install ${appName} --force --packages=expo-router --no-interactive`
+    );
+    expect(installResults.combinedOutput).toContain(
+      'Successfully ran target install'
+    );
+    const packageJson = readJson(join(appName, 'package.json'));
+    expect(packageJson).toMatchObject({
+      dependencies: {
+        'expo-router': '*',
+      },
+    });
+  });
 
   it('should run e2e for cypress', async () => {
     if (runE2ETests()) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

After running `nx run app:install expo-router`, nx updates the root `package.json` but fails before updating `app/package.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

After running `nx run app:install expo-router`, nx should update both the root `package.json` AND `app/package.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Relates to #29131
