### PR TITLE
fix(misc): set `hidden: true` for all init generators

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -2269,7 +2269,7 @@
       "/nx-api/gradle/generators/init": {
         "description": "Initializes a Gradle project in the current workspace",
         "file": "generated/packages/gradle/generators/init.json",
-        "hidden": false,
+        "hidden": true,
         "name": "init",
         "originalFilePath": "/packages/gradle/src/generators/init/schema.json",
         "path": "/nx-api/gradle/generators/init",
@@ -3749,7 +3749,7 @@
       "/nx-api/playwright/generators/init": {
         "description": "Initializes a Playwright project in the current workspace",
         "file": "generated/packages/playwright/generators/init.json",
-        "hidden": false,
+        "hidden": true,
         "name": "init",
         "originalFilePath": "/packages/playwright/src/generators/init/schema.json",
         "path": "/nx-api/playwright/generators/init",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -2253,7 +2253,7 @@
       {
         "description": "Initializes a Gradle project in the current workspace",
         "file": "generated/packages/gradle/generators/init.json",
-        "hidden": false,
+        "hidden": true,
         "name": "init",
         "originalFilePath": "/packages/gradle/src/generators/init/schema.json",
         "path": "gradle/generators/init",
@@ -3724,7 +3724,7 @@
       {
         "description": "Initializes a Playwright project in the current workspace",
         "file": "generated/packages/playwright/generators/init.json",
-        "hidden": false,
+        "hidden": true,
         "name": "init",
         "originalFilePath": "/packages/playwright/src/generators/init/schema.json",
         "path": "playwright/generators/init",

--- a/docs/generated/packages/gradle/generators/init.json
+++ b/docs/generated/packages/gradle/generators/init.json
@@ -37,9 +37,9 @@
     "presets": []
   },
   "description": "Initializes a Gradle project in the current workspace",
+  "hidden": true,
   "implementation": "/packages/gradle/src/generators/init/init#initGenerator.ts",
   "aliases": [],
-  "hidden": false,
   "path": "/packages/gradle/src/generators/init/schema.json",
   "type": "generator"
 }

--- a/docs/generated/packages/playwright/generators/init.json
+++ b/docs/generated/packages/playwright/generators/init.json
@@ -37,9 +37,9 @@
     "presets": []
   },
   "description": "Initializes a Playwright project in the current workspace",
+  "hidden": true,
   "implementation": "/packages/playwright/src/generators/init/init#initGeneratorInternal.ts",
   "aliases": [],
-  "hidden": false,
   "path": "/packages/playwright/src/generators/init/schema.json",
   "type": "generator"
 }

--- a/packages/gradle/generators.json
+++ b/packages/gradle/generators.json
@@ -5,7 +5,8 @@
     "init": {
       "factory": "./src/generators/init/init#initGenerator",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initializes a Gradle project in the current workspace"
+      "description": "Initializes a Gradle project in the current workspace",
+      "hidden": true
     },
     "ci-workflow": {
       "factory": "./src/generators/ci-workflow/generator",

--- a/packages/playwright/generators.json
+++ b/packages/playwright/generators.json
@@ -10,7 +10,8 @@
     "init": {
       "factory": "./src/generators/init/init#initGeneratorInternal",
       "schema": "./src/generators/init/schema.json",
-      "description": "Initializes a Playwright project in the current workspace"
+      "description": "Initializes a Playwright project in the current workspace",
+      "hidden": true
     },
     "convert-to-inferred": {
       "factory": "./src/generators/convert-to-inferred/convert-to-inferred",


### PR DESCRIPTION
This PR ensures that our init generators are hidden, such that they don't appear in Nx Console when running generators, for example.

The init generator is meant to be used when running other generators, like app or lib, and should not be run directly.

## Current Behavior
Init is not hidden

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Init is hidden
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
