### PR TITLE
fix(core): ensure @nx/module-federation is listed in package group

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -112,6 +112,7 @@
       "@nx/expo",
       "@nx/express",
       "@nx/gradle",
+      "@nx/module-federation",
       "@nx/nest",
       "@nx/next",
       "@nx/node",


### PR DESCRIPTION
## Current Behavior
`@nx/module-federation` is not listed in the `nx` package's `packageGroup`. 
This reports it incorrectly in `nx report` and can impact `nx migrate`.

## Expected Behavior
`@nx/module-federation` should be listed in the `packageGroup`

