### PR TITLE
fix(misc): fix misc generation issues with the ts solution setup

### DIFF
--- a/packages/angular/src/generators/ng-add/migrators/projects/__snapshots__/e2e.migrator.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/migrators/projects/__snapshots__/e2e.migrator.spec.ts.snap
@@ -15,14 +15,15 @@ export default defineConfig({
 
 exports[`e2e migrator cypress with project root at "" cypress version >=10 should create a cypress.config.ts file when it does not exist 1`] = `
 "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
     ...nxE2EPreset(__filename, {
       cypressDir: 'src',
-      webServerCommands: { default: 'nx run app1:serve' },
+      webServerCommands: {
+        default: 'nx run app1:serve',
+      },
     }),
     baseUrl: 'http://localhost:4200',
   },
@@ -98,14 +99,15 @@ export default defineConfig({
 
 exports[`e2e migrator cypress with project root at "projects/app1" cypress version >=10 should create a cypress.config.ts file when it does not exist 1`] = `
 "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
     ...nxE2EPreset(__filename, {
       cypressDir: 'src',
-      webServerCommands: { default: 'nx run app1:serve' },
+      webServerCommands: {
+        default: 'nx run app1:serve',
+      },
     }),
     baseUrl: 'http://localhost:4200',
   },

--- a/packages/cypress/src/generators/base-setup/files/tsconfig/ts-solution/__directory__/tsconfig.json__ext__
+++ b/packages/cypress/src/generators/base-setup/files/tsconfig/ts-solution/__directory__/tsconfig.json__ext__
@@ -1,8 +1,7 @@
 {
   "extends": "<%= tsConfigPath %>",
   "compilerOptions": {
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "outDir": "out-tsc/cypress",
     "allowJs": true,
     "types": ["cypress", "node"],
     "sourceMap": false
@@ -17,5 +16,5 @@
     <%_ if (jsx) { _%>"<%= offsetFromProjectRoot %>**/*.cy.jsx",<%_ } _%>
     "<%= offsetFromProjectRoot %>**/*.d.ts"
   ],
-  "exclude": ["dist"<% if (linter === 'eslint') { %>, "eslint.config.js"<% } %>]
+  "exclude": ["out-tsc", "test-output"<% if (linter === 'eslint') { %>, "eslint.config.js"<% } %>]
 }

--- a/packages/cypress/src/generators/configuration/configuration.spec.ts
+++ b/packages/cypress/src/generators/configuration/configuration.spec.ts
@@ -57,7 +57,6 @@ describe('Cypress e2e configuration', () => {
       expect(tree.read('apps/my-app/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
         import { defineConfig } from 'cypress';
 
         export default defineConfig({
@@ -116,7 +115,6 @@ describe('Cypress e2e configuration', () => {
       expect(tree.read('apps/my-app/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
         import { defineConfig } from 'cypress';
 
         export default defineConfig({
@@ -176,7 +174,6 @@ describe('Cypress e2e configuration', () => {
       expect(tree.read('libs/my-lib/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
         import { defineConfig } from 'cypress';
 
         export default defineConfig({
@@ -207,7 +204,6 @@ describe('Cypress e2e configuration', () => {
       expect(tree.read('apps/my-app/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
         import { defineConfig } from 'cypress';
 
         export default defineConfig({
@@ -450,14 +446,15 @@ export default defineConfig({
       expect(tree.read('libs/my-lib/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
         import { defineConfig } from 'cypress';
         import { nxComponentTestingPreset } from '@nx/angular/plugins/component-testing';
 
         export default defineConfig({
           component: nxComponentTestingPreset(__filename),
           e2e: {
-            ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+            ...nxE2EPreset(__filename, {
+              cypressDir: 'src',
+            }),
             baseUrl: 'http://localhost:4200',
           },
         });
@@ -513,12 +510,13 @@ export default defineConfig({
       expect(tree.read('libs/my-lib/cypress.config.js', 'utf-8'))
         .toMatchInlineSnapshot(`
         "const { nxE2EPreset } = require('@nx/cypress/plugins/cypress-preset');
-
         const { defineConfig } = require('cypress');
 
         module.exports = defineConfig({
           e2e: {
-            ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+            ...nxE2EPreset(__filename, {
+              cypressDir: 'src',
+            }),
             baseUrl: 'http://localhost:4200',
           },
         });
@@ -544,12 +542,13 @@ export default defineConfig({
       expect(tree.read('libs/my-lib/cypress.config.js', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
         import { defineConfig } from 'cypress';
 
         export default defineConfig({
           e2e: {
-            ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+            ...nxE2EPreset(__filename, {
+              cypressDir: 'src',
+            }),
             baseUrl: 'http://localhost:4200',
           },
         });

--- a/packages/cypress/src/utils/config.spec.ts
+++ b/packages/cypress/src/utils/config.spec.ts
@@ -42,13 +42,16 @@ export default defineConfig({
     );
     expect(actual).toMatchInlineSnapshot(`
       "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-          
-          import { defineConfig } from 'cypress';
+      import { defineConfig } from 'cypress';
       import { nxComponentTestingPreset } from '@nx/angular/plugins/component-testing';
 
       export default defineConfig({
         component: nxComponentTestingPreset(__filename),
-        e2e: { ...nxE2EPreset(__filename, {"cypressDir":"cypress"}) } 
+        e2e: {
+          ...nxE2EPreset(__filename, {
+            "cypressDir": "cypress"
+          })
+        } 
       });
       "
     `);
@@ -134,13 +137,16 @@ export default defineConfig({
     );
     expect(actual).toMatchInlineSnapshot(`
       "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-          
-          import { defineConfig } from 'cypress';
+      import { defineConfig } from 'cypress';
       import { nxComponentTestingPreset } from '@nx/angular/plugins/component-testing';
 
       export default defineConfig({
-        e2e: { ...nxE2EPreset(__filename, {"cypressDir":"cypress"}),
-      baseUrl: 'https://example.com' }
+        e2e: {
+          ...nxE2EPreset(__filename, {
+            "cypressDir": "cypress"
+          }),
+          baseUrl: 'https://example.com'
+        }
       });
       "
     `);
@@ -166,12 +172,20 @@ export default defineConfig({
     );
     expect(actual).toMatchInlineSnapshot(`
       "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-          
-          import { defineConfig } from 'cypress';
+      import { defineConfig } from 'cypress';
       import { nxComponentTestingPreset } from '@nx/angular/plugins/component-testing';
 
       export default defineConfig({
-        e2e: { ...nxE2EPreset(__filename, {"cypressDir":"cypress","webServerCommands":{"default":"my-app:serve","production":"my-app:serve:production"},"ciWebServerCommand":"my-app:serve-static"}) }
+        e2e: {
+          ...nxE2EPreset(__filename, {
+            "cypressDir": "cypress",
+            "webServerCommands": {
+              "default": "my-app:serve",
+              "production": "my-app:serve:production"
+            },
+            "ciWebServerCommand": "my-app:serve-static"
+          })
+        }
       });
       "
     `);

--- a/packages/cypress/src/utils/config.ts
+++ b/packages/cypress/src/utils/config.ts
@@ -39,32 +39,40 @@ export async function addDefaultE2EConfig(
   let updatedConfigContents = cyConfigContents;
 
   if (testingTypeConfig.length === 0) {
-    const configValue = `nxE2EPreset(__filename, ${JSON.stringify(options)})`;
+    const configValue = `nxE2EPreset(__filename, ${JSON.stringify(
+      options,
+      null,
+      2
+    )
+      .split('\n')
+      .join('\n    ')})`;
 
     updatedConfigContents = tsquery.replace(
       cyConfigContents,
       `${TS_QUERY_EXPORT_CONFIG_PREFIX} ObjectLiteralExpression:first-child`,
       (node: ObjectLiteralExpression) => {
-        let baseUrlContents = baseUrl ? `,\nbaseUrl: '${baseUrl}'` : '';
+        let baseUrlContents = baseUrl ? `,\n    baseUrl: '${baseUrl}'` : '';
         if (node.properties.length > 0) {
           return `{
   ${node.properties.map((p) => p.getText()).join(',\n')},
-  e2e: { ...${configValue}${baseUrlContents} } 
+  e2e: {
+    ...${configValue}${baseUrlContents}
+  } 
 }`;
         }
         return `{
-  e2e: { ...${configValue}${baseUrlContents} }
+  e2e: {
+    ...${configValue}${baseUrlContents}
+  }
 }`;
       }
     );
 
     return isCommonJS
       ? `const { nxE2EPreset } = require('@nx/cypress/plugins/cypress-preset');
-    
-    ${updatedConfigContents}`
+${updatedConfigContents}`
       : `import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-    
-    ${updatedConfigContents}`;
+${updatedConfigContents}`;
   }
   return updatedConfigContents;
 }

--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -370,19 +370,6 @@ describe('app', () => {
       `);
       expect(readJson(tree, 'my-app/tsconfig.json')).toMatchInlineSnapshot(`
         {
-          "compilerOptions": {
-            "allowSyntheticDefaultImports": true,
-            "declaration": true,
-            "jsx": "react-native",
-            "lib": [
-              "dom",
-              "esnext",
-            ],
-            "moduleResolution": "node",
-            "resolveJsonModule": true,
-            "skipLibCheck": true,
-            "strict": true,
-          },
           "extends": "../tsconfig.base.json",
           "files": [],
           "include": [],
@@ -410,6 +397,7 @@ describe('app', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "**/*.test.ts",
             "**/*.spec.ts",

--- a/packages/expo/src/generators/application/files/base/tsconfig.json.template
+++ b/packages/expo/src/generators/application/files/base/tsconfig.json.template
@@ -1,5 +1,6 @@
 {
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  <%_ if (!isTsSolutionSetup) { _%>
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "jsx": "react-native",
@@ -10,6 +11,7 @@
     "strict": true,
     "declaration": true
   },
+  <%_ } _%>
   "files": [],
   "include": [],
   "references": [

--- a/packages/expo/src/generators/application/lib/normalize-options.spec.ts
+++ b/packages/expo/src/generators/application/lib/normalize-options.spec.ts
@@ -39,6 +39,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'my-app-e2e',
       e2eProjectRoot: 'my-app-e2e',
+      isTsSolutionSetup: false,
     } as NormalizedSchema);
   });
 
@@ -70,6 +71,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'myApp-e2e',
       e2eProjectRoot: 'myApp-e2e',
+      isTsSolutionSetup: false,
     } as NormalizedSchema);
   });
 
@@ -102,6 +104,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'my-app-e2e',
       e2eProjectRoot: 'directory-e2e',
+      isTsSolutionSetup: false,
     } as NormalizedSchema);
   });
 
@@ -133,6 +136,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'my-app-e2e',
       e2eProjectRoot: 'directory/my-app-e2e',
+      isTsSolutionSetup: false,
     } as NormalizedSchema);
   });
 
@@ -165,6 +169,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'my-app-e2e',
       e2eProjectRoot: 'my-app-e2e',
+      isTsSolutionSetup: false,
     } as NormalizedSchema);
   });
 });

--- a/packages/expo/src/generators/application/lib/normalize-options.ts
+++ b/packages/expo/src/generators/application/lib/normalize-options.ts
@@ -3,6 +3,7 @@ import {
   determineProjectNameAndRootOptions,
   ensureProjectName,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { Schema } from '../schema';
 
 export interface NormalizedSchema extends Schema {
@@ -14,6 +15,7 @@ export interface NormalizedSchema extends Schema {
   rootProject: boolean;
   e2eProjectName: string;
   e2eProjectRoot: string;
+  isTsSolutionSetup: boolean;
 }
 
 export async function normalizeOptions(
@@ -59,5 +61,6 @@ export async function normalizeOptions(
     rootProject,
     e2eProjectName,
     e2eProjectRoot,
+    isTsSolutionSetup: isUsingTsSolutionSetup(host),
   };
 }

--- a/packages/expo/src/generators/library/files/lib/tsconfig.json.template
+++ b/packages/expo/src/generators/library/files/lib/tsconfig.json.template
@@ -1,11 +1,13 @@
 {
   "extends": "<%= rootTsConfigPath %>",
+  <%_ if (!isUsingTsSolutionConfig) { _%>
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true
   },
+  <%_ } _%>
   "files": [],
   "include": [],
   "references": [

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -106,7 +106,7 @@ export async function expoLibraryGeneratorInternal(
     updateLibPackageNpmScope(host, options);
   }
 
-  if (!options.skipTsConfig) {
+  if (!options.skipTsConfig && !options.isUsingTsSolutionConfig) {
     addTsConfigPath(host, options.importPath, [
       joinPathFragments(
         options.projectRoot,

--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -236,9 +236,6 @@ describe('app', () => {
       `);
       expect(readJson(appTree, 'myapp/tsconfig.json')).toMatchInlineSnapshot(`
         {
-          "compilerOptions": {
-            "esModuleInterop": true,
-          },
           "extends": "../tsconfig.base.json",
           "files": [],
           "include": [],
@@ -266,6 +263,7 @@ describe('app', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "jest.config.ts",
             "src/**/*.spec.ts",

--- a/packages/js/src/generators/library/files/lib/src/index.ts__tmpl__
+++ b/packages/js/src/generators/library/files/lib/src/index.ts__tmpl__
@@ -1,1 +1,1 @@
-export * from './lib/<%= fileName %>';
+export * from './lib/<%= fileNameImport %>';

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -523,6 +523,10 @@ function createFiles(tree: Tree, options: NormalizedLibraryGeneratorOptions) {
       tsConfig.options.moduleResolution === ts.ModuleResolutionKind.Node16 ||
       tsConfig.options.moduleResolution === ts.ModuleResolutionKind.NodeNext
     ) {
+      // Node16 and NodeNext require explicit file extensions for relative
+      // import paths. Since we generate the file with the `.ts` extension,
+      // we import it from the same file with the `.js` extension.
+      // https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution
       fileNameImport = `${options.fileName}.js`;
     }
   }

--- a/packages/js/src/utils/typescript/configuration.ts
+++ b/packages/js/src/utils/typescript/configuration.ts
@@ -1,7 +1,8 @@
 import type { Tree } from '@nx/devkit';
 import { dirname } from 'path';
-import type { CompilerOptions, System } from 'typescript';
+import type { CompilerOptions, ParsedCommandLine, System } from 'typescript';
 import { ensureTypescript } from './ensure-typescript';
+import { readTsConfig } from './ts-config';
 
 type CompilerOptionsEnumProps = Pick<
   CompilerOptions,

--- a/packages/js/src/utils/typescript/configuration.ts
+++ b/packages/js/src/utils/typescript/configuration.ts
@@ -1,8 +1,7 @@
 import type { Tree } from '@nx/devkit';
 import { dirname } from 'path';
-import type { CompilerOptions, ParsedCommandLine, System } from 'typescript';
+import type { CompilerOptions, System } from 'typescript';
 import { ensureTypescript } from './ensure-typescript';
-import { readTsConfig } from './ts-config';
 
 type CompilerOptionsEnumProps = Pick<
   CompilerOptions,

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -24,6 +24,22 @@ export function readTsConfig(
   );
 }
 
+export function readTsConfigFromTree(
+  tree: Tree,
+  tsConfigPath: string
+): ts.ParsedCommandLine {
+  if (!tsModule) {
+    tsModule = ensureTypescript();
+  }
+
+  const tsSysFromTree: ts.System = {
+    ...tsModule.sys,
+    readFile: (path) => tree.read(path, 'utf-8'),
+  };
+
+  return readTsConfig(tsConfigPath, tsSysFromTree);
+}
+
 export function getRootTsConfigPathInTree(tree: Tree): string | null {
   for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
     if (tree.exists(path)) {

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -142,7 +142,7 @@ export function updateTsconfigFiles(
       };
 
       const excludeSet: Set<string> = json.exclude
-        ? new Set(['dist', ...json.exclude, ...exclude])
+        ? new Set(['out-tsc', 'dist', ...json.exclude, ...exclude])
         : new Set(exclude);
       json.exclude = Array.from(excludeSet);
 

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -261,9 +261,6 @@ describe('application generator', () => {
       `);
       expect(readJson(tree, 'myapp/tsconfig.json')).toMatchInlineSnapshot(`
         {
-          "compilerOptions": {
-            "esModuleInterop": true,
-          },
           "extends": "../tsconfig.base.json",
           "files": [],
           "include": [],
@@ -291,6 +288,7 @@ describe('application generator', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "jest.config.ts",
             "src/**/*.spec.ts",

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -922,6 +922,7 @@ describe('app (legacy)', () => {
           "compilerOptions": {
             "allowJs": true,
             "allowSyntheticDefaultImports": true,
+            "emitDeclarationOnly": false,
             "esModuleInterop": true,
             "forceConsistentCasingInFileNames": true,
             "incremental": true,
@@ -955,6 +956,7 @@ describe('app (legacy)', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "node_modules",
             "jest.config.ts",
@@ -1013,16 +1015,16 @@ describe('app (legacy)', () => {
         {
           "compilerOptions": {
             "allowJs": true,
-            "outDir": "dist",
+            "outDir": "out-tsc/cypress",
             "sourceMap": false,
-            "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
             "types": [
               "cypress",
               "node",
             ],
           },
           "exclude": [
-            "dist",
+            "out-tsc",
+            "test-output",
           ],
           "extends": "../tsconfig.base.json",
           "include": [

--- a/packages/next/src/generators/application/files/common/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/common/tsconfig.json__tmpl__
@@ -5,6 +5,7 @@
     <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>
     "strict": true,
     "noEmit": true,
+    "emitDeclarationOnly": false,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -15,7 +15,10 @@ import { nextInitGenerator } from '../init/init';
 import { Schema } from './schema';
 import { normalizeOptions } from './lib/normalize-options';
 import { eslintConfigNextVersion, tsLibVersion } from '../../utils/versions';
-import { updateTsconfigFiles } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import {
+  isUsingTsSolutionSetup,
+  updateTsconfigFiles,
+} from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export async function libraryGenerator(host: Tree, rawOptions: Schema) {
   return await libraryGeneratorInternal(host, {
@@ -106,7 +109,11 @@ export async function libraryGeneratorInternal(host: Tree, rawOptions: Schema) {
       }
     `
   );
-  addTsConfigPath(host, `${options.importPath}/server`, [serverEntryPath]);
+
+  const isTsSolutionSetup = isUsingTsSolutionSetup(host);
+  if (!options.skipTsConfig && !isTsSolutionSetup) {
+    addTsConfigPath(host, `${options.importPath}/server`, [serverEntryPath]);
+  }
 
   updateJson(
     host,

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -639,9 +639,6 @@ describe('app', () => {
       `);
       expect(readJson(tree, 'myapp/tsconfig.json')).toMatchInlineSnapshot(`
         {
-          "compilerOptions": {
-            "esModuleInterop": true,
-          },
           "extends": "../tsconfig.base.json",
           "files": [],
           "include": [],
@@ -667,6 +664,7 @@ describe('app', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "jest.config.ts",
             "src/**/*.spec.ts",

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -398,6 +398,10 @@ function addProjectDependencies(
 }
 
 function updateTsConfigOptions(tree: Tree, options: NormalizedSchema) {
+  if (options.isUsingTsSolutionConfig) {
+    return;
+  }
+
   updateJson(tree, `${options.appProjectRoot}/tsconfig.json`, (json) => {
     if (options.rootProject) {
       return {

--- a/packages/nuxt/src/generators/application/application.spec.ts
+++ b/packages/nuxt/src/generators/application/application.spec.ts
@@ -269,6 +269,7 @@ describe('app', () => {
             "rootDir": "src",
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "vite.config.ts",
             "vite.config.mts",
@@ -339,12 +340,12 @@ describe('app', () => {
         {
           "compilerOptions": {
             "allowJs": true,
-            "outDir": "dist",
+            "outDir": "out-tsc/playwright",
             "sourceMap": false,
-            "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
           },
           "exclude": [
-            "dist",
+            "out-tsc",
+            "test-output",
             "eslint.config.js",
             "eslint.config.mjs",
             "eslint.config.cjs",

--- a/packages/nuxt/src/generators/application/lib/add-e2e.ts
+++ b/packages/nuxt/src/generators/application/lib/add-e2e.ts
@@ -1,10 +1,10 @@
 import {
   addProjectConfiguration,
   ensurePackage,
-  getPackageManagerCommand,
   joinPathFragments,
   readNxJson,
   Tree,
+  writeJson,
 } from '@nx/devkit';
 import { getE2EWebServerInfo } from '@nx/devkit/src/generators/e2e-web-server-info-utils';
 import { nxVersion } from '../../../utils/versions';
@@ -25,14 +25,31 @@ export async function addE2e(host: Tree, options: NormalizedSchema) {
     const { configurationGenerator } = ensurePackage<
       typeof import('@nx/cypress')
     >('@nx/cypress', nxVersion);
-    addProjectConfiguration(host, options.e2eProjectName, {
-      projectType: 'application',
-      root: options.e2eProjectRoot,
-      sourceRoot: joinPathFragments(options.e2eProjectRoot, 'src'),
-      targets: {},
-      tags: [],
-      implicitDependencies: [options.projectName],
-    });
+    if (options.isUsingTsSolutionConfig) {
+      writeJson(
+        host,
+        joinPathFragments(options.e2eProjectRoot, 'package.json'),
+        {
+          name: options.e2eProjectName,
+          version: '0.0.1',
+          private: true,
+          nx: {
+            projectType: 'application',
+            sourceRoot: joinPathFragments(options.e2eProjectRoot, 'src'),
+            implicitDependencies: [options.projectName],
+          },
+        }
+      );
+    } else {
+      addProjectConfiguration(host, options.e2eProjectName, {
+        projectType: 'application',
+        root: options.e2eProjectRoot,
+        sourceRoot: joinPathFragments(options.e2eProjectRoot, 'src'),
+        targets: {},
+        tags: [],
+        implicitDependencies: [options.projectName],
+      });
+    }
     const e2eTask = await configurationGenerator(host, {
       ...options,
       project: options.e2eProjectName,
@@ -80,12 +97,30 @@ export async function addE2e(host: Tree, options: NormalizedSchema) {
     const { configurationGenerator } = ensurePackage<
       typeof import('@nx/playwright')
     >('@nx/playwright', nxVersion);
-    addProjectConfiguration(host, options.e2eProjectName, {
-      root: options.e2eProjectRoot,
-      sourceRoot: joinPathFragments(options.e2eProjectRoot, 'src'),
-      targets: {},
-      implicitDependencies: [options.projectName],
-    });
+    if (options.isUsingTsSolutionConfig) {
+      writeJson(
+        host,
+        joinPathFragments(options.e2eProjectRoot, 'package.json'),
+        {
+          name: options.e2eProjectName,
+          version: '0.0.1',
+          private: true,
+          nx: {
+            projectType: 'application',
+            sourceRoot: joinPathFragments(options.e2eProjectRoot, 'src'),
+            implicitDependencies: [options.projectName],
+          },
+        }
+      );
+    } else {
+      addProjectConfiguration(host, options.e2eProjectName, {
+        projectType: 'application',
+        root: options.e2eProjectRoot,
+        sourceRoot: joinPathFragments(options.e2eProjectRoot, 'src'),
+        targets: {},
+        implicitDependencies: [options.projectName],
+      });
+    }
     const e2eTask = await configurationGenerator(host, {
       project: options.e2eProjectName,
       skipFormat: true,

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -95,18 +95,17 @@ export async function configurationGeneratorInternal(
     };
 
     if (isTsSolutionSetup) {
+      tsconfig.exclude = ['out-tsc', 'test-output'];
       // skip eslint from typechecking since it extends from root file that is outside rootDir
       if (options.linter === 'eslint') {
-        tsconfig.exclude = [
-          'dist',
+        tsconfig.exclude.push(
           'eslint.config.js',
           'eslint.config.mjs',
-          'eslint.config.cjs',
-        ];
+          'eslint.config.cjs'
+        );
       }
 
-      tsconfig.compilerOptions.outDir = 'dist';
-      tsconfig.compilerOptions.tsBuildInfoFile = 'dist/tsconfig.tsbuildinfo';
+      tsconfig.compilerOptions.outDir = 'out-tsc/playwright';
 
       if (!options.rootProject) {
         updateJson(tree, 'tsconfig.json', (json) => {

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -293,18 +293,6 @@ describe('app', () => {
       `);
       expect(readJson(tree, 'my-app/tsconfig.json')).toMatchInlineSnapshot(`
         {
-          "compilerOptions": {
-            "allowSyntheticDefaultImports": true,
-            "declaration": true,
-            "jsx": "react-native",
-            "lib": [
-              "dom",
-              "esnext",
-            ],
-            "moduleResolution": "node",
-            "resolveJsonModule": true,
-            "skipLibCheck": true,
-          },
           "extends": "../tsconfig.base.json",
           "files": [],
           "include": [],
@@ -335,6 +323,7 @@ describe('app', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",

--- a/packages/react-native/src/generators/application/files/app/tsconfig.json.template
+++ b/packages/react-native/src/generators/application/files/app/tsconfig.json.template
@@ -1,5 +1,6 @@
 {
   "extends": "<%= rootTsConfigPath %>",
+  <%_ if (!isTsSolutionSetup) { _%>
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "jsx": "react-native",
@@ -9,6 +10,7 @@
     "resolveJsonModule": true,
     "declaration": true
   },
+  <%_ } _%>
   "files": [],
   "include": [],
   "references": [

--- a/packages/react-native/src/generators/application/lib/normalize-options.spec.ts
+++ b/packages/react-native/src/generators/application/lib/normalize-options.spec.ts
@@ -43,6 +43,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'my-app-e2e',
       e2eProjectRoot: 'my-app-e2e',
+      isTsSolutionSetup: false,
     });
   });
 
@@ -78,6 +79,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'myApp-e2e',
       e2eProjectRoot: 'myApp-e2e',
+      isTsSolutionSetup: false,
     });
   });
 
@@ -114,6 +116,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'my-app-e2e',
       e2eProjectRoot: 'directory/my-app-e2e',
+      isTsSolutionSetup: false,
     });
   });
 
@@ -149,6 +152,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'my-app-e2e',
       e2eProjectRoot: 'directory/my-app-e2e',
+      isTsSolutionSetup: false,
     });
   });
 
@@ -185,6 +189,7 @@ describe('Normalize Options', () => {
       rootProject: false,
       e2eProjectName: 'my-app-e2e',
       e2eProjectRoot: 'my-app-e2e',
+      isTsSolutionSetup: false,
     });
   });
 });

--- a/packages/react-native/src/generators/application/lib/normalize-options.ts
+++ b/packages/react-native/src/generators/application/lib/normalize-options.ts
@@ -4,6 +4,7 @@ import {
   ensureProjectName,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { Schema } from '../schema';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export interface NormalizedSchema extends Schema {
   className: string; // app name in class case
@@ -18,6 +19,7 @@ export interface NormalizedSchema extends Schema {
   rootProject: boolean;
   e2eProjectName: string;
   e2eProjectRoot: string;
+  isTsSolutionSetup: boolean;
 }
 
 export async function normalizeOptions(
@@ -70,5 +72,6 @@ export async function normalizeOptions(
     rootProject,
     e2eProjectName,
     e2eProjectRoot,
+    isTsSolutionSetup: isUsingTsSolutionSetup(host),
   };
 }

--- a/packages/react-native/src/generators/library/files/lib/tsconfig.json.template
+++ b/packages/react-native/src/generators/library/files/lib/tsconfig.json.template
@@ -1,11 +1,13 @@
 {
   "extends": "<%= rootTsConfigPath %>",
+  <%_ if (!isUsingTsSolutionConfig) { _%>
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true
   },
+  <%_ } _%>
   "files": [],
   "include": [],
   "references": [

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -34,10 +34,7 @@ import { NormalizedSchema, normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
-import {
-  isUsingTsSolutionSetup,
-  updateTsconfigFiles,
-} from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { updateTsconfigFiles } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { getImportPath } from '@nx/js/src/utils/get-import-path';
 
 export async function reactNativeLibraryGenerator(
@@ -107,7 +104,7 @@ export async function reactNativeLibraryGeneratorInternal(
     updateLibPackageNpmScope(host, options);
   }
 
-  if (!options.skipTsConfig) {
+  if (!options.skipTsConfig && !options.isUsingTsSolutionConfig) {
     addTsConfigPath(host, options.importPath, [
       joinPathFragments(
         options.projectRoot,
@@ -222,6 +219,10 @@ async function addProject(
 }
 
 function updateTsConfig(tree: Tree, options: NormalizedSchema) {
+  if (options.isUsingTsSolutionConfig) {
+    return;
+  }
+
   updateJson(
     tree,
     joinPathFragments(options.projectRoot, 'tsconfig.json'),

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -86,20 +86,31 @@ describe('app', () => {
         addPlugin: true,
       });
 
-      const snapshot = `
-        "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-            
-            import { defineConfig } from 'cypress';
-
-        export default defineConfig({
-          e2e: { ...nxE2EPreset(__filename, {"cypressDir":"src","bundler":"vite","webServerCommands":{"default":"${packageCmd} nx run my-app:serve","production":"${packageCmd} nx run my-app:preview"},"ciWebServerCommand":"${packageCmd} nx run my-app:preview","ciBaseUrl":"http://localhost:4300"}),
-        baseUrl: 'http://localhost:4200' }
-        });
-        "
-      `;
       expect(
         appTree.read('my-app-e2e/cypress.config.ts', 'utf-8')
-      ).toMatchInlineSnapshot(snapshot);
+      ).toMatchInlineSnapshot(
+        `
+        "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+        import { defineConfig } from 'cypress';
+
+        export default defineConfig({
+          e2e: {
+            ...nxE2EPreset(__filename, {
+              "cypressDir": "src",
+              "bundler": "vite",
+              "webServerCommands": {
+                "default": "${packageCmd} nx run my-app:serve",
+                "production": "${packageCmd} nx run my-app:preview"
+              },
+              "ciWebServerCommand": "${packageCmd} nx run my-app:preview",
+              "ciBaseUrl": "http://localhost:4300"
+            }),
+            baseUrl: 'http://localhost:4200'
+          }
+        });
+        "
+      `
+      );
     });
 
     it('should setup playwright correctly for vite', async () => {
@@ -1340,6 +1351,7 @@ describe('app', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
@@ -1412,12 +1424,12 @@ describe('app', () => {
         {
           "compilerOptions": {
             "allowJs": true,
-            "outDir": "dist",
+            "outDir": "out-tsc/playwright",
             "sourceMap": false,
-            "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
           },
           "exclude": [
-            "dist",
+            "out-tsc",
+            "test-output",
             "eslint.config.js",
             "eslint.config.mjs",
             "eslint.config.cjs",

--- a/packages/react/src/generators/host/host.rspack.spec.ts
+++ b/packages/react/src/generators/host/host.rspack.spec.ts
@@ -516,6 +516,7 @@ describe('hostGenerator', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -1047,6 +1047,7 @@ module.exports = withNx(
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "**/*.spec.ts",
             "**/*.test.ts",

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -134,7 +134,6 @@ export default function Index() {
 
 exports[`Remix Application Integrated Repo --e2eTestRunner should generate a cypress e2e application for the app 1`] = `
 "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
@@ -386,7 +385,6 @@ export default function Index() {
 
 exports[`Remix Application Standalone Project Repo --e2eTestRunner should generate a cypress e2e application for the app 1`] = `
 "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
 import { defineConfig } from 'cypress';
 
 export default defineConfig({

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -431,6 +431,7 @@ describe('Remix Application', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "tests/**/*.spec.ts",
             "tests/**/*.test.ts",
@@ -500,12 +501,12 @@ describe('Remix Application', () => {
         {
           "compilerOptions": {
             "allowJs": true,
-            "outDir": "dist",
+            "outDir": "out-tsc/playwright",
             "sourceMap": false,
-            "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
           },
           "exclude": [
-            "dist",
+            "out-tsc",
+            "test-output",
             "eslint.config.js",
             "eslint.config.mjs",
             "eslint.config.cjs",

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -123,7 +123,6 @@ describe('App', () => {
 
 exports[`application generator should set up project correctly for cypress 5`] = `
 "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
 import { defineConfig } from 'cypress';
 
 export default defineConfig({

--- a/packages/vue/src/generators/application/application.spec.ts
+++ b/packages/vue/src/generators/application/application.spec.ts
@@ -211,6 +211,7 @@ describe('application generator', () => {
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",

--- a/packages/vue/src/generators/library/library.spec.ts
+++ b/packages/vue/src/generators/library/library.spec.ts
@@ -531,6 +531,7 @@ module.exports = [
             ],
           },
           "exclude": [
+            "out-tsc",
             "dist",
             "src/**/__tests__/*",
             "src/**/*.spec.vue",

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -184,7 +184,6 @@ describe('app', () => {
       expect(tree.read('cool-app-e2e/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
         import { defineConfig } from 'cypress';
 
         export default defineConfig({
@@ -217,7 +216,6 @@ describe('app', () => {
       expect(tree.read('cool-app-e2e/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
-
         import { defineConfig } from 'cypress';
 
         export default defineConfig({


### PR DESCRIPTION
Fix misc generation issues related to the new TS solution setup:

- Improve Cypress config default formatting (when no prettier)
- Remove leftover compiler options from `tsconfig.json` files
- Do not add TS path mappings
- Update `outDir` for `typecheck` tasks to be `out-tsc/...`
- Generate Nx configuration in `package.json` files for e2e test runner projects
- Fix issue with `@nx/js:library` and `--bundler=vite`
- Other smaller changes

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
