### PR TITLE
feat(nx-plugin): added support for vitest test runner

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -5,6 +5,8 @@ auth:
   htpasswd:
     file: ./htpasswd
 
+max_body_size: 15mb
+
 # a list of other known repositories we can talk to
 uplinks:
   npmjs:

--- a/docs/generated/packages/plugin/generators/create-package.json
+++ b/docs/generated/packages/plugin/generators/create-package.json
@@ -31,7 +31,7 @@
       },
       "unitTestRunner": {
         "type": "string",
-        "enum": ["none", "jest"],
+        "enum": ["none", "jest", "vitest"],
         "description": "Test runner to use for unit tests."
       },
       "linter": {

--- a/docs/generated/packages/plugin/generators/executor.json
+++ b/docs/generated/packages/plugin/generators/executor.json
@@ -28,7 +28,7 @@
       },
       "unitTestRunner": {
         "type": "string",
-        "enum": ["jest", "none"],
+        "enum": ["jest", "vitest", "none"],
         "description": "Test runner to use for unit tests.",
         "default": "jest"
       },

--- a/docs/generated/packages/plugin/generators/generator.json
+++ b/docs/generated/packages/plugin/generators/generator.json
@@ -41,7 +41,7 @@
       },
       "unitTestRunner": {
         "type": "string",
-        "enum": ["jest", "none"],
+        "enum": ["jest", "vitest", "none"],
         "description": "Test runner to use for unit tests.",
         "default": "jest"
       },

--- a/docs/generated/packages/plugin/generators/plugin.json
+++ b/docs/generated/packages/plugin/generators/plugin.json
@@ -40,7 +40,7 @@
       "unitTestRunner": {
         "description": "Test runner to use for unit tests.",
         "type": "string",
-        "enum": ["none", "jest"],
+        "enum": ["none", "jest", "vitest"],
         "x-priority": "important"
       },
       "tags": {

--- a/packages/plugin/src/generators/create-package/schema.d.ts
+++ b/packages/plugin/src/generators/create-package/schema.d.ts
@@ -8,7 +8,7 @@ export interface CreatePackageSchema {
   // options to create cli package, passed to js library generator
   skipFormat?: boolean;
   tags?: string;
-  unitTestRunner?: 'jest' | 'none';
+  unitTestRunner?: 'jest' | 'vitest' | 'none';
   linter?: Linter | LinterType;
   compiler?: 'swc' | 'tsc';
 

--- a/packages/plugin/src/generators/create-package/schema.json
+++ b/packages/plugin/src/generators/create-package/schema.json
@@ -33,7 +33,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["none", "jest"],
+      "enum": ["none", "jest", "vitest"],
       "description": "Test runner to use for unit tests."
     },
     "linter": {

--- a/packages/plugin/src/generators/create-package/utils/normalize-schema.ts
+++ b/packages/plugin/src/generators/create-package/utils/normalize-schema.ts
@@ -12,7 +12,7 @@ export interface NormalizedSchema extends CreatePackageSchema {
   bundler: 'swc' | 'tsc';
   projectName: string;
   projectRoot: string;
-  unitTestRunner: 'jest' | 'none';
+  unitTestRunner: 'jest' | 'vitest' | 'none';
   linter: LinterType;
   useProjectJson: boolean;
   addPlugin: boolean;

--- a/packages/plugin/src/generators/executor/schema.d.ts
+++ b/packages/plugin/src/generators/executor/schema.d.ts
@@ -2,7 +2,7 @@ export interface Schema {
   path: string;
   name?: string;
   description?: string;
-  unitTestRunner: 'jest' | 'none';
+  unitTestRunner: 'jest' | 'vitest' | 'none';
   includeHasher: boolean;
   skipLintChecks?: boolean;
   skipFormat?: boolean;

--- a/packages/plugin/src/generators/executor/schema.json
+++ b/packages/plugin/src/generators/executor/schema.json
@@ -28,7 +28,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "jest"
     },

--- a/packages/plugin/src/generators/generator/schema.d.ts
+++ b/packages/plugin/src/generators/generator/schema.d.ts
@@ -2,7 +2,7 @@ export interface Schema {
   path: string;
   name?: string;
   description?: string;
-  unitTestRunner: 'jest' | 'none';
+  unitTestRunner: 'jest' | 'vitest' | 'none';
   skipLintChecks?: boolean;
   skipFormat?: boolean;
 }

--- a/packages/plugin/src/generators/generator/schema.json
+++ b/packages/plugin/src/generators/generator/schema.json
@@ -41,7 +41,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "jest"
     },

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -172,9 +172,53 @@ describe('NxPlugin Plugin Generator', () => {
           expect(tree.exists(path)).toBeFalsy()
         );
 
+        ['my-plugin/vite.config.ts'].forEach((path) =>
+          expect(tree.exists(path)).toBeFalsy()
+        );
+
         expect(
           readProjectConfiguration(tree, 'my-plugin').targets.test
         ).not.toBeDefined();
+      });
+    });
+
+    describe('jest', () => {
+      it('should generate test files with jest.config.ts', async () => {
+        await pluginGenerator(
+          tree,
+          getSchema({
+            directory: 'my-plugin',
+            unitTestRunner: 'jest',
+          })
+        );
+
+        ['my-plugin/jest.config.ts'].forEach((path) =>
+          expect(tree.exists(path)).toBeTruthy()
+        );
+
+        expect(
+          readProjectConfiguration(tree, 'my-plugin').targets.test
+        ).toBeDefined();
+      });
+    });
+
+    describe('vitest', () => {
+      it('should generate test files with vite.config.ts', async () => {
+        await pluginGenerator(
+          tree,
+          getSchema({
+            directory: 'my-plugin',
+            unitTestRunner: 'vitest',
+          })
+        );
+
+        ['my-plugin/vite.config.ts'].forEach((path) =>
+          expect(tree.exists(path)).toBeTruthy()
+        );
+
+        expect(
+          readProjectConfiguration(tree, 'my-plugin').targets.test
+        ).toBeDefined();
       });
     });
   });

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -196,9 +196,13 @@ describe('NxPlugin Plugin Generator', () => {
           expect(tree.exists(path)).toBeTruthy()
         );
 
-        expect(
-          readProjectConfiguration(tree, 'my-plugin').targets.test
-        ).toBeDefined();
+        const projectTargets = readProjectConfiguration(
+          tree,
+          'my-plugin'
+        ).targets;
+
+        expect(projectTargets.test).toBeDefined();
+        expect(projectTargets.test?.executor).toEqual('@nx/jest:jest');
       });
     });
 
