### PR TITLE
fix(js): Update typescript plugin check for buildable projects

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1696,7 +1696,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       // Sibling package.json
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
-        'libs/my-lib/tsconfig.lib.json': `{}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/package.json': `{}`,
       });
@@ -1744,7 +1744,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       // Sibling package.json
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
-        'libs/my-lib/tsconfig.lib.json': `{}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/package.json': `{}`,
       });
@@ -1794,7 +1794,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       // Sibling package.json
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
-        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"rootDir": "src"}}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
       });
@@ -1842,7 +1842,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   "options": {
                     "cwd": "libs/my-lib",
                   },
-                  "outputs": [],
+                  "outputs": [
+                    "{projectRoot}/dist",
+                  ],
                   "syncGenerators": [
                     "@nx/js:typescript-sync",
                   ],
@@ -1855,8 +1857,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       // Sibling project.json
       await applyFilesToTempFsAndContext(tempFs, context, {
-        'libs/my-lib/tsconfig.json': `{"compilerOptions": {"rootDir": "src"}}`,
-        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"rootDir": "src"}}`,
+        'libs/my-lib/tsconfig.json': `{}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
@@ -1904,7 +1906,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   "options": {
                     "cwd": "libs/my-lib",
                   },
-                  "outputs": [],
+                  "outputs": [
+                    "{projectRoot}/dist",
+                  ],
                   "syncGenerators": [
                     "@nx/js:typescript-sync",
                   ],
@@ -1920,7 +1924,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       // Sibling package.json
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
-        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"rootDir": "src"}}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/package.json': `{ "main": "dist/index.js" }`,
       });
@@ -1970,7 +1974,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   "options": {
                     "cwd": "libs/my-lib",
                   },
-                  "outputs": [],
+                  "outputs": [
+                    "{projectRoot}/dist",
+                  ],
                   "syncGenerators": [
                     "@nx/js:typescript-sync",
                   ],
@@ -1987,7 +1993,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
-        'libs/my-lib/tsconfig.build.json': `{"compilerOptions": {"rootDir": "src"}}`,
+        'libs/my-lib/tsconfig.build.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/project.json': `{}`,
       });
       expect(
@@ -2036,7 +2042,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   "options": {
                     "cwd": "libs/my-lib",
                   },
-                  "outputs": [],
+                  "outputs": [
+                    "{projectRoot}/dist",
+                  ],
                   "syncGenerators": [
                     "@nx/js:typescript-sync",
                   ],
@@ -2070,7 +2078,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
-              rootDir: 'src',
+              outDir: 'dist',
             },
             include: ['src/**/*.ts'],
             exclude: ['src/**/*.spec.ts'],
@@ -2123,7 +2131,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     "options": {
                       "cwd": "libs/my-lib",
                     },
-                    "outputs": [],
+                    "outputs": [
+                      "{projectRoot}/dist",
+                    ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
                     ],
@@ -2148,7 +2158,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
             extends: '../../tsconfig.foo.json',
             include: ['src/**/*.ts'],
             compilerOptions: {
-              rootDir: 'src',
+              outDir: 'dist',
             },
           }),
           'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
@@ -2201,7 +2211,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     "options": {
                       "cwd": "libs/my-lib",
                     },
-                    "outputs": [],
+                    "outputs": [
+                      "{projectRoot}/dist",
+                    ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
                     ],
@@ -2226,7 +2238,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             extends: '../../tsconfig.foo.json',
             compilerOptions: {
-              rootDir: 'src',
+              outDir: 'dist',
             },
             include: ['src/**/*.ts'],
           }),
@@ -2286,7 +2298,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     "options": {
                       "cwd": "libs/my-lib",
                     },
-                    "outputs": [],
+                    "outputs": [
+                      "{projectRoot}/dist",
+                    ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
                     ],
