### PR TITLE
cleanup(core): move esbuild to use tinyglobby

### DIFF
--- a/packages/esbuild/.eslintrc.json
+++ b/packages/esbuild/.eslintrc.json
@@ -14,6 +14,10 @@
           {
             "name": "fs-extra",
             "message": "Please use equivalent utilities from `node:fs` instead."
+          },
+          {
+            "name": "fast-glob",
+            "message": "Please use `tinyglobby` in place of `fast-glob` for executing glob traversals"
           }
         ]
       }

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
-    "fast-glob": "3.2.7",
+    "tinyglobby": "^0.2.10",
     "picocolors": "^1.1.0",
     "tsconfig-paths": "^4.1.2",
     "tslib": "^2.3.0"

--- a/packages/esbuild/src/utils/get-entry-points.ts
+++ b/packages/esbuild/src/utils/get-entry-points.ts
@@ -1,7 +1,7 @@
 import { ExecutorContext, readJsonFile } from '@nx/devkit';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as glob from 'fast-glob';
+import { globSync } from 'tinyglobby';
 
 export interface GetEntryPointsOptions {
   recursive?: boolean;
@@ -50,12 +50,11 @@ export function getEntryPoints(
       const tsconfig = readJsonFile(
         path.join(project.data.root, foundTsConfig)
       );
-      const projectFiles = glob
-        .sync(tsconfig.include ?? [], {
-          cwd: project.data.root,
-          ignore: tsconfig.exclude ?? [],
-        })
-        .map((f) => path.join(project.data.root, f));
+      const projectFiles = globSync(tsconfig.include ?? [], {
+        cwd: project.data.root,
+        ignore: tsconfig.exclude ?? [],
+        expandDirectories: false,
+      }).map((f) => path.join(project.data.root, f));
 
       projectFiles.forEach((f) => entryPoints.add(f));
       options?.onProjectFilesMatched?.(projectName, projectFiles);

--- a/packages/esbuild/tsconfig.lib.json
+++ b/packages/esbuild/tsconfig.lib.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
-    "types": []
+    "types": ["node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
An alternative to #28037, switches the esbuild package to use `tinyglobby` instead of `fast-glob`.

This improves performance a fair chunk and reduces install complexity/size.

cc @benmccann @JamesHenry 
