### PR TITLE
fix(rsbuild): set publish config correctly

### DIFF
--- a/packages/rsbuild/package.json
+++ b/packages/rsbuild/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "commonjs",
   "publishConfig": {
-    "access": "private"
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
private is not a correct options for `publishConfig.access` in the package.json.
This was causing publishing errors.

Set it to public now that 20.2 has been released
