### PR TITLE
feat(angular): add migration to disable `@angular-eslint/prefer-standalone` when not set

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -292,7 +292,7 @@
       "cli": "nx",
       "version": "20.2.0-beta.5",
       "requires": {
-        "@angular/core": ">=19.0.0-rc.1"
+        "@angular/core": ">=19.0.0"
       },
       "description": "Add the '@angular/localize/init' polyfill to the 'polyfills' option of targets using esbuild-based executors.",
       "factory": "./src/migrations/update-20-2-0/add-localize-polyfill-to-targets"
@@ -301,10 +301,19 @@
       "cli": "nx",
       "version": "20.2.0-beta.5",
       "requires": {
-        "@angular/core": ">=19.0.0-rc.1"
+        "@angular/core": ">=19.0.0"
       },
       "description": "Update '@angular/ssr' import paths to use the new '/node' entry point when 'CommonEngine' is detected.",
       "factory": "./src/migrations/update-20-2-0/update-angular-ssr-imports-to-use-node-entry-point"
+    },
+    "disable-angular-eslint-prefer-standalone": {
+      "cli": "nx",
+      "version": "20.2.0-beta.6",
+      "requires": {
+        "@angular/core": ">=19.0.0"
+      },
+      "description": "Disable the Angular ESLint prefer-standalone rule if not set.",
+      "factory": "./src/migrations/update-20-2-0/disable-angular-eslint-prefer-standalone"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -66,10 +66,10 @@
     "piscina": "^4.4.0"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": ">= 16.0.0 < 19.0.0",
-    "@angular-devkit/core": ">= 16.0.0 < 19.0.0",
-    "@angular-devkit/schematics": ">= 16.0.0 < 19.0.0",
-    "@schematics/angular": ">= 16.0.0 < 19.0.0",
+    "@angular-devkit/build-angular": ">= 17.0.0 < 20.0.0",
+    "@angular-devkit/core": ">= 17.0.0 < 20.0.0",
+    "@angular-devkit/schematics": ">= 17.0.0 < 20.0.0",
+    "@schematics/angular": ">= 17.0.0 < 20.0.0",
     "rxjs": "^6.5.3 || ^7.5.0"
   },
   "publishConfig": {

--- a/packages/angular/src/migrations/update-20-2-0/disable-angular-eslint-prefer-standalone.spec.ts
+++ b/packages/angular/src/migrations/update-20-2-0/disable-angular-eslint-prefer-standalone.spec.ts
@@ -1,0 +1,428 @@
+import {
+  addProjectConfiguration,
+  writeJson,
+  type ProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './disable-angular-eslint-prefer-standalone';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: () => Promise.resolve(projectGraph),
+}));
+
+describe('disable-angular-eslint-prefer-standalone', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    const projectConfig: ProjectConfiguration = {
+      name: 'app1',
+      root: 'apps/app1',
+    };
+    projectGraph = {
+      dependencies: {
+        app1: [
+          {
+            source: 'app1',
+            target: 'npm:@angular/core',
+            type: 'static',
+          },
+        ],
+      },
+      nodes: {
+        app1: {
+          data: projectConfig,
+          name: 'app1',
+          type: 'app',
+        },
+      },
+    };
+    addProjectConfiguration(tree, projectConfig.name, projectConfig);
+  });
+
+  describe('.eslintrc.json', () => {
+    it('should not disable @angular-eslint/prefer-standalone when it is set', async () => {
+      writeJson(tree, 'apps/app1/.eslintrc.json', {
+        overrides: [
+          {
+            files: ['*.ts'],
+            rules: { '@angular-eslint/prefer-standalone': ['error'] },
+          },
+        ],
+      });
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/.eslintrc.json', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "overrides": [
+            {
+              "files": ["*.ts"],
+              "rules": {
+                "@angular-eslint/prefer-standalone": ["error"]
+              }
+            }
+          ]
+        }
+        "
+      `);
+    });
+
+    it('should not disable @angular-eslint/prefer-standalone when there are multiple overrides for angular eslint and the rule is set in one of them', async () => {
+      writeJson(tree, 'apps/app1/.eslintrc.json', {
+        overrides: [
+          {
+            files: ['*.ts'],
+            rules: {
+              '@angular-eslint/directive-selector': [
+                'error',
+                { type: 'attribute', prefix: 'app', style: 'camelCase' },
+              ],
+            },
+          },
+          {
+            files: ['*.ts'],
+            rules: { '@angular-eslint/prefer-standalone': ['error'] },
+          },
+        ],
+      });
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/.eslintrc.json', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "overrides": [
+            {
+              "files": ["*.ts"],
+              "rules": {
+                "@angular-eslint/directive-selector": [
+                  "error",
+                  {
+                    "type": "attribute",
+                    "prefix": "app",
+                    "style": "camelCase"
+                  }
+                ]
+              }
+            },
+            {
+              "files": ["*.ts"],
+              "rules": {
+                "@angular-eslint/prefer-standalone": ["error"]
+              }
+            }
+          ]
+        }
+        "
+      `);
+    });
+
+    it('should disable @angular-eslint/prefer-standalone in an existing override for angular eslint', async () => {
+      writeJson(tree, 'apps/app1/.eslintrc.json', {
+        overrides: [
+          {
+            files: ['*.ts'],
+            rules: { 'no-unused-vars': 'error' },
+          },
+          {
+            files: ['*.ts'],
+            rules: {
+              '@angular-eslint/directive-selector': [
+                'error',
+                { type: 'attribute', prefix: 'app', style: 'camelCase' },
+              ],
+            },
+          },
+        ],
+      });
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/.eslintrc.json', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "overrides": [
+            {
+              "files": ["*.ts"],
+              "rules": {
+                "no-unused-vars": "error"
+              }
+            },
+            {
+              "files": ["*.ts"],
+              "rules": {
+                "@angular-eslint/directive-selector": [
+                  "error",
+                  {
+                    "type": "attribute",
+                    "prefix": "app",
+                    "style": "camelCase"
+                  }
+                ],
+                "@angular-eslint/prefer-standalone": "off"
+              }
+            }
+          ]
+        }
+        "
+      `);
+    });
+
+    it('should disable @angular-eslint/prefer-standalone in an existing override for ts files', async () => {
+      writeJson(tree, 'apps/app1/.eslintrc.json', {
+        overrides: [
+          {
+            files: ['*.ts'],
+            rules: { 'no-unused-vars': 'error' },
+          },
+        ],
+      });
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/.eslintrc.json', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "overrides": [
+            {
+              "files": ["*.ts"],
+              "rules": {
+                "no-unused-vars": "error",
+                "@angular-eslint/prefer-standalone": "off"
+              }
+            }
+          ]
+        }
+        "
+      `);
+    });
+
+    it('should disable @angular-eslint/prefer-standalone in a new override', async () => {
+      writeJson(tree, 'apps/app1/.eslintrc.json', {
+        overrides: [
+          {
+            files: ['*.html'],
+            rules: { 'some-rule-for-html': 'error' },
+          },
+        ],
+      });
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/.eslintrc.json', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "overrides": [
+            {
+              "files": ["*.html"],
+              "rules": {
+                "some-rule-for-html": "error"
+              }
+            },
+            {
+              "files": ["*.ts"],
+              "rules": {
+                "@angular-eslint/prefer-standalone": "off"
+              }
+            }
+          ]
+        }
+        "
+      `);
+    });
+  });
+
+  describe('flat config', () => {
+    it('should not disable @angular-eslint/prefer-standalone when it is set', async () => {
+      tree.write('eslint.config.js', 'module.exports = [];');
+      tree.write(
+        'apps/app1/eslint.config.js',
+        `module.exports = [
+          {
+            files: ['*.ts'],
+            rules: { '@angular-eslint/prefer-standalone': ['error'] },
+          },
+        ];
+        `
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/eslint.config.js', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "module.exports = [
+          {
+            files: ['*.ts'],
+            rules: { '@angular-eslint/prefer-standalone': ['error'] },
+          },
+        ];
+        "
+      `);
+    });
+
+    it('should not disable @angular-eslint/prefer-standalone when there are multiple overrides for angular eslint and the rule is set in one of them', async () => {
+      tree.write('eslint.config.js', 'module.exports = [];');
+      tree.write(
+        'apps/app1/eslint.config.js',
+        `module.exports = [
+          {
+            files: ['*.ts'],
+            rules: {
+              '@angular-eslint/directive-selector': [
+                'error',
+                { type: 'attribute', prefix: 'app', style: 'camelCase' },
+              ],
+            },
+          },
+          {
+            files: ['*.ts'],
+            rules: { '@angular-eslint/prefer-standalone': ['error'] },
+          },
+        ];
+        `
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/eslint.config.js', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "module.exports = [
+          {
+            files: ['*.ts'],
+            rules: {
+              '@angular-eslint/directive-selector': [
+                'error',
+                { type: 'attribute', prefix: 'app', style: 'camelCase' },
+              ],
+            },
+          },
+          {
+            files: ['*.ts'],
+            rules: { '@angular-eslint/prefer-standalone': ['error'] },
+          },
+        ];
+        "
+      `);
+    });
+
+    it('should disable @angular-eslint/prefer-standalone in an existing override for angular eslint', async () => {
+      tree.write('eslint.config.js', 'module.exports = [];');
+      tree.write(
+        'apps/app1/eslint.config.js',
+        `module.exports = [
+          {
+            files: ['*.ts'],
+            rules: { 'no-unused-vars': 'error' },
+          },
+          {
+            files: ['*.ts'],
+            rules: {
+              '@angular-eslint/directive-selector': [
+                'error',
+                { type: 'attribute', prefix: 'app', style: 'camelCase' },
+              ],
+            },
+          },
+        ];
+        `
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/eslint.config.js', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "module.exports = [
+          {
+            files: ['*.ts'],
+            rules: { 'no-unused-vars': 'error' },
+          },
+          {
+            files: ['**/*.ts'],
+            rules: {
+              '@angular-eslint/directive-selector': [
+                'error',
+                {
+                  type: 'attribute',
+                  prefix: 'app',
+                  style: 'camelCase',
+                },
+              ],
+              '@angular-eslint/prefer-standalone': 'off',
+            },
+          },
+        ];
+        "
+      `);
+    });
+
+    it('should disable @angular-eslint/prefer-standalone in an existing override for ts files', async () => {
+      tree.write('eslint.config.js', 'module.exports = [];');
+      tree.write(
+        'apps/app1/eslint.config.js',
+        `module.exports = [
+          {
+            files: ['*.ts'],
+            rules: { 'no-unused-vars': 'error' },
+          },
+        ];
+        `
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/eslint.config.js', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "module.exports = [
+          {
+            files: ['**/*.ts'],
+            rules: {
+              'no-unused-vars': 'error',
+              '@angular-eslint/prefer-standalone': 'off',
+            },
+          },
+        ];
+        "
+      `);
+    });
+
+    it('should disable @angular-eslint/prefer-standalone in a new override', async () => {
+      tree.write('eslint.config.js', 'module.exports = [];');
+      tree.write(
+        'apps/app1/eslint.config.js',
+        `module.exports = [
+          {
+            files: ['*.html'],
+            rules: { 'some-rule-for-html': 'error' },
+          },
+        ];
+        `
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/eslint.config.js', 'utf8'))
+        .toMatchInlineSnapshot(`
+        "module.exports = [
+          {
+            files: ['*.html'],
+            rules: { 'some-rule-for-html': 'error' },
+          },
+          {
+            files: ['**/*.ts'],
+            rules: {
+              '@angular-eslint/prefer-standalone': 'off',
+            },
+          },
+        ];
+        "
+      `);
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-20-2-0/disable-angular-eslint-prefer-standalone.ts
+++ b/packages/angular/src/migrations/update-20-2-0/disable-angular-eslint-prefer-standalone.ts
@@ -1,0 +1,78 @@
+import { formatFiles, type Tree } from '@nx/devkit';
+import {
+  addOverrideToLintConfig,
+  isEslintConfigSupported,
+  lintConfigHasOverride,
+  updateOverrideInLintConfig,
+} from '@nx/eslint/src/generators/utils/eslint-file';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+
+const preferStandaloneRule = '@angular-eslint/prefer-standalone';
+
+export default async function (tree: Tree) {
+  const projects = await getProjectsFilteredByDependencies(tree, [
+    'npm:@angular/core',
+  ]);
+
+  for (const {
+    project: { root },
+  } of projects) {
+    if (!isEslintConfigSupported(tree, root)) {
+      // ESLint config is not supported, skip
+      continue;
+    }
+
+    if (
+      lintConfigHasOverride(
+        tree,
+        root,
+        (o) => !!o.rules?.[preferStandaloneRule],
+        true
+      )
+    ) {
+      // the @angular-eslint/prefer-standalone rule is set in an override, skip
+      continue;
+    }
+
+    const ngEslintOverrideLookup: Parameters<
+      typeof lintConfigHasOverride
+    >[2] = (o) =>
+      o.files?.includes('*.ts') &&
+      Object.keys(o.rules ?? {}).some((r) => r.startsWith('@angular-eslint/'));
+    const tsFilesOverrideLookup: Parameters<typeof lintConfigHasOverride>[2] = (
+      o
+    ) => o.files?.length === 1 && o.files[0] === '*.ts';
+
+    if (lintConfigHasOverride(tree, root, ngEslintOverrideLookup, false)) {
+      // there is an override containing an Angular ESLint rule
+      updateOverrideInLintConfig(tree, root, ngEslintOverrideLookup, (o) => {
+        o.rules = {
+          ...o.rules,
+          [preferStandaloneRule]: 'off',
+        };
+        return o;
+      });
+    } else if (
+      lintConfigHasOverride(tree, root, tsFilesOverrideLookup, false)
+    ) {
+      // there is an override for just *.ts files
+      updateOverrideInLintConfig(tree, root, tsFilesOverrideLookup, (o) => {
+        o.rules = {
+          ...o.rules,
+          [preferStandaloneRule]: 'off',
+        };
+        return o;
+      });
+    } else {
+      // there are no overrides for any Angular ESLint rule or just *.ts files, add a new override
+      addOverrideToLintConfig(tree, root, {
+        files: ['*.ts'],
+        rules: {
+          [preferStandaloneRule]: 'off',
+        },
+      });
+    }
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
- Add migration to disable the `@angular-eslint/prefer-standalone` rule when it's not already set. This prevents a breaking change due to the [rule being promoted to the recommended rules in v19](https://github.com/angular-eslint/angular-eslint/commit/8dfdc4f4d4b2a0b23f91aeb7ef14fa384bec3cec).
- Update the `@nx/angular` package peer dependencies range to drop Angular v16 and include Angular v20.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29163 
