### PR TITLE
docs(nx-dev): render keywords meta tag

### DIFF
--- a/docs/nx-cloud/features/split-e2e-tasks.md
+++ b/docs/nx-cloud/features/split-e2e-tasks.md
@@ -1,3 +1,7 @@
+---
+keywords: [split tasks, atomizer]
+---
+
 # Automatically Split E2E Tasks by File (Atomizer)
 
 {% youtube

--- a/docs/shared/concepts/common-tasks.md
+++ b/docs/shared/concepts/common-tasks.md
@@ -1,3 +1,7 @@
+---
+keywords: [build, serve, test, lint]
+---
+
 # Common Tasks
 
 The tasks that are [inferred by plugins](/concepts/inferred-tasks) or that you define in your [project configuration](/reference/project-configuration) can have any name that you want, but it is helpful for developers if you keep your task naming convention consistent across the projects in your repository. This way, if a developer moves from one project to another, they already know how to launch tasks for the new project. Here are some common task names that you can define for your projects.

--- a/docs/shared/features/automate-updating-dependencies.md
+++ b/docs/shared/features/automate-updating-dependencies.md
@@ -1,3 +1,7 @@
+---
+keywords: [update]
+---
+
 # Automate Updating Dependencies
 
 {% youtube

--- a/docs/shared/features/distribute-task-execution.md
+++ b/docs/shared/features/distribute-task-execution.md
@@ -1,3 +1,7 @@
+---
+keywords: [distributed tasks]
+---
+
 # Distribute Task Execution (Nx Agents)
 
 {% youtube

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -1,3 +1,7 @@
+---
+keywords: [project.json]
+---
+
 # Project Configuration
 
 A project's configuration is constructed by Nx from three sources:

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -96,6 +96,16 @@ export function DocViewer({
           siteName: 'Nx',
           type: 'website',
         }}
+        additionalMetaTags={
+          metadata.keywords
+            ? [
+                {
+                  name: 'keywords',
+                  content: metadata.keywords,
+                },
+              ]
+            : []
+        }
       />
 
       <div className="mx-auto w-full grow items-stretch px-4 sm:px-6 lg:px-8 2xl:max-w-6xl">


### PR DESCRIPTION
Renders `keywords` property from frontmatter as a `<meta>` tag.