### PR TITLE
fix(js): generate multiline project references in the sync generator

### DIFF
--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -282,7 +282,14 @@ describe('syncGenerator()', () => {
             // This is a nested comment
             "target": "es5"
           },
-          "references": [{ "path": "./packages/a" }, { "path": "./packages/b" }]
+          "references": [
+            {
+              "path": "./packages/a"
+            },
+            {
+              "path": "./packages/b"
+            }
+          ]
         }
         "
       `);
@@ -302,7 +309,11 @@ describe('syncGenerator()', () => {
           "compilerOptions": {
             "composite": true
           },
-          "references": [{ "path": "./packages/b" }]
+          "references": [
+            {
+              "path": "./packages/b"
+            }
+          ]
         }
         "
       `);
@@ -569,7 +580,11 @@ describe('syncGenerator()', () => {
             // This is a nested comment
             "target": "es5"
           },
-          "references": [{ "path": "../bar/tsconfig.build.json" }]
+          "references": [
+            {
+              "path": "../bar/tsconfig.build.json"
+            }
+          ]
         }
         "
       `);
@@ -593,9 +608,15 @@ describe('syncGenerator()', () => {
             "composite": true
           },
           "references": [
-            { "path": "./packages/a" },
-            { "path": "./packages/b" },
-            { "path": "./packages/foo" }
+            {
+              "path": "./packages/a"
+            },
+            {
+              "path": "./packages/b"
+            },
+            {
+              "path": "./packages/foo"
+            }
           ]
         }
         "
@@ -639,21 +660,21 @@ describe('syncGenerator()', () => {
 
           expect(readJson(tree, 'packages/b/tsconfig.json').references)
             .toMatchInlineSnapshot(`
-        [
-          {
-            "path": "../a",
-          },
-        ]
-      `);
+                    [
+                      {
+                        "path": "../a",
+                      },
+                    ]
+                `);
           expect(
             readJson(tree, `packages/b/${runtimeTsConfigFileName}`).references
           ).toMatchInlineSnapshot(`
-        [
-          {
-            "path": "../a/${runtimeTsConfigFileName}",
-          },
-        ]
-      `);
+                    [
+                      {
+                        "path": "../a/${runtimeTsConfigFileName}",
+                      },
+                    ]
+                `);
         }
       );
 
@@ -908,96 +929,96 @@ describe('syncGenerator()', () => {
           ).toBeUndefined();
           expect(readJson(tree, 'packages/b/tsconfig.json').references)
             .toMatchInlineSnapshot(`
-          [
-            {
-              "path": "../a",
-            },
-          ]
-        `);
+                      [
+                        {
+                          "path": "../a",
+                        },
+                      ]
+                  `);
           expect(
             readJson(tree, `packages/b/${runtimeTsConfigFileName}`).references
           ).toMatchInlineSnapshot(`
-          [
-            {
-              "path": "../a/${runtimeTsConfigFileName}",
-            },
-          ]
-        `);
+                      [
+                        {
+                          "path": "../a/${runtimeTsConfigFileName}",
+                        },
+                      ]
+                  `);
           expect(readJson(tree, 'packages/c/tsconfig.json').references)
             .toMatchInlineSnapshot(`
-          [
-            {
-              "path": "../a",
-            },
-            {
-              "path": "../b",
-            },
-          ]
-        `);
+                      [
+                        {
+                          "path": "../a",
+                        },
+                        {
+                          "path": "../b",
+                        },
+                      ]
+                  `);
           expect(
             readJson(tree, `packages/c/${runtimeTsConfigFileName}`).references
           ).toMatchInlineSnapshot(`
-          [
-            {
-              "path": "../a/${runtimeTsConfigFileName}",
-            },
-            {
-              "path": "../b/${runtimeTsConfigFileName}",
-            },
-          ]
-        `);
+                      [
+                        {
+                          "path": "../a/${runtimeTsConfigFileName}",
+                        },
+                        {
+                          "path": "../b/${runtimeTsConfigFileName}",
+                        },
+                      ]
+                  `);
           expect(readJson(tree, 'packages/d/tsconfig.json').references)
             .toMatchInlineSnapshot(`
-          [
-            {
-              "path": "../a",
-            },
-            {
-              "path": "../b",
-            },
-          ]
-        `);
+                      [
+                        {
+                          "path": "../a",
+                        },
+                        {
+                          "path": "../b",
+                        },
+                      ]
+                  `);
           expect(
             readJson(tree, `packages/d/${runtimeTsConfigFileName}`).references
           ).toMatchInlineSnapshot(`
-          [
-            {
-              "path": "../a/${runtimeTsConfigFileName}",
-            },
-            {
-              "path": "../b/${runtimeTsConfigFileName}",
-            },
-          ]
-        `);
+                      [
+                        {
+                          "path": "../a/${runtimeTsConfigFileName}",
+                        },
+                        {
+                          "path": "../b/${runtimeTsConfigFileName}",
+                        },
+                      ]
+                  `);
           expect(readJson(tree, 'packages/e/tsconfig.json').references)
             .toMatchInlineSnapshot(`
-          [
-            {
-              "path": "../a",
-            },
-            {
-              "path": "../b",
-            },
-            {
-              "path": "../d",
-            },
-          ]
-        `);
+                      [
+                        {
+                          "path": "../a",
+                        },
+                        {
+                          "path": "../b",
+                        },
+                        {
+                          "path": "../d",
+                        },
+                      ]
+                  `);
           expect(
             readJson(tree, `packages/e/${runtimeTsConfigFileName}`).references
           ).toMatchInlineSnapshot(`
-          [
-            {
-              "path": "../a/${runtimeTsConfigFileName}",
-            },
-            {
-              "path": "../b/${runtimeTsConfigFileName}",
-            },
-            {
-              "path": "../d/${runtimeTsConfigFileName}",
-            },
-          ]
-        `);
+                      [
+                        {
+                          "path": "../a/${runtimeTsConfigFileName}",
+                        },
+                        {
+                          "path": "../b/${runtimeTsConfigFileName}",
+                        },
+                        {
+                          "path": "../d/${runtimeTsConfigFileName}",
+                        },
+                      ]
+                  `);
         }
       );
 
@@ -1096,20 +1117,20 @@ describe('syncGenerator()', () => {
 
         expect(readJson(tree, 'packages/b/tsconfig.json').references)
           .toMatchInlineSnapshot(`
-        [
-          {
-            "path": "../a",
-          },
-        ]
-      `);
+                  [
+                    {
+                      "path": "../a",
+                    },
+                  ]
+              `);
         expect(readJson(tree, 'packages/b/tsconfig.custom.json').references)
           .toMatchInlineSnapshot(`
-        [
-          {
-            "path": "../a/tsconfig.custom.json",
-          },
-        ]
-      `);
+                  [
+                    {
+                      "path": "../a/tsconfig.custom.json",
+                    },
+                  ]
+              `);
       });
 
       it('should sync project references to multiple configured runtime tsconfig files', async () => {

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -604,7 +604,7 @@ function patchTsconfigJsonReferences(
     stringifiedJsonContents,
     ['references'],
     updatedReferences,
-    {}
+    { formattingOptions: { keepLines: false } }
   );
   const updatedJsonContents = applyEdits(stringifiedJsonContents, edits);
   // The final contents will be formatted by formatFiles() later


### PR DESCRIPTION
Update the `@nx/js:typescript-sync` sync generator to produce the updated project references in multiple lines. This improves the formatting of the generated project references when not using Prettier.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
