### PR TITLE
fix(gradle): cache gradle report

### DIFF
--- a/packages/gradle/src/utils/get-gradle-report.ts
+++ b/packages/gradle/src/utils/get-gradle-report.ts
@@ -4,7 +4,9 @@ import { join, relative } from 'node:path';
 import {
   AggregateCreateNodesError,
   normalizePath,
+  readJsonFile,
   workspaceRoot,
+  writeJsonFile,
 } from '@nx/devkit';
 
 import { hashWithWorkspaceContext } from 'nx/src/utils/workspace-context';
@@ -15,6 +17,7 @@ import {
   fileSeparator,
   newLineSeparator,
 } from './get-project-report-lines';
+import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 
 export interface GradleReport {
   gradleFileToGradleProjectMap: Map<string, string>;
@@ -27,8 +30,111 @@ export interface GradleReport {
   gradleProjectToChildProjects: Map<string, string[]>;
 }
 
+export interface GradleReportJSON {
+  hash: string;
+  gradleFileToGradleProjectMap: Record<string, string>;
+  buildFileToDepsMap: Record<string, string>;
+  gradleFileToOutputDirsMap: Record<string, Record<string, string>>;
+  gradleProjectToTasksTypeMap: Record<string, Record<string, string>>;
+  gradleProjectToTasksMap: Record<string, Array<String>>;
+  gradleProjectToProjectName: Record<string, string>;
+  gradleProjectNameToProjectRootMap: Record<string, string>;
+  gradleProjectToChildProjects: Record<string, string[]>;
+}
+
+function readGradleReportCache(
+  cachePath: string,
+  hash: string
+): GradleReport | undefined {
+  const gradleReportJson: Partial<GradleReportJSON> = existsSync(cachePath)
+    ? readJsonFile(cachePath)
+    : undefined;
+  if (!gradleReportJson || gradleReportJson.hash !== hash) {
+    return;
+  }
+  let results: GradleReport = {
+    gradleFileToGradleProjectMap: new Map(
+      Object.entries(gradleReportJson['gradleFileToGradleProjectMap'])
+    ),
+    buildFileToDepsMap: new Map(
+      Object.entries(gradleReportJson['buildFileToDepsMap'])
+    ),
+    gradleFileToOutputDirsMap: new Map(
+      Object.entries(gradleReportJson['gradleFileToOutputDirsMap']).map(
+        ([key, value]) => [key, new Map(Object.entries(value))]
+      )
+    ),
+    gradleProjectToTasksTypeMap: new Map(
+      Object.entries(gradleReportJson['gradleProjectToTasksTypeMap']).map(
+        ([key, value]) => [key, new Map(Object.entries(value))]
+      )
+    ),
+    gradleProjectToTasksMap: new Map(
+      Object.entries(gradleReportJson['gradleProjectToTasksMap']).map(
+        ([key, value]) => [key, new Set(value)]
+      )
+    ),
+    gradleProjectToProjectName: new Map(
+      Object.entries(gradleReportJson['gradleProjectToProjectName'])
+    ),
+    gradleProjectNameToProjectRootMap: new Map(
+      Object.entries(gradleReportJson['gradleProjectNameToProjectRootMap'])
+    ),
+    gradleProjectToChildProjects: new Map(
+      Object.entries(gradleReportJson['gradleProjectToChildProjects'])
+    ),
+  };
+  return results;
+}
+
+export function writeGradleReportToCache(
+  cachePath: string,
+  results: GradleReport
+) {
+  let gradleReportJson: GradleReportJSON = {
+    hash: gradleCurrentConfigHash,
+    gradleFileToGradleProjectMap: Object.fromEntries(
+      results.gradleFileToGradleProjectMap
+    ),
+    buildFileToDepsMap: Object.fromEntries(results.buildFileToDepsMap),
+    gradleFileToOutputDirsMap: Object.fromEntries(
+      Array.from(results.gradleFileToOutputDirsMap).map(([key, value]) => [
+        key,
+        Object.fromEntries(value),
+      ])
+    ),
+    gradleProjectToTasksTypeMap: Object.fromEntries(
+      Array.from(results.gradleProjectToTasksTypeMap).map(([key, value]) => [
+        key,
+        Object.fromEntries(value),
+      ])
+    ),
+    gradleProjectToTasksMap: Object.fromEntries(
+      Array.from(results.gradleProjectToTasksMap).map(([key, value]) => [
+        key,
+        Array.from(value),
+      ])
+    ),
+    gradleProjectToProjectName: Object.fromEntries(
+      results.gradleProjectToProjectName
+    ),
+    gradleProjectNameToProjectRootMap: Object.fromEntries(
+      results.gradleProjectNameToProjectRootMap
+    ),
+    gradleProjectToChildProjects: Object.fromEntries(
+      results.gradleProjectToChildProjects
+    ),
+  };
+
+  writeJsonFile(cachePath, gradleReportJson);
+}
+
 let gradleReportCache: GradleReport;
 let gradleCurrentConfigHash: string;
+let gradleReportCachePath: string = join(
+  workspaceDataDirectory,
+  'gradle-report.hash'
+);
 
 export function getCurrentGradleReport() {
   if (!gradleReportCache) {
@@ -64,7 +170,14 @@ export async function populateGradleReport(
   const gradleConfigHash = await hashWithWorkspaceContext(workspaceRoot, [
     gradleConfigAndTestGlob,
   ]);
-  if (gradleReportCache && gradleConfigHash === gradleCurrentConfigHash) {
+  gradleReportCache ??= readGradleReportCache(
+    gradleReportCachePath,
+    gradleConfigHash
+  );
+  if (
+    gradleReportCache &&
+    (!gradleCurrentConfigHash || gradleConfigHash === gradleCurrentConfigHash)
+  ) {
     return;
   }
 
@@ -92,6 +205,7 @@ export async function populateGradleReport(
   );
   gradleCurrentConfigHash = gradleConfigHash;
   gradleReportCache = processProjectReports(projectReportLines);
+  writeGradleReportToCache(gradleReportCachePath, gradleReportCache);
 }
 
 export function processProjectReports(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`./gradlew projectReport` is run everytime Nx calculates the graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Results of `./gradlew projectReport` are cached until gradle files have been changed. This improves the performance of the gradle graph plugin.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
