### PR TITLE
fix(vite): tsconfig paths plugin should not partially match paths

### DIFF
--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -206,6 +206,47 @@ describe('@nx/vite/plugin', () => {
 
       expect(() => runCLI(`test ${mylib}`)).not.toThrow();
     });
+
+    it('should not partially match a path mapping', () => {
+      const lib1 = uniq('lib1');
+      const lib2 = uniq('lib2');
+      const lib3 = uniq('lib3');
+      runCLI(
+        `generate @nx/react:library libs/${lib1} --bundler=none --unitTestRunner=vitest`
+      );
+      runCLI(
+        `generate @nx/react:library libs/${lib2} --bundler=none --unitTestRunner=vitest`
+      );
+      runCLI(
+        `generate @nx/react:library libs/${lib3} --bundler=none --unitTestRunner=vitest`
+      );
+      updateFile(`libs/${lib1}/src/foo.enum.ts`, `export const foo = 'foo';`);
+      updateFile(`libs/${lib2}/src/bar.enum.ts`, `export const bar = 'bar';`);
+      updateFile(`libs/${lib3}/src/bam.enum.ts`, `export const bam = 'bam';`);
+      updateFile(
+        `libs/${lib1}/src/foo.spec.ts`,
+        `
+          import { foo } from 'match-lib-deep/foo.enum';
+          import { bar } from 'match-lib-top-level';
+          import { bam } from 'match-lib/bam.enum';
+          test('should work', () => {
+            expect(foo).toBeDefined();
+            expect(bar).toBeDefined();
+            expect(bam).toBeDefined();
+          });
+        `
+      );
+      updateJson('tsconfig.base.json', (json) => {
+        json.compilerOptions.paths['match-lib-deep/*'] = [`libs/${lib1}/src/*`];
+        json.compilerOptions.paths['match-lib-top-level'] = [
+          `libs/${lib2}/src/bar.enum.ts`,
+        ];
+        json.compilerOptions.paths['match-lib/*'] = [`libs/${lib3}/src/*`];
+        return json;
+      });
+
+      expect(() => runCLI(`test ${lib1}`)).not.toThrow();
+    });
   });
 
   describe('react with vitest only', () => {

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -237,7 +237,10 @@ There should at least be a tsconfig.base.json or tsconfig.json in the root of th
 
       const normalizedImport = alias.replace(/\/\*$/, '');
 
-      if (importPath.startsWith(normalizedImport)) {
+      if (
+        importPath === normalizedImport ||
+        importPath.startsWith(normalizedImport + '/')
+      ) {
         const joinedPath = joinPathFragments(
           tsconfig.absoluteBaseUrl,
           paths[0].replace(/\/\*$/, '')


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When there is a path mapping like:
```
"match-lib-deep/": ["libs/lib1/src/*"],
"match-lib-top-level": ["libs/lib2/src/*"],
"match-lib/*": ["libs/lib3/src/*"],
```

Imports to `match-lib-deep` or `match-lib-top-level` will try and use the last `match-lib` path mapping as the trailing `/` is not accounted for in the `startsWith` check.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The correct path mapping is matched.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A
