### PR TITLE
fix(js): generate js libs with exports in package.json and ensure esm output when using rollup bundler

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -48,7 +48,7 @@ describe('EsBuild Plugin', () => {
       private: true,
       type: 'commonjs',
       main: './index.cjs',
-      typings: './index.d.ts',
+      types: './index.d.ts',
       dependencies: {},
     });
 

--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -567,7 +567,7 @@ describe('Linter', () => {
           name: `@proj/${mylib}`,
           private: true,
           type: 'commonjs',
-          typings: './src/index.d.ts',
+          types: './src/index.d.ts',
           version: '0.0.1',
         });
 

--- a/e2e/node/src/node-ts-solution.test.ts
+++ b/e2e/node/src/node-ts-solution.test.ts
@@ -116,9 +116,11 @@ packages:
     expect(() => runCLI(`lint ${nodeapp}`)).not.toThrow();
     expect(() => runCLI(`test ${nodeapp}`)).not.toThrow();
     expect(() => runCLI(`build ${nodeapp}`)).not.toThrow();
+    expect(() => runCLI(`typecheck ${nodeapp}`)).not.toThrow();
     expect(() => runCLI(`lint ${nodelib}`)).not.toThrow();
     expect(() => runCLI(`test ${nodelib}`)).not.toThrow();
     expect(() => runCLI(`build ${nodelib}`)).not.toThrow();
