### PR TITLE
docs(nx-dev): fix broken links to Nx Cloud runs

### DIFF
--- a/docs/blog/2024-05-08-nx-19-release.md
+++ b/docs/blog/2024-05-08-nx-19-release.md
@@ -80,9 +80,9 @@ You'll see the following in the project view:
 
 Notice how all tasks are now appropriately grouped in the `E2E (CI)` group!
 
-You can also find the same enhancements in Nx Cloud. Below is a view of all tasks in the [CI pipeline](https://staging.nx.app/runs/ctbAZfiLy3):
+You can also find the same enhancements in Nx Cloud. Below is a view of all tasks in the CI pipeline:
 
-{% video-player src="/documentation/blog/media/2024-05-08/nx-cloud-atomizer-groupings.mp4" alt="Showing the Atomizer in Nx Cloud" link="https://staging.nx.app/runs/ctbAZfiLy3" /%}
+{% video-player src="/documentation/blog/media/2024-05-08/nx-cloud-atomizer-groupings.mp4" alt="Showing the Atomizer in Nx Cloud" /%}
 
 Notice how all e2e groups are collapsed by default to give a concise view, while allowing you to expand to see how each individual task is progressing!
 
@@ -182,7 +182,7 @@ In February, we launched two big enhancements to Nx Cloud: the [Atomizer](/ci/fe
 
 Since then, the Atomizer has received a nice UI update (as we had seen earlier):
 
-{% video-player src="/documentation/blog/media/2024-05-08/nx-cloud-atomizer-groupings.mp4" alt="Showing the Atomizer in Nx Cloud" link="https://staging.nx.app/runs/ctbAZfiLy3" /%}
+{% video-player src="/documentation/blog/media/2024-05-08/nx-cloud-atomizer-groupings.mp4" alt="Showing the Atomizer in Nx Cloud" /%}
 
 Since February, we also revamped our task distribution algorithms. This has resulted in a 5-20% (depending on the repo) increase in both speed and cost efficiency for our users.
 


### PR DESCRIPTION
It removes redundant links from video player elements to ensure a cleaner presentation.