### PR TITLE
fix(linter): add files entry to react flat configs to avoid applying TS rules to JSON files

### DIFF
--- a/packages/eslint-plugin/src/flat-configs/react-base.ts
+++ b/packages/eslint-plugin/src/flat-configs/react-base.ts
@@ -18,11 +18,16 @@ import tseslint from 'typescript-eslint';
  * https://github.com/facebook/create-react-app/blob/567f36c9235f1e1fd4a76dc6d1ae00be754ca047/packages/eslint-config-react-app/index.js
  */
 export default tseslint.config({
-  // Files need to be specified or else typescript-eslint rules will be
-  // applied to non-TS files. For example, libs add rules to *.json
-  // files, and TS rules should not apply to them.
-  // See: https://github.com/nrwl/nx/issues/28245
-  files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+  files: [
+    '**/*.ts',
+    '**/*.cts',
+    '**/*.mts',
+    '**/*.tsx',
+    '**/*.js',
+    '**/*.cjs',
+    '**/*.mjs',
+    '**/*.jsx',
+  ],
   plugins: { import: importPlugin },
   languageOptions: {
     globals: {

--- a/packages/eslint-plugin/src/flat-configs/react-base.ts
+++ b/packages/eslint-plugin/src/flat-configs/react-base.ts
@@ -18,6 +18,11 @@ import tseslint from 'typescript-eslint';
  * https://github.com/facebook/create-react-app/blob/567f36c9235f1e1fd4a76dc6d1ae00be754ca047/packages/eslint-config-react-app/index.js
  */
 export default tseslint.config({
+  // Files need to be specified or else typescript-eslint rules will be
+  // applied to non-TS files. For example, libs add rules to *.json
+  // files, and TS rules should not apply to them.
+  // See: https://github.com/nrwl/nx/issues/28245
+  files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
   plugins: { import: importPlugin },
   languageOptions: {
     globals: {

--- a/packages/eslint-plugin/src/flat-configs/react-jsx.ts
+++ b/packages/eslint-plugin/src/flat-configs/react-jsx.ts
@@ -15,22 +15,32 @@ import tseslint from 'typescript-eslint';
  */
 export default tseslint.config(
   {
-    // Files need to be specified or else typescript-eslint rules will be
-    // applied to non-TS files. For example, libs add rules to *.json
-    // files, and TS rules should not apply to them.
-    // See: https://github.com/nrwl/nx/issues/28245
-    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    files: [
+      '**/*.ts',
+      '**/*.cts',
+      '**/*.mts',
+      '**/*.tsx',
+      '**/*.js',
+      '**/*.cjs',
+      '**/*.mjs',
+      '**/*.jsx',
+    ],
     plugins: {
       'react-hooks': reactHooksPlugin,
     },
     rules: reactHooksPlugin.configs.recommended.rules,
   },
   {
-    // Files need to be specified or else typescript-eslint rules will be
-    // applied to non-TS files. For example, libs add rules to *.json
-    // files, and TS rules should not apply to them.
-    // See: https://github.com/nrwl/nx/issues/28245
-    files: ['**/*.tsx', '**/*.jsx'],
+    files: [
+      '**/*.ts',
+      '**/*.cts',
+      '**/*.mts',
+      '**/*.tsx',
+      '**/*.js',
+      '**/*.cjs',
+      '**/*.mjs',
+      '**/*.jsx',
+    ],
     settings: { react: { version: 'detect' } },
     plugins: {
       'jsx-a11y': jsxA11yPlugin,

--- a/packages/eslint-plugin/src/flat-configs/react-jsx.ts
+++ b/packages/eslint-plugin/src/flat-configs/react-jsx.ts
@@ -15,12 +15,22 @@ import tseslint from 'typescript-eslint';
  */
 export default tseslint.config(
   {
+    // Files need to be specified or else typescript-eslint rules will be
+    // applied to non-TS files. For example, libs add rules to *.json
+    // files, and TS rules should not apply to them.
+    // See: https://github.com/nrwl/nx/issues/28245
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     plugins: {
       'react-hooks': reactHooksPlugin,
     },
     rules: reactHooksPlugin.configs.recommended.rules,
   },
   {
+    // Files need to be specified or else typescript-eslint rules will be
+    // applied to non-TS files. For example, libs add rules to *.json
+    // files, and TS rules should not apply to them.
+    // See: https://github.com/nrwl/nx/issues/28245
+    files: ['**/*.tsx', '**/*.jsx'],
     settings: { react: { version: 'detect' } },
     plugins: {
       'jsx-a11y': jsxA11yPlugin,

--- a/packages/eslint-plugin/src/flat-configs/react-typescript.ts
+++ b/packages/eslint-plugin/src/flat-configs/react-typescript.ts
@@ -11,6 +11,11 @@ import tseslint from 'typescript-eslint';
  * package.
  */
 export default tseslint.config({
+  // Files need to be specified or else typescript-eslint rules will be
+  // applied to non-TS files. For example, libs add rules to *.json
+  // files, and TS rules should not apply to them.
+  // See: https://github.com/nrwl/nx/issues/28245
+  files: ['**/*.ts', '**/*.tsx'],
   rules: {
     // TypeScript"s `noFallthroughCasesInSwitch` option is more robust (#6906)
     'default-case': 'off',

--- a/packages/eslint-plugin/src/flat-configs/react-typescript.ts
+++ b/packages/eslint-plugin/src/flat-configs/react-typescript.ts
@@ -11,11 +11,16 @@ import tseslint from 'typescript-eslint';
  * package.
  */
 export default tseslint.config({
-  // Files need to be specified or else typescript-eslint rules will be
-  // applied to non-TS files. For example, libs add rules to *.json
-  // files, and TS rules should not apply to them.
-  // See: https://github.com/nrwl/nx/issues/28245
-  files: ['**/*.ts', '**/*.tsx'],
+  files: [
+    '**/*.ts',
+    '**/*.cts',
+    '**/*.mts',
+    '**/*.tsx',
+    '**/*.js',
+    '**/*.cjs',
+    '**/*.mjs',
+    '**/*.jsx',
+  ],
   rules: {
     // TypeScript"s `noFallthroughCasesInSwitch` option is more robust (#6906)
     'default-case': 'off',


### PR DESCRIPTION
This PR fixes an issue with React libs, where TS rules are being applied to JSON files.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28245 