@@ -216,9 +220,13 @@ describe('NxPlugin Plugin Generator', () => {
           expect(tree.exists(path)).toBeTruthy()
         );
 
-        expect(
-          readProjectConfiguration(tree, 'my-plugin').targets.test
-        ).toBeDefined();
+        const projectTargets = readProjectConfiguration(
+          tree,
+          'my-plugin'
+        ).targets;
+
+        expect(projectTargets.test).toBeDefined();
+        expect(projectTargets.test?.executor).toEqual('@nx/vite:test');
       });
     });
   });

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -118,7 +118,8 @@ export async function pluginGeneratorInternal(host: Tree, schema: Schema) {
         '@nx/devkit': nxVersion,
       },
       {
-        '@nx/jest': nxVersion,
+        [options.unitTestRunner === 'vitest' ? '@nx/vite' : '@nx/jest']:
+          nxVersion,
         '@nx/js': nxVersion,
         '@nx/plugin': nxVersion,
       }

--- a/packages/plugin/src/generators/plugin/schema.d.ts
+++ b/packages/plugin/src/generators/plugin/schema.d.ts
@@ -9,7 +9,7 @@ export interface Schema {
   skipLintChecks?: boolean; // default is false
   e2eTestRunner?: 'jest' | 'none';
   tags?: string;
-  unitTestRunner?: 'jest' | 'none';
+  unitTestRunner?: 'jest' | 'vitest' | 'none';
   linter?: Linter | LinterType;
   setParserOptionsProject?: boolean;
   compiler?: 'swc' | 'tsc';

--- a/packages/plugin/src/generators/plugin/schema.json
+++ b/packages/plugin/src/generators/plugin/schema.json
@@ -40,7 +40,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["none", "jest"],
+      "enum": ["none", "jest", "vitest"],
       "x-priority": "important"
     },
     "tags": {

--- a/packages/plugin/src/generators/plugin/utils/normalize-schema.ts
+++ b/packages/plugin/src/generators/plugin/utils/normalize-schema.ts
@@ -20,7 +20,7 @@ export interface NormalizedSchema extends Schema {
   npmPackageName: string;
   bundler: 'swc' | 'tsc';
   publishable: boolean;
-  unitTestRunner: 'jest' | 'none';
+  unitTestRunner: 'jest' | 'vitest' | 'none';
   linter: LinterType;
   useProjectJson: boolean;
   addPlugin: boolean;
@@ -35,7 +35,7 @@ export async function normalizeOptions(
   const unitTestRunner = await normalizeUnitTestRunnerOption(
     host,
     options.unitTestRunner,
-    ['jest']
+    ['jest', 'vitest']
   );
 
   const isTsSolutionSetup = isUsingTsSolutionSetup(host);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx Plugin do not have the option to use Vitest as test runner

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This PR allow us to use Vitest as test runner in plugins projects.

Vitest for e2e targets is still missing and a new PR will be raised after https://github.com/nrwl/nx/issues/29139 is fixed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22882
