### PR TITLE
fix(react): fix issues with react ts setup

### DIFF
--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -136,7 +136,7 @@ export async function expoLibraryGeneratorInternal(
 
   // Always run install to link packages.
   if (options.isUsingTsSolutionConfig) {
-    tasks.push(() => installPackagesTask(host));
+    tasks.push(() => installPackagesTask(host, true));
   }
 
   tasks.push(() => {

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -136,7 +136,7 @@ export async function reactNativeLibraryGeneratorInternal(
 
   // Always run install to link packages.
   if (options.isUsingTsSolutionConfig) {
-    tasks.push(() => installPackagesTask(host));
+    tasks.push(() => installPackagesTask(host, true));
   }
 
   tasks.push(() => {

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1335,6 +1335,9 @@ describe('app', () => {
             "vite.config.mts",
             "vitest.config.ts",
             "vitest.config.mts",
+            "eslint.config.js",
+            "eslint.config.cjs",
+            "eslint.config.mjs",
           ],
           "extends": "../tsconfig.base.json",
           "include": [

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -361,11 +361,19 @@ export async function applicationGeneratorInternal(
     );
   }
 
-  updateTsconfigFiles(host, options.appProjectRoot, 'tsconfig.app.json', {
-    jsx: 'react-jsx',
-    module: 'esnext',
-    moduleResolution: 'bundler',
-  });
+  updateTsconfigFiles(
+    host,
+    options.appProjectRoot,
+    'tsconfig.app.json',
+    {
+      jsx: 'react-jsx',
+      module: 'esnext',
+      moduleResolution: 'bundler',
+    },
+    options.linter === 'eslint'
+      ? ['eslint.config.js', 'eslint.config.cjs', 'eslint.config.mjs']
+      : undefined
+  );
 
   if (!options.skipFormat) {
     await formatFiles(host);

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -286,7 +286,7 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
 
   // Always run install to link packages.
   if (options.isUsingTsSolutionConfig) {
-    tasks.push(() => installPackagesTask(host));
+    tasks.push(() => installPackagesTask(host, true));
   }
 
   tasks.push(() => {


### PR DESCRIPTION
Fixes a couple of things:

1. React application should ignore `eslint.config.js`, `eslint.config.cjs`, and `eslint.config.mjs` files since they are not part of the app runtime.
2. React lib generators should always run `npm install`. It currently runs only when `package.json` has changed, but we need to run it to link packages regardless of `package.json` changes.