### PR TITLE
docs(nx-dev): remove unnecessary directory flag from host & remote generation commands

### DIFF
--- a/docs/shared/recipes/module-federation/creating-a-host.md
+++ b/docs/shared/recipes/module-federation/creating-a-host.md
@@ -18,7 +18,7 @@ To generate only a host application in your workspace, run the following command
 {% tabs %}
 {% tab label="React" %}
 
-```{% command="nx g @nx/react:host apps/shell --directory=apps/react/shell" %}
+```{% command="nx g @nx/react:host apps/react/shell" %}
 NX  Generating @nx/react:host
 
 CREATE apps/react/shell/src/app/app.spec.tsx
@@ -48,7 +48,7 @@ CREATE apps/react/shell/webpack.config.prod.ts
 {% /tab %}
 {% tab label="Angular" %}
 
-```{% command="nx g @nx/angular:host apps/shell --directory=apps/angular/shell" %}
+```{% command="nx g @nx/angular:host apps/angular/shell" %}
 NX Generating @nx/angular:host
 
 CREATE apps/angular/shell/project.json


### PR DESCRIPTION
### Changes
Remove `--directory` flag if the arg is provided as a positional. If provided it will throw errors.