### PR TITLE
fix(storybook): only install react deps for storybook 7 #29213

### DIFF
--- a/packages/storybook/src/generators/configuration/lib/ensure-dependencies.ts
+++ b/packages/storybook/src/generators/configuration/lib/ensure-dependencies.ts
@@ -4,7 +4,7 @@ import {
   readJson,
   type Tree,
 } from '@nx/devkit';
-import { gte } from 'semver';
+import { coerce, gte } from 'semver';
 import {
   getInstalledStorybookVersion,
   storybookMajorVersion,
@@ -44,19 +44,21 @@ export function ensureDependencies(
   packageJson.dependencies ??= {};
   packageJson.devDependencies ??= {};
 
-  // Needed for Storybook 7
-  // https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-peer-dependencies-required
-  if (
-    !packageJson.dependencies['react'] &&
-    !packageJson.devDependencies['react']
-  ) {
-    dependencies['react'] = reactVersion;
-  }
-  if (
-    !packageJson.dependencies['react-dom'] &&
-    !packageJson.devDependencies['react-dom']
-  ) {
-    dependencies['react-dom'] = reactVersion;
+  if (!gte(coerce(storybook7VersionToInstall), '8.0.0')) {
+    // Needed for Storybook 7
+    // https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-peer-dependencies-required
+    if (
+      !packageJson.dependencies['react'] &&
+      !packageJson.devDependencies['react']
+    ) {
+      dependencies['react'] = reactVersion;
+    }
+    if (
+      !packageJson.dependencies['react-dom'] &&
+      !packageJson.devDependencies['react-dom']
+    ) {
+      dependencies['react-dom'] = reactVersion;
+    }
   }
 
   if (options.uiFramework) {


### PR DESCRIPTION
## Current Behavior
Storybook 7 requires `react` and `react-dom` to be installed as they are peer deps of the storybook package.
Storybook 8 does not require these deps to be installed as they are now bundled correctly into storybook

## Expected Behavior
When user's version of storybook < 8, install `react` and `react-dom`, otherwise, do not.

## Related Issue(s)

Fixes #29213
