### PR TITLE
fix(react-native): fix react native web configuration

### DIFF
--- a/packages/react-native/src/generators/web-configuration/lib/webpack-targets.spec.ts
+++ b/packages/react-native/src/generators/web-configuration/lib/webpack-targets.spec.ts
@@ -1,0 +1,101 @@
+import { Tree, joinPathFragments } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import {
+  createBuildTarget,
+  createServeTarget,
+  createNxWebpackPluginOptions,
+  determineTsConfig,
+} from './webpack-targets';
+import { NormalizedSchema } from './normalize-schema';
+
+describe('webpack-targets', () => {
+  let tree: Tree;
+  const projectRoot = 'apps/my-app';
+  const options: NormalizedSchema = {
+    project: 'my-app',
+    bundler: 'webpack',
+    skipFormat: false,
+    skipPackageJson: false,
+    projectRoot,
+    fileName: 'my-app',
+    className: 'MyApp',
+  };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      `${projectRoot}/project.json`,
+      JSON.stringify({
+        name: 'my-app',
+        root: projectRoot,
+        sourceRoot: `${projectRoot}/src`,
+        projectType: 'application',
+        targets: {},
+      })
+    );
+  });
+
+  it('should create a correct build target', () => {
+    const buildTarget = createBuildTarget(tree, options);
+    expect(buildTarget.executor).toEqual('@nx/webpack:webpack');
+    expect(buildTarget.outputs).toEqual(['{options.outputPath}']);
+    expect(buildTarget.options.outputPath).toEqual(
+      joinPathFragments('dist', projectRoot, 'web')
+    );
+    expect(buildTarget.options.index).toEqual(
+      joinPathFragments(projectRoot, 'src/index.html')
+    );
+    expect(buildTarget.options.main).toEqual(
+      joinPathFragments(projectRoot, 'src/main-web.tsx')
+    );
+    expect(buildTarget.options.tsConfig).toEqual(
+      joinPathFragments(projectRoot, 'tsconfig.json')
+    );
+    expect(buildTarget.options.assets).toEqual([
+      joinPathFragments(projectRoot, 'src/favicon.ico'),
+      joinPathFragments(projectRoot, 'src/assets'),
+    ]);
+    expect(buildTarget.options.webpackConfig).toEqual(
+      joinPathFragments(projectRoot, 'webpack.config.js')
+    );
+  });
+
+  it('should create a correct serve target', () => {
+    const serveTarget = createServeTarget(options);
+    expect(serveTarget.executor).toEqual('@nx/webpack:dev-server');
+    expect(serveTarget.options.buildTarget).toEqual('my-app:build');
+    expect(serveTarget.options.hmr).toBe(true);
+  });
+
+  it('should create correct NxWebpackPluginOptions', () => {
+    const nxWebpackPluginOptions = createNxWebpackPluginOptions(tree, options);
+    expect(nxWebpackPluginOptions.target).toEqual('web');
+    expect(nxWebpackPluginOptions.compiler).toEqual('babel');
+    expect(nxWebpackPluginOptions.outputPath).toEqual(
+      joinPathFragments('dist', projectRoot)
+    );
+    expect(nxWebpackPluginOptions.index).toEqual('./src/index.html');
+    expect(nxWebpackPluginOptions.main).toEqual('./src/main-web.tsx');
+    expect(nxWebpackPluginOptions.tsConfig).toEqual('tsconfig.json');
+    expect(nxWebpackPluginOptions.assets).toEqual([
+      './src/favicon.ico',
+      './src/assets',
+    ]);
+  });
+
+  describe('determineTsConfig', () => {
+    it('should return tsconfig.app.json if it exists', () => {
+      tree.write(`${projectRoot}/tsconfig.app.json`, '{}');
+      expect(determineTsConfig(tree, options)).toEqual('tsconfig.app.json');
+    });
+
+    it('should return tsconfig.lib.json if tsconfig.app.json does not exist but tsconfig.lib.json does', () => {
+      tree.write(`${projectRoot}/tsconfig.lib.json`, '{}');
+      expect(determineTsConfig(tree, options)).toEqual('tsconfig.lib.json');
+    });
+
+    it('should return tsconfig.json if neither tsconfig.app.json nor tsconfig.lib.json exist', () => {
+      expect(determineTsConfig(tree, options)).toEqual('tsconfig.json');
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
when serve up the react-native app using web configuration, it defaults tsconfig to
```
tsConfig: joinPathFragments(options.projectRoot, 'tsconfig.app.json'),
```
which is not right

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
not hard code ts config path, add a function determineTsConfig for that

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
