### PR TITLE
feat(web): support custom cors headers

### DIFF
--- a/docs/generated/packages/web/executors/file-server.json
+++ b/docs/generated/packages/web/executors/file-server.json
@@ -72,7 +72,7 @@
         "description": "Path where the build artifacts are located. If not provided then it will be infered from the buildTarget executor options as outputPath"
       },
       "cors": {
-        "type": "boolean",
+        "oneOf": [{ "type": "boolean" }, { "type": "string" }],
         "description": "Enable CORS",
         "default": true
       },

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -74,7 +74,14 @@
       "description": "Path where the build artifacts are located. If not provided then it will be infered from the buildTarget executor options as outputPath"
     },
     "cors": {
-      "type": "boolean",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
       "description": "Enable CORS",
       "default": true
     },


### PR DESCRIPTION
## Current Behavior

It is not possible to pass custom cors headers to the `@nx/web:file-server` executor despite `http-server` supporting it.

## Expected Behavior

`@nx/web:file-server` should pass-through a string of custom cors headers to `http-server`.

## Related Issue(s)

