### PR TITLE
feat(module-federation): alias host and remote generators to consumer and producer

### DIFF
--- a/docs/generated/packages/angular/generators/federate-module.json
+++ b/docs/generated/packages/angular/generators/federate-module.json
@@ -6,11 +6,15 @@
     "cli": "nx",
     "$id": "NxReactFederateModule",
     "title": "Federate Module",
-    "description": "Create a federated module, which is exposed by a remote and can be subsequently loaded by a host.",
+    "description": "Create a federated module, which is exposed by a Producer (remote) and can be subsequently loaded by a Consumer (host).",
     "examples": [
       {
-        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app --remoteDirectory=apps/my-remote-app",
+        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=myRemoteApp --remoteDirectory=apps/myRemoteApp",
         "description": "Create a federated module from my-remote-app, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
+      },
+      {
+        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --producer=myProducer --producerDirectory=apps/myProducer",
+        "description": "Create a federated module from myProducer, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
       }
     ],
     "type": "object",
@@ -30,15 +34,17 @@
       },
       "remote": {
         "type": "string",
-        "description": "The name of the remote.",
-        "x-prompt": "What is/should the remote be named?"
+        "description": "The name of the Producer (remote).",
+        "x-prompt": "What is/should the Producer (remote) be named?",
+        "alias": "producer"
       },
       "remoteDirectory": {
-        "description": "The directory of the new remote application if one needs to be created.",
-        "type": "string"
+        "description": "The directory of the new Producer (remote) application if one needs to be created.",
+        "type": "string",
+        "alias": "producerDirectory"
       },
       "style": {
-        "description": "The file extension to be used for style files for the remote if one needs to be created.",
+        "description": "The file extension to be used for style files for the Producer (remote) if one needs to be created.",
         "type": "string",
         "default": "css",
         "enum": ["css", "scss", "sass", "less"]
@@ -52,24 +58,25 @@
       "unitTestRunner": {
         "type": "string",
         "enum": ["jest", "vitest", "none"],
-        "description": "Test runner to use for unit tests of the remote if it needs to be created.",
+        "description": "Test runner to use for unit tests of the Producer (remote) if it needs to be created.",
         "x-prompt": "Which unit test runner would you like to use?",
         "default": "jest"
       },
       "e2eTestRunner": {
         "type": "string",
         "enum": ["cypress", "none"],
-        "description": "Test runner to use for end to end (e2e) tests of the remote if it needs to be created.",
+        "description": "Test runner to use for end to end (e2e) tests of the Producer (remote) if it needs to be created.",
         "default": "cypress"
       },
       "standalone": {
-        "description": "Whether to generate the remote application with standalone components if it needs to be created.",
+        "description": "Whether to generate the Producer (remote) application with standalone components if it needs to be created.",
         "type": "boolean",
         "default": true
       },
       "host": {
         "type": "string",
-        "description": "The host / shell application for this remote."
+        "description": "The Consumer (host) application for this Producer (remote).",
+        "alias": "consumer"
       }
     },
     "required": ["name", "path", "remote"],

--- a/docs/generated/packages/angular/generators/host.json
+++ b/docs/generated/packages/angular/generators/host.json
@@ -5,13 +5,17 @@
     "$schema": "https://json-schema.org/schema",
     "$id": "NxMFHost",
     "cli": "nx",
-    "title": "Nx Module Federation Host Application",
-    "description": "Create an Angular Host Module Federation Application.",
+    "title": "Nx Module Federation Consumer (Host) Application",
+    "description": "Create an Angular Consumer (Host) Module Federation Application.",
     "type": "object",
     "examples": [
       {
         "command": "nx g @nx/angular:host appName --remotes=remote1",
-        "description": "Create an Angular application with configuration in place for Module Federation. If the `remotes` option is provided, attach the remote application to this application's configuration"
+        "description": "Create an Angular application with configuration in place for Module Federation. If the `remotes` option is provided, attach the Producer (remote) application to this application's configuration"
+      },
+      {
+        "command": "nx g @nx/angular:consumer appName --producers=remote1",
+        "description": "Create an Angular application with configuration in place for Module Federation. If the `producers` option is provided, attach the Producer (remote) application to this application's configuration"
       }
     ],
     "properties": {
@@ -23,14 +27,15 @@
       },
       "name": {
         "type": "string",
-        "description": "The name to give to the host Angular application.",
+        "description": "The name to give to the Consumer (host) Angular application.",
         "pattern": "^[a-zA-Z][^:]*$",
         "x-priority": "important"
       },
       "remotes": {
         "type": "array",
-        "description": "The names of the remote applications to add to the host.",
-        "x-priority": "important"
+        "description": "The names of the Producers (remote) applications to add to the Consumer (host).",
+        "x-priority": "important",
+        "alias": "producers"
       },
       "dynamic": {
         "type": "boolean",
@@ -160,11 +165,11 @@
       },
       "standalone": {
         "type": "boolean",
-        "description": "Whether to generate a host application that uses standalone components.",
+        "description": "Whether to generate a Consumer (host) application that uses standalone components.",
         "default": true
       },
       "ssr": {
-        "description": "Whether to configure SSR for the host application",
+        "description": "Whether to configure SSR for the Consumer (host) application",
         "type": "boolean",
         "default": false,
         "x-priority": "important"
@@ -185,8 +190,8 @@
   },
   "x-type": "application",
   "description": "Generate a Host Angular Module Federation Application.",
+  "aliases": ["consumer"],
   "implementation": "/packages/angular/src/generators/host/host.ts",
-  "aliases": [],
   "hidden": false,
   "path": "/packages/angular/src/generators/host/schema.json",
   "type": "generator"

--- a/docs/generated/packages/angular/generators/remote.json
+++ b/docs/generated/packages/angular/generators/remote.json
@@ -5,13 +5,17 @@
     "$schema": "https://json-schema.org/schema",
     "$id": "NxMFRemote",
     "cli": "nx",
