### PR TITLE
fix(js): infer outputs correctly when both rootDir and outDir are set for tsconfig

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1194,6 +1194,118 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
       });
 
+      it('should include tsbuildinfo file when outDir and rootDir at both set', async () => {
+        await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            files: [],
+            references: [{ path: './tsconfig.lib.json' }],
+          }),
+          'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { outDir: 'out-tsc/my-lib', rootDir: 'src' },
+            files: ['src/main.ts'],
+          }),
+          'libs/my-lib/package.json': `{}`,
+        });
+
+        expect(
+          await invokeCreateNodesOnMatchingFiles(context, {
+            build: {
+              configName: 'tsconfig.lib.json',
+            },
+          })
+        ).toMatchInlineSnapshot(`
+          {
+            "projects": {
+              "libs/my-lib": {
+                "projectType": "library",
+                "targets": {
+                  "build": {
+                    "cache": true,
+                    "command": "tsc --build tsconfig.lib.json --pretty --verbose",
+                    "dependsOn": [
+                      "^build",
+                    ],
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "typescript",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Builds the project with \`tsc\`.",
+                      "help": {
+                        "command": "npx tsc --build --help",
+                        "example": {
+                          "args": [
+                            "--force",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "typescript",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "libs/my-lib",
+                    },
+                    "outputs": [
+                      "{projectRoot}/out-tsc/my-lib",
+                      "{projectRoot}/out-tsc/*.tsbuildinfo",
+                    ],
+                    "syncGenerators": [
+                      "@nx/js:typescript-sync",
+                    ],
+                  },
+                  "typecheck": {
+                    "cache": true,
+                    "command": "tsc --build --emitDeclarationOnly --pretty --verbose",
+                    "dependsOn": [
+                      "^typecheck",
+                    ],
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "typescript",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs type-checking for the project.",
+                      "help": {
+                        "command": "npx tsc --build --help",
+                        "example": {
+                          "args": [
+                            "--force",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "typescript",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "libs/my-lib",
+                    },
+                    "outputs": [
+                      "{projectRoot}/out-tsc/my-lib",
+                      "{projectRoot}/out-tsc/*.tsbuildinfo",
+                    ],
+                    "syncGenerators": [
+                      "@nx/js:typescript-sync",
+                    ],
+                  },
+                },
+              },
+            },
+          }
+        `);
+      });
+
       it('should add the inline output files when `outDir` is not defined', async () => {
         await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
@@ -2771,6 +2883,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     },
                     "outputs": [
                       "{workspaceRoot}/dist/libs/my-lib",
+                      "{workspaceRoot}/dist/libs/*.tsbuildinfo",
                     ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
@@ -2933,6 +3046,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{workspaceRoot}/dist/libs/my-lib/lib.d.ts.map",
                       "{workspaceRoot}/dist/libs/my-lib/lib.tsbuildinfo",
                       "{workspaceRoot}/dist/libs/my-lib/other",
+                      "{workspaceRoot}/dist/libs/my-lib/*.tsbuildinfo",
                     ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -571,14 +571,14 @@ function getOutputs(
           join(workspaceRoot, projectRoot)
         );
         outputs.add(
-          joinPathFragments(
-            pathToInputOrOutput(
+          pathToInputOrOutput(
+            joinPathFragments(
               config.options.outDir,
-              workspaceRoot,
-              projectRoot
+              relativeRootDir,
+              `*.tsbuildinfo`
             ),
-            relativeRootDir,
-            `*.tsbuildinfo`
+            workspaceRoot,
+            projectRoot
           )
         );
       }

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -549,18 +549,36 @@ function getOutputs(
         pathToInputOrOutput(config.options.outDir, workspaceRoot, projectRoot)
       );
 
-      if (
-        config.options.tsBuildInfoFile &&
-        !normalize(config.options.tsBuildInfoFile).startsWith(
-          `${normalize(config.options.outDir)}${sep}`
-        )
-      ) {
-        // https://www.typescriptlang.org/tsconfig#tsBuildInfoFile
+      if (config.options.tsBuildInfoFile) {
+        if (
+          !normalize(config.options.tsBuildInfoFile).startsWith(
+            `${normalize(config.options.outDir)}${sep}`
+          )
+        ) {
+          // https://www.typescriptlang.org/tsconfig#tsBuildInfoFile
+          outputs.add(
+            pathToInputOrOutput(
+              config.options.tsBuildInfoFile,
+              workspaceRoot,
+              projectRoot
+            )
+          );
+        }
+      } else if (config.options.rootDir && config.options.rootDir !== '.') {
+        // If rootDir is set, then the tsbuildinfo file will be outside the outDir so we need to add it.
+        const relativeRootDir = relative(
+          config.options.rootDir,
+          join(workspaceRoot, projectRoot)
+        );
         outputs.add(
-          pathToInputOrOutput(
-            config.options.tsBuildInfoFile,
-            workspaceRoot,
-            projectRoot
+          joinPathFragments(
+            pathToInputOrOutput(
+              config.options.outDir,
+              workspaceRoot,
+              projectRoot
+            ),
+            relativeRootDir,
+            `*.tsbuildinfo`
           )
         );
       }


### PR DESCRIPTION
When the tsconfig has `rootDir` and `outDir` both defined, then the `*.tsbuildinfo` file is not cached. This makes incremental tsc not work through distribution (e.g. agents).

For example, given this `tsconfig.lib.json` file:

```json
{
  "compilerOptions": {
    "outDir": "out-tsc/lib-1",
    "rootDir": "src"
  }
}
```

The outputs (e.g. `*.d.ts` files) are under `{projectRoot}/out-tsc/lib-1`, but the tsbuild info file is under `{projectRoot}/out-tsc/tsconfig.lib.tsbuildinfo`.

## Current Behavior
tsbuildinfo file is not cached

## Expected Behavior
tsbuildinfo file is cached

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
