### PR TITLE
fix(core): do not warn about custom tasks runners when explicitly using default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       NX_E2E_CI_CACHE_KEY: e2e-circleci-linux
       NX_DAEMON: 'true'
       NX_PERF_LOGGING: 'false'
-      NX_VERBOSE_LOGGING: 'false'
+      NX_VERBOSE_LOGGING: 'true'
       NX_NATIVE_LOGGING: 'false'
       NX_E2E_RUN_E2E: 'true'
       NX_CI_EXECUTION_ENV: 'linux'

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -912,8 +912,12 @@ export function getRunnerOptions(
 
   return result;
 }
+
 function isCustomRunnerPath(modulePath: string) {
-  return !['nx-cloud', '@nrwl/nx-cloud', defaultTasksRunnerPath].includes(
-    modulePath
-  );
+  return ![
+    'nx-cloud',
+    '@nrwl/nx-cloud',
+    'nx/tasks-runners/default',
+    defaultTasksRunnerPath,
+  ].includes(modulePath);
 }


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When default tasks runner is explicitly enabled a warning is shown.

## Expected Behavior
No warning

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
