### PR TITLE
fix(misc): generate remix libs correctly and install correct `@types/react` version for react libs

### DIFF
--- a/e2e/remix/src/remix-ts-solution.test.ts
+++ b/e2e/remix/src/remix-ts-solution.test.ts
@@ -1,0 +1,116 @@
+import { cleanupProject, newProject, runCLI, uniq } from '@nx/e2e/utils';
+
+describe('Remix - TS solution setup', () => {
+  beforeAll(() => {
+    newProject({
+      packages: ['@nx/remix'],
+      preset: 'ts',
+    });
+  });
+
+  afterAll(() => {
+    cleanupProject();
+  });
+
+  it('should generate apps and libraries with jest and vitest and work correctly', async () => {
+    const appJest = uniq('app-jest');
+    const appVitest = uniq('app-vitest');
+    const libJest = uniq('lib-jest');
+    const buildableLibJest = uniq('buildable-lib-jest');
+    const libVitest = uniq('lib-vitest');
+    const buildableLibVitest = uniq('buildable-lib-vitest');
+
+    runCLI(
+      `generate @nx/remix:application apps/${appVitest} --unitTestRunner=vitest --linter=eslint`
+    );
+    runCLI(
+      `generate @nx/remix:library libs/${libVitest} --unitTestRunner=vitest --linter=eslint`
+    );
+    runCLI(
+      `generate @nx/remix:library libs/${buildableLibVitest} --unitTestRunner=vitest --linter=eslint --buildable`
+    );
+    runCLI(
+      `generate @nx/remix:application apps/${appJest} --unitTestRunner=jest --linter=eslint`
+    );
+    runCLI(
+      `generate @nx/remix:library libs/${libJest} --unitTestRunner=jest --linter=eslint`
+    );
+    runCLI(
+      `generate @nx/remix:library libs/${buildableLibJest} --unitTestRunner=jest --linter=eslint --buildable`
+    );
+
+    // typecheck
+    expect(runCLI(`typecheck ${appVitest}`)).toContain(
+      `Successfully ran target typecheck for project @proj/${appVitest}`
+    );
+    expect(runCLI(`typecheck ${libVitest}`)).toContain(
+      `Successfully ran target typecheck for project @proj/${libVitest}`
+    );
+    expect(runCLI(`typecheck ${buildableLibVitest}`)).toContain(
+      `Successfully ran target typecheck for project @proj/${buildableLibVitest}`
+    );
+    expect(runCLI(`typecheck ${appJest}`)).toContain(
+      `Successfully ran target typecheck for project @proj/${appJest}`
+    );
+    expect(runCLI(`typecheck ${libJest}`)).toContain(
+      `Successfully ran target typecheck for project @proj/${libJest}`
+    );
+    expect(runCLI(`typecheck ${buildableLibJest}`)).toContain(
+      `Successfully ran target typecheck for project @proj/${buildableLibJest}`
+    );
+
+    // lint
+    expect(runCLI(`lint ${appVitest}`)).toContain(
+      `Successfully ran target lint for project @proj/${appVitest}`
+    );
+    expect(runCLI(`lint ${libVitest}`)).toContain(
+      `Successfully ran target lint for project @proj/${libVitest}`
+    );
+    expect(runCLI(`lint ${buildableLibVitest}`)).toContain(
+      `Successfully ran target lint for project @proj/${buildableLibVitest}`
+    );
+    expect(runCLI(`lint ${appJest}`)).toContain(
+      `Successfully ran target lint for project @proj/${appJest}`
+    );
+    expect(runCLI(`lint ${libJest}`)).toContain(
+      `Successfully ran target lint for project @proj/${libJest}`
+    );
+    expect(runCLI(`lint ${buildableLibJest}`)).toContain(
+      `Successfully ran target lint for project @proj/${buildableLibJest}`
+    );
+
+    // build
+    expect(runCLI(`build ${appVitest}`)).toContain(
+      `Successfully ran target build for project @proj/${appVitest}`
+    );
+    expect(runCLI(`build ${buildableLibVitest}`)).toContain(
+      `Successfully ran target build for project @proj/${buildableLibVitest}`
+    );
+    expect(runCLI(`build ${appJest}`)).toContain(
+      `Successfully ran target build for project @proj/${appJest}`
+    );
+    expect(runCLI(`build ${buildableLibJest}`)).toContain(
+      `Successfully ran target build for project @proj/${buildableLibJest}`
+    );
+
+    // test
+    expect(runCLI(`test ${appVitest}`)).toContain(
+      `Successfully ran target test for project @proj/${appVitest}`
+    );
+    expect(runCLI(`test ${libVitest}`)).toContain(
+      `Successfully ran target test for project @proj/${libVitest}`
+    );
+    expect(runCLI(`test ${buildableLibVitest}`)).toContain(
+      `Successfully ran target test for project @proj/${buildableLibVitest}`
+    );
+    expect(runCLI(`test ${appJest}`)).toContain(
+      `Successfully ran target test for project @proj/${appJest}`
+    );
+    expect(runCLI(`test ${libJest}`)).toContain(
+      `Successfully ran target test for project @proj/${libJest}`
+    );
+    expect(runCLI(`test ${buildableLibJest}`)).toContain(
+      `Successfully ran target test for project @proj/${buildableLibJest}`
+    );
+  }, 120_000);
+});

