### PR TITLE
fix(detox): use a version of Detox that works with React Native 0.76/Expo v52

### DIFF
--- a/packages/detox/migrations.json
+++ b/packages/detox/migrations.json
@@ -48,6 +48,19 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "20.4.0": {
+      "version": "20.4.0-beta.2",
+      "packages": {
+        "detox": {
+          "version": "~20.31.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@config-plugins/detox": {
+          "version": "~9.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/detox/src/utils/versions.ts
+++ b/packages/detox/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = require('../../package.json').version;
 
-export const detoxVersion = '~20.28.0';
+export const detoxVersion = '~20.31.0';
 export const testingLibraryJestDom = '~6.6.3';
-export const configPluginsDetoxVersion = '~8.0.0'; // only required for expo
+export const configPluginsDetoxVersion = '~9.0.0'; // only required for expo


### PR DESCRIPTION
## Current Behavior

After adding `@nx/detox` to a newly-generated project, Detox E2E apps will either fail to build or run with intermittent crashes on Android.

## Expected Behavior

Detox E2E apps should run as they normally did with React Native 0.74/Expo v51.
