### PR TITLE
fix(js): ignore bundler config files correctly in eslint config when using vitest in js library generator

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -440,6 +440,95 @@ describe('lib', () => {
       expect(packageJson.devDependencies['@nx/eslint-plugin']).toBeDefined();
     });
 
+    it.each`
+      bundler      | expectedIgnoredFile
+      ${'rollup'}  | ${'{projectRoot}/rollup.config.{js,ts,mjs,mts,cjs,cts}'}
+      ${'esbuild'} | ${'{projectRoot}/esbuild.config.{js,ts,mjs,mts}'}
+      ${'vite'}    | ${'{projectRoot}/vite.config.{js,ts,mjs,mts}'}
+    `(
+      'should ignore $expectedIgnoredFile when bundler=$bundler',
+      async ({ bundler, expectedIgnoredFile }) => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          directory: 'my-lib',
+          linter: 'eslint',
+          bundler,
+        });
+
+        expect(
+          readJson(tree, 'my-lib/.eslintrc.json').overrides
+        ).toContainEqual({
+          files: ['*.json'],
+          parser: 'jsonc-eslint-parser',
+          rules: {
+            '@nx/dependency-checks': [
+              'error',
+              {
+                ignoredFiles: [
+                  '{projectRoot}/eslint.config.{js,cjs,mjs}',
+                  expectedIgnoredFile,
+                ],
+              },
+            ],
+          },
+        });
+      }
+    );
+
+    it('should ignore rollup and vite config files when bundler=rollup and unitTestRunner=vitest', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        linter: 'eslint',
+        bundler: 'rollup',
+        unitTestRunner: 'vitest',
+      });
+
+      expect(readJson(tree, 'my-lib/.eslintrc.json').overrides).toContainEqual({
+        files: ['*.json'],
+        parser: 'jsonc-eslint-parser',
+        rules: {
+          '@nx/dependency-checks': [
+            'error',
+            {
+              ignoredFiles: [
+                '{projectRoot}/eslint.config.{js,cjs,mjs}',
+                '{projectRoot}/rollup.config.{js,ts,mjs,mts,cjs,cts}',
+                '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+              ],
+            },
+          ],
+        },
+      });
+    });
+
+    it('should ignore esbuild and vite config files when bundler=esbuild and unitTestRunner=vitest', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        linter: 'eslint',
+        bundler: 'esbuild',
+        unitTestRunner: 'vitest',
+      });
+
+      expect(readJson(tree, 'my-lib/.eslintrc.json').overrides).toContainEqual({
+        files: ['*.json'],
+        parser: 'jsonc-eslint-parser',
+        rules: {
+          '@nx/dependency-checks': [
+            'error',
+            {
+              ignoredFiles: [
+                '{projectRoot}/eslint.config.{js,cjs,mjs}',
+                '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
+                '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+              ],
+            },
+          ],
+        },
+      });
+    });
+
     describe('not nested', () => {
       it('should create a local .eslintrc.json', async () => {
         await libraryGenerator(tree, {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -471,25 +471,25 @@ export async function addLint(
           ruleSeverity = value;
           ruleOptions = {};
         }
-        if (options.bundler === 'vite' || options.unitTestRunner === 'vitest') {
-          ruleOptions.ignoredFiles ??= [];
-          ruleOptions.ignoredFiles.push(
-            '{projectRoot}/vite.config.{js,ts,mjs,mts}'
-          );
-          o.rules['@nx/dependency-checks'] = [ruleSeverity, ruleOptions];
+        const ignoredFiles = new Set(ruleOptions.ignoredFiles ?? []);
+        if (options.bundler === 'vite') {
+          ignoredFiles.add('{projectRoot}/vite.config.{js,ts,mjs,mts}');
         } else if (options.bundler === 'rollup') {
-          ruleOptions.ignoredFiles ??= [];
-          ruleOptions.ignoredFiles.push(
+          ignoredFiles.add(
             '{projectRoot}/rollup.config.{js,ts,mjs,mts,cjs,cts}'
           );
-          o.rules['@nx/dependency-checks'] = [ruleSeverity, ruleOptions];
         } else if (options.bundler === 'esbuild') {
-          ruleOptions.ignoredFiles ??= [];
-          ruleOptions.ignoredFiles.push(
-            '{projectRoot}/esbuild.config.{js,ts,mjs,mts}'
-          );
+          ignoredFiles.add('{projectRoot}/esbuild.config.{js,ts,mjs,mts}');
+        }
+        if (options.unitTestRunner === 'vitest') {
+          ignoredFiles.add('{projectRoot}/vite.config.{js,ts,mjs,mts}');
+        }
+
+        if (ignoredFiles.size) {
+          ruleOptions.ignoredFiles = Array.from(ignoredFiles);
           o.rules['@nx/dependency-checks'] = [ruleSeverity, ruleOptions];
         }
+
         return o;
       }
     );


### PR DESCRIPTION
## Current Behavior

Generating a js library with esbuild or rollup as bundlers and vitest as the unit test runner, results in an eslint configuration where the bundler config file is not ignored from the `@nx/dependency-checks` rule.

## Expected Behavior

Generating a js library with esbuild or rollup as bundlers and vitest as the unit test runner, should result in an eslint configuration where the bundler config file is ignored from the `@nx/dependency-checks` rule.

## Related Issue(s)

Fixes #
