### PR TITLE
fix(vite): plugin should infer 'vite' for dev/serve command

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -88,10 +88,8 @@ describe('app', () => {
         addPlugin: true,
       });
 
-      expect(
-        appTree.read('my-app-e2e/cypress.config.ts', 'utf-8')
-      ).toMatchInlineSnapshot(
-        `
+      expect(appTree.read('my-app-e2e/cypress.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
         "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
         import { defineConfig } from 'cypress';
 
@@ -101,18 +99,17 @@ describe('app', () => {
               "cypressDir": "src",
               "bundler": "vite",
               "webServerCommands": {
-                "default": "${packageCmd} nx run my-app:serve",
-                "production": "${packageCmd} nx run my-app:preview"
+                "default": "npx nx run my-app:dev",
+                "production": "npx nx run my-app:preview"
               },
-              "ciWebServerCommand": "${packageCmd} nx run my-app:preview",
+              "ciWebServerCommand": "npx nx run my-app:preview",
               "ciBaseUrl": "http://localhost:4300"
             }),
             baseUrl: 'http://localhost:4200'
           }
         });
         "
-      `
-      );
+      `);
     });
 
     it('should setup playwright correctly for vite', async () => {

--- a/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -537,6 +537,7 @@ describe('Vite - Convert Executors To Plugin', () => {
             ],
             "options": {
               "buildTargetName": "build",
+              "devTargetName": "dev",
               "previewTargetName": "preview",
               "serveStaticTargetName": "serve-static",
               "serveTargetName": "serve",
@@ -552,6 +553,7 @@ describe('Vite - Convert Executors To Plugin', () => {
             ],
             "options": {
               "buildTargetName": "bundle",
+              "devTargetName": "dev",
               "previewTargetName": "preview",
               "serveStaticTargetName": "serve-static",
               "serveTargetName": "serve",
@@ -566,6 +568,7 @@ describe('Vite - Convert Executors To Plugin', () => {
             ],
             "options": {
               "buildTargetName": "build-base",
+              "devTargetName": "dev",
               "previewTargetName": "preview",
               "serveStaticTargetName": "serve-static",
               "serveTargetName": "serve",

--- a/packages/vite/src/generators/init/init.spec.ts
+++ b/packages/vite/src/generators/init/init.spec.ts
@@ -81,6 +81,7 @@ describe('@nx/vite:init', () => {
               "options": {
                 "buildDepsTargetName": "build-deps",
                 "buildTargetName": "build",
+                "devTargetName": "dev",
                 "previewTargetName": "preview",
                 "serveStaticTargetName": "serve-static",
                 "serveTargetName": "serve",

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -72,6 +72,7 @@ export async function initGeneratorInternal(
         buildTargetName: ['build', 'vite:build', 'vite-build'],
         testTargetName: ['test', 'vite:test', 'vite-test'],
         serveTargetName: ['serve', 'vite:serve', 'vite-serve'],
+        devTargetName: ['dev', 'vite:dev', 'vite-dev'],
         previewTargetName: ['preview', 'vite:preview', 'vite-preview'],
         serveStaticTargetName: [
           'serve-static',

--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -120,9 +120,30 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
                 "{workspaceRoot}/dist/{projectRoot}",
               ],
             },
-            "my-serve": {
-              "command": "vite serve",
+            "dev": {
+              "command": "vite",
               "metadata": {
+                "description": "Starts Vite dev server",
+                "help": {
+                  "command": "npx vite --help",
+                  "example": {
+                    "options": {
+                      "port": 3000,
+                    },
+                  },
+                },
+                "technologies": [
+                  "vite",
+                ],
+              },
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "my-serve": {
+              "command": "vite",
+              "metadata": {
+                "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                 "description": "Starts Vite dev server",
                 "help": {
                   "command": "npx vite --help",
@@ -232,6 +253,26 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
                 "{projectRoot}/dist",
               ],
             },
+            "dev": {
+              "command": "vite",
+              "metadata": {
+                "description": "Starts Vite dev server",
+                "help": {
+                  "command": "npx vite --help",
+                  "example": {
+                    "options": {
+                      "port": 3000,
+                    },
+                  },
+                },
+                "technologies": [
+                  "vite",
+                ],
+              },
+              "options": {
+                "cwd": ".",
+              },
+            },
             "preview": {
               "command": "vite preview",
               "dependsOn": [
@@ -256,8 +297,9 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               },
             },
             "serve": {
-              "command": "vite serve",
+              "command": "vite",
               "metadata": {
+                "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                 "description": "Starts Vite dev server",
                 "help": {
                   "command": "npx vite --help",

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -321,6 +321,26 @@ describe('@nx/vite/plugin', () => {
                         "^build",
                       ],
                     },
+                    "dev": {
+                      "command": "vite",
+                      "metadata": {
+                        "description": "Starts Vite dev server",
+                        "help": {
+                          "command": "npx vite --help",
+                          "example": {
+                            "options": {
+                              "port": 3000,
+                            },
+                          },
+                        },
+                        "technologies": [
+                          "vite",
+                        ],
+                      },
+                      "options": {
+                        "cwd": "my-lib",
+                      },
+                    },
                     "preview": {
                       "command": "vite preview",
                       "dependsOn": [
@@ -345,8 +365,9 @@ describe('@nx/vite/plugin', () => {
                       },
                     },
                     "serve": {
-                      "command": "vite serve",
+                      "command": "vite",
                       "metadata": {
+                        "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                         "description": "Starts Vite dev server",
                         "help": {
                           "command": "npx vite --help",

--- a/packages/vite/src/utils/e2e-web-server-info-utils.spec.ts
+++ b/packages/vite/src/utils/e2e-web-server-info-utils.spec.ts
@@ -39,9 +39,9 @@ describe('getViteE2EWebServerInfo', () => {
       {
         "e2eCiBaseUrl": "http://localhost:4300",
         "e2eCiWebServerCommand": "npx nx run app:preview",
-        "e2eDevServerTarget": "app:serve",
+        "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:serve",
+        "e2eWebServerCommand": "npx nx run app:dev",
       }
     `);
   });