-    "title": "Nx Module Federation Remote App",
-    "description": "Create an Angular Remote Module Federation Application.",
+    "title": "Nx Module Federation Producer (Remote) App",
+    "description": "Create an Angular Producer (Remote) Module Federation Application.",
     "type": "object",
     "examples": [
       {
         "command": "nx g @nx/angular:remote appName --host=host --port=4201",
-        "description": "Create an Angular app with configuration in place for Module Federation. If host is provided, attach this remote app to host app's configuration."
+        "description": "Create an Angular app with configuration in place for Module Federation. If Consumer (host) is provided, attach this Producer (remote) app to Consumer (host) app's configuration."
+      },
+      {
+        "command": "nx g @nx/angular:producer appName --consumer=host --port=4201",
+        "description": "Create an Angular app with configuration in place for Module Federation. If Consumer (host) is provided, attach this Producer (remote) app to Consumer (host) app's configuration."
       }
     ],
     "properties": {
@@ -23,15 +27,16 @@
       },
       "name": {
         "type": "string",
-        "description": "The name to give to the remote Angular app.",
+        "description": "The name to give to the Producer (remote) Angular app.",
         "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
         "x-priority": "important"
       },
       "host": {
         "type": "string",
-        "description": "The name of the host app to attach this remote app to.",
+        "description": "The name of the Consumer (host) app to attach this Producer (remote) app to.",
         "x-dropdown": "projects",
-        "x-priority": "important"
+        "x-priority": "important",
+        "alias": "consumer"
       },
       "port": {
         "type": "number",
@@ -153,12 +158,12 @@
         "x-priority": "internal"
       },
       "standalone": {
-        "description": "Whether to generate a remote application with standalone components.",
+        "description": "Whether to generate a Producer (remote) application with standalone components.",
         "type": "boolean",
         "default": true
       },
       "ssr": {
-        "description": "Whether to configure SSR for the remote application to be consumed by a host application using SSR.",
+        "description": "Whether to configure SSR for the Producer (remote) application to be consumed by a Consumer (host) application using SSR.",
         "type": "boolean",
         "default": false
       },
@@ -178,8 +183,8 @@
   },
   "x-type": "application",
   "description": "Generate a Remote Angular Module Federation Application.",
+  "aliases": ["producer"],
   "implementation": "/packages/angular/src/generators/remote/remote.ts",
-  "aliases": [],
   "hidden": false,
   "path": "/packages/angular/src/generators/remote/schema.json",
   "type": "generator"

--- a/docs/generated/packages/angular/generators/setup-mf.json
+++ b/docs/generated/packages/angular/generators/setup-mf.json
@@ -34,15 +34,17 @@
       },
       "remotes": {
         "type": "array",
-        "description": "A list of remote application names that the host application should consume."
+        "description": "A list of remote application names that the Consumer (host) application should consume.",
+        "alias": "producers"
       },
       "host": {
         "type": "string",
-        "description": "The name of the host application that the remote application will be consumed by."
+        "description": "The name of the host application that the remote application will be consumed by.",
+        "alias": "consumer"
       },
       "routing": {
         "type": "boolean",
-        "description": "Generate a routing setup to allow a host application to route to the remote application.",
+        "description": "Generate a routing setup to allow a Consumer (host) application to route to the Producer (remote) application.",
         "x-priority": "important"
       },
       "skipFormat": {

--- a/docs/generated/packages/react/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-dev-server.json
@@ -25,14 +25,16 @@
             }
           ]
         },
-        "description": "List of remote applications to run in development mode (i.e. using serve target).",
-        "x-priority": "important"
+        "description": "List of Producer (remote) applications to run in development mode (i.e. using serve target).",
+        "x-priority": "important",
+        "alias": "devProducers"
       },
       "skipRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to not automatically serve, either statically or in development mode. This will not remove the remotes from the `module-federation.config` file, and therefore the application may still try to fetch these remotes.\nThis option is useful if you have other means for serving the `remote` application(s).\n**NOTE:** Remotes that are not in the workspace will be skipped automatically.",
-        "x-priority": "important"
+        "description": "List of Producer (remote) applications to not automatically serve, either statically or in development mode. This will not remove the Producers (remotes) from the `module-federation.config` file, and therefore the application may still try to fetch these Producers (remotes).\nThis option is useful if you have other means for serving the Producer (remote) application(s).\n**NOTE:** Producers (remotes) that are not in the workspace will be skipped automatically.",
+        "x-priority": "important",
+        "alias": "skipProducers"
       },
       "buildTarget": {
         "type": "string",
@@ -106,25 +108,27 @@
       },
       "static": {
         "type": "boolean",
-        "description": "Whether to use a static file server instead of the webpack-dev-server. This should be used for remote applications that are also host applications."
+        "description": "Whether to use a static file server instead of the webpack-dev-server. This should be used for Producer (remote) applications that are also Consumer (host) applications."
       },
       "isInitialHost": {
         "type": "boolean",
-        "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+        "description": "Whether the Consumer (host) that is running this executor is the first in the project tree to do so.",
         "default": true,
-        "x-priority": "internal"
+        "x-priority": "internal",
+        "alias": "isInitialConsumer"
       },
       "parallel": {
         "type": "number",
-        "description": "Max number of parallel processes for building static remotes"
+        "description": "Max number of parallel processes for building static Producers (remotes)"
       },
       "staticRemotesPort": {
         "type": "number",
-        "description": "The port at which to serve the file-server for the static remotes."
+        "description": "The port at which to serve the file-server for the static Producers (remotes).",
+        "alias": "staticProducersPort"
       },
       "pathToManifestFile": {
         "type": "string",
-        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic Producer (remote) applications relative to the workspace root."
       }
     },
     "examplesFile": "## Examples\n\n{% tabs %}\n\n{% tab label=\"Basic Usage\" %}\nThe Module Federation Dev Server will serve a host application and find the remote applications associated with the host and serve them statically also.  \nSee an example set up of it below:\n\n```json\n{\n  \"serve\": {\n    \"executor\": \"@nx/react:module-federation-dev-server\",\n    \"configurations\": {\n      \"production\": {\n        \"buildTarget\": \"host:build:production\"\n      },\n      \"development\": {\n        \"buildTarget\": \"host:build:development\"\n      }\n    },\n    \"defaultConfiguration\": \"development\",\n    \"options\": {\n      \"port\": 4200,\n      \"publicHost\": \"http://localhost:4200\"\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Serve host with remotes that can be live reloaded\" %}\nThe Module Federation Dev Server will serve a host application and find the remote applications associated with the host and serve a set selection with live reloading enabled also.  \nSee an example set up of it below:\n\n```json\n{\n  \"serve-with-hmr-remotes\": {\n    \"executor\": \"@nx/react:module-federation-dev-server\",\n    \"configurations\": {\n      \"production\": {\n        \"buildTarget\": \"host:build:production\"\n      },\n      \"development\": {\n        \"buildTarget\": \"host:build:development\"\n      }\n    },\n    \"defaultConfiguration\": \"development\",\n    \"options\": {\n      \"port\": 4200,\n      \"publicHost\": \"http://localhost:4200\",\n      \"devRemotes\": [\n        \"remote1\",\n        {\n          \"remoteName\": \"remote2\",\n          \"configuration\": \"development\"\n        }\n      ]\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% /tabs %}\n",

--- a/docs/generated/packages/react/executors/module-federation-ssr-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-ssr-dev-server.json
@@ -5,7 +5,7 @@
     "version": 2,
     "outputCapture": "direct-nodejs",
     "title": "Module Federation SSR Dev Server",
