### PR TITLE
feat(core): allow tasks to run with a substring of project name

### DIFF
--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -46,6 +46,28 @@ describe('Nx Running Tests', () => {
         });
       });
 
+      it('should support running using a substring of the project name', () => {
+        // Note: actual project name will have some numbers at the end.
+        expect(() => runCLI(`echo proj`)).not.toThrow();
+      });
+
+      it('should error when multiple projects match a substring', () => {
+        const test1 = uniq('test1');
+        const test2 = uniq('test2');
+        runCLI(`generate @nx/js:lib libs/${test1}`);
+        runCLI(`generate @nx/js:lib libs/${test2}`);
+        updateJson(`libs/${test1}/project.json`, (c) => {
+          c.targets['echo'] = { command: 'echo TEST' };
+          return c;
+        });
+        updateJson(`libs/${test2}/project.json`, (c) => {
+          c.targets['echo'] = { command: 'echo TEST' };
+          return c;
+        });
+
+        expect(() => runCLI(`echo test`)).toThrow();
+      });
+
       it.each([
         '--watch false',
         '--watch=false',

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -129,7 +129,11 @@ function getProjects(
       };
     } else if (matchingProjects.length > 1) {
       output.error({
-        title: `Multiple projects matched:\n- ${matchingProjects.join('\n- ')}`,
+        title: `Multiple projects matched:`,
+        bodyLines:
+          matchingProjects.length > 100
+            ? [...matchingProjects.slice(0, 100), '...']
+            : matchingProjects,
       });
       process.exit(1);
     }

--- a/packages/nx/src/command-line/show/project.ts
+++ b/packages/nx/src/command-line/show/project.ts
@@ -9,10 +9,25 @@ export async function showProjectHandler(
   performance.mark('code-loading:end');
   performance.measure('code-loading', 'init-local', 'code-loading:end');
   const graph = await createProjectGraphAsync();
-  const node = graph.nodes[args.projectName];
+  let node = graph.nodes[args.projectName];
   if (!node) {
-    console.log(`Could not find project ${args.projectName}`);
-    process.exit(1);
+    const matchingProjects = Object.keys(graph.nodes).filter((name) =>
+      name.includes(args.projectName)
+    );
+    if (matchingProjects.length === 1) {
+      node = graph.nodes[matchingProjects[0]];
+    } else if (matchingProjects.length > 1) {
+      console.log(
+        `Multiple projects matched:\n  ${(matchingProjects.length > 100
+          ? [...matchingProjects.slice(0, 100), '...']
+          : matchingProjects
+        ).join('  \n')}`
+      );
+      process.exit(1);
+    } else {
+      console.log(`Could not find project ${args.projectName}`);
+      process.exit(1);
+    }
   }
   if (args.json) {
     console.log(JSON.stringify(node.data));

--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -47,6 +47,39 @@ describe('findMatchingProjects', () => {
         tags: [],
       },
     },
+    '@acme/foo': {
+      name: '@acme/foo',
+      type: 'lib',
+      data: {
+        root: 'lib/foo',
+        tags: [],
+      },
+    },
+    '@acme/bar': {
+      name: '@acme/bar',
+      type: 'lib',
+      data: {
+        root: 'lib/bar',
+        tags: [],
+      },
+    },
+    foo_bar1: {
+      name: 'foo_bar11',
+      type: 'lib',
+      data: {
+        root: 'lib/foo_bar1',
+        tags: [],
+      },
+    },
+    // Technically, this isn't a valid npm package name, but we can handle it anyway just in case.
+    '@acme/nested/foo': {
+      name: '@acme/nested/foo',
+      type: 'lib',
+      data: {
+        root: 'lib/nested/foo',
+        tags: [],
+      },
+    },
   };
 
   it('should return no projects when passed no patterns', () => {
@@ -68,6 +101,10 @@ describe('findMatchingProjects', () => {
       'b',
       'c',
       'nested',
+      '@acme/foo',
+      '@acme/bar',
+      'foo_bar1',
+      '@acme/nested/foo',
     ]);
   });
 
@@ -77,6 +114,10 @@ describe('findMatchingProjects', () => {
       'b',
       'c',
       'nested',
+      '@acme/foo',
+      '@acme/bar',
+      'foo_bar1',
+      '@acme/nested/foo',
     ]);
     expect(findMatchingProjects(['a', '!*'], projectGraph)).toEqual([]);
   });
@@ -120,6 +161,10 @@ describe('findMatchingProjects', () => {
       'b',
       'c',
       'nested',
+      '@acme/foo',
+      '@acme/bar',
+      'foo_bar1',
+      '@acme/nested/foo',
     ]);
   });
 
