### PR TITLE
Revert "fix(core): support subpath exports when constructing the project graph"

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1011,52 +1011,6 @@ describe('TargetProjectLocator', () => {
       expect(result).toEqual('npm:foo@0.0.1');
     });
   });
-
-  describe('findDependencyInWorkspaceProjects', () => {
-    it.each`
-      pkgName        | project   | exports                                                      | dependency
-      ${'@org/pkg1'} | ${'pkg1'} | ${undefined}                                                 | ${'@org/pkg1'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${undefined}                                                 | ${'@org/pkg1/subpath'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${'dist/index.js'}                                           | ${'@org/pkg1'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${{}}                                                        | ${'@org/pkg1'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${{}}                                                        | ${'@org/pkg1/subpath'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${{ '.': 'dist/index.js' }}                                  | ${'@org/pkg1'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${{ '.': 'dist/index.js' }}                                  | ${'@org/pkg1/subpath'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${{ './subpath': './dist/subpath.js' }}                      | ${'@org/pkg1'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${{ './subpath': './dist/subpath.js' }}                      | ${'@org/pkg1/subpath'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${{ import: './dist/index.js', default: './dist/index.js' }} | ${'@org/pkg1'}
-      ${'@org/pkg1'} | ${'pkg1'} | ${{ import: './dist/index.js', default: './dist/index.js' }} | ${'@org/pkg1/subpath'}
-    `(
-      'should find "$dependency" as "$project" when exports="$exports"',
-      ({ pkgName, project, exports, dependency }) => {
-        let projects: Record<string, ProjectGraphProjectNode> = {
-          [project]: {
-            name: project,
-            type: 'lib' as const,
-            data: {
-              root: project,
-              metadata: {
-                js: {
-                  packageName: pkgName,
-                  packageExports: exports,
-                },
-              },
-            },
-          },
-        };
-
-        const targetProjectLocator = new TargetProjectLocator(
-          projects,
-          {},
-          new Map()
-        );
-        const result =
-          targetProjectLocator.findDependencyInWorkspaceProjects(dependency);
-
-        expect(result).toEqual(project);
-      }
-    );
-  });
 });
 
 describe('isBuiltinModuleImport()', () => {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -259,14 +259,7 @@ export class TargetProjectLocator {
       this.nodes
     );
 
-    return (
-      this.packageEntryPointsToProjectMap[dep]?.name ??
-      // if the package exports do not include ".", look for subpath exports
-      Object.entries(this.packageEntryPointsToProjectMap).find(([entryPoint]) =>
-        dep.startsWith(`${entryPoint}/`)
-      )?.[1]?.name ??
-      null
-    );
+    return this.packageEntryPointsToProjectMap[dep]?.name ?? null;
   }
 
   private resolveImportWithTypescript(

--- a/packages/nx/src/plugins/js/utils/packages.ts
+++ b/packages/nx/src/plugins/js/utils/packages.ts
@@ -15,28 +15,13 @@ export function getPackageEntryPointsToProjectMap<
     }
 
     const { packageName, packageExports } = metadata.js;
-    if (
-      !packageExports ||
-      typeof packageExports === 'string' ||
-      !Object.keys(packageExports).length
-    ) {
+    if (!packageExports || typeof packageExports === 'string') {
       // no `exports` or it points to a file, which would be the equivalent of
       // an '.' export, in which case the package name is the entry point
       result[packageName] = project;
     } else {
       for (const entryPoint of Object.keys(packageExports)) {
-        // if entrypoint begins with '.', it is a relative subpath export
-        // otherwise, it is a conditional export
-        // https://nodejs.org/api/packages.html#conditional-exports
-        if (entryPoint.startsWith('.')) {
-          result[join(packageName, entryPoint)] = project;
-        } else {
-          result[packageName] = project;
-        }
-      }
-      // if there was no '.' entrypoint, ensure the package name is matched with the project
-      if (!result[packageName]) {
-        result[packageName] = project;
+        result[join(packageName, entryPoint)] = project;
       }
     }
   }


### PR DESCRIPTION
Reverts nrwl/nx#29577

There is an issue with workspaces using tsconfig path alias, and when an invalid import is found, it'll match on the wrong package due to the name matching the prefix.