### PR TITLE
feat(node): update app generator for fastify to the next major v5

### DIFF
--- a/packages/node/migrations.json
+++ b/packages/node/migrations.json
@@ -18,6 +18,27 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "20.4.0": {
+      "version": "20.4.0-beta.3",
+      "packages": {
+        "fastify": {
+          "version": "~5.2.1",
+          "alwaysAddToPackageJson": false
+        },
+        "fastify-plugin": {
+          "version": "~5.0.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@fastify/autoload": {
+          "version": "~6.0.3",
+          "alwaysAddToPackageJson": false
+        },
+        "@fastify/sensible": {
+          "version": "~6.0.2",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/node/src/utils/versions.ts
+++ b/packages/node/src/utils/versions.ts
@@ -10,9 +10,9 @@ export const expressTypingsVersion = '~4.17.13';
 export const koaVersion = '~2.14.1';
 export const koaTypingsVersion = '~2.13.5';
 
-export const fastifyVersion = '~4.13.0';
-export const fastifyAutoloadVersion = '~5.7.1';
-export const fastifySensibleVersion = '~5.2.0';
-export const fastifyPluginVersion = '~4.5.0';
+export const fastifyVersion = '~5.2.1';
+export const fastifyAutoloadVersion = '~6.0.3';
+export const fastifySensibleVersion = '~6.0.2';
+export const fastifyPluginVersion = '~5.0.1';
 
 export const axiosVersion = '^1.6.0';


### PR DESCRIPTION
## Current Behavior
`npx create-nx-workspace`, when fastify is chosen, generates fastify 4 boilerplate

## Expected Behavior
fastify bumped their major version, and many latest plugins require v5 (e.g. [cors](https://github.com/fastify/fastify-cors))

## Related Issue(s)
no

- the combination of versions works on my setup
- the combinations of versions is the latest at the moment
