### PR TITLE
fix(js): identify correct circular dependecies

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -191,6 +191,7 @@ describe('nx release - independent projects', () => {
         {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
         {project-name} 📄 Using the provided version specifier "999.9.9-package.3".
         {project-name} ✍️  New version 999.9.9-package.3 written to {project-name}/package.json
+        {project-name} ✍️  Applying new version 999.9.9-package.3 to 1 package which depends on {project-name}
 
 
         "name": "@proj/{project-name}",

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -619,7 +619,7 @@ To fix this you will either need to add a package.json file at that location, or
       const allDependentProjects = Object.values(localPackageDependencies)
         .flat()
         .filter((localPackageDependency) => {
-          return localPackageDependency.target === project.name;
+          return localPackageDependency.target === projectName;
         });
 
       const includeTransitiveDependents =
@@ -643,10 +643,14 @@ To fix this you will either need to add a package.json file at that location, or
       const dependentProjectsOutsideCurrentBatch = [];
       // Track circular dependencies using value of project1:project2
       const circularDependencies = new Set<string>();
+      const projectsDependOnCurrentProject =
+        localPackageDependencies[projectName]?.map(
+          (localPackageDependencies) => localPackageDependencies.target
+        ) ?? [];
 
       for (const dependentProject of allDependentProjects) {
         // Track circular dependencies (add both directions for easy look up)
-        if (dependentProject.target === projectName) {
+        if (projectsDependOnCurrentProject.includes(dependentProject.source)) {
           circularDependencies.add(
             `${dependentProject.source}:${dependentProject.target}`
           );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
currently, when detecting circular dep in release, it tests `dependentProject.target === projectName`, which adds all projects as circular deps. because filter allDependentProjects  is `localPackageDependency.target === projectName`, so `dependentProject.target === projectName` is always true

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
correct the logic of detecting circular deps, it should test 
- current project.target -> a (source: current project, target: a)
- a.target -> current project (source: a, target: current project)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/28336