-    "description": "Serve a SSR host application along with its known remotes.",
+    "description": "Serve a SSR Consumer (host) application along with its known Producers (remotes).",
     "cli": "nx",
     "type": "object",
     "properties": {
@@ -28,14 +28,16 @@
       "devRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to run in development mode (i.e. using serve target).",
-        "x-priority": "important"
+        "description": "List of Producer (remote) applications to run in development mode (i.e. using serve target).",
+        "x-priority": "important",
+        "alias": "devProducers"
       },
       "skipRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to not automatically serve, either statically or in development mode.",
-        "x-priority": "important"
+        "description": "List of Producer (remote) applications to not automatically serve, either statically or in development mode.",
+        "x-priority": "important",
+        "alias": "skipProducers"
       },
       "host": {
         "type": "string",
@@ -44,11 +46,12 @@
       },
       "staticRemotesPort": {
         "type": "number",
-        "description": "The port at which to serve the file-server for the static remotes."
+        "description": "The port at which to serve the file-server for the static Producers (remotes).",
+        "alias": "staticProducersPort"
       },
       "pathToManifestFile": {
         "type": "string",
-        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic Producer (remote) applications relative to the workspace root."
       },
       "ssl": {
         "type": "boolean",
@@ -65,9 +68,10 @@
       },
       "isInitialHost": {
         "type": "boolean",
-        "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+        "description": "Whether the Consumer (host) that is running this executor is the first in the project tree to do so.",
         "default": true,
-        "x-priority": "internal"
+        "x-priority": "internal",
+        "alias": "isInitialConsumer"
       }
     },
     "required": ["browserTarget", "serverTarget"],

--- a/docs/generated/packages/react/executors/module-federation-static-server.json
+++ b/docs/generated/packages/react/executors/module-federation-static-server.json
@@ -5,7 +5,7 @@
     "version": 2,
     "outputCapture": "direct-nodejs",
     "title": "Module Federation Static Dev Server",
-    "description": "Serve a host application statically along with it's remotes.",
+    "description": "Serve a Consumer (host) application statically along with its Producers (remotes).",
     "cli": "nx",
     "type": "object",
     "properties": { "serveTarget": { "type": "string" } },

--- a/docs/generated/packages/react/generators/federate-module.json
+++ b/docs/generated/packages/react/generators/federate-module.json
@@ -6,11 +6,15 @@
     "cli": "nx",
     "$id": "NxReactFederateModule",
     "title": "Federate Module",
-    "description": "Create a federated module, which can be loaded by a remote host.",
+    "description": "Create a federated module, which can be loaded by a Consumer (host) via a Producer (remote).",
     "examples": [
       {
-        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app --remoteDirectory=apps/my-remote-app",
-        "description": "Create a federated module from my-remote-app, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
+        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=myRemote --remoteDirectory=apps/myRemote",
+        "description": "Create a federated module from myRemote, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
+      },
+      {
+        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --producer=myProducer --producerDirectory=apps/myProducer",
+        "description": "Create a federated module from myProducer, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
       }
     ],
     "type": "object",
@@ -30,12 +34,14 @@
       },
       "remote": {
         "type": "string",
-        "description": "The name of the remote.",
-        "x-prompt": "What is/should the remote be named?"
+        "description": "The name of the Producer (remote).",
+        "x-prompt": "What is/should the Producer (remote) be named?",
+        "alias": "producer"
       },
       "remoteDirectory": {
-        "description": "The directory of the new remote application if one needs to be created.",
-        "type": "string"
+        "description": "The directory of the new Producer (remote) application if one needs to be created.",
+        "type": "string",
+        "alias": "producerDirectory"
       },
       "style": {
         "description": "The file extension to be used for style files.",
@@ -70,7 +76,7 @@
       },
       "host": {
         "type": "string",
-        "description": "The host / shell application for this remote."
+        "description": "The Consumer (host) application for this Producer (remote)."
       },
       "bundler": {
         "description": "The bundler to use.",

--- a/docs/generated/packages/react/generators/host.json
+++ b/docs/generated/packages/react/generators/host.json
@@ -5,8 +5,8 @@
     "$schema": "https://json-schema.org/schema",
     "$id": "GeneratorReactHost",
     "cli": "nx",
-    "title": "Generate Module Federation Setup for React Host App",
-    "description": "Create Module Federation configuration files for given React Host Application.",
+    "title": "Generate Module Federation Setup for React Consumer (Host) App",
+    "description": "Create Module Federation configuration files for given React Consumer (Host) Application.",
     "type": "object",
     "properties": {
       "directory": {
@@ -18,7 +18,7 @@
       },
       "name": {
         "type": "string",
-        "description": "The name of the host application to generate the Module Federation configuration",
+        "description": "The name of the Consumer (host) application to generate the Module Federation configuration",
         "pattern": "^[a-zA-Z][^:]*$",
         "x-priority": "important"
       },
@@ -68,7 +68,7 @@
       },
       "dynamic": {
         "type": "boolean",
-        "description": "Should the host application use dynamic federation?",
+        "description": "Should the Consumer (host) application use dynamic federation?",
         "default": false
       },
       "skipFormat": {
@@ -135,18 +135,19 @@
       },
       "remotes": {
         "type": "array",
-        "description": "A list of remote application names that the host application should consume.",
+        "description": "A list of Producer (remote) application names that the Consumer (host) application should consume.",
         "default": [],
-        "x-priority": "important"
+        "x-priority": "important",
+        "alias": "producers"
       },
       "devServerPort": {
         "type": "number",
-        "description": "The port for the dev server of the remote app.",
+        "description": "The port for the dev server of the Producer (remote) app.",
         "default": 4200,
         "x-priority": "important"
       },
       "ssr": {
-        "description": "Whether to configure SSR for the host application",
+        "description": "Whether to configure SSR for the Consumer (host) application",
         "type": "boolean",
         "default": false
       },
@@ -181,8 +182,8 @@
   },
   "x-type": "application",
   "description": "Generate a host react application",
+  "aliases": ["consumer"],
   "implementation": "/packages/react/src/generators/host/host.ts",
-  "aliases": [],
   "hidden": false,
   "path": "/packages/react/src/generators/host/schema.json",
   "type": "generator"

--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -5,8 +5,8 @@
     "$schema": "https://json-schema.org/schema",
     "$id": "GeneratorReactRemote",
     "cli": "nx",
