### PR TITLE
feat(web): add support for TS solution setup for @nx/web

### DIFF
--- a/docs/generated/packages/web/generators/application.json
+++ b/docs/generated/packages/web/generators/application.json
@@ -51,8 +51,8 @@
       "bundler": {
         "type": "string",
         "description": "The bundler to use.",
-        "enum": ["webpack", "none", "vite"],
-        "default": "webpack",
+        "enum": ["vite", "webpack", "none"],
+        "default": "vite",
         "x-prompt": "Which bundler do you want to use?",
         "x-priority": "important"
       },
@@ -60,7 +60,8 @@
         "description": "The tool to use for running lint checks.",
         "type": "string",
         "enum": ["eslint", "none"],
-        "default": "eslint"
+        "default": "none",
+        "x-prompt": "Which linter would you like to use?"
       },
       "skipFormat": {
         "description": "Skip formatting files",
@@ -71,8 +72,9 @@
       "unitTestRunner": {
         "type": "string",
         "enum": ["vitest", "jest", "none"],
-        "default": "vitest",
-        "description": "Test runner to use for unit tests. Default value is 'jest' when using 'webpack' or 'none' as the bundler and 'vitest' when using 'vite' as the bundler"
+        "default": "none",
+        "description": "Test runner to use for unit tests. Default value is 'jest' when using 'webpack' or 'none' as the bundler and 'vitest' when using 'vite' as the bundler",
+        "x-prompt": "What unit test runner should be used?"
       },
       "inSourceTests": {
         "type": "boolean",
@@ -99,12 +101,6 @@
         "type": "boolean",
         "description": "Creates an application with strict mode and strict type checking.",
         "default": true
-      },
-      "standaloneConfig": {
-        "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside workspace.json",
-        "type": "boolean",
-        "default": true,
-        "x-deprecated": "Nx only supports standaloneConfig"
       }
     },
     "required": ["directory"],