--- a/packages/react/src/generators/library/lib/install-common-dependencies.ts
+++ b/packages/react/src/generators/library/lib/install-common-dependencies.ts
@@ -5,6 +5,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { addSwcDependencies } from '@nx/js/src/utils/swc/add-swc-dependencies';
+import { getReactDependenciesVersionsToInstall } from '../../../utils/version-utils';
 import {
   babelCoreVersion,
   babelPresetReactVersion,
@@ -13,22 +14,22 @@ import {
   testingLibraryReactVersion,
   tsLibVersion,
   typesNodeVersion,
-  typesReactDomVersion,
-  typesReactVersion,
 } from '../../../utils/versions';
 import { NormalizedSchema } from '../schema';
 
-export function installCommonDependencies(
+export async function installCommonDependencies(
   host: Tree,
   options: NormalizedSchema
 ) {
   const tasks: GeneratorCallback[] = [];
 
+  const reactVersions = await getReactDependenciesVersionsToInstall(host);
+
   const dependencies: Record<string, string> = {};
   const devDependencies: Record<string, string> = {
     '@types/node': typesNodeVersion,
-    '@types/react': typesReactVersion,
-    '@types/react-dom': typesReactDomVersion,
+    '@types/react': reactVersions['@types/react'],
+    '@types/react-dom': reactVersions['@types/react-dom'],
   };
 
   if (options.bundler !== 'vite') {

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -244,7 +244,7 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
   }
 
   if (!options.skipPackageJson) {
-    const installReactTask = installCommonDependencies(host, options);
+    const installReactTask = await installCommonDependencies(host, options);
     tasks.push(installReactTask);
   }
 

--- a/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
+++ b/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
@@ -16,7 +16,10 @@ export function addTsconfigEntryPoints(
     tree,
     options.projectName
   );
-  const serverFilePath = joinPathFragments(sourceRoot ?? 'src', 'server.ts');
+  const serverFilePath = joinPathFragments(
+    ...(sourceRoot ? [sourceRoot] : [projectRoot, 'src']),
+    'server.ts'
+  );
 
   tree.write(
     serverFilePath,

--- a/packages/remix/src/generators/library/lib/update-buildable-config.ts
+++ b/packages/remix/src/generators/library/lib/update-buildable-config.ts
@@ -5,16 +5,24 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import type { RemixLibraryOptions } from './normalize-options';
 
-export function updateBuildableConfig(tree: Tree, name: string) {
+export function updateBuildableConfig(
+  tree: Tree,
+  options: RemixLibraryOptions
+) {
+  if (options.isUsingTsSolutionConfig) {
+    return;
+  }
+
   // Nest dist under project root to we can link it
-  const project = readProjectConfiguration(tree, name);
+  const project = readProjectConfiguration(tree, options.projectName);
   project.targets.build.options = {
     ...project.targets.build.options,
     format: ['cjs'],
     outputPath: joinPathFragments(project.root, 'dist'),
   };
-  updateProjectConfiguration(tree, name, project);
+  updateProjectConfiguration(tree, options.name, project);
 
   // Point to nested dist for yarn/npm/pnpm workspaces
   updateJson(tree, joinPathFragments(project.root, 'package.json'), (json) => {

--- a/packages/remix/src/generators/library/library.impl.spec.ts
+++ b/packages/remix/src/generators/library/library.impl.spec.ts
@@ -201,7 +201,7 @@ describe('Remix Library Generator', () => {
         addPlugin: true,
       });
 
-      expect(tree.exists(`test/src/server.ts`));
+      expect(tree.exists(`test/src/server.ts`)).toBeTruthy();
       expect(tree.children(`test/src/lib`).sort()).toMatchInlineSnapshot(`
         [
           "test.module.css",

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -64,7 +64,7 @@ export async function remixLibraryGeneratorInternal(
   addTsconfigEntryPoints(tree, options);
 
   if (options.bundler === 'rollup' || options.buildable) {
-    updateBuildableConfig(tree, options.projectName);
+    updateBuildableConfig(tree, options);
   }
 
   updateTsconfigFiles(


### PR DESCRIPTION
- Fix server file location for the `@nx/remix:library` generator
- Do not error when generating a buildable Remix library in the TS solution setup
- Install the correct versions of react-related packages when generating a React library

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
