### PR TITLE
fix(devkit): add .riv to binary extension

### DIFF
--- a/packages/devkit/src/utils/binary-extensions.ts
+++ b/packages/devkit/src/utils/binary-extensions.ts
@@ -189,6 +189,7 @@ const binaryExtensions = new Set([
   '.resources',
   '.rgb',
   '.rip',
+  '.riv',
   '.rlc',
   '.rmf',
   '.rmvb',


### PR DESCRIPTION
`*.riv` is Runtime binary format for Rive app https://help.rive.app/runtimes/advanced_topics/format#runtime-format