### PR TITLE
fix(js): do not generate package.json file for non-buildable js libraries in non-ts solution setup

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1448,6 +1448,19 @@ describe('lib', () => {
     });
   });
 
+  describe('--bundler=none', () => {
+    it('should not generate a package.json when bundler is none', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        bundler: 'none',
+        unitTestRunner: 'none',
+      });
+
+      expect(tree.exists('my-lib/package.json')).toBe(false);
+    });
+  });
+
   describe('--minimal', () => {
     it('should generate a README.md when minimal is set to false', async () => {
       await libraryGenerator(tree, {
@@ -1602,14 +1615,7 @@ describe('lib', () => {
           },
         }
       `);
-      expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
-        {
-          "dependencies": {},
-          "name": "@proj/my-lib",
-          "private": true,
-          "version": "0.0.1",
-        }
-      `);
+      expect(tree.exists('my-lib/package.json')).toBe(false);
     });
   });
 

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -685,6 +685,13 @@ function createFiles(tree: Tree, options: NormalizedLibraryGeneratorOptions) {
       };
       return json;
     });
+  } else if (
+    !options.isUsingTsSolutionConfig &&
+    options.useProjectJson &&
+    (!options.bundler || options.bundler === 'none') &&
+    !(options.projectRoot === '.')
+  ) {
+    tree.delete(packageJsonPath);
   }
 
   if (options.minimal && !(options.projectRoot === '.')) {

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -251,10 +251,15 @@ function ensureDependencies(tree: Tree): GeneratorCallback {
 }
 
 function updatePackageJson(tree: Tree, options: NormalizedSchema) {
-  const packageJson = readJson(
-    tree,
-    joinPathFragments(options.projectRoot, 'package.json')
+  const packageJsonPath = joinPathFragments(
+    options.projectRoot,
+    'package.json'
   );
+  if (!tree.exists(packageJsonPath)) {
+    return;
+  }
+
+  const packageJson = readJson(tree, packageJsonPath);
 
   if (packageJson.type === 'module') {
     // The @nx/js:lib generator can set the type to 'module' which would
@@ -262,9 +267,5 @@ function updatePackageJson(tree: Tree, options: NormalizedSchema) {
     delete packageJson.type;
   }
 
-  writeJson(
-    tree,
-    joinPathFragments(options.projectRoot, 'package.json'),
-    packageJson
-  );
+  writeJson(tree, packageJsonPath, packageJson);
 }


### PR DESCRIPTION
## Current Behavior

When generating a non-buildable js library in a workspace using the integrated setup, a `package.json` file is generated.

## Expected Behavior

When generating a non-buildable js library in a workspace using the integrated setup, a `package.json` file should not be generated.

## Related Issue(s)

Fixes #
