### PR TITLE
fix(testing): infer correct file output paths for atomized targets

### DIFF
--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -262,6 +262,7 @@ describe('@nx/playwright/plugin', () => {
       testIgnore: [/.*skip.*/, '**/ignored/**'],
       reporter: [
         ['html', { outputFolder: 'test-results/html' }],
+        ['junit', { outputFile: 'test-results/report.xml' }],
       ],
     }`
     );
@@ -335,6 +336,7 @@ describe('@nx/playwright/plugin', () => {
         "outputs": [
           "{projectRoot}/test-results",
           "{projectRoot}/test-results/html",
+          "{projectRoot}/test-results/report.xml",
         ],
         "parallelism": false,
       }
@@ -371,11 +373,13 @@ describe('@nx/playwright/plugin', () => {
           "env": {
             "PLAYWRIGHT_HTML_OUTPUT_DIR": "test-results/html/tests-run-me-spec-ts",
             "PLAYWRIGHT_HTML_REPORT": "test-results/html/tests-run-me-spec-ts",
+            "PLAYWRIGHT_JUNIT_OUTPUT_FILE": "test-results/tests-run-me-spec-ts/report.xml",
           },
         },
         "outputs": [
           "{projectRoot}/test-results/tests-run-me-spec-ts",
           "{projectRoot}/test-results/html/tests-run-me-spec-ts",
+          "{projectRoot}/test-results/tests-run-me-spec-ts/report.xml",
         ],
         "parallelism": false,
       }
@@ -412,11 +416,13 @@ describe('@nx/playwright/plugin', () => {
           "env": {
             "PLAYWRIGHT_HTML_OUTPUT_DIR": "test-results/html/tests-run-me-2-spec-ts",
             "PLAYWRIGHT_HTML_REPORT": "test-results/html/tests-run-me-2-spec-ts",
+            "PLAYWRIGHT_JUNIT_OUTPUT_FILE": "test-results/tests-run-me-2-spec-ts/report.xml",
           },
         },
         "outputs": [
           "{projectRoot}/test-results/tests-run-me-2-spec-ts",
           "{projectRoot}/test-results/html/tests-run-me-2-spec-ts",
+          "{projectRoot}/test-results/tests-run-me-2-spec-ts/report.xml",
         ],
         "parallelism": false,
       }

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -407,12 +407,12 @@ function getTargetOutputs(
   reporterOutputs: Array<[string, string]>,
   workspaceRoot: string,
   projectRoot: string,
-  scope?: string
+  subFolder?: string
 ): string[] {
   const outputs = new Set<string>();
   outputs.add(
     normalizeOutput(
-      scope ? join(testOutput, scope) : testOutput,
+      addSubfolderToOutput(testOutput, subFolder),
       workspaceRoot,
       projectRoot
     )
@@ -420,13 +420,22 @@ function getTargetOutputs(
   for (const [, output] of reporterOutputs) {
     outputs.add(
       normalizeOutput(
-        scope ? join(output, scope) : output,
+        addSubfolderToOutput(output, subFolder),
         workspaceRoot,
         projectRoot
       )
     );
   }
   return Array.from(outputs);
+}
+
+function addSubfolderToOutput(output: string, subfolder?: string): string {
+  if (!subfolder) return output;
+  const parts = parse(output);
+  if (parts.ext !== '') {
+    return join(parts.dir, subfolder, parts.base);
+  }
+  return join(output, subfolder);
 }
 
 function normalizeOutput(
@@ -460,7 +469,7 @@ function getOutputEnvVars(
       const envVarName = `PLAYWRIGHT_${reporter.toUpperCase()}_OUTPUT_${
         isFile ? 'FILE' : 'DIR'
       }`;
-      env[envVarName] = join(output, outputSubfolder);
+      env[envVarName] = addSubfolderToOutput(output, outputSubfolder);
       // Also set PLAYWRIGHT_HTML_REPORT for Playwright prior to 1.45.0.
       // HTML prior to this version did not follow the pattern of "PLAYWRIGHT_<REPORTER>_OUTPUT_<FILE|DIR>".
       if (reporter === 'html') {


### PR DESCRIPTION
There is a bug when `outputFile` is specified in `playright.config.ts`, and atomizer is enabled via `ciTargetName`, then the path of the output file is wrong.

For example, if you have this reporters entry:

```
reporter: [
  [
    'junit',
    {
      outputFile: 'dist/report.xml',
    },
  ],
],

```

Then the atomized output file would be something like `dist/report.xml/example-spec-ts`, where `report.xml` is a directory. The correct output file should be `dist/example-spec-ts/report.xml` to avoid conflict with the non-atomized output of `dist/report.xml`.

## Current Behavior
If you run `nx e2e proj` then `nx e2e-ci proj` then you can run into an issue where `report.xml` (or whatever the file name is) is a directory in the cache, but it is a file currently -- or vice versa. This happens due to the bug described above.

## Expected Behavior

The `outputFile` should never cause a conflict where a path should be a directory but is currently a file, or vice versa.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
