### PR TITLE
fix(release): make commits separator in git log command more unique

### DIFF
--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -123,14 +123,15 @@ export async function getGitDiff(
     range = `${from}..${to}`;
   }
 
-  // Use a unique enough separator that we can be relatively certain will not occur within the commit message itself
-  const separator = '§§§';
+  // Use unique enough separators that we can be relatively certain will not occur within the commit message itself
+  const commitMetadataSeparator = '§§§';
+  const commitsSeparator = '|@-------@|';
   // https://git-scm.com/docs/pretty-formats
   const args = [
     '--no-pager',
     'log',
     range,
-    `--pretty="----%n%s${separator}%h${separator}%an${separator}%ae%n%b"`,
+    `--pretty="${commitsSeparator}%n%s${commitMetadataSeparator}%h${commitMetadataSeparator}%an${commitMetadataSeparator}%ae%n%b"`,
     '--name-status',
   ];
   // Support cases where the nx workspace root is located at a nested path within the git repo
@@ -142,12 +143,13 @@ export async function getGitDiff(
   const r = await execCommand('git', args);
 
   return r
-    .split('----\n')
+    .split(`${commitsSeparator}\n`)
     .splice(1)
     .map((line) => {
       const [firstLine, ..._body] = line.split('\n');
-      const [message, shortHash, authorName, authorEmail] =
-        firstLine.split(separator);
+      const [message, shortHash, authorName, authorEmail] = firstLine.split(
+        commitMetadataSeparator
+      );
       const r: RawGitCommit = {
         message,
         shortHash,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The commits separator `----` used for the `git log` formatting behind the  scenes could potentially appear in the commit body and is not unique enough.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We use a separator of `|@-------@|` which is extremely unlikely to appear organically in a commit message.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26241
