### PR TITLE
cleanup(angular): migrate angular to `picocolors`

### DIFF
--- a/packages/angular/.eslintrc.json
+++ b/packages/angular/.eslintrc.json
@@ -5,7 +5,15 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "name": "chalk",
+            "message": "Please use `picocolors` in place of `chalk` for rendering terminal colors"
+          }
+        ]
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -13,7 +13,7 @@
     "@schematics",
     "@phenomnomnominal/tsquery",
     "@typescript-eslint/",
-    "chalk",
+    "picocolors",
     "ignore",
     "minimatch",
     "rxjs-for-await",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@phenomnomnominal/tsquery": "~5.0.1",
     "@typescript-eslint/type-utils": "^8.0.0",
-    "chalk": "^4.1.0",
+    "picocolors": "^1.1.0",
     "magic-string": "~0.30.2",
     "minimatch": "9.0.3",
     "semver": "^7.5.3",

--- a/packages/angular/src/generators/ng-add/utilities/validation-logging.spec.ts
+++ b/packages/angular/src/generators/ng-add/utilities/validation-logging.spec.ts
@@ -1,4 +1,4 @@
-import chalk = require('chalk');
+import * as pc from 'picocolors';
 import {
   arrayToString,
   getProjectValidationResultMessage,
@@ -48,10 +48,10 @@ describe('getProjectValidationResultMessage', () => {
       },
     ]);
 
-    expect(message).toBe(`${chalk.bold(`Validation results`)}:
+    expect(message).toBe(`${pc.bold(`Validation results`)}:
 
   - Simple error message with hint
-  ${chalk.dim(chalk.italic(`  Some hint message`))}
+  ${pc.dim(pc.italic(`  Some hint message`))}
 
   - Simple error message without hint
 
@@ -60,7 +60,7 @@ describe('getProjectValidationResultMessage', () => {
       - First error message
       - Second error message
       - Third error message
-  ${chalk.dim(chalk.italic(`  - Some hint message`))}
+  ${pc.dim(pc.italic(`  - Some hint message`))}
 
   - Message group without hint:
     - Errors:

--- a/packages/angular/src/generators/ng-add/utilities/validation-logging.ts
+++ b/packages/angular/src/generators/ng-add/utilities/validation-logging.ts
@@ -1,4 +1,4 @@
-import chalk = require('chalk');
+import * as pc from 'picocolors';
 import type { ValidationError } from './types';
 
 export function arrayToString(array: string[]): string {
@@ -18,7 +18,7 @@ export function arrayToString(array: string[]): string {
 export function getProjectValidationResultMessage(
   validationResult: ValidationError[]
 ): string {
-  return `${chalk.bold('Validation results')}:
+  return `${pc.bold('Validation results')}:
 
   ${validationResult
     .map((error) => getValidationErrorText(error))
@@ -31,12 +31,12 @@ function getValidationErrorText({
   hint,
 }: ValidationError): string {
   let lines = message
-    ? [`- ${message}`, ...(hint ? [chalk.dim(chalk.italic(`  ${hint}`))] : [])]
+    ? [`- ${message}`, ...(hint ? [pc.dim(pc.italic(`  ${hint}`))] : [])]
     : [
         `- ${messageGroup.title}:`,
         '  - Errors:',
         ...messageGroup.messages.map((message) => `    - ${message}`),
-        ...(hint ? [chalk.dim(chalk.italic(`  - ${hint}`))] : []),
+        ...(hint ? [pc.dim(pc.italic(`  - ${hint}`))] : []),
       ];
 
   return lines.join('\n  ');


### PR DESCRIPTION
migrates `@nx/angular` from `chalk` to `picocolors`

Part of https://github.com/es-tooling/ecosystem-cleanup/issues/117

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
