### PR TITLE
feat(release): allow invalid conventional commits to be considered via custom config

### DIFF
--- a/e2e/release/src/conventional-commits-config.test.ts
+++ b/e2e/release/src/conventional-commits-config.test.ts
@@ -48,7 +48,7 @@ describe('nx release conventional commits config', () => {
   let pkg5: string;
   let pkg6: string;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     newProject({
       packages: ['@nx/js'],
     });
@@ -95,7 +95,7 @@ describe('nx release conventional commits config', () => {
     await runCommandAsync(`git tag -a ${pkg5}@0.0.1 -m "${pkg5}@0.0.1"`);
     await runCommandAsync(`git tag -a ${pkg6}@0.0.1 -m "${pkg6}@0.0.1"`);
   }, 60000);
-  afterAll(() => cleanupProject());
+  afterEach(() => cleanupProject());
 
   it('should respect custom conventional commits configuration', async () => {
     updateJson<NxJsonConfiguration>('nx.json', (json) => {
@@ -180,6 +180,35 @@ describe('nx release conventional commits config', () => {
       `${pkg5} 🚫 Skipping versioning "@proj/${pkg5}" as no changes were detected.`
     );
     expect(versionResultNoChanges).toContain(
+      `${pkg6} 🚫 Skipping versioning "@proj/${pkg6}" as no changes were detected.`
+    );
+
+    // Do an invalid conventional commit to ensure that it is not included in the changelog
+    updateJson(`${pkg6}/package.json`, (json) => ({
+      ...json,
+      license: 'ISC',
+    }));
+    await runCommandAsync(`git add ${pkg6}/package.json`);
+    await runCommandAsync(`git commit -m "This is not a conventional commit"`);
+
+    const versionResultInvalidConventionalCommit = runCLI(`release version -d`);
+
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg1} 🚫 Skipping versioning "@proj/${pkg1}" as no changes were detected.`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg2} 🚫 Skipping versioning "@proj/${pkg2}" as no changes were detected.`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg3} 🚫 Skipping versioning "@proj/${pkg3}" as no changes were detected.`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg4} 🚫 Skipping versioning "@proj/${pkg4}" as no changes were detected.`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg5} 🚫 Skipping versioning "@proj/${pkg5}" as no changes were detected.`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
       `${pkg6} 🚫 Skipping versioning "@proj/${pkg6}" as no changes were detected.`
     );
 
@@ -420,6 +449,149 @@ describe('nx release conventional commits config', () => {
       ### 📦 Build
 
       - this is a build
+    `);
+  });
+
+  it('should allow invalid commits with custom conventional commits configuration', async () => {
+    updateJson<NxJsonConfiguration>('nx.json', (json) => {
+      json.release = {
+        ...json.release,
+        version: {
+          conventionalCommits: true,
+        },
+        changelog: {
+          projectChangelogs: {
+            renderOptions: {
+              authors: false, // do not show authors in the e2e snapshots
+            },
+          },
+        },
+        conventionalCommits: {
+          types: {
+            __INVALID__: {
+              semverBump: 'patch',
+              changelog: {
+                title: 'Uncategorised changes',
+              },
+            },
+          },
+        },
+      };
+      return json;
+    });
+
+    // The invalid conventional commit should result in a patch bump
+    updateJson(`${pkg1}/package.json`, (json) => ({
+      ...json,
+      license: 'Apache',
+    }));
+    await runCommandAsync(`git add ${pkg1}/package.json`);
+    await runCommandAsync(
+      `git commit -m "This is an invalid conventional commit"`
+    );
+
+    const versionResultInvalidConventionalCommit = runCLI(`release version -d`);
+
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg1} ✍️  New version 0.0.2 written to ${pkg1}/package.json`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg2} ✍️  New version 0.0.2 written to ${pkg2}/package.json`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg3} 🚫 Skipping versioning "@proj/${pkg3}" as no changes were detected.`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg4} 🚫 Skipping versioning "@proj/${pkg4}" as no changes were detected.`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg5} 🚫 Skipping versioning "@proj/${pkg5}" as no changes were detected.`
+    );
+    expect(versionResultInvalidConventionalCommit).toContain(
+      `${pkg6} 🚫 Skipping versioning "@proj/${pkg6}" as no changes were detected.`
+    );
+
+    // update my-pkg-1 with a feature commit
+    updateJson(`${pkg1}/package.json`, (json) => ({
+      ...json,
+      license: 'MIT',
+    }));
+    await runCommandAsync(`git add ${pkg1}/package.json`);
+    await runCommandAsync(`git commit -m "feat: This is a feature"`);
+
+    const versionResultFixCommit = runCLI(`release version -d`);
+
+    expect(versionResultFixCommit).toContain(
+      `${pkg1} ✍️  New version 0.1.0 written to ${pkg1}/package.json`
+    );
+    expect(versionResultFixCommit).toContain(
+      `${pkg2} ✍️  New version 0.0.2 written to ${pkg2}/package.json`
+    );
+    expect(versionResultFixCommit).toContain(
+      `${pkg3} 🚫 Skipping versioning "@proj/${pkg3}" as no changes were detected.`
+    );
+    expect(versionResultFixCommit).toContain(
+      `${pkg4} 🚫 Skipping versioning "@proj/${pkg4}" as no changes were detected.`
+    );
+    expect(versionResultFixCommit).toContain(
+      `${pkg5} 🚫 Skipping versioning "@proj/${pkg5}" as no changes were detected.`
+    );
+    expect(versionResultFixCommit).toContain(
+      `${pkg6} 🚫 Skipping versioning "@proj/${pkg6}" as no changes were detected.`
+    );
+
+    // Normally, users would use `nx release` or the programmatic api to ensure that
+    // changelogs are generated for the above version bumps, but for the sake of this
+    // test, we just want to ensure that each commit is included/excluded as expected.
+    // Therefore, any version number will work - in this case it's 1.0.0.
+    runCLI(`release changelog 1.0.0`);
+
+    const pkg1Changelog = readFile(`${pkg1}/CHANGELOG.md`);
+    expect(pkg1Changelog).toMatchInlineSnapshot(`
+      # 1.0.0 (YYYY-MM-DD)
+
+      ### 🚀 Features
+
+      - This is a feature
+
+      ### Uncategorised changes
+
+      - This is an invalid conventional commit
+    `);
+
+    const pkg2Changelog = readFile(`${pkg2}/CHANGELOG.md`);
+    expect(pkg2Changelog).toMatchInlineSnapshot(`
+      # 1.0.0 (YYYY-MM-DD)
+
+      This was a version bump only for {project-name} to align it with other projects, there were no code changes.
+    `);
+
+    const pkg3Changelog = readFile(`${pkg3}/CHANGELOG.md`);
+    expect(pkg3Changelog).toMatchInlineSnapshot(`
+      # 1.0.0 (YYYY-MM-DD)
+
+      This was a version bump only for {project-name} to align it with other projects, there were no code changes.
+    `);
+
+    const pkg4Changelog = readFile(`${pkg4}/CHANGELOG.md`);
+    expect(pkg4Changelog).toMatchInlineSnapshot(`
+      # 1.0.0 (YYYY-MM-DD)
+
+      This was a version bump only for {project-name} to align it with other projects, there were no code changes.
+    `);
+
+    const pkg5Changelog = readFile(`${pkg5}/CHANGELOG.md`);
+    expect(pkg5Changelog).toMatchInlineSnapshot(`
+      # 1.0.0 (YYYY-MM-DD)
+
+      This was a version bump only for {project-name} to align it with other projects, there were no code changes.
+    `);
+
+    const pkg6Changelog = readFile(`${pkg6}/CHANGELOG.md`);
+    expect(pkg6Changelog).toMatchInlineSnapshot(`
+      # 1.0.0 (YYYY-MM-DD)
+
+      This was a version bump only for {project-name} to align it with other projects, there were no code changes.
     `);
   });
 });

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -159,6 +159,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -338,6 +345,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -520,6 +534,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -733,6 +754,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -930,6 +958,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -1136,6 +1171,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -1340,6 +1382,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -1529,6 +1578,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -1713,6 +1769,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -1899,6 +1962,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -2101,6 +2171,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -2291,6 +2368,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -2504,6 +2588,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -2703,6 +2794,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -2892,6 +2990,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -3080,6 +3185,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -3264,6 +3376,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -3453,6 +3572,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -3655,6 +3781,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -3837,6 +3970,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -4031,6 +4171,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -4219,6 +4366,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -4425,6 +4579,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -4632,6 +4793,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -4828,6 +4996,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -5021,6 +5196,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -5215,6 +5397,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -5471,6 +5660,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -5681,6 +5877,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -6071,6 +6274,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -6254,6 +6464,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -6459,6 +6676,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -6661,6 +6885,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -6859,6 +7090,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -7058,6 +7296,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -7260,6 +7505,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -7481,6 +7733,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -7751,6 +8010,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -7977,6 +8243,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -8184,6 +8457,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -8624,6 +8904,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -8990,6 +9277,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -9177,6 +9471,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -9365,6 +9666,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -9556,6 +9864,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -9746,6 +10061,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -9944,6 +10266,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -10132,6 +10461,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -10367,6 +10703,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -10558,6 +10901,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -10755,6 +11105,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -10955,6 +11312,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -11159,6 +11523,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,
@@ -11363,6 +11734,13 @@ describe('createNxReleaseConfig()', () => {
             },
             "conventionalCommits": {
               "types": {
+                "__INVALID__": {
+                  "changelog": {
+                    "hidden": true,
+                    "title": "Invalid based on conventional commits specification",
+                  },
+                  "semverBump": "none",
+                },
                 "build": {
                   "changelog": {
                     "hidden": true,

--- a/packages/nx/src/command-line/release/config/conventional-commits.ts
+++ b/packages/nx/src/command-line/release/config/conventional-commits.ts
@@ -94,5 +94,12 @@ export const DEFAULT_CONVENTIONAL_COMMITS_CONFIG: NxReleaseConfig['conventionalC
           hidden: true,
         },
       },
+      __INVALID__: {
+        semverBump: 'none',
+        changelog: {
+          title: 'Invalid based on conventional commits specification',
+          hidden: true,
+        },
+      },
     },
   };

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -412,7 +412,12 @@ export function parseConventionalCommitsMessage(message: string): {
 } | null {
   const match = message.match(ConventionalCommitRegex);
   if (!match) {
-    return null;
+    return {
+      type: '__INVALID__',
+      scope: '',
+      description: message,
+      breaking: false,
+    };
   }
 
   return {


### PR DESCRIPTION
This allows users with repos that are a mix of conventional commits and other commits to configure that non-conventional commits will result in for example a patch version bump.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Currently any commit that does match the conventional commit regex is dropped, and does not cause a version bump.

## Expected Behavior
Due the content of our monorepo we have a mix of conventional commits and other commits. With this change we will be able to configure that a non-conventional commit should cause for example a patch semver version bump.
The default behaviour remains the same and will not bump versions for non-conventional commits.

## Related Issue(s)
Haven't been able to find any.
