### PR TITLE
fix(nextjs): enhance support for custom server with SWC configuration

### DIFF
--- a/e2e/next/src/next-legacy.test.ts
+++ b/e2e/next/src/next-legacy.test.ts
@@ -279,4 +279,44 @@ describe('@nx/next (legacy)', () => {
     await killPort(prodServePort);
     await killPort(selfContainedPort);
   }, 600_000);
+
+  it('should support --custom-server flag (swc)', async () => {
+    const appName = uniq('app');
+
+    runCLI(
+      `generate @nx/next:app ${appName} --no-interactive --custom-server --linter=eslint --unitTestRunner=jest`,
+      { env: { NX_ADD_PLUGINS: 'false' } }
+    );
+
+    // Check for custom server files added to source
+    checkFilesExist(`${appName}/server/main.ts`);
+    checkFilesExist(`${appName}/.server.swcrc`);
+
+    const result = runCLI(`build ${appName}`);
+
+    checkFilesExist(`dist/${appName}-server/server/main.js`);
+
+    expect(result).toContain(
+      `Successfully ran target build for project ${appName}`
+    );
+  }, 300_000);
+
+  it('should support --custom-server flag (tsc)', async () => {
+    const appName = uniq('app');
+
+    runCLI(
+      `generate @nx/next:app ${appName} --swc=false --no-interactive --custom-server --linter=eslint --unitTestRunner=jest`,
+      { env: { NX_ADD_PLUGINS: 'false' } }
+    );
+
+    checkFilesExist(`${appName}/server/main.ts`);
+
+    const result = runCLI(`build ${appName}`);
+
+    checkFilesExist(`dist/${appName}-server/server/main.js`);
+
+    expect(result).toContain(
+      `Successfully ran target build for project ${appName}`
+    );
+  }, 300_000);
 });

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -158,11 +158,13 @@ describe('Next.js Applications', () => {
       `generate @nx/next:app ${appName} --no-interactive --custom-server --linter=eslint --unitTestRunner=jest`
     );
 
+    // Check for custom server files added to source
     checkFilesExist(`${appName}/server/main.ts`);
+    checkFilesExist(`${appName}/.server.swcrc`);
 
     const result = runCLI(`build ${appName}`);
 
-    checkFilesExist(`dist/${appName}/server/main.js`);
+    checkFilesExist(`dist/${appName}-server/server/main.js`);
 
     expect(result).toContain(
       `Successfully ran target build for project ${appName}`
@@ -180,7 +182,7 @@ describe('Next.js Applications', () => {
 
     const result = runCLI(`build ${appName}`);
 
-    checkFilesExist(`dist/${appName}/server/main.js`);
+    checkFilesExist(`dist/${appName}-server/server/main.js`);
 
     expect(result).toContain(
       `Successfully ran target build for project ${appName}`

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -145,7 +145,7 @@ export async function* nodeExecutor(
           // Wait for build to finish.
           const result = await buildResult;
 
-          if (!result.success) {
+          if (result && !result.success) {
             // If in watch-mode, don't throw or else the process exits.
             if (options.watch) {
               if (!task.killed) {

--- a/packages/js/src/utils/swc/add-swc-config.ts
+++ b/packages/js/src/utils/swc/add-swc-config.ts
@@ -54,11 +54,20 @@ export function addSwcConfig(
   tree: Tree,
   projectDir: string,
   type: 'commonjs' | 'es6' = 'commonjs',
-  supportTsx: boolean = false
+  supportTsx: boolean = false,
+  swcName: string = '.swcrc',
+  additionalExcludes: string[] = []
 ) {
-  const swcrcPath = join(projectDir, '.swcrc');
+  const swcrcPath = join(projectDir, swcName);
   if (tree.exists(swcrcPath)) return;
-  tree.write(swcrcPath, swcOptionsString(type, defaultExclude, supportTsx));
+  tree.write(
+    swcrcPath,
+    swcOptionsString(
+      type,
+      [...defaultExclude, ...additionalExcludes],
+      supportTsx
+    )
+  );
 }
 
 export function addSwcTestConfig(

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -32,6 +32,7 @@ import {
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
+import { configureForSwc } from '../../utils/add-swc-to-custom-server';
 
 export async function applicationGenerator(host: Tree, schema: Schema) {
   return await applicationGeneratorInternal(host, {
@@ -92,6 +93,11 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
   updateJestConfig(host, options);
   updateCypressTsConfig(host, options);
   setDefaults(host, options);
+
+  if (options.swc) {
+    const swcTask = configureForSwc(host, options.appProjectRoot);
+    tasks.push(swcTask);
+  }
 
   if (options.customServer) {
     await customServerGenerator(host, {

--- a/packages/next/src/generators/custom-server/files/server/main.ts__tmpl__
+++ b/packages/next/src/generators/custom-server/files/server/main.ts__tmpl__
@@ -15,8 +15,8 @@ import next from 'next';
 // - The fallback `__dirname` is for production builds.
 // - Feel free to change this to suit your needs.
 
-const dir = process.env.NX_NEXT_DIR || <%- hasPlugin ? `path.join(__dirname, '${projectPathFromDist}')` : `path.join(__dirname, '..')`; %> 
 const dev = process.env.NODE_ENV === 'development';
+const dir = process.env.NX_NEXT_DIR || <%- hasPlugin ? `path.join(__dirname, '${projectPathFromDist}')` : `path.join(__dirname, dev ? '..' : '', '${projectPathFromDist}')`; %> 
 
 // HTTP Server options:
 // - Feel free to change this to suit your needs.


### PR DESCRIPTION
This pull request contains a few changes to enhance our swc support for Next.js with a custom server.

### Issues
Currently, we have a few issues with our configuration when using executors for Next.js with a custom server:

1. The custom server does not have an independent build configuration.
2. The custom server does not have an independent output directory.
3. Serving via `@nx/next-server` or via `@nx/js:node` with configurations `production` and `development` does not always work. (These are contained inside `project.json`).

### Changes
All the above issues have been addressed

1. We now have an independent swc build configuration called`.server.swrc` (_follows the same format as `.eslintrc`, `.babelrc`_) etc...
2. Now each custom server output will be named `{app}-server` such that if you have multiple custom servers for multiple apps the names will not clash.
3. Serving now works out of the box but can be adjusted to suit your needs via updating the custom server entry file `main.ts`