### PR TITLE
feat(angular): add migration to remove the `tailwindConfig` option from ng-packager executors

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -323,6 +323,15 @@
       },
       "description": "Remove Angular ESLint rules that were removed in v19.0.0.",
       "factory": "./src/migrations/update-20-2-0/remove-angular-eslint-rules"
+    },
+    "remove-tailwind-config-from-ng-packagr-executors": {
+      "cli": "nx",
+      "version": "20.2.0-beta.8",
+      "requires": {
+        "@angular/core": ">=19.0.0"
+      },
+      "description": "Remove the deprecated 'tailwindConfig' option from ng-packagr executors. Tailwind CSS configurations located at the project or workspace root will be picked up automatically.",
+      "factory": "./src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.spec.ts
+++ b/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.spec.ts
@@ -1,0 +1,267 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  readProjectConfiguration,
+  updateJson,
+  type NxJsonConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import * as devkit from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  executors,
+} from './remove-tailwind-config-from-ng-packagr-executors';
+
+describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    jest
+      .spyOn(devkit, 'formatFiles')
+      .mockImplementation(() => Promise.resolve());
+  });
+
+  it.each(executors)(
+    'should remove "tailwindConfig" option from target using the "%s" executor',
+    async (executor) => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        targets: {
+          build: {
+            executor,
+            options: {
+              project: 'libs/lib1/ng-package.json',
+              tailwindConfig: 'libs/lib1/tailwind.config.js',
+            },
+            configurations: {
+              development: {
+                tsConfig: 'libs/lib1/tsconfig.lib.json',
+                tailwindConfig: 'libs/lib1/tailwind.config.dev.js',
+              },
+              production: {
+                tsConfig: 'libs/lib1/tsconfig.lib.prod.json',
+                tailwindConfig: 'libs/lib1/tailwind.config.prod.js',
+              },
+            },
+          },
+        },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(project.targets.build.options.tailwindConfig).toBeUndefined();
+      expect(
+        project.targets.build.configurations.development.tailwindConfig
+      ).toBeUndefined();
+      expect(
+        project.targets.build.configurations.production.tailwindConfig
+      ).toBeUndefined();
+    }
+  );
+
+  it.each(executors)(
+    'should remove empty objects from target using the "%s" executor',
+    async (executor) => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        targets: {
+          build: {
+            executor,
+            options: {
+              tailwindConfig: 'libs/lib1/tailwind.config.js',
+            },
+            configurations: {
+              development: {
+                tailwindConfig: 'libs/lib1/tailwind.config.dev.js',
+              },
+              production: {
+                tailwindConfig: 'libs/lib1/tailwind.config.prod.js',
+              },
+            },
+          },
+        },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(project.targets.build.options).toBeUndefined();
+      expect(project.targets.build.configurations).toBeUndefined();
+    }
+  );
+
+  it('should not delete "tailwindConfig" from target not using the relevant executors', async () => {
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      targets: {
+        build: {
+          executor: '@org/awesome-plugin:executor',
+          options: {
+            tailwindConfig: 'libs/lib1/tailwind.config.js',
+          },
+          configurations: {
+            development: {
+              tailwindConfig: 'libs/lib1/tailwind.config.dev.js',
+            },
+            production: {
+              tailwindConfig: 'libs/lib1/tailwind.config.prod.js',
+            },
+          },
+        },
+      },
+    });
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'lib1');
+    expect(project.targets.build.options.tailwindConfig).toBe(
+      'libs/lib1/tailwind.config.js'
+    );
+    expect(
+      project.targets.build.configurations.development.tailwindConfig
+    ).toBe('libs/lib1/tailwind.config.dev.js');
+    expect(project.targets.build.configurations.production.tailwindConfig).toBe(
+      'libs/lib1/tailwind.config.prod.js'
+    );
+  });
+
+  it.each(executors)(
+    'should delete "tailwindConfig" option in nx.json target defaults for a target with the "%s" executor',
+    async (executor) => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults ??= {};
+        json.targetDefaults.build = {
+          executor,
+          options: {
+            project: '{projectRoot}/ng-package.json',
+            tailwindConfig: '{projectRoot}/tailwind.config.js',
+          },
+          configurations: {
+            development: {
+              tsConfig: '{projectRoot}/tsconfig.lib.json',
+              tailwindConfig: '{projectRoot}/tailwind.config.dev.js',
+            },
+            production: {
+              tsConfig: '{projectRoot}/tsconfig.lib.prod.json',
+              tailwindConfig: '{projectRoot}/tailwind.config.prod.js',
+            },
+          },
+        };
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(
+        nxJson.targetDefaults.build.options.tailwindConfig
+      ).toBeUndefined();
+      expect(
+        nxJson.targetDefaults.build.configurations.development.tailwindConfig
+      ).toBeUndefined();
+      expect(
+        nxJson.targetDefaults.build.configurations.production.tailwindConfig
+      ).toBeUndefined();
+    }
+  );
+
+  it.each(executors)(
+    'should delete empty target defaults for a target with the "%s" executor',
+    async (executor) => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults ??= {};
+        json.targetDefaults.build = {
+          executor,
+          options: {
+            tailwindConfig: '{projectRoot}/tailwind.config.js',
+          },
+          configurations: {
+            development: {
+              tailwindConfig: '{projectRoot}/tailwind.config.dev.js',
+            },
+            production: {
+              tailwindConfig: '{projectRoot}/tailwind.config.prod.js',
+            },
+          },
+        };
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.targetDefaults.build).toBeUndefined();
+    }
+  );
+
+  it.each(executors)(
+    'should delete "tailwindConfig" option in nx.json target defaults for the "%s" executor',
+    async (executor) => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults ??= {};
+        json.targetDefaults[executor] = {
+          options: {
+            project: '{projectRoot}/ng-package.json',
+            tailwindConfig: '{projectRoot}/tailwind.config.js',
+          },
+          configurations: {
+            development: {
+              tsConfig: '{projectRoot}/tsconfig.lib.json',
+              tailwindConfig: '{projectRoot}/tailwind.config.dev.js',
+            },
+            production: {
+              tsConfig: '{projectRoot}/tsconfig.lib.prod.json',
+              tailwindConfig: '{projectRoot}/tailwind.config.prod.js',
+            },
+          },
+        };
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(
+        nxJson.targetDefaults[executor].options.tailwindConfig
+      ).toBeUndefined();
+      expect(
+        nxJson.targetDefaults[executor].configurations.development
+          .tailwindConfig
+      ).toBeUndefined();
+      expect(
+        nxJson.targetDefaults[executor].configurations.production.tailwindConfig
+      ).toBeUndefined();
+    }
+  );
+
+  it.each(executors)(
+    'should delete empty target defaults for a target with the "%s" executor',
+    async (executor) => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults ??= {};
+        json.targetDefaults[executor] = {
+          options: {
+            tailwindConfig: '{projectRoot}/tailwind.config.js',
+          },
+          configurations: {
+            development: {
+              tailwindConfig: '{projectRoot}/tailwind.config.dev.js',
+            },
+            production: {
+              tailwindConfig: '{projectRoot}/tailwind.config.prod.js',
+            },
+          },
+        };
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      console.log(nxJson.targetDefaults);
+      expect(nxJson.targetDefaults[executor]).toBeUndefined();
+    }
+  );
+});

