### PR TITLE
fix(core): create multi-glob function

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -34,7 +34,10 @@ import {
   ProjectGraphError,
 } from '../../project-graph/error-types';
 import { IS_WASM, NxWorkspaceFiles, TaskRun, TaskTarget } from '../../native';
-import { HandleGlobMessage } from '../message-types/glob';
+import {
+  HandleGlobMessage,
+  HandleMultiGlobMessage,
+} from '../message-types/glob';
 import {
   GET_NX_WORKSPACE_FILES,
   HandleNxWorkspaceFilesMessage,
@@ -333,6 +336,15 @@ export class DaemonClient {
   glob(globs: string[], exclude?: string[]): Promise<string[]> {
     const message: HandleGlobMessage = {
       type: 'GLOB',
+      globs,
+      exclude,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  multiGlob(globs: string[], exclude?: string[]): Promise<string[][]> {
+    const message: HandleMultiGlobMessage = {
+      type: 'MULTI_GLOB',
       globs,
       exclude,
     };

--- a/packages/nx/src/daemon/message-types/glob.ts
+++ b/packages/nx/src/daemon/message-types/glob.ts
@@ -16,3 +16,21 @@ export function isHandleGlobMessage(
     message['type'] === GLOB
   );
 }
+
+export const MULTI_GLOB = 'MULTI_GLOB' as const;
+export type HandleMultiGlobMessage = {
+  type: typeof MULTI_GLOB;
+  globs: string[];
+  exclude?: string[];
+};
+
+export function isHandleMultiGlobMessage(
+  message: unknown
+): message is HandleMultiGlobMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === MULTI_GLOB
+  );
+}

--- a/packages/nx/src/daemon/server/handle-glob.ts
+++ b/packages/nx/src/daemon/server/handle-glob.ts
@@ -1,5 +1,8 @@
 import { workspaceRoot } from '../../utils/workspace-root';
-import { globWithWorkspaceContext } from '../../utils/workspace-context';
+import {
+  globWithWorkspaceContext,
+  multiGlobWithWorkspaceContext,
+} from '../../utils/workspace-context';
 import { HandlerResult } from './server';
 
 export async function handleGlob(
@@ -10,5 +13,20 @@ export async function handleGlob(
   return {
     response: JSON.stringify(files),
     description: 'handleGlob',
+  };
+}
+
+export async function handleMultiGlob(
+  globs: string[],
+  exclude?: string[]
+): Promise<HandlerResult> {
+  const files = await multiGlobWithWorkspaceContext(
+    workspaceRoot,
+    globs,
+    exclude
+  );
+  return {
+    response: JSON.stringify(files),
+    description: 'handleMultiGlob',
   };
 }

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -55,8 +55,13 @@ import {
   watchOutputFiles,
   watchWorkspace,
 } from './watcher';
-import { handleGlob } from './handle-glob';
-import { GLOB, isHandleGlobMessage } from '../message-types/glob';
+import { handleGlob, handleMultiGlob } from './handle-glob';
+import {
+  GLOB,
+  isHandleGlobMessage,
+  isHandleMultiGlobMessage,
+  MULTI_GLOB,
+} from '../message-types/glob';
 import {
   GET_NX_WORKSPACE_FILES,
   isHandleNxWorkspaceFilesMessage,
@@ -238,6 +243,10 @@ async function handleMessage(socket, data: string) {
   } else if (isHandleGlobMessage(payload)) {
     await handleResult(socket, GLOB, () =>
       handleGlob(payload.globs, payload.exclude)
+    );
+  } else if (isHandleMultiGlobMessage(payload)) {
+    await handleResult(socket, MULTI_GLOB, () =>
+      handleMultiGlob(payload.globs, payload.exclude)
     );
   } else if (isHandleNxWorkspaceFilesMessage(payload)) {
     await handleResult(socket, GET_NX_WORKSPACE_FILES, () =>

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -93,6 +93,13 @@ export declare class WorkspaceContext {
   constructor(workspaceRoot: string, cacheDir: string)
   getWorkspaceFiles(projectRootMap: Record<string, string>): NxWorkspaceFiles
   glob(globs: Array<string>, exclude?: Array<string> | undefined | null): Array<string>
+  /**
+   * Performs multiple glob pattern matches against workspace files in parallel
+   * @returns An array of arrays, where each inner array contains the file paths
+   * that matched the corresponding glob pattern in the input. The outer array maintains the same order
+   * as the input globs.
+   */
+  multiGlob(globs: Array<string>, exclude?: Array<string> | undefined | null): Array<Array<string>>
   hashFilesMatchingGlob(globs: Array<string>, exclude?: Array<string> | undefined | null): string
   incrementalUpdate(updatedFiles: Array<string>, deletedFiles: Array<string>): Record<string, string>
   updateProjectFiles(projectRootMappings: ProjectRootMappings, projectFiles: ExternalObject<ProjectFiles>, globalFiles: ExternalObject<Array<FileData>>, updatedFiles: Record<string, string>, deletedFiles: Array<string>): UpdatedWorkspaceFiles

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -231,6 +231,28 @@ impl WorkspaceContext {
         Ok(globbed_files.map(|file| file.file.to_owned()).collect())
     }
 
+    /// Performs multiple glob pattern matches against workspace files in parallel
+    /// @returns An array of arrays, where each inner array contains the file paths
+    /// that matched the corresponding glob pattern in the input. The outer array maintains the same order
+    /// as the input globs.
+    #[napi]
+    pub fn multi_glob(
+        &self,
+        globs: Vec<String>,
+        exclude: Option<Vec<String>>,
+    ) -> napi::Result<Vec<Vec<String>>> {
+        let file_data = self.all_file_data();
+
+        globs
+            .into_par_iter()
+            .map(|glob| {
+                let globbed_files =
+                    config_files::glob_files(&file_data, vec![glob], exclude.clone())?;
+                Ok(globbed_files.map(|file| file.file.to_owned()).collect())
+            })
+            .collect()
+    }
+
     #[napi]
     pub fn hash_files_matching_glob(
         &self,

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -244,7 +244,7 @@ impl WorkspaceContext {
         let file_data = self.all_file_data();
 
         globs
-            .into_par_iter()
+            .into_iter()
             .map(|glob| {
                 let globbed_files =
                     config_files::glob_files(&file_data, vec![glob], exclude.clone())?;

--- a/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
+++ b/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
@@ -3,7 +3,7 @@ import { minimatch } from 'minimatch';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import { join } from 'path';
 import { existsSync } from 'fs';
-import { configurationGlobs } from '../../utils/retrieve-workspace-files';
+import { getGlobPatternsOfPlugins } from '../../utils/retrieve-workspace-files';
 import { combineGlobPatterns } from '../../../utils/globs';
 import { getPlugins } from '../../plugins/get-plugins';
 
@@ -20,8 +20,8 @@ export const getTouchedProjectsFromProjectGlobChanges: TouchedProjectLocator =
           'package.json',
         ]);
       }
-      const plugins = await getPlugins();
-      return combineGlobPatterns(configurationGlobs(plugins));
+      const plugins = (await getPlugins()).filter((p) => !!p.createNodes);
+      return combineGlobPatterns(getGlobPatternsOfPlugins(plugins));
     })();
 
     const touchedProjects = new Set<string>();

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1682,7 +1682,7 @@ describe('project-configuration-utils', () => {
       const projectConfigurations = await createProjectConfigurations(
         undefined,
         {},
-        ['libs/a/project.json', 'libs/b/project.json'],
+        [['libs/a/project.json', 'libs/b/project.json']],
         [
           new LoadedNxPlugin(fakeTagPlugin, {
             plugin: fakeTagPlugin.name,
@@ -1708,7 +1708,7 @@ describe('project-configuration-utils', () => {
       const projectConfigurations = await createProjectConfigurations(
         undefined,
         {},
-        ['libs/a/project.json', 'libs/b/project.json'],
+        [['libs/a/project.json', 'libs/b/project.json']],
         [
           new LoadedNxPlugin(fakeTagPlugin, {
             plugin: fakeTagPlugin.name,
@@ -1730,7 +1730,7 @@ describe('project-configuration-utils', () => {
       const projectConfigurations = await createProjectConfigurations(
         undefined,
         {},
-        ['libs/a/project.json', 'libs/b/project.json'],
+        [['libs/a/project.json', 'libs/b/project.json']],
         [
           new LoadedNxPlugin(fakeTagPlugin, {
             plugin: fakeTagPlugin.name,
@@ -1752,7 +1752,7 @@ describe('project-configuration-utils', () => {
       const { projects } = await createProjectConfigurations(
         undefined,
         {},
-        ['libs/a/project.json'],
+        [['libs/a/project.json'], ['libs/a/project.json']],
         [
           new LoadedNxPlugin(fakeTargetsPlugin, 'fake-targets-plugin'),
           new LoadedNxPlugin(fakeTagPlugin, 'fake-tag-plugin'),
@@ -1774,7 +1774,7 @@ describe('project-configuration-utils', () => {
       const error = await createProjectConfigurations(
         undefined,
         {},
-        ['libs/a/project.json', 'libs/b/project.json', 'libs/c/project.json'],
+        [['libs/a/project.json', 'libs/b/project.json', 'libs/c/project.json']],
         [new LoadedNxPlugin(sameNamePlugin, 'same-name-plugin')]
       ).catch((e) => e);
       const isErrorType = isProjectConfigurationsError(error);
@@ -1798,7 +1798,7 @@ describe('project-configuration-utils', () => {
       const error = await createProjectConfigurations(
         undefined,
         {},
-        ['libs/a/project.json', 'libs/b/project.json', 'libs/c/project.json'],
+        [['libs/a/project.json', 'libs/b/project.json', 'libs/c/project.json']],
         [new LoadedNxPlugin(fakeTargetsPlugin, 'fake-targets-plugin')]
       ).catch((e) => e);
       const isErrorType = isProjectConfigurationsError(error);
@@ -1819,7 +1819,7 @@ describe('project-configuration-utils', () => {
       const { sourceMaps } = await createProjectConfigurations(
         undefined,
         {},
-        ['libs/a/project.json'],
+        [['libs/a/project.json'], ['libs/a/project.json']],
         [
           new LoadedNxPlugin(fakeTargetsPlugin, 'fake-targets-plugin'),
           new LoadedNxPlugin(fakeTagPlugin, 'fake-tag-plugin'),

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -5,7 +5,7 @@ import {
 import {
   ConfigurationSourceMaps,
   SourceInformation,
-  createProjectConfigurations,
+  createProjectConfigurationsWithPlugins,
   isCompatibleTarget,
   mergeProjectConfigurationIntoRootMap,
   mergeTargetConfigurations,
@@ -1679,16 +1679,17 @@ describe('project-configuration-utils', () => {
     };
 
     it('should create nodes for files matching included patterns only', async () => {
-      const projectConfigurations = await createProjectConfigurations(
-        undefined,
-        {},
-        [['libs/a/project.json', 'libs/b/project.json']],
-        [
-          new LoadedNxPlugin(fakeTagPlugin, {
-            plugin: fakeTagPlugin.name,
-          }),
-        ]
-      );
+      const projectConfigurations =
+        await createProjectConfigurationsWithPlugins(
+          undefined,
+          {},
+          [['libs/a/project.json', 'libs/b/project.json']],
+          [
+            new LoadedNxPlugin(fakeTagPlugin, {
+              plugin: fakeTagPlugin.name,
+            }),
+          ]
+        );
 
       expect(projectConfigurations.projects).toEqual({
         'libs/a': {
@@ -1705,17 +1706,18 @@ describe('project-configuration-utils', () => {
     });
 
     it('should create nodes for files matching included patterns only', async () => {
-      const projectConfigurations = await createProjectConfigurations(
-        undefined,
-        {},
-        [['libs/a/project.json', 'libs/b/project.json']],
-        [
-          new LoadedNxPlugin(fakeTagPlugin, {
-            plugin: fakeTagPlugin.name,
-            include: ['libs/a/**'],
-          }),
-        ]
-      );
+      const projectConfigurations =
+        await createProjectConfigurationsWithPlugins(
+          undefined,
+          {},
+          [['libs/a/project.json', 'libs/b/project.json']],
+          [
+            new LoadedNxPlugin(fakeTagPlugin, {
+              plugin: fakeTagPlugin.name,
+              include: ['libs/a/**'],
+            }),
+          ]
+        );
 
       expect(projectConfigurations.projects).toEqual({
         'libs/a': {
@@ -1727,17 +1729,18 @@ describe('project-configuration-utils', () => {
     });
 
     it('should not create nodes for files matching excluded patterns', async () => {
-      const projectConfigurations = await createProjectConfigurations(
-        undefined,
-        {},
-        [['libs/a/project.json', 'libs/b/project.json']],
-        [
-          new LoadedNxPlugin(fakeTagPlugin, {
-            plugin: fakeTagPlugin.name,
-            exclude: ['libs/b/**'],
-          }),
-        ]
-      );
+      const projectConfigurations =
+        await createProjectConfigurationsWithPlugins(
+          undefined,
+          {},
+          [['libs/a/project.json', 'libs/b/project.json']],
+          [
+            new LoadedNxPlugin(fakeTagPlugin, {
+              plugin: fakeTagPlugin.name,
+              exclude: ['libs/b/**'],
+            }),
+          ]
+        );
 
       expect(projectConfigurations.projects).toEqual({
         'libs/a': {
@@ -1749,7 +1752,7 @@ describe('project-configuration-utils', () => {
     });
 
     it('should normalize targets', async () => {
-      const { projects } = await createProjectConfigurations(
+      const { projects } = await createProjectConfigurationsWithPlugins(
         undefined,
         {},
         [['libs/a/project.json'], ['libs/a/project.json']],
@@ -1771,7 +1774,7 @@ describe('project-configuration-utils', () => {
     });
 
     it('should validate that project names are unique', async () => {
-      const error = await createProjectConfigurations(
+      const error = await createProjectConfigurationsWithPlugins(
         undefined,
         {},
         [['libs/a/project.json', 'libs/b/project.json', 'libs/c/project.json']],
@@ -1795,7 +1798,7 @@ describe('project-configuration-utils', () => {
     });
 
     it('should validate that projects have a name', async () => {
-      const error = await createProjectConfigurations(
+      const error = await createProjectConfigurationsWithPlugins(
         undefined,
         {},
         [['libs/a/project.json', 'libs/b/project.json', 'libs/c/project.json']],
@@ -1816,7 +1819,7 @@ describe('project-configuration-utils', () => {
     });
 
     it('should correctly set source maps', async () => {
-      const { sourceMaps } = await createProjectConfigurations(
+      const { sourceMaps } = await createProjectConfigurationsWithPlugins(
         undefined,
         {},
         [['libs/a/project.json'], ['libs/a/project.json']],

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1678,16 +1678,6 @@ describe('project-configuration-utils', () => {
       ],
     };
 
-    const noProjectsPlugin: NxPluginV2 = {
-      name: 'no-projects-plugin',
-      createNodesV2: [
-        '!**/*',
-        async () => {
-          return [];
-        },
-      ],
-    };
-
     it('should create nodes for files matching included patterns only', async () => {
       const projectConfigurations = await createProjectConfigurations(
         undefined,

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1678,6 +1678,16 @@ describe('project-configuration-utils', () => {
       ],
     };
 
+    const noProjectsPlugin: NxPluginV2 = {
+      name: 'no-projects-plugin',
+      createNodesV2: [
+        '!**/*',
+        async () => {
+          return [];
+        },
+      ],
+    };
+
     it('should create nodes for files matching included patterns only', async () => {
       const projectConfigurations = await createProjectConfigurations(
         undefined,

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -322,7 +322,7 @@ export type ConfigurationResult = {
 export async function createProjectConfigurations(
   root: string = workspaceRoot,
   nxJson: NxJsonConfiguration,
-  projectFiles: string[], // making this parameter allows devkit to pick up newly created projects
+  projectFiles: string[][], // making this parameter allows devkit to pick up newly created projects
   plugins: LoadedNxPlugin[]
 ): Promise<ConfigurationResult> {
   performance.mark('build-project-configs:start');
@@ -386,7 +386,7 @@ export async function createProjectConfigurations(
     }
 
     const matchingConfigFiles: string[] = findMatchingConfigFiles(
-      projectFiles,
+      projectFiles[index],
       pattern,
       include,
       exclude
@@ -439,7 +439,7 @@ export async function createProjectConfigurations(
         externalNodes,
         projectRootMap: rootMap,
         sourceMaps: configurationSourceMaps,
-        matchingProjectFiles: projectFiles,
+        matchingProjectFiles: projectFiles.flat(),
       };
     } else {
       throw new ProjectConfigurationsError(errors, {
@@ -447,7 +447,7 @@ export async function createProjectConfigurations(
         externalNodes,
         projectRootMap: rootMap,
         sourceMaps: configurationSourceMaps,
-        matchingProjectFiles: projectFiles,
+        matchingProjectFiles: projectFiles.flat(),
       });
     }
   });

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -319,7 +319,7 @@ export type ConfigurationResult = {
  * @param workspaceFiles A list of non-ignored workspace files
  * @param plugins The plugins that should be used to infer project configuration
  */
-export async function createProjectConfigurations(
+export async function createProjectConfigurationsWithPlugins(
   root: string = workspaceRoot,
   nxJson: NxJsonConfiguration,
   projectFiles: string[][], // making this parameter allows devkit to pick up newly created projects

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -81,10 +81,13 @@ describe('retrieve-workspace-files', () => {
           root: 'project2',
         })
       );
-      await fs.createFile('project3/package.json', JSON.stringify({
-        name: 'project3',
-        root: 'project3',
-      }));
+      await fs.createFile(
+        'project3/package.json',
+        JSON.stringify({
+          name: 'project3',
+          root: 'project3',
+        })
+      );
 
       const mockPlugin = createTestPlugin('test-plugin', '**/project.json');
       const noCreateNodesOption = { name: 'no-create-nodes' };

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -1,43 +1,168 @@
 import { TempFs } from '../../internal-testing-utils/temp-fs';
-import { retrieveProjectConfigurationPaths } from './retrieve-workspace-files';
+import {
+  retrieveProjectConfigurationPaths,
+  retrieveProjectConfigurations,
+  configurationGlobs,
+  retrieveProjectConfigurationsWithoutPluginInference,
+} from './retrieve-workspace-files';
+import { NxJsonConfiguration } from '../../config/nx-json';
+import { LoadedNxPlugin } from '../plugins/loaded-nx-plugin';
+import { dirname, join } from 'path';
+import { readFile } from 'fs/promises';
+import {
+  CreateNodesContextV2,
+  createNodesFromFiles,
+  CreateNodesResultV2,
+} from '../plugins';
 
-describe('retrieveProjectConfigurationPaths', () => {
-  let fs: TempFs;
-  beforeAll(() => {
-    fs = new TempFs('retrieveProjectConfigurationPaths');
+describe('retrieve-workspace-files', () => {
+  describe('retrieveProjectConfigurationPaths', () => {
+    let fs: TempFs;
+    beforeAll(() => {
+      fs = new TempFs('retrieveProjectConfigurationPaths');
+    });
+    afterAll(() => {
+      fs.cleanup();
+    });
+
+    it('should not find files that are listed by .nxignore', async () => {
+      await fs.createFile('.nxignore', `not-projects`);
+      await fs.createFile(
+        'not-projects/project.json',
+        JSON.stringify({
+          name: 'not-project-1',
+        })
+      );
+      await fs.createFile(
+        'projects/project.json',
+        JSON.stringify({
+          name: 'project-1',
+        })
+      );
+
+      const configPaths = await retrieveProjectConfigurationPaths(fs.tempDir, [
+        {
+          name: 'test',
+          createNodes: [
+            '{project.json,**/project.json}',
+            async () => {
+              return [];
+            },
+          ],
+        },
+      ]);
+
+      expect(configPaths).not.toContain('not-projects/project.json');
+      expect(configPaths).toContain('projects/project.json');
+    });
   });
-  afterAll(() => {
-    fs.cleanup();
-  });
 
-  it('should not find files that are listed by .nxignore', async () => {
-    await fs.createFile('.nxignore', `not-projects`);
-    await fs.createFile(
-      'not-projects/project.json',
-      JSON.stringify({
-        name: 'not-project-1',
-      })
-    );
-    await fs.createFile(
-      'projects/project.json',
-      JSON.stringify({
-        name: 'project-1',
-      })
-    );
+  describe('retrieveProjectConfigurations', () => {
+    let fs: TempFs;
+    beforeAll(() => {
+      fs = new TempFs('retrieveProjectConfigurations');
+    });
+    afterAll(() => {
+      fs.cleanup();
+    });
 
-    const configPaths = await retrieveProjectConfigurationPaths(fs.tempDir, [
-      {
-        name: 'test',
-        createNodes: [
-          '{project.json,**/project.json}',
-          async () => {
-            return [];
-          },
-        ],
-      },
-    ]);
+    it('should find project configurations based on plugin globs', async () => {
+      await fs.createFile(
+        'project1/project.json',
+        JSON.stringify({
+          name: 'project1',
+          root: 'project1',
+        })
+      );
+      await fs.createFile(
+        'project2/project.json',
+        JSON.stringify({
+          name: 'project2',
+          root: 'project2',
+        })
+      );
 
-    expect(configPaths).not.toContain('not-projects/project.json');
-    expect(configPaths).toContain('projects/project.json');
+      const mockPlugin = createTestPlugin('test-plugin', '**/project.json');
+
+      const result = await retrieveProjectConfigurations(
+        [mockPlugin],
+        fs.tempDir,
+        {}
+      );
+
+      expect(result.projects).toBeDefined();
+      expect(Object.keys(result.projects)).toHaveLength(2);
+      expect(result.projects['project1']).toBeDefined();
+      expect(result.projects['project2']).toBeDefined();
+    });
+
+    it('multiple plugins should not affect other plugins', async () => {
+      await fs.createFile(
+        'project1/project.json',
+        JSON.stringify({
+          name: 'project1',
+          root: 'project1',
+        })
+      );
+      await fs.createFile(
+        'project2/project.json',
+        JSON.stringify({
+          name: 'project2',
+          root: 'project2',
+        })
+      );
+
+      const mockPlugin1 = createTestPlugin('test-plugin-1', '**/project.json');
+      // this plugin would exclude all files, so it should not affect the first plugin's results
+      const mockPlugin2 = createTestPlugin('test-plugin-2', '!**/*');
+
+      const result = await retrieveProjectConfigurations(
+        [mockPlugin1, mockPlugin2],
+        fs.tempDir,
+        {}
+      );
+
+      expect(result.projects).toBeDefined();
+      expect(Object.keys(result.projects)).toHaveLength(2);
+      expect(result.projects['project1']).toBeDefined();
+      expect(result.projects['project2']).toBeDefined();
+    });
   });
 });
+
+function createTestPlugin(name: string, pattern: string): LoadedNxPlugin {
+  return new LoadedNxPlugin(
+    {
+      name,
+      createNodesV2: [
+        pattern,
+        async (
+          projectFiles: string[],
+          _,
+          context: CreateNodesContextV2
+        ): Promise<CreateNodesResultV2> => {
+          return await createNodesFromFiles(
+            async (configFile, options, context) => {
+              const fullPath = join(context.workspaceRoot, configFile);
+              const project = JSON.parse(await readFile(fullPath, 'utf8'));
+              return {
+                projects: {
+                  [project.name]: {
+                    name: project.name,
+                    root: dirname(configFile),
+                  },
+                },
+              };
+            },
+            projectFiles,
+            _,
+            context
+          );
+        },
+      ],
+    },
+    {
+      plugin: name,
+    }
+  );
+}

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -2,7 +2,7 @@ import { TempFs } from '../../internal-testing-utils/temp-fs';
 import {
   retrieveProjectConfigurationPaths,
   retrieveProjectConfigurations,
-  configurationGlobs,
+  getGlobPatternsOfPlugins,
   retrieveProjectConfigurationsWithoutPluginInference,
 } from './retrieve-workspace-files';
 import { NxJsonConfiguration } from '../../config/nx-json';

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -2,10 +2,7 @@ import { TempFs } from '../../internal-testing-utils/temp-fs';
 import {
   retrieveProjectConfigurationPaths,
   retrieveProjectConfigurations,
-  getGlobPatternsOfPlugins,
-  retrieveProjectConfigurationsWithoutPluginInference,
 } from './retrieve-workspace-files';
-import { NxJsonConfiguration } from '../../config/nx-json';
 import { LoadedNxPlugin } from '../plugins/loaded-nx-plugin';
 import { dirname, join } from 'path';
 import { readFile } from 'fs/promises';
@@ -90,11 +87,10 @@ describe('retrieve-workspace-files', () => {
       );
 
       const mockPlugin = createTestPlugin('test-plugin', '**/project.json');
-      const noCreateNodesOption = { name: 'no-create-nodes' };
       const mockPlugin3 = createTestPlugin('test-plugin-3', '**/package.json');
 
       const result = await retrieveProjectConfigurations(
-        [mockPlugin, noCreateNodesOption, mockPlugin3],
+        [mockPlugin, mockPlugin3],
         fs.tempDir,
         {}
       );

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -81,19 +81,26 @@ describe('retrieve-workspace-files', () => {
           root: 'project2',
         })
       );
+      await fs.createFile('project3/package.json', JSON.stringify({
+        name: 'project3',
+        root: 'project3',
+      }));
 
       const mockPlugin = createTestPlugin('test-plugin', '**/project.json');
+      const noCreateNodesOption = { name: 'no-create-nodes' };
+      const mockPlugin3 = createTestPlugin('test-plugin-3', '**/package.json');
 
       const result = await retrieveProjectConfigurations(
-        [mockPlugin],
+        [mockPlugin, noCreateNodesOption, mockPlugin3],
         fs.tempDir,
         {}
       );
 
       expect(result.projects).toBeDefined();
-      expect(Object.keys(result.projects)).toHaveLength(2);
+      expect(Object.keys(result.projects)).toHaveLength(3);
       expect(result.projects['project1']).toBeDefined();
       expect(result.projects['project2']).toBeDefined();
+      expect(result.projects['project3']).toBeDefined();
     });
 
     it('multiple plugins should not affect other plugins', async () => {

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -158,7 +158,7 @@ export function configurationGlobs(plugins: Array<LoadedNxPlugin>): string[] {
       globPatterns.push(plugin.createNodes[0]);
     } else {
       // if there is no glob in the plugin, add an empty glob so that we can still map the globs by index to the plugin
-      globPatterns.push('')
+      globPatterns.push('');
     }
   }
   return globPatterns;

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -156,6 +156,9 @@ export function configurationGlobs(plugins: Array<LoadedNxPlugin>): string[] {
   for (const plugin of plugins) {
     if ('createNodes' in plugin && plugin.createNodes) {
       globPatterns.push(plugin.createNodes[0]);
+    } else {
+      // if there is no glob in the plugin, add an empty glob so that we can still map the globs by index to the plugin
+      globPatterns.push('')
     }
   }
   return globPatterns;

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -13,6 +13,7 @@ import { LoadedNxPlugin } from '../plugins/loaded-nx-plugin';
 import {
   getNxWorkspaceFilesFromContext,
   globWithWorkspaceContext,
+  multiGlobWithWorkspaceContext,
 } from '../../utils/workspace-context';
 import { buildAllWorkspaceFiles } from './build-all-workspace-files';
 import { join } from 'path';
@@ -67,7 +68,7 @@ export async function retrieveProjectConfigurations(
   nxJson: NxJsonConfiguration
 ): Promise<ConfigurationResult> {
   const globPatterns = configurationGlobs(plugins);
-  const workspaceFiles = await globWithWorkspaceContext(
+  const workspaceFiles = await multiGlobWithWorkspaceContext(
     workspaceRoot,
     globPatterns
   );
@@ -137,7 +138,7 @@ export async function retrieveProjectConfigurationsWithoutPluginInference(
   }
 
   const projectFiles =
-    (await globWithWorkspaceContext(root, projectGlobPatterns)) ?? [];
+    (await multiGlobWithWorkspaceContext(root, projectGlobPatterns)) ?? [];
   const { projects } = await createProjectConfigurations(
     root,
     nxJson,

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -62,6 +62,18 @@ export async function globWithWorkspaceContext(
   }
 }
 
+export async function multiGlobWithWorkspaceContext(
+  workspaceRoot: string,
+  globs: string[],
+  exclude?: string[]
+) {
+  if (isOnDaemon() || !daemonClient.enabled()) {
+    ensureContextAvailable(workspaceRoot);
+    return workspaceContext.multiGlob(globs, exclude);
+  }
+  return daemonClient.multiGlob(globs, exclude);
+}
+
 export async function hashWithWorkspaceContext(
   workspaceRoot: string,
   globs: string[],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Whenever there are multiple plugins using in a workspace, all the configuration paths are collected and used as 1 giant glob to test against the workspace context files. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Each plugin configuration glob is now handled separately and are not joined together into one giant one. This allows each glob pattern to have separate files for each plugin. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29473
