### PR TITLE
fix(nuxt): correct webServerAddress and webServerCommand options in add-e2e.ts generator. 

### DIFF
--- a/packages/nuxt/src/generators/application/lib/add-e2e.ts
+++ b/packages/nuxt/src/generators/application/lib/add-e2e.ts
@@ -129,8 +129,8 @@ export async function addE2e(host: Tree, options: NormalizedSchema) {
       js: false,
       linter: options.linter,
       setParserOptionsProject: options.setParserOptionsProject,
-      webServerAddress: e2eWebServerInfo.e2eCiWebServerCommand,
-      webServerCommand: e2eWebServerInfo.e2eCiBaseUrl,
+      webServerAddress: e2eWebServerInfo.e2eCiBaseUrl,
+      webServerCommand: e2eWebServerInfo.e2eCiWebServerCommand,
       addPlugin: true,
     });
 


### PR DESCRIPTION
## Current Behavior
Currently, the add-e2e.ts generator has redundant lines for the webServerAddress and webServerCommand configuration when generating Playwright configuration. 
Produces `TypeError: Invalid URL` when running playwright tests on a clean create-nx-workspace project. 

## Expected Behavior
The generator should configure webServerAddress and webServerCommand correctly. The changes fix the configuration generation for Playwright tests.
