### PR TITLE
docs(nx-dev): update "ebook" references to "guide" in button texts

### DIFF
--- a/nx-dev/nx-dev/pages/whitepaper-fast-ci.tsx
+++ b/nx-dev/nx-dev/pages/whitepaper-fast-ci.tsx
@@ -83,7 +83,7 @@ export function WhitePaperFastCI(): ReactElement {
                     </SectionHeading>
                     <ButtonLink
                       href="/assets/enterprise/Fast-CI-Whitepaper.pdf"
-                      title="Download the ebook"
+                      title="Download the guide"
                       target="_blank"
                       variant="secondary"
                       size="small"
@@ -100,7 +100,7 @@ export function WhitePaperFastCI(): ReactElement {
                         aria-hidden="true"
                         className="size-5 shrink-0"
                       />
-                      <span>Download the ebook</span>
+                      <span>Download the guide</span>
                     </ButtonLink>
                   </div>
 

--- a/nx-dev/ui-enterprise/src/lib/trial-nx-enterprise.tsx
+++ b/nx-dev/ui-enterprise/src/lib/trial-nx-enterprise.tsx
@@ -38,7 +38,7 @@ export function TrialNxEnterprise(): ReactElement {
               </SectionHeading>
               <ButtonLink
                 href="/assets/enterprise/Nx-Enterprise-POV.pdf"
-                title="Download the ebook"
+                title="Download the guide"
                 target="_blank"
                 variant="secondary"
                 size="small"
@@ -55,7 +55,7 @@ export function TrialNxEnterprise(): ReactElement {
                   aria-hidden="true"
                   className="size-5 shrink-0"
                 />
-                <span>Download the ebook</span>
+                <span>Download the guide</span>
               </ButtonLink>
             </div>
             <figure className="mt-16 rounded-lg bg-slate-100 p-4 pl-8 dark:bg-slate-800">

--- a/nx-dev/ui-enterprise/src/lib/vmware-testimonial.tsx
+++ b/nx-dev/ui-enterprise/src/lib/vmware-testimonial.tsx
@@ -29,7 +29,7 @@ export function VmwareTestimonial(): ReactElement {
               </SectionHeading>
               <ButtonLink
                 href="https://go.nx.dev/ci-ebook"
-                title="Download the ebook"
+                title="Download the guide"
                 variant="secondary"
                 size="small"
               >
@@ -37,7 +37,7 @@ export function VmwareTestimonial(): ReactElement {
                   aria-hidden="true"
                   className="size-5 shrink-0"
                 />
-                <span>Download the ebook</span>
+                <span>Download the guide</span>
               </ButtonLink>
             </div>
           </footer>


### PR DESCRIPTION
Revised all button texts and titles to consistently use "guide" instead of "ebook" across multiple components.
