### PR TITLE
fix(testing): infer correct outputs when absolute paths are provided in playwright config

### DIFF
--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1,8 +1,8 @@
 import { CreateNodesContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
-
-import { createNodesV2 } from './plugin';
 import { PlaywrightTestConfig } from '@playwright/test';
+import { join } from 'node:path';
+import { createNodesV2 } from './plugin';
 
 describe('@nx/playwright/plugin', () => {
   let createNodesFunction = createNodesV2[1];
@@ -139,7 +139,12 @@ describe('@nx/playwright/plugin', () => {
     await mockPlaywrightConfig(tempFs, {
       reporter: [
         ['list'],
-        ['json', { outputFile: 'test-results/report.json' }],
+        [
+          'json',
+          // test absolute path
+          { outputFile: join(tempFs.tempDir, 'test-results/report.json') },
+        ],
+        // test relative path
         ['html', { outputFolder: 'test-results/html' }],
       ],
     });

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from 'node:fs';
-import { dirname, join, parse, relative } from 'node:path';
+import { dirname, join, parse, relative, resolve } from 'node:path';
 
 import {
   CreateNodes,
@@ -188,7 +188,12 @@ async function buildPlaywrightTargets(
         : ['default', '^default']),
       { externalDependencies: ['@playwright/test'] },
     ],
-    outputs: getTargetOutputs(testOutput, reporterOutputs, projectRoot),
+    outputs: getTargetOutputs(
+      testOutput,
+      reporterOutputs,
+      context.workspaceRoot,
+      projectRoot
+    ),
   };
 
   if (options.ciTargetName) {
@@ -201,7 +206,12 @@ async function buildPlaywrightTargets(
           : ['default', '^default']),
         { externalDependencies: ['@playwright/test'] },
       ],
-      outputs: getTargetOutputs(testOutput, reporterOutputs, projectRoot),
+      outputs: getTargetOutputs(
+        testOutput,
+        reporterOutputs,
+        context.workspaceRoot,
+        projectRoot
+      ),
     };
 
     const groupName = 'E2E (CI)';
@@ -236,6 +246,7 @@ async function buildPlaywrightTargets(
           outputs: getTargetOutputs(
             testOutput,
             reporterOutputs,
+            context.workspaceRoot,
             projectRoot,
             outputSubfolder
           ),
@@ -394,27 +405,48 @@ function getReporterOutputs(
 function getTargetOutputs(
   testOutput: string,
   reporterOutputs: Array<[string, string]>,
+  workspaceRoot: string,
   projectRoot: string,
   scope?: string
 ): string[] {
   const outputs = new Set<string>();
   outputs.add(
-    normalizeOutput(projectRoot, scope ? join(testOutput, scope) : testOutput)
+    normalizeOutput(
+      scope ? join(testOutput, scope) : testOutput,
+      workspaceRoot,
+      projectRoot
+    )
   );
   for (const [, output] of reporterOutputs) {
     outputs.add(
-      normalizeOutput(projectRoot, scope ? join(output, scope) : output)
+      normalizeOutput(
+        scope ? join(output, scope) : output,
+        workspaceRoot,
+        projectRoot
+      )
     );
   }
   return Array.from(outputs);
 }
 
-function normalizeOutput(projectRoot: string, path: string): string {
-  if (path.startsWith('..')) {
-    return join('{workspaceRoot}', join(projectRoot, path));
-  } else {
-    return join('{projectRoot}', path);
+function normalizeOutput(
+  path: string,
+  workspaceRoot: string,
+  projectRoot: string
+): string {
+  const fullProjectRoot = resolve(workspaceRoot, projectRoot);
+  const fullPath = resolve(fullProjectRoot, path);
+  const pathRelativeToProjectRoot = normalizePath(
+    relative(fullProjectRoot, fullPath)
+  );
+  if (pathRelativeToProjectRoot.startsWith('..')) {
+    return joinPathFragments(
+      '{workspaceRoot}',
+      relative(workspaceRoot, fullPath)
+    );
   }
+
+  return joinPathFragments('{projectRoot}', pathRelativeToProjectRoot);
 }
 
 function getOutputEnvVars(


### PR DESCRIPTION
Update `@nx/playwright/plugin` to properly handle absolute paths set in the playwright config to infer outputs correctly.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
