### PR TITLE
feat(core): show progress on ci if graph construction takes longer than expected

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -77,10 +77,7 @@ import {
   FLUSH_SYNC_GENERATOR_CHANGES_TO_DISK,
   type HandleFlushSyncGeneratorChangesToDiskMessage,
 } from '../message-types/flush-sync-generator-changes-to-disk';
-import {
-  DelayedSpinner,
-  SHOULD_SHOW_SPINNERS,
-} from '../../utils/delayed-spinner';
+import { DelayedSpinner } from '../../utils/delayed-spinner';
 
 const DAEMON_ENV_SETTINGS = {
   NX_PROJECT_GLOB_CACHE: 'false',
@@ -200,15 +197,12 @@ export class DaemonClient {
   }> {
     let spinner: DelayedSpinner;
     // If the graph takes a while to load, we want to show a spinner.
-    spinner = new DelayedSpinner({
-      message: 'Calculating the project graph on the Nx Daemon',
-      ciDelay: 10_000,
-    }).scheduleMessageUpdate({
-      message:
-        'Calculating the project graph on the Nx Daemon is taking longer than expected. Re-run with NX_DAEMON=false to see more details.',
-      ciDelay: 60_000,
-      delay: 30_000,
-    });
+    spinner = new DelayedSpinner(
+      'Calculating the project graph on the Nx Daemon'
+    ).scheduleMessageUpdate(
+      'Calculating the project graph on the Nx Daemon is taking longer than expected. Re-run with NX_DAEMON=false to see more details.',
+      { ciDelay: 60_000, delay: 30_000 }
+    );
     try {
       const response = await this.sendToDaemonViaQueue({
         type: 'REQUEST_PROJECT_GRAPH',

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -199,16 +199,16 @@ export class DaemonClient {
     sourceMaps: ConfigurationSourceMaps;
   }> {
     let spinner: DelayedSpinner;
-    if (SHOULD_SHOW_SPINNERS) {
-      // If the graph takes a while to load, we want to show a spinner.
-      spinner = new DelayedSpinner(
-        'Calculating the project graph on the Nx Daemon',
-        500
-      ).scheduleMessageUpdate(
+    // If the graph takes a while to load, we want to show a spinner.
+    spinner = new DelayedSpinner({
+      message: 'Calculating the project graph on the Nx Daemon',
+      ciDelay: 10_000,
+    }).scheduleMessageUpdate({
+      message:
         'Calculating the project graph on the Nx Daemon is taking longer than expected. Re-run with NX_DAEMON=false to see more details.',
-        30_000
-      );
-    }
+      ciDelay: 60_000,
+      delay: 30_000,
+    });
     try {
       const response = await this.sendToDaemonViaQueue({
         type: 'REQUEST_PROJECT_GRAPH',

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -44,7 +44,7 @@ import {
   ConfigurationSourceMaps,
   mergeMetadata,
 } from './utils/project-configuration-utils';
-import { DelayedSpinner, SHOULD_SHOW_SPINNERS } from '../utils/delayed-spinner';
+import { DelayedSpinner } from '../utils/delayed-spinner';
 
 let storedFileMap: FileMap | null = null;
 let storedAllWorkspaceFiles: FileData[] | null = null;
@@ -342,10 +342,9 @@ async function updateProjectGraphWithPlugins(
     }
   }
 
-  spinner = new DelayedSpinner({
-    message: `Creating project graph dependencies with ${plugins.length} plugins`,
-    ciDelay: 10_000,
-  });
+  spinner = new DelayedSpinner(
+    `Creating project graph dependencies with ${plugins.length} plugins`
+  );
 
   await Promise.all(
     createDependencyPlugins.map(async (plugin) => {
@@ -461,12 +460,9 @@ export async function applyProjectMetadata(
     }
   }
 
-  if (SHOULD_SHOW_SPINNERS) {
-    spinner = new DelayedSpinner({
-      message: `Creating project metadata with ${plugins.length} plugins`,
-      ciDelay: 10_000,
-    });
-  }
+  spinner = new DelayedSpinner(
+    `Creating project metadata with ${plugins.length} plugins`
+  );
 
   const promises = plugins.map(async (plugin) => {
     if (plugin.createMetadata) {

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -323,24 +323,29 @@ async function updateProjectGraphWithPlugins(
       return;
     }
     if (inProgressPlugins.size === 1) {
-      return `Creating project graph dependencies with ${
-        inProgressPlugins.keys()[0]
-      }`;
+      spinner.setMessage(
+        `Creating project graph dependencies with ${
+          inProgressPlugins.keys()[0]
+        }`
+      );
     } else if (process.env.NX_VERBOSE_LOGGING === 'true') {
-      return [
-        `Creating project graph dependencies with ${inProgressPlugins.size} plugins`,
-        ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
-      ].join('\n');
+      spinner.setMessage(
+        [
+          `Creating project graph dependencies with ${inProgressPlugins.size} plugins`,
+          ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
+        ].join('\n')
+      );
     } else {
-      return `Creating project graph dependencies with ${inProgressPlugins.size} plugins`;
+      spinner.setMessage(
+        `Creating project graph dependencies with ${inProgressPlugins.size} plugins`
+      );
     }
   }
 
-  if (SHOULD_SHOW_SPINNERS) {
-    spinner = new DelayedSpinner(
-      `Creating project graph dependencies with ${plugins.length} plugins`
-    );
-  }
+  spinner = new DelayedSpinner({
+    message: `Creating project graph dependencies with ${plugins.length} plugins`,
+    ciDelay: 10_000,
+  });
 
   await Promise.all(
     createDependencyPlugins.map(async (plugin) => {
@@ -439,21 +444,28 @@ export async function applyProjectMetadata(
       return;
     }
     if (inProgressPlugins.size === 1) {
-      return `Creating project metadata with ${inProgressPlugins.keys()[0]}`;
+      spinner.setMessage(
+        `Creating project metadata with ${inProgressPlugins.keys()[0]}`
+      );
     } else if (process.env.NX_VERBOSE_LOGGING === 'true') {
-      return [
-        `Creating project metadata with ${inProgressPlugins.size} plugins`,
-        ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
-      ].join('\n');
+      spinner.setMessage(
+        [
+          `Creating project metadata with ${inProgressPlugins.size} plugins`,
+          ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
+        ].join('\n')
+      );
     } else {
-      return `Creating project metadata with ${inProgressPlugins.size} plugins`;
+      spinner.setMessage(
+        `Creating project metadata with ${inProgressPlugins.size} plugins`
+      );
     }
   }
 
   if (SHOULD_SHOW_SPINNERS) {
-    spinner = new DelayedSpinner(
-      `Creating project metadata with ${plugins.length} plugins`
-    );
+    spinner = new DelayedSpinner({
+      message: `Creating project metadata with ${plugins.length} plugins`,
+      ciDelay: 10_000,
+    });
   }
 
   const promises = plugins.map(async (plugin) => {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -31,11 +31,7 @@ import {
 } from '../error-types';
 import { CreateNodesResult } from '../plugins/public-api';
 import { isGlobPattern } from '../../utils/globs';
-import { isOnDaemon } from '../../daemon/is-on-daemon';
-import {
-  DelayedSpinner,
-  SHOULD_SHOW_SPINNERS,
-} from '../../utils/delayed-spinner';
+import { DelayedSpinner } from '../../utils/delayed-spinner';
 
 export type SourceInformation = [file: string | null, plugin: string];
 export type ConfigurationSourceMaps = Record<

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -339,22 +339,26 @@ export async function createProjectConfigurations(
     }
 
     if (inProgressPlugins.size === 1) {
-      return `Creating project graph nodes with ${inProgressPlugins.keys()[0]}`;
+      spinner.setMessage(
+        `Creating project graph nodes with ${inProgressPlugins.keys()[0]}`
+      );
     } else if (process.env.NX_VERBOSE_LOGGING === 'true') {
-      return [
-        `Creating project graph nodes with ${inProgressPlugins.size} plugins`,
-        ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
-      ].join('\n');
+      spinner.setMessage(
+        [
+          `Creating project graph nodes with ${inProgressPlugins.size} plugins`,
+          ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
+        ].join('\n')
+      );
     } else {
-      return `Creating project graph nodes with ${inProgressPlugins.size} plugins`;
+      spinner.setMessage(
+        `Creating project graph nodes with ${inProgressPlugins.size} plugins`
+      );
     }
   }
 
-  if (SHOULD_SHOW_SPINNERS) {
-    spinner = new DelayedSpinner(
-      `Creating project graph nodes with ${plugins.length} plugins`
-    );
-  }
+  spinner = new DelayedSpinner(
+    `Creating project graph nodes with ${plugins.length} plugins`
+  );
 
   const results: Array<ReturnType<LoadedNxPlugin['createNodes'][1]>> = [];
   const errors: Array<


### PR DESCRIPTION
Progress spinners currently only show up when the terminal is a tty. This updates it to show static text on CI, but at a longer duration