-    "title": "Generate Module Federation Setup for React Remote App",
-    "description": "Create Module Federation configuration files for given React Remote Application.",
+    "title": "Generate Module Federation Setup for React Producer (Remote) App",
+    "description": "Create Module Federation configuration files for given React Producer (Remote) Application.",
     "type": "object",
     "properties": {
       "directory": {
@@ -18,13 +18,13 @@
       },
       "name": {
         "type": "string",
-        "description": "The name of the remote application to generate the Module Federation configuration",
+        "description": "The name of the Producer (remote) application to generate the Module Federation configuration",
         "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
         "x-priority": "important"
       },
       "dynamic": {
         "type": "boolean",
-        "description": "Should the host application use dynamic federation?",
+        "description": "Should the Consumer (host) application use dynamic federation?",
         "default": false,
         "x-priority": "internal"
       },
@@ -141,16 +141,17 @@
       },
       "host": {
         "type": "string",
-        "description": "The host / shell application for this remote.",
-        "x-priority": "important"
+        "description": "The Consumer (host) application for this Producer (remote).",
+        "x-priority": "important",
+        "alias": "consumer"
       },
       "devServerPort": {
         "type": "number",
-        "description": "The port for the dev server of the remote app.",
+        "description": "The port for the dev server of the Producer (remote) app.",
         "x-priority": "important"
       },
       "ssr": {
-        "description": "Whether to configure SSR for the host application",
+        "description": "Whether to configure SSR for the Consumer (host) application",
         "type": "boolean",
         "default": false
       },
@@ -180,8 +181,8 @@
   },
   "x-type": "application",
   "description": "Generate a remote react application",
+  "aliases": ["producer"],
   "implementation": "/packages/react/src/generators/remote/remote.ts",
-  "aliases": [],
   "hidden": false,
   "path": "/packages/react/src/generators/remote/schema.json",
   "type": "generator"

--- a/docs/generated/packages/rspack/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/rspack/executors/module-federation-dev-server.json
@@ -25,14 +25,16 @@
             }
           ]
         },
-        "description": "List of remote applications to run in development mode (i.e. using serve target).",
-        "x-priority": "important"
+        "description": "List of Producer (remote) applications to run in development mode (i.e. using serve target).",
+        "x-priority": "important",
+        "alias": "devProducers"
       },
       "skipRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to not automatically serve, either statically or in development mode. This will not remove the remotes from the `module-federation.config` file, and therefore the application may still try to fetch these remotes.\nThis option is useful if you have other means for serving the `remote` application(s).\n**NOTE:** Remotes that are not in the workspace will be skipped automatically.",
-        "x-priority": "important"
+        "description": "List of Producer (remote) applications to not automatically serve, either statically or in development mode. This will not remove the Producers (remotes) from the `module-federation.config` file, and therefore the application may still try to fetch these Producers (remotes).\nThis option is useful if you have other means for serving the Producer (remote) application(s).\n**NOTE:** Producers (remotes) that are not in the workspace will be skipped automatically.",
+        "x-priority": "important",
+        "alias": "skipProducers"
       },
       "buildTarget": {
         "type": "string",
@@ -69,25 +71,27 @@
       },
       "static": {
         "type": "boolean",
-        "description": "Whether to use a static file server instead of the rspack-dev-server. This should be used for remote applications that are also host applications."
+        "description": "Whether to use a static file server instead of the rspack-dev-server. This should be used for Producer (remote) applications that are also Consumer (host) applications."
       },
       "isInitialHost": {
         "type": "boolean",
-        "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+        "description": "Whether the Consumer (host) that is running this executor is the first in the project tree to do so.",
         "default": true,
-        "x-priority": "internal"
+        "x-priority": "internal",
+        "alias": "isInitialConsumer"
       },
       "parallel": {
         "type": "number",
-        "description": "Max number of parallel processes for building static remotes"
+        "description": "Max number of parallel processes for building static Producers (remotes)."
       },
       "staticRemotesPort": {
         "type": "number",
-        "description": "The port at which to serve the file-server for the static remotes."
+        "description": "The port at which to serve the file-server for the static Producers (remotes).",
+        "alias": "staticProducersPort"
       },
       "pathToManifestFile": {
         "type": "string",
-        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic Producer (remote) applications relative to the workspace root."
       }
     },
     "presets": []

--- a/docs/generated/packages/rspack/executors/module-federation-ssr-dev-server.json
+++ b/docs/generated/packages/rspack/executors/module-federation-ssr-dev-server.json
@@ -5,7 +5,7 @@
     "version": 2,
     "outputCapture": "direct-nodejs",
     "title": "Module Federation SSR Dev Server",
-    "description": "Serve a SSR host application along with its known remotes.",
+    "description": "Serve a SSR Consumer (host) application along with its known Producers (remotes).",
     "cli": "nx",
     "type": "object",
     "properties": {
@@ -28,14 +28,16 @@
       "devRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to run in development mode (i.e. using serve target).",
-        "x-priority": "important"
+        "description": "List of Producers (remote) applications to run in development mode (i.e. using serve target).",
+        "x-priority": "important",
+        "alias": "devProducers"
       },
       "skipRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to not automatically serve, either statically or in development mode.",
-        "x-priority": "important"
+        "description": "List of Producers (remote) applications to not automatically serve, either statically or in development mode.",
+        "x-priority": "important",
+        "alias": "skipProducers"
       },
       "host": {
         "type": "string",
@@ -44,11 +46,12 @@
       },
       "staticRemotesPort": {
         "type": "number",
-        "description": "The port at which to serve the file-server for the static remotes."
+        "description": "The port at which to serve the file-server for the static Producers (remotes).",
+        "alias": "staticProducersPort"
       },
       "pathToManifestFile": {
         "type": "string",
-        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic Producers (remote) applications relative to the workspace root."
       },
       "ssl": {
         "type": "boolean",
@@ -69,9 +72,10 @@
       },
       "isInitialHost": {
         "type": "boolean",
-        "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+        "description": "Whether the Consumer (host) that is running this executor is the first in the project tree to do so.",
         "default": true,
-        "x-priority": "internal"
+        "x-priority": "internal",
+        "alias": "isInitialConsumer"
       }
     },
     "required": ["browserTarget", "serverTarget"],

--- a/docs/generated/packages/rspack/executors/module-federation-static-server.json
+++ b/docs/generated/packages/rspack/executors/module-federation-static-server.json
@@ -5,7 +5,7 @@
     "version": 2,
     "outputCapture": "direct-nodejs",
     "title": "Module Federation Static Dev Server",
-    "description": "Serve a host application statically along with it's remotes.",
+    "description": "Serve a Consumer (host) application statically along with it's Producers (remotes).",
     "cli": "nx",
     "type": "object",
     "properties": { "serveTarget": { "type": "string" } },

--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -73,7 +73,8 @@
       "factory": "./src/generators/remote/remote",
       "schema": "./src/generators/remote/schema.json",
       "x-type": "application",