+    expect(() => runCLI(`typecheck ${nodelib}`)).not.toThrow();
 
     const p = await runCommandUntil(
       `serve ${nodeapp}`,

--- a/packages/express/src/generators/application/application.ts
+++ b/packages/express/src/generators/application/application.ts
@@ -82,6 +82,7 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
   const applicationTask = await nodeApplicationGenerator(tree, {
     ...options,
     bundler: 'webpack',
+    framework: 'express',
     skipFormat: true,
   });
   tasks.push(applicationTask);

--- a/packages/jest/src/generators/configuration/lib/create-files.ts
+++ b/packages/jest/src/generators/configuration/lib/create-files.ts
@@ -62,7 +62,8 @@ export function createFiles(
       ? `${rootOffset}tsconfig.base.json`
       : './tsconfig.json',
     outDir: isTsSolutionSetup ? `./out-tsc/jest` : `${rootOffset}dist/out-tsc`,
-    module: !isTsSolutionSetup ? 'commonjs' : undefined,
+    module:
+      !isTsSolutionSetup || transformer === 'ts-jest' ? 'commonjs' : undefined,
   });
 
   if (options.setupFile === 'none') {

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1688,6 +1688,7 @@ describe('lib', () => {
           },
           "exports": {
             ".": {
+              "default": "./dist/index.js",
               "import": "./dist/index.js",
               "types": "./dist/index.d.ts",
             },
@@ -1720,6 +1721,7 @@ describe('lib', () => {
           },
           "exports": {
             ".": {
+              "default": "./dist/index.js",
               "import": "./dist/index.js",
               "types": "./dist/index.d.ts",
             },

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1653,6 +1653,14 @@ describe('lib', () => {
       expect(readJson(tree, 'my-ts-lib/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {},
+          "exports": {
+            ".": {
+              "default": "./src/index.ts",
+              "import": "./src/index.ts",
+              "types": "./src/index.ts",
+            },
+            "./package.json": "./package.json",
+          },
           "main": "./src/index.ts",
           "name": "@proj/my-ts-lib",
           "private": true,
@@ -1663,6 +1671,10 @@ describe('lib', () => {
       expect(readJson(tree, 'my-js-lib/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {},
+          "exports": {
+            ".": "./src/index.js",
+            "./package.json": "./package.json",
+          },
           "main": "./src/index.js",
           "name": "@proj/my-js-lib",
           "private": true,

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1686,11 +1686,19 @@ describe('lib', () => {
           "dependencies": {
             "tslib": "^2.3.0",
           },
+          "exports": {
+            ".": {
+              "import": "./dist/index.js",
+              "types": "./dist/index.d.ts",
+            },
+            "./package.json": "./package.json",
+          },
           "main": "./dist/index.js",
+          "module": "./dist/index.js",
           "name": "@proj/my-ts-lib",
           "private": true,
           "type": "module",
-          "typings": "./dist/index.d.ts",
+          "types": "./dist/index.d.ts",
           "version": "0.0.1",
         }
       `);
@@ -1710,11 +1718,19 @@ describe('lib', () => {
           "dependencies": {
             "@swc/helpers": "~0.5.11",
           },
+          "exports": {
+            ".": {
+              "import": "./dist/index.js",
+              "types": "./dist/index.d.ts",
+            },
+            "./package.json": "./package.json",
+          },
           "main": "./dist/index.js",
+          "module": "./dist/index.js",
           "name": "@proj/my-ts-lib",
           "private": true,
           "type": "module",
-          "typings": "./dist/index.d.ts",
+          "types": "./dist/index.d.ts",
           "version": "0.0.1",
         }
       `);

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -1139,7 +1139,6 @@ function determineEntryFields(
         return {
           type: 'module',
           main: './dist/index.js',
-          module: './dist/index.js',
           types: './dist/index.d.ts',
         };
       } else {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -1185,23 +1185,32 @@ function determineEntryFields(
           types: './index.d.ts',
         };
       }
-    default: {
+    case 'none': {
+      if (options.isUsingTsSolutionConfig) {
+        return {
+          main: options.js ? './src/index.js' : './src/index.ts',
+          types: options.js ? './src/index.js' : './src/index.ts',
+          exports: {
+            '.': options.js
+              ? './src/index.js'
+              : {
+                  types: './src/index.ts',
+                  import: './src/index.ts',
+                  default: './src/index.ts',
+                },
+            './package.json': './package.json',
+          },
+        };
+      }
+
       return {
         // Safest option is to not set a type field.
         // Allow the user to decide which module format their library is using
         type: undefined,
-        // For non-buildable libraries, point to source so we can still use them in apps via bundlers like Vite.
-        main: options.isUsingTsSolutionConfig
-          ? options.js
-            ? './src/index.js'
-            : './src/index.ts'
-          : undefined,
-        types: options.isUsingTsSolutionConfig
-          ? options.js
-            ? './src/index.js'
-            : './src/index.ts'
-          : undefined,
       };
+    }
+    default: {
+      return {};
     }
   }
 }

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -1177,7 +1177,6 @@ function determineEntryFields(
         return {
           type: 'module',
           main: './dist/index.js',
-          module: './dist/index.js',
           types: './dist/index.d.ts',
         };
       } else {

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -144,7 +144,7 @@ export async function setupBuildGenerator(
         tsConfig: tsConfigFile,
         project: options.project,
         compiler: 'tsc',
-        format: ['cjs', 'esm'],
+        format: isTsSolutionSetup ? ['esm'] : ['cjs', 'esm'],
         addPlugin,
         skipFormat: true,
         skipValidation: true,

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1919,7 +1919,18 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
-        'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
+        'libs/my-lib/package.json': JSON.stringify({
+          main: 'dist/index.js',
+          types: 'dist/index.d.ts',
+          exports: {
+            '.': {
+              types: './dist/index.d.ts',
+              import: './dist/index.js',
+              default: './dist/index.js',
+            },
+            './package.json': './package.json',
+          },
+        }),
       });
       expect(
         await invokeCreateNodesOnMatchingFiles(context, {

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -633,18 +633,17 @@ function getOutputs(
  * @returns `true` if the package has a valid build configuration; otherwise, `false`.
  */
 function isValidPackageJsonBuildConfig(
-  tsConfig,
+  tsConfig: ParsedCommandLine,
   workspaceRoot: string,
   projectRoot: string
 ): boolean {
-  if (!existsSync(joinPathFragments(projectRoot, 'package.json'))) {
+  const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json');
+  if (!existsSync(packageJsonPath)) {
     // If the package.json file does not exist.
     // Assume it's valid because it would be using `project.json` instead.
     return true;
   }
-  const packageJson = readJsonFile(
-    joinPathFragments(projectRoot, 'package.json')
-  );
+  const packageJson = readJsonFile(packageJsonPath);
 
   const outDir = tsConfig.options.outFile
     ? dirname(tsConfig.options.outFile)
@@ -691,10 +690,9 @@ function isValidPackageJsonBuildConfig(
   if (exports) {
     if (typeof exports === 'string') {
       return !isPathSourceFile(exports);
-    } else if (typeof exports === 'object' && '.' in exports) {
-      if (containsInvalidPath(exports['.'])) {
-        return false;
-      }
+    }
+    if (typeof exports === 'object' && '.' in exports) {
+      return !containsInvalidPath(exports['.']);
     }
 
     // Check other exports if `.` is not defined or valid.

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -723,9 +723,16 @@ function pathToInputOrOutput(
   workspaceRoot: string,
   projectRoot: string
 ): string {
-  const pathRelativeToProjectRoot = normalizePath(relative(projectRoot, path));
+  const fullProjectRoot = resolve(workspaceRoot, projectRoot);
+  const fullPath = resolve(workspaceRoot, path);
+  const pathRelativeToProjectRoot = normalizePath(
+    relative(fullProjectRoot, fullPath)
+  );
   if (pathRelativeToProjectRoot.startsWith('..')) {
-    return joinPathFragments('{workspaceRoot}', relative(workspaceRoot, path));
+    return joinPathFragments(
+      '{workspaceRoot}',
+      relative(workspaceRoot, fullPath)
+    );
   }
 
   return joinPathFragments('{projectRoot}', pathRelativeToProjectRoot);

--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -157,6 +157,7 @@ describe('getUpdatedPackageJsonContent', () => {
         version: '0.0.1',
         exports: {
           '.': {
+            default: './src/index.js',
             import: './src/index.js',
             types: './src/index.d.ts',
           },
@@ -268,6 +269,7 @@ describe('getUpdatedPackageJsonContent', () => {
         version: '0.0.1',
         exports: {
           '.': {
+            default: './src/index.js',
             import: './src/index.js',
             types: './src/index.d.ts',
           },

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -326,6 +326,9 @@ export function getUpdatedPackageJsonContent(
             : filePath;
         } else if (typeof packageJson.exports[exportEntry] === 'object') {
           packageJson.exports[exportEntry].import ??= filePath;
+          if (!hasCjsFormat) {
+            packageJson.exports[exportEntry].default ??= filePath;
+          }
         }
       }
     }

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -8,9 +8,9 @@ import {
   updateJson,
   workspaceRoot,
 } from '@nx/devkit';
+import { basename, dirname, join } from 'node:path/posix';
 import { FsTree } from 'nx/src/generators/tree';
 import { isUsingPackageManagerWorkspaces } from '../package-manager-workspaces';
-import { basename, dirname, join, relative } from 'node:path/posix';
 
 export function isUsingTypeScriptPlugin(tree: Tree): boolean {
   const nxJson = readNxJson(tree);

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -433,6 +433,8 @@ describe('lib', () => {
       expect(readJson(tree, 'mylib/tsconfig.spec.json')).toMatchInlineSnapshot(`
         {
           "compilerOptions": {
+            "module": "commonjs",
+            "moduleResolution": "node10",
             "outDir": "./out-tsc/jest",
             "types": [
               "jest",

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -652,6 +652,7 @@ describe('lib', () => {
           },
           "exports": {
             ".": {
+              "default": "./dist/index.js",
               "import": "./dist/index.js",
               "types": "./dist/index.d.ts",
             },
@@ -681,7 +682,6 @@ describe('lib', () => {
             },
           },
           "private": true,
-          "type": "module",
           "types": "./dist/index.d.ts",
           "version": "0.0.1",
         }

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -612,6 +612,8 @@ describe('lib', () => {
       expect(readJson(tree, 'mylib/tsconfig.spec.json')).toMatchInlineSnapshot(`
         {
           "compilerOptions": {
+            "module": "commonjs",
+            "moduleResolution": "node10",
             "outDir": "./out-tsc/jest",
             "types": [
               "jest",
@@ -648,7 +650,15 @@ describe('lib', () => {
           "dependencies": {
             "tslib": "^2.3.0",
           },
+          "exports": {
+            ".": {
+              "import": "./dist/index.js",
+              "types": "./dist/index.d.ts",
+            },
+            "./package.json": "./package.json",
+          },
           "main": "./dist/index.js",
+          "module": "./dist/index.js",
           "name": "@proj/mylib",
           "nx": {
             "name": "mylib",
@@ -672,7 +682,7 @@ describe('lib', () => {
           },
           "private": true,
           "type": "module",
-          "typings": "./dist/index.d.ts",
+          "types": "./dist/index.d.ts",
           "version": "0.0.1",
         }
       `);

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -556,6 +556,14 @@ describe('lib', () => {
       expect(readJson(tree, 'mylib/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {},
+          "exports": {
+            ".": {
+              "default": "./src/index.ts",
+              "import": "./src/index.ts",
+              "types": "./src/index.ts",
+            },
+            "./package.json": "./package.json",
+          },
           "main": "./src/index.ts",
           "name": "@proj/mylib",
           "nx": {

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -1226,6 +1226,7 @@ module.exports = withNx(
         {
           "exports": {
             ".": {
+              "default": "./dist/index.esm.js",
               "import": "./dist/index.esm.js",
               "types": "./dist/index.esm.d.ts",
             },

--- a/packages/vite/src/generators/configuration/configuration.spec.ts
+++ b/packages/vite/src/generators/configuration/configuration.spec.ts
@@ -370,6 +370,7 @@ describe('@nx/vite:configuration', () => {
         {
           "exports": {
             ".": {
+              "default": "./dist/index.js",
               "import": "./dist/index.js",
               "types": "./dist/index.d.ts",
             },


### PR DESCRIPTION
- Ensure libs are generated with `exports` in `package.json`
- Generate `types` instead of `typings` in package.json
- Update js lib with rollup to only output esm
- Update `tsconfig.spec.json` for js libraries with rollup to set `module: esnext` and `moduleResolution: bundler` (they use `@swc/jest`)
- Fix `@nx/js/typescript` issue with absolute paths when normalizing inputs/outputs
- Fix `@nx/js/typescript` issue identifying buildable libs
- Fix express app generator not installing `@types/express`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
