### PR TITLE
fix(repo): cleanup old plugins promise

### DIFF
--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -24,6 +24,7 @@ export async function getPlugins() {
 
   // Cleanup current plugins before loading new ones
   if (cleanup) {
+    pendingPluginsPromise = undefined;
     cleanup();
   }
 
@@ -50,6 +51,7 @@ export async function getOnlyDefaultPlugins() {
 
   // Cleanup current plugins before loading new ones
   if (cleanupDefaultPlugins) {
+    pendingDefaultPluginPromise = undefined;
     cleanupDefaultPlugins();
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When plugins in `nx.json` are changed, the daemon can no longer communicate with plugin workers and create the graph. It will just hang waiting for messages to go through.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Proper cleanup is done when plugins in `nx.json` are changed and the daemon continues responding properly with project graphs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
