### PR TITLE
fix(angular): correctly normalize dev-server options

### DIFF
--- a/packages/angular/src/builders/dev-server/lib/normalize-options.ts
+++ b/packages/angular/src/builders/dev-server/lib/normalize-options.ts
@@ -21,7 +21,7 @@ export function normalizeOptions(schema: Schema): NormalizedSchema {
     host: schema.host ?? 'localhost',
     port: schema.port ?? 4200,
     liveReload: schema.liveReload ?? true,
-    hmr: angularMajorVersion < 19 ? schema.hmr ?? false : undefined,
+    hmr: schema.hmr ?? (angularMajorVersion < 19 ? false : undefined),
     open: schema.open ?? false,
     ssl: schema.ssl ?? false,
   };


### PR DESCRIPTION
For Angular > 18 schema hmr option was ignored, it was impossible to disable hmr and default value changed in ng19 https://github.com/angular/angular/issues/59058

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
