### PR TITLE
fix(js): update detection of ts solution setup

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -2905,7 +2905,6 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     },
                     "outputs": [
                       "{workspaceRoot}/dist/libs/my-lib",
-                      "{workspaceRoot}/dist/libs/*.tsbuildinfo",
                     ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
@@ -3066,7 +3065,6 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{workspaceRoot}/dist/libs/my-lib/lib.d.ts.map",
                       "{workspaceRoot}/dist/libs/my-lib/lib.tsbuildinfo",
                       "{workspaceRoot}/dist/libs/my-lib/other",
-                      "{workspaceRoot}/dist/libs/my-lib/*.tsbuildinfo",
                     ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -62,7 +62,7 @@ function isWorkspaceSetupWithTsSolution(tree: Tree): boolean {
   if (
     !baseTsconfigJson.compilerOptions ||
     !baseTsconfigJson.compilerOptions.composite ||
-    !baseTsconfigJson.compilerOptions.declaration
+    baseTsconfigJson.compilerOptions.declaration === false
   ) {
     return false;
   }


### PR DESCRIPTION
Since we simplified `tsconfig.base.json`'s `compilerOptions` to not include values that match defaults (as per Jake's feedback), the logic to detect TS solution setup should check that `declaration` is explicitly set to `false`, rather than that it is falsy.


Clean up PR: https://github.com/nrwl/nx/pull/29550

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
We're not detecting TS solution setup correctly

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Detection works

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