-      "description": "Generate a Remote Angular Module Federation Application."
+      "description": "Generate a Remote Angular Module Federation Application.",
+      "aliases": ["producer"]
     },
     "move": {
       "factory": "./src/generators/move/move#angularMoveGenerator",
@@ -91,7 +92,8 @@
       "factory": "./src/generators/host/host",
       "schema": "./src/generators/host/schema.json",
       "x-type": "application",
-      "description": "Generate a Host Angular Module Federation Application."
+      "description": "Generate a Host Angular Module Federation Application.",
+      "aliases": ["consumer"]
     },
     "ng-add": {
       "factory": "./src/generators/ng-add/ng-add",

--- a/packages/angular/src/generators/federate-module/schema.json
+++ b/packages/angular/src/generators/federate-module/schema.json
@@ -3,11 +3,15 @@
   "cli": "nx",
   "$id": "NxReactFederateModule",
   "title": "Federate Module",
-  "description": "Create a federated module, which is exposed by a remote and can be subsequently loaded by a host.",
+  "description": "Create a federated module, which is exposed by a Producer (remote) and can be subsequently loaded by a Consumer (host).",
   "examples": [
     {
-      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app --remoteDirectory=apps/my-remote-app",
+      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=myRemoteApp --remoteDirectory=apps/myRemoteApp",
       "description": "Create a federated module from my-remote-app, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
+    },
+    {
+      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --producer=myProducer --producerDirectory=apps/myProducer",
+      "description": "Create a federated module from myProducer, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
     }
   ],
   "type": "object",
@@ -30,15 +34,17 @@
     },
     "remote": {
       "type": "string",
-      "description": "The name of the remote.",
-      "x-prompt": "What is/should the remote be named?"
+      "description": "The name of the Producer (remote).",
+      "x-prompt": "What is/should the Producer (remote) be named?",
+      "alias": "producer"
     },
     "remoteDirectory": {
-      "description": "The directory of the new remote application if one needs to be created.",
-      "type": "string"
+      "description": "The directory of the new Producer (remote) application if one needs to be created.",
+      "type": "string",
+      "alias": "producerDirectory"
     },
     "style": {
-      "description": "The file extension to be used for style files for the remote if one needs to be created.",
+      "description": "The file extension to be used for style files for the Producer (remote) if one needs to be created.",
       "type": "string",
       "default": "css",
       "enum": ["css", "scss", "sass", "less"]
@@ -52,24 +58,25 @@
     "unitTestRunner": {
       "type": "string",
       "enum": ["jest", "vitest", "none"],
-      "description": "Test runner to use for unit tests of the remote if it needs to be created.",
+      "description": "Test runner to use for unit tests of the Producer (remote) if it needs to be created.",
       "x-prompt": "Which unit test runner would you like to use?",
       "default": "jest"
     },
     "e2eTestRunner": {
       "type": "string",
       "enum": ["cypress", "none"],
-      "description": "Test runner to use for end to end (e2e) tests of the remote if it needs to be created.",
+      "description": "Test runner to use for end to end (e2e) tests of the Producer (remote) if it needs to be created.",
       "default": "cypress"
     },
     "standalone": {
-      "description": "Whether to generate the remote application with standalone components if it needs to be created.",
+      "description": "Whether to generate the Producer (remote) application with standalone components if it needs to be created.",
       "type": "boolean",
       "default": true
     },
     "host": {
       "type": "string",
-      "description": "The host / shell application for this remote."
+      "description": "The Consumer (host) application for this Producer (remote).",
+      "alias": "consumer"
     }
   },
   "required": ["name", "path", "remote"],

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -2,13 +2,17 @@
   "$schema": "https://json-schema.org/schema",
   "$id": "NxMFHost",
   "cli": "nx",
-  "title": "Nx Module Federation Host Application",
-  "description": "Create an Angular Host Module Federation Application.",
+  "title": "Nx Module Federation Consumer (Host) Application",
+  "description": "Create an Angular Consumer (Host) Module Federation Application.",
   "type": "object",
   "examples": [
     {
       "command": "nx g @nx/angular:host appName --remotes=remote1",
-      "description": "Create an Angular application with configuration in place for Module Federation. If the `remotes` option is provided, attach the remote application to this application's configuration"
+      "description": "Create an Angular application with configuration in place for Module Federation. If the `remotes` option is provided, attach the Producer (remote) application to this application's configuration"
+    },
+    {
+      "command": "nx g @nx/angular:consumer appName --producers=remote1",
+      "description": "Create an Angular application with configuration in place for Module Federation. If the `producers` option is provided, attach the Producer (remote) application to this application's configuration"
     }
   ],
   "properties": {
@@ -23,14 +27,15 @@
     },
     "name": {
       "type": "string",
-      "description": "The name to give to the host Angular application.",
+      "description": "The name to give to the Consumer (host) Angular application.",
       "pattern": "^[a-zA-Z][^:]*$",
       "x-priority": "important"
     },
     "remotes": {
       "type": "array",
-      "description": "The names of the remote applications to add to the host.",
-      "x-priority": "important"
+      "description": "The names of the Producers (remote) applications to add to the Consumer (host).",
+      "x-priority": "important",
+      "alias": "producers"
     },
     "dynamic": {
       "type": "boolean",
@@ -163,11 +168,11 @@
     },
     "standalone": {
       "type": "boolean",
-      "description": "Whether to generate a host application that uses standalone components.",
+      "description": "Whether to generate a Consumer (host) application that uses standalone components.",
       "default": true
     },
     "ssr": {
-      "description": "Whether to configure SSR for the host application",
+      "description": "Whether to configure SSR for the Consumer (host) application",
       "type": "boolean",
       "default": false,
       "x-priority": "important"

--- a/packages/angular/src/generators/remote/schema.json
+++ b/packages/angular/src/generators/remote/schema.json
@@ -2,13 +2,17 @@
   "$schema": "https://json-schema.org/schema",
   "$id": "NxMFRemote",
   "cli": "nx",
-  "title": "Nx Module Federation Remote App",
-  "description": "Create an Angular Remote Module Federation Application.",
+  "title": "Nx Module Federation Producer (Remote) App",
+  "description": "Create an Angular Producer (Remote) Module Federation Application.",
   "type": "object",
   "examples": [
     {
       "command": "nx g @nx/angular:remote appName --host=host --port=4201",
-      "description": "Create an Angular app with configuration in place for Module Federation. If host is provided, attach this remote app to host app's configuration."
+      "description": "Create an Angular app with configuration in place for Module Federation. If Consumer (host) is provided, attach this Producer (remote) app to Consumer (host) app's configuration."
+    },
+    {
+      "command": "nx g @nx/angular:producer appName --consumer=host --port=4201",
+      "description": "Create an Angular app with configuration in place for Module Federation. If Consumer (host) is provided, attach this Producer (remote) app to Consumer (host) app's configuration."
     }
   ],
   "properties": {
@@ -23,15 +27,16 @@
     },
     "name": {
       "type": "string",
-      "description": "The name to give to the remote Angular app.",
+      "description": "The name to give to the Producer (remote) Angular app.",
       "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
       "x-priority": "important"
     },
     "host": {
       "type": "string",
-      "description": "The name of the host app to attach this remote app to.",
+      "description": "The name of the Consumer (host) app to attach this Producer (remote) app to.",
       "x-dropdown": "projects",
-      "x-priority": "important"
+      "x-priority": "important",
+      "alias": "consumer"
     },
     "port": {
       "type": "number",
@@ -156,12 +161,12 @@
       "x-priority": "internal"
     },
     "standalone": {
-      "description": "Whether to generate a remote application with standalone components.",
+      "description": "Whether to generate a Producer (remote) application with standalone components.",
       "type": "boolean",
       "default": true
     },
     "ssr": {
-      "description": "Whether to configure SSR for the remote application to be consumed by a host application using SSR.",
+      "description": "Whether to configure SSR for the Producer (remote) application to be consumed by a Consumer (host) application using SSR.",
       "type": "boolean",
       "default": false
     },

--- a/packages/angular/src/generators/setup-mf/schema.json
+++ b/packages/angular/src/generators/setup-mf/schema.json
@@ -34,15 +34,17 @@
     },
     "remotes": {
       "type": "array",
-      "description": "A list of remote application names that the host application should consume."
+      "description": "A list of remote application names that the Consumer (host) application should consume.",
+      "alias": "producers"
     },
     "host": {
       "type": "string",
-      "description": "The name of the host application that the remote application will be consumed by."
+      "description": "The name of the host application that the remote application will be consumed by.",
+      "alias": "consumer"
     },
     "routing": {
       "type": "boolean",
-      "description": "Generate a routing setup to allow a host application to route to the remote application.",
+      "description": "Generate a routing setup to allow a Consumer (host) application to route to the Producer (remote) application.",
       "x-priority": "important"
     },
     "skipFormat": {

--- a/packages/react/generators.json
+++ b/packages/react/generators.json
@@ -64,13 +64,15 @@
       "factory": "./src/generators/host/host",
       "schema": "./src/generators/host/schema.json",
       "x-type": "application",
-      "description": "Generate a host react application"
+      "description": "Generate a host react application",
+      "aliases": ["consumer"]
     },
     "remote": {
       "factory": "./src/generators/remote/remote",
       "schema": "./src/generators/remote/schema.json",
       "x-type": "application",
-      "description": "Generate a remote react application"
+      "description": "Generate a remote react application",
+      "aliases": ["producer"]
     },
     "cypress-component-configuration": {
       "factory": "./src/generators/cypress-component-configuration/cypress-component-configuration#cypressComponentConfigGenerator",

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -28,16 +28,18 @@
           }
         ]
       },
