### PR TITLE
fix(js): fix typo so `exports` field in package.json is properly sorted

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -486,6 +486,29 @@ export function runNgNew(
     env: process.env,
     encoding: 'utf-8',
   });
+
+  // ensure angular packages are installed with ~ instead of ^ to prevent
+  // potential failures when new minor versions are released
+  function updateAngularDependencies(dependencies: any): void {
+    Object.keys(dependencies).forEach((key) => {
+      if (key.startsWith('@angular/') || key.startsWith('@angular-devkit/')) {
+        dependencies[key] = dependencies[key].replace(/^\^/, '~');
+      }
+    });
+  }
+  updateJson('package.json', (json) => {
+    updateAngularDependencies(json.dependencies ?? {});
+    updateAngularDependencies(json.devDependencies ?? {});
+    return json;
+  });
+
+  execSync(pmc.install, {
+    cwd: join(e2eCwd, projName),
+    stdio: isVerbose() ? 'inherit' : 'pipe',
+    env: process.env,
+    encoding: 'utf-8',
+  });
+
   copySync(tmpProjPath(), tmpBackupNgCliProjPath());
 
   if (isVerboseE2ERun()) {

--- a/packages/js/src/utils/package-json/sort-fields.ts
+++ b/packages/js/src/utils/package-json/sort-fields.ts
@@ -14,7 +14,7 @@ export function sortPackageJsonFields(tree: Tree, projectRoot: string) {
       'main',
       'module',
       'types',
-      'exported',
+      'exports',
     ]);
     const orderedBottomFields = new Set([
       'dependencies',

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -1027,8 +1027,8 @@ module.exports = withNx(
           "main",
           "module",
           "types",
-          "nx",
           "exports",
+          "nx",
         ]
       `);
       expect(readJson(tree, 'mylib/tsconfig.json')).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Current Behavior

It tries to sort `exported` which is an invalid field.

## Expected Behavior

It should sort `exports`.

## Related Issue(s)

Fixes #
