### PR TITLE
fix(module-federation): depend on a range of versions of webpack to prevent peer dep issues

### DIFF
--- a/packages/module-federation/package.json
+++ b/packages/module-federation/package.json
@@ -29,7 +29,7 @@
     "@nx/js": "file:../js",
     "@nx/web": "file:../web",
     "picocolors": "^1.1.0",
-    "webpack": "5.88.0",
+    "webpack": "^5.88.0",
     "@rspack/core": "^1.1.5",
     "@module-federation/enhanced": "^0.8.8",
     "@module-federation/node": "^2.6.21",


### PR DESCRIPTION
## Current Behavior
`@nx/module-federation` is currently pinned to depend on `webpack@5.88.0`. However, other Nx packages such as `@nx/webpack` depend on a range of versions `^5.80.0`.

This leads to peerDep issues when package managers attempt to resolve the packages.

## Expected Behavior
Change `@nx/module-federation` to depend on a range of versions. `wepback@^5.88.0`. 

## Related Issue(s)

Fixes #29682
