### PR TITLE
feat(testing): add option `ciGroupName` to `@nx/jest/plugin`

### DIFF
--- a/docs/generated/packages/jest/documents/overview.md
+++ b/docs/generated/packages/jest/documents/overview.md
@@ -91,6 +91,27 @@ target with that name which can be used in CI to run the tests for each file in 
 }
 ```
 
+### Customizing atomized unit/e2e tasks group name
+
+By default, the atomized tasks group name is derived from the `ciTargetName`. For example, atomized tasks for the `e2e-ci` target will be grouped under the name "E2E (CI)" when displayed in Nx Cloud or `nx show project <project> --web` UI.
+You can customize that name by explicitly providing the optional `ciGroupName` plugin option as such:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/jest/plugin",
+      "include": ["e2e/**/*"],
+      "options": {
+        "targetName": "e2e-local",
+        "ciTargetName": "e2e-ci",
+        "ciGroupname": "My E2E tests (CI)"
+      }
+    }
+  ]
+}
+```
+
 ### How @nx/jest Infers Tasks
 
 {% callout type="note" title="Inferred Tasks" %}

--- a/docs/shared/packages/jest/jest-plugin.md
+++ b/docs/shared/packages/jest/jest-plugin.md
@@ -91,6 +91,27 @@ target with that name which can be used in CI to run the tests for each file in 
 }
 ```
 
+### Customizing atomized unit/e2e tasks group name
+
+By default, the atomized tasks group name is derived from the `ciTargetName`. For example, atomized tasks for the `e2e-ci` target will be grouped under the name "E2E (CI)" when displayed in Nx Cloud or `nx show project <project> --web` UI.
+You can customize that name by explicitly providing the optional `ciGroupName` plugin option as such:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/jest/plugin",
+      "include": ["e2e/**/*"],
+      "options": {
+        "targetName": "e2e-local",
+        "ciTargetName": "e2e-ci",
+        "ciGroupname": "My E2E tests (CI)"
+      }
+    }
+  ]
+}
+```
+
 ### How @nx/jest Infers Tasks
 
 {% callout type="note" title="Inferred Tasks" %}

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -140,7 +140,7 @@ describe('@nx/jest/plugin', () => {
               "proj": {
                 "metadata": {
                   "targetGroups": {
-                    "E2E (CI)": [
+                    "TEST (CI)": [
                       "test-ci",
                       "test-ci--src/unit.spec.ts",
                     ],
@@ -381,135 +381,135 @@ describe('@nx/jest/plugin', () => {
       );
 
       expect(results).toMatchInlineSnapshot(`
-      [
-        [
-          "proj/jest.config.js",
-          {
-            "projects": {
-              "proj": {
-                "metadata": {
-                  "targetGroups": {
-                    "E2E (CI)": [
-                      "test-ci",
-                      "test-ci--src/unit.spec.ts",
-                    ],
-                  },
-                },
-                "root": "proj",
-                "targets": {
-                  "test": {
-                    "cache": true,
-                    "command": "jest",
-                    "inputs": [
-                      "default",
-                      "^production",
-                      {
-                        "externalDependencies": [
-                          "jest",
-                        ],
-                      },
-                    ],
-                    "metadata": {
-                      "description": "Run Jest Tests",
-                      "help": {
-                        "command": "npx jest --help",
-                        "example": {
-                          "options": {
-                            "coverage": true,
+              [
+                [
+                  "proj/jest.config.js",
+                  {
+                    "projects": {
+                      "proj": {
+                        "metadata": {
+                          "targetGroups": {
+                            "TEST (CI)": [
+                              "test-ci",
+                              "test-ci--src/unit.spec.ts",
+                            ],
+                          },
+                        },
+                        "root": "proj",
+                        "targets": {
+                          "test": {
+                            "cache": true,
+                            "command": "jest",
+                            "inputs": [
+                              "default",
+                              "^production",
+                              {
+                                "externalDependencies": [
+                                  "jest",
+                                ],
+                              },
+                            ],
+                            "metadata": {
+                              "description": "Run Jest Tests",
+                              "help": {
+                                "command": "npx jest --help",
+                                "example": {
+                                  "options": {
+                                    "coverage": true,
+                                  },
+                                },
+                              },
+                              "technologies": [
+                                "jest",
+                              ],
+                            },
+                            "options": {
+                              "cwd": "proj",
+                              "env": {
+                                "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                              },
+                            },
+                            "outputs": [
+                              "{workspaceRoot}/coverage",
+                            ],
+                          },
+                          "test-ci": {
+                            "cache": true,
+                            "dependsOn": [
+                              "test-ci--src/unit.spec.ts",
+                            ],
+                            "executor": "nx:noop",
+                            "inputs": [
+                              "default",
+                              "^production",
+                              {
+                                "externalDependencies": [
+                                  "jest",
+                                ],
+                              },
+                            ],
+                            "metadata": {
+                              "description": "Run Jest Tests in CI",
+                              "help": {
+                                "command": "npx jest --help",
+                                "example": {
+                                  "options": {
+                                    "coverage": true,
+                                  },
+                                },
+                              },
+                              "nonAtomizedTarget": "test",
+                              "technologies": [
+                                "jest",
+                              ],
+                            },
+                            "outputs": [
+                              "{workspaceRoot}/coverage",
+                            ],
+                          },
+                          "test-ci--src/unit.spec.ts": {
+                            "cache": true,
+                            "command": "jest src/unit.spec.ts",
+                            "inputs": [
+                              "default",
+                              "^production",
+                              {
+                                "externalDependencies": [
+                                  "jest",
+                                ],
+                              },
+                            ],
+                            "metadata": {
+                              "description": "Run Jest Tests in src/unit.spec.ts",
+                              "help": {
+                                "command": "npx jest --help",
+                                "example": {
+                                  "options": {
+                                    "coverage": true,
+                                  },
+                                },
+                              },
+                              "technologies": [
+                                "jest",
+                              ],
+                            },
+                            "options": {
+                              "cwd": "proj",
+                              "env": {
+                                "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                              },
+                            },
+                            "outputs": [
+                              "{workspaceRoot}/coverage",
+                            ],
                           },
                         },
                       },
-                      "technologies": [
-                        "jest",
-                      ],
                     },
-                    "options": {
-                      "cwd": "proj",
-                      "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
-                      },
-                    },
-                    "outputs": [
-                      "{workspaceRoot}/coverage",
-                    ],
                   },
-                  "test-ci": {
-                    "cache": true,
-                    "dependsOn": [
-                      "test-ci--src/unit.spec.ts",
-                    ],
-                    "executor": "nx:noop",
-                    "inputs": [
-                      "default",
-                      "^production",
-                      {
-                        "externalDependencies": [
-                          "jest",
-                        ],
-                      },
-                    ],
-                    "metadata": {
-                      "description": "Run Jest Tests in CI",
-                      "help": {
-                        "command": "npx jest --help",
-                        "example": {
-                          "options": {
-                            "coverage": true,
-                          },
-                        },
-                      },
-                      "nonAtomizedTarget": "test",
-                      "technologies": [
-                        "jest",
-                      ],
-                    },
-                    "outputs": [
-                      "{workspaceRoot}/coverage",
-                    ],
-                  },
-                  "test-ci--src/unit.spec.ts": {
-                    "cache": true,
-                    "command": "jest src/unit.spec.ts",
-                    "inputs": [
-                      "default",
-                      "^production",
-                      {
-                        "externalDependencies": [
-                          "jest",
-                        ],
-                      },
-                    ],
-                    "metadata": {
-                      "description": "Run Jest Tests in src/unit.spec.ts",
-                      "help": {
-                        "command": "npx jest --help",
-                        "example": {
-                          "options": {
-                            "coverage": true,
-                          },
-                        },
-                      },
-                      "technologies": [
-                        "jest",
-                      ],
-                    },
-                    "options": {
-                      "cwd": "proj",
-                      "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
-                      },
-                    },
-                    "outputs": [
-                      "{workspaceRoot}/coverage",
-                    ],
-                  },
-                },
-              },
-            },
-          },
-        ],
-      ]
-    `);
+                ],
+              ]
+          `);
     });
 
     it.each`
@@ -567,137 +567,587 @@ describe('@nx/jest/plugin', () => {
         );
 
         expect(results).toMatchInlineSnapshot(`
-      [
+                [
+                  [
+                    "proj/jest.config.js",
+                    {
+                      "projects": {
+                        "proj": {
+                          "metadata": {
+                            "targetGroups": {
+                              "TEST (CI)": [
+                                "test-ci",
+                                "test-ci--src/unit.spec.ts",
+                              ],
+                            },
+                          },
+                          "root": "proj",
+                          "targets": {
+                            "test": {
+                              "cache": true,
+                              "command": "jest",
+                              "inputs": [
+                                "default",
+                                "^production",
+                                {
+                                  "externalDependencies": [
+                                    "jest",
+                                  ],
+                                },
+                              ],
+                              "metadata": {
+                                "description": "Run Jest Tests",
+                                "help": {
+                                  "command": "npx jest --help",
+                                  "example": {
+                                    "options": {
+                                      "coverage": true,
+                                    },
+                                  },
+                                },
+                                "technologies": [
+                                  "jest",
+                                ],
+                              },
+                              "options": {
+                                "cwd": "proj",
+                                "env": {
+                                  "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                                },
+                              },
+                              "outputs": [
+                                "{workspaceRoot}/coverage",
+                              ],
+                            },
+                            "test-ci": {
+                              "cache": true,
+                              "dependsOn": [
+                                "test-ci--src/unit.spec.ts",
+                              ],
+                              "executor": "nx:noop",
+                              "inputs": [
+                                "default",
+                                "^production",
+                                {
+                                  "externalDependencies": [
+                                    "jest",
+                                  ],
+                                },
+                              ],
+                              "metadata": {
+                                "description": "Run Jest Tests in CI",
+                                "help": {
+                                  "command": "npx jest --help",
+                                  "example": {
+                                    "options": {
+                                      "coverage": true,
+                                    },
+                                  },
+                                },
+                                "nonAtomizedTarget": "test",
+                                "technologies": [
+                                  "jest",
+                                ],
+                              },
+                              "outputs": [
+                                "{workspaceRoot}/coverage",
+                              ],
+                            },
+                            "test-ci--src/unit.spec.ts": {
+                              "cache": true,
+                              "command": "jest src/unit.spec.ts",
+                              "inputs": [
+                                "default",
+                                "^production",
+                                {
+                                  "externalDependencies": [
+                                    "jest",
+                                  ],
+                                },
+                              ],
+                              "metadata": {
+                                "description": "Run Jest Tests in src/unit.spec.ts",
+                                "help": {
+                                  "command": "npx jest --help",
+                                  "example": {
+                                    "options": {
+                                      "coverage": true,
+                                    },
+                                  },
+                                },
+                                "technologies": [
+                                  "jest",
+                                ],
+                              },
+                              "options": {
+                                "cwd": "proj",
+                                "env": {
+                                  "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                                },
+                              },
+                              "outputs": [
+                                "{workspaceRoot}/coverage",
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    },
+                  ],
+                ]
+            `);
+      }
+    );
+  });
+
+  describe('ciGroupName', () => {
+    it('should name atomized tasks group using provided group name', async () => {
+      mockJestConfig(
+        {
+          coverageDirectory: '../coverage',
+          testMatch: ['**/*.spec.ts'],
+          testPathIgnorePatterns: ['ignore.spec.ts'],
+        },
+        context
+      );
+      const results = await createNodesFunction(
+        ['proj/jest.config.js'],
+        {
+          ciTargetName: 'test-ci',
+          ciGroupName: 'MY ATOMIZED TEST TASKS (CI)',
+        },
+        context
+      );
+
+      expect(results).toMatchInlineSnapshot(`
         [
-          "proj/jest.config.js",
-          {
-            "projects": {
-              "proj": {
-                "metadata": {
-                  "targetGroups": {
-                    "E2E (CI)": [
-                      "test-ci",
-                      "test-ci--src/unit.spec.ts",
-                    ],
+          [
+            "proj/jest.config.js",
+            {
+              "projects": {
+                "proj": {
+                  "metadata": {
+                    "targetGroups": {
+                      "MY ATOMIZED TEST TASKS (CI)": [
+                        "test-ci",
+                        "test-ci--src/unit.spec.ts",
+                      ],
+                    },
                   },
-                },
-                "root": "proj",
-                "targets": {
-                  "test": {
-                    "cache": true,
-                    "command": "jest",
-                    "inputs": [
-                      "default",
-                      "^production",
-                      {
-                        "externalDependencies": [
+                  "root": "proj",
+                  "targets": {
+                    "test": {
+                      "cache": true,
+                      "command": "jest",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "technologies": [
                           "jest",
                         ],
                       },
-                    ],
-                    "metadata": {
-                      "description": "Run Jest Tests",
-                      "help": {
-                        "command": "npx jest --help",
-                        "example": {
-                          "options": {
-                            "coverage": true,
-                          },
+                      "options": {
+                        "cwd": "proj",
+                        "env": {
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
                         },
                       },
-                      "technologies": [
-                        "jest",
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
                       ],
                     },
-                    "options": {
-                      "cwd": "proj",
-                      "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
-                      },
-                    },
-                    "outputs": [
-                      "{workspaceRoot}/coverage",
-                    ],
-                  },
-                  "test-ci": {
-                    "cache": true,
-                    "dependsOn": [
-                      "test-ci--src/unit.spec.ts",
-                    ],
-                    "executor": "nx:noop",
-                    "inputs": [
-                      "default",
-                      "^production",
-                      {
-                        "externalDependencies": [
+                    "test-ci": {
+                      "cache": true,
+                      "dependsOn": [
+                        "test-ci--src/unit.spec.ts",
+                      ],
+                      "executor": "nx:noop",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests in CI",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "nonAtomizedTarget": "test",
+                        "technologies": [
                           "jest",
                         ],
                       },
-                    ],
-                    "metadata": {
-                      "description": "Run Jest Tests in CI",
-                      "help": {
-                        "command": "npx jest --help",
-                        "example": {
-                          "options": {
-                            "coverage": true,
-                          },
-                        },
-                      },
-                      "nonAtomizedTarget": "test",
-                      "technologies": [
-                        "jest",
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
                       ],
                     },
-                    "outputs": [
-                      "{workspaceRoot}/coverage",
-                    ],
-                  },
-                  "test-ci--src/unit.spec.ts": {
-                    "cache": true,
-                    "command": "jest src/unit.spec.ts",
-                    "inputs": [
-                      "default",
-                      "^production",
-                      {
-                        "externalDependencies": [
+                    "test-ci--src/unit.spec.ts": {
+                      "cache": true,
+                      "command": "jest src/unit.spec.ts",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests in src/unit.spec.ts",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "technologies": [
                           "jest",
                         ],
                       },
-                    ],
-                    "metadata": {
-                      "description": "Run Jest Tests in src/unit.spec.ts",
-                      "help": {
-                        "command": "npx jest --help",
-                        "example": {
-                          "options": {
-                            "coverage": true,
-                          },
+                      "options": {
+                        "cwd": "proj",
+                        "env": {
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
                         },
                       },
-                      "technologies": [
-                        "jest",
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
                       ],
                     },
-                    "options": {
-                      "cwd": "proj",
-                      "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
-                      },
-                    },
-                    "outputs": [
-                      "{workspaceRoot}/coverage",
-                    ],
                   },
                 },
               },
             },
-          },
-        ],
-      ]
-    `);
-      }
-    );
+          ],
+        ]
+      `);
+    });
+
+    it('should deduct atomized tasks group name (from ci target name) when not explicitly provided', async () => {
+      mockJestConfig(
+        {
+          coverageDirectory: '../coverage',
+          testMatch: ['**/*.spec.ts'],
+          testPathIgnorePatterns: ['ignore.spec.ts'],
+        },
+        context
+      );
+      const results = await createNodesFunction(
+        ['proj/jest.config.js'],
+        {
+          ciTargetName: 'test-ci',
+        },
+        context
+      );
+
+      expect(results).toMatchInlineSnapshot(`
+        [
+          [
+            "proj/jest.config.js",
+            {
+              "projects": {
+                "proj": {
+                  "metadata": {
+                    "targetGroups": {
+                      "TEST (CI)": [
+                        "test-ci",
+                        "test-ci--src/unit.spec.ts",
+                      ],
+                    },
+                  },
+                  "root": "proj",
+                  "targets": {
+                    "test": {
+                      "cache": true,
+                      "command": "jest",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "technologies": [
+                          "jest",
+                        ],
+                      },
+                      "options": {
+                        "cwd": "proj",
+                        "env": {
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                        },
+                      },
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
+                      ],
+                    },
+                    "test-ci": {
+                      "cache": true,
+                      "dependsOn": [
+                        "test-ci--src/unit.spec.ts",
+                      ],
+                      "executor": "nx:noop",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests in CI",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "nonAtomizedTarget": "test",
+                        "technologies": [
+                          "jest",
+                        ],
+                      },
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
+                      ],
+                    },
+                    "test-ci--src/unit.spec.ts": {
+                      "cache": true,
+                      "command": "jest src/unit.spec.ts",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests in src/unit.spec.ts",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "technologies": [
+                          "jest",
+                        ],
+                      },
+                      "options": {
+                        "cwd": "proj",
+                        "env": {
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                        },
+                      },
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ]
+      `);
+    });
+
+    it('should default to "${ciTargetName.toUpperCase()} (CI)" when group name cannot be automatically deducted from ci target name', async () => {
+      mockJestConfig(
+        {
+          coverageDirectory: '../coverage',
+          testMatch: ['**/*.spec.ts'],
+          testPathIgnorePatterns: ['ignore.spec.ts'],
+        },
+        context
+      );
+      const results = await createNodesFunction(
+        ['proj/jest.config.js'],
+        {
+          ciTargetName: 'testci', // missing "-ci" suffix or similar construct, so group name cannot reliably be deducted from ci target name
+        },
+        context
+      );
+
+      expect(results).toMatchInlineSnapshot(`
+        [
+          [
+            "proj/jest.config.js",
+            {
+              "projects": {
+                "proj": {
+                  "metadata": {
+                    "targetGroups": {
+                      "TESTCI (CI)": [
+                        "testci",
+                        "testci--src/unit.spec.ts",
+                      ],
+                    },
+                  },
+                  "root": "proj",
+                  "targets": {
+                    "test": {
+                      "cache": true,
+                      "command": "jest",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "technologies": [
+                          "jest",
+                        ],
+                      },
+                      "options": {
+                        "cwd": "proj",
+                        "env": {
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                        },
+                      },
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
+                      ],
+                    },
+                    "testci": {
+                      "cache": true,
+                      "dependsOn": [
+                        "testci--src/unit.spec.ts",
+                      ],
+                      "executor": "nx:noop",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests in CI",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "nonAtomizedTarget": "test",
+                        "technologies": [
+                          "jest",
+                        ],
+                      },
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
+                      ],
+                    },
+                    "testci--src/unit.spec.ts": {
+                      "cache": true,
+                      "command": "jest src/unit.spec.ts",
+                      "inputs": [
+                        "default",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "jest",
+                          ],
+                        },
+                      ],
+                      "metadata": {
+                        "description": "Run Jest Tests in src/unit.spec.ts",
+                        "help": {
+                          "command": "npx jest --help",
+                          "example": {
+                            "options": {
+                              "coverage": true,
+                            },
+                          },
+                        },
+                        "technologies": [
+                          "jest",
+                        ],
+                      },
+                      "options": {
+                        "cwd": "proj",
+                        "env": {
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10"}",
+                        },
+                      },
+                      "outputs": [
+                        "{workspaceRoot}/coverage",
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ]
+      `);
+    });
   });
 });
 

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -38,6 +38,11 @@ const pmc = getPackageManagerCommand();
 export interface JestPluginOptions {
   targetName?: string;
   ciTargetName?: string;
+
+  /**
+   * The name that should be used to group atomized tasks on CI
+   */
+  ciGroupName?: string;
   /**
    *  Whether to use jest-config and jest-runtime to load Jest configuration and context.
    *  Disabling this is much faster but could be less correct since we are using our own config loader
@@ -221,7 +226,8 @@ async function buildJestTargets(
 
   let metadata: ProjectConfiguration['metadata'];
 
-  const groupName = 'E2E (CI)';
+  const groupName =
+    options?.ciGroupName ?? deductGroupNameFromTarget(options?.ciTargetName);
 
   if (options.disableJestRuntime) {
     const outputs = (target.outputs = getOutputs(
@@ -689,4 +695,29 @@ async function getJestOption<T = any>(
   }
 
   return undefined;
+}
+
+/**
+ * Helper that tries to deduct the name of the CI group, based on the related target name.
+ *
+ * This will work well, when the CI target name follows the documented naming convention or similar (for e.g `test-ci`, `e2e-ci`, `ny-e2e-ci`, etc).
+ *
+ * For example, `test-ci` => `TEST (CI)`,  `e2e-ci` => `E2E (CI)`,  `my-e2e-ci` => `MY E2E (CI)`
+ *
+ *
+ * @param ciTargetName name of the CI target
+ * @returns the deducted group name or `${ciTargetName.toUpperCase()} (CI)` if cannot be deducted automatically
+ */
+function deductGroupNameFromTarget(ciTargetName: string | undefined) {
+  if (!ciTargetName) {
+    return null;
+  }
+
+  const parts = ciTargetName.split('-').map((v) => v.toUpperCase());
+
+  if (parts.length > 1) {
+    return `${parts.slice(0, -1).join(' ')} (${parts[parts.length - 1]})`;
+  }
+
+  return `${parts[0]} (CI)`; // default group name when there is a single segment
 }


### PR DESCRIPTION
Add option `ciGroupName` to the `@nx/jest/plugin` to allow customizing the `Jest` atomized taks group on CI.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When using Atomizer on Jest for **unit tests** (via the `"ciTargetName": "test-ci"`), the atomized tasks will be grouped under the misleading name **"E2E (CI)"**.

Worst, if Atomizer is enabled for both  **unit** and **e2e** tests,  it will result on E2E atomized tasks being overwritten by the one from unit tests... when run on Nx Cloud.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Allow customizing the name of the atomized tasks group.  The group name can be derived from the `ciTargetName` , when not explicitly provided. 


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28066
