### PR TITLE
fix(bundling): Correct declarationRootDir handling for esbuild

### DIFF
--- a/docs/generated/packages/esbuild/executors/esbuild.json
+++ b/docs/generated/packages/esbuild/executors/esbuild.json
@@ -58,7 +58,7 @@
       },
       "declarationRootDir": {
         "type": "string",
-        "description": "Sets the rootDir for the declaration (*.d.ts) files."
+        "description": "Sets the rootDir for the declaration (*.d.ts) files. If not specified, the generator will attempt to determine the the correct location. Declarations files will be output to `outputPath`."
       },
       "watch": {
         "type": "boolean",

--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -313,4 +313,42 @@ describe('EsBuild Plugin', () => {
       new RegExp(`${declarationPkg}-sub`)
     );
   }, 300_000);
+
+  it('should support declaration builds specifying declarationRootDir', () => {
+    const declarationPkg = uniq('declaration-pkg');
+    runCLI(
+      `generate @nx/js:lib ${declarationPkg} --directory=libs/${declarationPkg} --bundler=esbuild`
+    );
+    createFile(
+      `libs/${declarationPkg}/src/lib/testDir/sub.ts`,
+      `
+        export function sub(): string {
+          return 'sub';
+        }
+      `
+    );
+    updateFile(
+      `libs/${declarationPkg}/src/lib/${declarationPkg}.ts`,
+      `
+        import { sub } from './testDir/sub';
+        
+        console.log('${declarationPkg}-' + sub());
+      `
+    );
+
+    runCLI(
+      `build ${declarationPkg} --declaration=true --declarationRootDir='libs/${declarationPkg}/src'`
+    );
+
+    checkFilesExist(
+      `dist/libs/${declarationPkg}/index.cjs`,
+      `dist/libs/${declarationPkg}/index.d.ts`,
+      `dist/libs/${declarationPkg}/lib/${declarationPkg}.d.ts`,
+      `dist/libs/${declarationPkg}/lib/testDir/sub.d.ts`
+    );
+
+    expect(runCommand(`node dist/libs/${declarationPkg}`)).toMatch(
+      new RegExp(`${declarationPkg}-sub`)
+    );
+  }, 300_000);
 });

--- a/packages/esbuild/src/executors/esbuild/schema.json
+++ b/packages/esbuild/src/executors/esbuild/schema.json
@@ -60,7 +60,7 @@
     },
     "declarationRootDir": {
       "type": "string",
-      "description": "Sets the rootDir for the declaration (*.d.ts) files."
+      "description": "Sets the rootDir for the declaration (*.d.ts) files. If not specified, the generator will attempt to determine the the correct location. Declarations files will be output to `outputPath`."
     },
     "watch": {
       "type": "boolean",

--- a/packages/js/src/utils/typescript/run-type-check.ts
+++ b/packages/js/src/utils/typescript/run-type-check.ts
@@ -142,6 +142,7 @@ async function setupTypeScript(options: TypeCheckOptions) {
   const dfltStructure =
     options.mode === 'emitDeclarationOnly'
       ? options.projectRoot &&
+        options.outDir &&
         rootDirIsWorkspaceRoot &&
         path.normalize(options.outDir).endsWith(_projectRoot)
       : undefined;


### PR DESCRIPTION
Refine declarationDir logic for esbuild plugin as follows

- IF no custom declaration root AND outDir structure mirrors {projectRoot} e.g if project root packages/mylib and output directory is dist/packages/mylib THEN we adjust declarationDir to place types in outDir
- ELSE if we have specified a custom declarationRootDir, place declarations in outDir

Add test to check for the case when declarationDir id specified.

Closes #28814.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
As reported in #28814, the esbuild plugin declarationRootDir configuration was/is not working properly when output path matches workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When specifying the esbuild plugin declarationRootDir configuration setting, this setting should be honoured when types are generated AND the generated types should be placed in the configured output path.

The specific new behaviour is detail in the PR outline above.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28814.
