### PR TITLE
docs(misc): fix typo in microfrontend architecture article

### DIFF
--- a/docs/shared/concepts/module-federation/micro-frontend-architecture.md
+++ b/docs/shared/concepts/module-federation/micro-frontend-architecture.md
@@ -92,7 +92,7 @@ in case of a bad deployment.
 ## Shared libraries
 
 Since deployments with MFEs are not atomic, there is a chance that shared libraries -- both external (npm) and workspace --
-between the host and remotes are mismatched. The default the Nx setup configures all libraries as singletons, which requires
+between the host and remotes are mismatched. The default Nx setup configures all libraries as singletons, which requires
 that all affected applications be deployed for any given changeset, and makes à la carte deployments riskier.
 
 There are mitigation strategies that can minimize mismatch errors. One such strategy is to share as little as possible


### PR DESCRIPTION
## Current Behavior
There's a typo in the [microfrontend architecture article](https://nx.dev/concepts/module-federation/micro-frontend-architecture#shared-libraries) under the "Shared Libraries" section.

`The default the Nx setup configures`

## Expected Behavior
Should be `The default Nx setup configures`

Fixes #
