### PR TITLE
chore(nx-dev): enable search click through rate

### DIFF
--- a/nx-dev/feature-search/src/lib/algolia-search.tsx
+++ b/nx-dev/feature-search/src/lib/algolia-search.tsx
@@ -153,6 +153,7 @@ export function AlgoliaSearch({
                 router.push(itemUrl);
               },
             }}
+            insights={true}
             hitComponent={Hit}
             transformItems={(items) => {
               return items.map((item, index) => {


### PR DESCRIPTION
Enables `insights` on Algolia search component so that click through rate will be tracked on the search analytics