### PR TITLE
fix(node): set correct compilerOptions for Nest applications

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -278,6 +278,7 @@ describe('application generator', () => {
         {
           "compilerOptions": {
             "emitDecoratorMetadata": true,
+            "experimentalDecorators": true,
             "module": "nodenext",
             "moduleResolution": "nodenext",
             "outDir": "out-tsc/myapp",
@@ -307,6 +308,8 @@ describe('application generator', () => {
       expect(readJson(tree, 'myapp/tsconfig.spec.json')).toMatchInlineSnapshot(`
         {
           "compilerOptions": {
+            "emitDecoratorMetadata": true,
+            "experimentalDecorators": true,
             "module": "nodenext",
             "moduleResolution": "nodenext",
             "outDir": "./out-tsc/jest",

--- a/packages/nest/src/generators/application/lib/update-tsconfig.ts
+++ b/packages/nest/src/generators/application/lib/update-tsconfig.ts
@@ -1,12 +1,14 @@
 import type { Tree } from '@nx/devkit';
 import { joinPathFragments, updateJson } from '@nx/devkit';
 import type { NormalizedOptions } from '../schema';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export function updateTsConfig(tree: Tree, options: NormalizedOptions): void {
   updateJson(
     tree,
     joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
     (json) => {
+      json.compilerOptions.experimentalDecorators = true;
       json.compilerOptions.emitDecoratorMetadata = true;
       json.compilerOptions.target = 'es2021';
       if (options.strict) {
@@ -22,4 +24,20 @@ export function updateTsConfig(tree: Tree, options: NormalizedOptions): void {
       return json;
     }
   );
+
+  // For TS solution, we don't extend from shared tsconfig.json, so we need to make sure decorators are also turned on for spec tsconfig.
+  if (isUsingTsSolutionSetup(tree)) {
+    const tsconfigSpecPath = joinPathFragments(
+      options.appProjectRoot,
+      'tsconfig.spec.json'
+    );
+    if (tree.exists(tsconfigSpecPath)) {
+      updateJson(tree, tsconfigSpecPath, (json) => {
+        json.compilerOptions ??= {};
+        json.compilerOptions.experimentalDecorators = true;
+        json.compilerOptions.emitDecoratorMetadata = true;
+        return json;
+      });
+    }
+  }
 }

--- a/packages/node/src/generators/e2e-project/e2e-project.spec.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.spec.ts
@@ -153,11 +153,7 @@ describe('e2eProjectGenerator', () => {
             "jest.config.ts",
             "src/**/*.ts",
           ],
-          "references": [
-            {
-              "path": "../api",
-            },
-          ],
+          "references": [],
         }
       `);
     });

--- a/packages/node/src/generators/e2e-project/files/ts-solution/tsconfig.json__tmpl__
+++ b/packages/node/src/generators/e2e-project/files/ts-solution/tsconfig.json__tmpl__
@@ -10,7 +10,5 @@
     "jest.config.ts",
     "src/**/*.ts"
   ],
-  "references": [
-   { "path": "<%= relativeProjectReferencePath %>" }
-  ]
+  "references": []
 }


### PR DESCRIPTION
This PR fixes and issue where generating Nest app in the new TS setup results in a build error due to missing `experimentalDecorators` option in tsconfig. Decorators are required for Nest to work, but we do not set it anymore in `tsconfig.base.json` by default.


## Current Behavior
Nest apps are broken

## Expected Behavior
Nest apps work

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
