### PR TITLE
feat(rspack): improve plugin createNodes performance

### DIFF
--- a/packages/rspack/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/rspack/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -10,6 +10,7 @@ import {
   type ProjectConfiguration,
   type ProjectGraph,
   type Tree,
+  detectPackageManager,
 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -17,6 +18,7 @@ import { join } from 'node:path';
 import { getRelativeProjectJsonSchemaPath } from 'nx/src/generators/utils/project-configuration';
 import type { RspackPluginOptions } from '../../plugins/plugin';
 import { convertToInferred } from './convert-to-inferred';
+import { getLockFileName } from '@nx/js';
 
 let fs: TempFs;
 let projectGraph: ProjectGraph;
@@ -248,6 +250,9 @@ describe('convert-to-inferred', () => {
     fs = new TempFs('rspack');
     tree = createTreeWithEmptyWorkspace();
     tree.root = fs.tempDir;
+    const lockFileName = getLockFileName(detectPackageManager(fs.tempDir));
+    fs.createFileSync(lockFileName, '');
+    tree.write(lockFileName, '');
 
     projectGraph = {
       nodes: {},


### PR DESCRIPTION
## Current Behavior
Currently, calculating nodes via the `@nx/rspack/plugin` takes a long time because the hash generation attempts to hash every source file.
This is problematic because the targets that are inferred do not rely on the source files themselves and rather just the config file.

It also means the time taken to infer the targets grows as the project grows.

## Expected Behavior
Calculate the hash based off the config file and the installed dependencies, allowing it to scale as the project grows and allowing it to be invalidated if dependencies change.

## Tested Results
Application with 90k files
Previous:  2mins
New: 1.18s

