### PR TITLE
fix(core): connections to daemon from plugin workers should not keep daemon alive

### DIFF
--- a/packages/nx/src/daemon/message-types/connect.ts
+++ b/packages/nx/src/daemon/message-types/connect.ts
@@ -1,0 +1,18 @@
+export const CONNECT = 'CONNECT' as const;
+
+export type ConnectMessage = {
+  type: typeof CONNECT;
+  data: {
+    source: string;
+    unref: boolean;
+  };
+};
+
+export function isConnectMessage(message: unknown): message is ConnectMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === 'connect'
+  );
+}


### PR DESCRIPTION
## Current Behavior
The daemon uses ref counts to shut down automatically when it is not being actively used. Plugin workers are started by the daemon and shut down automatically when the daemon shuts down. If one of these plugins communicates with the daemon, a reference is counted. This plugin worker will not shut down until the daemon shuts down, so its socket will not be closed... so the daemon will stay alive.

## Expected Behavior
Connections to the daemon from a plugin worker do not track a reference. More generally, connections from any source can unref themselves.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