-      "description": "List of remote applications to run in development mode (i.e. using serve target).",
-      "x-priority": "important"
+      "description": "List of Producer (remote) applications to run in development mode (i.e. using serve target).",
+      "x-priority": "important",
+      "alias": "devProducers"
     },
     "skipRemotes": {
       "type": "array",
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to not automatically serve, either statically or in development mode. This will not remove the remotes from the `module-federation.config` file, and therefore the application may still try to fetch these remotes.\nThis option is useful if you have other means for serving the `remote` application(s).\n**NOTE:** Remotes that are not in the workspace will be skipped automatically.",
-      "x-priority": "important"
+      "description": "List of Producer (remote) applications to not automatically serve, either statically or in development mode. This will not remove the Producers (remotes) from the `module-federation.config` file, and therefore the application may still try to fetch these Producers (remotes).\nThis option is useful if you have other means for serving the Producer (remote) application(s).\n**NOTE:** Producers (remotes) that are not in the workspace will be skipped automatically.",
+      "x-priority": "important",
+      "alias": "skipProducers"
     },
     "buildTarget": {
       "type": "string",
@@ -111,25 +113,27 @@
     },
     "static": {
       "type": "boolean",
-      "description": "Whether to use a static file server instead of the webpack-dev-server. This should be used for remote applications that are also host applications."
+      "description": "Whether to use a static file server instead of the webpack-dev-server. This should be used for Producer (remote) applications that are also Consumer (host) applications."
     },
     "isInitialHost": {
       "type": "boolean",
-      "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+      "description": "Whether the Consumer (host) that is running this executor is the first in the project tree to do so.",
       "default": true,
-      "x-priority": "internal"
+      "x-priority": "internal",
+      "alias": "isInitialConsumer"
     },
     "parallel": {
       "type": "number",
-      "description": "Max number of parallel processes for building static remotes"
+      "description": "Max number of parallel processes for building static Producers (remotes)"
     },
     "staticRemotesPort": {
       "type": "number",
-      "description": "The port at which to serve the file-server for the static remotes."
+      "description": "The port at which to serve the file-server for the static Producers (remotes).",
+      "alias": "staticProducersPort"
     },
     "pathToManifestFile": {
       "type": "string",
-      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic Producer (remote) applications relative to the workspace root."
     }
   },
   "examplesFile": "../../../docs/module-federation-dev-server-examples.md"

--- a/packages/react/src/executors/module-federation-ssr-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/schema.json
@@ -2,7 +2,7 @@
   "version": 2,
   "outputCapture": "direct-nodejs",
   "title": "Module Federation SSR Dev Server",
-  "description": "Serve a SSR host application along with its known remotes.",
+  "description": "Serve a SSR Consumer (host) application along with its known Producers (remotes).",
   "cli": "nx",
   "type": "object",
   "properties": {
@@ -27,16 +27,18 @@
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to run in development mode (i.e. using serve target).",
-      "x-priority": "important"
+      "description": "List of Producer (remote) applications to run in development mode (i.e. using serve target).",
+      "x-priority": "important",
+      "alias": "devProducers"
     },
     "skipRemotes": {
       "type": "array",
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to not automatically serve, either statically or in development mode.",
-      "x-priority": "important"
+      "description": "List of Producer (remote) applications to not automatically serve, either statically or in development mode.",
+      "x-priority": "important",
+      "alias": "skipProducers"
     },
     "host": {
       "type": "string",
@@ -45,11 +47,12 @@
     },
     "staticRemotesPort": {
       "type": "number",
-      "description": "The port at which to serve the file-server for the static remotes."
+      "description": "The port at which to serve the file-server for the static Producers (remotes).",
+      "alias": "staticProducersPort"
     },
     "pathToManifestFile": {
       "type": "string",
-      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic Producer (remote) applications relative to the workspace root."
     },
     "ssl": {
       "type": "boolean",
@@ -66,9 +69,10 @@
     },
     "isInitialHost": {
       "type": "boolean",
-      "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+      "description": "Whether the Consumer (host) that is running this executor is the first in the project tree to do so.",
       "default": true,
-      "x-priority": "internal"
+      "x-priority": "internal",
+      "alias": "isInitialConsumer"
     }
   },
   "required": ["browserTarget", "serverTarget"]

--- a/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -112,7 +112,7 @@ async function buildHost(
 
       if (stdoutString.includes('Successfully ran target build')) {
         staticProcess.stdout.removeAllListeners('data');
-        logger.info(`NX Built host`);
+        logger.info(`NX Built Consumer (host)`);
         res();
       }
     });
