### PR TITLE
fix(js): handle resolution from within node_module in the sync generator

### DIFF
--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -114,10 +114,20 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
   const tsSysFromTree: ts.System = {
     ...ts.sys,
     fileExists(path) {
-      return tsconfigExists(tree, tsconfigInfoCaches, path);
+      // Given ts.System.resolve resolve full path for tsconfig within node_modules
+      // We need to remove the workspace root to ensure we don't have double workspace root within the Tree
+      const correctPath = path.startsWith(tree.root)
+        ? relative(tree.root, path)
+        : path;
+      return tsconfigExists(tree, tsconfigInfoCaches, correctPath);
     },
     readFile(path) {
-      return readRawTsconfigContents(tree, tsconfigInfoCaches, path);
+      // Given ts.System.resolve resolve full path for tsconfig within node_modules
+      // We need to remove the workspace root to ensure we don't have double workspace root within the Tree
+      const correctPath = path.startsWith(tree.root)
+        ? relative(tree.root, path)
+        : path;
+      return readRawTsconfigContents(tree, tsconfigInfoCaches, correctPath);
     },
   };
 


### PR DESCRIPTION
closed #29411

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The resolve function from ts.System returning the full path, and so including the workspaceRoot that is also append by the FsTree

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Resolution within node_modules are correctly followed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29411