--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -22,7 +22,9 @@ describe('file-server', () => {
     const appName = uniq('app');
     const port = 4301;
 
-    runCLI(`generate @nx/web:app apps/${appName} --no-interactive`);
+    runCLI(
+      `generate @nx/web:app apps/${appName} --no-interactive --bundler=webpack`
+    );
     updateJson(join('apps', appName, 'project.json'), (config) => {
       config.targets['serve'] = {
         executor: '@nx/web:file-server',
@@ -52,7 +54,9 @@ describe('file-server', () => {
     const appName = uniq('app');
     const port = 4301;
 
-    runCLI(`generate @nx/web:app apps/${appName} --no-interactive`);
+    runCLI(
+      `generate @nx/web:app apps/${appName} --no-interactive --bundler=webpack`
+    );
     // Used to copy index.html rather than the normal webpack build.
     updateFile(
       `apps/${appName}/copy-index.js`,

--- a/e2e/web/src/web-vite.test.ts
+++ b/e2e/web/src/web-vite.test.ts
@@ -19,7 +19,7 @@ describe('Web Components Applications with bundler set as vite', () => {
   it('should be able to generate a web app', async () => {
     const appName = uniq('app');
     runCLI(
-      `generate @nx/web:app apps/${appName} --bundler=vite --no-interactive`
+      `generate @nx/web:app apps/${appName} --bundler=vite --no-interactive --linter=eslint --unitTestRunner=vitest`
     );
 
     const lintResults = runCLI(`lint ${appName}`);
@@ -50,10 +50,10 @@ describe('Web Components Applications with bundler set as vite', () => {
     const libName = uniq('lib');
 
     runCLI(
-      `generate @nx/web:app apps/${appName} --bundler=vite --no-interactive`
+      `generate @nx/web:app apps/${appName} --bundler=vite --no-interactive --linter=eslint --unitTestRunner=vitest`
     );
     runCLI(
-      `generate @nx/react:lib libs/${libName} --bundler=vite --no-interactive --unitTestRunner=vitest`
+      `generate @nx/react:lib libs/${libName} --bundler=vite --no-interactive --unitTestRunner=vitest --linter=eslint`
     );
 
     createFile(`dist/apps/${appName}/_should_remove.txt`);

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -26,7 +26,7 @@ describe('Web Components Applications', () => {
   it('should be able to generate a web app', async () => {
     const appName = uniq('app');
     runCLI(
-      `generate @nx/web:app apps/${appName} --bundler=webpack --no-interactive`
+      `generate @nx/web:app apps/${appName} --bundler=webpack --no-interactive --unitTestRunner=vitest --linter=eslint`
     );
 
     const lintResults = runCLI(`lint ${appName}`);
@@ -110,7 +110,7 @@ describe('Web Components Applications', () => {
   it('should emit decorator metadata when --compiler=babel and it is enabled in tsconfig', async () => {
     const appName = uniq('app');
     runCLI(
-      `generate @nx/web:app apps/${appName} --bundler=webpack --compiler=babel --no-interactive`
+      `generate @nx/web:app apps/${appName} --bundler=webpack --compiler=babel --no-interactive --unitTestRunner=vitest --linter=eslint`
     );
 
     updateFile(`apps/${appName}/src/app/app.element.ts`, (content) => {
@@ -175,7 +175,7 @@ describe('Web Components Applications', () => {
   it('should emit decorator metadata when using --compiler=swc', async () => {
     const appName = uniq('app');
     runCLI(
-      `generate @nx/web:app apps/${appName} --bundler=webpack --compiler=swc --no-interactive`
+      `generate @nx/web:app apps/${appName} --bundler=webpack --compiler=swc --no-interactive --unitTestRunner=vitest --linter=eslint`
     );
 
     updateFile(`apps/${appName}/src/app/app.element.ts`, (content) => {
@@ -223,7 +223,7 @@ describe('Web Components Applications', () => {
     const appName = uniq('app1');
 
     runCLI(
-      `generate @nx/web:app ${appName} --bundler=webpack --no-interactive`
+      `generate @nx/web:app ${appName} --bundler=webpack --no-interactive --unitTestRunner=vitest --linter=eslint`
     );
 
     // check files are generated without the layout directory ("apps/") and
@@ -285,7 +285,7 @@ describe('CLI - Environment Variables', () => {
       `;
 
     runCLI(
-      `generate @nx/web:app apps/${appName} --bundler=webpack --no-interactive --compiler=babel`
+      `generate @nx/web:app apps/${appName} --bundler=webpack --no-interactive --compiler=babel --unitTestRunner=vitest --linter=eslint`
     );
 
     const content = readFile(main);
@@ -310,7 +310,7 @@ describe('CLI - Environment Variables', () => {
     const newCode2 = `const envVars = [process.env.NODE_ENV, process.env.NX_PUBLIC_WS_BASE, process.env.NX_PUBLIC_WS_ENV_LOCAL, process.env.NX_PUBLIC_WS_LOCAL_ENV, process.env.NX_PUBLIC_APP_BASE, process.env.NX_PUBLIC_APP_ENV_LOCAL, process.env.NX_PUBLIC_APP_LOCAL_ENV, process.env.NX_PUBLIC_SHARED_ENV];`;
 
     runCLI(
-      `generate @nx/web:app apps/${appName2} --bundler=webpack --no-interactive --compiler=babel`
+      `generate @nx/web:app apps/${appName2} --bundler=webpack --no-interactive --compiler=babel --unitTestRunner=vitest --linter=eslint`
     );
 
     const content2 = readFile(main2);
@@ -351,7 +351,7 @@ describe('index.html interpolation', () => {
     const appName = uniq('app');
 
     runCLI(
-      `generate @nx/web:app apps/${appName} --bundler=webpack --no-interactive`
+      `generate @nx/web:app apps/${appName} --bundler=webpack --no-interactive --unitTestRunner=vitest --linter=eslint`
     );
 
     const srcPath = `apps/${appName}/src`;

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -5,7 +5,9 @@ import {
   readNxJson,
   readProjectConfiguration,
   Tree,
+  updateJson,
   updateNxJson,
+  writeJson,
 } from '@nx/devkit';
 import { getProjects, readJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -692,6 +694,163 @@ describe('app', () => {
       expect(
         viteAppTree.exists('/insource-tests/src/app/app.element.spec.ts')
       ).toBe(false);
+    });
+  });
+
+  describe('TS solution setup', () => {
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => {
+        json.workspaces = ['packages/*', 'apps/*'];
+        return json;
+      });
+      writeJson(tree, 'tsconfig.base.json', {
+        compilerOptions: {
+          composite: true,
+          declaration: true,
+        },
+      });
+      writeJson(tree, 'tsconfig.json', {
+        extends: './tsconfig.base.json',
+        files: [],
+        references: [],
+      });
+    });
+
+    it('should add project references when using TS solution', async () => {
+      await applicationGenerator(tree, {
+        directory: 'apps/myapp',
+        addPlugin: true,
+        linter: 'none',
+        style: 'none',
+        bundler: 'vite',
+        unitTestRunner: 'vitest',
+        e2eTestRunner: 'playwright',
+      });
+
+      expect(readJson(tree, 'tsconfig.json').references).toMatchInlineSnapshot(`
+        [
+          {
+            "path": "./apps/myapp-e2e",
+          },
+          {
+            "path": "./apps/myapp",
+          },
+        ]
+      `);
+      expect(readJson(tree, 'apps/myapp/tsconfig.json')).toMatchInlineSnapshot(`
+        {
+          "extends": "../../tsconfig.base.json",
+          "files": [],
+          "include": [],
+          "references": [
+            {
+              "path": "./tsconfig.app.json",
+            },
+            {
+              "path": "./tsconfig.spec.json",
+            },
+          ],
+        }
+      `);
+      expect(readJson(tree, 'apps/myapp/tsconfig.app.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "compilerOptions": {
+            "module": "esnext",
+            "moduleResolution": "bundler",
+            "outDir": "out-tsc/myapp",
+            "rootDir": "src",
+            "tsBuildInfoFile": "out-tsc/myapp/tsconfig.app.tsbuildinfo",
+            "types": [
+              "node",
+            ],
+          },
+          "exclude": [
+            "out-tsc",
+            "dist",
+            "src/**/*.spec.ts",
+            "src/**/*.test.ts",
+            "vite.config.ts",
+            "vite.config.mts",
+            "vitest.config.ts",
+            "vitest.config.mts",
+            "src/**/*.test.tsx",
+            "src/**/*.spec.tsx",
+            "src/**/*.test.js",
+            "src/**/*.spec.js",
+            "src/**/*.test.jsx",
+            "src/**/*.spec.jsx",
+          ],
+          "extends": "../../tsconfig.base.json",
+          "include": [
+            "src/**/*.ts",
+          ],
+        }
+      `);
+      expect(readJson(tree, 'apps/myapp/tsconfig.spec.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "compilerOptions": {
+            "module": "esnext",
+            "moduleResolution": "bundler",
+            "outDir": "./out-tsc/vitest",
+            "types": [
+              "vitest/globals",
+              "vitest/importMeta",
+              "vite/client",
+              "node",
+              "vitest",
+            ],
+          },
+          "extends": "../../tsconfig.base.json",
+          "include": [
+            "vite.config.ts",
+            "vite.config.mts",
+            "vitest.config.ts",
+            "vitest.config.mts",
+            "src/**/*.test.ts",
+            "src/**/*.spec.ts",
+            "src/**/*.test.tsx",
+            "src/**/*.spec.tsx",
+            "src/**/*.test.js",
+            "src/**/*.spec.js",
+            "src/**/*.test.jsx",
+            "src/**/*.spec.jsx",
+            "src/**/*.d.ts",
+          ],
+          "references": [
+            {
+              "path": "./tsconfig.app.json",
+            },
+          ],
+        }
+      `);
+      expect(readJson(tree, 'apps/myapp-e2e/tsconfig.json'))
+        .toMatchInlineSnapshot(`
+        {
+          "compilerOptions": {
+            "allowJs": true,
+            "outDir": "out-tsc/playwright",
+            "sourceMap": false,
+          },
+          "exclude": [
+            "out-tsc",
+            "test-output",
+          ],
+          "extends": "../../tsconfig.base.json",
+          "include": [
+            "**/*.ts",
+            "**/*.js",
+            "playwright.config.ts",
+            "src/**/*.spec.ts",
+            "src/**/*.spec.js",
+            "src/**/*.test.ts",
+            "src/**/*.test.js",
+            "src/**/*.d.ts",
+          ],
+        }
+      `);
     });
   });
 });

--- a/packages/web/src/generators/application/schema.d.ts
+++ b/packages/web/src/generators/application/schema.d.ts
@@ -13,7 +13,6 @@ export interface Schema {
   inSourceTests?: boolean;
   e2eTestRunner?: 'cypress' | 'playwright' | 'none';
   linter?: Linter | LinterType;
-  standaloneConfig?: boolean;
   setParserOptionsProject?: boolean;
   strict?: boolean;
   addPlugin?: boolean;

--- a/packages/web/src/generators/application/schema.json
+++ b/packages/web/src/generators/application/schema.json
@@ -54,8 +54,8 @@
     "bundler": {
       "type": "string",
       "description": "The bundler to use.",
-      "enum": ["webpack", "none", "vite"],
-      "default": "webpack",
+      "enum": ["vite", "webpack", "none"],
+      "default": "vite",
       "x-prompt": "Which bundler do you want to use?",
       "x-priority": "important"
     },
@@ -63,7 +63,8 @@
       "description": "The tool to use for running lint checks.",
       "type": "string",
       "enum": ["eslint", "none"],
-      "default": "eslint"
+      "default": "none",
+      "x-prompt": "Which linter would you like to use?"
     },
     "skipFormat": {
       "description": "Skip formatting files",
@@ -74,8 +75,9 @@
     "unitTestRunner": {
       "type": "string",
       "enum": ["vitest", "jest", "none"],
-      "default": "vitest",
-      "description": "Test runner to use for unit tests. Default value is 'jest' when using 'webpack' or 'none' as the bundler and 'vitest' when using 'vite' as the bundler"
+      "default": "none",
+      "description": "Test runner to use for unit tests. Default value is 'jest' when using 'webpack' or 'none' as the bundler and 'vitest' when using 'vite' as the bundler",
+      "x-prompt": "What unit test runner should be used?"
     },
     "inSourceTests": {
       "type": "boolean",
@@ -102,12 +104,6 @@
       "type": "boolean",
       "description": "Creates an application with strict mode and strict type checking.",
       "default": true
-    },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside workspace.json",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
     }
   },
   "required": ["directory"],

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -6,7 +6,6 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
-import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -27,8 +26,6 @@ function updateDependencies(tree: Tree, schema: Schema) {
 }
 
 export async function webInitGenerator(tree: Tree, schema: Schema) {
-  assertNotUsingTsSolutionSetup(tree, 'web', 'init');
-
   let installTask: GeneratorCallback = () => {};
   if (!schema.skipPackageJson) {
     installTask = updateDependencies(tree, schema);


### PR DESCRIPTION
This PR adds the new TS setup support to `@nx/web:app` generator. Previously it errored out since it was not handled.

## Current Behavior
Cannot generate webapp in new setup/

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Can generate webapp in new setup

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
