### PR TITLE
fix(nest): enable emitDecoratorMetadata in tsconfig update

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -104,6 +104,7 @@ describe('application generator', () => {
 
     const tsConfig = devkit.readJson(tree, `${appDirectory}/tsconfig.app.json`);
     expect(tsConfig.compilerOptions.emitDecoratorMetadata).toBe(true);
+    expect(tsConfig.compilerOptions.experimentalDecorators).toBe(true);
     expect(tsConfig.compilerOptions.target).toBe('es2021');
     expect(tsConfig.exclude).toEqual([
       'jest.config.ts',
@@ -278,6 +279,7 @@ describe('application generator', () => {
         {
           "compilerOptions": {
             "emitDecoratorMetadata": true,
+            "experimentalDecorators": true,
             "module": "nodenext",
             "moduleResolution": "nodenext",
             "outDir": "out-tsc/myapp",

--- a/packages/nest/src/generators/application/lib/update-tsconfig.ts
+++ b/packages/nest/src/generators/application/lib/update-tsconfig.ts
@@ -8,6 +8,7 @@ export function updateTsConfig(tree: Tree, options: NormalizedOptions): void {
     joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
     (json) => {
       json.compilerOptions.emitDecoratorMetadata = true;
+      json.compilerOptions.experimentalDecorators = true;
       json.compilerOptions.target = 'es2021';
       if (options.strict) {
         json.compilerOptions = {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
A TypeScript error occurs when initializing and serving a new NestJS application due to the absence of the `experimentalDecorators` option, which is required when `emitDecoratorMetadata` is enabled.

![error](https://github.com/user-attachments/assets/a63bb90f-d825-4155-8cb4-677df7d55add)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `tsconfig.json` file for new NestJS applications should include the `experimentalDecorators` option by default to prevent the TypeScript error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Couldn't find any related issues.