### PR TITLE
fix(core): Optimize loading local plugin TS options

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -293,8 +293,7 @@ export function getTranspiler(
  * @returns cleanup method
  */
 export function registerTranspiler(
-  compilerOptions: CompilerOptions,
-  tsConfigRaw?: unknown
+  compilerOptions: CompilerOptions
 ): () => void {
   // Function to register transpiler that returns cleanup function
   const transpiler = getTranspiler(compilerOptions);

--- a/packages/nx/src/plugins/js/utils/typescript.ts
+++ b/packages/nx/src/plugins/js/utils/typescript.ts
@@ -23,7 +23,7 @@ export function readTsConfig(tsConfigPath: string) {
   );
 }
 
-function readTsConfigOptions(tsConfigPath: string) {
+export function readTsConfigOptions(tsConfigPath: string) {
   if (!tsModule) {
     tsModule = require('typescript');
   }

--- a/packages/nx/src/project-graph/plugins/transpiler.ts
+++ b/packages/nx/src/project-graph/plugins/transpiler.ts
@@ -5,7 +5,7 @@ import {
   registerTranspiler,
   registerTsConfigPaths,
 } from '../../plugins/js/utils/register';
-import { readTsConfig } from '../../plugins/js/utils/typescript';
+import { readTsConfigOptions } from '../../plugins/js/utils/typescript';
 import type * as ts from 'typescript';
 
 export let unregisterPluginTSTranspiler: (() => void) | null = null;
@@ -25,19 +25,16 @@ export function registerPluginTSTranspiler() {
     return;
   }
 
-  const tsConfig: Partial<ts.ParsedCommandLine> = tsConfigName
-    ? readTsConfig(tsConfigName)
+  const tsConfigOptions: Partial<ts.CompilerOptions> = tsConfigName
+    ? readTsConfigOptions(tsConfigName)
     : {};
   const cleanupFns = [
     registerTsConfigPaths(tsConfigName),
-    registerTranspiler(
-      {
-        experimentalDecorators: true,
-        emitDecoratorMetadata: true,
-        ...tsConfig.options,
-      },
-      tsConfig.raw
-    ),
+    registerTranspiler({
+      experimentalDecorators: true,
+      emitDecoratorMetadata: true,
+      ...tsConfigOptions,
+    }),
   ];
   unregisterPluginTSTranspiler = () => {
     cleanupFns.forEach((fn) => fn?.());


### PR DESCRIPTION
## Current Behavior

All of the TS source trees are unnecessarily traversed when a local plugin is being registered.

## Expected Behavior

TS source trees are not unnecessarily traversed.

## Related Issue(s)

Fixes #29102 (see issue for more context)