### PR TITLE
fix(core): ensure that nx is backwards compatible with older versions of Nx Cloud

### DIFF
--- a/packages/nx/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/default-tasks-runner.ts
@@ -8,7 +8,7 @@ import { Task, TaskGraph } from '../config/task-graph';
 import { NxArgs } from '../utils/command-line-utils';
 import { DaemonClient } from '../daemon/client/client';
 import { cacheDir } from '../utils/cache-directory';
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, rename, readdir } from 'fs/promises';
 import { join } from 'path';
 import { CachedResult } from '../native';
 
@@ -38,7 +38,7 @@ export abstract class RemoteCacheV2 {
             ),
           ]);
           return {
-            outputsPath: cacheDirectory,
+            outputsPath: join(cacheDirectory, hash, 'outputs'),
             terminalOutput: terminalOutput ?? oldTerminalOutput,
             code,
           };
@@ -46,8 +46,34 @@ export abstract class RemoteCacheV2 {
           return null;
         }
       },
-      store: async (hash, cacheDirectory, __, code) => {
+      store: async (hash, cacheDirectory, terminalOutput, code) => {
+        // The new db cache places the outputs directly into the cacheDirectory + hash.
+        // old instances of Nx Cloud expect these outputs to be in cacheDirectory + hash + outputs
+        // this ensures that everything that was in the cache directory is moved to the outputs directory
+        const cacheDir = join(cacheDirectory, hash);
+        const outputDir = join(cacheDir, 'outputs');
+        await mkdir(outputDir, { recursive: true });
+        const files = await readdir(cacheDir);
+        await Promise.all(
+          files.map(async (file) => {
+            const filePath = join(cacheDir, file);
+            // we don't want to move these files to the outputs directory because they are not artifacts of the task
+            if (
+              filePath === outputDir ||
+              file === 'code' ||
+              file === 'terminalOutput'
+            ) {
+              return;
+            }
+            await rename(filePath, join(outputDir, file));
+          })
+        );
+
         await writeFile(join(cacheDirectory, hash, 'code'), code.toString());
+        await writeFile(
+          join(cacheDirectory, hash, 'terminalOutput'),
+          terminalOutput
+        );
 
         return cache.store(hash, cacheDirectory);
       },


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When using a older version of Nx Cloud, it expects the cache output to be in a specific location. Nx has a compatibility layer, but the folder structure was not correct

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx's compatibility layer is now compatible with older versions of Nx Cloud

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
