### PR TITLE
fix(core): update package script logic to handle cli tool name as command

### DIFF
--- a/packages/devkit/src/utils/add-plugin.ts
+++ b/packages/devkit/src/utils/add-plugin.ts
@@ -232,6 +232,7 @@ function processProject(
   if (!tree.exists(packageJsonPath)) {
     return;
   }
+
   const packageJson = readJson<PackageJson>(tree, packageJsonPath);
   if (!packageJson.scripts || !Object.keys(packageJson.scripts).length) {
     return;
@@ -243,6 +244,9 @@ function processProject(
   }
 
   let hasChanges = false;
+  targetCommands.sort(
+    (a, b) => b.command.split(/\s/).length - a.command.split(/\s/).length
+  );
   for (const targetCommand of targetCommands) {
     const { command, target, configuration } = targetCommand;
     const targetCommandRegex = new RegExp(
@@ -325,9 +329,8 @@ function processProject(
 
           if (!hasArgsWithDifferentValues && !scriptHasExtraArgs) {
             // they are the same, replace with the command removing the args
-            packageJson.scripts[scriptName] = packageJson.scripts[
-              scriptName
-            ].replace(
+            const script = packageJson.scripts[scriptName];
+            packageJson.scripts[scriptName] = script.replace(
               match,
               match.replace(
                 commandRegex,


### PR DESCRIPTION
## Current Behavior
When we have an inferred target command that matches the entry point of the cli tool, there is a chance we do not replace package scripts correctly

e.g.

```
{
  "dev": "vite",
  "build": "tsc -b && vite build",
  "preview": "vite preview"
}
```

this could result in package scripts being updated to

```
{
  "dev": "nx dev",
  "build": "tsc -b && nx vite:build",
  "preview": "nx dev preview"
}
```

## Expected Behavior
We should update the package scripts correctly to match the desired inferred target

```
{
  "preview": "nx preview"
}
```
