### PR TITLE
fix(misc): generate `module` and `moduleResolution` in base tsconfig based on cnw preset

### DIFF
--- a/packages/expo/src/generators/application/application.ts
+++ b/packages/expo/src/generators/application/application.ts
@@ -45,6 +45,7 @@ export async function expoApplicationGeneratorInternal(
     skipFormat: true,
     addTsPlugin: schema.useTsSolution,
     formatter: schema.formatter,
+    platform: 'web',
   });
 
   const options = await normalizeOptions(host, schema);

--- a/packages/js/src/generators/init/files/ts-solution/tsconfig.base.json__tmpl__
+++ b/packages/js/src/generators/init/files/ts-solution/tsconfig.base.json__tmpl__
@@ -5,9 +5,11 @@
     "emitDeclarationOnly": true,
     "importHelpers": true,
     "isolatedModules": true,
-    "lib": ["es2022"],
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "lib": ["es2022"],<% if (platform === 'node') { %>
+    "module": "nodenext",
+    "moduleResolution": "nodenext",<% } else { %>
+    "module": "esnext",
+    "moduleResolution": "bundler",<% } %>
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,

--- a/packages/js/src/generators/init/init.spec.ts
+++ b/packages/js/src/generators/init/init.spec.ts
@@ -199,8 +199,8 @@ describe('js init generator', () => {
           "importHelpers": true,
           "isolatedModules": true,
           "lib": ["es2022"],
-          "module": "NodeNext",
-          "moduleResolution": "NodeNext",
+          "module": "nodenext",
+          "moduleResolution": "nodenext",
           "noEmitOnError": true,
           "noFallthroughCasesInSwitch": true,
           "noImplicitOverride": true,
@@ -214,4 +214,21 @@ describe('js init generator', () => {
       "
     `);
   });
+
+  it.each`
+    platform  | module        | moduleResolution
+    ${'web'}  | ${'esnext'}   | ${'bundler'}
+    ${'node'} | ${'nodenext'} | ${'nodenext'}
+  `(
+    'should set module: $module and moduleResolution: $moduleResolution in tsconfig.base.json for platform: $platform',
+    async ({ platform, module, moduleResolution }) => {
+      await init(tree, { addTsPlugin: true, platform });
+
+      const tsconfigBaseJson = readJson(tree, 'tsconfig.base.json');
+      expect(tsconfigBaseJson.compilerOptions.module).toBe(module);
+      expect(tsconfigBaseJson.compilerOptions.moduleResolution).toBe(
+        moduleResolution
+      );
+    }
+  );
 });

--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -131,7 +131,9 @@ export async function initGeneratorInternal(
 
   if (schema.addTsConfigBase && !getRootTsConfigFileName(tree)) {
     if (schema.addTsPlugin) {
+      const platform = schema.platform ?? 'node';
       generateFiles(tree, join(__dirname, './files/ts-solution'), '.', {
+        platform,
         tmpl: '',
       });
     } else {

--- a/packages/js/src/generators/init/schema.d.ts
+++ b/packages/js/src/generators/init/schema.d.ts
@@ -9,4 +9,5 @@ export interface InitSchema {
   addPlugin?: boolean;
   updatePackageScripts?: boolean;
   addTsPlugin?: boolean;
+  platform?: 'web' | 'node';
 }

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -206,10 +206,23 @@ export async function libraryGeneratorInternal(
         json.references ??= [];
         json.references.push({ path: './tsconfig.lib.json' });
 
-        if (options.isUsingTsSolutionConfig && options.bundler === 'rollup') {
-          json.compilerOptions.module = 'esnext';
-          json.compilerOptions.moduleResolution = 'bundler';
+        const compilerOptions = getCompilerOptions(options);
+        // respect the module and moduleResolution set by the test runner generator
+        if (json.compilerOptions.module) {
+          compilerOptions.module = json.compilerOptions.module;
         }
+        if (json.compilerOptions.moduleResolution) {
+          compilerOptions.moduleResolution =
+            json.compilerOptions.moduleResolution;
+        }
+
+        // filter out options already set with the same value in root tsconfig file that we're going to extend from
+        json.compilerOptions = getNeededCompilerOptionOverrides(
+          tree,
+          { ...json.compilerOptions, ...compilerOptions },
+          // must have been created by now
+          getRootTsConfigFileName(tree)!
+        );
 
         return json;
       }
@@ -965,34 +978,8 @@ function createProjectTsConfigs(
 ) {
   const rootOffset = offsetFromRoot(options.projectRoot);
 
-  let compilerOptionOverrides: Record<keyof CompilerOptions, any> = {
-    module: options.isUsingTsSolutionConfig
-      ? options.bundler === 'rollup'
-        ? 'esnext'
-        : 'nodenext'
-      : 'commonjs',
-    ...(options.isUsingTsSolutionConfig
-      ? options.bundler === 'rollup'
-        ? { moduleResolution: 'bundler' }
-        : { moduleResolution: 'nodenext' }
-      : {}),
-    ...(options.js ? { allowJs: true } : {}),
-    ...(options.strict
-      ? {
-          forceConsistentCasingInFileNames: true,
-          strict: true,
-          importHelpers: true,
-          noImplicitOverride: true,
-          noImplicitReturns: true,
-          noFallthroughCasesInSwitch: true,
-          ...(!options.isUsingTsSolutionConfig
-            ? { noPropertyAccessFromIndexSignature: true }
-            : {}),
-        }
-      : {}),
-  };
-
-  if (!options.rootProject || options.isUsingTsSolutionConfig) {
+  let compilerOptionOverrides = getCompilerOptions(options);
+  if (options.isUsingTsSolutionConfig) {
     // filter out options already set with the same value in root tsconfig file that we're going to extend from
     compilerOptionOverrides = getNeededCompilerOptionOverrides(
       tree,
@@ -1088,6 +1075,38 @@ function createProjectTsConfigs(
     joinPathFragments(options.projectRoot, 'tsconfig.json'),
     tsconfig
   );
+}
+
+function getCompilerOptions(
+  options: NormalizedLibraryGeneratorOptions
+): Record<keyof CompilerOptions, any> {
+  return {
+    module: options.isUsingTsSolutionConfig
+      ? options.bundler === 'rollup'
+        ? 'esnext'
+        : 'nodenext'
+      : 'commonjs',
+    ...(options.isUsingTsSolutionConfig
+      ? {
+          moduleResolution:
+            options.bundler === 'rollup' ? 'bundler' : 'nodenext',
+        }
+      : {}),
+    ...(options.js ? { allowJs: true } : {}),
+    ...(options.strict
+      ? {
+          forceConsistentCasingInFileNames: true,
+          strict: true,
+          importHelpers: true,
+          noImplicitOverride: true,
+          noImplicitReturns: true,
+          noFallthroughCasesInSwitch: true,
+          ...(!options.isUsingTsSolutionConfig
+            ? { noPropertyAccessFromIndexSignature: true }
+            : {}),
+        }
+      : {}),
+  };
 }
 
 function determineDependencies(

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -11,6 +11,7 @@ import {
 import { basename, dirname, join } from 'node:path/posix';
 import { FsTree } from 'nx/src/generators/tree';
 import { isUsingPackageManagerWorkspaces } from '../package-manager-workspaces';
+import { getNeededCompilerOptionOverrides } from './configuration';
 
 export function isUsingTypeScriptPlugin(tree: Tree): boolean {
   const nxJson = readNxJson(tree);
@@ -122,16 +123,16 @@ export function updateTsconfigFiles(
   exclude: string[] = [],
   rootDir = 'src'
 ) {
-  if (!isUsingTsSolutionSetup(tree)) return;
+  if (!isUsingTsSolutionSetup(tree)) {
+    return;
+  }
 
   const offset = offsetFromRoot(projectRoot);
-  const tsconfig = `${projectRoot}/${runtimeTsconfigFileName}`;
-  const tsconfigSpec = `${projectRoot}/tsconfig.spec.json`;
-  const e2eRoot = `${projectRoot}-e2e`;
-  const tsconfigE2E = `${e2eRoot}/tsconfig.json`;
+  const runtimeTsconfigPath = `${projectRoot}/${runtimeTsconfigFileName}`;
+  const specTsconfigPath = `${projectRoot}/tsconfig.spec.json`;
 
-  if (tree.exists(tsconfig)) {
-    updateJson(tree, tsconfig, (json) => {
+  if (tree.exists(runtimeTsconfigPath)) {
+    updateJson(tree, runtimeTsconfigPath, (json) => {
       json.extends = joinPathFragments(offset, 'tsconfig.base.json');
 
       json.compilerOptions = {
@@ -149,8 +150,7 @@ export function updateTsconfigFiles(
         // to set it explicitly to ensure it's output to the outDir
         // https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile
         json.compilerOptions.tsBuildInfoFile = join(
-          'out-tsc',
-          projectRoot.split('/').at(-1),
+          json.compilerOptions.outDir,
           basename(runtimeTsconfigFileName, '.json') + '.tsbuildinfo'
         );
       } else if (json.compilerOptions.tsBuildInfoFile) {
@@ -158,6 +158,13 @@ export function updateTsconfigFiles(
         // we don't need to set it explicitly
         delete json.compilerOptions.tsBuildInfoFile;
       }
+
+      // don't duplicate compiler options from base tsconfig
+      json.compilerOptions = getNeededCompilerOptionOverrides(
+        tree,
+        json.compilerOptions,
+        'tsconfig.base.json'
+      );
 
       const excludeSet: Set<string> = json.exclude
         ? new Set(['out-tsc', 'dist', ...json.exclude, ...exclude])
@@ -168,17 +175,24 @@ export function updateTsconfigFiles(
     });
   }
 
-  if (tree.exists(tsconfigSpec)) {
-    updateJson(tree, tsconfigSpec, (json) => {
+  if (tree.exists(specTsconfigPath)) {
+    updateJson(tree, specTsconfigPath, (json) => {
       json.extends = joinPathFragments(offset, 'tsconfig.base.json');
       json.compilerOptions = {
         ...json.compilerOptions,
         ...compilerOptions,
       };
+      // don't duplicate compiler options from base tsconfig
+      json.compilerOptions = getNeededCompilerOptionOverrides(
+        tree,
+        json.compilerOptions,
+        'tsconfig.base.json'
+      );
       const runtimePath = `./${runtimeTsconfigFileName}`;
       json.references ??= [];
-      if (!json.references.some((x) => x.path === runtimePath))
+      if (!json.references.some((x) => x.path === runtimePath)) {
         json.references.push({ path: runtimePath });
+      }
       return json;
     });
   }
@@ -187,8 +201,9 @@ export function updateTsconfigFiles(
     updateJson(tree, 'tsconfig.json', (json) => {
       const projectPath = './' + projectRoot;
       json.references ??= [];
-      if (!json.references.some((x) => x.path === projectPath))
+      if (!json.references.some((x) => x.path === projectPath)) {
         json.references.push({ path: projectPath });
+      }
       return json;
     });
   }

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -433,9 +433,15 @@ describe('lib', () => {
       expect(readJson(tree, 'mylib/tsconfig.spec.json')).toMatchInlineSnapshot(`
         {
           "compilerOptions": {
+            "forceConsistentCasingInFileNames": true,
+            "importHelpers": true,
             "module": "commonjs",
             "moduleResolution": "node10",
+            "noFallthroughCasesInSwitch": true,
+            "noImplicitOverride": true,
+            "noImplicitReturns": true,
             "outDir": "./out-tsc/jest",
+            "strict": true,
             "types": [
               "jest",
               "node",

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -54,6 +54,7 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
     skipFormat: true,
     addTsPlugin: schema.useTsSolution,
     formatter: schema.formatter,
+    platform: 'web',
   });
   tasks.push(jsInitTask);
 

--- a/packages/nuxt/src/generators/application/application.spec.ts
+++ b/packages/nuxt/src/generators/application/application.spec.ts
@@ -259,7 +259,6 @@ describe('app', () => {
       expect(readJson(tree, 'myapp/tsconfig.app.json')).toMatchInlineSnapshot(`
         {
           "compilerOptions": {
-            "composite": true,
             "jsx": "preserve",
             "jsxImportSource": "vue",
             "module": "esnext",
@@ -298,7 +297,6 @@ describe('app', () => {
       expect(readJson(tree, 'myapp/tsconfig.spec.json')).toMatchInlineSnapshot(`
         {
           "compilerOptions": {
-            "composite": true,
             "jsx": "preserve",
             "jsxImportSource": "vue",
             "module": "esnext",

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -46,6 +46,7 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
     tsConfigName: schema.rootProject ? 'tsconfig.json' : 'tsconfig.base.json',
     skipFormat: true,
     addTsPlugin: schema.useTsSolution,
+    platform: 'web',
   });
   tasks.push(jsInitTask);
 

--- a/packages/react-native/src/generators/application/application.ts
+++ b/packages/react-native/src/generators/application/application.ts
@@ -50,6 +50,7 @@ export async function reactNativeApplicationGeneratorInternal(
     skipFormat: true,
     addTsPlugin: schema.useTsSolution,
     formatter: schema.formatter,
+    platform: 'web',
   });
   tasks.push(jsInitTask);
 

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -66,6 +66,7 @@ export async function applicationGeneratorInternal(
     skipFormat: true,
     addTsPlugin: schema.useTsSolution,
     formatter: schema.formatter,
+    platform: 'web',
   });
   tasks.push(jsInitTask);
 

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -73,6 +73,7 @@ export async function remixApplicationGeneratorInternal(
       skipFormat: true,
       addTsPlugin: _options.useTsSolution,
       formatter: _options.formatter,
+      platform: 'web',
     }),
   ];
 

--- a/packages/vue/src/generators/application/application.ts
+++ b/packages/vue/src/generators/application/application.ts
@@ -46,6 +46,7 @@ export async function applicationGeneratorInternal(
       skipFormat: true,
       addTsPlugin: _options.useTsSolution,
       formatter: _options.formatter,
+      platform: 'web',
     })
   );
 

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -293,6 +293,7 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
   const jsInitTask = await jsInitGenerator(host, {
     js: false,
     skipFormat: true,
+    platform: 'web',
   });
   tasks.push(jsInitTask);
   const webTask = await webInitGenerator(host, {


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Creating a new workspace using the TS solution setup always generates a `tsconfig.base.json` with `module: nodenext` and `moduleResolution: nodenext`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Creating a new workspace using the TS solution setup should generate a `tsconfig.base.json` with `module: nodenext`/`moduleResolution: nodenext` for Node stacks and `module: esnext`/`moduleResolution: bundler` for Web stacks (React, Vue).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
