### PR TITLE
fix(nx-dev): revert show alt text as label below markdown images

### DIFF
--- a/nx-dev/nx-dev/styles/main.css
+++ b/nx-dev/nx-dev/styles/main.css
@@ -53,7 +53,7 @@ iframe[src*='youtube'] {
   aspect-ratio: 16 / 9;
 }
 .prose iframe,
-.prose img:not(figure img) {
+.prose img {
   display: block;
   margin: 2rem auto;
 }

--- a/nx-dev/ui-markdoc/src/lib/nodes/image.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/image.schema.ts
@@ -8,7 +8,7 @@ import {
 import { transformImagePath } from './helpers/transform-image-path';
 
 export const getImageSchema = (documentFilePath: string): Schema => ({
-  render: 'figure',
+  render: 'img',
   attributes: {
     src: { type: 'String', required: true },
     alt: { type: 'String', required: true },
@@ -17,15 +17,11 @@ export const getImageSchema = (documentFilePath: string): Schema => ({
     const attributes = node.transformAttributes(config);
     const children = node.transformChildren(config);
     const src = transformImagePath(documentFilePath)(attributes['src']);
-    const alt = attributes['alt'];
 
-    return new Tag(this.render, { className: 'not-prose my-8 text-center' }, [
-      new Tag('img', { src, alt, loading: 'lazy', className: 'mx-auto !my-0' }),
-      new Tag(
-        'figcaption',
-        { className: 'mt-2 text-sm text-slate-600 dark:text-slate-400' },
-        [alt]
-      ),
-    ]);
+    return new Tag(
+      this.render,
+      { ...attributes, src, loading: 'lazy' },
+      children
+    );
   },
 });


### PR DESCRIPTION
This reverts commit a4f07dbb641d655d65128acd6ff2330b1068ec62.

Markdoc wraps everything in a `<p>` tag which is not valid HTML when `figure` is inside. I'll have a follow-up PR to properly fix this, but for now I need to revert this to not block other stuff that needs to go out.