### PR TITLE
fix(linter): install @eslint/eslintrc package as necessary

### DIFF
--- a/packages/eslint/src/generators/utils/eslint-file.spec.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.spec.ts
@@ -120,6 +120,45 @@ describe('@nx/eslint:lint-file', () => {
       ]);
     });
 
+    it('should install necessary dependencies', () => {
+      // mock eslint version
+      jest.spyOn(devkitInternals, 'readModulePackageJson').mockReturnValue({
+        packageJson: { name: 'eslint', version: '9.0.0' },
+        path: '',
+      });
+      tree.write('eslint.config.cjs', 'module.exports = {};');
+      tree.write(
+        'apps/demo/eslint.config.cjs',
+        `const baseConfig = require("../../eslint.config.cjs");
+
+module.exports = [
+  ...baseConfig,
+  {
+    files: [
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.js",
+      "**/*.jsx"
+    ],
+    rules: {}
+  },
+];`
+      );
+
+      addExtendsToLintConfig(tree, 'apps/demo', {
+        name: 'plugin:playwright/recommend',
+        needCompatFixup: true,
+      });
+
+      expect(readJson(tree, 'package.json').devDependencies)
+        .toMatchInlineSnapshot(`
+        {
+          "@eslint/compat": "^1.1.1",
+          "@eslint/eslintrc": "^2.1.1",
+        }
+      `);
+    });
+
     it('should add extends to flat config', () => {
       tree.write('eslint.config.cjs', 'module.exports = {};');
       tree.write(

--- a/packages/eslint/src/generators/utils/eslint-file.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.ts
@@ -20,7 +20,11 @@ import {
   useFlatConfig,
 } from '../../utils/flat-config';
 import { getInstalledEslintVersion } from '../../utils/version-utils';
-import { eslint9__eslintVersion, eslintCompat } from '../../utils/versions';
+import {
+  eslint9__eslintVersion,
+  eslintCompat,
+  eslintrcVersion,
+} from '../../utils/versions';
 import {
   addBlockToFlatConfigExport,
   addFlatCompatToFlatConfig,
@@ -493,13 +497,19 @@ export function addExtendsToLintConfig(
       return addDependenciesToPackageJson(
         tree,
         {},
-        { '@eslint/compat': eslintCompat },
+        { '@eslint/compat': eslintCompat, '@eslint/eslintrc': eslintrcVersion },
         undefined,
         true
       );
     }
 
-    return () => {};
+    return addDependenciesToPackageJson(
+      tree,
+      {},
+      { '@eslint/eslintrc': eslintrcVersion },
+      undefined,
+      true
+    );
   } else {
     const plugins = (Array.isArray(plugin) ? plugin : [plugin]).map((p) =>
       typeof p === 'string' ? p : p.name


### PR DESCRIPTION
When flat compat is necessary, we don't ensure that `@eslint/eslintrc` is installed, even though we import it. Depending on the package manager and hoisting, it may still work, but as we see with pnpm v10, it is not working without an explicit dependency in `package.json`.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Some app generators are broken is we use eslint compat.

## Expected Behavior
App generators should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29845
