### PR TITLE
fix(core): handle tty on windows

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -139,13 +139,13 @@ export class ForkedProcessTaskRunner {
     }
   ): Promise<{ code: number; terminalOutput: string }> {
     return pipeOutput
-      ? await this.forkProcessPipeOutputCapture(task, {
-          temporaryOutputPath,
+      ? this.forkProcessWithPrefixAndNotTTY(task, {
           streamOutput,
+          temporaryOutputPath,
           taskGraph,
           env,
         })
-      : await this.forkProcessDirectOutputCapture(task, {
+      : this.forkProcessDirectOutputCapture(task, {
           temporaryOutputPath,
           streamOutput,
           taskGraph,
@@ -158,6 +158,7 @@ export class ForkedProcessTaskRunner {
     {
       temporaryOutputPath,
       streamOutput,
+      pipeOutput,
       taskGraph,
       env,
       disablePseudoTerminal,
@@ -181,9 +182,10 @@ export class ForkedProcessTaskRunner {
       !streamOutput ||
       shouldPrefix
     ) {
-      return this.forkProcessWithPrefixAndNotTTY(task, {
+      return this.forkProcessLegacy(task, {
         temporaryOutputPath,
         streamOutput,
+        pipeOutput,
         taskGraph,
         env,
       });
@@ -249,28 +251,6 @@ export class ForkedProcessTaskRunner {
           terminalOutput,
         });
       });
-    });
-  }
-
-  private forkProcessPipeOutputCapture(
-    task: Task,
-    {
-      streamOutput,
-      temporaryOutputPath,
-      taskGraph,
-      env,
-    }: {
-      streamOutput: boolean;
-      temporaryOutputPath: string;
-      taskGraph: TaskGraph;
-      env: NodeJS.ProcessEnv;
-    }
-  ) {
-    return this.forkProcessWithPrefixAndNotTTY(task, {
-      streamOutput,
-      temporaryOutputPath,
-      taskGraph,
-      env,
     });
   }
 

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -64,13 +64,8 @@ async function getTerminalOutputLifeCycle(
   nxJson: NxJsonConfiguration,
   overrides: Record<string, unknown>
 ): Promise<{ lifeCycle: LifeCycle; renderIsDone: Promise<void> }> {
-  const { runnerOptions } = getRunner(nxArgs, nxJson);
   const isRunOne = initiatingProject != null;
-  const useDynamicOutput = shouldUseDynamicLifeCycle(
-    tasks,
-    runnerOptions,
-    nxArgs.outputStyle
-  );
+  const useDynamicOutput = shouldUseDynamicLifeCycle(tasks, nxArgs.outputStyle);
 
   const overridesWithoutHidden = { ...overrides };
   delete overridesWithoutHidden['__overrides_unparsed__'];
@@ -741,11 +736,7 @@ async function convertObservableToPromise(
   });
 }
 
-function shouldUseDynamicLifeCycle(
-  tasks: Task[],
-  options: any,
-  outputStyle: string
-) {
+function shouldUseDynamicLifeCycle(tasks: Task[], outputStyle: string) {
   if (
     process.env.NX_BATCH_MODE === 'true' ||
     process.env.NX_VERBOSE_LOGGING === 'true' ||

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -671,10 +671,6 @@ export class TaskOrchestrator {
 
   private async pipeOutputCapture(task: Task) {
     try {
-      if (process.env.NX_NATIVE_COMMAND_RUNNER !== 'false') {
-        return true;
-      }
-
       const { schema } = getExecutorForTask(task, this.projectGraph);
 
       return (


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
currently even isTTY, but on some windows platforms, `PseudoTerminal.isSupported()` will be false, so `this.pseudoTerminal` will always be null.
currently logic will call forkProcessWithPrefixAndNotTTY even isTTY.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
it should not call forkProcessWithPrefixAndNotTTY when isTTY and on some windows platforms.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/27936
