### PR TITLE
fix(nx-dev): error on course detail page on mobile

### DIFF
--- a/nx-dev/ui-courses/src/lib/lesson-player.tsx
+++ b/nx-dev/ui-courses/src/lib/lesson-player.tsx
@@ -175,7 +175,7 @@ export function LessonPlayer({ course, lesson }: LessonPlayerProps) {
             </div>
             {isExpanded && (
               <div className="border-t border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/50">
-                <LessonsList />
+                <LessonsList course={course} lesson={lesson} />
               </div>
             )}
           </div>


### PR DESCRIPTION
Fixes issue where the course detail page on mobile wouldn't open the lesson list

![Screenshot 2025-02-07 at 11 59 40](https://github.com/user-attachments/assets/99b31aa3-273a-4a4f-8013-7ea04c2e793e)
