### PR TITLE
fix(rspack): make subresourceIntegrity usage configurable

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -69,7 +69,7 @@ export function applyWebConfig(
     plugins.push(
       new HtmlRspackPlugin({
         template: options.index,
-        sri: 'sha256',
+        sri: options.subresourceIntegrity ? 'sha256' : undefined,
         ...(options.baseHref ? { base: { href: options.baseHref } } : {}),
         ...(config.output?.scriptType === 'module'
           ? { scriptLoading: 'module' }

--- a/packages/rspack/src/plugins/utils/models.ts
+++ b/packages/rspack/src/plugins/utils/models.ts
@@ -200,6 +200,10 @@ export interface NxAppRspackPluginOptions {
    */
   styles?: Array<ExtraEntryPointClass | string>;
   /**
+   * Enables the use of subresource integrity validation.
+   */
+  subresourceIntegrity?: boolean;
+  /**
    * Override the `target` option in rspack configuration. This setting is not recommended and exists for backwards compatibility.
    */
   target?: string | string[];

--- a/packages/rspack/src/plugins/utils/plugins/normalize-options.ts
+++ b/packages/rspack/src/plugins/utils/plugins/normalize-options.ts
@@ -124,6 +124,8 @@ export function normalizeOptions(
     sourceMap: combinedPluginAndMaybeExecutorOptions.sourceMap ?? !isProd,
     sourceRoot,
     styles: combinedPluginAndMaybeExecutorOptions.styles ?? [],
+    subresourceIntegrity:
+      combinedPluginAndMaybeExecutorOptions.subresourceIntegrity ?? false,
     target: combinedPluginAndMaybeExecutorOptions.target ?? 'web',
     targetName,
     vendorChunk: combinedPluginAndMaybeExecutorOptions.vendorChunk ?? !isProd,


### PR DESCRIPTION
## Current Behavior
We currently set Subresource Integrity (SRI) on all scripts injected via `HtmlRspackPlugin`. 
This should be configurable.

## Expected Behavior
Expose an option to set SRI - mark false by default to match Rspack's `HtmlRspackPlugin` behaviour