@@ -65,9 +65,9 @@ describe('getViteE2EWebServerInfo', () => {
       {
         "e2eCiBaseUrl": "http://localhost:4300",
         "e2eCiWebServerCommand": "npx nx run app:preview",
-        "e2eDevServerTarget": "app:serve",
+        "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:serve",
+        "e2eWebServerCommand": "npx nx run app:dev",
       }
     `);
   });
@@ -98,9 +98,9 @@ describe('getViteE2EWebServerInfo', () => {
       {
         "e2eCiBaseUrl": "http://localhost:4300",
         "e2eCiWebServerCommand": "npx nx run app:vite:preview",
-        "e2eDevServerTarget": "app:vite:serve",
+        "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:vite:serve",
+        "e2eWebServerCommand": "npx nx run app:dev",
       }
     `);
   });
@@ -140,9 +140,9 @@ describe('getViteE2EWebServerInfo', () => {
       {
         "e2eCiBaseUrl": "http://localhost:4300",
         "e2eCiWebServerCommand": "npx nx run app:vite-preview",
-        "e2eDevServerTarget": "app:vite-serve",
+        "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:vite-serve",
+        "e2eWebServerCommand": "npx nx run app:dev",
       }
     `);
   });

--- a/packages/vite/src/utils/e2e-web-server-info-utils.ts
+++ b/packages/vite/src/utils/e2e-web-server-info-utils.ts
@@ -12,10 +12,14 @@ export async function getViteE2EWebServerInfo(
   let e2ePort = e2ePortOverride ?? 4200;
 
   if (
-    nxJson.targetDefaults?.['serve'] &&
-    nxJson.targetDefaults?.['serve'].options?.port
+    (nxJson.targetDefaults?.['dev'] &&
+      nxJson.targetDefaults?.['dev'].options?.port) ||
+    (nxJson.targetDefaults?.['serve'] &&
+      nxJson.targetDefaults?.['serve'].options?.port)
   ) {
-    e2ePort = nxJson.targetDefaults?.['serve'].options?.port;
+    e2ePort =
+      nxJson.targetDefaults?.['dev'].options?.port ??
+      nxJson.targetDefaults?.['serve'].options?.port;
   }
 
   return getE2EWebServerInfo(
@@ -23,12 +27,12 @@ export async function getViteE2EWebServerInfo(
     projectName,
     {
       plugin: '@nx/vite/plugin',
-      serveTargetName: 'serveTargetName',
+      serveTargetName: 'devTargetName',
       serveStaticTargetName: 'previewTargetName',
       configFilePath,
     },
     {
-      defaultServeTargetName: 'serve',
+      defaultServeTargetName: 'dev',
       defaultServeStaticTargetName: 'preview',
       defaultE2EWebServerAddress: `http://localhost:${e2ePort}`,
       defaultE2ECiBaseUrl: 'http://localhost:4300',

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -131,7 +131,7 @@ export default defineConfig({
       cypressDir: 'src',
       bundler: 'vite',
       webServerCommands: {
-        default: 'npx nx run test:serve',
+        default: 'npx nx run test:dev',
         production: 'npx nx run test:preview',
       },
       ciWebServerCommand: 'npx nx run test:preview',

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -194,7 +194,7 @@ describe('app', () => {
               cypressDir: 'src',
               bundler: 'vite',
               webServerCommands: {
-                default: 'npx nx run cool-app:serve',
+                default: 'npx nx run cool-app:dev',
                 production: 'npx nx run cool-app:preview',
               },
               ciWebServerCommand: 'npx nx run cool-app:preview',


### PR DESCRIPTION
## Current Behavior
We currently have a `serveTargetName` that defaults to `serve` in the `@nx/vite/plugin`.
This infers a `vite serve` command for the `serve` task to vite projects.

While not incorrect, it could be abrasive for users coming from the `vite` ecosystem to Nx.
The command to start the Vite Dev Server is `vite`, so we should infer this.

`create-vite` also creates a package.json script with `"dev": "vite"` meaning users are likely running `npm run dev`.

This creates two points of differences for vite ecosystem users.

## Expected Behavior
Deprecate `serveTargetName` in favour of `devTargetName` to more closely align with lanugage from the Vite ecosystem.

Infer the command `vite` instead of `vite serve` for the `serve` and `dev` tasks.
