### PR TITLE
fix(remix): update app generator with valid package.json without Prettier

### DIFF
--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -316,8 +316,10 @@ describe('Remix Application', () => {
   });
 
   describe('TS solution setup', () => {
-    it('should add project references when using TS solution', async () => {
-      const tree = createTreeWithEmptyWorkspace();
+    let tree: Tree;
+
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace();
       updateJson(tree, 'package.json', (json) => {
         json.workspaces = ['packages/*', 'apps/*'];
         return json;
@@ -333,7 +335,9 @@ describe('Remix Application', () => {
         files: [],
         references: [],
       });
+    });
 
+    it('should add project references when using TS solution', async () => {
       await applicationGenerator(tree, {
         directory: 'myapp',
         e2eTestRunner: 'playwright',
@@ -522,6 +526,20 @@ describe('Remix Application', () => {
           ],
         }
       `);
+    });
+
+    it('should generate valid package.json without formatting', async () => {
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        e2eTestRunner: 'playwright',
+        unitTestRunner: 'jest',
+        addPlugin: true,
+        skipFormat: true,
+      });
+
+      expect(() =>
+        JSON.parse(tree.read('myapp/package.json', 'utf-8'))
+      ).not.toThrow();
     });
   });
 });

--- a/packages/remix/src/generators/application/files/ts-solution/package.json__tmpl__
+++ b/packages/remix/src/generators/application/files/ts-solution/package.json__tmpl__
@@ -24,8 +24,7 @@
   <%_ if (name !== projectName) { _%>
     "name": "<%= name %>",<%_ } _%>
     "projectType": "application",
-    "sourceRoot": "<%- projectRoot %>",
-    <%_ if (parsedTags?.length) { _%>
+    "sourceRoot": "<%- projectRoot %>"<%_ if (parsedTags?.length) { _%>,
     "tags": <%- JSON.stringify(parsedTags) %>
     <%_ } _%>
   }<% } %>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
If you don't have Prettier installed, then `nx g @nx/remix:app apps/myapp` will generate a `package.json` with trailing comma, and `npm install` fails.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`package.json` should be valid without Prettier.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
