### PR TITLE
docs(nx-dev): update Nx Powerpack messaging & links

### DIFF
--- a/nx-dev/ui-powerpack/src/lib/faq.tsx
+++ b/nx-dev/ui-powerpack/src/lib/faq.tsx
@@ -35,6 +35,11 @@ export function Faq(): ReactElement {
         'You can get a trial license immediately. Read more here: https://nx.dev/nx-enterprise/powerpack/free-licenses-and-trials',
     },
     {
+      question: 'Want to use Powerpack for OSS?',
+      answer:
+        'You can apply for a free OSS license here: https://nx.dev/powerpack/special-offer',
+    },
+    {
       question:
         'Only interested in Nx Powerpack because of Custom Tasks Runner deprecation',
       answer:

--- a/nx-dev/ui-powerpack/src/lib/hero.tsx
+++ b/nx-dev/ui-powerpack/src/lib/hero.tsx
@@ -63,14 +63,14 @@ export function Hero(): ReactElement {
           </a>
         </div>
         <p className="mt-6 text-sm italic">
-          Want to use Powerpack for OSS?
+          Nx Powerpack is included in Nx Enterprise.
           <br />
           <Link
-            href="/powerpack/special-offer"
+            href="/enterprise/trial"
             prefetch={false}
             className="font-semibold underline"
           >
-            Apply for a free OSS license.
+            Request a free trial of Nx Enterprise
           </Link>
         </p>
       </div>

--- a/nx-dev/ui-powerpack/src/lib/powerpack-features.tsx
+++ b/nx-dev/ui-powerpack/src/lib/powerpack-features.tsx
@@ -207,14 +207,7 @@ export function PowerpackFeatures(): ReactElement {
                   procurement processes
                 </Strong>
                 . Your teams can get started quickly without lengthy
-                negotiations, ensuring a faster go-to-market.{' '}
-                <TextLink
-                  href="https://cloud.nx.app/powerpack/request/trial?utm_source=nx-website&utm_medium=referral&utm_campaign=powerpack-landing-page&utm_content=link&utm_term=free-trial-available-for-enterprises"
-                  title="Get a Powerpack license"
-                >
-                  Free trial available for Enterprises
-                </TextLink>
-                .
+                negotiations, ensuring a faster go-to-market.
               </p>
             </div>
           </div>
@@ -234,7 +227,11 @@ export function PowerpackFeatures(): ReactElement {
                   customers
                 </Strong>
                 , unlocking additional capabilities without needing to manage
-                more tools or onboard a new vendor.
+                more tools or onboard a new vendor.{' '}
+                <TextLink href="/enterprise/trial" title="Nx Enterprise trial">
+                  Request a free trial of Nx Enterprise
+                </TextLink>
+                .
               </p>
             </div>
           </div>


### PR DESCRIPTION
Revised FAQ and hero section to clarify that Nx Powerpack is included in Nx Enterprise, replacing references to OSS licenses with trial-related messaging.
