### PR TITLE
fix(vite): do not stop the test process of failure in watch mode

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -58,7 +58,10 @@ export async function* vitestExecutor(
   }
 
   // vitest sets the exitCode in case of exception without notifying reporters
-  if (process.exitCode === undefined) {
+  if (
+    process.exitCode === undefined ||
+    (watch && ctx.state.getFiles().length > 0)
+  ) {
     for await (const report of nxReporter) {
       // vitest sets the exitCode = 1 when code coverage isn't met
       hasErrors =


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

When you run `nx run <lib>:test --watch` it only works correctly if there are no failing tests. In case you have some failing test, the process finishes immediately after all tests are finished.

## Expected Behavior

Watch mode should work the same as with Jest or when you use `vitest` on its own.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

The logic seems to be broken with introduction of https://github.com/nrwl/nx/pull/27722

Fixes #28050
