### PR TITLE
Revert "fix(testing): move webpack and vite to optional peer dep (#29…

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -37,23 +37,17 @@
     "@phenomnomnominal/tsquery": "~5.0.1",
     "@nx/devkit": "file:../devkit",
     "@nx/eslint": "file:../eslint",
+    "@nx/webpack": "file:../webpack",
+    "@nx/vite": "file:../vite",
     "@nx/js": "file:../js",
     "tslib": "^2.3.0",
     "minimatch": "9.0.3"
   },
   "peerDependencies": {
-    "@playwright/test": "^1.36.0",
-    "@nx/webpack": "file:../webpack",
-    "@nx/vite": "file:../vite"
+    "@playwright/test": "^1.36.0"
   },
   "peerDependenciesMeta": {
     "@playwright/test": {
-      "optional": true
-    },
-    "@nx/webpack": {
-      "optional": true
-    },
-    "@nx/vite": {
       "optional": true
     }
   },

--- a/packages/playwright/src/migrations/update-19-6-0/use-serve-static-preview-for-command.ts
+++ b/packages/playwright/src/migrations/update-19-6-0/use-serve-static-preview-for-command.ts
@@ -15,6 +15,8 @@ import type { ConfigurationResult } from 'nx/src/project-graph/utils/project-con
 import { LoadedNxPlugin } from 'nx/src/project-graph/plugins/loaded-nx-plugin';
 import { retrieveProjectConfigurations } from 'nx/src/project-graph/utils/retrieve-workspace-files';
 import { ProjectConfigurationsError } from 'nx/src/project-graph/error-types';
+import { createNodesV2 as webpackCreateNodesV2 } from '@nx/webpack/src/plugins/plugin';
+import { createNodesV2 as viteCreateNodesV2 } from '@nx/vite/plugin';
 import type { Node } from 'typescript';
 
 export default async function (tree: Tree) {
@@ -127,20 +129,8 @@ export default async function (tree: Tree) {
           ? 'serveStaticTargetName'
           : 'previewTargetName',
         projectToMigrate.configFileType === 'webpack'
-          ? (
-              await getDynamicImportedModule<
-                typeof import('@nx/webpack/src/plugins/plugin')
-              >(
-                '@nx/webpack/src/plugins/plugin',
-                '@nx/webpack should be installed when attempting to setup @nx/playwright with a webpack config file.'
-              )
-            ).createNodesV2
-          : (
-              await getDynamicImportedModule<typeof import('@nx/vite/plugin')>(
-                '@nx/vite/plugin',
-                '@nx/vite should be installed when attempting to setup @nx/playwright with a vite config file.'
-              )
-            ).createNodesV2
+          ? webpackCreateNodesV2
+          : viteCreateNodesV2
       )) ??
       getServeStaticLikeTarget(
         tree,
@@ -244,14 +234,6 @@ export default async function (tree: Tree) {
 
   await addE2eCiTargetDefaults(tree);
   await formatFiles(tree);
-}
-
-async function getDynamicImportedModule<T>(moduleName: string, error: string) {
-  try {
-    return (await import(moduleName)) as T;
-  } catch {
-    throw new Error(error);
-  }
 }
 
 async function getServeStaticTargetNameForConfigFile<T>(


### PR DESCRIPTION
…800)"

This reverts commit a5f13a28b1a49b44c159e902e8f81cbe075ba409.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nx/playwright` is published with improper peer dependencies because `nx release` does not support this apparently.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nx/playwright` is published with `dependencies` again for now.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/29921
