### PR TITLE
fix(rspack): handle configs with default exports

### DIFF
--- a/e2e/react/project.json
+++ b/e2e/react/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "e2e/react",
   "projectType": "application",
-  "implicitDependencies": ["react"],
+  "implicitDependencies": ["react", "rspack"],
   "// targets": "to see all targets run: nx show project e2e-react --web",
   "targets": {}
 }

--- a/packages/rspack/src/executors/rspack/lib/config.ts
+++ b/packages/rspack/src/executors/rspack/lib/config.ts
@@ -13,10 +13,16 @@ export async function getRspackConfigs(
   options: NormalizedRspackExecutorSchema & { devServer?: any },
   context: ExecutorContext
 ): Promise<Configuration | Configuration[]> {
-  let userDefinedConfig = await resolveUserDefinedRspackConfig(
+  let maybeUserDefinedConfig = await resolveUserDefinedRspackConfig(
     options.rspackConfig,
     options.tsConfig
   );
+  let userDefinedConfig =
+    'default' in maybeUserDefinedConfig
+      ? 'default' in maybeUserDefinedConfig.default
+        ? maybeUserDefinedConfig.default.default
+        : maybeUserDefinedConfig.default
+      : maybeUserDefinedConfig;
 
   if (typeof userDefinedConfig.then === 'function') {
     userDefinedConfig = await userDefinedConfig;


### PR DESCRIPTION
## Current Behavior
When we resolve the config file for rspack, it can be provided in a few different formats:

```
config

config.default

config.default.default
```

We do not handle if the config is provided in any of the named default methods.

## Expected Behavior

Handle named defaults for the resolved user config for Rspack.
