### PR TITLE
fix(js): set --ws=false when running npm config for jest e2e

### DIFF
--- a/e2e/plugin/src/nx-plugin-ts-solution.test.ts
+++ b/e2e/plugin/src/nx-plugin-ts-solution.test.ts
@@ -77,6 +77,24 @@ describe('Nx Plugin (TS solution)', () => {
     expect(runCLI(`e2e @proj/${plugin}-e2e`)).toContain(
       `Successfully ran target e2e for project @proj/${plugin}-e2e`
     );
+
+    // Check that inferred targets also work
+    updateJson('nx.json', (json) => {
+      json.plugins.push({
+        plugin: '@nx/jest/plugin',
+        include: ['packages/*-e2e/**/*'],
+        options: {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+      });
+      return json;
+    });
+    updateJson(`packages/${plugin}-e2e/package.json`, (json) => {
+      delete json.targets;
+      return json;
+    });
+    expect(() => runCLI(`e2e @proj/${plugin}-e2e`)).not.toThrow();
   }, 90000);
 
   it('should be able to infer projects and targets', async () => {

--- a/packages/js/src/plugins/jest/start-local-registry.ts
+++ b/packages/js/src/plugins/jest/start-local-registry.ts
@@ -54,7 +54,7 @@ export function startLocalRegistry({
 
         process.env.npm_config_registry = registry;
         execSync(
-          `npm config set //${listenAddress}:${port}/:_authToken "secretVerdaccioToken"`,
+          `npm config set //${listenAddress}:${port}/:_authToken "secretVerdaccioToken" --ws=false`,
           {
             windowsHide: false,
           }
@@ -70,9 +70,12 @@ export function startLocalRegistry({
 
         resolve(() => {
           childProcess.kill();
-          execSync(`npm config delete //${listenAddress}:${port}/:_authToken`, {
-            windowsHide: false,
-          });
+          execSync(
+            `npm config delete //${listenAddress}:${port}/:_authToken --ws=false`,
+            {
+              windowsHide: false,
+            }
+          );
         });
         childProcess?.stdout?.off('data', listener);
       }


### PR DESCRIPTION
When we run inferred Jest tasks with workspaces enabled, it'll result in an error like this:

```
npm ERR! A complete log of this run can be found in: /Users/jack/.npm/_logs/2025-02-05T13_41_51_079Z-debug-0.log
Error: Command failed: npm config set //localhost:4873/:_authToken "secretVerdaccioToken"
npm ERR! code ENOWORKSPACES
npm ERR! This command does not support workspaces.
```

This is because the cwd is the project root (e.g. `packages/mypkg-e2e`), and `npm config set` cannot be run on packages inside the workspaces. By passing `--ws=false`, it'll only be run in the workspace root and won't error.

## Current Behavior
Jest e2e tests inferred from `@nx/jest/plugin` fail when starting a local registry.

## Expected Behavior
Jest e2e tests should work even if they are inferred (or have cwd other than workspace root).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
