### PR TITLE
fix(angular): set up host and remote ssr apps correctly #29442

### DIFF
--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -158,7 +158,7 @@ export default AppServerModule;
 `;
 
 exports[`Host App Generator --ssr should generate the correct files 5`] = `
-"import('./src/main.server');
+"import('./main.server');
 "
 `;
 
@@ -350,7 +350,7 @@ export default bootstrap;
 `;
 
 exports[`Host App Generator --ssr should generate the correct files for standalone 4`] = `
-"import('./src/main.server');
+"import('./main.server');
 "
 `;
 
@@ -573,7 +573,7 @@ export default bootstrap;
 "
 `;
 
-exports[`Host App Generator --ssr should generate the correct files for standalone when --typescript=true 4`] = `"import('./src/main.server');"`;
+exports[`Host App Generator --ssr should generate the correct files for standalone when --typescript=true 4`] = `"import('./main.server');"`;
 
 exports[`Host App Generator --ssr should generate the correct files for standalone when --typescript=true 5`] = `
 "import { ModuleFederationConfig } from '@nx/module-federation';
@@ -815,7 +815,7 @@ export default AppServerModule;
 "
 `;
 
-exports[`Host App Generator --ssr should generate the correct files when --typescript=true 5`] = `"import('./src/main.server');"`;
+exports[`Host App Generator --ssr should generate the correct files when --typescript=true 5`] = `"import('./main.server');"`;
 
 exports[`Host App Generator --ssr should generate the correct files when --typescript=true 6`] = `
 "import { ModuleFederationConfig } from '@nx/module-federation';

--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -365,7 +365,7 @@ describe('Host App Generator', () => {
         tree.read(`test/src/bootstrap.server.ts`, 'utf-8')
       ).toMatchSnapshot();
       expect(tree.read(`test/src/main.server.ts`, 'utf-8')).toMatchSnapshot();
-      expect(tree.read(`test/server.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`test/src/server.ts`, 'utf-8')).toMatchSnapshot();
       expect(
         tree.read(`test/module-federation.config.js`, 'utf-8')
       ).toMatchSnapshot();
@@ -402,7 +402,7 @@ describe('Host App Generator', () => {
         tree.read(`test/src/bootstrap.server.ts`, 'utf-8')
       ).toMatchSnapshot();
       expect(tree.read(`test/src/main.server.ts`, 'utf-8')).toMatchSnapshot();
-      expect(tree.read(`test/server.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`test/src/server.ts`, 'utf-8')).toMatchSnapshot();
       expect(
         tree.read(`test/module-federation.config.ts`, 'utf-8')
       ).toMatchSnapshot();
@@ -435,7 +435,7 @@ describe('Host App Generator', () => {
         tree.read(`test/src/bootstrap.server.ts`, 'utf-8')
       ).toMatchSnapshot();
       expect(tree.read(`test/src/main.server.ts`, 'utf-8')).toMatchSnapshot();
-      expect(tree.read(`test/server.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`test/src/server.ts`, 'utf-8')).toMatchSnapshot();
       expect(
         tree.read(`test/module-federation.config.js`, 'utf-8')
       ).toMatchSnapshot();
@@ -475,7 +475,7 @@ describe('Host App Generator', () => {
         tree.read(`test/src/bootstrap.server.ts`, 'utf-8')
       ).toMatchSnapshot();
       expect(tree.read(`test/src/main.server.ts`, 'utf-8')).toMatchSnapshot();
-      expect(tree.read(`test/server.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`test/src/server.ts`, 'utf-8')).toMatchSnapshot();
       expect(
         tree.read(`test/module-federation.config.ts`, 'utf-8')
       ).toMatchSnapshot();

--- a/packages/angular/src/generators/host/lib/update-ssr-setup.ts
+++ b/packages/angular/src/generators/host/lib/update-ssr-setup.ts
@@ -21,18 +21,23 @@ export async function updateSsrSetup(
   appName: string,
   typescriptConfiguration: boolean
 ) {
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
   let project = readProjectConfiguration(tree, appName);
 
   tree.rename(
     joinPathFragments(project.sourceRoot, 'main.server.ts'),
     joinPathFragments(project.sourceRoot, 'bootstrap.server.ts')
   );
-  tree.write(
-    joinPathFragments(project.root, 'server.ts'),
-    "import('./src/main.server');"
+  const pathToServerEntry = joinPathFragments(
+    angularMajorVersion >= 19
+      ? project.sourceRoot ?? joinPathFragments(project.root, 'src')
+      : project.root,
+    'server.ts'
   );
-
-  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+  tree.write(
+    pathToServerEntry,
+    `import('./${angularMajorVersion >= 19 ? '' : 'src/'}main.server');`
+  );
 
   generateFiles(tree, join(__dirname, '../files/common'), project.root, {
     appName,

--- a/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -125,7 +125,7 @@ export default AppServerModule;
 `;
 
 exports[`MF Remote App Generator --ssr should generate the correct files 5`] = `
-"import('./src/main.server');
+"import('./main.server');
 "
 `;
 
@@ -357,7 +357,7 @@ export default AppServerModule;
 "
 `;
 
-exports[`MF Remote App Generator --ssr should generate the correct files when --typescriptConfiguration=true 5`] = `"import('./src/main.server');"`;
+exports[`MF Remote App Generator --ssr should generate the correct files when --typescriptConfiguration=true 5`] = `"import('./main.server');"`;
 
 exports[`MF Remote App Generator --ssr should generate the correct files when --typescriptConfiguration=true 6`] = `
 "import { ModuleFederationConfig } from '@nx/module-federation';

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -329,7 +329,7 @@ describe('MF Remote App Generator', () => {
         tree.read(`test/src/bootstrap.server.ts`, 'utf-8')
       ).toMatchSnapshot();
       expect(tree.read(`test/src/main.server.ts`, 'utf-8')).toMatchSnapshot();
-      expect(tree.read(`test/server.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`test/src/server.ts`, 'utf-8')).toMatchSnapshot();
       expect(
         tree.read(`test/module-federation.config.js`, 'utf-8')
       ).toMatchSnapshot();
@@ -378,7 +378,7 @@ describe('MF Remote App Generator', () => {
         tree.read(`test/src/bootstrap.server.ts`, 'utf-8')
       ).toMatchSnapshot();
       expect(tree.read(`test/src/main.server.ts`, 'utf-8')).toMatchSnapshot();
-      expect(tree.read(`test/server.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`test/src/server.ts`, 'utf-8')).toMatchSnapshot();
       expect(
         tree.read(`test/module-federation.config.ts`, 'utf-8')
       ).toMatchSnapshot();


### PR DESCRIPTION
## Current Behavior
During the update to support Angular 19, the host and remote generators' `updateSsrSetup` function was missed.

This led to the creation of a second `server.ts` file, which would result in the node server trying to instantiate twice.

## Expected Behavior
Fix the path normalization dependent on angular major version to ensure only one server will be instantiated.

## Related Issue(s)

Fixes #29442
