### PR TITLE
fix(gradle): build nx graph for gradle projects regardless of build gradle file location (#29783)

### DIFF
--- a/e2e/gradle/src/gradle-import.test.ts
+++ b/e2e/gradle/src/gradle-import.test.ts
@@ -184,6 +184,12 @@ describe('Nx Import Gradle', () => {
       `${directory}/gradlew`,
       `${directory}/gradlew.bat`
     );
+    const nxJson = readJson('nx.json');
+    const gradlePlugin = nxJson.plugins.find(
+      (plugin) => plugin.plugin === '@nx/gradle'
+    );
+    gradlePlugin.exclude = [];
+    updateJson('nx.json', () => nxJson);
     expect(() => {
       runCLI(`show projects`);
       runCLI('build groovy-app');

--- a/packages/gradle/src/utils/get-project-report-lines.ts
+++ b/packages/gradle/src/utils/get-project-report-lines.ts
@@ -22,17 +22,7 @@ export async function getProjectReportLines(
 ): Promise<string[]> {
   let projectReportBuffer: Buffer;
 
-  // if there is no build.gradle or build.gradle.kts file, we cannot run the projectReport nor projectReportAll task
-  if (
-    !existsSync(join(dirname(gradlewFile), 'build.gradle')) &&
-    !existsSync(join(dirname(gradlewFile), 'build.gradle.kts'))
-  ) {
-    logger.warn(
-      `Could not find build file near ${gradlewFile}. Please run 'nx generate @nx/gradle:init' to generate the necessary tasks.`
-    );
-    return [];
-  }
-
+  // Attempt to run projectReport or projectReportAll task, regardless of build.gradle or build.gradle.kts location
   try {
     projectReportBuffer = await execGradleAsync(gradlewFile, [
       'projectReportAll',

--- a/packages/nx/src/command-line/init/implementation/check-compatible-with-plugins.ts
+++ b/packages/nx/src/command-line/init/implementation/check-compatible-with-plugins.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { bold } from 'chalk';
 
 import { NxJsonConfiguration } from '../../../config/nx-json';
@@ -83,7 +83,13 @@ function findPluginAndFilesWithError(
       },
     ];
   }
-  excludeFiles = excludeFiles.filter(Boolean);
+  excludeFiles = excludeFiles.filter(Boolean).map((excludeFile) => {
+    const file = excludeFile.file;
+    excludeFile.file = file.startsWith(workspaceRoot)
+      ? relative(workspaceRoot, file)
+      : file;
+    return excludeFile;
+  });
   return {
     pluginIndex,
     excludeFiles,

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -409,7 +409,7 @@ export async function createProjectConfigurationsWithPlugins(
             e
           : // This represents a single plugin erroring out with a hard error.
             new AggregateCreateNodesError([[null, e]], []);
-        if (pluginIndex) {
+        if (pluginIndex !== undefined) {
           error.pluginIndex = pluginIndex;
         }
         formatAggregateCreateNodesError(error, pluginName);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
With a project structure where build.gradle.kts is defined in a separate buildSrc directory, and not in the root project directory where `gradlew` is defined, the gradle project is not included in nx project graph. This is a valid gradle project configuration, with project-report tasks configured. Running ./gradlew projectReport works and builds the projectReport.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

With the fix, as long as expected tasks - projectReport or projectReportAll - is defined, nx should be able to build the nx graph regardless of the location of the `build.gradle` or `build.gradle.kts` file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29783