--- a/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.ts
+++ b/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.ts
@@ -1,0 +1,105 @@
+import {
+  formatFiles,
+  readNxJson,
+  readProjectConfiguration,
+  updateNxJson,
+  updateProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+
+export const executors = ['@nx/angular:ng-packagr-lite', '@nx/angular:package'];
+
+export default async function (tree: Tree) {
+  // update options from project configs
+  executors.forEach((executor) => {
+    forEachExecutorOptions<{ tailwindConfig?: string }>(
+      tree,
+      executor,
+      (options, project, target, configuration) => {
+        if (options.tailwindConfig === undefined) {
+          return;
+        }
+
+        const projectConfiguration = readProjectConfiguration(tree, project);
+        if (configuration) {
+          const config =
+            projectConfiguration.targets[target].configurations[configuration];
+          delete config.tailwindConfig;
+          if (!Object.keys(config).length) {
+            delete projectConfiguration.targets[target].configurations[
+              configuration
+            ];
+          }
+          if (
+            !Object.keys(projectConfiguration.targets[target].configurations)
+              .length
+          ) {
+            delete projectConfiguration.targets[target].configurations;
+          }
+        } else {
+          const config = projectConfiguration.targets[target].options;
+          delete config.tailwindConfig;
+          if (!Object.keys(config).length) {
+            delete projectConfiguration.targets[target].options;
+          }
+        }
+
+        updateProjectConfiguration(tree, project, projectConfiguration);
+      }
+    );
+  });
+
+  // update options from nx.json target defaults
+  const nxJson = readNxJson(tree);
+  if (!nxJson.targetDefaults) {
+    return;
+  }
+
+  for (const [targetOrExecutor, targetConfig] of Object.entries(
+    nxJson.targetDefaults
+  )) {
+    if (
+      !executors.includes(targetOrExecutor) &&
+      !executors.includes(targetConfig.executor)
+    ) {
+      continue;
+    }
+
+    if (targetConfig.options) {
+      delete targetConfig.options.tailwindConfig;
+      if (!Object.keys(targetConfig.options).length) {
+        delete targetConfig.options;
+      }
+    }
+
+    Object.entries(targetConfig.configurations ?? {}).forEach(
+      ([name, config]) => {
+        delete config.tailwindConfig;
+        if (!Object.keys(config).length) {
+          delete targetConfig.configurations[name];
+        }
+      }
+    );
+
+    if (!Object.keys(targetConfig.configurations ?? {}).length) {
+      delete targetConfig.configurations;
+    }
+
+    if (
+      !Object.keys(targetConfig).length ||
+      (Object.keys(targetConfig).length === 1 &&
+        Object.keys(targetConfig)[0] === 'executor')
+    ) {
+      delete nxJson.targetDefaults[targetOrExecutor];
+    }
+
+    if (!Object.keys(nxJson.targetDefaults).length) {
+      delete nxJson.targetDefaults;
+    }
+  }
+
+  updateNxJson(tree, nxJson);
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
Add migration to remove the `tailwindConfig` option from the ng-packagr executors, which have been unused since Angular v17. Tailwind CSS configurations located at the project or workspace root will be picked up automatically.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29217 
