### PR TITLE
feat(core): add sync generators option to target defaults in nx-schema

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -569,6 +569,13 @@
         "cache": {
           "type": "boolean",
           "description": "Specifies if the given target should be cacheable"
+        },
+        "syncGenerators": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of generators to run before the target to ensure the workspace is up to date"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The JSON schema of`targetDefaults` in `nx.json` doesn't accept `syncGenerators` even though it can be defined and NX respects it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

To be able to define default `syncGenerators` for targets in `nx.json` without schema violations.
