### PR TITLE
chore(repo): use extra-large resource class for memory intensive nx-dev build

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -56,8 +56,8 @@ launch-templates:
 
       - name: Install zip and unzip
         script: sudo apt-get -yqq install zip unzip
-  linux-large:
-    resource-class: 'docker_linux_amd64/large'
+  linux-extra-large:
+    resource-class: 'docker_linux_amd64/extra_large'
     image: 'ubuntu22.04-node20.11-v10'
     env:
       GIT_AUTHOR_EMAIL: test@test.com

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,10 +1,10 @@
 distribute-on:
-  default: auto linux-medium, 1 linux-large
+  default: auto linux-medium, 1 linux-extra-large
 assignment-rules:
   - project: nx-dev
     target: build-base
     runs-on:
-      - linux-large
+      - linux-extra-large
   - target: test
     runs-on:
       - linux-medium


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

nx-dev build is still very memory intensive and can overwhelm the agent it is running on sometimes.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We run nx-dev build on a higher resource class of agent.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
