### PR TITLE
fix(remix): update lib generator to generate valid names in package.json

### DIFF
--- a/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
+++ b/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
@@ -6,12 +6,16 @@ import {
 } from '@nx/devkit';
 import { getRootTsConfigPathInTree } from '@nx/js';
 import type { RemixLibraryOptions } from './normalize-options';
+import { resolveImportPath } from '@nx/devkit/src/generators/project-name-and-root-utils';
 
 export function addTsconfigEntryPoints(
   tree: Tree,
   options: RemixLibraryOptions
 ) {
-  const { sourceRoot } = readProjectConfiguration(tree, options.projectName);
+  const { root: projectRoot, sourceRoot } = readProjectConfiguration(
+    tree,
+    options.projectName
+  );
   const serverFilePath = joinPathFragments(sourceRoot, 'server.ts');
 
   tree.write(
@@ -20,14 +24,13 @@ export function addTsconfigEntryPoints(
   );
 
   const baseTsConfig = getRootTsConfigPathInTree(tree);
+  // Use same logic as `determineProjectNameAndRootOptions` to get the import path
+  const importPath = resolveImportPath(tree, options.name, projectRoot);
   updateJson(tree, baseTsConfig, (json) => {
-    if (
-      json.compilerOptions.paths &&
-      json.compilerOptions.paths[options.importPath]
-    ) {
-      json.compilerOptions.paths[
-        joinPathFragments(options.importPath, 'server')
-      ] = [serverFilePath];
+    if (json.compilerOptions.paths && json.compilerOptions.paths[importPath]) {
+      json.compilerOptions.paths[joinPathFragments(importPath, 'server')] = [
+        serverFilePath,
+      ];
     }
 
     return json;

--- a/packages/remix/src/generators/library/lib/normalize-options.ts
+++ b/packages/remix/src/generators/library/lib/normalize-options.ts
@@ -3,7 +3,6 @@ import {
   determineProjectNameAndRootOptions,
   ensureProjectName,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
-import { getImportPath } from '@nx/js/src/utils/get-import-path';
 import type { NxRemixGeneratorSchema } from '../schema';
 
 export interface RemixLibraryOptions extends NxRemixGeneratorSchema {
@@ -31,12 +30,9 @@ export async function normalizeOptions(
     nxJson.useInferencePlugins !== false;
   options.addPlugin ??= addPluginDefault;
 
-  const importPath = options.importPath ?? getImportPath(tree, projectRoot);
-
   return {
     ...options,
     unitTestRunner: options.unitTestRunner ?? 'vitest',
-    importPath,
     projectName,
     projectRoot,
   };

--- a/packages/remix/src/generators/library/library.impl.spec.ts
+++ b/packages/remix/src/generators/library/library.impl.spec.ts
@@ -1,6 +1,12 @@
 import 'nx/src/internal-testing-utils/mock-project-graph';
 
-import { readJson, readProjectConfiguration } from '@nx/devkit';
+import {
+  readJson,
+  readProjectConfiguration,
+  Tree,
+  updateJson,
+  writeJson,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import libraryGenerator from './library.impl';
@@ -128,5 +134,49 @@ describe('Remix Library Generator', () => {
     expect(project.targets.build.options.outputPath).toEqual(`test/dist`);
     expect(pkgJson.main).toEqual('./dist/index.cjs.js');
     expect(pkgJson.typings).toEqual('./dist/index.d.ts');
+  });
+  describe('TS solution setup', () => {
+    let tree: Tree;
+
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => {
+        json.workspaces = ['packages/*', 'apps/*'];
+        return json;
+      });
+      writeJson(tree, 'tsconfig.base.json', {
+        compilerOptions: {
+          composite: true,
+          declaration: true,
+        },
+      });
+      writeJson(tree, 'tsconfig.json', {
+        extends: './tsconfig.base.json',
+        files: [],
+        references: [],
+      });
+    });
+
+    it('should generate valid package.json', async () => {
+      await libraryGenerator(tree, {
+        directory: 'packages/foo',
+        style: 'css',
+        addPlugin: true,
+      });
+
+      expect(readJson(tree, 'packages/foo/package.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "main": "./src/index.ts",
+          "name": "@proj/foo",
+          "nx": {
+            "name": "foo",
+            "projectType": "library",
+            "sourceRoot": "packages/foo/src",
+          },
+          "types": "./src/index.ts",
+        }
+      `);
+    });
   });
 });

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -32,12 +32,12 @@ export async function remixLibraryGeneratorInternal(
   tasks.push(jsInitTask);
 
   const libGenTask = await libraryGenerator(tree, {
-    name: options.projectName,
+    directory: options.directory,
+    name: options.name,
     style: options.style,
     unitTestRunner: options.unitTestRunner,
     tags: options.tags,
     importPath: options.importPath,
-    directory: options.projectRoot,
     skipFormat: true,
     skipTsConfig: false,
     linter: options.linter,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
`nx g @nx/remix:lib packages/foo` generates invalid package names in new TS setup. e.g. `@acme/packages/foo`.

## Expected Behavior
The name should be valid in `package.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
