### PR TITLE
fix(linter): produce type information for the eslint-plugin main entry point

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -24,50 +24,52 @@ import dependencyChecks, {
 // Resolve any custom rules that might exist in the current workspace
 import { workspaceRules } from './resolve-workspace-rules';
 
-module.exports = {
-  configs: {
-    // eslintrc configs
-    typescript,
-    javascript,
-    react: reactTmp,
-    'react-base': reactBase,
-    'react-typescript': reactTypescript,
-    'react-jsx': reactJsx,
-    angular: angularCode,
-    'angular-template': angularTemplate,
+const configs = {
+  // eslintrc configs
+  typescript,
+  javascript,
+  react: reactTmp,
+  'react-base': reactBase,
+  'react-typescript': reactTypescript,
+  'react-jsx': reactJsx,
+  angular: angularCode,
+  'angular-template': angularTemplate,
 
-    // flat configs
-    // Note: Using getters here to avoid importing packages `angular-eslint` statically, which can lead to errors if not installed.
-    'flat/base': flatBase,
-    get ['flat/typescript']() {
-      return require('./flat-configs/typescript').default;
-    },
-    get ['flat/javascript']() {
-      return require('./flat-configs/javascript').default;
-    },
-    get ['flat/react']() {
-      return require('./flat-configs/react-tmp').default;
-    },
-    get ['flat/react-base']() {
-      return require('./flat-configs/react-base').default;
-    },
-    get ['flat/react-typescript']() {
-      return require('./flat-configs/react-typescript').default;
-    },
-    get ['flat/react-jsx']() {
-      return require('./flat-configs/react-jsx').default;
-    },
-    get ['flat/angular']() {
-      return require('./flat-configs/angular').default;
-    },
-    get ['flat/angular-template']() {
-      return require('./flat-configs/angular-template').default;
-    },
+  // flat configs
+  // Note: Using getters here to avoid importing packages `angular-eslint` statically, which can lead to errors if not installed.
+  'flat/base': flatBase,
+  get ['flat/typescript'](): typeof import('./flat-configs/typescript').default {
+    return require('./flat-configs/typescript').default;
   },
-  rules: {
-    [enforceModuleBoundariesRuleName]: enforceModuleBoundaries,
-    [nxPluginChecksRuleName]: nxPluginChecksRule,
-    [dependencyChecksRuleName]: dependencyChecks,
-    ...workspaceRules,
+  get ['flat/javascript'](): typeof import('./flat-configs/javascript').default {
+    return require('./flat-configs/javascript').default;
+  },
+  get ['flat/react'](): typeof import('./flat-configs/react-tmp').default {
+    return require('./flat-configs/react-tmp').default;
+  },
+  get ['flat/react-base'](): typeof import('./flat-configs/react-base').default {
+    return require('./flat-configs/react-base').default;
+  },
+  get ['flat/react-typescript'](): typeof import('./flat-configs/react-typescript').default {
+    return require('./flat-configs/react-typescript').default;
+  },
+  get ['flat/react-jsx'](): typeof import('./flat-configs/react-jsx').default {
+    return require('./flat-configs/react-jsx').default;
+  },
+  get ['flat/angular'](): typeof import('./flat-configs/angular').default {
+    return require('./flat-configs/angular').default;
+  },
+  get ['flat/angular-template'](): typeof import('./flat-configs/angular-template').default {
+    return require('./flat-configs/angular-template').default;
   },
 };
+
+const rules = {
+  [enforceModuleBoundariesRuleName]: enforceModuleBoundaries,
+  [nxPluginChecksRuleName]: nxPluginChecksRule,
+  [dependencyChecksRuleName]: dependencyChecks,
+  ...workspaceRules,
+};
+
+export default { configs, rules };
+export { configs, rules };


### PR DESCRIPTION
## Current Behavior

The `@nx/eslint-plugin` main entry point is untyped.

## Expected Behavior

The `@nx/eslint-plugin` main entry point should provide types.

## Related Issue(s)

Fixes #28448 
Fixes #29816 
