### PR TITLE
fix(nx-plugin): reduce memory usage of `projectReportAll` when using @nx/gradle plugin

### DIFF
--- a/packages/gradle/src/generators/init/init.ts
+++ b/packages/gradle/src/generators/init/init.ts
@@ -94,6 +94,11 @@ function addProjectReportToBuildGradle(settingsGradleFile: string, tree: Tree) {
     if (!buildGradleContent.includes('"project-report"')) {
       logger.warn(`Please add the project-report plugin to your ${gradleFilePath}:
 allprojects {
+  tasks.whenTaskAdded {task ->
+    if(task.name.contains("htmlDependencyReport")){
+      task.enabled = false
+    }
+  }
   apply {
       plugin("project-report")
   }


### PR DESCRIPTION
The project-report Gradle plugin includes 4 tasks [dependencyReport, propertyReport, taskReport, htmlDependencyReport ] but only uses the dependency, propertyReport and taskReport tasks. The htmlDependencyReport is intended for viewing in a browser and is often too large for Nodes default memory settings causing the Nx graph creation to fail. This change disables the task completely for Nxs purposes.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/gradle` plugin template includes the `project-report` Gradle plugin, including the `htmlDependencyReport` task, which it does not require to compute the Graph but which consumes lots of memory in process, resulting in OutOfMemory errors when computing the Graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Projects to which the `@nx/gradle` plugin is added will continue to include the `project-report` gradle plugin but disable the `htmlDependencyReport` task to reduce the risk of this issue.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/27750

Fixes #27750