@@ -131,7 +176,7 @@ describe('findMatchingProjects', () => {
       projectGraph
     );
     expect(matches).toEqual(expect.arrayContaining(['a', 'b', 'nested']));
-    expect(matches.length).toEqual(3);
+    expect(matches.length).toEqual(7);
   });
 
   it('should expand generic glob patterns for tags', () => {
@@ -156,6 +201,9 @@ describe('findMatchingProjects', () => {
       'test-project',
       'a',
       'b',
+      '@acme/foo',
+      '@acme/bar',
+      'foo_bar1',
     ]);
     expect(findMatchingProjects(['apps/*'], projectGraph)).toEqual(['c']);
     expect(findMatchingProjects(['**/nested'], projectGraph)).toEqual([
@@ -169,21 +217,50 @@ describe('findMatchingProjects', () => {
       'b',
       'c',
       'nested',
+      '@acme/foo',
+      '@acme/bar',
+      'foo_bar1',
+      '@acme/nested/foo',
     ]);
     expect(findMatchingProjects(['!tag:api'], projectGraph)).toEqual([
       'b',
       'nested',
+      '@acme/foo',
+      '@acme/bar',
+      'foo_bar1',
+      '@acme/nested/foo',
     ]);
     expect(
       findMatchingProjects(['!tag:api', 'test-project'], projectGraph)
-    ).toEqual(['b', 'nested', 'test-project']);
+    ).toEqual([
+      'b',
+      'nested',
+      '@acme/foo',
+      '@acme/bar',
+      'foo_bar1',
+      '@acme/nested/foo',
+      'test-project',
+    ]);
   });
 
-  it('should match on substring of names', () => {
-    expect(findMatchingProjects(['test', 'nest'], projectGraph)).toEqual([
-      'test-project',
-      'nested',
+  it('should match on name segments', () => {
+    expect(findMatchingProjects(['foo'], projectGraph)).toEqual([
+      '@acme/foo',
+      'foo_bar1',
+      '@acme/nested/foo',
     ]);
+    expect(findMatchingProjects(['bar'], projectGraph)).toEqual(['@acme/bar']);
+    // Case insensitive
+    expect(findMatchingProjects(['Bar1'], projectGraph)).toEqual(['foo_bar1']);
+    expect(findMatchingProjects(['foo_bar1'], projectGraph)).toEqual([
+      'foo_bar1',
+    ]);
+    expect(findMatchingProjects(['nested/foo'], projectGraph)).toEqual([
+      '@acme/nested/foo',
+    ]);
+    // Only full segments are matched
+    expect(findMatchingProjects(['fo'], projectGraph)).toEqual([]);
+    expect(findMatchingProjects(['nested/fo'], projectGraph)).toEqual([]);
   });
 });
 

--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -178,6 +178,13 @@ describe('findMatchingProjects', () => {
       findMatchingProjects(['!tag:api', 'test-project'], projectGraph)
     ).toEqual(['b', 'nested', 'test-project']);
   });
+
+  it('should match on substring of names', () => {
+    expect(findMatchingProjects(['test', 'nest'], projectGraph)).toEqual([
+      'test-project',
+      'nested',
+    ]);
+  });
 });
 
 const projects = [

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -167,6 +167,20 @@ function addMatchingProjectsByName(
   }
 
   if (!isGlobPattern(pattern.value)) {
+    // Only matching substrings when string is long enough, otherwise there will be too many matches.
+    // This is consistent with the behavior of run-one.ts.
+    if (pattern.value.length > 1) {
+      const matchingProjects = Object.keys(projects).filter((name) =>
+        name.includes(pattern.value)
+      );
+      for (const projectName of matchingProjects) {
+        if (pattern.exclude) {
+          matchedProjects.delete(projectName);
+        } else {
+          matchedProjects.add(projectName);
+        }
+      }
+    }
     return;
   }
 

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -167,18 +167,19 @@ function addMatchingProjectsByName(
   }
 
   if (!isGlobPattern(pattern.value)) {
-    // Only matching substrings when string is long enough, otherwise there will be too many matches.
-    // This is consistent with the behavior of run-one.ts.
-    if (pattern.value.length > 1) {
-      const matchingProjects = Object.keys(projects).filter((name) =>
-        name.includes(pattern.value)
-      );
-      for (const projectName of matchingProjects) {
-        if (pattern.exclude) {
-          matchedProjects.delete(projectName);
-        } else {
-          matchedProjects.add(projectName);
-        }
+    // Custom regex that is basically \b without underscores, so "foo" pattern matches "foo_bar".
+    const regex = new RegExp(
+      `(?<![a-zA-Z0-9])${pattern.value}(?![a-zA-Z0-9])`,
+      'i'
+    );
+    const matchingProjects = Object.keys(projects).filter((name) =>
+      regex.test(name)
+    );
+    for (const projectName of matchingProjects) {
+      if (pattern.exclude) {
+        matchedProjects.delete(projectName);
+      } else {
+        matchedProjects.add(projectName);
       }
     }
     return;


### PR DESCRIPTION
When projects use only `package.json` and not `project.json`, we need to set the simple name in the `nx` property of `package.json`. This isn't ideal because it's yet another Nx-specific thing that needs to be configured when our goal is to reduce boilerplate.

This PR allows users to pass a substring that matches exactly one project when running a task.

For example, if `@acme/foo` is the name in `package.json`, then running `nx build foo` will match it.

If more than one projects match, then an error is thrown showing all the matched projects, and the user has to be more specific or type in the fully qualified name.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Users need to pass exact matches for project names when running tasks.

## Expected Behavior
User can pass a substring matching the project name.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
