### PR TITLE
fix(js): not generate tsconfig if already exists

### DIFF
--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -445,6 +445,9 @@ export function createTmpTsConfig(
     process.env.NX_TASK_TARGET_TARGET ?? 'build',
     'tsconfig.generated.json'
   );
+  if (tsconfigPath === tmpTsConfigPath) {
+    return tsconfigPath;
+  }
   const parsedTSConfig = readTsConfigWithRemappedPaths(
     tsconfigPath,
     tmpTsConfigPath,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
- in serve target, it uses executor `@nx/webpack:dev-server`
- in `packages/webpack/src/executors/dev-server/dev-server.impl.ts`, when buildLibsFromSource is false, it calls createTmpTsConfig to create a temp config
- in webpack.config.js, it has `module.exports = composePlugins(withNx()`. in withNx, it calls NxTsconfigPathsWebpackPlugin.
- when buildLibsFromSource is false, it called createTmpTsConfig again based on the temp config. it created an infinite loop because it creates a tsconfig that extends itself.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- do not create a temp config if it is a generated ts config

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/28006
