### PR TITLE
fix(bundling): ensure vitest timestamp files are ignored

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -7,7 +7,8 @@ exports[`app generated files content - as-provided - my-app general application 
 .nuxt
 .nitro
 .cache
-vite.config.*.timestamp*"
+vite.config.*.timestamp*
+vitest.config.*.timestamp*"
 `;
 
 exports[`app generated files content - as-provided - my-app general application should add the nuxt and vitest plugins 1`] = `
@@ -366,7 +367,8 @@ exports[`app generated files content - as-provided - myApp general application s
 .nuxt
 .nitro
 .cache
-vite.config.*.timestamp*"
+vite.config.*.timestamp*
+vitest.config.*.timestamp*"
 `;
 
 exports[`app generated files content - as-provided - myApp general application should add the nuxt and vitest plugins 1`] = `

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -29,6 +29,11 @@
       "version": "20.0.6-beta.0",
       "description": "Add gitignore entry for temporary vite config files and remove previous incorrect glob.",
       "implementation": "./src/migrations/update-20-0-4/add-vite-temp-files-to-git-ignore"
+    },
+    "update-20-3-0": {
+      "version": "20.3.0-beta.2",
+      "description": "Add gitignore entry for temporary vitest config files.",
+      "implementation": "./src/migrations/update-20-3-0/add-vitest-temp-files-to-git-ignore"
     }
   },
   "packageJsonUpdates": {

--- a/packages/vite/src/generators/init/init.spec.ts
+++ b/packages/vite/src/generators/init/init.spec.ts
@@ -137,8 +137,9 @@ describe('@nx/vite:init', () => {
     await initGenerator(tree, {});
 
     // ASSERT
-    expect(tree.read('.gitignore', 'utf-8')).toMatchInlineSnapshot(
-      `"vite.config.*.timestamp*"`
-    );
+    expect(tree.read('.gitignore', 'utf-8')).toMatchInlineSnapshot(`
+      "vite.config.*.timestamp*
+      vitest.config.*.timestamp*"
+    `);
   });
 });

--- a/packages/vite/src/migrations/update-20-3-0/add-vitest-temp-files-to-git-ignore.spec.ts
+++ b/packages/vite/src/migrations/update-20-3-0/add-vitest-temp-files-to-git-ignore.spec.ts
@@ -1,5 +1,5 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import addViteTempFilesToGitIgnore from './add-vite-temp-files-to-git-ignore';
+import addViteTempFilesToGitIgnore from './add-vitest-temp-files-to-git-ignore';
 
 describe('addViteTempFilesToGitIgnore', () => {
   it('should update an existing .gitignore file to add the glob correctly', () => {
@@ -24,7 +24,7 @@ describe('addViteTempFilesToGitIgnore', () => {
     tree.write(
       '.gitignore',
       `.idea
-      **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*`
+      **/vitest.config.{js,ts,mjs,mts,cjs,cts}.timestamp*`
     );
 
     // ACT

--- a/packages/vite/src/migrations/update-20-3-0/add-vitest-temp-files-to-git-ignore.ts
+++ b/packages/vite/src/migrations/update-20-3-0/add-vitest-temp-files-to-git-ignore.ts
@@ -1,0 +1,26 @@
+import { Tree } from '@nx/devkit';
+import { addViteTempFilesToGitIgnore as _addViteTempFilesToGitIgnore } from '../../utils/add-vite-temp-files-to-gitignore';
+
+export default function addViteTempFilesToGitIgnore(tree: Tree) {
+  // need to check if .gitignore exists before adding to it
+  // then need to check if it contains the following pattern
+  // **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*
+  // if it does, remove just this pattern
+  if (tree.exists('.gitignore')) {
+    const gitIgnoreContents = tree.read('.gitignore', 'utf-8');
+    if (
+      gitIgnoreContents.includes(
+        '**/vitest.config.{js,ts,mjs,mts,cjs,cts}.timestamp*'
+      )
+    ) {
+      tree.write(
+        '.gitignore',
+        gitIgnoreContents.replace(
+          '**/vitest.config.{js,ts,mjs,mts,cjs,cts}.timestamp*',
+          ''
+        )
+      );
+    }
+  }
+  _addViteTempFilesToGitIgnore(tree);
+}

--- a/packages/vite/src/utils/add-vite-temp-files-to-gitignore.ts
+++ b/packages/vite/src/utils/add-vite-temp-files-to-gitignore.ts
@@ -13,4 +13,17 @@ export function addViteTempFilesToGitIgnore(tree: Tree) {
   } else {
     tree.write('.gitignore', newGitIgnoreContents);
   }
+
+  newGitIgnoreContents = `vitest.config.*.timestamp*`;
+  if (tree.exists('.gitignore')) {
+    const gitIgnoreContents = tree.read('.gitignore', 'utf-8');
+    if (!gitIgnoreContents.includes(newGitIgnoreContents)) {
+      newGitIgnoreContents = stripIndents`${gitIgnoreContents}
+        ${newGitIgnoreContents}`;
+
+      tree.write('.gitignore', newGitIgnoreContents);
+    }
+  } else {
+    tree.write('.gitignore', newGitIgnoreContents);
+  }
 }


### PR DESCRIPTION
## Current Behavior
Vitest TS config files produce timestamp temp files during project graph creation which are cleaned up.
However, the creation and deletion of these files triggers the daemon to recalculate graph.
It ends up in a loop.
The vite timestamp files were already added to the gitignore to prevent this.

## Expected Behavior
Add vitest timestamp files to gitignore
