### PR TITLE
fix(release): set make_latest legacy during github release creation

### DIFF
--- a/packages/nx/src/command-line/release/utils/github.ts
+++ b/packages/nx/src/command-line/release/utils/github.ts
@@ -29,6 +29,7 @@ interface GithubRequestConfig {
   token: string | null;
 }
 
+// https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release--parameters
 interface GithubRelease {
   id?: string;
   tag_name: string;
@@ -37,6 +38,7 @@ interface GithubRelease {
   body?: string;
   draft?: boolean;
   prerelease?: boolean;
+  make_latest?: 'legacy' | boolean;
 }
 
 export interface GithubRepoData {
@@ -310,6 +312,8 @@ async function syncGithubRelease(
     name: release.version,
     body: release.body,
     prerelease: release.prerelease,
+    // legacy specifies that the latest release should be determined based on the release creation date and higher semantic version.
+    make_latest: 'legacy',
   };
 
   try {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When a github release is created, and it is not a prerelease version, it will be marked as the latest even if its version is "older" based on semantic versioning.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a github release is created, and it is not a prerelease version, it will be marked as the latest ONLY if its version is "newer" based on semantic versioning (thanks to the inference on github API side)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