@@ -121,7 +121,7 @@ async function buildHost(
       staticProcess.stdout.removeAllListeners('data');
       staticProcess.stderr.removeAllListeners('data');
       if (code !== 0) {
-        rej(`Host failed to build. See above for details.`);
+        rej(`Consumer (host) failed to build. See above for details.`);
       } else {
         res();
       }
@@ -213,8 +213,8 @@ export function startProxies(
     process.on('SIGTERM', () => proxyServer.close());
     process.on('exit', () => proxyServer.close());
   }
-  logger.info(`NX Static remotes proxies started successfully`);
-  logger.info(`NX Starting static host proxy...`);
+  logger.info(`NX Static Producers (remotes) proxies started successfully`);
+  logger.info(`NX Starting static Consumer (host) proxy...`);
   const expressProxy: Express = express();
   expressProxy.use(
     createProxyMiddleware({
@@ -238,7 +238,7 @@ export function startProxies(
     .listen(hostServeOptions.port);
   process.on('SIGTERM', () => proxyServer.close());
   process.on('exit', () => proxyServer.close());
-  logger.info('NX Static host proxy started successfully');
+  logger.info('NX Static Consumer (host) proxy started successfully');
 }
 
 export default async function* moduleFederationStaticServer(

--- a/packages/react/src/executors/module-federation-static-server/schema.json
+++ b/packages/react/src/executors/module-federation-static-server/schema.json
@@ -2,7 +2,7 @@
   "version": 2,
   "outputCapture": "direct-nodejs",
   "title": "Module Federation Static Dev Server",
-  "description": "Serve a host application statically along with it's remotes.",
+  "description": "Serve a Consumer (host) application statically along with its Producers (remotes).",
   "cli": "nx",
   "type": "object",
   "properties": {

--- a/packages/react/src/generators/federate-module/schema.json
+++ b/packages/react/src/generators/federate-module/schema.json
@@ -3,11 +3,15 @@
   "cli": "nx",
   "$id": "NxReactFederateModule",
   "title": "Federate Module",
-  "description": "Create a federated module, which can be loaded by a remote host.",
+  "description": "Create a federated module, which can be loaded by a Consumer (host) via a Producer (remote).",
   "examples": [
     {
-      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app --remoteDirectory=apps/my-remote-app",
-      "description": "Create a federated module from my-remote-app, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
+      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=myRemote --remoteDirectory=apps/myRemote",
+      "description": "Create a federated module from myRemote, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
+    },
+    {
+      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --producer=myProducer --producerDirectory=apps/myProducer",
+      "description": "Create a federated module from myProducer, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
     }
   ],
   "type": "object",
@@ -30,12 +34,14 @@
     },
     "remote": {
       "type": "string",
-      "description": "The name of the remote.",
-      "x-prompt": "What is/should the remote be named?"
+      "description": "The name of the Producer (remote).",
+      "x-prompt": "What is/should the Producer (remote) be named?",
+      "alias": "producer"
     },
     "remoteDirectory": {
-      "description": "The directory of the new remote application if one needs to be created.",
-      "type": "string"
+      "description": "The directory of the new Producer (remote) application if one needs to be created.",
+      "type": "string",
+      "alias": "producerDirectory"
     },
     "style": {
       "description": "The file extension to be used for style files.",
@@ -70,7 +76,7 @@
     },
     "host": {
       "type": "string",
-      "description": "The host / shell application for this remote."
+      "description": "The Consumer (host) application for this Producer (remote)."
     },
     "bundler": {
       "description": "The bundler to use.",

--- a/packages/react/src/generators/host/schema.json
+++ b/packages/react/src/generators/host/schema.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/schema",
   "$id": "GeneratorReactHost",
   "cli": "nx",
-  "title": "Generate Module Federation Setup for React Host App",
-  "description": "Create Module Federation configuration files for given React Host Application.",
+  "title": "Generate Module Federation Setup for React Consumer (Host) App",
+  "description": "Create Module Federation configuration files for given React Consumer (Host) Application.",
   "type": "object",
   "properties": {
     "directory": {
@@ -18,7 +18,7 @@
     },
     "name": {
       "type": "string",
-      "description": "The name of the host application to generate the Module Federation configuration",
+      "description": "The name of the Consumer (host) application to generate the Module Federation configuration",
       "pattern": "^[a-zA-Z][^:]*$",
       "x-priority": "important"
     },
@@ -74,7 +74,7 @@
     },
     "dynamic": {
       "type": "boolean",
-      "description": "Should the host application use dynamic federation?",
+      "description": "Should the Consumer (host) application use dynamic federation?",
       "default": false
     },
     "skipFormat": {
@@ -141,18 +141,19 @@
     },
     "remotes": {
       "type": "array",
-      "description": "A list of remote application names that the host application should consume.",
+      "description": "A list of Producer (remote) application names that the Consumer (host) application should consume.",
       "default": [],
-      "x-priority": "important"
+      "x-priority": "important",
+      "alias": "producers"
     },
     "devServerPort": {
       "type": "number",
-      "description": "The port for the dev server of the remote app.",
+      "description": "The port for the dev server of the Producer (remote) app.",
       "default": 4200,
       "x-priority": "important"
     },
     "ssr": {
-      "description": "Whether to configure SSR for the host application",
+      "description": "Whether to configure SSR for the Consumer (host) application",
       "type": "boolean",
       "default": false
     },

--- a/packages/react/src/generators/remote/lib/update-host-with-remote.ts
+++ b/packages/react/src/generators/remote/lib/update-host-with-remote.ts
@@ -56,7 +56,7 @@ export function updateHostWithRemote(
   } else {
     // TODO(jack): Point to the nx.dev guide when ready.
     logger.warn(
-      `Could not find configuration at ${moduleFederationConfigPath}. Did you generate this project with "@nx/react:host"?`
+      `Could not find configuration at ${moduleFederationConfigPath}. Did you generate this project with "@nx/react:host" or "@nx/react:consumer"?`
     );
   }
 
@@ -78,7 +78,7 @@ export function updateHostWithRemote(
     );
   } else {
     logger.warn(
-      `Could not find app component at ${appComponentPath}. Did you generate this project with "@nx/react:host"?`
+      `Could not find app component at ${appComponentPath}. Did you generate this project with "@nx/react:host" or "@nx/react:consumer"?`
     );
   }
 }

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/schema",
   "$id": "GeneratorReactRemote",
   "cli": "nx",
-  "title": "Generate Module Federation Setup for React Remote App",
-  "description": "Create Module Federation configuration files for given React Remote Application.",
+  "title": "Generate Module Federation Setup for React Producer (Remote) App",
+  "description": "Create Module Federation configuration files for given React Producer (Remote) Application.",
   "type": "object",
   "properties": {
     "directory": {
@@ -18,13 +18,13 @@
     },
     "name": {
       "type": "string",
-      "description": "The name of the remote application to generate the Module Federation configuration",
+      "description": "The name of the Producer (remote) application to generate the Module Federation configuration",
       "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
       "x-priority": "important"
     },
     "dynamic": {
       "type": "boolean",
-      "description": "Should the host application use dynamic federation?",
+      "description": "Should the Consumer (host) application use dynamic federation?",
       "default": false,
       "x-priority": "internal"
     },
@@ -147,16 +147,17 @@
     },
     "host": {
       "type": "string",
-      "description": "The host / shell application for this remote.",
-      "x-priority": "important"
+      "description": "The Consumer (host) application for this Producer (remote).",
+      "x-priority": "important",
+      "alias": "consumer"
     },
     "devServerPort": {
       "type": "number",
-      "description": "The port for the dev server of the remote app.",
+      "description": "The port for the dev server of the Producer (remote) app.",
       "x-priority": "important"
     },
     "ssr": {
-      "description": "Whether to configure SSR for the host application",
+      "description": "Whether to configure SSR for the Consumer (host) application",
       "type": "boolean",
       "default": false
     },

--- a/packages/rspack/src/executors/module-federation-dev-server/schema.json
+++ b/packages/rspack/src/executors/module-federation-dev-server/schema.json
@@ -28,16 +28,18 @@
           }
         ]
       },
-      "description": "List of remote applications to run in development mode (i.e. using serve target).",
-      "x-priority": "important"
+      "description": "List of Producer (remote) applications to run in development mode (i.e. using serve target).",
+      "x-priority": "important",
+      "alias": "devProducers"
     },
     "skipRemotes": {
       "type": "array",
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to not automatically serve, either statically or in development mode. This will not remove the remotes from the `module-federation.config` file, and therefore the application may still try to fetch these remotes.\nThis option is useful if you have other means for serving the `remote` application(s).\n**NOTE:** Remotes that are not in the workspace will be skipped automatically.",
-      "x-priority": "important"
+      "description": "List of Producer (remote) applications to not automatically serve, either statically or in development mode. This will not remove the Producers (remotes) from the `module-federation.config` file, and therefore the application may still try to fetch these Producers (remotes).\nThis option is useful if you have other means for serving the Producer (remote) application(s).\n**NOTE:** Producers (remotes) that are not in the workspace will be skipped automatically.",
+      "x-priority": "important",
+      "alias": "skipProducers"
     },
     "buildTarget": {
       "type": "string",
@@ -74,25 +76,27 @@
     },
     "static": {
       "type": "boolean",
-      "description": "Whether to use a static file server instead of the rspack-dev-server. This should be used for remote applications that are also host applications."
+      "description": "Whether to use a static file server instead of the rspack-dev-server. This should be used for Producer (remote) applications that are also Consumer (host) applications."
     },
     "isInitialHost": {
       "type": "boolean",
-      "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+      "description": "Whether the Consumer (host) that is running this executor is the first in the project tree to do so.",
       "default": true,
-      "x-priority": "internal"
+      "x-priority": "internal",
+      "alias": "isInitialConsumer"
     },
     "parallel": {
       "type": "number",
-      "description": "Max number of parallel processes for building static remotes"
+      "description": "Max number of parallel processes for building static Producers (remotes)."
     },
     "staticRemotesPort": {
       "type": "number",
-      "description": "The port at which to serve the file-server for the static remotes."
+      "description": "The port at which to serve the file-server for the static Producers (remotes).",
+      "alias": "staticProducersPort"
     },
     "pathToManifestFile": {
       "type": "string",
-      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic Producer (remote) applications relative to the workspace root."
     }
   }
 }

