### PR TITLE
feat(react): Update react-router-dom to latest

### DIFF
--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -31,7 +31,7 @@ export const emotionBabelPlugin = '11.11.0';
 // WARNING: This needs to be in sync with Next.js' dependency or else there might be issues.
 export const styledJsxVersion = '5.1.2';
 
-export const reactRouterDomVersion = '6.11.2';
+export const reactRouterDomVersion = '6.29.0';
 
 export const testingLibraryReactVersion = '16.1.0';
 export const testingLibraryDomVersion = '10.4.0';

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -364,15 +364,15 @@ describe('Remix Application', () => {
       expect(readJson(tree, 'myapp/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {
-            "@remix-run/node": "^2.14.0",
-            "@remix-run/react": "^2.14.0",
-            "@remix-run/serve": "^2.14.0",
+            "@remix-run/node": "^2.15.0",
+            "@remix-run/react": "^2.15.0",
+            "@remix-run/serve": "^2.15.0",
             "isbot": "^4.4.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
           },
           "devDependencies": {
-            "@remix-run/dev": "^2.14.0",
+            "@remix-run/dev": "^2.15.0",
             "@types/react": "^18.2.0",
             "@types/react-dom": "^18.2.0",
           },
@@ -550,15 +550,15 @@ describe('Remix Application', () => {
       expect(readJson(tree, 'apps/myapp/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {
-            "@remix-run/node": "^2.14.0",
-            "@remix-run/react": "^2.14.0",
-            "@remix-run/serve": "^2.14.0",
+            "@remix-run/node": "^2.15.0",
+            "@remix-run/react": "^2.15.0",
+            "@remix-run/serve": "^2.15.0",
             "isbot": "^4.4.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
           },
           "devDependencies": {
-            "@remix-run/dev": "^2.14.0",
+            "@remix-run/dev": "^2.15.0",
             "@types/react": "^18.2.0",
             "@types/react-dom": "^18.2.0",
           },

--- a/packages/remix/src/generators/init/init.spec.ts
+++ b/packages/remix/src/generators/init/init.spec.ts
@@ -18,13 +18,13 @@ describe('Remix Init Generator', () => {
     const pkgJson = readJson(tree, 'package.json');
     expect(pkgJson.dependencies).toMatchInlineSnapshot(`
       {
-        "@remix-run/serve": "^2.14.0",
+        "@remix-run/serve": "^2.15.0",
       }
     `);
     expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
       {
         "@nx/web": "0.0.1",
-        "@remix-run/dev": "^2.14.0",
+        "@remix-run/dev": "^2.15.0",
       }
     `);
 
@@ -72,13 +72,13 @@ describe('Remix Init Generator', () => {
       const pkgJson = readJson(tree, 'package.json');
       expect(pkgJson.dependencies).toMatchInlineSnapshot(`
         {
-          "@remix-run/serve": "^2.14.0",
+          "@remix-run/serve": "^2.15.0",
         }
       `);
       expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
         {
           "@nx/web": "0.0.1",
-          "@remix-run/dev": "^2.14.0",
+          "@remix-run/dev": "^2.15.0",
         }
       `);
     });

--- a/packages/remix/src/utils/versions.ts
+++ b/packages/remix/src/utils/versions.ts
@@ -2,7 +2,7 @@ import { readJson, Tree } from '@nx/devkit';
 
 export const nxVersion = require('../../package.json').version;
 
-export const remixVersion = '^2.14.0';
+export const remixVersion = '^2.15.0';
 export const isbotVersion = '^4.4.0';
 export const reactVersion = '^18.2.0';
 export const reactDomVersion = '^18.2.0';


### PR DESCRIPTION
Update `react-router-dom` and `remix` package versions to latest.
Currently, there should be no breaking changes from our generators.