### PR TITLE
fix(core): quick fix to support trailing commas when reading hoisted …

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../project-graph/project-graph-builder';
 import { CreateDependenciesContext } from '../../../project-graph/plugins';
 
-jest.mock('fs', () => {
+jest.mock('node:fs', () => {
   const memFs = require('memfs').fs;
   return {
     ...memFs,

--- a/packages/nx/src/plugins/js/lock-file/utils/package-json.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/package-json.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync } from 'fs';
 import { PackageJson } from '../../../../utils/package-json';
 import { workspaceRoot } from '../../../../utils/workspace-root';
+import { readJsonFile } from '../../../../utils/fileutils';
 
 /**
  * Get version of hoisted package if available
@@ -8,11 +8,11 @@ import { workspaceRoot } from '../../../../utils/workspace-root';
 export function getHoistedPackageVersion(packageName: string): string {
   const fullPath = `${workspaceRoot}/node_modules/${packageName}/package.json`;
 
-  if (existsSync(fullPath)) {
-    const content = readFileSync(fullPath, 'utf-8');
-    return JSON.parse(content)?.version;
+  try {
+    return readJsonFile(fullPath)?.version;
+  } catch (e) {
+    return;
   }
-  return;
 }
 
 export type NormalizedPackageJson = Pick<

--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -16,7 +16,7 @@ import type {
   ProjectSnapshot,
   ResolvedDependencies,
 } from '@pnpm/lockfile-types';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { valid } from 'semver';
 import { workspaceRoot } from '../../../../utils/workspace-root';
 import { hashObject } from '../../../../hasher/file-hasher';

--- a/packages/nx/src/plugins/js/lock-file/yarn-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/yarn-parser.spec.ts
@@ -11,7 +11,7 @@ import { PackageJson } from '../../../utils/package-json';
 import { ProjectGraphBuilder } from '../../../project-graph/project-graph-builder';
 import { CreateDependenciesContext } from '../../../project-graph/plugins';
 
-jest.mock('fs', () => {
+jest.mock('node:fs', () => {
   const memFs = require('memfs').fs;
   return {
     ...memFs,


### PR DESCRIPTION
…versions

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Graph fails when there is a trailing comma in a package.json

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Graph does not fail and works when there is a trailing comma in a package.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