--- a/packages/rspack/src/executors/module-federation-ssr-dev-server/schema.json
+++ b/packages/rspack/src/executors/module-federation-ssr-dev-server/schema.json
@@ -2,7 +2,7 @@
   "version": 2,
   "outputCapture": "direct-nodejs",
   "title": "Module Federation SSR Dev Server",
-  "description": "Serve a SSR host application along with its known remotes.",
+  "description": "Serve a SSR Consumer (host) application along with its known Producers (remotes).",
   "cli": "nx",
   "type": "object",
   "properties": {
@@ -27,16 +27,18 @@
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to run in development mode (i.e. using serve target).",
-      "x-priority": "important"
+      "description": "List of Producers (remote) applications to run in development mode (i.e. using serve target).",
+      "x-priority": "important",
+      "alias": "devProducers"
     },
     "skipRemotes": {
       "type": "array",
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to not automatically serve, either statically or in development mode.",
-      "x-priority": "important"
+      "description": "List of Producers (remote) applications to not automatically serve, either statically or in development mode.",
+      "x-priority": "important",
+      "alias": "skipProducers"
     },
     "host": {
       "type": "string",
@@ -45,11 +47,12 @@
     },
     "staticRemotesPort": {
       "type": "number",
-      "description": "The port at which to serve the file-server for the static remotes."
+      "description": "The port at which to serve the file-server for the static Producers (remotes).",
+      "alias": "staticProducersPort"
     },
     "pathToManifestFile": {
       "type": "string",
-      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic Producers (remote) applications relative to the workspace root."
     },
     "ssl": {
       "type": "boolean",
@@ -70,9 +73,10 @@
     },
     "isInitialHost": {
       "type": "boolean",
-      "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+      "description": "Whether the Consumer (host) that is running this executor is the first in the project tree to do so.",
       "default": true,
-      "x-priority": "internal"
+      "x-priority": "internal",
+      "alias": "isInitialConsumer"
     }
   },
   "required": ["browserTarget", "serverTarget"]

--- a/packages/rspack/src/executors/module-federation-static-server/schema.json
+++ b/packages/rspack/src/executors/module-federation-static-server/schema.json
@@ -2,7 +2,7 @@
   "version": 2,
   "outputCapture": "direct-nodejs",
   "title": "Module Federation Static Dev Server",
-  "description": "Serve a host application statically along with it's remotes.",
+  "description": "Serve a Consumer (host) application statically along with it's Producers (remotes).",
   "cli": "nx",
   "type": "object",
   "properties": {


### PR DESCRIPTION
## Current Behavior
Our Module Federation support across Angular and React contains Host and Remote generators.
The module-federation.io docs have started to shift towards Consumer and Producer terminology for better translation of meanings across languages.


## Expected Behavior
To stay consistent with official terminology, add aliases for the host and remote generators to allow for the new terminology. i.e. host -> consumer, remote -> producer.

Therefore the following are all valid

```shell
nx g host shell --remotes=remote1
nx g host shell --producers=producer1
nx g consumer shell --remotes=remote1
nx g consumer shell --producers=remote1

nx g remote remote1 --host=shell
nx g remote remote1 --consumer=shell
nx g producer producer1 --host=shell
nx g producer producer1 --consumer=shell
```
