### PR TITLE
fix(angular): add-localize-polyfill-to-targets fails if polyfills is a string

### DIFF
--- a/packages/angular/src/migrations/update-20-2-0/add-localize-polyfill-to-targets.spec.ts
+++ b/packages/angular/src/migrations/update-20-2-0/add-localize-polyfill-to-targets.spec.ts
@@ -80,6 +80,30 @@ describe('add-localize-polyfill-to-targets migration', () => {
   );
 
   test.each(executorsToAddPolyfillTo)(
+    'should add the "@angular/localize/init" polyfill when target is a string when using the "%s" executor',
+    async (executor) => {
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor,
+            options: { localize: true, polyfills: 'some-other-polyfill' },
+          },
+        },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'app1');
+      expect(project.targets.build.options.polyfills).toStrictEqual([
+        'some-other-polyfill',
+        '@angular/localize/init',
+      ]);
+    }
+  );
+
+  test.each(executorsToAddPolyfillTo)(
     'should not add the "@angular/localize/init" polyfill when using the "%s" executor and the "localize" option is disabled',
     async (executor) => {
       addProjectConfiguration(tree, 'app1', {

--- a/packages/angular/src/migrations/update-20-2-0/add-localize-polyfill-to-targets.ts
+++ b/packages/angular/src/migrations/update-20-2-0/add-localize-polyfill-to-targets.ts
@@ -45,7 +45,13 @@ export default async function (tree: Tree) {
       for (const [, options] of allTargetOptions(target)) {
         if (options['localize']) {
           target.options ??= {};
-          target.options['polyfills'] ??= [];
+          const polyfills = target.options['polyfills'];
+          // Ensure polyfills is an array before pushing
+          if (typeof polyfills === 'string') {
+            target.options['polyfills'] = [polyfills];
+          } else if (!Array.isArray(polyfills)) {
+            target.options['polyfills'] = [];
+          }
           target.options['polyfills'].push('@angular/localize/init');
           isUpdated = true;
           break;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Migration fails if polyfills is a string

## Expected Behavior
Migration should work even if polyfills is a string

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

