### PR TITLE
fix(module-federation): dynamic federation helpers should normalize remote names

### DIFF
--- a/packages/module-federation/src/utils/get-remotes-for-host.ts
+++ b/packages/module-federation/src/utils/get-remotes-for-host.ts
@@ -102,7 +102,16 @@ export function getRemotes(
     (r) => !remotesToSkip.has(r)
   );
 
-  const knownDynamicRemotes = dynamicRemotes.filter(
+  // With dynamic remotes, the manifest file may contain the names with `_` due to MF limitations on naming
+  // The project graph might contain these names with `-` rather than `_`. Check for both.
+  // This can occur after migration of existing remotes past Nx 19.8
+  let normalizedDynamicRemotes = dynamicRemotes.map((r) => {
+    if (context.projectGraph.nodes[r.replace(/_/g, '-')]) {
+      return r.replace(/_/g, '-');
+    }
+    return r;
+  });
+  const knownDynamicRemotes = normalizedDynamicRemotes.filter(
     (r) => !remotesToSkip.has(r) && context.projectGraph.nodes[r]
   );
 


### PR DESCRIPTION
## Current Behavior
After migration of existing remotes beyond Nx 19.8, dynamic manifest federation files may be updated to match the normalized names of JS variables (`_` instead of `-`).
Project names will not have been migrated, and therefore the logic to find the projects based on the remote names is broken.

## Expected Behavior
Check the project graph for remote names as-is and by transforming `_` to `-` to see if the project exists

