### PR TITLE
fix(core): update nx cloud bundle install directory logic

### DIFF
--- a/packages/nx/src/nx-cloud/update-manager.ts
+++ b/packages/nx/src/nx-cloud/update-manager.ts
@@ -19,6 +19,7 @@ import { cacheDir } from '../utils/cache-directory';
 import { createHash } from 'crypto';
 import { TasksRunner } from '../tasks-runner/tasks-runner';
 import { RemoteCacheV2 } from '../tasks-runner/default-tasks-runner';
+import { workspaceRoot } from '../utils/workspace-root';
 
 interface CloudBundleInstall {
   version: string;
@@ -150,7 +151,26 @@ export async function verifyOrUpdateNxCloudClient(
     nxCloudClient: require(currentBundle.fullPath),
   };
 }
-const runnerBundleInstallDirectory = join(cacheDir, 'cloud');
+
+function getBundleInstallDefaultLocation() {
+  const legacyPath = join(
+    workspaceRoot,
+    'node_modules',
+    '.cache',
+    'nx',
+    'cloud'
+  );
+
+  // this legacy path is used when the nx-cloud package is installed.
+  // make sure to reuse it so that we don't `require` different the client bundles
+  if (existsSync(legacyPath)) {
+    return legacyPath;
+  } else {
+    return join(cacheDir, 'cloud');
+  }
+}
+
+const runnerBundleInstallDirectory = getBundleInstallDefaultLocation();
 
 function getLatestInstalledRunnerBundle(): CloudBundleInstall | null {
   if (!existsSync(runnerBundleInstallDirectory)) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Whenever the `nx-cloud` package is installed in a workspace, we get errors about certain properties not being instantiated. 

This happens because the old `nx-cloud` package placed the nx cloud bundle in `node_modules/.cache/nx/cloud`. 

Nx will then eventually try to use the cloud bundle, and not look into the `node_modules/.cache/nx/cloud` directory, and instead look into `.nx/cache/cloud`. Because the bundle doesnt exist in the `.nx/cache/cloud` location, we will redownload the bundle, and not properly instantiate it. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx will now look into the legacy location in `node_modules/.cache/nx/cloud` when trying to get the cloud bundle.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
