### PR TITLE
fix(storybook): ensure 'storybook' dep is installed for non-crystal workspaces

### DIFF
--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -30,18 +30,15 @@ function checkDependenciesInstalled(
     '@nx/web': nxVersion,
   };
 
-  if (schema.addPlugin) {
-    let storybookVersionToInstall = storybookVersion;
-    if (
-      storybookMajorVersion() >= 7 &&
-      getInstalledStorybookVersion() &&
-      gte(getInstalledStorybookVersion(), '7.0.0')
-    ) {
-      storybookVersionToInstall = getInstalledStorybookVersion();
-    }
-
-    devDependencies['storybook'] = storybookVersionToInstall;
+  let storybookVersionToInstall = storybookVersion;
+  if (
+    storybookMajorVersion() >= 7 &&
+    getInstalledStorybookVersion() &&
+    gte(getInstalledStorybookVersion(), '7.0.0')
+  ) {
+    storybookVersionToInstall = getInstalledStorybookVersion();
   }
+  devDependencies['storybook'] = storybookVersionToInstall;
 
   return addDependenciesToPackageJson(
     host,


### PR DESCRIPTION
## Current Behavior
The `storybook` package is required to be installed to correctly find paths correctly.
It acts almost like a shim.
It was not being installed for non-crystal workspaces

## Expected Behavior
Ensure `storybook` is installed
