### PR TITLE
fix(js): Configure typescript plugin to handle non-buildable libs

### DIFF
--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -62,27 +62,6 @@ describe('React Applications', () => {
       }
     }, 250_000);
 
-    it('None buildable libs using (useTsSolution = true) should be excluded from js/ts plugin', async () => {
-      const appName = uniq('app');
-      const libName = uniq('lib');
-
-      runCLI(
-        `generate @nx/react:app apps/${appName} --name=${appName} --useTsSolution=true --bundler=vite --no-interactive --skipFormat --linter=eslint --unitTestRunner=vitest`
-      );
-      runCLI(
-        `generate @nx/react:lib ${libName} --bundler=none --no-interactive --unit-test-runner=vitest --skipFormat --linter=eslint`
-      );
-
-      const nxJson = readJson('nx.json');
-
-      const jsTypescriptPlugin = nxJson.plugins.find(
-        (plugin) => plugin.plugin === '@nx/js/typescript'
-      );
-      expect(jsTypescriptPlugin).toBeDefined();
-
-      expect(jsTypescriptPlugin.exclude.includes(`${libName}/*`)).toBeTruthy();
-    }, 250_000);
-
     it('should be able to use Rspack to build and test apps', async () => {
       const appName = uniq('app');
       const libName = uniq('lib');

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -43,10 +43,7 @@ import { addSwcConfig } from '../../utils/swc/add-swc-config';
 import { getSwcDependencies } from '../../utils/swc/add-swc-dependencies';
 import { getNeededCompilerOptionOverrides } from '../../utils/typescript/configuration';
 import { tsConfigBaseOptions } from '../../utils/typescript/create-ts-config';
-import {
-  ensureProjectIsExcludedFromPluginRegistrations,
-  ensureProjectIsIncludedInPluginRegistrations,
-} from '../../utils/typescript/plugin';
+import { ensureProjectIsIncludedInPluginRegistrations } from '../../utils/typescript/plugin';
 import {
   addTsConfigPath,
   getRelativePathToRootTsConfig,
@@ -255,14 +252,7 @@ async function configureProject(
 ) {
   if (options.hasPlugin) {
     const nxJson = readNxJson(tree);
-    if (options.bundler === 'none') {
-      ensureProjectIsExcludedFromPluginRegistrations(
-        nxJson,
-        options.projectRoot
-      );
-    } else {
-      ensureProjectIsIncludedInPluginRegistrations(nxJson, options.projectRoot);
-    }
+    ensureProjectIsIncludedInPluginRegistrations(nxJson, options.projectRoot);
     updateNxJson(tree, nxJson);
   }
 

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1794,9 +1794,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       // Sibling package.json
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
-        'libs/my-lib/tsconfig.lib.json': `{}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"rootDir": "src"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
-        'libs/my-lib/package.json': `{}`,
+        'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
       });
       expect(
         await invokeCreateNodesOnMatchingFiles(context, {
@@ -1855,8 +1855,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       // Sibling project.json
       await applyFilesToTempFsAndContext(tempFs, context, {
-        'libs/my-lib/tsconfig.json': `{}`,
-        'libs/my-lib/tsconfig.lib.json': `{}`,
+        'libs/my-lib/tsconfig.json': `{"compilerOptions": {"rootDir": "src"}}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"rootDir": "src"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
@@ -1920,9 +1920,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       // Sibling package.json
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
-        'libs/my-lib/tsconfig.lib.json': `{}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"rootDir": "src"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
-        'libs/my-lib/package.json': `{}`,
+        'libs/my-lib/package.json': `{ "main": "dist/index.js" }`,
       });
       expect(
         await invokeCreateNodesOnMatchingFiles(context, {
@@ -1987,7 +1987,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
-        'libs/my-lib/tsconfig.build.json': `{}`,
+        'libs/my-lib/tsconfig.build.json': `{"compilerOptions": {"rootDir": "src"}}`,
         'libs/my-lib/project.json': `{}`,
       });
       expect(
@@ -2069,11 +2069,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       it('should add the config file and the `include` and `exclude` patterns', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: {
+              rootDir: 'src',
+            },
             include: ['src/**/*.ts'],
             exclude: ['src/**/*.spec.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2132,7 +2135,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
       });
 
-      it('should add extended config files', async () => {
+      it('should be able to extended config files', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'tsconfig.base.json': JSON.stringify({
             exclude: ['node_modules', 'tmp'],
@@ -2144,8 +2147,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             extends: '../../tsconfig.foo.json',
             include: ['src/**/*.ts'],
+            compilerOptions: {
+              rootDir: 'src',
+            },
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2219,9 +2225,12 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             extends: '../../tsconfig.foo.json',
+            compilerOptions: {
+              rootDir: 'src',
+            },
             include: ['src/**/*.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         // simulate @tsconfig/strictest package
         tempFs.createFilesSync({
@@ -2293,6 +2302,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { rootDir: 'src' },
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'], // should be ignored because a referenced internal project includes this same pattern
             references: [
@@ -2306,7 +2316,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/other-lib/tsconfig.json': JSON.stringify({
             include: ['**/*.ts'], // different pattern that should not be included because it's an external project
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`, // Should be defined so that the project is considered buildable
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2374,6 +2384,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { rootDir: 'src' }, // rootDir is required to determine if the project is buildable
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'], // should be ignored
             references: [{ path: './tsconfig.other.json' }],
@@ -2381,7 +2392,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.other.json': JSON.stringify({
             include: ['other/**/*.ts', 'src/**/foo.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js" }`,
         });
 
         let result = await invokeCreateNodesOnMatchingFiles(context, {
@@ -2409,6 +2420,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { rootDir: 'src' },
             include: ['**/*.ts'],
             exclude: ['**/foo.ts'], // should be ignored
             references: [{ path: './tsconfig.other.json' }],
@@ -2416,7 +2428,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.other.json': JSON.stringify({
             include: ['other/**/*.ts', 'src/**/foo.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         result = await invokeCreateNodesOnMatchingFiles(context, {
           typecheck: false,
@@ -2443,6 +2455,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { rootDir: 'src' }, // rooDir is required to determine if the project is buildable
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'], // should be ignored
             references: [{ path: './tsconfig.other.json' }],
@@ -2450,7 +2463,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.other.json': JSON.stringify({
             include: ['other/**/*.ts', '**/foo.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js" }`, // Should be defined so that the project is considered buildable
         });
         result = await invokeCreateNodesOnMatchingFiles(context, {
           typecheck: false,
@@ -2477,6 +2490,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { rootDir: 'src' },
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'], // should be ignored
             references: [{ path: './tsconfig.other.json' }],
@@ -2484,7 +2498,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.other.json': JSON.stringify({
             include: ['./other/**/*.ts', './**/foo.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js" }`,
         });
         result = await invokeCreateNodesOnMatchingFiles(context, {
           typecheck: false,
@@ -2511,6 +2525,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { rootDir: 'src' },
             include: ['src/**/*.ts'],
             exclude: [
               'src/**/foo.ts', // should be ignored
@@ -2521,7 +2536,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.other.json': JSON.stringify({
             include: ['other/**/*.ts', 'src/**/foo.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js" }`,
         });
         result = await invokeCreateNodesOnMatchingFiles(context, {
           typecheck: false,
@@ -2549,10 +2564,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       it('should fall back to named inputs when not using include', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { rootDir: 'src' },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2628,11 +2644,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       it('should add the `outFile`', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { outFile: '../../dist/libs/my-lib/index.js' },
+            compilerOptions: {
+              outFile: '../../dist/libs/my-lib/index.js',
+              rootDir: 'src',
+            },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2698,11 +2717,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       it('should add the `outDir`', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { outDir: '../../dist/libs/my-lib' },
+            compilerOptions: {
+              outDir: '../../dist/libs/my-lib',
+              rootDir: 'src',
+            },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2764,6 +2786,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       it('should add the inline output files when `outDir` is not defined', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { rootDir: 'src' },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
@@ -2842,15 +2865,21 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { outFile: '../../dist/libs/my-lib/lib.js' },
+            compilerOptions: {
+              outFile: '../../dist/libs/my-lib/lib.js',
+              rootDir: 'src',
+            },
             files: ['main.ts'],
             references: [{ path: './tsconfig.other.json' }],
           }),
           'libs/my-lib/tsconfig.other.json': JSON.stringify({
-            compilerOptions: { outDir: '../../dist/libs/my-lib/other' },
+            compilerOptions: {
+              outDir: '../../dist/libs/my-lib/other',
+              rootDir: 'src',
+            },
             include: ['other/**/*.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/lib.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2923,11 +2952,12 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outFile: '../../dist/libs/my-lib/index.js',
+              rootDir: 'src',
               tsBuildInfoFile: '../../dist/libs/my-lib/my-lib.tsbuildinfo',
             },
             files: ['main.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2994,11 +3024,12 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
+              rootDir: 'src',
               tsBuildInfoFile: '../../dist/libs/my-lib/my-lib.tsbuildinfo',
             },
             files: ['main.ts'],
           }),
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -3073,13 +3104,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
+              rootDir: 'src',
               outDir: 'dist',
               tsBuildInfoFile: 'my-lib.tsbuildinfo',
             },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
 
         expect(
@@ -3145,12 +3177,13 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
+              rootDir: 'src',
               tsBuildInfoFile: 'dist/my-lib.tsbuildinfo',
             },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
-          'libs/my-lib/package.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
 
         expect(

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -35,7 +35,6 @@ import {
   addProjectToTsSolutionWorkspace,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
-import { ensureProjectIsExcludedFromPluginRegistrations } from '@nx/js/src/utils/typescript/plugin';
 
 export async function libraryGenerator(host: Tree, schema: Schema) {
   return await libraryGeneratorInternal(host, {
@@ -145,10 +144,6 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
   } else if (options.buildable && options.bundler === 'rollup') {
     const rollupTask = await addRollupBuildTarget(host, options);
     tasks.push(rollupTask);
-  } else if (options.bundler === 'none' && options.addPlugin) {
-    const nxJson = readNxJson(host);
-    ensureProjectIsExcludedFromPluginRegistrations(nxJson, options.projectRoot);
-    updateNxJson(host, nxJson);
   }
 
   // Set up test target

--- a/packages/vue/src/generators/library/library.spec.ts
+++ b/packages/vue/src/generators/library/library.spec.ts
@@ -605,48 +605,5 @@ module.exports = [
         }
       `);
     });
-
-    it('should exclude non-buildable libraries from TS plugin registration', async () => {
-      updateJson(tree, 'nx.json', (json) => {
-        json.plugins = ['@nx/js/typescript'];
-        return json;
-      });
-      await libraryGenerator(tree, {
-        ...defaultSchema,
-        addPlugin: true,
-        setParserOptionsProject: true,
-        linter: 'eslint',
-        bundler: 'none',
-      });
-
-      const nxJson = readJson(tree, 'nx.json');
-      expect(nxJson.plugins).toMatchInlineSnapshot(`
-        [
-          {
-            "exclude": [
-              "my-lib/*",
-            ],
-            "plugin": "@nx/js/typescript",
-          },
-          {
-            "options": {
-              "targetName": "lint",
-            },
-            "plugin": "@nx/eslint/plugin",
-          },
-          {
-            "options": {
-              "buildTargetName": "build",
-              "previewTargetName": "preview",
-              "serveStaticTargetName": "serve-static",
-              "serveTargetName": "serve",
-              "testTargetName": "test",
-              "typecheckTargetName": "typecheck",
-            },
-            "plugin": "@nx/vite/plugin",
-          },
-        ]
-      `);
-    });
   });
 });

--- a/packages/vue/src/generators/library/library.ts
+++ b/packages/vue/src/generators/library/library.ts
@@ -27,7 +27,6 @@ import { getRelativeCwd } from '@nx/devkit/src/generators/artifact-name-and-dire
 import { relative } from 'path';
 import { getImportPath } from '@nx/js/src/utils/get-import-path';
 import { updateTsconfigFiles } from '@nx/js/src/utils/typescript/ts-solution-setup';
-import { ensureProjectIsExcludedFromPluginRegistrations } from '@nx/js/src/utils/typescript/plugin';
 
 export function libraryGenerator(tree: Tree, schema: Schema) {
   return libraryGeneratorInternal(tree, { addPlugin: false, ...schema });
@@ -128,12 +127,6 @@ export async function libraryGeneratorInternal(tree: Tree, schema: Schema) {
       json.name = options.importPath;
       return json;
     });
-  }
-
-  if (options.bundler === 'none') {
-    const nxJson = readNxJson(tree);
-    ensureProjectIsExcludedFromPluginRegistrations(nxJson, options.projectRoot);
-    updateNxJson(tree, nxJson);
   }
 
   if (!options.skipTsConfig && !options.isUsingTsSolutionConfig) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, we are excluding non-buildable libs from the `@nx/js/typescript` plugin. Although that allows non-buildable projects from have the build target being inferred it also as a side-effect removes the `typecheck` target which is unintended. Additionally, to breaks the pattern of being self containment that TS project solutions brings as we were modifying the root `nx.json`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
1. Non-buildable libs should not have a build target.
2. Non-buildable libs should have the typecheck target.
3. Buildable libs remain unchanged and should have both a build and typecheck target.
4. Remove the `exclude` from `nx.json` for non-buildable libs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
