### PR TITLE
fix(release): skip changelog generation for projects without available version data

### DIFF
--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -1230,7 +1230,10 @@ async function generateChangelogForProjects({
      * newVersion will be null in the case that no changes were detected (e.g. in conventional commits mode),
      * no changelog entry is relevant in that case.
      */
-    if (projectsVersionData[project.name].newVersion === null) {
+    if (
+      !projectsVersionData[project.name] ||
+      projectsVersionData[project.name].newVersion === null
+    ) {
       continue;
     }
 


### PR DESCRIPTION
Other places in code also check if the project exists in the versionData object before accessing its properties. 

Fixes https://github.com/nrwl/nx/issues/29211