@@ -2302,7 +2316,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { rootDir: 'src' },
+            compilerOptions: { outDir: 'dist' },
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'], // should be ignored because a referenced internal project includes this same pattern
             references: [
@@ -2367,7 +2381,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     "options": {
                       "cwd": "libs/my-lib",
                     },
-                    "outputs": [],
+                    "outputs": [
+                      "{projectRoot}/dist",
+                    ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
                     ],
@@ -2384,7 +2400,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { rootDir: 'src' }, // rootDir is required to determine if the project is buildable
+            compilerOptions: { outDir: 'dist' }, // outDir is required to determine if the project is buildable
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'], // should be ignored
             references: [{ path: './tsconfig.other.json' }],
@@ -2420,7 +2436,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { rootDir: 'src' },
+            compilerOptions: { outDir: 'dist' },
             include: ['**/*.ts'],
             exclude: ['**/foo.ts'], // should be ignored
             references: [{ path: './tsconfig.other.json' }],
@@ -2455,7 +2471,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { rootDir: 'src' }, // rooDir is required to determine if the project is buildable
+            compilerOptions: { outDir: 'dist' }, // outDir is required to determine if the project is buildable
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'], // should be ignored
             references: [{ path: './tsconfig.other.json' }],
@@ -2490,7 +2506,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { rootDir: 'src' },
+            compilerOptions: { outDir: 'dist' },
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'], // should be ignored
             references: [{ path: './tsconfig.other.json' }],
@@ -2525,7 +2541,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { rootDir: 'src' },
+            compilerOptions: { outDir: 'dist' },
             include: ['src/**/*.ts'],
             exclude: [
               'src/**/foo.ts', // should be ignored
@@ -2564,7 +2580,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       it('should fall back to named inputs when not using include', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { rootDir: 'src' },
+            compilerOptions: { outDir: 'dist' },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
@@ -2614,19 +2630,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "cwd": "libs/my-lib",
                     },
                     "outputs": [
-                      "{projectRoot}/**/*.js",
-                      "{projectRoot}/**/*.cjs",
-                      "{projectRoot}/**/*.mjs",
-                      "{projectRoot}/**/*.jsx",
-                      "{projectRoot}/**/*.js.map",
-                      "{projectRoot}/**/*.jsx.map",
-                      "{projectRoot}/**/*.d.ts",
-                      "{projectRoot}/**/*.d.cts",
-                      "{projectRoot}/**/*.d.mts",
-                      "{projectRoot}/**/*.d.ts.map",
-                      "{projectRoot}/**/*.d.cts.map",
-                      "{projectRoot}/**/*.d.mts.map",
-                      "{projectRoot}/tsconfig.lib.tsbuildinfo",
+                      "{projectRoot}/dist",
                     ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
@@ -2646,12 +2650,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outFile: '../../dist/libs/my-lib/index.js',
-              rootDir: 'src',
             },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
-          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/index.js"}`,
+          'libs/my-lib/package.json': `{}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2719,12 +2722,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: '../../dist/libs/my-lib',
-              rootDir: 'src',
             },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
-          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/index.js"}`,
+          'libs/my-lib/package.json': `{"main": "../../dist/libs/my-lib/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2786,7 +2788,6 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       it('should add the inline output files when `outDir` is not defined', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
-            compilerOptions: { rootDir: 'src' },
             files: ['main.ts'],
           }),
           'libs/my-lib/tsconfig.json': `{}`,
@@ -2867,7 +2868,6 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outFile: '../../dist/libs/my-lib/lib.js',
-              rootDir: 'src',
             },
             files: ['main.ts'],
             references: [{ path: './tsconfig.other.json' }],
@@ -2875,11 +2875,10 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.other.json': JSON.stringify({
             compilerOptions: {
               outDir: '../../dist/libs/my-lib/other',
-              rootDir: 'src',
             },
             include: ['other/**/*.ts'],
           }),
-          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/lib.js"}`,
+          'libs/my-lib/package.json': `{"main": "../../dist/libs/my-lib/lib.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -2952,12 +2951,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outFile: '../../dist/libs/my-lib/index.js',
-              rootDir: 'src',
               tsBuildInfoFile: '../../dist/libs/my-lib/my-lib.tsbuildinfo',
             },
             files: ['main.ts'],
           }),
-          'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/index.js"}`,
+          'libs/my-lib/package.json': `{"main": "../../dist/libs/my-lib/index.js"}`,
         });
         expect(
           await invokeCreateNodesOnMatchingFiles(context, {
@@ -3024,7 +3022,6 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
-              rootDir: 'src',
               tsBuildInfoFile: '../../dist/libs/my-lib/my-lib.tsbuildinfo',
             },
             files: ['main.ts'],
@@ -3104,7 +3101,6 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
-              rootDir: 'src',
               outDir: 'dist',
               tsBuildInfoFile: 'my-lib.tsbuildinfo',
             },
@@ -3177,7 +3173,6 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
-              rootDir: 'src',
               tsBuildInfoFile: 'dist/my-lib.tsbuildinfo',
             },
             files: ['main.ts'],

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -643,13 +643,6 @@ function isValidPackageJsonBuildConfig(
     return ['.ts', '.tsx', '.cts', '.mts'].includes(ext);
   };
 
-  // If `outFile` is defined, check the validity of the path.
-  if (tsConfig.options.outFile) {
-    if (isPathSourceFile(tsConfig.options.outFile)) {
-      return false;
-    }
-  }
-
   // Checks if the value is a path within the `src` directory.
   const containsInvalidPath = (
     value: string | Record<string, string>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, we use `rootDir` to check if the project is buildable. This might not be correct in the case where the transpiled files are inside source.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should work the for projects as long as the main / exports files are not source files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
