### PR TITLE
feat(remix): add continuous task support

### DIFF
--- a/packages/remix/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/remix/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -9,12 +9,14 @@ import {
   readNxJson,
   type ExpandedPluginConfiguration,
   updateNxJson,
+  detectPackageManager,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { getRelativeProjectJsonSchemaPath } from 'nx/src/generators/utils/project-configuration';
 import { join } from 'path';
 import { convertToInferred } from './convert-to-inferred';
+import { getLockFileName } from '@nx/js';
 
 let fs: TempFs;
 let projectGraph: ProjectGraph;
@@ -165,7 +167,9 @@ describe('Remix - Convert To Inferred', () => {
     fs = new TempFs('remix');
     tree = createTreeWithEmptyWorkspace();
     tree.root = fs.tempDir;
-
+    const lockFileName = getLockFileName(detectPackageManager(fs.tempDir));
+    fs.createFileSync(lockFileName, '');
+    tree.write(lockFileName, '');
     projectGraph = {
       nodes: {},
       dependencies: {},

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -40,12 +40,14 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
             },
             "dev": {
               "command": "remix dev --manual",
+              "continuous": true,
               "options": {
                 "cwd": "my-app",
               },
             },
             "serve-static": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -55,6 +57,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
             },
             "start": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -64,6 +67,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
             },
             "static-serve": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -155,12 +159,14 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
             },
             "dev": {
               "command": "remix dev --manual",
+              "continuous": true,
               "options": {
                 "cwd": "my-app",
               },
             },
             "serve-static": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -170,6 +176,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
             },
             "start": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -179,6 +186,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
             },
             "static-serve": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -265,12 +273,14 @@ exports[`@nx/remix/plugin Remix Classic Compiler root project should create node
             },
             "dev": {
               "command": "remix dev --manual",
+              "continuous": true,
               "options": {
                 "cwd": ".",
               },
             },
             "serve-static": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -280,6 +290,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler root project should create node
             },
             "start": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -289,6 +300,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler root project should create node
             },
             "static-serve": {
               "command": "remix-serve build/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -373,12 +385,14 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
             },
             "dev": {
               "command": "remix vite:dev",
+              "continuous": true,
               "options": {
                 "cwd": "my-app",
               },
             },
             "serve-static": {
               "command": "remix-serve build/server/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -388,6 +402,7 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
             },
             "start": {
               "command": "remix-serve build/server/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -397,6 +412,7 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
             },
             "static-serve": {
               "command": "remix-serve build/server/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -482,12 +498,14 @@ exports[`@nx/remix/plugin Remix Vite Compiler root project should create nodes 1
             },
             "dev": {
               "command": "remix vite:dev",
+              "continuous": true,
               "options": {
                 "cwd": ".",
               },
             },
             "serve-static": {
               "command": "remix-serve build/server/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -497,6 +515,7 @@ exports[`@nx/remix/plugin Remix Vite Compiler root project should create nodes 1
             },
             "start": {
               "command": "remix-serve build/server/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -506,6 +525,7 @@ exports[`@nx/remix/plugin Remix Vite Compiler root project should create nodes 1
             },
             "static-serve": {
               "command": "remix-serve build/server/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],

--- a/packages/remix/src/plugins/plugin.spec.ts
+++ b/packages/remix/src/plugins/plugin.spec.ts
@@ -1,8 +1,13 @@
-import { type CreateNodesContext, joinPathFragments } from '@nx/devkit';
+import {
+  type CreateNodesContext,
+  detectPackageManager,
+  joinPathFragments,
+} from '@nx/devkit';
 import { createNodesV2 as createNodes } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { loadViteDynamicImport } from '../utils/executor-utils';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { getLockFileName } from '@nx/js';
 
 jest.mock('../utils/executor-utils', () => ({
   loadViteDynamicImport: jest.fn().mockResolvedValue({
@@ -69,6 +74,10 @@ module.exports = {
 };
 `
         );
+        const lockFileName = getLockFileName(
+          detectPackageManager(tempFs.tempDir)
+        );
+        tempFs.createFileSync(lockFileName, '');
         process.chdir(tempFs.tempDir);
       });
 
@@ -116,6 +125,10 @@ module.exports = {
           'my-app/project.json',
           JSON.stringify({ name: 'my-app' })
         );
+        const lockFileName = getLockFileName(
+          detectPackageManager(tempFs.tempDir)
+        );
+        tempFs.createFileSync(lockFileName, '');
 
         tempFs.createFileSync(
           'my-app/remix.config.cjs',
@@ -221,7 +234,7 @@ module.exports = {
         (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(true);
         tempFs.createFileSync(
           'my-app/package.json',
-          JSON.stringify('{"name": "my-app"}')
+          JSON.stringify('{"name": "my-app", "version": "0.0.0"}')
         );
 
         const nodes = await createNodesFunction(
@@ -294,6 +307,10 @@ module.exports = {
           'package.json',
           JSON.stringify('{name: "my-app", type: "module"}')
         );
+        const lockFileName = getLockFileName(
+          detectPackageManager(tempFs.tempDir)
+        );
+        tempFs.createFileSync(lockFileName, '');
         tempFs.createFileSync(
           'vite.config.js',
           `const {defineConfig} = require('vite');
@@ -378,6 +395,11 @@ module.exports = {
             },
           }),
         });
+
+        const lockFileName = getLockFileName(
+          detectPackageManager(tempFs.tempDir)
+        );
+        tempFs.createFileSync(lockFileName, '');
 
         process.chdir(tempFs.tempDir);
       });

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -305,6 +305,7 @@ function devTarget(
   isUsingTsSolutionSetup: boolean
 ): TargetConfiguration {
   const devTarget: TargetConfiguration = {
+    continuous: true,
     command:
       remixCompiler === RemixCompiler.IsVte
         ? 'remix vite:dev'
@@ -335,6 +336,7 @@ function startTarget(
 
   const startTarget: TargetConfiguration = {
     dependsOn: [buildTargetName],
+    continuous: true,
     command: `remix-serve ${serverPath}`,
     options: {
       cwd: projectRoot,


### PR DESCRIPTION
## Current Behavior
When `serve, dev, start` targets are inferred by the `@nx/remix` plugin, they are not inferring `continuous`.


## Expected Behavior
When `NX_CONTINUOUS_TASKS_PREVIEW` env var exists, infer the `continuous` property.
