### PR TITLE
fix(core): do not write filemap cache when there are errors

### DIFF
--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -223,11 +223,16 @@ export function writeCache(
       });
       renameSync(tmpProjectGraphPath, nxProjectGraph);
 
-      writeJsonFile(tmpFileMapPath, cache);
-      renameSync(tmpFileMapPath, nxFileMap);
-
       writeJsonFile(tmpSourceMapPath, sourceMaps);
       renameSync(tmpSourceMapPath, nxSourceMaps);
+
+      // only write the file map if there are no errors
+      // if there were errors, the errors make the filemap invalid
+      // TODO: We should be able to keep the valid part of the filemap if the errors being thrown told us which parts of the filemap were invalid
+      if (errors.length === 0) {
+        writeJsonFile(tmpFileMapPath, cache);
+        renameSync(tmpFileMapPath, nxFileMap);
+      }
       done = true;
     } catch (err: any) {
       if (err instanceof Error) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Errors when processing the project graph still result in the project file map being cached causing invalid information to be used when recalculating the project graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The project file map will not be cached if there are errors calculating the project graph. The dependencies of the graph will be recalculated from scratch the next time Nx runs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
