### PR TITLE
fix(nx-dev): add playsInline to video loop component

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/tags/video-loop.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/video-loop.component.tsx
@@ -42,7 +42,7 @@ export function VideoLoop({
   }, []);
 
   return (
-    <video ref={videoRef} autoPlay muted loop>
+    <video ref={videoRef} autoPlay muted loop playsInline>
       <source src={src} type="video/mp4" />
       <div className="p-4 text-center">
         <p className="pb-3 font-bold">


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Embedded videos in Markdown using the `video-player` tag play in fullscreen on mobile Safari

## Expected Behavior
Embedded videos in Markdown using the `video-player` tag play inline on mobile Safari.

For reference on the `playsinline` attribute: https://css-tricks.com/what-does-playsinline-mean-in-web-video/

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
