### PR TITLE
fix(core): defer loading package manager until necessary

### DIFF
--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -177,8 +177,8 @@ export function readTargetsFromPackageJson(
   const { scripts, nx, private: isPrivate } = packageJson ?? {};
   const res: Record<string, TargetConfiguration> = {};
   const includedScripts = nx?.includedScripts || Object.keys(scripts ?? {});
-  packageManagerCommand ??= getPackageManagerCommand();
   for (const script of includedScripts) {
+    packageManagerCommand ??= getPackageManagerCommand();
     res[script] = buildTargetFromScript(script, scripts, packageManagerCommand);
   }
   for (const targetName in nx?.targets) {


### PR DESCRIPTION
Only load package manager context when actually necessary for scripts

## Related Issue(s)
https://github.com/nrwl/nx/issues/29244
