### PR TITLE
fix(js): ensure typescript-sync generator produces formatted references when no prettier is installed

### DIFF
--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -14,6 +14,7 @@ let projectGraph: ProjectGraph;
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual('@nx/devkit'),
   createProjectGraphAsync: jest.fn(() => Promise.resolve(projectGraph)),
+  formatFiles: jest.fn(() => Promise.resolve()),
 }));
 
 describe('syncGenerator()', () => {
@@ -562,11 +563,11 @@ describe('syncGenerator()', () => {
   "compilerOptions": {
     "composite": true,
     // This is a nested comment
-    "target": "es5",
+    "target": "es5"
   },
   "references": []
 }
-      `
+`
       );
 
       await syncGenerator(tree);

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -604,7 +604,7 @@ function patchTsconfigJsonReferences(
     stringifiedJsonContents,
     ['references'],
     updatedReferences,
-    { formattingOptions: { keepLines: false } }
+    { formattingOptions: { keepLines: true, insertSpaces: true, tabSize: 2 } }
   );
   const updatedJsonContents = applyEdits(stringifiedJsonContents, edits);
   // The final contents will be formatted by formatFiles() later


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
