### PR TITLE
fix(core): ensure rsbuild is part of nx package group

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -124,6 +124,7 @@
       "@nx/rollup",
       "@nx/remix",
       "@nx/rspack",
+      "@nx/rsbuild",
       "@nx/storybook",
       "@nx/vite",
       "@nx/vue",


### PR DESCRIPTION
## Current Behavior
The new `@nx/rsbuild` package is not listed as part of the Nx package group.
This can lead to issues with reporting and migrations.

## Expected Behavior
Ensure `@nx/rsbuild` package is listed in the packageGroup
