### PR TITLE
chore(core): handle project graph errors which do not have a message

### DIFF
--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -198,7 +198,7 @@ export function handleProjectGraphError(opts: { exitOnError: boolean }, e) {
         title,
         bodyLines: bodyLines,
       });
-    } else {
+    } else if (typeof e.message === 'string') {
       const lines = e.message.split('\n');
       output.error({
         title: lines[0],
@@ -207,6 +207,8 @@ export function handleProjectGraphError(opts: { exitOnError: boolean }, e) {
       if (isVerbose) {
         console.error(e);
       }
+    } else {
+      console.error(e);
     }
     process.exit(1);
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When weird errors which do not have a message get thrown, a weird error gets thrown by Nx saying cannot read `split` of `undefined`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When weird errors which do not have a message get thrown, the weird error is `console.error`ed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
