### PR TITLE
fix(core): do not check open connections during inactivity

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -17,6 +17,7 @@ import {
   killSocketOrPath,
 } from '../socket-utils';
 import {
+  hasRegisteredFileWatcherSockets,
   registeredFileWatcherSockets,
   removeRegisteredFileWatcherSocket,
 } from './file-watching/file-watcher-sockets';
@@ -311,9 +312,9 @@ export async function handleResult(
 }
 
 function handleInactivityTimeout() {
-  if (numberOfOpenConnections > 0) {
+  if (hasRegisteredFileWatcherSockets()) {
     serverLogger.log(
-      `There are ${numberOfOpenConnections} open connections. Reset inactivity timer.`
+      `There are open file watchers. Resetting inactivity timer.`
     );
     resetInactivityTimeout(handleInactivityTimeout);
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

We currently second guess our inactivity timer by checking if there are any open connections. However, there's also a strong chance that plugin workers will remain open as long as the daemon is open. This means the daemon stays alive forever and the daemon never shuts down even though it is inactive.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Instead of checking for open connections in general, the daemon server will only check for open file watchers. Most Daemon client requests will restart the server when sending messages so we can safely shut the server down in most cases. The only case where shutting down the daemon would cause a disruption is if a file watcher is registered. In those cases, the daemon will not shutdown due to inactivity.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
