### PR TITLE
Feat/29454/nx version resolve local dependency protocols

### DIFF
--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -1957,6 +1957,132 @@ Valid values are: "auto", "", "~", "^", "="`,
     });
   });
 
+  describe('local dependency protocols', () => {
+    it('should resolve all local `file:` references', async () => {
+      projectGraph = createWorkspaceWithPackageDependencies(tree, {
+        'package-a': {
+          projectRoot: 'packages/package-a',
+          packageName: 'package-a',
+          version: '1.0.0',
+          packageJsonPath: 'packages/package-a/package.json',
+          localDependencies: [
+            {
+              projectName: 'package-b',
+              dependencyCollection: 'dependencies',
+              version: 'file:../package-b',
+            },
+            {
+              projectName: 'package-c',
+              dependencyCollection: 'dependencies',
+              version: 'file:../package-c',
+            },
+          ],
+        },
+        'package-b': {
+          projectRoot: 'packages/package-b',
+          packageName: 'package-b',
+          version: '1.0.0',
+          packageJsonPath: 'packages/package-b/package.json',
+          localDependencies: [],
+        },
+        'package-c': {
+          projectRoot: 'packages/package-c',
+          packageName: 'package-c',
+          version: '1.0.0',
+          packageJsonPath: 'packages/package-c/package.json',
+          localDependencies: [],
+        },
+      });
+
+      expect(readJson(tree, 'packages/package-a/package.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "package-b": "file:../package-b",
+          },
+          "name": "package-a",
+          "version": "1.0.0",
+        }
+      `);
+      expect(readJson(tree, 'packages/package-b/package.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "name": "package-b",
+          "version": "1.0.0",
+        }
+      `);
+
+      expect(
+        await releaseVersionGenerator(tree, {
+          projects: [projectGraph.nodes['package-b']], // version only package-b
+          projectGraph,
+          specifier: '2.0.0',
+          currentVersionResolver: 'disk',
+          specifierSource: 'prompt',
+          releaseGroup: createReleaseGroup('independent'),
+          updateDependents: 'auto',
+          preserveLocalDependencyProtocols: false,
+        })
+      ).toMatchInlineSnapshot(`
+        {
+          "callback": [Function],
+          "data": {
+            "package-a": {
+              "currentVersion": "1.0.0",
+              "dependentProjects": [],
+              "newVersion": "1.0.1",
+            },
+            "package-b": {
+              "currentVersion": "1.0.0",
+              "dependentProjects": [
+                {
+                  "dependencyCollection": "dependencies",
+                  "rawVersionSpec": "file:../package-b",
+                  "source": "package-a",
+                  "target": "package-b",
+                  "type": "static",
+                },
+              ],
+              "newVersion": "2.0.0",
+            },
+            "package-c": {
+              "currentVersion": "1.0.0",
+              "TODO": "what is expected here?",
+            }
+          },
+        }
+      `);
+
+      expect(readJson(tree, 'packages/package-a/package.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "package-b": "2.0.0",
+            "package-c": "1.0.0",
+          },
+          "name": "package-a",
+          "version": "1.0.1",
+        }
+      `);
+
+      expect(readJson(tree, 'packages/package-b/package.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "name": "package-b",
+          "version": "2.0.0",
+        }
+      `);
+
+      expect(readJson(tree, 'packages/package-c/package.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "name": "package-c",
+          "version": "1.0.0",
+        }
+      `);
+    });
+  });
+
   describe('preserveLocalDependencyProtocols', () => {
     it('should preserve local `workspace:` references when preserveLocalDependencyProtocols is true', async () => {
       // Supported package manager for workspace: protocol


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

Local dependency protocols to link packages aren't resolved to the actual version for packages that aren't bumped during `nx release version`. Only packages that are bumped will have their local dependency protocol replaced.

## Expected Behavior

All local dependency protocols should have been replaced in every `package.json` touched by the version command.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29454
