### PR TITLE
docs(nx-dev): fix inconsistent styling in SectionHeading components

### DIFF
--- a/nx-dev/nx-dev/pages/whitepaper-fast-ci.tsx
+++ b/nx-dev/nx-dev/pages/whitepaper-fast-ci.tsx
@@ -78,11 +78,7 @@ export function WhitePaperFastCI(): ReactElement {
                   </p>
 
                   <div className="mt-12 text-center">
-                    <SectionHeading
-                      as="p"
-                      variant="subtitle"
-                      className="text-white"
-                    >
+                    <SectionHeading as="p" variant="subtitle">
                       See how to get fast CI, built for monorepos
                     </SectionHeading>
                     <ButtonLink

--- a/nx-dev/ui-enterprise/src/lib/trial-nx-enterprise.tsx
+++ b/nx-dev/ui-enterprise/src/lib/trial-nx-enterprise.tsx
@@ -33,7 +33,7 @@ export function TrialNxEnterprise(): ReactElement {
             </p>
 
             <div className="mt-12 text-center">
-              <SectionHeading as="p" variant="subtitle" className="text-white">
+              <SectionHeading as="p" variant="subtitle">
                 How a Proof of Value works?
               </SectionHeading>
               <ButtonLink


### PR DESCRIPTION
Removed the redundant "text-white" class from SectionHeading components to standardize styles.
