### PR TITLE
fix(react): None buildable libs should not have a build target

### DIFF
--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -63,6 +63,27 @@ describe('React Applications', () => {
       }
     }, 250_000);
 
+    it('None buildable libs using (useTsSolution = true) should be excluded from js/ts plugin', async () => {
+      const appName = uniq('app');
+      const libName = uniq('lib');
+
+      runCLI(
+        `generate @nx/react:app apps/${appName} --name=${appName} --useTsSolution true --bundler=vite --no-interactive --skipFormat --linter=eslint --unitTestRunner=vitest`
+      );
+      runCLI(
+        `generate @nx/react:lib ${libName} --bundler=none --no-interactive --unit-test-runner=vitest --skipFormat --linter=eslint`
+      );
+
+      const nxJson = JSON.parse(readFile('nx.json'));
+
+      const jsTypescriptPlugin = nxJson.plugins.find(
+        (plugin) => plugin.plugin === '@nx/js/typescript'
+      );
+      expect(jsTypescriptPlugin).toBeDefined();
+
+      expect(jsTypescriptPlugin.exclude.includes(`${libName}/*`)).toBeTruthy();
+    }, 250_000);
+
     it('should be able to use Rspack to build and test apps', async () => {
       const appName = uniq('app');
       const libName = uniq('lib');

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -6,9 +6,11 @@ import {
   GeneratorCallback,
   installPackagesTask,
   joinPathFragments,
+  readNxJson,
   runTasksInSerial,
   Tree,
   updateJson,
+  updateNxJson,
   writeJson,
 } from '@nx/devkit';
 import { getRelativeCwd } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
@@ -30,6 +32,7 @@ import { extractTsConfigBase } from '../../utils/create-ts-config';
 import { installCommonDependencies } from './lib/install-common-dependencies';
 import { setDefaults } from './lib/set-defaults';
 import { updateTsconfigFiles } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { ensureProjectIsExcludedFromPluginRegistrations } from '@nx/js/src/utils/typescript/plugin';
 
 export async function libraryGenerator(host: Tree, schema: Schema) {
   return await libraryGeneratorInternal(host, {
@@ -137,6 +140,10 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
   } else if (options.buildable && options.bundler === 'rollup') {
     const rollupTask = await addRollupBuildTarget(host, options);
     tasks.push(rollupTask);
+  } else if (options.bundler === 'none' && options.addPlugin) {
+    const nxJson = readNxJson(host);
+    ensureProjectIsExcludedFromPluginRegistrations(nxJson, options.projectRoot);
+    updateNxJson(host, nxJson);
   }
 
   // Set up test target


### PR DESCRIPTION
When using the new `useTsSolution` option for applications libraries are automatically opted into using a `build` target even though they may not be buildable.

This change ensures non-buildable libs are excluded from being built.