### PR TITLE
fix(react): ensure project name is escaped in spec matcher when generating an application

### DIFF
--- a/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -223,7 +223,7 @@ if (import.meta.vitest) {
 
   it('should have a greeting as the title', () => {
     const { getByText } = render(<App />);
-    expect(getByText(/Welcome plain/gi)).toBeTruthy();
+    expect(getByText(new RegExp('Welcome plain', 'gi'))).toBeTruthy();
   });
 
 }

--- a/packages/react/src/generators/application/lib/get-app-tests.ts
+++ b/packages/react/src/generators/application/lib/get-app-tests.ts
@@ -16,7 +16,9 @@ export function getAppTests(options: NormalizedSchema) {
         ? 'const { getByText } = render(<BrowserRouter><App /></BrowserRouter>);'
         : 'const { getByText } = render(<App />);'
     }
-    expect(getByText(/Welcome ${options.projectName}/gi)).toBeTruthy();
+    expect(getByText(new RegExp('Welcome ${
+      options.projectName
+    }', 'gi'))).toBeTruthy();
   });
 `;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
