### PR TITLE
fix(module-federation): tuple remotes should have global identifier added if missing

### DIFF
--- a/packages/module-federation/src/utils/remotes.spec.ts
+++ b/packages/module-federation/src/utils/remotes.spec.ts
@@ -1,0 +1,58 @@
+import { mapRemotes } from './remotes';
+
+describe('mapRemotes', () => {
+  it('should map string remotes', () => {
+    expect(
+      mapRemotes(
+        ['remote1', 'remote2', 'remote3'],
+        'js',
+        (remote) => {
+          return `http://localhost:300${remote.at(-1)}/remoteEntry.js`;
+        },
+        true
+      )
+    ).toEqual({
+      remote1: 'remote1@http://localhost:3001/remoteEntry.js',
+      remote2: 'remote2@http://localhost:3002/remoteEntry.js',
+      remote3: 'remote3@http://localhost:3003/remoteEntry.js',
+    });
+  });
+
+  it('should map array remotes', () => {
+    expect(
+      mapRemotes(
+        [
+          ['remote1', 'http://localhost:4201'],
+          ['remote2', 'http://localhost:4202'],
+          ['remote3', 'http://localhost:4203'],
+        ],
+        'js',
+        (remote) => remote,
+        true
+      )
+    ).toEqual({
+      remote1: 'remote1@http://localhost:4201/remoteEntry.js',
+      remote2: 'remote2@http://localhost:4202/remoteEntry.js',
+      remote3: 'remote3@http://localhost:4203/remoteEntry.js',
+    });
+  });
+
+  it('should map array remotes with path to remoteEntry', () => {
+    expect(
+      mapRemotes(
+        [
+          ['remote1', 'http://localhost:4201/remoteEntry.js'],
+          ['remote2', 'http://localhost:4202/remoteEntry.mjs'],
+          ['remote3', 'http://localhost:4203/mf-manifest.json'],
+        ],
+        'js',
+        (remote) => remote,
+        true
+      )
+    ).toEqual({
+      remote1: 'remote1@http://localhost:4201/remoteEntry.js',
+      remote2: 'remote2@http://localhost:4202/remoteEntry.mjs',
+      remote3: 'remote3@http://localhost:4203/mf-manifest.json',
+    });
+  });
+});

--- a/packages/module-federation/src/utils/remotes.ts
+++ b/packages/module-federation/src/utils/remotes.ts
@@ -51,6 +51,9 @@ function handleArrayRemote(
 
   // If remote location already has .js or .mjs extension
   if (['.js', '.mjs', '.json'].includes(remoteLocationExt)) {
+    if (isRemoteGlobal && !remoteLocation.startsWith(`${mfRemoteName}@`)) {
+      return `${mfRemoteName}@${remoteLocation}`;
+    }
     return remoteLocation;
   }
 


### PR DESCRIPTION
## Current Behavior
Our Module Federation Config allows passing tuple remotes:

```js
remotes: [
  ["remote1", "http://localhost:4201/remoteEntry.js"]
]
```

However, if the Module Federation system is expecting the remotes to be loaded as Global variables in the browser, then we erroneously pass just the url to webpack/rspack's `extractUrlAndGlobal` method.

This expects a string of format `name@url`. For non-tuple remote configurations, we create this correctly.
However, when a tuple is passed, we simply return the url.


## Expected Behavior
We should ensure that the string is massaged to `name@url` even when a tuple is provided.

