### PR TITLE
fix(nx-dev): fix heroicons for safari

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/tags/cards.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/cards.component.tsx
@@ -101,9 +101,9 @@ export function Cards({
   );
 }
 
-function callIfFunction(fn: any) {
+function callIfFunction(fn: any, props: { [key: string]: string } = {}) {
   if (typeof fn === 'function') {
-    return fn({});
+    return fn(props);
   }
   return fn;
 }
@@ -142,7 +142,8 @@ export function LinkCard({
             (frameworkIcons[icon as Framework]?.image ||
               callIfFunction(nxDevIcons[icon as keyof typeof nxDevIcons]) ||
               callIfFunction(
-                (heroIcons[icon as keyof typeof heroIcons] as any)?.render
+                (heroIcons[icon as keyof typeof heroIcons] as any)?.render,
+                { className: 'w-full h-full' }
               ))}
         </div>
       )}


### PR DESCRIPTION
Currently safari doesn't show any heroicons because they lack width/height. This fixes that by passing in default width/height classes from tailwind

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
