### PR TITLE
fix(misc): use the ts sync generator with other bundler tasks

### DIFF
--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -17,7 +17,7 @@ import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-default
 import { basename, dirname, join } from 'node:path/posix';
 import { mergeTargetConfigurations } from 'nx/src/devkit-internals';
 import type { PackageJson } from 'nx/src/utils/package-json';
-import { ensureProjectIsIncludedInPluginRegistrations } from '../..//utils/typescript/plugin';
+import { ensureProjectIsIncludedInPluginRegistrations } from '../../utils/typescript/plugin';
 import { getImportPath } from '../../utils/get-import-path';
 import {
   getUpdatedPackageJsonContent,

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -20,6 +20,7 @@ import { getLockFileName } from '@nx/js';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { type RollupOptions } from 'rollup';
 import { hashObject } from 'nx/src/hasher/file-hasher';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 const pmc = getPackageManagerCommand();
 
@@ -59,7 +60,8 @@ export const createNodes: CreateNodes<RollupPluginOptions> = [
       configFilePath,
       normalizeOptions(options),
       context,
-      {}
+      {},
+      isUsingTsSolutionSetup()
     );
   },
 ];
@@ -74,6 +76,7 @@ export const createNodesV2: CreateNodesV2<RollupPluginOptions> = [
       `rollup-${optionsHash}.hash`
     );
     const targetsCache = readTargetsCache(cachePath);
+    const isTsSolutionSetup = isUsingTsSolutionSetup();
 
     try {
       return await createNodesFromFiles(
@@ -82,7 +85,8 @@ export const createNodesV2: CreateNodesV2<RollupPluginOptions> = [
             configFile,
             normalizedOptions,
             context,
-            targetsCache
+            targetsCache,
+            isTsSolutionSetup
           ),
         configFilePaths,
         normalizedOptions,
@@ -98,7 +102,8 @@ async function createNodesInternal(
   configFilePath: string,
   options: Required<RollupPluginOptions>,
   context: CreateNodesContext,
-  targetsCache: Record<string, Record<string, TargetConfiguration>>
+  targetsCache: Record<string, Record<string, TargetConfiguration>>,
+  isTsSolutionSetup: boolean
 ) {
   const projectRoot = dirname(configFilePath);
   const fullyQualifiedProjectRoot = join(context.workspaceRoot, projectRoot);
@@ -123,7 +128,8 @@ async function createNodesInternal(
     configFilePath,
     projectRoot,
     options,
-    context
+    context,
+    isTsSolutionSetup
   );
 
   return {
@@ -140,7 +146,8 @@ async function buildRollupTarget(
   configFilePath: string,
   projectRoot: string,
   options: RollupPluginOptions,
-  context: CreateNodesContext
+  context: CreateNodesContext,
+  isTsSolutionSetup: boolean
 ): Promise<Record<string, TargetConfiguration>> {
   let loadConfigFile: (
     path: string,
@@ -200,6 +207,13 @@ async function buildRollupTarget(
       },
     },
   };
+
+  if (isTsSolutionSetup) {
+    targets[options.buildTargetName].syncGenerators = [
+      '@nx/js:typescript-sync',
+    ];
+  }
+
   return targets;
 }
 

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -17,6 +17,7 @@ import {
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { getLockFileName, getRootTsConfigPath } from '@nx/js';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { existsSync, readdirSync } from 'fs';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
@@ -65,10 +66,17 @@ export const createNodesV2: CreateNodesV2<WebpackPluginOptions> = [
     );
     const targetsCache = readTargetsCache(cachePath);
     const normalizedOptions = normalizeOptions(options);
+    const isTsSolutionSetup = isUsingTsSolutionSetup();
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
-          createNodesInternal(configFile, options, context, targetsCache),
+          createNodesInternal(
+            configFile,
+            options,
+            context,
+            targetsCache,
+            isTsSolutionSetup
+          ),
         configFilePaths,
         normalizedOptions,
         context
@@ -86,7 +94,13 @@ export const createNodes: CreateNodes<WebpackPluginOptions> = [
       '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
     );
     const normalizedOptions = normalizeOptions(options);
-    return createNodesInternal(configFilePath, normalizedOptions, context, {});
+    return createNodesInternal(
+      configFilePath,
+      normalizedOptions,
+      context,
+      {},
+      isUsingTsSolutionSetup()
+    );
   },
 ];
 
@@ -94,7 +108,8 @@ async function createNodesInternal(
   configFilePath: string,
   options: Required<WebpackPluginOptions>,
   context: CreateNodesContext,
-  targetsCache: Record<string, WebpackTargets>
+  targetsCache: Record<string, WebpackTargets>,
+  isTsSolutionSetup: boolean
 ): Promise<CreateNodesResult> {
   const projectRoot = dirname(configFilePath);
 
@@ -118,7 +133,8 @@ async function createNodesInternal(
     configFilePath,
     projectRoot,
     options,
-    context
+    context,
+    isTsSolutionSetup
   );
 
   const { targets, metadata } = targetsCache[hash];
@@ -138,7 +154,8 @@ async function createWebpackTargets(
   configFilePath: string,
   projectRoot: string,
   options: Required<WebpackPluginOptions>,
-  context: CreateNodesContext
+  context: CreateNodesContext,
+  isTsSolutionSetup: boolean
 ): Promise<WebpackTargets> {
   const namedInputs = getNamedInputs(projectRoot, context);
 
@@ -242,6 +259,21 @@ async function createWebpackTargets(
       spa: true,
     },
   };
+
+  if (isTsSolutionSetup) {
+    targets[options.buildTargetName].syncGenerators = [
+      '@nx/js:typescript-sync',
+    ];
+    targets[options.serveTargetName].syncGenerators = [
+      '@nx/js:typescript-sync',
+    ];
+    targets[options.previewTargetName].syncGenerators = [
+      '@nx/js:typescript-sync',
+    ];
+    targets[options.serveStaticTargetName].syncGenerators = [
+      '@nx/js:typescript-sync',
+    ];
+  }
 
   return { targets, metadata: {} };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Only targets using `tsc` trigger the `@nx/js:typescript-sync` generator to run.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generating projects with other bundlers should also infer the `@nx/js:typescript-sync` generator in their relevant targets.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
