### PR TITLE
docs(core): common tasks page

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -607,6 +607,14 @@
             "disableCollapsible": false
           },
           {
+            "name": "Common Tasks",
+            "path": "/concepts/common-tasks",
+            "id": "common-tasks",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
             "name": "Nx Daemon",
             "path": "/concepts/nx-daemon",
             "id": "nx-daemon",
@@ -807,6 +815,14 @@
         "name": "Executors and Configurations",
         "path": "/concepts/executors-and-configurations",
         "id": "executors-and-configurations",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Common Tasks",
+        "path": "/concepts/common-tasks",
+        "id": "common-tasks",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -832,6 +832,17 @@
         "tags": ["run-tasks"]
       },
       {
+        "id": "common-tasks",
+        "name": "Common Tasks",
+        "description": "",
+        "mediaImage": "",
+        "file": "shared/concepts/common-tasks",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/concepts/common-tasks",
+        "tags": ["run-tasks"]
+      },
+      {
         "id": "nx-daemon",
         "name": "Nx Daemon",
         "description": "",
@@ -1111,6 +1122,17 @@
     "itemList": [],
     "isExternal": false,
     "path": "/concepts/executors-and-configurations",
+    "tags": ["run-tasks"]
+  },
+  "/concepts/common-tasks": {
+    "id": "common-tasks",
+    "name": "Common Tasks",
+    "description": "",
+    "mediaImage": "",
+    "file": "shared/concepts/common-tasks",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/concepts/common-tasks",
     "tags": ["run-tasks"]
   },
   "/concepts/nx-daemon": {

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -60,6 +60,13 @@
     },
     {
       "description": "",
+      "file": "shared/concepts/common-tasks",
+      "id": "common-tasks",
+      "name": "Common Tasks",
+      "path": "/concepts/common-tasks"
+    },
+    {
+      "description": "",
       "file": "shared/recipes/running-tasks/configure-inputs",
       "id": "configure-inputs",
       "name": "Configure Inputs for Task Caching",

--- a/docs/map.json
+++ b/docs/map.json
@@ -237,6 +237,12 @@
               "file": "shared/concepts/executors-and-configurations"
             },
             {
+              "name": "Common Tasks",
+              "id": "common-tasks",
+              "tags": ["run-tasks"],
+              "file": "shared/concepts/common-tasks"
+            },
+            {
               "name": "Nx Daemon",
               "id": "nx-daemon",
               "tags": ["daemon"],

--- a/docs/shared/concepts/common-tasks.md
+++ b/docs/shared/concepts/common-tasks.md
@@ -1,0 +1,283 @@
+# Common Tasks
+
+The tasks that are [inferred by plugins](/concepts/inferred-tasks) or that you define in your [project configuration](/reference/project-configuration) can have any name that you want, but it is helpful for developers if you keep your task naming convention consistent across the projects in your repository. This way, if a developer moves from one project to another, they already know how to launch tasks for the new project. Here are some common task names that you can define for your projects.
+
+## `build`
+
+This task should produce the compiled output of this project. Typically, you'll want to have `build` tasks depend on the `build` tasks of project dependencies across the whole repository. You can set this default in the `nx.json` file like this:
+
+```json {% fileName="nx.json" %}
+{
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"]
+    }
+  }
+}
+```
+
+The task might use the [@nx/vite](/nx-api/vite), [@nx/webpack](/nx-api/webpack) or [@nx/rspack](/nx-api/rspack) plugins. Or you could have the task launch your own custom script.
+
+{% tabs %}
+{% tab label="Vite" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `build` task for every project that has a Vite configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "buildTargetName": "build"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="Webpack" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `build` task for every project that has a Webpack configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/webpack/plugin",
+      "options": {
+        "buildTargetName": "build"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="rspack" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `build` task for every project that has an rspack configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/rspack/plugin",
+      "options": {
+        "buildTargetName": "build"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="Custom Script" %}
+
+You can define your own `build` task in your project configuration. Here is an example that uses `ts-node` to run a node script.
+
+```json {% fileName="packages/my-project/project.json" %}
+{
+  "targets": {
+    "build": {
+      "command": "ts-node build-script.ts"
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+## `serve`
+
+This task should run your project in a developer preview mode. The task might use the [@nx/vite](/nx-api/vite), [@nx/webpack](/nx-api/webpack) or [@nx/rspack](/nx-api/rspack) plugins. Or you could have the task launch your own custom script.
+
+{% tabs %}
+{% tab label="Vite" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `serve` task for every project that has a Vite configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "serveTargetName": "serve"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="Webpack" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `serve` task for every project that has a Webpack configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/webpack/plugin",
+      "options": {
+        "serveTargetName": "serve"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="rspack" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `serve` task for every project that has an rspack configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/rspack/plugin",
+      "options": {
+        "serveTargetName": "serve"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="Custom Script" %}
+
+You can define your own `serve` task in your project configuration. Here is an example that uses `ts-node` to run the entry point of your project.
+
+```json {% fileName="packages/my-project/project.json" %}
+{
+  "targets": {
+    "serve": {
+      "command": "ts-node main.ts"
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+## `test`
+
+This task typically runs unit tests for a project. The task might use the [@nx/vite](/nx-api/vite) or [@nx/jest](/nx-api/jest) plugins. Or you could have the task launch your own custom script.
+
+{% tabs %}
+{% tab label="Vitest" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `test` task for every project that has a Vitest configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "testTargetName": "test"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="Jest" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `test` task for every project that has a Jest configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/jest/plugin",
+      "options": {
+        "targetName": "test"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="Custom Script" %}
+
+You can define your own `test` task in your project configuration. Here is an example that runs the `ava` test tool.
+
+```json {% fileName="packages/my-project/project.json" %}
+{
+  "targets": {
+    "test": {
+      "command": "ava"
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+## `lint`
+
+This task should run lint rules for a project. The task might use the [@nx/eslint](/nx-api/eslint) plugin or run your own custom script.
+
+{% tabs %}
+{% tab label="ESLint" %}
+
+Set up an [inferred](/concepts/inferred-tasks) `lint` task for every project that has an ESLint configuration file with this configuration in `nx.json`:
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    }
+  ]
+}
+```
+
+You can also [override the inferred task configuration](/concepts/inferred-tasks#overriding-inferred-task-configuration) as needed.
+
+{% /tab %}
+{% tab label="Custom Script" %}
+
+You can define your own `lint` task in your project configuration. Here is an example that runs the `sonarts` lint tool.
+
+```json {% fileName="packages/my-project/project.json" %}
+{
+  "targets": {
+    "lint": {
+      "command": "sonarts"
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}

--- a/docs/shared/concepts/common-tasks.md
+++ b/docs/shared/concepts/common-tasks.md
@@ -83,12 +83,10 @@ You can also [override the inferred task configuration](/concepts/inferred-tasks
 
 You can define your own `build` task in your project configuration. Here is an example that uses `ts-node` to run a node script.
 
-```json {% fileName="packages/my-project/project.json" %}
+```json {% fileName="packages/my-project/package.json" %}
 {
-  "targets": {
-    "build": {
-      "command": "ts-node build-script.ts"
-    }
+  "scripts": {
+    "build": "ts-node build-script.ts"
   }
 }
 ```
@@ -165,12 +163,10 @@ You can also [override the inferred task configuration](/concepts/inferred-tasks
 
 You can define your own `serve` task in your project configuration. Here is an example that uses `ts-node` to run the entry point of your project.
 
-```json {% fileName="packages/my-project/project.json" %}
+```json {% fileName="packages/my-project/package.json" %}
 {
-  "targets": {
-    "serve": {
-      "command": "ts-node main.ts"
-    }
+  "scripts": {
+    "serve": "ts-node main.ts"
   }
 }
 ```
@@ -227,12 +223,10 @@ You can also [override the inferred task configuration](/concepts/inferred-tasks
 
 You can define your own `test` task in your project configuration. Here is an example that runs the `ava` test tool.
 
-```json {% fileName="packages/my-project/project.json" %}
+```json {% fileName="packages/my-project/package.json" %}
 {
-  "targets": {
-    "test": {
-      "command": "ava"
-    }
+  "scripts": {
+    "test": "ava"
   }
 }
 ```
@@ -269,12 +263,10 @@ You can also [override the inferred task configuration](/concepts/inferred-tasks
 
 You can define your own `lint` task in your project configuration. Here is an example that runs the `sonarts` lint tool.
 
-```json {% fileName="packages/my-project/project.json" %}
+```json {% fileName="packages/my-project/package.json" %}
 {
-  "targets": {
-    "lint": {
-      "command": "sonarts"
-    }
+  "scripts": {
+    "lint": "sonarts"
   }
 }
 ```

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -30,6 +30,7 @@
     - [Inferred Tasks](/concepts/inferred-tasks)
     - [Types of Configuration](/concepts/types-of-configuration)
     - [Executors and Configurations](/concepts/executors-and-configurations)
+    - [Common Tasks](/concepts/common-tasks)
     - [Nx Daemon](/concepts/nx-daemon)
     - [Sync Generators](/concepts/sync-generators)
     - [Nx and Turborepo](/concepts/turbo-and-nx)


### PR DESCRIPTION
Create a common task names concept page.

The main purpose of this page is to have a good search result for people searching for "build", "test" or "lint" in our docs search.  These terms are regularly in the top 10 most searched terms.