### PR TITLE
fix(gradle): fix gradle undefined dependency target

### DIFF
--- a/packages/gradle/src/plugin/dependencies.ts
+++ b/packages/gradle/src/plugin/dependencies.ts
@@ -44,14 +44,16 @@ export const createDependencies: CreateDependencies = async (
         const targetProjectName = Object.values(context.projects).find(
           (project) => project.root === targetProjectRoot
         )?.name;
-        const dependency: RawProjectGraphDependency = {
-          source: projectName as string,
-          target: targetProjectName as string,
-          type: DependencyType.static,
-          sourceFile: gradleFile,
-        };
-        validateDependency(dependency, context);
-        dependencies.add(dependency);
+        if (targetProjectName) {
+          const dependency: RawProjectGraphDependency = {
+            source: projectName as string,
+            target: targetProjectName as string,
+            type: DependencyType.static,
+            sourceFile: gradleFile,
+          };
+          validateDependency(dependency, context);
+          dependencies.add(dependency);
+        }
       });
     }
     gradleProjectToChildProjects.get(gradleProject)?.forEach((childProject) => {

--- a/packages/gradle/src/utils/__mocks__/gradle-custom-dependencies.txt
+++ b/packages/gradle/src/utils/__mocks__/gradle-custom-dependencies.txt
@@ -1,0 +1,7530 @@
+
+------------------------------------------------------------
+Project ':spring-boot-project:spring-boot-docs' - Spring Boot Docs
+------------------------------------------------------------
+
+actuatorRestApiAntoraAggregateContent - Configuration for actuator-rest-api Antora aggregate content.
+\--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+
+actuatorRestApiAntoraSource
+\--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+
+annotationProcessor - Annotation processors and their dependencies for source set 'main'.
+\--- project :spring-boot-project:spring-boot-parent
+     +--- org.codehaus.janino:janino:3.1.10
+     +--- project :spring-boot-project:spring-boot-dependencies
+     |    +--- org.apache.activemq:activemq-bom:6.1.5
+     |    +--- org.apache.activemq:artemis-bom:2.39.0
+     |    +--- org.assertj:assertj-bom:3.27.3
+     |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+     |    +--- io.zipkin.brave:brave-bom:6.0.3
+     |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+     |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+     |    +--- org.apache.groovy:groovy-bom:4.0.25
+     |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+     |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+     |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+     |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+     |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+     |    +--- org.junit:junit-bom:5.11.4
+     |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+     |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+     |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+     |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+     |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+     |    +--- org.mockito:mockito-bom:5.15.2
+     |    +--- io.netty:netty-bom:4.1.117.Final
+     |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+     |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+     |    +--- io.prometheus:simpleclient_bom:0.16.0
+     |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+     |    +--- com.querydsl:querydsl-bom:5.1.0
+     |    +--- io.projectreactor:reactor-bom:2024.0.2
+     |    +--- io.rest-assured:rest-assured-bom:5.5.0
+     |    +--- io.rsocket:rsocket-bom:1.1.5
+     |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+     |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+     |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+     |    +--- org.springframework.data:spring-data-bom:2024.1.2
+     |    +--- org.springframework:spring-framework-bom:6.2.2
+     |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+     |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+     |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+     |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+     |    +--- org.springframework.session:spring-session-bom:3.4.1
+     |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+     |    +--- org.testcontainers:testcontainers-bom:1.20.4
+     |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+     |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+     |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+     |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3
+     |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+     |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+     |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1
+     |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5
+     |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25
+     |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+     |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2
+     |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10
+     |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+     |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+     |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4
+     |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+     |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+     |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3
+     |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1
+     |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1
+     |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2
+     |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final
+     |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0
+     |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5
+     |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+     |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2
+     |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+     |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2
+     |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0
+     |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+     |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+     |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2
+     |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1
+     |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2
+     |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2
+     |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+     |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2
+     |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3
+     |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+     |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+     |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11
+     |    \--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4
+     \--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10
+
+api - API dependencies for null/main (n)
+No dependencies
+
+apiAntoraCatalogContent - Configuration for api Antora catalog content artifacts. (n)
+No dependencies
+
+apiDependenciesMetadata
+No dependencies
+
+apiElements - API elements for the 'main' feature. (n)
+No dependencies
+
+apiElements-published (n)
+No dependencies
+
+autoConfiguration
++--- project :spring-boot-project:spring-boot-autoconfigure
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
++--- project :spring-boot-project:spring-boot-devtools
+\--- project :spring-boot-project:spring-boot-testcontainers
+
+checkstyle - The Checkstyle libraries to be used for this project.
++--- com.puppycrawl.tools:checkstyle:10.12.4
+|    +--- info.picocli:picocli:4.7.5
+|    +--- org.antlr:antlr4-runtime:4.13.1
+|    +--- commons-beanutils:commons-beanutils:1.9.4
+|    |    \--- commons-collections:commons-collections:3.2.2
+|    +--- com.google.guava:guava:32.0.1-jre
+|    |    +--- com.google.guava:failureaccess:1.0.1
+|    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    +--- com.google.errorprone:error_prone_annotations:2.18.0
+|    |    \--- com.google.j2objc:j2objc-annotations:2.8
+|    +--- org.reflections:reflections:0.10.2
+|    |    +--- org.javassist:javassist:3.28.0-GA
+|    |    \--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- net.sf.saxon:Saxon-HE:12.3
+|    |    \--- org.xmlresolver:xmlresolver:5.2.0
+|    |         +--- org.apache.httpcomponents.client5:httpclient5:5.1.3
+|    |         |    +--- org.apache.httpcomponents.core5:httpcore5:5.1.3
+|    |         |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.1.3
+|    |         |    |    \--- org.apache.httpcomponents.core5:httpcore5:5.1.3
+|    |         |    \--- commons-codec:commons-codec:1.15
+|    |         \--- org.apache.httpcomponents.core5:httpcore5:5.1.3
+|    +--- org.checkerframework:checker-qual:3.27.0
+|    +--- org.apache.maven.doxia:doxia-core:1.12.0
+|    |    +--- org.apache.maven.doxia:doxia-sink-api:1.12.0
+|    |    |    \--- org.apache.maven.doxia:doxia-logging-api:1.12.0
+|    |    |         \--- org.codehaus.plexus:plexus-container-default:2.1.0
+|    |    |              +--- org.codehaus.plexus:plexus-utils:3.1.1 -> 3.3.0
+|    |    |              +--- org.codehaus.plexus:plexus-classworlds:2.6.0
+|    |    |              +--- org.apache.xbean:xbean-reflect:3.7
+|    |    |              \--- com.google.collections:google-collections:1.0
+|    |    +--- org.apache.maven.doxia:doxia-logging-api:1.12.0 (*)
+|    |    +--- org.codehaus.plexus:plexus-utils:3.3.0
+|    |    +--- org.codehaus.plexus:plexus-container-default:2.1.0 (*)
+|    |    +--- org.codehaus.plexus:plexus-component-annotations:2.1.0
+|    |    +--- org.apache.commons:commons-lang3:3.8.1
+|    |    +--- org.apache.commons:commons-text:1.3
+|    |    |    \--- org.apache.commons:commons-lang3:3.7 -> 3.8.1
+|    |    +--- org.apache.httpcomponents:httpclient:4.5.13
+|    |    |    +--- org.apache.httpcomponents:httpcore:4.4.13 -> 4.4.14
+|    |    |    \--- commons-codec:commons-codec:1.11 -> 1.15
+|    |    \--- org.apache.httpcomponents:httpcore:4.4.14
+|    \--- org.apache.maven.doxia:doxia-module-xdoc:1.12.0
+|         +--- org.codehaus.plexus:plexus-utils:3.3.0
+|         +--- org.apache.maven.doxia:doxia-core:1.12.0 (*)
+|         +--- org.apache.maven.doxia:doxia-sink-api:1.12.0 (*)
+|         \--- org.codehaus.plexus:plexus-component-annotations:2.1.0
++--- io.spring.javaformat:spring-javaformat-checkstyle:0.0.43
+|    +--- io.spring.javaformat:spring-javaformat-config:0.0.43
+|    \--- com.puppycrawl.tools:checkstyle:9.3 -> 10.12.4 (*)
+\--- io.spring.nohttp:nohttp-checkstyle:0.0.11
+     +--- com.puppycrawl.tools:checkstyle:8.33 -> 10.12.4 (*)
+     \--- io.spring.nohttp:nohttp:0.0.11
+          \--- ch.qos.logback:logback-classic:1.2.3
+               \--- ch.qos.logback:logback-core:1.2.3
+
+compileClasspath - Compile classpath for null/main.
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    |    \--- junit:junit:4.13.1 -> 4.13.2 (c)
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    |    \--- org.assertj:assertj-core:3.27.3 (c)
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+|    |    |    +--- org.apache.cassandra:java-driver-query-builder:4.18.1 (c)
+|    |    |    +--- com.datastax.oss:native-protocol:1.5.1 (c)
+|    |    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1 (c)
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0 (c)
+|    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    |    +--- org.apache.groovy:groovy:4.0.25 (c)
+|    |    |    +--- org.apache.groovy:groovy-xml:4.0.25 (c)
+|    |    |    \--- org.apache.groovy:groovy-json:4.0.25 (c)
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (c)
+|    |    |    \--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (c)
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    |    +--- org.glassfish.jersey.core:jersey-server:3.1.10 (c)
+|    |    |    +--- org.glassfish.jersey.containers:jersey-container-servlet-core:3.1.10 (c)
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (c)
+|    |    |    \--- org.glassfish.jersey.core:jersey-client:3.1.10 (c)
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    |    +--- org.junit.jupiter:junit-jupiter:5.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-launcher:1.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-params:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-commons:1.11.4 (c)
+|    |    |    \--- org.junit.platform:junit-platform-engine:1.11.4 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.24.3 (c)
+|    |    |    \--- org.apache.logging.log4j:log4j-api:2.24.3 (c)
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    |    |    \--- io.micrometer:context-propagation:1.1.2 (c)
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-tracing:1.5.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    |    |    \--- io.micrometer:context-propagation:1.1.2 (c)
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    |    \--- org.mockito:mockito-core:5.15.2 (c)
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    |    +--- io.netty:netty-codec-http:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec-http2:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-native-epoll:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-handler:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-handler-proxy:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-common:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec-dns:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-classes-epoll:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-tcnative-classes:2.0.69.Final (c)
+|    |    |    \--- io.netty:netty-codec-socks:4.1.117.Final (c)
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    |    +--- io.opentelemetry:opentelemetry-api:1.46.0 (c)
+|    |    |    \--- io.opentelemetry:opentelemetry-context:1.46.0 (c)
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    |    \--- com.google.guava:guava:33.3.1-jre (c)
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-all:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (c)
+|    |    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2 (c)
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    |    +--- io.projectreactor.netty:reactor-netty-http:1.2.2 (c)
+|    |    |    +--- io.projectreactor:reactor-core:3.7.2 (c)
+|    |    |    +--- io.projectreactor.netty:reactor-netty-core:1.2.2 (c)
+|    |    |    \--- org.reactivestreams:reactive-streams:1.0.4 (c)
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    |    +--- io.rest-assured:rest-assured:5.5.0 (c)
+|    |    |    +--- io.rest-assured:json-path:5.5.0 (c)
+|    |    |    +--- io.rest-assured:xml-path:5.5.0 (c)
+|    |    |    \--- io.rest-assured:rest-assured-common:5.5.0 (c)
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    |    +--- org.springframework.amqp:spring-amqp:3.2.2 (c)
+|    |    |    \--- org.springframework.amqp:spring-rabbit:3.2.2 (c)
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    |    +--- org.springframework.batch:spring-batch-core:5.2.1 (c)
+|    |    |    \--- org.springframework.batch:spring-batch-infrastructure:5.2.1 (c)
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    |    +--- org.springframework.data:spring-data-cassandra:4.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-couchbase:5.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-elasticsearch:5.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-r2dbc:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-jpa:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-envers:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-mongodb:4.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-neo4j:7.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-redis:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-ldap:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-commons:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-relational:3.4.2 (c)
+|    |    |    \--- org.springframework.data:spring-data-keyvalue:3.4.2 (c)
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    |    +--- org.springframework:spring-context:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-core:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-jdbc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-jms:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-orm:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-test:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-web:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-webflux:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-webmvc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-websocket:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-messaging:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-tx:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-aop:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-beans:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-expression:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-context-support:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-r2dbc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-oxm:6.2.2 (c)
+|    |    |    \--- org.springframework:spring-jcl:6.2.2 (c)
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    |    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (c)
+|    |    |    +--- org.springframework.pulsar:spring-pulsar-reactive:1.2.2 (c)
+|    |    |    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2 (c)
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-mockmvc:3.0.3 (c)
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-restassured:3.0.3 (c)
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-webtestclient:3.0.3 (c)
+|    |    |    \--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (c)
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    |    +--- org.springframework.security:spring-security-config:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-oauth2-client:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-test:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-web:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1 (c)
+|    |    |    \--- org.springframework.security:spring-security-crypto:6.5.0-M1 (c)
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    |    +--- org.springframework.ws:spring-ws-core:4.0.11 (c)
+|    |    |    +--- org.springframework.ws:spring-ws-test:4.0.11 (c)
+|    |    |    \--- org.springframework.ws:spring-xml:4.0.11 (c)
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    |    +--- org.testcontainers:junit-jupiter:1.20.4 (c)
+|    |    |    +--- org.testcontainers:mongodb:1.20.4 (c)
+|    |    |    +--- org.testcontainers:neo4j:1.20.4 (c)
+|    |    |    \--- org.testcontainers:testcontainers:1.20.4 (c)
+|    |    +--- org.cache2k:cache2k-spring:2.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-dbcp2:2.13.0 (c)
+|    |    +--- org.hibernate.orm:hibernate-jcache:6.6.6.Final (c)
+|    |    +--- com.zaxxer:HikariCP:6.2.1 (c)
+|    |    +--- org.htmlunit:htmlunit:4.9.0 (c)
+|    |    +--- org.apache.httpcomponents.client5:httpclient5:5.4.2 (c)
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1 (c)
+|    |    +--- jakarta.jms:jakarta.jms-api:3.1.0 (c)
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0 (c)
+|    |    +--- jakarta.servlet:jakarta.servlet-api:6.0.0 (c)
+|    |    +--- jakarta.validation:jakarta.validation-api:3.0.2 (c)
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.jooq:jooq:3.19.18 (c)
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (c)
+|    |    +--- ch.qos.logback:logback-classic:1.5.16 (c)
+|    |    +--- org.mongodb:mongodb-driver-sync:5.3.1 (c)
+|    |    +--- org.quartz-scheduler:quartz:2.5.0 (c)
+|    |    +--- org.postgresql:r2dbc-postgresql:1.0.7.RELEASE (c)
+|    |    +--- org.springframework.boot:spring-boot:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot (c)
+|    |    +--- org.springframework.boot:spring-boot-test:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test (c)
+|    |    +--- org.springframework.boot:spring-boot-test-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-testcontainers:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-testcontainers (c)
+|    |    +--- org.springframework.boot:spring-boot-actuator:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator (c)
+|    |    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-devtools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-devtools (c)
+|    |    +--- org.springframework.boot:spring-boot-docker-compose:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-docker-compose (c)
+|    |    +--- org.springframework.boot:spring-boot-loader-tools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools (c)
+|    |    +--- org.slf4j:jul-to-slf4j:2.0.16 (c)
+|    |    +--- org.yaml:snakeyaml:2.3 (c)
+|    |    +--- org.springframework.graphql:spring-graphql:1.3.3 (c)
+|    |    +--- org.springframework.graphql:spring-graphql-test:1.3.3 (c)
+|    |    +--- org.springframework.kafka:spring-kafka:3.3.2 (c)
+|    |    +--- org.springframework.kafka:spring-kafka-test:3.3.2 (c)
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (c)
+|    |    +--- io.undertow:undertow-core:2.3.18.Final (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3 (*)
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1 (*)
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5 (*)
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25 (*)
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2 (*)
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10 (*)
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3 (*)
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1 (*)
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1 (*)
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2 (*)
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final (*)
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0 (*)
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5 (*)
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2 (*)
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2 (*)
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0 (*)
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2 (*)
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1 (*)
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2 (*)
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2 (*)
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2 (*)
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3 (*)
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1 (*)
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11 (*)
+|    |    +--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4 (*)
+|    |    +--- org.cache2k:cache2k-api:2.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-pool2:2.12.1 (c)
+|    |    +--- jakarta.transaction:jakarta.transaction-api:2.0.1 (c)
+|    |    +--- org.hibernate.orm:hibernate-core:6.6.6.Final (c)
+|    |    +--- javax.cache:cache-api:1.1.1 (c)
+|    |    +--- org.slf4j:slf4j-api:2.0.16 (c)
+|    |    +--- org.apache.commons:commons-lang3:3.17.0 (c)
+|    |    +--- commons-codec:commons-codec:1.18.0 (c)
+|    |    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3 (c)
+|    |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3 (c)
+|    |    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (c)
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0 (c)
+|    |    +--- ch.qos.logback:logback-core:1.5.16 (c)
+|    |    +--- org.mongodb:bson:5.3.1 (c)
+|    |    +--- org.mongodb:mongodb-driver-core:5.3.1 (c)
+|    |    +--- com.graphql-java:graphql-java:22.3 (c)
+|    |    +--- com.jayway.jsonpath:json-path:2.9.0 (c)
+|    |    +--- org.springframework.retry:spring-retry:2.0.11 (c)
+|    |    +--- org.apache.kafka:kafka-server:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-metadata:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-streams-test-utils:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka_2.13:3.9.0 (c)
+|    |    +--- org.apache.tomcat:tomcat-annotations-api:10.1.34 (c)
+|    |    +--- org.jboss.logging:jboss-logging:3.6.1.Final (c)
+|    |    +--- net.bytebuddy:byte-buddy:1.17.0 (c)
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0 (c)
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1 (c)
+|    |    +--- net.bytebuddy:byte-buddy-agent:1.17.0 (c)
+|    |    +--- com.rabbitmq:amqp-client:5.24.0 (c)
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+|    |    +--- com.couchbase.client:java-client:3.7.7 (c)
+|    |    +--- co.elastic.clients:elasticsearch-java:8.15.5 (c)
+|    |    +--- org.hibernate.orm:hibernate-envers:6.6.6.Final (c)
+|    |    +--- org.neo4j.driver:neo4j-java-driver:5.25.0 (c)
+|    |    +--- org.springframework.ldap:spring-ldap-core:3.3.0-M1 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10 (c)
+|    |    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.2 (c)
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:3.0.4 (c)
+|    |    +--- org.xmlunit:xmlunit-core:2.10.0 (c)
+|    |    +--- junit:junit:4.13.2 (c)
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4 (c)
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5 (c)
+|    |    +--- jakarta.json:jakarta.json-api:2.1.3 (c)
+|    |    +--- org.hamcrest:hamcrest:3.0 (c)
+|    |    +--- net.minidev:json-smart:2.5.1 (c)
+|    |    +--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+|    |    +--- org.hamcrest:hamcrest-core:3.0 (c)
+|    |    +--- org.apache.httpcomponents:httpcore:4.4.16 (c)
+|    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5 (c)
+|    |    \--- org.apache.httpcomponents:httpcore-nio:4.4.16 (c)
+|    +--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.7.0-alpha (c)
+|    +--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10 (*)
+|    +--- org.apache.commons:commons-compress:1.25.0 (c)
+|    +--- io.micrometer:context-propagation:1.0.5 -> 1.1.2 (c)
+|    \--- org.apiguardian:apiguardian-api:1.1.2 (c)
++--- project :spring-boot-project:spring-boot-actuator
+|    \--- project :spring-boot-project:spring-boot
+|         +--- org.springframework:spring-core -> 6.2.2
+|         |    \--- org.springframework:spring-jcl:6.2.2
+|         \--- org.springframework:spring-context -> 6.2.2
+|              +--- org.springframework:spring-aop:6.2.2
+|              |    +--- org.springframework:spring-beans:6.2.2
+|              |    |    \--- org.springframework:spring-core:6.2.2 (*)
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-beans:6.2.2 (*)
+|              +--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-expression:6.2.2
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1
+|                   \--- io.micrometer:micrometer-commons:1.15.0-M1
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+|    +--- project :spring-boot-project:spring-boot-actuator (*)
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure
+|         \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-docker-compose
+|    \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-tools:spring-boot-cli
++--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools
+|    +--- org.apache.commons:commons-compress -> 1.25.0
+|    \--- org.springframework:spring-core -> 6.2.2 (*)
++--- project :spring-boot-project:spring-boot-test
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- org.springframework:spring-test -> 6.2.2
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- project :spring-boot-project:spring-boot-test-autoconfigure
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- project :spring-boot-project:spring-boot-test (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-testcontainers
+|    +--- project :spring-boot-project:spring-boot-autoconfigure (*)
+|    \--- org.testcontainers:testcontainers -> 1.20.4
+|         +--- junit:junit:4.13.2
+|         |    \--- org.hamcrest:hamcrest-core:1.3 -> 3.0
+|         |         \--- org.hamcrest:hamcrest:3.0
+|         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- org.apache.commons:commons-compress:1.24.0 -> 1.25.0
+|         +--- org.rnorth.duct-tape:duct-tape:1.0.8
+|         |    \--- org.jetbrains:annotations:17.0.0
+|         +--- com.github.docker-java:docker-java-api:3.4.0
+|         |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.3 -> 2.18.2
+|         |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|         |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|         \--- com.github.docker-java:docker-java-transport-zerodep:3.4.0
+|              +--- com.github.docker-java:docker-java-transport:3.4.0
+|              +--- org.slf4j:slf4j-api:1.7.25 -> 2.0.16
+|              \--- net.java.dev.jna:jna:5.13.0
++--- project :spring-boot-project:spring-boot-devtools
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- ch.qos.logback:logback-classic -> 1.5.16
+|    +--- ch.qos.logback:logback-core:1.5.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- com.zaxxer:HikariCP -> 6.2.1
+|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-jakarta9 -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    |    \--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    \--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
++--- io.micrometer:micrometer-tracing -> 1.5.0-M1
+|    +--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    +--- io.micrometer:context-propagation:1.1.2
+|    \--- aopalliance:aopalliance:1.0
++--- io.micrometer:micrometer-registry-graphite -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-graphite:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- com.rabbitmq:amqp-client:5.23.0 -> 5.24.0
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-registry-jmx -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-jmx:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29 (*)
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0 -> 2.7.0-alpha
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0
+|    |    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0
+|    |         \--- io.opentelemetry:opentelemetry-context:1.46.0
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:2.7.0-alpha
+|    |    +--- io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha
+|    |    \--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0 (*)
+|    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0 (*)
++--- io.projectreactor.netty:reactor-netty-http -> 1.2.2
+|    +--- io.netty:netty-codec-http:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final
+|    |    |    \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-transport:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-resolver:4.1.117.Final
+|    |    |         \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-codec:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport-native-unix-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-codec:4.1.117.Final (*)
+|    +--- io.netty:netty-codec-http2:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler:4.1.117.Final (*)
+|    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec-dns:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final
+|    |    \--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver-dns:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    |    \--- io.netty:netty-transport-classes-epoll:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.projectreactor.netty:reactor-netty-core:1.2.2
+|    |    +--- io.netty:netty-handler:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler-proxy:4.1.116.Final -> 4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec-socks:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final (*)
+|    |    \--- io.projectreactor:reactor-core:3.7.2
+|    |         \--- org.reactivestreams:reactive-streams:1.0.4
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- io.undertow:undertow-core -> 2.3.18.Final
+|    +--- org.jboss.logging:jboss-logging:3.4.3.Final -> 3.6.1.Final
+|    +--- org.jboss.xnio:xnio-api:3.8.16.Final
+|    |    +--- org.wildfly.common:wildfly-common:1.5.4.Final
+|    |    \--- org.wildfly.client:wildfly-client-config:1.0.1.Final
+|    |         \--- org.jboss.logging:jboss-logging:3.3.1.Final -> 3.6.1.Final
+|    \--- org.jboss.threads:jboss-threads:3.5.0.Final
+|         \--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.6.1.Final
++--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
++--- jakarta.jms:jakarta.jms-api -> 3.1.0
++--- jakarta.persistence:jakarta.persistence-api -> 3.1.0
++--- jakarta.servlet:jakarta.servlet-api -> 6.0.0
++--- jakarta.validation:jakarta.validation-api -> 3.0.2
++--- org.apache.httpcomponents.client5:httpclient5 -> 5.4.2
+|    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3
+|    |    \--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- org.apache.commons:commons-dbcp2 -> 2.13.0
+|    +--- org.apache.commons:commons-pool2:2.12.0 -> 2.12.1
+|    \--- jakarta.transaction:jakarta.transaction-api:1.3.3 -> 2.0.1
++--- org.apache.kafka:kafka-streams -> 3.9.0
+|    +--- org.apache.kafka:kafka-clients:3.9.0
+|    \--- org.rocksdb:rocksdbjni:7.9.2
++--- org.apache.logging.log4j:log4j-to-slf4j -> 2.24.3
+|    +--- org.apache.logging.log4j:log4j-api:2.24.3
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.apache.tomcat.embed:tomcat-embed-core -> 10.1.34
+|    \--- org.apache.tomcat:tomcat-annotations-api:10.1.34
++--- org.assertj:assertj-core -> 3.27.3
+|    \--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
++--- org.cache2k:cache2k-spring -> 2.6.1.Final
+|    \--- org.cache2k:cache2k-api:2.6.1.Final
++--- org.apache.groovy:groovy -> 4.0.25
+|    \--- org.apache.groovy:groovy-bom:4.0.25 (*)
++--- org.glassfish.jersey.containers:jersey-container-servlet-core -> 3.1.10
+|    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    +--- org.glassfish.jersey.core:jersey-common:3.1.10
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- org.glassfish.hk2:osgi-resource-locator:1.0.3
+|    +--- org.glassfish.jersey.core:jersey-server:3.1.10
+|    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    +--- org.glassfish.jersey.core:jersey-client:3.1.10
+|    |    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    |    \--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- jakarta.validation:jakarta.validation-api:3.0.2
+|    \--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
++--- org.glassfish.jersey.core:jersey-server -> 3.1.10 (*)
++--- org.hibernate.orm:hibernate-jcache -> 6.6.6.Final
+|    +--- org.hibernate.orm:hibernate-core:6.6.6.Final
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0
+|    |    \--- jakarta.transaction:jakarta.transaction-api:2.0.1
+|    \--- javax.cache:cache-api:1.0.0 -> 1.1.1
++--- org.htmlunit:htmlunit -> 4.9.0
+|    +--- org.apache.httpcomponents:httpmime:4.5.14
+|    |    \--- org.apache.httpcomponents:httpclient:4.5.14
+|    |         +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |         \--- commons-codec:commons-codec:1.11 -> 1.18.0
+|    +--- org.htmlunit:htmlunit-core-js:4.9.0
+|    +--- org.htmlunit:neko-htmlunit:4.9.0
+|    +--- org.htmlunit:htmlunit-cssparser:4.9.0
+|    +--- org.htmlunit:htmlunit-xpath:4.9.0
+|    +--- org.htmlunit:htmlunit-csp:4.9.0
+|    +--- org.htmlunit:htmlunit-websocket-client:4.9.0
+|    +--- org.apache.commons:commons-lang3:3.17.0
+|    +--- commons-io:commons-io:2.18.0
+|    +--- commons-codec:commons-codec:1.17.2 -> 1.18.0
+|    \--- org.brotli:dec:0.1.2
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+|    |    +--- org.jetbrains:annotations:13.0 -> 17.0.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.25 (c)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.25 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
++--- org.jooq:jooq -> 3.19.18
+|    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE
+|         \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
++--- org.mockito:mockito-core -> 5.15.2
+|    +--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
+|    \--- net.bytebuddy:byte-buddy-agent:1.15.11 -> 1.17.0
++--- org.mongodb:mongodb-driver-sync -> 5.3.1
+|    +--- org.mongodb:bson:5.3.1
+|    \--- org.mongodb:mongodb-driver-core:5.3.1
+|         \--- org.mongodb:bson:5.3.1
++--- org.postgresql:r2dbc-postgresql -> 1.0.7.RELEASE
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- com.ongres.scram:client:2.1
+|    |    \--- com.ongres.scram:common:2.1
+|    |         \--- com.ongres.stringprep:saslprep:1.1
+|    |              \--- com.ongres.stringprep:stringprep:1.1
+|    +--- io.projectreactor:reactor-core:3.5.20 -> 3.7.2 (*)
+|    \--- io.projectreactor.netty:reactor-netty-core:1.1.22 -> 1.2.2 (*)
++--- org.quartz-scheduler:quartz -> 2.5.0
++--- org.slf4j:jul-to-slf4j -> 2.0.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.springframework:spring-jdbc -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework:spring-jms -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-orm -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2 (*)
++--- org.springframework:spring-test -> 6.2.2 (*)
++--- org.springframework:spring-web -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-webflux -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- org.springframework:spring-webmvc -> 6.2.2
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework:spring-websocket -> 6.2.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework.amqp:spring-amqp -> 3.2.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework.retry:spring-retry:2.0.11
++--- org.springframework.amqp:spring-rabbit -> 3.2.2
+|    +--- org.springframework.amqp:spring-amqp:3.2.2 (*)
+|    +--- com.rabbitmq:amqp-client:5.22.0 -> 5.24.0 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.batch:spring-batch-core -> 5.2.1
+|    +--- org.springframework.batch:spring-batch-infrastructure:5.2.1
+|    |    +--- org.springframework:spring-core:6.2.1 -> 6.2.2 (*)
+|    |    \--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.springframework:spring-aop:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.1 -> 6.2.2 (*)
+|    +--- io.micrometer:micrometer-core:1.14.2 -> 1.15.0-M1 (*)
+|    +--- io.micrometer:micrometer-observation:1.14.2 -> 1.15.0-M1 (*)
+|    \--- org.springframework.data:spring-data-commons:3.4.1 -> 3.4.2
+|         +--- org.springframework:spring-core:6.2.2 (*)
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-cassandra -> 4.4.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.apache.cassandra:java-driver-core:4.18.0 -> 4.18.1
+|    |    +--- com.datastax.oss:native-protocol:1.5.1
+|    |    +--- io.netty:netty-handler:4.1.94.Final -> 4.1.117.Final (*)
+|    |    +--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    |    +--- com.typesafe:config:1.4.1
+|    |    +--- com.github.jnr:jnr-posix:3.1.15
+|    |    |    +--- com.github.jnr:jnr-ffi:2.2.11
+|    |    |    |    +--- com.github.jnr:jffi:1.3.9
+|    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    +--- org.ow2.asm:asm-commons:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2
+|    |    |    |    |    |    \--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2
+|    |    |    |    |         \--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-util:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- com.github.jnr:jnr-a64asm:1.0.0
+|    |    |    |    \--- com.github.jnr:jnr-x86asm:1.0.2
+|    |    |    \--- com.github.jnr:jnr-constants:0.10.3
+|    |    +--- org.slf4j:slf4j-api:1.7.26 -> 2.0.16
+|    |    +--- io.dropwizard.metrics:metrics-core:4.1.18 -> 4.2.29 (*)
+|    |    +--- org.hdrhistogram:HdrHistogram:2.1.12
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.4 -> 2.18.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 -> 2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- org.apache.cassandra:java-driver-query-builder:4.18.0 -> 4.18.1
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (*)
+|    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-couchbase -> 5.4.2
+|    +--- org.springframework:spring-context-support:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- com.couchbase.client:java-client:3.7.7
+|    |    \--- com.couchbase.client:core-io:3.7.7
+|    |         +--- io.projectreactor:reactor-core:3.6.9 -> 3.7.2 (*)
+|    |         +--- org.reactivestreams:reactive-streams:1.0.4
+|    |         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-elasticsearch -> 5.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- co.elastic.clients:elasticsearch-java:8.15.5
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.5.14 (*)
+|    |    |    +--- org.apache.httpcomponents:httpcore:4.4.13 -> 4.4.16
+|    |    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5
+|    |    |    +--- org.apache.httpcomponents:httpcore-nio:4.4.13 -> 4.4.16
+|    |    |    \--- commons-codec:commons-codec:1.15 -> 1.18.0
+|    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    +--- jakarta.json:jakarta.json-api:2.0.1 -> 2.1.3
+|    |    \--- org.eclipse.parsson:parsson:1.0.5
+|    |         \--- jakarta.json:jakarta.json-api:2.0.2 -> 2.1.3
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-envers -> 3.4.2
+|    +--- org.springframework.data:spring-data-jpa:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-orm:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.antlr:antlr4-runtime:4.13.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.0.0 -> 2.1.1
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.hibernate.orm:hibernate-envers:6.6.4.Final -> 6.6.6.Final
+|    |    \--- org.hibernate.orm:hibernate-core:6.6.6.Final (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-jpa -> 3.4.2 (*)
++--- org.springframework.data:spring-data-ldap -> 3.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.ldap:spring-ldap-core:3.2.10 -> 3.3.0-M1
+|    |    +--- org.springframework:spring-core:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.1.16 -> 6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-core:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-mongodb -> 4.4.2
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.mongodb:mongodb-driver-core:5.2.1 -> 5.3.1 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-neo4j -> 7.4.2
+|    +--- jakarta.transaction:jakarta.transaction-api:2.0.0 -> 2.0.1
+|    +--- org.apiguardian:apiguardian-api:1.1.1 -> 1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl:2024.2.0
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl-schema-name-support:2024.2.0
+|    +--- org.neo4j.driver:neo4j-java-driver:5.25.0
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4
+|    |    +--- io.netty:netty-handler:4.1.113.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-tcnative-classes:2.0.66.Final -> 2.0.69.Final
+|    |    \--- io.projectreactor:reactor-core:3.6.10 -> 3.7.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-redis -> 3.4.2
+|    +--- org.springframework.data:spring-data-keyvalue:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-context-support:6.2.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-r2dbc -> 3.4.2
+|    +--- org.springframework.data:spring-data-relational:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-r2dbc:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    |    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.graphql:spring-graphql -> 1.3.3
+|    +--- com.graphql-java:graphql-java:22.3
+|    |    +--- com.graphql-java:java-dataloader:3.3.0
+|    |    |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    \--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
++--- org.springframework.graphql:spring-graphql-test -> 1.3.3
+|    +--- org.springframework.graphql:spring-graphql:1.3.3 (*)
+|    +--- com.graphql-java:graphql-java:22.3 (*)
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    +--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
+|    +--- org.springframework:spring-test:6.1.14 -> 6.2.2 (*)
+|    \--- com.jayway.jsonpath:json-path:2.9.0
++--- org.springframework.kafka:spring-kafka -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.kafka:spring-kafka-test -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-test:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.zookeeper:zookeeper:3.8.4
+|    |    +--- org.apache.zookeeper:zookeeper-jute:3.8.4
+|    |    |    \--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- io.netty:netty-handler:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    +--- ch.qos.logback:logback-core:1.2.13 -> 1.5.16
+|    |    +--- ch.qos.logback:logback-classic:1.2.13 -> 1.5.16 (*)
+|    |    \--- commons-io:commons-io:2.11.0 -> 2.18.0
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-server:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-metadata:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-server-common:3.8.1 -> 3.9.0
+|    |    \--- org.apache.kafka:kafka-clients:3.9.0
+|    +--- org.apache.kafka:kafka-streams-test-utils:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (*)
+|    |    \--- org.apache.kafka:kafka-clients:3.9.0
+|    +--- org.apache.kafka:kafka_2.13:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0
+|    |    \--- org.scala-lang:scala-library:2.13.14
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4
+|    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    +--- org.opentest4j:opentest4j:1.3.0
+|    |    +--- org.junit.platform:junit-platform-commons:1.11.4
+|    |    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    \--- org.junit.platform:junit-platform-launcher:1.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         +--- org.junit.platform:junit-platform-engine:1.11.4
+|         |    +--- org.junit:junit-bom:5.11.4 (*)
+|         |    +--- org.opentest4j:opentest4j:1.3.0
+|         |    +--- org.junit.platform:junit-platform-commons:1.11.4 (*)
+|         |    \--- org.apiguardian:apiguardian-api:1.1.2
+|         \--- org.apiguardian:apiguardian-api:1.1.2
++--- org.springframework.pulsar:spring-pulsar -> 1.2.2
+|    +--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.apache.pulsar:pulsar-client-all:3.3.4 -> 4.0.2
+|    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2
+|    |    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1
+|    |    |    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    |    \--- org.bouncycastle:bcutil-jdk18on:1.78.1
+|    |    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    \--- org.bouncycastle:bcprov-ext-jdk18on:1.78.1
+|    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcutil-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0 (*)
+|    |    +--- io.opentelemetry:opentelemetry-context:1.45.0 -> 1.46.0
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.45.0-alpha
+|    |    |    \--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0 (*)
+|    |    +--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.17.2 -> 2.18.2 (*)
+|    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    |    \--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2
+|    |         +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (*)
+|    |         +--- com.google.guava:guava:32.1.2-jre -> 33.3.1-jre
+|    |         |    +--- com.google.guava:failureaccess:1.0.2
+|    |         |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |         |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |         |    +--- org.checkerframework:checker-qual:3.43.0
+|    |         |    +--- com.google.errorprone:error_prone_annotations:2.28.0
+|    |         |    \--- com.google.j2objc:j2objc-annotations:3.0.0
+|    |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2
++--- org.springframework.pulsar:spring-pulsar-reactive -> 1.2.2
+|    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (*)
+|    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    \--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10
++--- org.springframework.restdocs:spring-restdocs-mockmvc -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    +--- org.springframework:spring-webmvc:6.1.13 -> 6.2.2 (*)
+|    \--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
++--- org.springframework.restdocs:spring-restdocs-restassured -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    \--- io.rest-assured:rest-assured:5.2.1 -> 5.5.0
+|         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25
+|         |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|         |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|         +--- org.apache.httpcomponents:httpclient:4.5.13 -> 4.5.14 (*)
+|         +--- org.apache.httpcomponents:httpmime:4.5.13 -> 4.5.14 (*)
+|         +--- org.hamcrest:hamcrest:2.2 -> 3.0
+|         +--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
+|         +--- io.rest-assured:json-path:5.5.0
+|         |    +--- org.apache.groovy:groovy-json:4.0.22 -> 4.0.25
+|         |    |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|         |    |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|         |    +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         |    \--- io.rest-assured:rest-assured-common:5.5.0
+|         |         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|         \--- io.rest-assured:xml-path:5.5.0
+|              +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25 (*)
+|              +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|              +--- io.rest-assured:rest-assured-common:5.5.0 (*)
+|              +--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|              \--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
++--- org.springframework.restdocs:spring-restdocs-webtestclient -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    +--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
+|    \--- org.springframework:spring-webflux:6.1.13 -> 6.2.2 (*)
++--- org.springframework.security:spring-security-config -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-crypto:6.5.0-M1
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework.security:spring-security-oauth2-client -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- com.nimbusds:oauth2-oidc-sdk:9.43.4
+|         +--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|         +--- com.nimbusds:content-type:2.2
+|         +--- net.minidev:json-smart:[1.3.3,2.4.10] -> 2.5.1
+|         |    \--- net.minidev:accessors-smart:2.5.1
+|         |         \--- org.ow2.asm:asm:9.6
+|         +--- com.nimbusds:lang-tag:1.7
+|         \--- com.nimbusds:nimbus-jose-jwt:9.37.3
+|              \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
++--- org.springframework.security:spring-security-test -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-test:6.2.2 (*)
++--- org.springframework.security:spring-security-web -> 6.5.0-M1 (*)
++--- org.springframework.ws:spring-ws-core -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11
+|    |    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.0 -> 2.1.3
+|    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
+|    +--- org.springframework:spring-aop:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-web:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-webmvc:6.0.16 -> 6.2.2 (*)
+|    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.0 -> 3.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.springframework.ws:spring-ws-test -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11 (*)
+|    +--- org.springframework.ws:spring-ws-core:4.0.11 (*)
+|    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    +--- xmlunit:xmlunit:1.6
+|    +--- org.xmlunit:xmlunit-core:2.9.0 -> 2.10.0
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.testcontainers:junit-jupiter -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:neo4j -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:mongodb -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.junit.jupiter:junit-jupiter -> 5.11.4
+|    +--- org.junit:junit-bom:5.11.4 (*)
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|    \--- org.junit.jupiter:junit-jupiter-params:5.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|         \--- org.apiguardian:apiguardian-api:1.1.2
+\--- org.yaml:snakeyaml -> 2.3
+
+compileOnly - Compile only dependencies for null/main. (n)
+No dependencies
+
+compileOnlyDependenciesMetadata
+No dependencies
+
+configurationProperties
++--- project :spring-boot-project:spring-boot
++--- project :spring-boot-project:spring-boot-actuator
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
++--- project :spring-boot-project:spring-boot-autoconfigure
++--- project :spring-boot-project:spring-boot-docker-compose
++--- project :spring-boot-project:spring-boot-devtools
++--- project :spring-boot-project:spring-boot-test-autoconfigure
+\--- project :spring-boot-project:spring-boot-testcontainers
+
+default - Configuration for default artifacts. (n)
+No dependencies
+
+dependencyManagement (n)
+\--- project spring-boot-parent (n)
+
+dependencyVersions
+\--- project :spring-boot-project:spring-boot-dependencies
+     +--- org.apache.activemq:activemq-bom:6.1.5
+     +--- org.apache.activemq:artemis-bom:2.39.0
+     +--- org.assertj:assertj-bom:3.27.3
+     +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+     +--- io.zipkin.brave:brave-bom:6.0.3
+     +--- org.apache.cassandra:java-driver-bom:4.18.1
+     +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+     +--- org.apache.groovy:groovy-bom:4.0.25
+     +--- org.infinispan:infinispan-bom:15.1.5.Final
+     +--- com.fasterxml.jackson:jackson-bom:2.18.2
+     +--- org.glassfish.jersey:jersey-bom:3.1.10
+     +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+     +--- org.eclipse.jetty:jetty-bom:12.0.16
+     +--- org.junit:junit-bom:5.11.4
+     +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+     +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+     +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+     +--- org.apache.logging.log4j:log4j-bom:2.24.3
+     +--- io.micrometer:micrometer-bom:1.15.0-M1
+     +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+     +--- org.mockito:mockito-bom:5.15.2
+     +--- io.netty:netty-bom:4.1.117.Final
+     +--- io.opentelemetry:opentelemetry-bom:1.46.0
+     +--- io.prometheus:prometheus-metrics-bom:1.3.5
+     +--- io.prometheus:simpleclient_bom:0.16.0
+     +--- org.apache.pulsar:pulsar-bom:4.0.2
+     +--- com.querydsl:querydsl-bom:5.1.0
+     +--- io.projectreactor:reactor-bom:2024.0.2
+     +--- io.rest-assured:rest-assured-bom:5.5.0
+     +--- io.rsocket:rsocket-bom:1.1.5
+     +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+     +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+     +--- org.springframework.batch:spring-batch-bom:5.2.1
+     +--- org.springframework.data:spring-data-bom:2024.1.2
+     +--- org.springframework:spring-framework-bom:6.2.2
+     +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+     +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+     +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+     +--- org.springframework.security:spring-security-bom:6.5.0-M1
+     +--- org.springframework.session:spring-session-bom:3.4.1
+     +--- org.springframework.ws:spring-ws-bom:4.0.11
+     +--- org.testcontainers:testcontainers-bom:1.20.4
+     +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+     +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+     +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3
+     +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+     +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+     +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1
+     +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5
+     +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25
+     +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+     +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2
+     +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10
+     +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+     +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+     +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4
+     +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25
+     +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+     +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+     +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3
+     +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1
+     +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1
+     +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2
+     +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final
+     +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0
+     +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5
+     +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+     +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2
+     +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+     +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2
+     +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0
+     +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+     +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+     +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2
+     +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1
+     +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2
+     +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2
+     +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+     +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2
+     +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3
+     +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+     +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+     +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11
+     \--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4
+
+devtools
+\--- project :spring-boot-project:spring-boot-devtools
+
+dokkatoo - Fetch all Dokkatoo files from all configurations in other subprojects. (n)
++--- project spring-boot (n)
+\--- project spring-boot-test (n)
+
+dokkatooHtmlGeneratorClasspath - Dokka Generator runtime classpath for html - will be used in Dokka Worker. Should contain all transitive dependencies, plugins (and their transitive dependencies), so Dokka Worker can run. (n)
++--- org.jetbrains.dokka:analysis-kotlin-descriptors:1.9.20 (n)
++--- org.jetbrains.dokka:dokka-core:1.9.20 (n)
++--- org.freemarker:freemarker:2.3.32 (n)
++--- org.jetbrains:markdown:0.5.2 (n)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (n)
+\--- org.jetbrains.kotlinx:kotlinx-html:0.9.1 (n)
+
+dokkatooHtmlGeneratorClasspathResolver - Dokka Generator runtime classpath for html - will be used in Dokka Worker. Should contain all transitive dependencies, plugins (and their transitive dependencies), so Dokka Worker can run.
++--- org.jetbrains.dokka:analysis-kotlin-descriptors:1.9.20
++--- org.jetbrains.dokka:dokka-core:1.9.20
+|    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.22
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
+|    |         +--- org.jetbrains:annotations:13.0 -> 23.0.0
+|    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3
+|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3
+|    |         +--- org.jetbrains:annotations:23.0.0
+|    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3
+|    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3 (c)
+|    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
+|    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
+|    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
+|    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-kotlin:2.12.7
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.12.7.1
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.12.7
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.12.7 (c)
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.12.7 (c)
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.12.7.1 (c)
+|    |    |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.7 (c)
+|    |    |    |         +--- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.7 (c)
+|    |    |    |         \--- com.fasterxml.jackson.module:jackson-module-kotlin:2.12.7 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.12.7
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.12.7 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.4.21 -> 1.9.22 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.7
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.12.7 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.12.7 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.12.7.1 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.7
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.12.7 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.12.7 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.12.7.1 (*)
+|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:1.2.1
+|    |    |    +--- jakarta.activation:jakarta.activation-api:1.2.1
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
+|    |    +--- org.codehaus.woodstox:stax2-api:4.2.1
+|    |    +--- com.fasterxml.woodstox:woodstox-core:6.2.4
+|    |    |    \--- org.codehaus.woodstox:stax2-api:4.2.1
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|    \--- com.fasterxml.jackson.core:jackson-databind:2.12.7.1 (c)
++--- org.freemarker:freemarker:2.3.32
++--- org.jetbrains:markdown:0.5.2
+|    \--- org.jetbrains:markdown-jvm:0.5.2
+|         +--- it.unimi.dsi:fastutil-core:8.5.12
+|         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.0 -> 1.9.22 (*)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
++--- org.jetbrains.kotlinx:kotlinx-html:0.9.1
+|    \--- org.jetbrains.kotlinx:kotlinx-html-jvm:0.9.1
+|         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.20 -> 1.9.22 (*)
+|         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22 (*)
++--- org.jetbrains.dokka:templating-plugin:1.9.20
+|    +--- org.jetbrains.dokka:dokka-base:1.9.20
+|    |    +--- org.jetbrains.dokka:analysis-markdown:1.9.20
+|    |    |    +--- org.jsoup:jsoup:1.16.1
+|    |    |    +--- org.jetbrains:markdown:0.5.2 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.22 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jsoup:jsoup:1.16.1
+|    |    +--- org.freemarker:freemarker:2.3.32
+|    |    +--- org.jetbrains.kotlinx:kotlinx-html-jvm:0.9.1 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-kotlin:2.12.7 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.12.7.1 (c)
+|    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.22 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    +--- org.jsoup:jsoup:1.16.1
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+\--- org.jetbrains.dokka:dokka-base:1.9.20 (*)
+
+dokkatooHtmlModuleOutputDirectoriesConsumable - Provides Dokkatoo html ModuleOutputDirectories files for consumption by other subprojects. (n)
+No dependencies
+
+dokkatooHtmlModuleOutputDirectoriesResolver - Resolves Dokkatoo html ModuleOutputDirectories files.
++--- project :spring-boot-project:spring-boot
+\--- project :spring-boot-project:spring-boot-test
+
+dokkatooHtmlPluginsClasspathIntransitiveResolver - Resolves Dokka Plugins classpath for html - for internal use. Fetch only the plugins (no transitive dependencies) for use in the Dokka JSON Configuration.
++--- org.jetbrains.dokka:templating-plugin:1.9.20
+\--- org.jetbrains.dokka:dokka-base:1.9.20
+
+dokkatooHtmlPublicationPluginClasspath - Dokka Plugins classpath for a html Publication (consisting of 1+ Dokka Module). (n)
+No dependencies
+
+dokkatooHtmlPublicationPluginClasspathApiOnly - Dokka Plugins for consumers that will assemble a html Publication using the Dokka Module that this project produces (n)
+\--- org.jetbrains.dokka:all-modules-page-plugin:1.9.20 (n)
+
+dokkatooHtmlPublicationPluginClasspathApiOnlyConsumable - Shared Dokka Plugins for consumers that will assemble a html Publication using the Dokka Module that this project produces (n)
+No dependencies
+
+dokkatooHtmlPublicationPluginClasspathResolver - Resolves Dokka Plugins classpath for a html Publication (consisting of 1+ Dokka Module).
++--- project :spring-boot-project:spring-boot
+|    \--- org.jetbrains.dokka:all-modules-page-plugin:1.9.20
+|         +--- org.jetbrains.dokka:dokka-base:1.9.20
+|         |    +--- org.jetbrains.dokka:analysis-markdown:1.9.20
+|         |    |    +--- org.jsoup:jsoup:1.16.1
+|         |    |    +--- org.jetbrains:markdown:0.5.2
+|         |    |    |    \--- org.jetbrains:markdown-jvm:0.5.2
+|         |    |    |         +--- it.unimi.dsi:fastutil-core:8.5.12
+|         |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0
+|         |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22
+|         |    |    |         |    |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
+|         |    |    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|         |    |    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|         |    |    |         |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|         |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
+|         |    |    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|         |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.0 -> 1.9.22
+|         |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|         |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|         |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.22
+|         |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3
+|         |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3
+|         |    |         +--- org.jetbrains:annotations:23.0.0
+|         |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3
+|         |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3 (c)
+|         |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|         |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22 (*)
+|         |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|         |    +--- org.jsoup:jsoup:1.16.1
+|         |    +--- org.freemarker:freemarker:2.3.32
+|         |    +--- org.jetbrains.kotlinx:kotlinx-html-jvm:0.9.1
+|         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.20 -> 1.9.22 (*)
+|         |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22 (*)
+|         |    +--- com.fasterxml.jackson.module:jackson-module-kotlin:2.12.7
+|         |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.12.7.1
+|         |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.12.7
+|         |    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7
+|         |    |    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.12.7 (c)
+|         |    |    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.12.7.1 (c)
+|         |    |    |    |         +--- com.fasterxml.jackson.module:jackson-module-kotlin:2.12.7 (c)
+|         |    |    |    |         \--- com.fasterxml.jackson.core:jackson-core:2.12.7 (c)
+|         |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.12.7
+|         |    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
+|         |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
+|         |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.12.7 (*)
+|         |    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.4.21 -> 1.9.22 (*)
+|         |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.7 (*)
+|         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|         |    \--- com.fasterxml.jackson.core:jackson-databind:2.12.7.1 (c)
+|         +--- org.jetbrains.dokka:templating-plugin:1.9.20
+|         |    +--- org.jetbrains.dokka:dokka-base:1.9.20 (*)
+|         |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.22 (*)
+|         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|         |    +--- org.jsoup:jsoup:1.16.1
+|         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+|         +--- org.jetbrains.dokka:analysis-markdown:1.9.20 (*)
+|         +--- org.jetbrains.kotlinx:kotlinx-html-jvm:0.9.1 (*)
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
+\--- project :spring-boot-project:spring-boot-test
+     \--- org.jetbrains.dokka:all-modules-page-plugin:1.9.20 (*)
+
+dokkatooPlugin - Dokka Plugins classpath, that will be used by all formats. (n)
+No dependencies
+
+dokkatooPluginHtml - Dokka Plugins classpath for html. (n)
++--- org.jetbrains.dokka:templating-plugin:1.9.20 (n)
+\--- org.jetbrains.dokka:dokka-base:1.9.20 (n)
+
+gradlePluginAntoraCatalogContent - Configuration for gradle-plugin Antora catalog content.
+\--- project :spring-boot-project:spring-boot-tools:spring-boot-gradle-plugin
+
+gradlePluginAntoraSource
+\--- project :spring-boot-project:spring-boot-tools:spring-boot-gradle-plugin
+
+implementation - Implementation only dependencies for null/main. (n)
++--- project spring-boot-actuator (n)
++--- project spring-boot-actuator-autoconfigure (n)
++--- project spring-boot-autoconfigure (n)
++--- project spring-boot-docker-compose (n)
++--- project spring-boot-cli (n)
++--- project spring-boot-loader-tools (n)
++--- project spring-boot-test (n)
++--- project spring-boot-test-autoconfigure (n)
++--- project spring-boot-testcontainers (n)
++--- project spring-boot-devtools (n)
++--- ch.qos.logback:logback-classic (n)
++--- com.zaxxer:HikariCP (n)
++--- io.micrometer:micrometer-jakarta9 (n)
++--- io.micrometer:micrometer-tracing (n)
++--- io.micrometer:micrometer-registry-graphite (n)
++--- io.micrometer:micrometer-registry-jmx (n)
++--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0 (n)
++--- io.projectreactor.netty:reactor-netty-http (n)
++--- io.undertow:undertow-core (n)
++--- jakarta.annotation:jakarta.annotation-api (n)
++--- jakarta.jms:jakarta.jms-api (n)
++--- jakarta.persistence:jakarta.persistence-api (n)
++--- jakarta.servlet:jakarta.servlet-api (n)
++--- jakarta.validation:jakarta.validation-api (n)
++--- org.apache.httpcomponents.client5:httpclient5 (n)
++--- org.apache.commons:commons-dbcp2 (n)
++--- org.apache.kafka:kafka-streams (n)
++--- org.apache.logging.log4j:log4j-to-slf4j (n)
++--- org.apache.tomcat.embed:tomcat-embed-core (n)
++--- org.assertj:assertj-core (n)
++--- org.cache2k:cache2k-spring (n)
++--- org.apache.groovy:groovy (n)
++--- org.glassfish.jersey.containers:jersey-container-servlet-core (n)
++--- org.glassfish.jersey.core:jersey-server (n)
++--- org.hibernate.orm:hibernate-jcache (n)
++--- org.htmlunit:htmlunit (n)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8 (n)
++--- org.jooq:jooq (n)
++--- org.mockito:mockito-core (n)
++--- org.mongodb:mongodb-driver-sync (n)
++--- org.postgresql:r2dbc-postgresql (n)
++--- org.quartz-scheduler:quartz (n)
++--- org.slf4j:jul-to-slf4j (n)
++--- org.springframework:spring-jdbc (n)
++--- org.springframework:spring-jms (n)
++--- org.springframework:spring-orm (n)
++--- org.springframework:spring-test (n)
++--- org.springframework:spring-web (n)
++--- org.springframework:spring-webflux (n)
++--- org.springframework:spring-webmvc (n)
++--- org.springframework:spring-websocket (n)
++--- org.springframework.amqp:spring-amqp (n)
++--- org.springframework.amqp:spring-rabbit (n)
++--- org.springframework.batch:spring-batch-core (n)
++--- org.springframework.data:spring-data-cassandra (n)
++--- org.springframework.data:spring-data-couchbase (n)
++--- org.springframework.data:spring-data-elasticsearch (n)
++--- org.springframework.data:spring-data-envers (n)
++--- org.springframework.data:spring-data-jpa (n)
++--- org.springframework.data:spring-data-ldap (n)
++--- org.springframework.data:spring-data-mongodb (n)
++--- org.springframework.data:spring-data-neo4j (n)
++--- org.springframework.data:spring-data-redis (n)
++--- org.springframework.data:spring-data-r2dbc (n)
++--- org.springframework.graphql:spring-graphql (n)
++--- org.springframework.graphql:spring-graphql-test (n)
++--- org.springframework.kafka:spring-kafka (n)
++--- org.springframework.kafka:spring-kafka-test (n)
++--- org.springframework.pulsar:spring-pulsar (n)
++--- org.springframework.pulsar:spring-pulsar-reactive (n)
++--- org.springframework.restdocs:spring-restdocs-mockmvc (n)
++--- org.springframework.restdocs:spring-restdocs-restassured (n)
++--- org.springframework.restdocs:spring-restdocs-webtestclient (n)
++--- org.springframework.security:spring-security-config (n)
++--- org.springframework.security:spring-security-oauth2-client (n)
++--- org.springframework.security:spring-security-test (n)
++--- org.springframework.security:spring-security-web (n)
++--- org.springframework.ws:spring-ws-core (n)
++--- org.springframework.ws:spring-ws-test (n)
++--- org.testcontainers:junit-jupiter (n)
++--- org.testcontainers:neo4j (n)
++--- org.testcontainers:mongodb (n)
++--- org.junit.jupiter:junit-jupiter (n)
+\--- org.yaml:snakeyaml (n)
+
+implementationDependenciesMetadata
++--- project :spring-boot-project:spring-boot-actuator
+|    \--- project :spring-boot-project:spring-boot
+|         +--- org.springframework:spring-core FAILED
+|         \--- org.springframework:spring-context FAILED
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+|    +--- project :spring-boot-project:spring-boot-actuator (*)
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure
+|         \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-docker-compose
+|    \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-tools:spring-boot-cli
++--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools
+|    +--- org.apache.commons:commons-compress FAILED
+|    \--- org.springframework:spring-core FAILED
++--- project :spring-boot-project:spring-boot-test
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- org.springframework:spring-test FAILED
++--- project :spring-boot-project:spring-boot-test-autoconfigure
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- project :spring-boot-project:spring-boot-test (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-testcontainers
+|    +--- project :spring-boot-project:spring-boot-autoconfigure (*)
+|    \--- org.testcontainers:testcontainers FAILED
++--- project :spring-boot-project:spring-boot-devtools
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- ch.qos.logback:logback-classic FAILED
++--- com.zaxxer:HikariCP FAILED
++--- io.micrometer:micrometer-jakarta9 FAILED
++--- io.micrometer:micrometer-tracing FAILED
++--- io.micrometer:micrometer-registry-graphite FAILED
++--- io.micrometer:micrometer-registry-jmx FAILED
++--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0 FAILED
++--- io.projectreactor.netty:reactor-netty-http FAILED
++--- io.undertow:undertow-core FAILED
++--- jakarta.annotation:jakarta.annotation-api FAILED
++--- jakarta.jms:jakarta.jms-api FAILED
++--- jakarta.persistence:jakarta.persistence-api FAILED
++--- jakarta.servlet:jakarta.servlet-api FAILED
++--- jakarta.validation:jakarta.validation-api FAILED
++--- org.apache.httpcomponents.client5:httpclient5 FAILED
++--- org.apache.commons:commons-dbcp2 FAILED
++--- org.apache.kafka:kafka-streams FAILED
++--- org.apache.logging.log4j:log4j-to-slf4j FAILED
++--- org.apache.tomcat.embed:tomcat-embed-core FAILED
++--- org.assertj:assertj-core FAILED
++--- org.cache2k:cache2k-spring FAILED
++--- org.apache.groovy:groovy FAILED
++--- org.glassfish.jersey.containers:jersey-container-servlet-core FAILED
++--- org.glassfish.jersey.core:jersey-server FAILED
++--- org.hibernate.orm:hibernate-jcache FAILED
++--- org.htmlunit:htmlunit FAILED
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
++--- org.jooq:jooq FAILED
++--- org.mockito:mockito-core FAILED
++--- org.mongodb:mongodb-driver-sync FAILED
++--- org.postgresql:r2dbc-postgresql FAILED
++--- org.quartz-scheduler:quartz FAILED
++--- org.slf4j:jul-to-slf4j FAILED
++--- org.springframework:spring-jdbc FAILED
++--- org.springframework:spring-jms FAILED
++--- org.springframework:spring-orm FAILED
++--- org.springframework:spring-test FAILED
++--- org.springframework:spring-web FAILED
++--- org.springframework:spring-webflux FAILED
++--- org.springframework:spring-webmvc FAILED
++--- org.springframework:spring-websocket FAILED
++--- org.springframework.amqp:spring-amqp FAILED
++--- org.springframework.amqp:spring-rabbit FAILED
++--- org.springframework.batch:spring-batch-core FAILED
++--- org.springframework.data:spring-data-cassandra FAILED
++--- org.springframework.data:spring-data-couchbase FAILED
++--- org.springframework.data:spring-data-elasticsearch FAILED
++--- org.springframework.data:spring-data-envers FAILED
++--- org.springframework.data:spring-data-jpa FAILED
++--- org.springframework.data:spring-data-ldap FAILED
++--- org.springframework.data:spring-data-mongodb FAILED
++--- org.springframework.data:spring-data-neo4j FAILED
++--- org.springframework.data:spring-data-redis FAILED
++--- org.springframework.data:spring-data-r2dbc FAILED
++--- org.springframework.graphql:spring-graphql FAILED
++--- org.springframework.graphql:spring-graphql-test FAILED
++--- org.springframework.kafka:spring-kafka FAILED
++--- org.springframework.kafka:spring-kafka-test FAILED
++--- org.springframework.pulsar:spring-pulsar FAILED
++--- org.springframework.pulsar:spring-pulsar-reactive FAILED
++--- org.springframework.restdocs:spring-restdocs-mockmvc FAILED
++--- org.springframework.restdocs:spring-restdocs-restassured FAILED
++--- org.springframework.restdocs:spring-restdocs-webtestclient FAILED
++--- org.springframework.security:spring-security-config FAILED
++--- org.springframework.security:spring-security-oauth2-client FAILED
++--- org.springframework.security:spring-security-test FAILED
++--- org.springframework.security:spring-security-web FAILED
++--- org.springframework.ws:spring-ws-core FAILED
++--- org.springframework.ws:spring-ws-test FAILED
++--- org.testcontainers:junit-jupiter FAILED
++--- org.testcontainers:neo4j FAILED
++--- org.testcontainers:mongodb FAILED
++--- org.junit.jupiter:junit-jupiter FAILED
+\--- org.yaml:snakeyaml FAILED
+
+intransitiveDependenciesMetadata
+No dependencies
+
+javadocElements - javadoc elements for main. (n)
+No dependencies
+
+kotlinBuildToolsApiClasspath
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-daemon-client:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11
+|    |    \--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4
+|    \--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10
+\--- org.jetbrains.kotlin:kotlin-build-tools-impl:1.9.25
+     +--- org.jetbrains.kotlin:kotlin-build-tools-api:1.9.25
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+     |    \--- org.jetbrains:annotations:13.0
+     +--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.25
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25
+     |    +--- org.jetbrains.kotlin:kotlin-reflect:1.6.10 -> 1.9.25
+     |    +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.9.25
+     |    \--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
+     \--- org.jetbrains.kotlin:kotlin-compiler-runner:1.9.25
+          +--- org.jetbrains.kotlin:kotlin-build-common:1.9.25
+          +--- org.jetbrains.kotlin:kotlin-daemon-client:1.9.25
+          +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.0 -> 1.8.1
+          \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.25 (*)
+
+kotlinCompilerClasspath
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11
+|    |    \--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4
+|    \--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10
+\--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.25
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+     |    \--- org.jetbrains:annotations:13.0
+     +--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25
+     +--- org.jetbrains.kotlin:kotlin-reflect:1.6.10 -> 1.9.25
+     +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.9.25
+     \--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
+
+kotlinCompilerPluginClasspath
+\--- project :spring-boot-project:spring-boot-parent
+     +--- org.codehaus.janino:janino:3.1.10
+     +--- project :spring-boot-project:spring-boot-dependencies
+     |    +--- org.apache.activemq:activemq-bom:6.1.5
+     |    +--- org.apache.activemq:artemis-bom:2.39.0
+     |    +--- org.assertj:assertj-bom:3.27.3
+     |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+     |    +--- io.zipkin.brave:brave-bom:6.0.3
+     |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+     |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+     |    +--- org.apache.groovy:groovy-bom:4.0.25
+     |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+     |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+     |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+     |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+     |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+     |    +--- org.junit:junit-bom:5.11.4
+     |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+     |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+     |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+     |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+     |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+     |    +--- org.mockito:mockito-bom:5.15.2
+     |    +--- io.netty:netty-bom:4.1.117.Final
+     |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+     |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+     |    +--- io.prometheus:simpleclient_bom:0.16.0
+     |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+     |    +--- com.querydsl:querydsl-bom:5.1.0
+     |    +--- io.projectreactor:reactor-bom:2024.0.2
+     |    +--- io.rest-assured:rest-assured-bom:5.5.0
+     |    +--- io.rsocket:rsocket-bom:1.1.5
+     |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+     |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+     |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+     |    +--- org.springframework.data:spring-data-bom:2024.1.2
+     |    +--- org.springframework:spring-framework-bom:6.2.2
+     |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+     |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+     |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+     |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+     |    +--- org.springframework.session:spring-session-bom:3.4.1
+     |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+     |    +--- org.testcontainers:testcontainers-bom:1.20.4
+     |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+     |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+     |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+     |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3
+     |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+     |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+     |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1
+     |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5
+     |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25
+     |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+     |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2
+     |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10
+     |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+     |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+     |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4
+     |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+     |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+     |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3
+     |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1
+     |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1
+     |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2
+     |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final
+     |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0
+     |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5
+     |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+     |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2
+     |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+     |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2
+     |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0
+     |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+     |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+     |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2
+     |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1
+     |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2
+     |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2
+     |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+     |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2
+     |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3
+     |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+     |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+     |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11
+     |    \--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4
+     \--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10
+
+kotlinCompilerPluginClasspathMain - Kotlin compiler plugins for compilation
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-scripting-common:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-scripting-jvm:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11
+|    |    \--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4
+|    \--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10
+\--- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.9.25
+     +--- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:1.9.25
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-common:1.9.25
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+     |    |         \--- org.jetbrains:annotations:13.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-jvm:1.9.25
+     |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-scripting-common:1.9.25 (*)
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
+
+kotlinCompilerPluginClasspathTest - Kotlin compiler plugins for compilation
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-scripting-common:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-scripting-jvm:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11
+|    |    \--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4
+|    \--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10
+\--- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.9.25
+     +--- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:1.9.25
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-common:1.9.25
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+     |    |         \--- org.jetbrains:annotations:13.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-jvm:1.9.25
+     |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-scripting-common:1.9.25 (*)
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
+
+kotlinKlibCommonizerClasspath
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11
+|    |    \--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4
+|    \--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10
+\--- org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:1.9.25
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+     |    \--- org.jetbrains:annotations:13.0
+     \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.25
+          +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
+          +--- org.jetbrains.kotlin:kotlin-script-runtime:1.9.25
+          +--- org.jetbrains.kotlin:kotlin-reflect:1.6.10 -> 1.9.25
+          +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.9.25
+          \--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
+
+kotlinNativeCompilerPluginClasspath
+\--- project :spring-boot-project:spring-boot-parent
+
+kotlinScriptDef - Script filename extensions discovery classpath configuration
+No dependencies
+
+kotlinScriptDefExtensions
+No dependencies
+
+mainSourceElements - List of source directories contained in the Main SourceSet. (n)
+No dependencies
+
+mavenPluginAntoraAggregateContent - Configuration for maven-plugin Antora aggregate content.
+\--- project :spring-boot-project:spring-boot-tools:spring-boot-maven-plugin
+
+mavenPluginAntoraCatalogContent - Configuration for maven-plugin Antora catalog content.
+\--- project :spring-boot-project:spring-boot-tools:spring-boot-maven-plugin
+
+mavenPluginAntoraSource
+\--- project :spring-boot-project:spring-boot-tools:spring-boot-maven-plugin
+
+mavenRepository
++--- project :spring-boot-project:spring-boot-actuator
+|    \--- project :spring-boot-project:spring-boot
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+|    +--- project :spring-boot-project:spring-boot-actuator (*)
+|    +--- project :spring-boot-project:spring-boot
+|    \--- project :spring-boot-project:spring-boot-autoconfigure
+|         \--- project :spring-boot-project:spring-boot
++--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-docker-compose
+|    \--- project :spring-boot-project:spring-boot
++--- project :spring-boot-project:spring-boot-tools:spring-boot-cli
+|    \--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools
++--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools
++--- project :spring-boot-project:spring-boot-test
+|    \--- project :spring-boot-project:spring-boot
++--- project :spring-boot-project:spring-boot-test-autoconfigure
+|    +--- project :spring-boot-project:spring-boot
+|    +--- project :spring-boot-project:spring-boot-test (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-testcontainers
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
+\--- project :spring-boot-project:spring-boot-devtools
+     +--- project :spring-boot-project:spring-boot
+     \--- project :spring-boot-project:spring-boot-autoconfigure (*)
+
+nohttp
+\--- io.spring.nohttp:nohttp-checkstyle:0.0.11
+     +--- com.puppycrawl.tools:checkstyle:8.33
+     |    +--- info.picocli:picocli:4.3.1
+     |    +--- antlr:antlr:2.7.7
+     |    +--- org.antlr:antlr4-runtime:4.8-1
+     |    +--- commons-beanutils:commons-beanutils:1.9.4
+     |    |    +--- commons-logging:commons-logging:1.2
+     |    |    \--- commons-collections:commons-collections:3.2.2
+     |    +--- com.google.guava:guava:29.0-jre
+     |    |    +--- com.google.guava:failureaccess:1.0.1
+     |    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+     |    |    +--- com.google.code.findbugs:jsr305:3.0.2
+     |    |    +--- org.checkerframework:checker-qual:2.11.1
+     |    |    +--- com.google.errorprone:error_prone_annotations:2.3.4
+     |    |    \--- com.google.j2objc:j2objc-annotations:1.3
+     |    \--- net.sf.saxon:Saxon-HE:9.9.1-7
+     \--- io.spring.nohttp:nohttp:0.0.11
+          +--- ch.qos.logback:logback-classic:1.2.3
+          |    +--- ch.qos.logback:logback-core:1.2.3
+          |    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.26
+          \--- org.slf4j:slf4j-api:1.7.26
+
+remoteSpringApplicationExample
++--- project :spring-boot-project:spring-boot-dependencies
+|    +--- org.apache.activemq:activemq-bom:6.1.5
+|    +--- org.apache.activemq:artemis-bom:2.39.0
+|    +--- org.assertj:assertj-bom:3.27.3
+|    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    +--- io.zipkin.brave:brave-bom:6.0.3
+|    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    +--- org.apache.groovy:groovy-bom:4.0.25
+|    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    +--- org.junit:junit-bom:5.11.4
+|    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.24.3 (c)
+|    |    \--- org.apache.logging.log4j:log4j-api:2.24.3 (c)
+|    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    \--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    \--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    +--- org.mockito:mockito-bom:5.15.2
+|    +--- io.netty:netty-bom:4.1.117.Final
+|    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    +--- io.prometheus:simpleclient_bom:0.16.0
+|    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    +--- com.querydsl:querydsl-bom:5.1.0
+|    +--- io.projectreactor:reactor-bom:2024.0.2
+|    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    +--- io.rsocket:rsocket-bom:1.1.5
+|    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    +--- org.springframework:spring-web:6.2.2 (c)
+|    |    +--- org.springframework:spring-core:6.2.2 (c)
+|    |    +--- org.springframework:spring-context:6.2.2 (c)
+|    |    +--- org.springframework:spring-beans:6.2.2 (c)
+|    |    +--- org.springframework:spring-jcl:6.2.2 (c)
+|    |    +--- org.springframework:spring-aop:6.2.2 (c)
+|    |    \--- org.springframework:spring-expression:6.2.2 (c)
+|    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    +--- org.springframework.session:spring-session-bom:3.4.1
+|    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    +--- org.springframework.boot:spring-boot-devtools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-devtools (c)
+|    +--- org.springframework.boot:spring-boot-starter-logging:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-logging (c)
+|    +--- org.springframework.boot:spring-boot:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot (c)
+|    +--- org.springframework.boot:spring-boot-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-autoconfigure (c)
+|    +--- ch.qos.logback:logback-classic:1.5.16 (c)
+|    +--- org.slf4j:jul-to-slf4j:2.0.16 (c)
+|    +--- ch.qos.logback:logback-core:1.5.16 (c)
+|    \--- org.slf4j:slf4j-api:2.0.16 (c)
++--- project :spring-boot-project:spring-boot-devtools
+|    +--- project :spring-boot-project:spring-boot
+|    |    +--- org.springframework:spring-core -> 6.2.2
+|    |    |    \--- org.springframework:spring-jcl:6.2.2
+|    |    \--- org.springframework:spring-context -> 6.2.2
+|    |         +--- org.springframework:spring-aop:6.2.2
+|    |         |    +--- org.springframework:spring-beans:6.2.2
+|    |         |    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    |         |    \--- org.springframework:spring-core:6.2.2 (*)
+|    |         +--- org.springframework:spring-beans:6.2.2 (*)
+|    |         +--- org.springframework:spring-core:6.2.2 (*)
+|    |         +--- org.springframework:spring-expression:6.2.2
+|    |         |    \--- org.springframework:spring-core:6.2.2 (*)
+|    |         \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1
+|    |              \--- io.micrometer:micrometer-commons:1.15.0-M1
+|    \--- project :spring-boot-project:spring-boot-autoconfigure
+|         \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-logging
+|    +--- ch.qos.logback:logback-classic -> 1.5.16
+|    |    +--- ch.qos.logback:logback-core:1.5.16
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    +--- org.apache.logging.log4j:log4j-to-slf4j -> 2.24.3
+|    |    +--- org.apache.logging.log4j:log4j-api:2.24.3
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    \--- org.slf4j:jul-to-slf4j -> 2.0.16
+|         \--- org.slf4j:slf4j-api:2.0.16
+\--- org.springframework:spring-web -> 6.2.2
+     +--- org.springframework:spring-beans:6.2.2 (*)
+     +--- org.springframework:spring-core:6.2.2 (*)
+     \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+
+rootAntoraAggregateContent - Configuration for root Antora aggregate content artifacts. (n)
+No dependencies
+
+runtimeClasspath - Runtime classpath of null/main.
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    |    \--- junit:junit:4.13.1 -> 4.13.2 (c)
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    |    \--- org.assertj:assertj-core:3.27.3 (c)
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+|    |    |    +--- org.apache.cassandra:java-driver-query-builder:4.18.1 (c)
+|    |    |    +--- com.datastax.oss:native-protocol:1.5.1 (c)
+|    |    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1 (c)
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+|    |    |    +--- org.glassfish.jaxb:jaxb-runtime:4.0.5 (c)
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0 (c)
+|    |    |    +--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+|    |    |    +--- org.glassfish.jaxb:jaxb-core:4.0.5 (c)
+|    |    |    +--- org.eclipse.angus:angus-activation:2.0.2 (c)
+|    |    |    +--- org.glassfish.jaxb:txw2:4.0.5 (c)
+|    |    |    \--- com.sun.istack:istack-commons-runtime:4.1.2 (c)
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    |    +--- org.apache.groovy:groovy:4.0.25 (c)
+|    |    |    +--- org.apache.groovy:groovy-xml:4.0.25 (c)
+|    |    |    \--- org.apache.groovy:groovy-json:4.0.25 (c)
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.module:jackson-module-scala_2.13:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.18.2 (c)
+|    |    |    \--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2 (c)
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    |    +--- org.glassfish.jersey.core:jersey-server:3.1.10 (c)
+|    |    |    +--- org.glassfish.jersey.containers:jersey-container-servlet-core:3.1.10 (c)
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (c)
+|    |    |    \--- org.glassfish.jersey.core:jersey-client:3.1.10 (c)
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    |    +--- org.junit.jupiter:junit-jupiter:5.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-launcher:1.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-params:5.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-engine:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-commons:1.11.4 (c)
+|    |    |    \--- org.junit.platform:junit-platform-engine:1.11.4 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.24.3 (c)
+|    |    |    +--- org.apache.logging.log4j:log4j-api:2.24.3 (c)
+|    |    |    \--- org.jspecify:jspecify:1.0.0 (c)
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:context-propagation:1.1.2 (c)
+|    |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+|    |    |    \--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-tracing:1.5.0-M1 (c)
+|    |    |    +--- io.micrometer:context-propagation:1.1.2 (c)
+|    |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+|    |    |    \--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    |    \--- org.mockito:mockito-core:5.15.2 (c)
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    |    +--- io.netty:netty-codec-http:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec-http2:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-native-epoll:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-handler:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-handler-proxy:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-common:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec-dns:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-classes-epoll:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-tcnative-classes:2.0.69.Final (c)
+|    |    |    \--- io.netty:netty-codec-socks:4.1.117.Final (c)
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    |    +--- io.opentelemetry:opentelemetry-api:1.46.0 (c)
+|    |    |    \--- io.opentelemetry:opentelemetry-context:1.46.0 (c)
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    |    \--- com.google.guava:guava:33.3.1-jre (c)
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-all:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (c)
+|    |    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2 (c)
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    |    +--- io.projectreactor.netty:reactor-netty-http:1.2.2 (c)
+|    |    |    +--- io.projectreactor:reactor-core:3.7.2 (c)
+|    |    |    +--- io.projectreactor.netty:reactor-netty-core:1.2.2 (c)
+|    |    |    \--- org.reactivestreams:reactive-streams:1.0.4 (c)
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    |    +--- io.rest-assured:rest-assured:5.5.0 (c)
+|    |    |    +--- io.rest-assured:json-path:5.5.0 (c)
+|    |    |    +--- io.rest-assured:xml-path:5.5.0 (c)
+|    |    |    \--- io.rest-assured:rest-assured-common:5.5.0 (c)
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    |    +--- org.springframework.amqp:spring-amqp:3.2.2 (c)
+|    |    |    \--- org.springframework.amqp:spring-rabbit:3.2.2 (c)
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    |    +--- org.springframework.batch:spring-batch-core:5.2.1 (c)
+|    |    |    \--- org.springframework.batch:spring-batch-infrastructure:5.2.1 (c)
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    |    +--- org.springframework.data:spring-data-cassandra:4.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-couchbase:5.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-elasticsearch:5.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-r2dbc:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-jpa:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-envers:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-mongodb:4.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-neo4j:7.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-redis:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-ldap:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-commons:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-relational:3.4.2 (c)
+|    |    |    \--- org.springframework.data:spring-data-keyvalue:3.4.2 (c)
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    |    +--- org.springframework:spring-context:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-core:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-jdbc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-jms:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-orm:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-test:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-web:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-webflux:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-webmvc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-websocket:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-messaging:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-tx:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-aop:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-beans:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-expression:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-context-support:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-r2dbc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-oxm:6.2.2 (c)
+|    |    |    \--- org.springframework:spring-jcl:6.2.2 (c)
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    |    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (c)
+|    |    |    +--- org.springframework.pulsar:spring-pulsar-reactive:1.2.2 (c)
+|    |    |    +--- org.springframework.pulsar:spring-pulsar-cache-provider-caffeine:1.2.2 (c)
+|    |    |    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2 (c)
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-mockmvc:3.0.3 (c)
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-restassured:3.0.3 (c)
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-webtestclient:3.0.3 (c)
+|    |    |    \--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (c)
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    |    +--- org.springframework.security:spring-security-config:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-crypto:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-oauth2-client:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-test:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-web:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (c)
+|    |    |    \--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1 (c)
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    |    +--- org.springframework.ws:spring-ws-core:4.0.11 (c)
+|    |    |    +--- org.springframework.ws:spring-ws-test:4.0.11 (c)
+|    |    |    \--- org.springframework.ws:spring-xml:4.0.11 (c)
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    |    +--- org.testcontainers:junit-jupiter:1.20.4 (c)
+|    |    |    +--- org.testcontainers:mongodb:1.20.4 (c)
+|    |    |    +--- org.testcontainers:neo4j:1.20.4 (c)
+|    |    |    \--- org.testcontainers:testcontainers:1.20.4 (c)
+|    |    +--- org.cache2k:cache2k-spring:2.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-dbcp2:2.13.0 (c)
+|    |    +--- org.hibernate.orm:hibernate-jcache:6.6.6.Final (c)
+|    |    +--- com.zaxxer:HikariCP:6.2.1 (c)
+|    |    +--- org.htmlunit:htmlunit:4.9.0 (c)
+|    |    +--- org.apache.httpcomponents.client5:httpclient5:5.4.2 (c)
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1 (c)
+|    |    +--- jakarta.jms:jakarta.jms-api:3.1.0 (c)
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0 (c)
+|    |    +--- jakarta.servlet:jakarta.servlet-api:6.0.0 (c)
+|    |    +--- jakarta.validation:jakarta.validation-api:3.0.2 (c)
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.jooq:jooq:3.19.18 (c)
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (c)
+|    |    +--- ch.qos.logback:logback-classic:1.5.16 (c)
+|    |    +--- org.mongodb:mongodb-driver-sync:5.3.1 (c)
+|    |    +--- org.quartz-scheduler:quartz:2.5.0 (c)
+|    |    +--- org.postgresql:r2dbc-postgresql:1.0.7.RELEASE (c)
+|    |    +--- org.springframework.boot:spring-boot:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot (c)
+|    |    +--- org.springframework.boot:spring-boot-test:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test (c)
+|    |    +--- org.springframework.boot:spring-boot-test-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-testcontainers:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-testcontainers (c)
+|    |    +--- org.springframework.boot:spring-boot-actuator:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator (c)
+|    |    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-devtools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-devtools (c)
+|    |    +--- org.springframework.boot:spring-boot-docker-compose:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-docker-compose (c)
+|    |    +--- org.springframework.boot:spring-boot-loader-tools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools (c)
+|    |    +--- org.slf4j:jul-to-slf4j:2.0.16 (c)
+|    |    +--- org.slf4j:slf4j-simple:2.0.16 (c)
+|    |    +--- org.yaml:snakeyaml:2.3 (c)
+|    |    +--- org.springframework.graphql:spring-graphql:1.3.3 (c)
+|    |    +--- org.springframework.graphql:spring-graphql-test:1.3.3 (c)
+|    |    +--- org.springframework.kafka:spring-kafka:3.3.2 (c)
+|    |    +--- org.springframework.kafka:spring-kafka-test:3.3.2 (c)
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (c)
+|    |    +--- io.undertow:undertow-core:2.3.18.Final (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3 (*)
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1 (*)
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5 (*)
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25 (*)
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2 (*)
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10 (*)
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3 (*)
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1 (*)
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1 (*)
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2 (*)
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final (*)
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0 (*)
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5 (*)
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2 (*)
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2 (*)
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0 (*)
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2 (*)
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1 (*)
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2 (*)
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2 (*)
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2 (*)
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3 (*)
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1 (*)
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11 (*)
+|    |    +--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4 (*)
+|    |    +--- org.cache2k:cache2k-api:2.6.1.Final (c)
+|    |    +--- org.cache2k:cache2k-core:2.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-pool2:2.12.1 (c)
+|    |    +--- jakarta.transaction:jakarta.transaction-api:2.0.1 (c)
+|    |    +--- org.hibernate.orm:hibernate-core:6.6.6.Final (c)
+|    |    +--- javax.cache:cache-api:1.1.1 (c)
+|    |    +--- org.jboss.logging:jboss-logging:3.6.1.Final (c)
+|    |    +--- org.slf4j:slf4j-api:2.0.16 (c)
+|    |    +--- org.apache.commons:commons-lang3:3.17.0 (c)
+|    |    +--- commons-codec:commons-codec:1.18.0 (c)
+|    |    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3 (c)
+|    |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3 (c)
+|    |    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (c)
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0 (c)
+|    |    +--- ch.qos.logback:logback-core:1.5.16 (c)
+|    |    +--- org.mongodb:bson:5.3.1 (c)
+|    |    +--- org.mongodb:mongodb-driver-core:5.3.1 (c)
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+|    |    +--- com.graphql-java:graphql-java:22.3 (c)
+|    |    +--- com.jayway.jsonpath:json-path:2.9.0 (c)
+|    |    +--- org.springframework.retry:spring-retry:2.0.11 (c)
+|    |    +--- org.apache.kafka:kafka-server:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-metadata:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-streams-test-utils:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka_2.13:3.9.0 (c)
+|    |    +--- org.apache.tomcat:tomcat-annotations-api:10.1.34 (c)
+|    |    +--- net.bytebuddy:byte-buddy:1.17.0 (c)
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0 (c)
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1 (c)
+|    |    +--- net.bytebuddy:byte-buddy-agent:1.17.0 (c)
+|    |    +--- com.rabbitmq:amqp-client:5.24.0 (c)
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+|    |    +--- com.couchbase.client:java-client:3.7.7 (c)
+|    |    +--- co.elastic.clients:elasticsearch-java:8.15.5 (c)
+|    |    +--- org.hibernate.orm:hibernate-envers:6.6.6.Final (c)
+|    |    +--- org.neo4j.driver:neo4j-java-driver:5.25.0 (c)
+|    |    +--- org.springframework.ldap:spring-ldap-core:3.3.0-M1 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10 (c)
+|    |    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.2 (c)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:3.0.4 (c)
+|    |    +--- org.xmlunit:xmlunit-core:2.10.0 (c)
+|    |    +--- junit:junit:4.13.2 (c)
+|    |    +--- com.fasterxml:classmate:1.7.0 (c)
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4 (c)
+|    |    +--- org.mongodb:bson-record-codec:5.3.1 (c)
+|    |    +--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+|    |    +--- net.minidev:json-smart:2.5.1 (c)
+|    |    +--- org.apache.kafka:kafka-storage-api:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-raft:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-storage:3.9.0 (c)
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5 (c)
+|    |    +--- jakarta.json:jakarta.json-api:2.1.3 (c)
+|    |    +--- org.hamcrest:hamcrest:3.0 (c)
+|    |    +--- org.hamcrest:hamcrest-core:3.0 (c)
+|    |    +--- org.apache.httpcomponents:httpcore:4.4.16 (c)
+|    |    +--- com.github.ben-manes.caffeine:caffeine:3.2.0 (c)
+|    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5 (c)
+|    |    \--- org.apache.httpcomponents:httpcore-nio:4.4.16 (c)
+|    +--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.7.0-alpha (c)
+|    +--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10 (*)
+|    +--- com.vaadin.external.google:android-json:0.0.20131108.vaadin1 (c)
+|    +--- jline:jline:2.11 (c)
+|    +--- net.sf.jopt-simple:jopt-simple:5.0.4 (c)
+|    +--- org.apache.commons:commons-compress:1.25.0 (c)
+|    +--- io.micrometer:context-propagation:1.0.5 -> 1.1.2 (c)
+|    \--- org.apiguardian:apiguardian-api:1.1.2 (c)
++--- project :spring-boot-project:spring-boot-actuator
+|    \--- project :spring-boot-project:spring-boot
+|         +--- org.springframework:spring-core -> 6.2.2
+|         |    \--- org.springframework:spring-jcl:6.2.2
+|         \--- org.springframework:spring-context -> 6.2.2
+|              +--- org.springframework:spring-aop:6.2.2
+|              |    +--- org.springframework:spring-beans:6.2.2
+|              |    |    \--- org.springframework:spring-core:6.2.2 (*)
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-beans:6.2.2 (*)
+|              +--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-expression:6.2.2
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1
+|                   \--- io.micrometer:micrometer-commons:1.15.0-M1
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+|    +--- project :spring-boot-project:spring-boot-actuator (*)
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- project :spring-boot-project:spring-boot-autoconfigure
+|    |    \--- project :spring-boot-project:spring-boot (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind -> 2.18.2
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    \--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310 -> 2.18.2
+|         +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|         +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|         +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|         \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
++--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-docker-compose
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind -> 2.18.2 (*)
+|    \--- com.fasterxml.jackson.module:jackson-module-parameter-names -> 2.18.2
+|         +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|         +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|         \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
++--- project :spring-boot-project:spring-boot-tools:spring-boot-cli
+|    +--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools
+|    |    +--- org.apache.commons:commons-compress -> 1.25.0
+|    |    \--- org.springframework:spring-core -> 6.2.2 (*)
+|    +--- com.vaadin.external.google:android-json -> 0.0.20131108.vaadin1
+|    +--- jline:jline -> 2.11
+|    +--- net.sf.jopt-simple:jopt-simple -> 5.0.4
+|    +--- org.apache.httpcomponents.client5:httpclient5 -> 5.4.2
+|    |    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3
+|    |    |    \--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- org.slf4j:slf4j-simple -> 2.0.16
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    +--- org.springframework:spring-core -> 6.2.2 (*)
+|    \--- org.springframework.security:spring-security-crypto -> 6.5.0-M1
++--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools (*)
++--- project :spring-boot-project:spring-boot-test
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- org.springframework:spring-test -> 6.2.2
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- project :spring-boot-project:spring-boot-test-autoconfigure
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- project :spring-boot-project:spring-boot-test (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-testcontainers
+|    +--- project :spring-boot-project:spring-boot-autoconfigure (*)
+|    \--- org.testcontainers:testcontainers -> 1.20.4
+|         +--- junit:junit:4.13.2
+|         |    \--- org.hamcrest:hamcrest-core:1.3 -> 3.0
+|         |         \--- org.hamcrest:hamcrest:3.0
+|         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- org.apache.commons:commons-compress:1.24.0 -> 1.25.0
+|         +--- org.rnorth.duct-tape:duct-tape:1.0.8
+|         |    \--- org.jetbrains:annotations:17.0.0
+|         +--- com.github.docker-java:docker-java-api:3.4.0
+|         |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.3 -> 2.18.2 (*)
+|         |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|         \--- com.github.docker-java:docker-java-transport-zerodep:3.4.0
+|              +--- com.github.docker-java:docker-java-transport:3.4.0
+|              +--- org.slf4j:slf4j-api:1.7.25 -> 2.0.16
+|              \--- net.java.dev.jna:jna:5.13.0
++--- project :spring-boot-project:spring-boot-devtools
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- ch.qos.logback:logback-classic -> 1.5.16
+|    +--- ch.qos.logback:logback-core:1.5.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- com.zaxxer:HikariCP -> 6.2.1
+|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-jakarta9 -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    |    +--- org.hdrhistogram:HdrHistogram:2.2.2
+|    |    \--- org.latencyutils:LatencyUtils:2.0.3
+|    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    \--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
++--- io.micrometer:micrometer-tracing -> 1.5.0-M1
+|    +--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    +--- io.micrometer:context-propagation:1.1.2
+|    \--- aopalliance:aopalliance:1.0
++--- io.micrometer:micrometer-registry-graphite -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-graphite:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- com.rabbitmq:amqp-client:5.23.0 -> 5.24.0
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-registry-jmx -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-jmx:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29 (*)
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0 -> 2.7.0-alpha
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.41.0-alpha -> 1.45.0-alpha
+|    |    |    \--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0
+|    |    |         \--- io.opentelemetry:opentelemetry-context:1.46.0
+|    |    +--- io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha
+|    |    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0 (*)
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:2.7.0-alpha
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.41.0-alpha -> 1.45.0-alpha (*)
+|    |    +--- io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha
+|    |    \--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0 (*)
+|    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0 (*)
++--- io.projectreactor.netty:reactor-netty-http -> 1.2.2
+|    +--- io.netty:netty-codec-http:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final
+|    |    |    \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-transport:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-resolver:4.1.117.Final
+|    |    |         \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-codec:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport-native-unix-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-codec:4.1.117.Final (*)
+|    +--- io.netty:netty-codec-http2:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler:4.1.117.Final (*)
+|    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec-dns:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final
+|    |    \--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver-dns:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    |    \--- io.netty:netty-transport-classes-epoll:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.projectreactor.netty:reactor-netty-core:1.2.2
+|    |    +--- io.netty:netty-handler:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler-proxy:4.1.116.Final -> 4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec-socks:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final (*)
+|    |    \--- io.projectreactor:reactor-core:3.7.2
+|    |         \--- org.reactivestreams:reactive-streams:1.0.4
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- io.undertow:undertow-core -> 2.3.18.Final
+|    +--- org.jboss.logging:jboss-logging:3.4.3.Final -> 3.6.1.Final
+|    +--- org.jboss.xnio:xnio-api:3.8.16.Final
+|    |    +--- org.wildfly.common:wildfly-common:1.5.4.Final
+|    |    +--- org.wildfly.client:wildfly-client-config:1.0.1.Final
+|    |    |    \--- org.jboss.logging:jboss-logging:3.3.1.Final -> 3.6.1.Final
+|    |    \--- org.jboss.threads:jboss-threads:2.3.6.Final -> 3.5.0.Final
+|    |         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.6.1.Final
+|    |         \--- org.wildfly.common:wildfly-common:1.5.0.Final -> 1.5.4.Final
+|    +--- org.jboss.xnio:xnio-nio:3.8.16.Final
+|    |    \--- org.jboss.xnio:xnio-api:3.8.16.Final (*)
+|    \--- org.jboss.threads:jboss-threads:3.5.0.Final (*)
++--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
++--- jakarta.jms:jakarta.jms-api -> 3.1.0
++--- jakarta.persistence:jakarta.persistence-api -> 3.1.0
++--- jakarta.servlet:jakarta.servlet-api -> 6.0.0
++--- jakarta.validation:jakarta.validation-api -> 3.0.2
++--- org.apache.httpcomponents.client5:httpclient5 -> 5.4.2 (*)
++--- org.apache.commons:commons-dbcp2 -> 2.13.0
+|    +--- org.apache.commons:commons-pool2:2.12.0 -> 2.12.1
+|    \--- jakarta.transaction:jakarta.transaction-api:1.3.3 -> 2.0.1
++--- org.apache.kafka:kafka-streams -> 3.9.0
+|    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- com.fasterxml.jackson.core:jackson-annotations:2.16.2 -> 2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    +--- org.apache.kafka:kafka-clients:3.9.0
+|    |    +--- com.github.luben:zstd-jni:1.5.6-4
+|    |    +--- org.lz4:lz4-java:1.8.0
+|    |    +--- org.xerial.snappy:snappy-java:1.1.10.5
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    \--- org.rocksdb:rocksdbjni:7.9.2
++--- org.apache.logging.log4j:log4j-to-slf4j -> 2.24.3
+|    +--- org.apache.logging.log4j:log4j-api:2.24.3
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.apache.tomcat.embed:tomcat-embed-core -> 10.1.34
+|    \--- org.apache.tomcat:tomcat-annotations-api:10.1.34
++--- org.assertj:assertj-core -> 3.27.3
+|    \--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
++--- org.cache2k:cache2k-spring -> 2.6.1.Final
+|    +--- org.cache2k:cache2k-api:2.6.1.Final
+|    \--- org.cache2k:cache2k-core:2.6.1.Final
+|         \--- org.cache2k:cache2k-api:2.6.1.Final
++--- org.apache.groovy:groovy -> 4.0.25
+|    \--- org.apache.groovy:groovy-bom:4.0.25 (*)
++--- org.glassfish.jersey.containers:jersey-container-servlet-core -> 3.1.10
+|    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    +--- org.glassfish.jersey.core:jersey-common:3.1.10
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- org.glassfish.hk2:osgi-resource-locator:1.0.3
+|    +--- org.glassfish.jersey.core:jersey-server:3.1.10
+|    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    +--- org.glassfish.jersey.core:jersey-client:3.1.10
+|    |    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    |    \--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- jakarta.validation:jakarta.validation-api:3.0.2
+|    \--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
++--- org.glassfish.jersey.core:jersey-server -> 3.1.10 (*)
++--- org.hibernate.orm:hibernate-jcache -> 6.6.6.Final
+|    +--- org.hibernate.orm:hibernate-core:6.6.6.Final
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0
+|    |    +--- jakarta.transaction:jakarta.transaction-api:2.0.1
+|    |    +--- org.jboss.logging:jboss-logging:3.5.0.Final -> 3.6.1.Final
+|    |    +--- org.hibernate.common:hibernate-commons-annotations:7.0.3.Final
+|    |    +--- io.smallrye:jandex:3.2.0
+|    |    +--- com.fasterxml:classmate:1.5.1 -> 1.7.0
+|    |    +--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2
+|    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    +--- org.glassfish.jaxb:jaxb-runtime:4.0.2 -> 4.0.5
+|    |    |    \--- org.glassfish.jaxb:jaxb-core:4.0.5
+|    |    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (*)
+|    |    |         +--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    |         +--- org.eclipse.angus:angus-activation:2.0.2
+|    |    |         |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    |         +--- org.glassfish.jaxb:txw2:4.0.5
+|    |    |         \--- com.sun.istack:istack-commons-runtime:4.1.2
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- org.antlr:antlr4-runtime:4.13.0
+|    +--- javax.cache:cache-api:1.0.0 -> 1.1.1
+|    \--- org.jboss.logging:jboss-logging:3.5.0.Final -> 3.6.1.Final
++--- org.htmlunit:htmlunit -> 4.9.0
+|    +--- org.apache.httpcomponents:httpmime:4.5.14
+|    |    \--- org.apache.httpcomponents:httpclient:4.5.14
+|    |         +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |         \--- commons-codec:commons-codec:1.11 -> 1.18.0
+|    +--- org.htmlunit:htmlunit-core-js:4.9.0
+|    +--- org.htmlunit:neko-htmlunit:4.9.0
+|    +--- org.htmlunit:htmlunit-cssparser:4.9.0
+|    +--- org.htmlunit:htmlunit-xpath:4.9.0
+|    +--- org.htmlunit:htmlunit-csp:4.9.0
+|    +--- org.htmlunit:htmlunit-websocket-client:4.9.0
+|    +--- org.apache.commons:commons-lang3:3.17.0
+|    +--- commons-io:commons-io:2.18.0
+|    +--- commons-codec:commons-codec:1.17.2 -> 1.18.0
+|    \--- org.brotli:dec:0.1.2
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+|    |    +--- org.jetbrains:annotations:13.0 -> 17.0.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.25 (c)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.25 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
++--- org.jooq:jooq -> 3.19.18
+|    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE
+|         \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
++--- org.mockito:mockito-core -> 5.15.2
+|    +--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
+|    +--- net.bytebuddy:byte-buddy-agent:1.15.11 -> 1.17.0
+|    \--- org.objenesis:objenesis:3.3
++--- org.mongodb:mongodb-driver-sync -> 5.3.1
+|    +--- org.mongodb:bson:5.3.1
+|    \--- org.mongodb:mongodb-driver-core:5.3.1
+|         +--- org.mongodb:bson:5.3.1
+|         \--- org.mongodb:bson-record-codec:5.3.1
+|              \--- org.mongodb:bson:5.3.1
++--- org.postgresql:r2dbc-postgresql -> 1.0.7.RELEASE
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- com.ongres.scram:client:2.1
+|    |    \--- com.ongres.scram:common:2.1
+|    |         \--- com.ongres.stringprep:saslprep:1.1
+|    |              \--- com.ongres.stringprep:stringprep:1.1
+|    +--- io.projectreactor:reactor-core:3.5.20 -> 3.7.2 (*)
+|    \--- io.projectreactor.netty:reactor-netty-core:1.1.22 -> 1.2.2 (*)
++--- org.quartz-scheduler:quartz -> 2.5.0
+|    +--- org.slf4j:slf4j-api:2.0.16
+|    \--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (*)
++--- org.slf4j:jul-to-slf4j -> 2.0.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.springframework:spring-jdbc -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework:spring-jms -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-orm -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2 (*)
++--- org.springframework:spring-test -> 6.2.2 (*)
++--- org.springframework:spring-web -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-webflux -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- org.springframework:spring-webmvc -> 6.2.2
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework:spring-websocket -> 6.2.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework.amqp:spring-amqp -> 3.2.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework.retry:spring-retry:2.0.11
++--- org.springframework.amqp:spring-rabbit -> 3.2.2
+|    +--- org.springframework.amqp:spring-amqp:3.2.2 (*)
+|    +--- com.rabbitmq:amqp-client:5.22.0 -> 5.24.0 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.batch:spring-batch-core -> 5.2.1
+|    +--- org.springframework.batch:spring-batch-infrastructure:5.2.1
+|    |    +--- org.springframework:spring-core:6.2.1 -> 6.2.2 (*)
+|    |    \--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.springframework:spring-aop:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.1 -> 6.2.2 (*)
+|    +--- io.micrometer:micrometer-core:1.14.2 -> 1.15.0-M1 (*)
+|    +--- io.micrometer:micrometer-observation:1.14.2 -> 1.15.0-M1 (*)
+|    \--- org.springframework.data:spring-data-commons:3.4.1 -> 3.4.2
+|         +--- org.springframework:spring-core:6.2.2 (*)
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-cassandra -> 4.4.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.apache.cassandra:java-driver-core:4.18.0 -> 4.18.1
+|    |    +--- com.datastax.oss:native-protocol:1.5.1
+|    |    +--- io.netty:netty-handler:4.1.94.Final -> 4.1.117.Final (*)
+|    |    +--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    |    +--- com.typesafe:config:1.4.1
+|    |    +--- com.github.jnr:jnr-posix:3.1.15
+|    |    |    +--- com.github.jnr:jnr-ffi:2.2.11
+|    |    |    |    +--- com.github.jnr:jffi:1.3.9
+|    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    +--- org.ow2.asm:asm-commons:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2
+|    |    |    |    |    |    \--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2
+|    |    |    |    |         \--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-util:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- com.github.jnr:jnr-a64asm:1.0.0
+|    |    |    |    \--- com.github.jnr:jnr-x86asm:1.0.2
+|    |    |    \--- com.github.jnr:jnr-constants:0.10.3
+|    |    +--- org.slf4j:slf4j-api:1.7.26 -> 2.0.16
+|    |    +--- io.dropwizard.metrics:metrics-core:4.1.18 -> 4.2.29 (*)
+|    |    +--- org.hdrhistogram:HdrHistogram:2.1.12 -> 2.2.2
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.4 -> 2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 -> 2.18.2 (*)
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- org.apache.cassandra:java-driver-query-builder:4.18.0 -> 4.18.1
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (*)
+|    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-couchbase -> 5.4.2
+|    +--- org.springframework:spring-context-support:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- com.couchbase.client:java-client:3.7.7
+|    |    \--- com.couchbase.client:core-io:3.7.7
+|    |         +--- io.projectreactor:reactor-core:3.6.9 -> 3.7.2 (*)
+|    |         +--- org.reactivestreams:reactive-streams:1.0.4
+|    |         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-elasticsearch -> 5.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- co.elastic.clients:elasticsearch-java:8.15.5
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.5.14 (*)
+|    |    |    +--- org.apache.httpcomponents:httpcore:4.4.13 -> 4.4.16
+|    |    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5
+|    |    |    +--- org.apache.httpcomponents:httpcore-nio:4.4.13 -> 4.4.16
+|    |    |    \--- commons-codec:commons-codec:1.15 -> 1.18.0
+|    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    +--- jakarta.json:jakarta.json-api:2.0.1 -> 2.1.3
+|    |    +--- org.eclipse.parsson:parsson:1.0.5
+|    |    |    \--- jakarta.json:jakarta.json-api:2.0.2 -> 2.1.3
+|    |    \--- io.opentelemetry:opentelemetry-api:1.29.0 -> 1.46.0 (*)
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-envers -> 3.4.2
+|    +--- org.springframework.data:spring-data-jpa:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-orm:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.antlr:antlr4-runtime:4.13.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.0.0 -> 2.1.1
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.hibernate.orm:hibernate-envers:6.6.4.Final -> 6.6.6.Final
+|    |    +--- org.hibernate.orm:hibernate-core:6.6.6.Final (*)
+|    |    +--- org.jboss.logging:jboss-logging:3.5.0.Final -> 3.6.1.Final
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2 (*)
+|    |    +--- org.glassfish.jaxb:jaxb-runtime:4.0.2 -> 4.0.5 (*)
+|    |    +--- org.hibernate.common:hibernate-commons-annotations:7.0.3.Final
+|    |    \--- io.smallrye:jandex:3.2.0
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-jpa -> 3.4.2 (*)
++--- org.springframework.data:spring-data-ldap -> 3.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.ldap:spring-ldap-core:3.2.10 -> 3.3.0-M1
+|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- org.springframework:spring-core:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.1.16 -> 6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-core:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-mongodb -> 4.4.2
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.mongodb:mongodb-driver-core:5.2.1 -> 5.3.1 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-neo4j -> 7.4.2
+|    +--- jakarta.transaction:jakarta.transaction-api:2.0.0 -> 2.0.1
+|    +--- org.apiguardian:apiguardian-api:1.1.1 -> 1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl:2024.2.0
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl-schema-name-support:2024.2.0
+|    +--- org.neo4j.driver:neo4j-java-driver:5.25.0
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4
+|    |    +--- io.netty:netty-handler:4.1.113.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-tcnative-classes:2.0.66.Final -> 2.0.69.Final
+|    |    \--- io.projectreactor:reactor-core:3.6.10 -> 3.7.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-redis -> 3.4.2
+|    +--- org.springframework.data:spring-data-keyvalue:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.2.2
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:3.0.1 -> 4.0.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-context-support:6.2.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-r2dbc -> 3.4.2
+|    +--- org.springframework.data:spring-data-relational:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-r2dbc:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    |    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.graphql:spring-graphql -> 1.3.3
+|    +--- io.micrometer:context-propagation:1.1.2
+|    +--- com.graphql-java:graphql-java:22.3
+|    |    +--- com.graphql-java:java-dataloader:3.3.0
+|    |    |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    \--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
++--- org.springframework.graphql:spring-graphql-test -> 1.3.3
+|    +--- org.springframework.graphql:spring-graphql:1.3.3 (*)
+|    +--- com.graphql-java:graphql-java:22.3 (*)
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    +--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
+|    +--- org.springframework:spring-test:6.1.14 -> 6.2.2 (*)
+|    \--- com.jayway.jsonpath:json-path:2.9.0
+|         +--- net.minidev:json-smart:2.5.0 -> 2.5.1
+|         |    \--- net.minidev:accessors-smart:2.5.1
+|         |         \--- org.ow2.asm:asm:9.6
+|         \--- org.slf4j:slf4j-api:2.0.11 -> 2.0.16
++--- org.springframework.kafka:spring-kafka -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.kafka:spring-kafka-test -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-test:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.zookeeper:zookeeper:3.8.4
+|    |    +--- org.apache.zookeeper:zookeeper-jute:3.8.4
+|    |    |    \--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- io.netty:netty-handler:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    +--- ch.qos.logback:logback-core:1.2.13 -> 1.5.16
+|    |    +--- ch.qos.logback:logback-classic:1.2.13 -> 1.5.16 (*)
+|    |    \--- commons-io:commons-io:2.11.0 -> 2.18.0
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0 (*)
+|    +--- org.apache.kafka:kafka-server:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-metadata:3.9.0
+|    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    |    +--- com.yammer.metrics:metrics-core:2.2.0
+|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.2 -> 2.0.16
+|    |    |    |    +--- net.sf.jopt-simple:jopt-simple:5.0.4
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    |    +--- org.pcollections:pcollections:4.0.1
+|    |    |    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-raft:3.9.0
+|    |    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.2 -> 2.18.2
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    |    \--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-storage:3.9.0
+|    |    |    +--- org.apache.kafka:kafka-storage-api:3.9.0
+|    |    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    |    |    +--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-transaction-coordinator:3.9.0
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- com.github.ben-manes.caffeine:caffeine:2.9.3 -> 3.2.0
+|    |    |    |    +--- org.jspecify:jspecify:1.0.0
+|    |    |    |    \--- com.google.errorprone:error_prone_annotations:2.36.0
+|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    \--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- org.apache.kafka:kafka-group-coordinator:3.9.0
+|    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-metadata:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-group-coordinator-api:3.9.0
+|    |    |    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-storage:3.9.0 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.2 -> 2.18.2 (*)
+|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    \--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- org.apache.kafka:kafka-transaction-coordinator:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-raft:3.9.0 (*)
+|    |    +--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- org.apache.kafka:kafka-metadata:3.8.1 -> 3.9.0 (*)
+|    +--- org.apache.kafka:kafka-server-common:3.8.1 -> 3.9.0 (*)
+|    +--- org.apache.kafka:kafka-streams-test-utils:3.8.1 -> 3.9.0
+|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (*)
+|    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    +--- org.apache.kafka:kafka_2.13:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-group-coordinator-api:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-group-coordinator:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-transaction-coordinator:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-metadata:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-storage-api:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-tools-api:3.9.0
+|    |    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-raft:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-storage:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-server:3.9.0 (*)
+|    |    +--- net.sourceforge.argparse4j:argparse4j:0.7.0
+|    |    +--- commons-validator:commons-validator:1.7
+|    |    |    +--- commons-beanutils:commons-beanutils:1.9.4
+|    |    |    |    \--- commons-collections:commons-collections:3.2.2
+|    |    |    +--- commons-digester:commons-digester:2.1
+|    |    |    \--- commons-collections:commons-collections:3.2.2
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-scala_2.13:2.16.2 -> 2.18.2
+|    |    |    +--- org.scala-lang:scala-library:2.13.15
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    |    |    \--- com.thoughtworks.paranamer:paranamer:2.8
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.16.2 -> 2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.2 -> 2.18.2 (*)
+|    |    +--- net.sf.jopt-simple:jopt-simple:5.0.4
+|    |    +--- org.bitbucket.b_c:jose4j:0.9.4
+|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- org.scala-lang.modules:scala-collection-compat_2.13:2.10.0
+|    |    |    \--- org.scala-lang:scala-library:2.13.10 -> 2.13.15
+|    |    +--- org.scala-lang.modules:scala-java8-compat_2.13:1.0.2
+|    |    |    \--- org.scala-lang:scala-library:2.13.6 -> 2.13.15
+|    |    +--- org.scala-lang:scala-reflect:2.13.14
+|    |    |    \--- org.scala-lang:scala-library:2.13.14 -> 2.13.15
+|    |    +--- com.typesafe.scala-logging:scala-logging_2.13:3.9.5
+|    |    |    +--- org.scala-lang:scala-library:2.13.8 -> 2.13.15
+|    |    |    +--- org.scala-lang:scala-reflect:2.13.8 -> 2.13.14 (*)
+|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- commons-io:commons-io:2.14.0 -> 2.18.0
+|    |    +--- io.dropwizard.metrics:metrics-core:4.1.12.1 -> 4.2.29 (*)
+|    |    +--- org.apache.zookeeper:zookeeper:3.8.4 (*)
+|    |    +--- commons-cli:commons-cli:1.4
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    \--- org.scala-lang:scala-library:2.13.14 -> 2.13.15
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4
+|    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    +--- org.opentest4j:opentest4j:1.3.0
+|    |    \--- org.junit.platform:junit-platform-commons:1.11.4
+|    |         \--- org.junit:junit-bom:5.11.4 (*)
+|    \--- org.junit.platform:junit-platform-launcher:1.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         \--- org.junit.platform:junit-platform-engine:1.11.4
+|              +--- org.junit:junit-bom:5.11.4 (*)
+|              +--- org.opentest4j:opentest4j:1.3.0
+|              \--- org.junit.platform:junit-platform-commons:1.11.4 (*)
++--- org.springframework.pulsar:spring-pulsar -> 1.2.2
+|    +--- org.springframework.pulsar:spring-pulsar-cache-provider-caffeine:1.2.2
+|    |    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.apache.pulsar:pulsar-client-all:3.3.4 -> 4.0.2
+|    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2
+|    |    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1
+|    |    |    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    |    \--- org.bouncycastle:bcutil-jdk18on:1.78.1
+|    |    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    \--- org.bouncycastle:bcprov-ext-jdk18on:1.78.1
+|    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcutil-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0 (*)
+|    |    +--- io.opentelemetry:opentelemetry-context:1.45.0 -> 1.46.0
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.45.0-alpha (*)
+|    |    +--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.17.2 -> 2.18.2 (*)
+|    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    |    \--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2
+|    |         +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (*)
+|    |         +--- com.google.guava:guava:32.1.2-jre -> 33.3.1-jre
+|    |         |    +--- com.google.guava:failureaccess:1.0.2
+|    |         |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |         |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |         |    +--- org.checkerframework:checker-qual:3.43.0
+|    |         |    +--- com.google.errorprone:error_prone_annotations:2.28.0 -> 2.36.0
+|    |         |    \--- com.google.j2objc:j2objc-annotations:3.0.0
+|    |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2
++--- org.springframework.pulsar:spring-pulsar-reactive -> 1.2.2
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (*)
+|    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10
+|    |    +--- org.jctools:jctools-core:3.3.0
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    \--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10
++--- org.springframework.restdocs:spring-restdocs-mockmvc -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.14.0 -> 2.18.2 (*)
+|    |    \--- org.springframework:spring-web:6.1.13 -> 6.2.2 (*)
+|    +--- org.springframework:spring-webmvc:6.1.13 -> 6.2.2 (*)
+|    +--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
+|    \--- jakarta.servlet:jakarta.servlet-api:6.0.0
++--- org.springframework.restdocs:spring-restdocs-restassured -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (*)
+|    +--- io.rest-assured:rest-assured:5.2.1 -> 5.5.0
+|    |    +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|    |    +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25
+|    |    |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|    |    |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|    |    +--- org.apache.httpcomponents:httpclient:4.5.13 -> 4.5.14 (*)
+|    |    +--- org.apache.httpcomponents:httpmime:4.5.13 -> 4.5.14 (*)
+|    |    +--- org.hamcrest:hamcrest:2.2 -> 3.0
+|    |    +--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
+|    |    +--- io.rest-assured:json-path:5.5.0
+|    |    |    +--- org.apache.groovy:groovy-json:4.0.22 -> 4.0.25
+|    |    |    |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|    |    |    |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|    |    |    +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|    |    |    \--- io.rest-assured:rest-assured-common:5.5.0
+|    |    |         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|    |    |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    |    \--- io.rest-assured:xml-path:5.5.0
+|    |         +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25 (*)
+|    |         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|    |         +--- io.rest-assured:rest-assured-common:5.5.0 (*)
+|    |         +--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    |         \--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
+|    \--- org.springframework:spring-web:6.1.13 -> 6.2.2 (*)
++--- org.springframework.restdocs:spring-restdocs-webtestclient -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (*)
+|    +--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
+|    \--- org.springframework:spring-webflux:6.1.13 -> 6.2.2 (*)
++--- org.springframework.security:spring-security-config -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-crypto:6.5.0-M1
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework.security:spring-security-oauth2-client -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- com.nimbusds:oauth2-oidc-sdk:9.43.4
+|         +--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|         +--- com.nimbusds:content-type:2.2
+|         +--- net.minidev:json-smart:[1.3.3,2.4.10] -> 2.5.1 (*)
+|         +--- com.nimbusds:lang-tag:1.7
+|         \--- com.nimbusds:nimbus-jose-jwt:9.37.3
+|              \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
++--- org.springframework.security:spring-security-test -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-test:6.2.2 (*)
++--- org.springframework.security:spring-security-web -> 6.5.0-M1 (*)
++--- org.springframework.ws:spring-ws-core -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11
+|    |    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.0 -> 2.1.3
+|    |    |    +--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    |    \--- org.eclipse.angus:angus-activation:2.0.2 (*)
+|    |    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
+|    +--- org.springframework:spring-aop:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-web:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-webmvc:6.0.16 -> 6.2.2 (*)
+|    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.0 -> 3.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2 (*)
+|    +--- org.glassfish.jaxb:jaxb-runtime:4.0.1 -> 4.0.5 (*)
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.springframework.ws:spring-ws-test -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11 (*)
+|    +--- org.springframework.ws:spring-ws-core:4.0.11 (*)
+|    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    +--- xmlunit:xmlunit:1.6
+|    +--- org.xmlunit:xmlunit-core:2.9.0 -> 2.10.0
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.testcontainers:junit-jupiter -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:neo4j -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:mongodb -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.junit.jupiter:junit-jupiter -> 5.11.4
+|    +--- org.junit:junit-bom:5.11.4 (*)
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|    +--- org.junit.jupiter:junit-jupiter-params:5.11.4
+|    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    \--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|    \--- org.junit.jupiter:junit-jupiter-engine:5.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         +--- org.junit.platform:junit-platform-engine:1.11.4 (*)
+|         \--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+\--- org.yaml:snakeyaml -> 2.3
+
+runtimeElements - Runtime elements for the 'main' feature. (n)
+No dependencies
+
+runtimeElements-published (n)
+No dependencies
+
+runtimeOnly - Runtime only dependencies for null/main. (n)
+No dependencies
+
+sourcesElements - sources elements for main. (n)
+No dependencies
+
+sourcesElements-published (n)
+No dependencies
+
+springApplicationExample
++--- project :spring-boot-project:spring-boot-dependencies
+|    +--- org.apache.activemq:activemq-bom:6.1.5
+|    +--- org.apache.activemq:artemis-bom:2.39.0
+|    +--- org.assertj:assertj-bom:3.27.3
+|    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    +--- io.zipkin.brave:brave-bom:6.0.3
+|    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    +--- org.apache.groovy:groovy-bom:4.0.25
+|    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (c)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2 (c)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2 (c)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.18.2 (c)
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (c)
+|    |    \--- com.fasterxml.jackson.core:jackson-core:2.18.2 (c)
+|    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    +--- org.junit:junit-bom:5.11.4
+|    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.24.3 (c)
+|    |    \--- org.apache.logging.log4j:log4j-api:2.24.3 (c)
+|    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    \--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    \--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    +--- org.mockito:mockito-bom:5.15.2
+|    +--- io.netty:netty-bom:4.1.117.Final
+|    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    +--- io.prometheus:simpleclient_bom:0.16.0
+|    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    +--- com.querydsl:querydsl-bom:5.1.0
+|    +--- io.projectreactor:reactor-bom:2024.0.2
+|    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    +--- io.rsocket:rsocket-bom:1.1.5
+|    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    +--- org.springframework:spring-web:6.2.2 (c)
+|    |    +--- org.springframework:spring-webmvc:6.2.2 (c)
+|    |    +--- org.springframework:spring-core:6.2.2 (c)
+|    |    +--- org.springframework:spring-beans:6.2.2 (c)
+|    |    +--- org.springframework:spring-aop:6.2.2 (c)
+|    |    +--- org.springframework:spring-context:6.2.2 (c)
+|    |    +--- org.springframework:spring-expression:6.2.2 (c)
+|    |    \--- org.springframework:spring-jcl:6.2.2 (c)
+|    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    +--- org.springframework.session:spring-session-bom:3.4.1
+|    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    +--- org.springframework.boot:spring-boot-starter-web:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-web (c)
+|    +--- org.springframework.boot:spring-boot-starter:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter (c)
+|    +--- org.springframework.boot:spring-boot-starter-json:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-json (c)
+|    +--- org.springframework.boot:spring-boot-starter-tomcat:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-tomcat (c)
+|    +--- org.springframework.boot:spring-boot:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot (c)
+|    +--- org.springframework.boot:spring-boot-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-autoconfigure (c)
+|    +--- org.springframework.boot:spring-boot-starter-logging:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-logging (c)
+|    +--- jakarta.annotation:jakarta.annotation-api:2.1.1 (c)
+|    +--- org.yaml:snakeyaml:2.3 (c)
+|    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (c)
+|    +--- org.apache.tomcat.embed:tomcat-embed-el:10.1.34 (c)
+|    +--- org.apache.tomcat.embed:tomcat-embed-websocket:10.1.34 (c)
+|    +--- ch.qos.logback:logback-classic:1.5.16 (c)
+|    +--- org.slf4j:jul-to-slf4j:2.0.16 (c)
+|    +--- org.slf4j:slf4j-api:2.0.16 (c)
+|    \--- ch.qos.logback:logback-core:1.5.16 (c)
+\--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-web
+     +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter
+     |    +--- project :spring-boot-project:spring-boot
+     |    |    +--- org.springframework:spring-core -> 6.2.2
+     |    |    |    \--- org.springframework:spring-jcl:6.2.2
+     |    |    \--- org.springframework:spring-context -> 6.2.2
+     |    |         +--- org.springframework:spring-aop:6.2.2
+     |    |         |    +--- org.springframework:spring-beans:6.2.2
+     |    |         |    |    \--- org.springframework:spring-core:6.2.2 (*)
+     |    |         |    \--- org.springframework:spring-core:6.2.2 (*)
+     |    |         +--- org.springframework:spring-beans:6.2.2 (*)
+     |    |         +--- org.springframework:spring-core:6.2.2 (*)
+     |    |         +--- org.springframework:spring-expression:6.2.2
+     |    |         |    \--- org.springframework:spring-core:6.2.2 (*)
+     |    |         \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1
+     |    |              \--- io.micrometer:micrometer-commons:1.15.0-M1
+     |    +--- project :spring-boot-project:spring-boot-autoconfigure
+     |    |    \--- project :spring-boot-project:spring-boot (*)
+     |    +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-logging
+     |    |    +--- ch.qos.logback:logback-classic -> 1.5.16
+     |    |    |    +--- ch.qos.logback:logback-core:1.5.16
+     |    |    |    \--- org.slf4j:slf4j-api:2.0.16
+     |    |    +--- org.apache.logging.log4j:log4j-to-slf4j -> 2.24.3
+     |    |    |    +--- org.apache.logging.log4j:log4j-api:2.24.3
+     |    |    |    \--- org.slf4j:slf4j-api:2.0.16
+     |    |    \--- org.slf4j:jul-to-slf4j -> 2.0.16
+     |    |         \--- org.slf4j:slf4j-api:2.0.16
+     |    +--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
+     |    +--- org.springframework:spring-core -> 6.2.2 (*)
+     |    \--- org.yaml:snakeyaml -> 2.3
+     +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-json
+     |    +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter (*)
+     |    +--- org.springframework:spring-web -> 6.2.2
+     |    |    +--- org.springframework:spring-beans:6.2.2 (*)
+     |    |    +--- org.springframework:spring-core:6.2.2 (*)
+     |    |    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+     |    +--- com.fasterxml.jackson.core:jackson-databind -> 2.18.2
+     |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2
+     |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+     |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2
+     |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+     |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+     |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8 -> 2.18.2
+     |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+     |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+     |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+     |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310 -> 2.18.2
+     |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+     |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+     |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+     |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+     |    \--- com.fasterxml.jackson.module:jackson-module-parameter-names -> 2.18.2
+     |         +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+     |         +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+     |         \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+     +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-tomcat
+     |    +--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
+     |    +--- org.apache.tomcat.embed:tomcat-embed-core -> 10.1.34
+     |    +--- org.apache.tomcat.embed:tomcat-embed-el -> 10.1.34
+     |    \--- org.apache.tomcat.embed:tomcat-embed-websocket -> 10.1.34
+     |         \--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34
+     +--- org.springframework:spring-web -> 6.2.2 (*)
+     \--- org.springframework:spring-webmvc -> 6.2.2
+          +--- org.springframework:spring-aop:6.2.2 (*)
+          +--- org.springframework:spring-beans:6.2.2 (*)
+          +--- org.springframework:spring-context:6.2.2 (*)
+          +--- org.springframework:spring-core:6.2.2 (*)
+          +--- org.springframework:spring-expression:6.2.2 (*)
+          \--- org.springframework:spring-web:6.2.2 (*)
+
+starters
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-activemq
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-actuator
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-amqp
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-aop
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-artemis
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-batch
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-cache
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-cassandra
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-cassandra-reactive
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-couchbase
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-couchbase-reactive
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-elasticsearch
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-jdbc
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-jpa
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-ldap
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-mongodb
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-mongodb-reactive
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-neo4j
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-r2dbc
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-redis
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-redis-reactive
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-data-rest
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-freemarker
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-graphql
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-groovy-templates
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-hateoas
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-integration
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-jdbc
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-jersey
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-jetty
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-jooq
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-json
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-log4j2
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-logging
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-mail
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-mustache
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-oauth2-authorization-server
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-oauth2-client
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-oauth2-resource-server
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-pulsar
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-pulsar-reactive
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-quartz
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-reactor-netty
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-rsocket
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-security
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-test
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-thymeleaf
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-tomcat
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-undertow
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-validation
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-web
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-web-services
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-webflux
+\--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-websocket
+
+testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
+No dependencies
+
+testApi - API dependencies for null/test (n)
+No dependencies
+
+testApiDependenciesMetadata
+No dependencies
+
+testCompileClasspath - Compile classpath for null/test.
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    |    \--- junit:junit:4.13.1 -> 4.13.2 (c)
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    |    \--- org.assertj:assertj-core:3.27.3 (c)
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+|    |    |    +--- org.apache.cassandra:java-driver-query-builder:4.18.1 (c)
+|    |    |    +--- com.datastax.oss:native-protocol:1.5.1 (c)
+|    |    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1 (c)
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0 (c)
+|    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    |    +--- org.apache.groovy:groovy:4.0.25 (c)
+|    |    |    +--- org.apache.groovy:groovy-xml:4.0.25 (c)
+|    |    |    \--- org.apache.groovy:groovy-json:4.0.25 (c)
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (c)
+|    |    |    \--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (c)
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    |    +--- org.glassfish.jersey.core:jersey-server:3.1.10 (c)
+|    |    |    +--- org.glassfish.jersey.containers:jersey-container-servlet-core:3.1.10 (c)
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (c)
+|    |    |    \--- org.glassfish.jersey.core:jersey-client:3.1.10 (c)
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    |    +--- org.junit.jupiter:junit-jupiter:5.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-launcher:1.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-params:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-commons:1.11.4 (c)
+|    |    |    \--- org.junit.platform:junit-platform-engine:1.11.4 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.24.3 (c)
+|    |    |    \--- org.apache.logging.log4j:log4j-api:2.24.3 (c)
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    |    |    \--- io.micrometer:context-propagation:1.1.2 (c)
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-tracing:1.5.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    |    |    \--- io.micrometer:context-propagation:1.1.2 (c)
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    |    \--- org.mockito:mockito-core:5.15.2 (c)
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    |    +--- io.netty:netty-codec-http:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec-http2:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-native-epoll:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-handler:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-handler-proxy:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-common:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec-dns:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-classes-epoll:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-tcnative-classes:2.0.69.Final (c)
+|    |    |    \--- io.netty:netty-codec-socks:4.1.117.Final (c)
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    |    +--- io.opentelemetry:opentelemetry-api:1.46.0 (c)
+|    |    |    \--- io.opentelemetry:opentelemetry-context:1.46.0 (c)
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    |    \--- com.google.guava:guava:33.3.1-jre (c)
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-all:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (c)
+|    |    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2 (c)
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    |    +--- io.projectreactor.netty:reactor-netty-http:1.2.2 (c)
+|    |    |    +--- io.projectreactor:reactor-core:3.7.2 (c)
+|    |    |    +--- io.projectreactor.netty:reactor-netty-core:1.2.2 (c)
+|    |    |    \--- org.reactivestreams:reactive-streams:1.0.4 (c)
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    |    +--- io.rest-assured:rest-assured:5.5.0 (c)
+|    |    |    +--- io.rest-assured:json-path:5.5.0 (c)
+|    |    |    +--- io.rest-assured:xml-path:5.5.0 (c)
+|    |    |    \--- io.rest-assured:rest-assured-common:5.5.0 (c)
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    |    +--- org.springframework.amqp:spring-amqp:3.2.2 (c)
+|    |    |    \--- org.springframework.amqp:spring-rabbit:3.2.2 (c)
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    |    +--- org.springframework.batch:spring-batch-core:5.2.1 (c)
+|    |    |    \--- org.springframework.batch:spring-batch-infrastructure:5.2.1 (c)
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    |    +--- org.springframework.data:spring-data-cassandra:4.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-couchbase:5.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-elasticsearch:5.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-r2dbc:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-jpa:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-envers:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-mongodb:4.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-neo4j:7.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-redis:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-ldap:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-commons:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-relational:3.4.2 (c)
+|    |    |    \--- org.springframework.data:spring-data-keyvalue:3.4.2 (c)
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    |    +--- org.springframework:spring-context:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-core:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-jdbc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-jms:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-orm:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-test:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-web:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-webflux:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-webmvc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-websocket:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-messaging:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-tx:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-aop:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-beans:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-expression:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-context-support:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-r2dbc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-oxm:6.2.2 (c)
+|    |    |    \--- org.springframework:spring-jcl:6.2.2 (c)
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    |    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (c)
+|    |    |    +--- org.springframework.pulsar:spring-pulsar-reactive:1.2.2 (c)
+|    |    |    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2 (c)
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-mockmvc:3.0.3 (c)
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-restassured:3.0.3 (c)
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-webtestclient:3.0.3 (c)
+|    |    |    \--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (c)
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    |    +--- org.springframework.security:spring-security-config:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-oauth2-client:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-test:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-web:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1 (c)
+|    |    |    \--- org.springframework.security:spring-security-crypto:6.5.0-M1 (c)
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    |    +--- org.springframework.ws:spring-ws-core:4.0.11 (c)
+|    |    |    +--- org.springframework.ws:spring-ws-test:4.0.11 (c)
+|    |    |    \--- org.springframework.ws:spring-xml:4.0.11 (c)
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    |    +--- org.testcontainers:junit-jupiter:1.20.4 (c)
+|    |    |    +--- org.testcontainers:mongodb:1.20.4 (c)
+|    |    |    +--- org.testcontainers:neo4j:1.20.4 (c)
+|    |    |    \--- org.testcontainers:testcontainers:1.20.4 (c)
+|    |    +--- org.cache2k:cache2k-spring:2.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-dbcp2:2.13.0 (c)
+|    |    +--- org.hibernate.orm:hibernate-jcache:6.6.6.Final (c)
+|    |    +--- com.zaxxer:HikariCP:6.2.1 (c)
+|    |    +--- org.htmlunit:htmlunit:4.9.0 (c)
+|    |    +--- org.apache.httpcomponents.client5:httpclient5:5.4.2 (c)
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1 (c)
+|    |    +--- jakarta.jms:jakarta.jms-api:3.1.0 (c)
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0 (c)
+|    |    +--- jakarta.servlet:jakarta.servlet-api:6.0.0 (c)
+|    |    +--- jakarta.validation:jakarta.validation-api:3.0.2 (c)
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.jooq:jooq:3.19.18 (c)
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (c)
+|    |    +--- ch.qos.logback:logback-classic:1.5.16 (c)
+|    |    +--- org.mongodb:mongodb-driver-sync:5.3.1 (c)
+|    |    +--- org.quartz-scheduler:quartz:2.5.0 (c)
+|    |    +--- org.postgresql:r2dbc-postgresql:1.0.7.RELEASE (c)
+|    |    +--- org.springframework.boot:spring-boot:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot (c)
+|    |    +--- org.springframework.boot:spring-boot-test:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test (c)
+|    |    +--- org.springframework.boot:spring-boot-test-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-testcontainers:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-testcontainers (c)
+|    |    +--- org.springframework.boot:spring-boot-actuator:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator (c)
+|    |    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-devtools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-devtools (c)
+|    |    +--- org.springframework.boot:spring-boot-docker-compose:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-docker-compose (c)
+|    |    +--- org.springframework.boot:spring-boot-loader-tools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools (c)
+|    |    +--- org.slf4j:jul-to-slf4j:2.0.16 (c)
+|    |    +--- org.yaml:snakeyaml:2.3 (c)
+|    |    +--- org.springframework.graphql:spring-graphql:1.3.3 (c)
+|    |    +--- org.springframework.graphql:spring-graphql-test:1.3.3 (c)
+|    |    +--- org.springframework.kafka:spring-kafka:3.3.2 (c)
+|    |    +--- org.springframework.kafka:spring-kafka-test:3.3.2 (c)
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (c)
+|    |    +--- io.undertow:undertow-core:2.3.18.Final (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3 (*)
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1 (*)
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5 (*)
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25 (*)
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2 (*)
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10 (*)
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3 (*)
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1 (*)
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1 (*)
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2 (*)
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final (*)
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0 (*)
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5 (*)
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2 (*)
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2 (*)
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0 (*)
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2 (*)
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1 (*)
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2 (*)
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2 (*)
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2 (*)
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3 (*)
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1 (*)
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11 (*)
+|    |    +--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4 (*)
+|    |    +--- org.cache2k:cache2k-api:2.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-pool2:2.12.1 (c)
+|    |    +--- jakarta.transaction:jakarta.transaction-api:2.0.1 (c)
+|    |    +--- org.hibernate.orm:hibernate-core:6.6.6.Final (c)
+|    |    +--- javax.cache:cache-api:1.1.1 (c)
+|    |    +--- org.slf4j:slf4j-api:2.0.16 (c)
+|    |    +--- org.apache.commons:commons-lang3:3.17.0 (c)
+|    |    +--- commons-codec:commons-codec:1.18.0 (c)
+|    |    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3 (c)
+|    |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3 (c)
+|    |    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (c)
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0 (c)
+|    |    +--- ch.qos.logback:logback-core:1.5.16 (c)
+|    |    +--- org.mongodb:bson:5.3.1 (c)
+|    |    +--- org.mongodb:mongodb-driver-core:5.3.1 (c)
+|    |    +--- com.graphql-java:graphql-java:22.3 (c)
+|    |    +--- com.jayway.jsonpath:json-path:2.9.0 (c)
+|    |    +--- org.springframework.retry:spring-retry:2.0.11 (c)
+|    |    +--- org.apache.kafka:kafka-server:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-metadata:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-streams-test-utils:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka_2.13:3.9.0 (c)
+|    |    +--- org.apache.tomcat:tomcat-annotations-api:10.1.34 (c)
+|    |    +--- org.jboss.logging:jboss-logging:3.6.1.Final (c)
+|    |    +--- net.bytebuddy:byte-buddy:1.17.0 (c)
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0 (c)
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1 (c)
+|    |    +--- net.bytebuddy:byte-buddy-agent:1.17.0 (c)
+|    |    +--- com.rabbitmq:amqp-client:5.24.0 (c)
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+|    |    +--- com.couchbase.client:java-client:3.7.7 (c)
+|    |    +--- co.elastic.clients:elasticsearch-java:8.15.5 (c)
+|    |    +--- org.hibernate.orm:hibernate-envers:6.6.6.Final (c)
+|    |    +--- org.neo4j.driver:neo4j-java-driver:5.25.0 (c)
+|    |    +--- org.springframework.ldap:spring-ldap-core:3.3.0-M1 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10 (c)
+|    |    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.2 (c)
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:3.0.4 (c)
+|    |    +--- org.xmlunit:xmlunit-core:2.10.0 (c)
+|    |    +--- junit:junit:4.13.2 (c)
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4 (c)
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5 (c)
+|    |    +--- jakarta.json:jakarta.json-api:2.1.3 (c)
+|    |    +--- org.hamcrest:hamcrest:3.0 (c)
+|    |    +--- net.minidev:json-smart:2.5.1 (c)
+|    |    +--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+|    |    +--- org.hamcrest:hamcrest-core:3.0 (c)
+|    |    +--- org.apache.httpcomponents:httpcore:4.4.16 (c)
+|    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5 (c)
+|    |    \--- org.apache.httpcomponents:httpcore-nio:4.4.16 (c)
+|    +--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.7.0-alpha (c)
+|    +--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10 (*)
+|    +--- org.apache.commons:commons-compress:1.25.0 (c)
+|    +--- io.micrometer:context-propagation:1.0.5 -> 1.1.2 (c)
+|    \--- org.apiguardian:apiguardian-api:1.1.2 (c)
++--- project :spring-boot-project:spring-boot-actuator
+|    \--- project :spring-boot-project:spring-boot
+|         +--- org.springframework:spring-core -> 6.2.2
+|         |    \--- org.springframework:spring-jcl:6.2.2
+|         \--- org.springframework:spring-context -> 6.2.2
+|              +--- org.springframework:spring-aop:6.2.2
+|              |    +--- org.springframework:spring-beans:6.2.2
+|              |    |    \--- org.springframework:spring-core:6.2.2 (*)
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-beans:6.2.2 (*)
+|              +--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-expression:6.2.2
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1
+|                   \--- io.micrometer:micrometer-commons:1.15.0-M1
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+|    +--- project :spring-boot-project:spring-boot-actuator (*)
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure
+|         \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-docker-compose
+|    \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-tools:spring-boot-cli
++--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools
+|    +--- org.apache.commons:commons-compress -> 1.25.0
+|    \--- org.springframework:spring-core -> 6.2.2 (*)
++--- project :spring-boot-project:spring-boot-test
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- org.springframework:spring-test -> 6.2.2
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- project :spring-boot-project:spring-boot-test-autoconfigure
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- project :spring-boot-project:spring-boot-test (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-testcontainers
+|    +--- project :spring-boot-project:spring-boot-autoconfigure (*)
+|    \--- org.testcontainers:testcontainers -> 1.20.4
+|         +--- junit:junit:4.13.2
+|         |    \--- org.hamcrest:hamcrest-core:1.3 -> 3.0
+|         |         \--- org.hamcrest:hamcrest:3.0
+|         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- org.apache.commons:commons-compress:1.24.0 -> 1.25.0
+|         +--- org.rnorth.duct-tape:duct-tape:1.0.8
+|         |    \--- org.jetbrains:annotations:17.0.0
+|         +--- com.github.docker-java:docker-java-api:3.4.0
+|         |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.3 -> 2.18.2
+|         |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|         |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|         \--- com.github.docker-java:docker-java-transport-zerodep:3.4.0
+|              +--- com.github.docker-java:docker-java-transport:3.4.0
+|              +--- org.slf4j:slf4j-api:1.7.25 -> 2.0.16
+|              \--- net.java.dev.jna:jna:5.13.0
++--- project :spring-boot-project:spring-boot-devtools
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- ch.qos.logback:logback-classic -> 1.5.16
+|    +--- ch.qos.logback:logback-core:1.5.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- com.zaxxer:HikariCP -> 6.2.1
+|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-jakarta9 -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    |    \--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    \--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
++--- io.micrometer:micrometer-tracing -> 1.5.0-M1
+|    +--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    +--- io.micrometer:context-propagation:1.1.2
+|    \--- aopalliance:aopalliance:1.0
++--- io.micrometer:micrometer-registry-graphite -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-graphite:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- com.rabbitmq:amqp-client:5.23.0 -> 5.24.0
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-registry-jmx -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-jmx:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29 (*)
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0 -> 2.7.0-alpha
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0
+|    |    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0
+|    |         \--- io.opentelemetry:opentelemetry-context:1.46.0
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:2.7.0-alpha
+|    |    +--- io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha
+|    |    \--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0 (*)
+|    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0 (*)
++--- io.projectreactor.netty:reactor-netty-http -> 1.2.2
+|    +--- io.netty:netty-codec-http:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final
+|    |    |    \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-transport:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-resolver:4.1.117.Final
+|    |    |         \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-codec:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport-native-unix-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-codec:4.1.117.Final (*)
+|    +--- io.netty:netty-codec-http2:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler:4.1.117.Final (*)
+|    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec-dns:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final
+|    |    \--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver-dns:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    |    \--- io.netty:netty-transport-classes-epoll:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.projectreactor.netty:reactor-netty-core:1.2.2
+|    |    +--- io.netty:netty-handler:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler-proxy:4.1.116.Final -> 4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec-socks:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final (*)
+|    |    \--- io.projectreactor:reactor-core:3.7.2
+|    |         \--- org.reactivestreams:reactive-streams:1.0.4
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- io.undertow:undertow-core -> 2.3.18.Final
+|    +--- org.jboss.logging:jboss-logging:3.4.3.Final -> 3.6.1.Final
+|    +--- org.jboss.xnio:xnio-api:3.8.16.Final
+|    |    +--- org.wildfly.common:wildfly-common:1.5.4.Final
+|    |    \--- org.wildfly.client:wildfly-client-config:1.0.1.Final
+|    |         \--- org.jboss.logging:jboss-logging:3.3.1.Final -> 3.6.1.Final
+|    \--- org.jboss.threads:jboss-threads:3.5.0.Final
+|         \--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.6.1.Final
++--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
++--- jakarta.jms:jakarta.jms-api -> 3.1.0
++--- jakarta.persistence:jakarta.persistence-api -> 3.1.0
++--- jakarta.servlet:jakarta.servlet-api -> 6.0.0
++--- jakarta.validation:jakarta.validation-api -> 3.0.2
++--- org.apache.httpcomponents.client5:httpclient5 -> 5.4.2
+|    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3
+|    |    \--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- org.apache.commons:commons-dbcp2 -> 2.13.0
+|    +--- org.apache.commons:commons-pool2:2.12.0 -> 2.12.1
+|    \--- jakarta.transaction:jakarta.transaction-api:1.3.3 -> 2.0.1
++--- org.apache.kafka:kafka-streams -> 3.9.0
+|    +--- org.apache.kafka:kafka-clients:3.9.0
+|    \--- org.rocksdb:rocksdbjni:7.9.2
++--- org.apache.logging.log4j:log4j-to-slf4j -> 2.24.3
+|    +--- org.apache.logging.log4j:log4j-api:2.24.3
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.apache.tomcat.embed:tomcat-embed-core -> 10.1.34
+|    \--- org.apache.tomcat:tomcat-annotations-api:10.1.34
++--- org.assertj:assertj-core -> 3.27.3
+|    \--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
++--- org.cache2k:cache2k-spring -> 2.6.1.Final
+|    \--- org.cache2k:cache2k-api:2.6.1.Final
++--- org.apache.groovy:groovy -> 4.0.25
+|    \--- org.apache.groovy:groovy-bom:4.0.25 (*)
++--- org.glassfish.jersey.containers:jersey-container-servlet-core -> 3.1.10
+|    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    +--- org.glassfish.jersey.core:jersey-common:3.1.10
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- org.glassfish.hk2:osgi-resource-locator:1.0.3
+|    +--- org.glassfish.jersey.core:jersey-server:3.1.10
+|    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    +--- org.glassfish.jersey.core:jersey-client:3.1.10
+|    |    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    |    \--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- jakarta.validation:jakarta.validation-api:3.0.2
+|    \--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
++--- org.glassfish.jersey.core:jersey-server -> 3.1.10 (*)
++--- org.hibernate.orm:hibernate-jcache -> 6.6.6.Final
+|    +--- org.hibernate.orm:hibernate-core:6.6.6.Final
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0
+|    |    \--- jakarta.transaction:jakarta.transaction-api:2.0.1
+|    \--- javax.cache:cache-api:1.0.0 -> 1.1.1
++--- org.htmlunit:htmlunit -> 4.9.0
+|    +--- org.apache.httpcomponents:httpmime:4.5.14
+|    |    \--- org.apache.httpcomponents:httpclient:4.5.14
+|    |         +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |         \--- commons-codec:commons-codec:1.11 -> 1.18.0
+|    +--- org.htmlunit:htmlunit-core-js:4.9.0
+|    +--- org.htmlunit:neko-htmlunit:4.9.0
+|    +--- org.htmlunit:htmlunit-cssparser:4.9.0
+|    +--- org.htmlunit:htmlunit-xpath:4.9.0
+|    +--- org.htmlunit:htmlunit-csp:4.9.0
+|    +--- org.htmlunit:htmlunit-websocket-client:4.9.0
+|    +--- org.apache.commons:commons-lang3:3.17.0
+|    +--- commons-io:commons-io:2.18.0
+|    +--- commons-codec:commons-codec:1.17.2 -> 1.18.0
+|    \--- org.brotli:dec:0.1.2
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+|    |    +--- org.jetbrains:annotations:13.0 -> 17.0.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.25 (c)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.25 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
++--- org.jooq:jooq -> 3.19.18
+|    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE
+|         \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
++--- org.mockito:mockito-core -> 5.15.2
+|    +--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
+|    \--- net.bytebuddy:byte-buddy-agent:1.15.11 -> 1.17.0
++--- org.mongodb:mongodb-driver-sync -> 5.3.1
+|    +--- org.mongodb:bson:5.3.1
+|    \--- org.mongodb:mongodb-driver-core:5.3.1
+|         \--- org.mongodb:bson:5.3.1
++--- org.postgresql:r2dbc-postgresql -> 1.0.7.RELEASE
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- com.ongres.scram:client:2.1
+|    |    \--- com.ongres.scram:common:2.1
+|    |         \--- com.ongres.stringprep:saslprep:1.1
+|    |              \--- com.ongres.stringprep:stringprep:1.1
+|    +--- io.projectreactor:reactor-core:3.5.20 -> 3.7.2 (*)
+|    \--- io.projectreactor.netty:reactor-netty-core:1.1.22 -> 1.2.2 (*)
++--- org.quartz-scheduler:quartz -> 2.5.0
++--- org.slf4j:jul-to-slf4j -> 2.0.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.springframework:spring-jdbc -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework:spring-jms -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-orm -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2 (*)
++--- org.springframework:spring-test -> 6.2.2 (*)
++--- org.springframework:spring-web -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-webflux -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- org.springframework:spring-webmvc -> 6.2.2
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework:spring-websocket -> 6.2.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework.amqp:spring-amqp -> 3.2.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework.retry:spring-retry:2.0.11
++--- org.springframework.amqp:spring-rabbit -> 3.2.2
+|    +--- org.springframework.amqp:spring-amqp:3.2.2 (*)
+|    +--- com.rabbitmq:amqp-client:5.22.0 -> 5.24.0 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.batch:spring-batch-core -> 5.2.1
+|    +--- org.springframework.batch:spring-batch-infrastructure:5.2.1
+|    |    +--- org.springframework:spring-core:6.2.1 -> 6.2.2 (*)
+|    |    \--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.springframework:spring-aop:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.1 -> 6.2.2 (*)
+|    +--- io.micrometer:micrometer-core:1.14.2 -> 1.15.0-M1 (*)
+|    +--- io.micrometer:micrometer-observation:1.14.2 -> 1.15.0-M1 (*)
+|    \--- org.springframework.data:spring-data-commons:3.4.1 -> 3.4.2
+|         +--- org.springframework:spring-core:6.2.2 (*)
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-cassandra -> 4.4.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.apache.cassandra:java-driver-core:4.18.0 -> 4.18.1
+|    |    +--- com.datastax.oss:native-protocol:1.5.1
+|    |    +--- io.netty:netty-handler:4.1.94.Final -> 4.1.117.Final (*)
+|    |    +--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    |    +--- com.typesafe:config:1.4.1
+|    |    +--- com.github.jnr:jnr-posix:3.1.15
+|    |    |    +--- com.github.jnr:jnr-ffi:2.2.11
+|    |    |    |    +--- com.github.jnr:jffi:1.3.9
+|    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    +--- org.ow2.asm:asm-commons:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2
+|    |    |    |    |    |    \--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2
+|    |    |    |    |         \--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-util:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- com.github.jnr:jnr-a64asm:1.0.0
+|    |    |    |    \--- com.github.jnr:jnr-x86asm:1.0.2
+|    |    |    \--- com.github.jnr:jnr-constants:0.10.3
+|    |    +--- org.slf4j:slf4j-api:1.7.26 -> 2.0.16
+|    |    +--- io.dropwizard.metrics:metrics-core:4.1.18 -> 4.2.29 (*)
+|    |    +--- org.hdrhistogram:HdrHistogram:2.1.12
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.4 -> 2.18.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 -> 2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- org.apache.cassandra:java-driver-query-builder:4.18.0 -> 4.18.1
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (*)
+|    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-couchbase -> 5.4.2
+|    +--- org.springframework:spring-context-support:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- com.couchbase.client:java-client:3.7.7
+|    |    \--- com.couchbase.client:core-io:3.7.7
+|    |         +--- io.projectreactor:reactor-core:3.6.9 -> 3.7.2 (*)
+|    |         +--- org.reactivestreams:reactive-streams:1.0.4
+|    |         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-elasticsearch -> 5.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- co.elastic.clients:elasticsearch-java:8.15.5
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.5.14 (*)
+|    |    |    +--- org.apache.httpcomponents:httpcore:4.4.13 -> 4.4.16
+|    |    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5
+|    |    |    +--- org.apache.httpcomponents:httpcore-nio:4.4.13 -> 4.4.16
+|    |    |    \--- commons-codec:commons-codec:1.15 -> 1.18.0
+|    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    +--- jakarta.json:jakarta.json-api:2.0.1 -> 2.1.3
+|    |    \--- org.eclipse.parsson:parsson:1.0.5
+|    |         \--- jakarta.json:jakarta.json-api:2.0.2 -> 2.1.3
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-envers -> 3.4.2
+|    +--- org.springframework.data:spring-data-jpa:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-orm:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.antlr:antlr4-runtime:4.13.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.0.0 -> 2.1.1
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.hibernate.orm:hibernate-envers:6.6.4.Final -> 6.6.6.Final
+|    |    \--- org.hibernate.orm:hibernate-core:6.6.6.Final (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-jpa -> 3.4.2 (*)
++--- org.springframework.data:spring-data-ldap -> 3.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.ldap:spring-ldap-core:3.2.10 -> 3.3.0-M1
+|    |    +--- org.springframework:spring-core:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.1.16 -> 6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-core:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-mongodb -> 4.4.2
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.mongodb:mongodb-driver-core:5.2.1 -> 5.3.1 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-neo4j -> 7.4.2
+|    +--- jakarta.transaction:jakarta.transaction-api:2.0.0 -> 2.0.1
+|    +--- org.apiguardian:apiguardian-api:1.1.1 -> 1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl:2024.2.0
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl-schema-name-support:2024.2.0
+|    +--- org.neo4j.driver:neo4j-java-driver:5.25.0
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4
+|    |    +--- io.netty:netty-handler:4.1.113.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-tcnative-classes:2.0.66.Final -> 2.0.69.Final
+|    |    \--- io.projectreactor:reactor-core:3.6.10 -> 3.7.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-redis -> 3.4.2
+|    +--- org.springframework.data:spring-data-keyvalue:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-context-support:6.2.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-r2dbc -> 3.4.2
+|    +--- org.springframework.data:spring-data-relational:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-r2dbc:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    |    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.graphql:spring-graphql -> 1.3.3
+|    +--- com.graphql-java:graphql-java:22.3
+|    |    +--- com.graphql-java:java-dataloader:3.3.0
+|    |    |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    \--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
++--- org.springframework.graphql:spring-graphql-test -> 1.3.3
+|    +--- org.springframework.graphql:spring-graphql:1.3.3 (*)
+|    +--- com.graphql-java:graphql-java:22.3 (*)
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    +--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
+|    +--- org.springframework:spring-test:6.1.14 -> 6.2.2 (*)
+|    \--- com.jayway.jsonpath:json-path:2.9.0
++--- org.springframework.kafka:spring-kafka -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.kafka:spring-kafka-test -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-test:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.zookeeper:zookeeper:3.8.4
+|    |    +--- org.apache.zookeeper:zookeeper-jute:3.8.4
+|    |    |    \--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- io.netty:netty-handler:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    +--- ch.qos.logback:logback-core:1.2.13 -> 1.5.16
+|    |    +--- ch.qos.logback:logback-classic:1.2.13 -> 1.5.16 (*)
+|    |    \--- commons-io:commons-io:2.11.0 -> 2.18.0
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-server:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-metadata:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-server-common:3.8.1 -> 3.9.0
+|    |    \--- org.apache.kafka:kafka-clients:3.9.0
+|    +--- org.apache.kafka:kafka-streams-test-utils:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (*)
+|    |    \--- org.apache.kafka:kafka-clients:3.9.0
+|    +--- org.apache.kafka:kafka_2.13:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0
+|    |    \--- org.scala-lang:scala-library:2.13.14
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4
+|    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    +--- org.opentest4j:opentest4j:1.3.0
+|    |    +--- org.junit.platform:junit-platform-commons:1.11.4
+|    |    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    \--- org.junit.platform:junit-platform-launcher:1.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         +--- org.junit.platform:junit-platform-engine:1.11.4
+|         |    +--- org.junit:junit-bom:5.11.4 (*)
+|         |    +--- org.opentest4j:opentest4j:1.3.0
+|         |    +--- org.junit.platform:junit-platform-commons:1.11.4 (*)
+|         |    \--- org.apiguardian:apiguardian-api:1.1.2
+|         \--- org.apiguardian:apiguardian-api:1.1.2
++--- org.springframework.pulsar:spring-pulsar -> 1.2.2
+|    +--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.apache.pulsar:pulsar-client-all:3.3.4 -> 4.0.2
+|    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2
+|    |    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1
+|    |    |    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    |    \--- org.bouncycastle:bcutil-jdk18on:1.78.1
+|    |    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    \--- org.bouncycastle:bcprov-ext-jdk18on:1.78.1
+|    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcutil-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0 (*)
+|    |    +--- io.opentelemetry:opentelemetry-context:1.45.0 -> 1.46.0
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.45.0-alpha
+|    |    |    \--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0 (*)
+|    |    +--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.17.2 -> 2.18.2 (*)
+|    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    |    \--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2
+|    |         +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (*)
+|    |         +--- com.google.guava:guava:32.1.2-jre -> 33.3.1-jre
+|    |         |    +--- com.google.guava:failureaccess:1.0.2
+|    |         |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |         |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |         |    +--- org.checkerframework:checker-qual:3.43.0
+|    |         |    +--- com.google.errorprone:error_prone_annotations:2.28.0
+|    |         |    \--- com.google.j2objc:j2objc-annotations:3.0.0
+|    |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2
++--- org.springframework.pulsar:spring-pulsar-reactive -> 1.2.2
+|    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (*)
+|    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    \--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10
++--- org.springframework.restdocs:spring-restdocs-mockmvc -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    +--- org.springframework:spring-webmvc:6.1.13 -> 6.2.2 (*)
+|    \--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
++--- org.springframework.restdocs:spring-restdocs-restassured -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    \--- io.rest-assured:rest-assured:5.2.1 -> 5.5.0
+|         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25
+|         |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|         |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|         +--- org.apache.httpcomponents:httpclient:4.5.13 -> 4.5.14 (*)
+|         +--- org.apache.httpcomponents:httpmime:4.5.13 -> 4.5.14 (*)
+|         +--- org.hamcrest:hamcrest:2.2 -> 3.0
+|         +--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
+|         +--- io.rest-assured:json-path:5.5.0
+|         |    +--- org.apache.groovy:groovy-json:4.0.22 -> 4.0.25
+|         |    |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|         |    |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|         |    +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         |    \--- io.rest-assured:rest-assured-common:5.5.0
+|         |         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|         \--- io.rest-assured:xml-path:5.5.0
+|              +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25 (*)
+|              +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|              +--- io.rest-assured:rest-assured-common:5.5.0 (*)
+|              +--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|              \--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
++--- org.springframework.restdocs:spring-restdocs-webtestclient -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    +--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
+|    \--- org.springframework:spring-webflux:6.1.13 -> 6.2.2 (*)
++--- org.springframework.security:spring-security-config -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-crypto:6.5.0-M1
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework.security:spring-security-oauth2-client -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- com.nimbusds:oauth2-oidc-sdk:9.43.4
+|         +--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|         +--- com.nimbusds:content-type:2.2
+|         +--- net.minidev:json-smart:[1.3.3,2.4.10] -> 2.5.1
+|         |    \--- net.minidev:accessors-smart:2.5.1
+|         |         \--- org.ow2.asm:asm:9.6
+|         +--- com.nimbusds:lang-tag:1.7
+|         \--- com.nimbusds:nimbus-jose-jwt:9.37.3
+|              \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
++--- org.springframework.security:spring-security-test -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-test:6.2.2 (*)
++--- org.springframework.security:spring-security-web -> 6.5.0-M1 (*)
++--- org.springframework.ws:spring-ws-core -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11
+|    |    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.0 -> 2.1.3
+|    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
+|    +--- org.springframework:spring-aop:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-web:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-webmvc:6.0.16 -> 6.2.2 (*)
+|    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.0 -> 3.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.springframework.ws:spring-ws-test -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11 (*)
+|    +--- org.springframework.ws:spring-ws-core:4.0.11 (*)
+|    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    +--- xmlunit:xmlunit:1.6
+|    +--- org.xmlunit:xmlunit-core:2.9.0 -> 2.10.0
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.testcontainers:junit-jupiter -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:neo4j -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:mongodb -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.junit.jupiter:junit-jupiter -> 5.11.4
+|    +--- org.junit:junit-bom:5.11.4 (*)
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|    \--- org.junit.jupiter:junit-jupiter-params:5.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|         \--- org.apiguardian:apiguardian-api:1.1.2
++--- org.yaml:snakeyaml -> 2.3
+\--- project :spring-boot-project:spring-boot-tools:spring-boot-test-support
+     \--- project :spring-boot-project:spring-boot-parent (*)
+
+testCompileOnly - Compile only dependencies for null/test. (n)
+No dependencies
+
+testCompileOnlyDependenciesMetadata
+No dependencies
+
+testImplementation - Implementation only dependencies for null/test. (n)
++--- project spring-boot-actuator-autoconfigure (n)
++--- project spring-boot-test-support (n)
++--- org.assertj:assertj-core (n)
+\--- org.junit.jupiter:junit-jupiter (n)
+
+testImplementationDependenciesMetadata
++--- project :spring-boot-project:spring-boot-actuator
+|    \--- project :spring-boot-project:spring-boot
+|         +--- org.springframework:spring-core -> 6.2.2
+|         |    \--- org.springframework:spring-jcl:6.2.2
+|         \--- org.springframework:spring-context -> 6.2.2
+|              +--- org.springframework:spring-aop:6.2.2
+|              |    +--- org.springframework:spring-beans:6.2.2
+|              |    |    \--- org.springframework:spring-core:6.2.2 (*)
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-beans:6.2.2 (*)
+|              +--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-expression:6.2.2
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1
+|                   \--- io.micrometer:micrometer-commons:1.15.0-M1
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+|    +--- project :spring-boot-project:spring-boot-actuator (*)
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure
+|         \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-docker-compose
+|    \--- project :spring-boot-project:spring-boot (*)
++--- project :spring-boot-project:spring-boot-tools:spring-boot-cli
++--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools
+|    +--- org.apache.commons:commons-compress -> 1.25.0
+|    \--- org.springframework:spring-core -> 6.2.2 (*)
++--- project :spring-boot-project:spring-boot-test
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- org.springframework:spring-test -> 6.2.2
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- project :spring-boot-project:spring-boot-test-autoconfigure
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- project :spring-boot-project:spring-boot-test (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-testcontainers
+|    +--- project :spring-boot-project:spring-boot-autoconfigure (*)
+|    \--- org.testcontainers:testcontainers -> 1.20.4
+|         +--- junit:junit:4.13.2
+|         |    \--- org.hamcrest:hamcrest-core:1.3 -> 3.0
+|         |         \--- org.hamcrest:hamcrest:3.0
+|         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- org.apache.commons:commons-compress:1.24.0 -> 1.25.0
+|         +--- org.rnorth.duct-tape:duct-tape:1.0.8
+|         |    \--- org.jetbrains:annotations:17.0.0
+|         +--- com.github.docker-java:docker-java-api:3.4.0
+|         |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.3 -> 2.18.2
+|         |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2
+|         |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (c)
+|         |    |         +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (c)
+|         |    |         \--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (c)
+|         |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|         \--- com.github.docker-java:docker-java-transport-zerodep:3.4.0
+|              +--- com.github.docker-java:docker-java-transport:3.4.0
+|              +--- org.slf4j:slf4j-api:1.7.25 -> 2.0.16
+|              \--- net.java.dev.jna:jna:5.13.0
++--- project :spring-boot-project:spring-boot-devtools
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- ch.qos.logback:logback-classic -> 1.5.16
+|    +--- ch.qos.logback:logback-core:1.5.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- com.zaxxer:HikariCP -> 6.2.1
+|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-jakarta9 -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    |    \--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    \--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
++--- io.micrometer:micrometer-tracing -> 1.5.0-M1
+|    +--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    +--- io.micrometer:context-propagation:1.1.2
+|    \--- aopalliance:aopalliance:1.0
++--- io.micrometer:micrometer-registry-graphite -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-graphite:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- com.rabbitmq:amqp-client:5.23.0 -> 5.24.0
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-registry-jmx -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-jmx:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29 (*)
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0 -> 2.7.0-alpha
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0
+|    |    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0
+|    |         \--- io.opentelemetry:opentelemetry-context:1.46.0
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:2.7.0-alpha
+|    |    +--- io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha
+|    |    \--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0 (*)
+|    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0 (*)
++--- io.projectreactor.netty:reactor-netty-http -> 1.2.2
+|    +--- io.netty:netty-codec-http:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final
+|    |    |    \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-transport:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-resolver:4.1.117.Final
+|    |    |         \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-codec:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport-native-unix-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-codec:4.1.117.Final (*)
+|    +--- io.netty:netty-codec-http2:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler:4.1.117.Final (*)
+|    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec-dns:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final
+|    |    \--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver-dns:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    |    \--- io.netty:netty-transport-classes-epoll:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.projectreactor.netty:reactor-netty-core:1.2.2
+|    |    +--- io.netty:netty-handler:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler-proxy:4.1.116.Final -> 4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec-socks:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final (*)
+|    |    \--- io.projectreactor:reactor-core:3.7.2
+|    |         \--- org.reactivestreams:reactive-streams:1.0.4
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- io.undertow:undertow-core -> 2.3.18.Final
+|    +--- org.jboss.logging:jboss-logging:3.4.3.Final -> 3.6.1.Final
+|    +--- org.jboss.xnio:xnio-api:3.8.16.Final
+|    |    +--- org.wildfly.common:wildfly-common:1.5.4.Final
+|    |    \--- org.wildfly.client:wildfly-client-config:1.0.1.Final
+|    |         \--- org.jboss.logging:jboss-logging:3.3.1.Final -> 3.6.1.Final
+|    \--- org.jboss.threads:jboss-threads:3.5.0.Final
+|         \--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.6.1.Final
++--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
++--- jakarta.jms:jakarta.jms-api -> 3.1.0
++--- jakarta.persistence:jakarta.persistence-api -> 3.1.0
++--- jakarta.servlet:jakarta.servlet-api -> 6.0.0
++--- jakarta.validation:jakarta.validation-api -> 3.0.2
++--- org.apache.httpcomponents.client5:httpclient5 -> 5.4.2
+|    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3
+|    |    \--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- org.apache.commons:commons-dbcp2 -> 2.13.0
+|    +--- org.apache.commons:commons-pool2:2.12.0 -> 2.12.1
+|    \--- jakarta.transaction:jakarta.transaction-api:1.3.3 -> 2.0.1
++--- org.apache.kafka:kafka-streams -> 3.9.0
+|    +--- org.apache.kafka:kafka-clients:3.9.0
+|    \--- org.rocksdb:rocksdbjni:7.9.2
++--- org.apache.logging.log4j:log4j-to-slf4j -> 2.24.3
+|    +--- org.apache.logging.log4j:log4j-api:2.24.3
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.apache.tomcat.embed:tomcat-embed-core -> 10.1.34
+|    \--- org.apache.tomcat:tomcat-annotations-api:10.1.34
++--- org.assertj:assertj-core -> 3.27.3
+|    \--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
++--- org.cache2k:cache2k-spring -> 2.6.1.Final
+|    \--- org.cache2k:cache2k-api:2.6.1.Final
++--- org.apache.groovy:groovy -> 4.0.25
+|    \--- org.apache.groovy:groovy-bom:4.0.25
+|         +--- org.apache.groovy:groovy:4.0.25 (c)
+|         +--- org.apache.groovy:groovy-xml:4.0.25 (c)
+|         \--- org.apache.groovy:groovy-json:4.0.25 (c)
++--- org.glassfish.jersey.containers:jersey-container-servlet-core -> 3.1.10
+|    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    +--- org.glassfish.jersey.core:jersey-common:3.1.10
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- org.glassfish.hk2:osgi-resource-locator:1.0.3
+|    +--- org.glassfish.jersey.core:jersey-server:3.1.10
+|    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    +--- org.glassfish.jersey.core:jersey-client:3.1.10
+|    |    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    |    \--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- jakarta.validation:jakarta.validation-api:3.0.2
+|    \--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
++--- org.glassfish.jersey.core:jersey-server -> 3.1.10 (*)
++--- org.hibernate.orm:hibernate-jcache -> 6.6.6.Final
+|    +--- org.hibernate.orm:hibernate-core:6.6.6.Final
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0
+|    |    \--- jakarta.transaction:jakarta.transaction-api:2.0.1
+|    \--- javax.cache:cache-api:1.0.0 -> 1.1.1
++--- org.htmlunit:htmlunit -> 4.9.0
+|    +--- org.apache.httpcomponents:httpmime:4.5.14
+|    |    \--- org.apache.httpcomponents:httpclient:4.5.14
+|    |         +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |         \--- commons-codec:commons-codec:1.11 -> 1.18.0
+|    +--- org.htmlunit:htmlunit-core-js:4.9.0
+|    +--- org.htmlunit:neko-htmlunit:4.9.0
+|    +--- org.htmlunit:htmlunit-cssparser:4.9.0
+|    +--- org.htmlunit:htmlunit-xpath:4.9.0
+|    +--- org.htmlunit:htmlunit-csp:4.9.0
+|    +--- org.htmlunit:htmlunit-websocket-client:4.9.0
+|    +--- org.apache.commons:commons-lang3:3.17.0
+|    +--- commons-io:commons-io:2.18.0
+|    +--- commons-codec:commons-codec:1.17.2 -> 1.18.0
+|    \--- org.brotli:dec:0.1.2
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
++--- org.jooq:jooq -> 3.19.18
+|    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE
+|         \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
++--- org.mockito:mockito-core -> 5.15.2
+|    +--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
+|    \--- net.bytebuddy:byte-buddy-agent:1.15.11 -> 1.17.0
++--- org.mongodb:mongodb-driver-sync -> 5.3.1
+|    +--- org.mongodb:bson:5.3.1
+|    \--- org.mongodb:mongodb-driver-core:5.3.1
+|         \--- org.mongodb:bson:5.3.1
++--- org.postgresql:r2dbc-postgresql -> 1.0.7.RELEASE
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- com.ongres.scram:client:2.1
+|    |    \--- com.ongres.scram:common:2.1
+|    |         \--- com.ongres.stringprep:saslprep:1.1
+|    |              \--- com.ongres.stringprep:stringprep:1.1
+|    +--- io.projectreactor:reactor-core:3.5.20 -> 3.7.2 (*)
+|    \--- io.projectreactor.netty:reactor-netty-core:1.1.22 -> 1.2.2 (*)
++--- org.quartz-scheduler:quartz -> 2.5.0
++--- org.slf4j:jul-to-slf4j -> 2.0.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.springframework:spring-jdbc -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework:spring-jms -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-orm -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2 (*)
++--- org.springframework:spring-test -> 6.2.2 (*)
++--- org.springframework:spring-web -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-webflux -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- org.springframework:spring-webmvc -> 6.2.2
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework:spring-websocket -> 6.2.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework.amqp:spring-amqp -> 3.2.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework.retry:spring-retry:2.0.11
++--- org.springframework.amqp:spring-rabbit -> 3.2.2
+|    +--- org.springframework.amqp:spring-amqp:3.2.2 (*)
+|    +--- com.rabbitmq:amqp-client:5.22.0 -> 5.24.0 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.batch:spring-batch-core -> 5.2.1
+|    +--- org.springframework.batch:spring-batch-infrastructure:5.2.1
+|    |    +--- org.springframework:spring-core:6.2.1 -> 6.2.2 (*)
+|    |    \--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.springframework:spring-aop:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.1 -> 6.2.2 (*)
+|    +--- io.micrometer:micrometer-core:1.14.2 -> 1.15.0-M1 (*)
+|    +--- io.micrometer:micrometer-observation:1.14.2 -> 1.15.0-M1 (*)
+|    \--- org.springframework.data:spring-data-commons:3.4.1 -> 3.4.2
+|         +--- org.springframework:spring-core:6.2.2 (*)
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-cassandra -> 4.4.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.apache.cassandra:java-driver-core:4.18.0 -> 4.18.1
+|    |    +--- com.datastax.oss:native-protocol:1.5.1
+|    |    +--- io.netty:netty-handler:4.1.94.Final -> 4.1.117.Final (*)
+|    |    +--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    |    +--- com.typesafe:config:1.4.1
+|    |    +--- com.github.jnr:jnr-posix:3.1.15
+|    |    |    +--- com.github.jnr:jnr-ffi:2.2.11
+|    |    |    |    +--- com.github.jnr:jffi:1.3.9
+|    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    +--- org.ow2.asm:asm-commons:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2
+|    |    |    |    |    |    \--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2
+|    |    |    |    |         \--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-util:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- com.github.jnr:jnr-a64asm:1.0.0
+|    |    |    |    \--- com.github.jnr:jnr-x86asm:1.0.2
+|    |    |    \--- com.github.jnr:jnr-constants:0.10.3
+|    |    +--- org.slf4j:slf4j-api:1.7.26 -> 2.0.16
+|    |    +--- io.dropwizard.metrics:metrics-core:4.1.18 -> 4.2.29 (*)
+|    |    +--- org.hdrhistogram:HdrHistogram:2.1.12
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.4 -> 2.18.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 -> 2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- org.apache.cassandra:java-driver-query-builder:4.18.0 -> 4.18.1
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (*)
+|    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-couchbase -> 5.4.2
+|    +--- org.springframework:spring-context-support:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- com.couchbase.client:java-client:3.7.7
+|    |    \--- com.couchbase.client:core-io:3.7.7
+|    |         +--- io.projectreactor:reactor-core:3.6.9 -> 3.7.2 (*)
+|    |         +--- org.reactivestreams:reactive-streams:1.0.4
+|    |         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-elasticsearch -> 5.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- co.elastic.clients:elasticsearch-java:8.15.5
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.5.14 (*)
+|    |    |    +--- org.apache.httpcomponents:httpcore:4.4.13 -> 4.4.16
+|    |    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5
+|    |    |    +--- org.apache.httpcomponents:httpcore-nio:4.4.13 -> 4.4.16
+|    |    |    \--- commons-codec:commons-codec:1.15 -> 1.18.0
+|    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    +--- jakarta.json:jakarta.json-api:2.0.1 -> 2.1.3
+|    |    \--- org.eclipse.parsson:parsson:1.0.5
+|    |         \--- jakarta.json:jakarta.json-api:2.0.2 -> 2.1.3
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-envers -> 3.4.2
+|    +--- org.springframework.data:spring-data-jpa:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-orm:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.antlr:antlr4-runtime:4.13.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.0.0 -> 2.1.1
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.hibernate.orm:hibernate-envers:6.6.4.Final -> 6.6.6.Final
+|    |    \--- org.hibernate.orm:hibernate-core:6.6.6.Final (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-jpa -> 3.4.2 (*)
++--- org.springframework.data:spring-data-ldap -> 3.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.ldap:spring-ldap-core:3.2.10 -> 3.3.0-M1
+|    |    +--- org.springframework:spring-core:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.1.16 -> 6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-core:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-mongodb -> 4.4.2
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.mongodb:mongodb-driver-core:5.2.1 -> 5.3.1 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-neo4j -> 7.4.2
+|    +--- jakarta.transaction:jakarta.transaction-api:2.0.0 -> 2.0.1
+|    +--- org.apiguardian:apiguardian-api:1.1.1 -> 1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl:2024.2.0
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl-schema-name-support:2024.2.0
+|    +--- org.neo4j.driver:neo4j-java-driver:5.25.0
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4
+|    |    +--- io.netty:netty-handler:4.1.113.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-tcnative-classes:2.0.66.Final -> 2.0.69.Final
+|    |    \--- io.projectreactor:reactor-core:3.6.10 -> 3.7.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-redis -> 3.4.2
+|    +--- org.springframework.data:spring-data-keyvalue:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-context-support:6.2.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-r2dbc -> 3.4.2
+|    +--- org.springframework.data:spring-data-relational:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-r2dbc:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    |    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.graphql:spring-graphql -> 1.3.3
+|    +--- com.graphql-java:graphql-java:22.3
+|    |    +--- com.graphql-java:java-dataloader:3.3.0
+|    |    |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    \--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
++--- org.springframework.graphql:spring-graphql-test -> 1.3.3
+|    +--- org.springframework.graphql:spring-graphql:1.3.3 (*)
+|    +--- com.graphql-java:graphql-java:22.3 (*)
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    +--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
+|    +--- org.springframework:spring-test:6.1.14 -> 6.2.2 (*)
+|    \--- com.jayway.jsonpath:json-path:2.9.0
++--- org.springframework.kafka:spring-kafka -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.kafka:spring-kafka-test -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-test:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.zookeeper:zookeeper:3.8.4
+|    |    +--- org.apache.zookeeper:zookeeper-jute:3.8.4
+|    |    |    \--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- io.netty:netty-handler:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    +--- ch.qos.logback:logback-core:1.2.13 -> 1.5.16
+|    |    +--- ch.qos.logback:logback-classic:1.2.13 -> 1.5.16 (*)
+|    |    \--- commons-io:commons-io:2.11.0 -> 2.18.0
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-server:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-metadata:3.8.1 -> 3.9.0
+|    +--- org.apache.kafka:kafka-server-common:3.8.1 -> 3.9.0
+|    |    \--- org.apache.kafka:kafka-clients:3.9.0
+|    +--- org.apache.kafka:kafka-streams-test-utils:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (*)
+|    |    \--- org.apache.kafka:kafka-clients:3.9.0
+|    +--- org.apache.kafka:kafka_2.13:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0
+|    |    \--- org.scala-lang:scala-library:2.13.14
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    |    +--- org.junit.jupiter:junit-jupiter:5.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-commons:1.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-engine:1.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-launcher:1.11.4 (c)
+|    |    |    \--- org.junit.jupiter:junit-jupiter-params:5.11.4 (c)
+|    |    +--- org.opentest4j:opentest4j:1.3.0
+|    |    +--- org.junit.platform:junit-platform-commons:1.11.4
+|    |    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    \--- org.junit.platform:junit-platform-launcher:1.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         +--- org.junit.platform:junit-platform-engine:1.11.4
+|         |    +--- org.junit:junit-bom:5.11.4 (*)
+|         |    +--- org.opentest4j:opentest4j:1.3.0
+|         |    +--- org.junit.platform:junit-platform-commons:1.11.4 (*)
+|         |    \--- org.apiguardian:apiguardian-api:1.1.2
+|         \--- org.apiguardian:apiguardian-api:1.1.2
++--- org.springframework.pulsar:spring-pulsar -> 1.2.2
+|    +--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.apache.pulsar:pulsar-client-all:3.3.4 -> 4.0.2
+|    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2
+|    |    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1
+|    |    |    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    |    \--- org.bouncycastle:bcutil-jdk18on:1.78.1
+|    |    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    \--- org.bouncycastle:bcprov-ext-jdk18on:1.78.1
+|    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcutil-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0 (*)
+|    |    +--- io.opentelemetry:opentelemetry-context:1.45.0 -> 1.46.0
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.45.0-alpha
+|    |    |    \--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0 (*)
+|    |    +--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.17.2 -> 2.18.2 (*)
+|    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    |    \--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2
+|    |         +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (*)
+|    |         +--- com.google.guava:guava:32.1.2-jre -> 33.3.1-jre
+|    |         |    +--- com.google.guava:failureaccess:1.0.2
+|    |         |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |         |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |         |    +--- org.checkerframework:checker-qual:3.43.0
+|    |         |    +--- com.google.errorprone:error_prone_annotations:2.28.0
+|    |         |    \--- com.google.j2objc:j2objc-annotations:3.0.0
+|    |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2
++--- org.springframework.pulsar:spring-pulsar-reactive -> 1.2.2
+|    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (*)
+|    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    \--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10
++--- org.springframework.restdocs:spring-restdocs-mockmvc -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    +--- org.springframework:spring-webmvc:6.1.13 -> 6.2.2 (*)
+|    \--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
++--- org.springframework.restdocs:spring-restdocs-restassured -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    \--- io.rest-assured:rest-assured:5.2.1 -> 5.5.0
+|         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25
+|         |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|         |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|         +--- org.apache.httpcomponents:httpclient:4.5.13 -> 4.5.14 (*)
+|         +--- org.apache.httpcomponents:httpmime:4.5.13 -> 4.5.14 (*)
+|         +--- org.hamcrest:hamcrest:2.2 -> 3.0
+|         +--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
+|         +--- io.rest-assured:json-path:5.5.0
+|         |    +--- org.apache.groovy:groovy-json:4.0.22 -> 4.0.25
+|         |    |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|         |    |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|         |    +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         |    \--- io.rest-assured:rest-assured-common:5.5.0
+|         |         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|         |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|         \--- io.rest-assured:xml-path:5.5.0
+|              +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25 (*)
+|              +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|              +--- io.rest-assured:rest-assured-common:5.5.0 (*)
+|              +--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|              \--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
++--- org.springframework.restdocs:spring-restdocs-webtestclient -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    +--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
+|    \--- org.springframework:spring-webflux:6.1.13 -> 6.2.2 (*)
++--- org.springframework.security:spring-security-config -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-crypto:6.5.0-M1
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework.security:spring-security-oauth2-client -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- com.nimbusds:oauth2-oidc-sdk:9.43.4
+|         +--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|         +--- com.nimbusds:content-type:2.2
+|         +--- net.minidev:json-smart:[1.3.3,2.4.10] -> 2.5.1
+|         |    \--- net.minidev:accessors-smart:2.5.1
+|         |         \--- org.ow2.asm:asm:9.6
+|         +--- com.nimbusds:lang-tag:1.7
+|         \--- com.nimbusds:nimbus-jose-jwt:9.37.3
+|              \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
++--- org.springframework.security:spring-security-test -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-test:6.2.2 (*)
++--- org.springframework.security:spring-security-web -> 6.5.0-M1 (*)
++--- org.springframework.ws:spring-ws-core -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11
+|    |    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.0 -> 2.1.3
+|    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
+|    +--- org.springframework:spring-aop:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-web:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-webmvc:6.0.16 -> 6.2.2 (*)
+|    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.0 -> 3.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.springframework.ws:spring-ws-test -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11 (*)
+|    +--- org.springframework.ws:spring-ws-core:4.0.11 (*)
+|    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    +--- xmlunit:xmlunit:1.6
+|    +--- org.xmlunit:xmlunit-core:2.9.0 -> 2.10.0
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.testcontainers:junit-jupiter -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:neo4j -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:mongodb -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.junit.jupiter:junit-jupiter -> 5.11.4
+|    +--- org.junit:junit-bom:5.11.4 (*)
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|    \--- org.junit.jupiter:junit-jupiter-params:5.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|         \--- org.apiguardian:apiguardian-api:1.1.2
++--- org.yaml:snakeyaml -> 2.3
+\--- project :spring-boot-project:spring-boot-tools:spring-boot-test-support
+     \--- project :spring-boot-project:spring-boot-parent
+          +--- org.codehaus.janino:janino:3.1.10 -> 3.1.12
+          |    \--- junit:junit:4.13.1 -> 4.13.2 (c)
+          +--- project :spring-boot-project:spring-boot-dependencies
+          |    +--- org.apache.activemq:activemq-bom:6.1.5
+          |    +--- org.apache.activemq:artemis-bom:2.39.0
+          |    +--- org.assertj:assertj-bom:3.27.3
+          |    |    \--- org.assertj:assertj-core:3.27.3 (c)
+          |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+          |    +--- io.zipkin.brave:brave-bom:6.0.3
+          |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+          |    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+          |    |    +--- org.apache.cassandra:java-driver-query-builder:4.18.1 (c)
+          |    |    +--- com.datastax.oss:native-protocol:1.5.1 (c)
+          |    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1 (c)
+          |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+          |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+          |    |    +--- org.jvnet.staxex:stax-ex:2.1.0 (c)
+          |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+          |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+          |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+          |    +--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+          |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+          |    |    +--- org.glassfish.jersey.core:jersey-server:3.1.10 (c)
+          |    |    +--- org.glassfish.jersey.containers:jersey-container-servlet-core:3.1.10 (c)
+          |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (c)
+          |    |    \--- org.glassfish.jersey.core:jersey-client:3.1.10 (c)
+          |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+          |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+          |    +--- org.junit:junit-bom:5.11.4 (*)
+          |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+          |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+          |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25 (c)
+          |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25 (c)
+          |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+          |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+          |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+          |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.24.3 (c)
+          |    |    \--- org.apache.logging.log4j:log4j-api:2.24.3 (c)
+          |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+          |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+          |    |    \--- io.micrometer:context-propagation:1.1.2 (c)
+          |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+          |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-tracing:1.5.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+          |    |    +--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+          |    |    \--- io.micrometer:context-propagation:1.1.2 (c)
+          |    +--- org.mockito:mockito-bom:5.15.2
+          |    |    \--- org.mockito:mockito-core:5.15.2 (c)
+          |    +--- io.netty:netty-bom:4.1.117.Final
+          |    |    +--- io.netty:netty-handler:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-transport-native-epoll:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-common:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-resolver:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-buffer:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-transport:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-codec:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-transport-classes-epoll:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-handler-proxy:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-resolver-dns:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-codec-http:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-codec-http2:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-codec-socks:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-codec-dns:4.1.117.Final (c)
+          |    |    +--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final (c)
+          |    |    \--- io.netty:netty-tcnative-classes:2.0.69.Final (c)
+          |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+          |    |    +--- io.opentelemetry:opentelemetry-api:1.46.0 (c)
+          |    |    \--- io.opentelemetry:opentelemetry-context:1.46.0 (c)
+          |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+          |    |    \--- com.google.guava:guava:33.3.1-jre (c)
+          |    +--- io.prometheus:simpleclient_bom:0.16.0
+          |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+          |    |    +--- org.apache.pulsar:pulsar-client-all:4.0.2 (c)
+          |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2 (c)
+          |    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2 (c)
+          |    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (c)
+          |    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2 (c)
+          |    +--- com.querydsl:querydsl-bom:5.1.0
+          |    +--- io.projectreactor:reactor-bom:2024.0.2
+          |    |    +--- org.reactivestreams:reactive-streams:1.0.4 (c)
+          |    |    +--- io.projectreactor:reactor-core:3.7.2 (c)
+          |    |    +--- io.projectreactor.netty:reactor-netty-core:1.2.2 (c)
+          |    |    \--- io.projectreactor.netty:reactor-netty-http:1.2.2 (c)
+          |    +--- io.rest-assured:rest-assured-bom:5.5.0
+          |    |    +--- io.rest-assured:rest-assured:5.5.0 (c)
+          |    |    +--- io.rest-assured:json-path:5.5.0 (c)
+          |    |    +--- io.rest-assured:xml-path:5.5.0 (c)
+          |    |    \--- io.rest-assured:rest-assured-common:5.5.0 (c)
+          |    +--- io.rsocket:rsocket-bom:1.1.5
+          |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+          |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+          |    |    +--- org.springframework.amqp:spring-amqp:3.2.2 (c)
+          |    |    \--- org.springframework.amqp:spring-rabbit:3.2.2 (c)
+          |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+          |    |    +--- org.springframework.batch:spring-batch-core:5.2.1 (c)
+          |    |    \--- org.springframework.batch:spring-batch-infrastructure:5.2.1 (c)
+          |    +--- org.springframework.data:spring-data-bom:2024.1.2
+          |    |    +--- org.springframework.data:spring-data-cassandra:4.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-couchbase:5.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-elasticsearch:5.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-r2dbc:3.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-jpa:3.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-envers:3.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-mongodb:4.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-neo4j:7.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-redis:3.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-ldap:3.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-commons:3.4.2 (c)
+          |    |    +--- org.springframework.data:spring-data-relational:3.4.2 (c)
+          |    |    \--- org.springframework.data:spring-data-keyvalue:3.4.2 (c)
+          |    +--- org.springframework:spring-framework-bom:6.2.2
+          |    |    +--- org.springframework:spring-aop:6.2.2 (c)
+          |    |    +--- org.springframework:spring-beans:6.2.2 (c)
+          |    |    +--- org.springframework:spring-context:6.2.2 (c)
+          |    |    +--- org.springframework:spring-core:6.2.2 (c)
+          |    |    +--- org.springframework:spring-expression:6.2.2 (c)
+          |    |    +--- org.springframework:spring-jdbc:6.2.2 (c)
+          |    |    +--- org.springframework:spring-jms:6.2.2 (c)
+          |    |    +--- org.springframework:spring-messaging:6.2.2 (c)
+          |    |    +--- org.springframework:spring-orm:6.2.2 (c)
+          |    |    +--- org.springframework:spring-test:6.2.2 (c)
+          |    |    +--- org.springframework:spring-tx:6.2.2 (c)
+          |    |    +--- org.springframework:spring-web:6.2.2 (c)
+          |    |    +--- org.springframework:spring-webflux:6.2.2 (c)
+          |    |    +--- org.springframework:spring-webmvc:6.2.2 (c)
+          |    |    +--- org.springframework:spring-websocket:6.2.2 (c)
+          |    |    +--- org.springframework:spring-jcl:6.2.2 (c)
+          |    |    +--- org.springframework:spring-context-support:6.2.2 (c)
+          |    |    +--- org.springframework:spring-r2dbc:6.2.2 (c)
+          |    |    \--- org.springframework:spring-oxm:6.2.2 (c)
+          |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+          |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+          |    |    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (c)
+          |    |    +--- org.springframework.pulsar:spring-pulsar-reactive:1.2.2 (c)
+          |    |    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2 (c)
+          |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+          |    |    +--- org.springframework.restdocs:spring-restdocs-mockmvc:3.0.3 (c)
+          |    |    +--- org.springframework.restdocs:spring-restdocs-restassured:3.0.3 (c)
+          |    |    +--- org.springframework.restdocs:spring-restdocs-webtestclient:3.0.3 (c)
+          |    |    \--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (c)
+          |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+          |    |    +--- org.springframework.security:spring-security-config:6.5.0-M1 (c)
+          |    |    +--- org.springframework.security:spring-security-oauth2-client:6.5.0-M1 (c)
+          |    |    +--- org.springframework.security:spring-security-test:6.5.0-M1 (c)
+          |    |    +--- org.springframework.security:spring-security-web:6.5.0-M1 (c)
+          |    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (c)
+          |    |    +--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1 (c)
+          |    |    \--- org.springframework.security:spring-security-crypto:6.5.0-M1 (c)
+          |    +--- org.springframework.session:spring-session-bom:3.4.1
+          |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+          |    |    +--- org.springframework.ws:spring-ws-core:4.0.11 (c)
+          |    |    +--- org.springframework.ws:spring-ws-test:4.0.11 (c)
+          |    |    \--- org.springframework.ws:spring-xml:4.0.11 (c)
+          |    +--- org.testcontainers:testcontainers-bom:1.20.4
+          |    |    +--- org.testcontainers:junit-jupiter:1.20.4 (c)
+          |    |    +--- org.testcontainers:mongodb:1.20.4 (c)
+          |    |    +--- org.testcontainers:neo4j:1.20.4 (c)
+          |    |    \--- org.testcontainers:testcontainers:1.20.4 (c)
+          |    +--- org.cache2k:cache2k-api:2.6.1.Final (c)
+          |    +--- org.cache2k:cache2k-spring:2.6.1.Final (c)
+          |    +--- commons-codec:commons-codec:1.18.0 (c)
+          |    +--- org.apache.commons:commons-dbcp2:2.13.0 (c)
+          |    +--- org.apache.commons:commons-lang3:3.17.0 (c)
+          |    +--- org.apache.commons:commons-pool2:2.12.1 (c)
+          |    +--- com.graphql-java:graphql-java:22.3 (c)
+          |    +--- org.hibernate.orm:hibernate-core:6.6.6.Final (c)
+          |    +--- org.hibernate.orm:hibernate-jcache:6.6.6.Final (c)
+          |    +--- com.zaxxer:HikariCP:6.2.1 (c)
+          |    +--- org.htmlunit:htmlunit:4.9.0 (c)
+          |    +--- org.apache.httpcomponents.client5:httpclient5:5.4.2 (c)
+          |    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3 (c)
+          |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3 (c)
+          |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1 (c)
+          |    +--- jakarta.jms:jakarta.jms-api:3.1.0 (c)
+          |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0 (c)
+          |    +--- jakarta.servlet:jakarta.servlet-api:6.0.0 (c)
+          |    +--- jakarta.transaction:jakarta.transaction-api:2.0.1 (c)
+          |    +--- jakarta.validation:jakarta.validation-api:3.0.2 (c)
+          |    +--- org.codehaus.janino:janino:3.1.12 (c)
+          |    +--- javax.cache:cache-api:1.1.1 (c)
+          |    +--- org.jboss.logging:jboss-logging:3.6.1.Final (c)
+          |    +--- org.jooq:jooq:3.19.18 (c)
+          |    +--- com.jayway.jsonpath:json-path:2.9.0 (c)
+          |    +--- org.apache.kafka:kafka-clients:3.9.0 (c)
+          |    +--- org.apache.kafka:kafka-metadata:3.9.0 (c)
+          |    +--- org.apache.kafka:kafka-server:3.9.0 (c)
+          |    +--- org.apache.kafka:kafka-server-common:3.9.0 (c)
+          |    +--- org.apache.kafka:kafka-streams:3.9.0 (c)
+          |    +--- org.apache.kafka:kafka-streams-test-utils:3.9.0 (c)
+          |    +--- org.apache.kafka:kafka_2.13:3.9.0 (c)
+          |    +--- ch.qos.logback:logback-classic:1.5.16 (c)
+          |    +--- ch.qos.logback:logback-core:1.5.16 (c)
+          |    +--- org.mongodb:bson:5.3.1 (c)
+          |    +--- org.mongodb:mongodb-driver-core:5.3.1 (c)
+          |    +--- org.mongodb:mongodb-driver-sync:5.3.1 (c)
+          |    +--- org.quartz-scheduler:quartz:2.5.0 (c)
+          |    +--- org.postgresql:r2dbc-postgresql:1.0.7.RELEASE (c)
+          |    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (c)
+          |    +--- org.springframework.boot:spring-boot:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot (c)
+          |    +--- org.springframework.boot:spring-boot-test:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test (c)
+          |    +--- org.springframework.boot:spring-boot-test-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test-autoconfigure (c)
+          |    +--- org.springframework.boot:spring-boot-testcontainers:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-testcontainers (c)
+          |    +--- org.springframework.boot:spring-boot-actuator:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator (c)
+          |    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator-autoconfigure (c)
+          |    +--- org.springframework.boot:spring-boot-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-autoconfigure (c)
+          |    +--- org.springframework.boot:spring-boot-devtools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-devtools (c)
+          |    +--- org.springframework.boot:spring-boot-docker-compose:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-docker-compose (c)
+          |    +--- org.springframework.boot:spring-boot-loader-tools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools (c)
+          |    +--- org.slf4j:jul-to-slf4j:2.0.16 (c)
+          |    +--- org.slf4j:slf4j-api:2.0.16 (c)
+          |    +--- org.yaml:snakeyaml:2.3 (c)
+          |    +--- org.springframework.graphql:spring-graphql:1.3.3 (c)
+          |    +--- org.springframework.graphql:spring-graphql-test:1.3.3 (c)
+          |    +--- org.springframework.kafka:spring-kafka:3.3.2 (c)
+          |    +--- org.springframework.kafka:spring-kafka-test:3.3.2 (c)
+          |    +--- org.springframework.retry:spring-retry:2.0.11 (c)
+          |    +--- org.apache.tomcat:tomcat-annotations-api:10.1.34 (c)
+          |    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (c)
+          |    +--- io.undertow:undertow-core:2.3.18.Final (c)
+          |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+          |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+          |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3 (*)
+          |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+          |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+          |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1 (*)
+          |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5 (*)
+          |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25 (*)
+          |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+          |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2 (*)
+          |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10 (*)
+          |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+          |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+          |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4 (*)
+          |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+          |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+          |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+          |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3 (*)
+          |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1 (*)
+          |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1 (*)
+          |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2 (*)
+          |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final (*)
+          |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0 (*)
+          |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5 (*)
+          |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+          |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2 (*)
+          |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+          |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2 (*)
+          |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0 (*)
+          |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+          |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+          |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2 (*)
+          |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1 (*)
+          |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2 (*)
+          |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2 (*)
+          |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+          |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2 (*)
+          |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3 (*)
+          |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1 (*)
+          |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+          |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11 (*)
+          |    +--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4 (*)
+          |    +--- org.reactivestreams:reactive-streams:1.0.4 (c)
+          |    +--- org.apache.httpcomponents:httpcore:4.4.16 (c)
+          |    +--- net.bytebuddy:byte-buddy:1.17.0 (c)
+          |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0 (c)
+          |    +--- jakarta.inject:jakarta.inject-api:2.0.1 (c)
+          |    +--- net.bytebuddy:byte-buddy-agent:1.17.0 (c)
+          |    +--- com.rabbitmq:amqp-client:5.24.0 (c)
+          |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+          |    +--- com.couchbase.client:java-client:3.7.7 (c)
+          |    +--- co.elastic.clients:elasticsearch-java:8.15.5 (c)
+          |    +--- org.hibernate.orm:hibernate-envers:6.6.6.Final (c)
+          |    +--- org.neo4j.driver:neo4j-java-driver:5.25.0 (c)
+          |    +--- org.springframework.ldap:spring-ldap-core:3.3.0-M1 (c)
+          |    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10 (c)
+          |    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10 (c)
+          |    +--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10 (c)
+          |    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.2 (c)
+          |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+          |    +--- com.sun.xml.messaging.saaj:saaj-impl:3.0.4 (c)
+          |    +--- org.xmlunit:xmlunit-core:2.10.0 (c)
+          |    +--- junit:junit:4.13.2 (c)
+          |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5 (c)
+          |    +--- jakarta.json:jakarta.json-api:2.1.3 (c)
+          |    +--- org.hamcrest:hamcrest:3.0 (c)
+          |    +--- net.minidev:json-smart:2.5.1 (c)
+          |    +--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+          |    +--- org.hamcrest:hamcrest-core:3.0 (c)
+          |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5 (c)
+          |    \--- org.apache.httpcomponents:httpcore-nio:4.4.16 (c)
+          +--- org.apache.commons:commons-compress:1.25.0 (c)
+          +--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.7.0-alpha (c)
+          +--- org.apiguardian:apiguardian-api:1.1.2 (c)
+          \--- io.micrometer:context-propagation:1.0.5 -> 1.1.2 (c)
+
+testIntransitiveDependenciesMetadata
+No dependencies
+
+testKotlinScriptDef - Script filename extensions discovery classpath configuration
+No dependencies
+
+testKotlinScriptDefExtensions
+No dependencies
+
+testRuntimeClasspath - Runtime classpath of null/test.
++--- project :spring-boot-project:spring-boot-parent
+|    +--- org.codehaus.janino:janino:3.1.10
+|    |    \--- junit:junit:4.13.1 -> 4.13.2 (c)
+|    +--- project :spring-boot-project:spring-boot-dependencies
+|    |    +--- org.apache.activemq:activemq-bom:6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:2.39.0
+|    |    +--- org.assertj:assertj-bom:3.27.3
+|    |    |    \--- org.assertj:assertj-core:3.27.3 (c)
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:4.18.1
+|    |    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+|    |    |    +--- org.apache.cassandra:java-driver-query-builder:4.18.1 (c)
+|    |    |    +--- com.datastax.oss:native-protocol:1.5.1 (c)
+|    |    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1 (c)
+|    |    +--- org.glassfish.jaxb:jaxb-bom:4.0.5
+|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+|    |    |    +--- org.glassfish.jaxb:jaxb-runtime:4.0.5 (c)
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0 (c)
+|    |    |    +--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+|    |    |    +--- org.glassfish.jaxb:jaxb-core:4.0.5 (c)
+|    |    |    +--- org.eclipse.angus:angus-activation:2.0.2 (c)
+|    |    |    +--- org.glassfish.jaxb:txw2:4.0.5 (c)
+|    |    |    \--- com.sun.istack:istack-commons-runtime:4.1.2 (c)
+|    |    +--- org.apache.groovy:groovy-bom:4.0.25
+|    |    |    +--- org.apache.groovy:groovy:4.0.25 (c)
+|    |    |    +--- org.apache.groovy:groovy-xml:4.0.25 (c)
+|    |    |    \--- org.apache.groovy:groovy-json:4.0.25 (c)
+|    |    +--- org.infinispan:infinispan-bom:15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (c)
+|    |    |    +--- com.fasterxml.jackson.module:jackson-module-scala_2.13:2.18.2 (c)
+|    |    |    \--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.18.2 (c)
+|    |    +--- org.glassfish.jersey:jersey-bom:3.1.10
+|    |    |    +--- org.glassfish.jersey.core:jersey-server:3.1.10 (c)
+|    |    |    +--- org.glassfish.jersey.containers:jersey-container-servlet-core:3.1.10 (c)
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (c)
+|    |    |    \--- org.glassfish.jersey.core:jersey-client:3.1.10 (c)
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:12.0.16
+|    |    +--- org.junit:junit-bom:5.11.4
+|    |    |    +--- org.junit.jupiter:junit-jupiter:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-launcher:1.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-params:5.11.4 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-engine:5.11.4 (c)
+|    |    |    +--- org.junit.platform:junit-platform-engine:1.11.4 (c)
+|    |    |    \--- org.junit.platform:junit-platform-commons:1.11.4 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:1.9.25
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25 (c)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:2.24.3
+|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.24.3 (c)
+|    |    |    +--- org.apache.logging.log4j:log4j-api:2.24.3 (c)
+|    |    |    \--- org.jspecify:jspecify:1.0.0 (c)
+|    |    +--- io.micrometer:micrometer-bom:1.15.0-M1
+|    |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:context-propagation:1.1.2 (c)
+|    |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+|    |    |    \--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    |    +--- io.micrometer:micrometer-tracing-bom:1.5.0-M1
+|    |    |    +--- io.micrometer:micrometer-jakarta9:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-graphite:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-registry-jmx:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-tracing:1.5.0-M1 (c)
+|    |    |    +--- io.micrometer:context-propagation:1.1.2 (c)
+|    |    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (c)
+|    |    |    +--- io.micrometer:micrometer-core:1.15.0-M1 (c)
+|    |    |    \--- io.micrometer:micrometer-commons:1.15.0-M1 (c)
+|    |    +--- org.mockito:mockito-bom:5.15.2
+|    |    |    \--- org.mockito:mockito-core:5.15.2 (c)
+|    |    +--- io.netty:netty-bom:4.1.117.Final
+|    |    |    +--- io.netty:netty-codec-http:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec-http2:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-native-epoll:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-handler:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-handler-proxy:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-common:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-codec-dns:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-transport-classes-epoll:4.1.117.Final (c)
+|    |    |    +--- io.netty:netty-tcnative-classes:2.0.69.Final (c)
+|    |    |    \--- io.netty:netty-codec-socks:4.1.117.Final (c)
+|    |    +--- io.opentelemetry:opentelemetry-bom:1.46.0
+|    |    |    +--- io.opentelemetry:opentelemetry-api:1.46.0 (c)
+|    |    |    \--- io.opentelemetry:opentelemetry-context:1.46.0 (c)
+|    |    +--- io.prometheus:prometheus-metrics-bom:1.3.5
+|    |    |    \--- com.google.guava:guava:33.3.1-jre (c)
+|    |    +--- io.prometheus:simpleclient_bom:0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-all:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2 (c)
+|    |    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (c)
+|    |    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2 (c)
+|    |    +--- com.querydsl:querydsl-bom:5.1.0
+|    |    +--- io.projectreactor:reactor-bom:2024.0.2
+|    |    |    +--- io.projectreactor.netty:reactor-netty-http:1.2.2 (c)
+|    |    |    +--- io.projectreactor:reactor-core:3.7.2 (c)
+|    |    |    +--- io.projectreactor.netty:reactor-netty-core:1.2.2 (c)
+|    |    |    \--- org.reactivestreams:reactive-streams:1.0.4 (c)
+|    |    +--- io.rest-assured:rest-assured-bom:5.5.0
+|    |    |    +--- io.rest-assured:rest-assured:5.5.0 (c)
+|    |    |    +--- io.rest-assured:json-path:5.5.0 (c)
+|    |    |    +--- io.rest-assured:xml-path:5.5.0 (c)
+|    |    |    \--- io.rest-assured:rest-assured-common:5.5.0 (c)
+|    |    +--- io.rsocket:rsocket-bom:1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:3.2.2
+|    |    |    +--- org.springframework.amqp:spring-amqp:3.2.2 (c)
+|    |    |    \--- org.springframework.amqp:spring-rabbit:3.2.2 (c)
+|    |    +--- org.springframework.batch:spring-batch-bom:5.2.1
+|    |    |    +--- org.springframework.batch:spring-batch-core:5.2.1 (c)
+|    |    |    \--- org.springframework.batch:spring-batch-infrastructure:5.2.1 (c)
+|    |    +--- org.springframework.data:spring-data-bom:2024.1.2
+|    |    |    +--- org.springframework.data:spring-data-cassandra:4.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-couchbase:5.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-elasticsearch:5.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-r2dbc:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-jpa:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-envers:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-mongodb:4.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-neo4j:7.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-redis:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-ldap:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-commons:3.4.2 (c)
+|    |    |    +--- org.springframework.data:spring-data-relational:3.4.2 (c)
+|    |    |    \--- org.springframework.data:spring-data-keyvalue:3.4.2 (c)
+|    |    +--- org.springframework:spring-framework-bom:6.2.2
+|    |    |    +--- org.springframework:spring-context:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-core:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-core-test:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-jdbc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-jms:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-orm:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-test:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-web:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-webflux:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-webmvc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-websocket:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-messaging:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-tx:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-aop:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-beans:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-expression:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-context-support:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-r2dbc:6.2.2 (c)
+|    |    |    +--- org.springframework:spring-oxm:6.2.2 (c)
+|    |    |    \--- org.springframework:spring-jcl:6.2.2 (c)
+|    |    +--- org.springframework.integration:spring-integration-bom:6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:1.2.2
+|    |    |    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (c)
+|    |    |    +--- org.springframework.pulsar:spring-pulsar-reactive:1.2.2 (c)
+|    |    |    +--- org.springframework.pulsar:spring-pulsar-cache-provider-caffeine:1.2.2 (c)
+|    |    |    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2 (c)
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:3.0.3
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-mockmvc:3.0.3 (c)
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-restassured:3.0.3 (c)
+|    |    |    +--- org.springframework.restdocs:spring-restdocs-webtestclient:3.0.3 (c)
+|    |    |    \--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (c)
+|    |    +--- org.springframework.security:spring-security-bom:6.5.0-M1
+|    |    |    +--- org.springframework.security:spring-security-config:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-crypto:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-oauth2-client:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-test:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-web:6.5.0-M1 (c)
+|    |    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (c)
+|    |    |    \--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1 (c)
+|    |    +--- org.springframework.session:spring-session-bom:3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:4.0.11
+|    |    |    +--- org.springframework.ws:spring-ws-core:4.0.11 (c)
+|    |    |    +--- org.springframework.ws:spring-ws-test:4.0.11 (c)
+|    |    |    \--- org.springframework.ws:spring-xml:4.0.11 (c)
+|    |    +--- org.testcontainers:testcontainers-bom:1.20.4
+|    |    |    +--- org.testcontainers:junit-jupiter:1.20.4 (c)
+|    |    |    +--- org.testcontainers:mongodb:1.20.4 (c)
+|    |    |    +--- org.testcontainers:neo4j:1.20.4 (c)
+|    |    |    \--- org.testcontainers:testcontainers:1.20.4 (c)
+|    |    +--- org.cache2k:cache2k-spring:2.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-dbcp2:2.13.0 (c)
+|    |    +--- com.h2database:h2:2.3.232 (c)
+|    |    +--- org.hamcrest:hamcrest-core:3.0 (c)
+|    |    +--- org.hamcrest:hamcrest-library:3.0 (c)
+|    |    +--- org.hibernate.orm:hibernate-jcache:6.6.6.Final (c)
+|    |    +--- com.zaxxer:HikariCP:6.2.1 (c)
+|    |    +--- org.htmlunit:htmlunit:4.9.0 (c)
+|    |    +--- org.apache.httpcomponents.client5:httpclient5:5.4.2 (c)
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1 (c)
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1 (c)
+|    |    +--- jakarta.jms:jakarta.jms-api:3.1.0 (c)
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0 (c)
+|    |    +--- jakarta.servlet:jakarta.servlet-api:6.0.0 (c)
+|    |    +--- jakarta.validation:jakarta.validation-api:3.0.2 (c)
+|    |    +--- org.codehaus.janino:janino:3.1.12 -> 3.1.10 (c)
+|    |    +--- org.jooq:jooq:3.19.18 (c)
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (c)
+|    |    +--- ch.qos.logback:logback-classic:1.5.16 (c)
+|    |    +--- org.mongodb:mongodb-driver-sync:5.3.1 (c)
+|    |    +--- org.quartz-scheduler:quartz:2.5.0 (c)
+|    |    +--- org.postgresql:r2dbc-postgresql:1.0.7.RELEASE (c)
+|    |    +--- org.springframework.boot:spring-boot:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot (c)
+|    |    +--- org.springframework.boot:spring-boot-test:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test (c)
+|    |    +--- org.springframework.boot:spring-boot-test-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-test-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-testcontainers:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-testcontainers (c)
+|    |    +--- org.springframework.boot:spring-boot-actuator:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator (c)
+|    |    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-actuator-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-autoconfigure:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-autoconfigure (c)
+|    |    +--- org.springframework.boot:spring-boot-devtools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-devtools (c)
+|    |    +--- org.springframework.boot:spring-boot-docker-compose:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-docker-compose (c)
+|    |    +--- org.springframework.boot:spring-boot-loader-tools:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools (c)
+|    |    +--- org.springframework.boot:spring-boot-starter:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter (c)
+|    |    +--- org.springframework.boot:spring-boot-starter-json:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-json (c)
+|    |    +--- org.springframework.boot:spring-boot-starter-tomcat:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-tomcat (c)
+|    |    +--- org.springframework.boot:spring-boot-starter-web:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-web (c)
+|    |    +--- org.slf4j:jul-to-slf4j:2.0.16 (c)
+|    |    +--- org.slf4j:slf4j-simple:2.0.16 (c)
+|    |    +--- org.yaml:snakeyaml:2.3 (c)
+|    |    +--- org.springframework.graphql:spring-graphql:1.3.3 (c)
+|    |    +--- org.springframework.graphql:spring-graphql-test:1.3.3 (c)
+|    |    +--- org.springframework.kafka:spring-kafka:3.3.2 (c)
+|    |    +--- org.springframework.kafka:spring-kafka-test:3.3.2 (c)
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (c)
+|    |    +--- io.undertow:undertow-core:2.3.18.Final (c)
+|    |    +--- org.apache.activemq:activemq-bom:{strictly 6.1.5} -> 6.1.5
+|    |    +--- org.apache.activemq:artemis-bom:{strictly 2.39.0} -> 2.39.0
+|    |    +--- org.assertj:assertj-bom:{strictly 3.27.3} -> 3.27.3 (*)
+|    |    +--- io.zipkin.reporter2:zipkin-reporter-bom:{strictly 3.4.3} -> 3.4.3
+|    |    +--- io.zipkin.brave:brave-bom:{strictly 6.0.3} -> 6.0.3
+|    |    +--- org.apache.cassandra:java-driver-bom:{strictly 4.18.1} -> 4.18.1 (*)
+|    |    +--- org.glassfish.jaxb:jaxb-bom:{strictly 4.0.5} -> 4.0.5 (*)
+|    |    +--- org.apache.groovy:groovy-bom:{strictly 4.0.25} -> 4.0.25 (*)
+|    |    +--- org.infinispan:infinispan-bom:{strictly 15.1.5.Final} -> 15.1.5.Final
+|    |    +--- com.fasterxml.jackson:jackson-bom:{strictly 2.18.2} -> 2.18.2 (*)
+|    |    +--- org.glassfish.jersey:jersey-bom:{strictly 3.1.10} -> 3.1.10 (*)
+|    |    +--- org.eclipse.jetty.ee10:jetty-ee10-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.eclipse.jetty:jetty-bom:{strictly 12.0.16} -> 12.0.16
+|    |    +--- org.junit:junit-bom:{strictly 5.11.4} -> 5.11.4 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-bom:{strictly 1.9.25} -> 1.9.25 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.8.1} -> 1.8.1
+|    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-bom:{strictly 1.6.3} -> 1.6.3
+|    |    +--- org.apache.logging.log4j:log4j-bom:{strictly 2.24.3} -> 2.24.3 (*)
+|    |    +--- io.micrometer:micrometer-bom:{strictly 1.15.0-M1} -> 1.15.0-M1 (*)
+|    |    +--- io.micrometer:micrometer-tracing-bom:{strictly 1.5.0-M1} -> 1.5.0-M1 (*)
+|    |    +--- org.mockito:mockito-bom:{strictly 5.15.2} -> 5.15.2 (*)
+|    |    +--- io.netty:netty-bom:{strictly 4.1.117.Final} -> 4.1.117.Final (*)
+|    |    +--- io.opentelemetry:opentelemetry-bom:{strictly 1.46.0} -> 1.46.0 (*)
+|    |    +--- io.prometheus:prometheus-metrics-bom:{strictly 1.3.5} -> 1.3.5 (*)
+|    |    +--- io.prometheus:simpleclient_bom:{strictly 0.16.0} -> 0.16.0
+|    |    +--- org.apache.pulsar:pulsar-bom:{strictly 4.0.2} -> 4.0.2 (*)
+|    |    +--- com.querydsl:querydsl-bom:{strictly 5.1.0} -> 5.1.0
+|    |    +--- io.projectreactor:reactor-bom:{strictly 2024.0.2} -> 2024.0.2 (*)
+|    |    +--- io.rest-assured:rest-assured-bom:{strictly 5.5.0} -> 5.5.0 (*)
+|    |    +--- io.rsocket:rsocket-bom:{strictly 1.1.5} -> 1.1.5
+|    |    +--- org.seleniumhq.selenium:selenium-bom:{strictly 4.28.1} -> 4.28.1
+|    |    +--- org.springframework.amqp:spring-amqp-bom:{strictly 3.2.2} -> 3.2.2 (*)
+|    |    +--- org.springframework.batch:spring-batch-bom:{strictly 5.2.1} -> 5.2.1 (*)
+|    |    +--- org.springframework.data:spring-data-bom:{strictly 2024.1.2} -> 2024.1.2 (*)
+|    |    +--- org.springframework:spring-framework-bom:{strictly 6.2.2} -> 6.2.2 (*)
+|    |    +--- org.springframework.integration:spring-integration-bom:{strictly 6.5.0-M1} -> 6.5.0-M1
+|    |    +--- org.springframework.pulsar:spring-pulsar-bom:{strictly 1.2.2} -> 1.2.2 (*)
+|    |    +--- org.springframework.restdocs:spring-restdocs-bom:{strictly 3.0.3} -> 3.0.3 (*)
+|    |    +--- org.springframework.security:spring-security-bom:{strictly 6.5.0-M1} -> 6.5.0-M1 (*)
+|    |    +--- org.springframework.session:spring-session-bom:{strictly 3.4.1} -> 3.4.1
+|    |    +--- org.springframework.ws:spring-ws-bom:{strictly 4.0.11} -> 4.0.11 (*)
+|    |    +--- org.testcontainers:testcontainers-bom:{strictly 1.20.4} -> 1.20.4 (*)
+|    |    +--- org.slf4j:slf4j-api:2.0.16 (c)
+|    |    +--- org.apache.httpcomponents:httpcore:4.4.16 (c)
+|    |    +--- org.springframework.boot:spring-boot-starter-logging:3.5.0-SNAPSHOT -> project :spring-boot-project:spring-boot-starters:spring-boot-starter-logging (c)
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-el:10.1.34 (c)
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-websocket:10.1.34 (c)
+|    |    +--- org.cache2k:cache2k-api:2.6.1.Final (c)
+|    |    +--- org.cache2k:cache2k-core:2.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-pool2:2.12.1 (c)
+|    |    +--- jakarta.transaction:jakarta.transaction-api:2.0.1 (c)
+|    |    +--- org.hamcrest:hamcrest:3.0 (c)
+|    |    +--- org.hibernate.orm:hibernate-core:6.6.6.Final (c)
+|    |    +--- javax.cache:cache-api:1.1.1 (c)
+|    |    +--- org.jboss.logging:jboss-logging:3.6.1.Final (c)
+|    |    +--- org.apache.commons:commons-lang3:3.17.0 (c)
+|    |    +--- commons-codec:commons-codec:1.18.0 (c)
+|    |    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3 (c)
+|    |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3 (c)
+|    |    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (c)
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0 (c)
+|    |    +--- ch.qos.logback:logback-core:1.5.16 (c)
+|    |    +--- org.mongodb:bson:5.3.1 (c)
+|    |    +--- org.mongodb:mongodb-driver-core:5.3.1 (c)
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (c)
+|    |    +--- com.graphql-java:graphql-java:22.3 (c)
+|    |    +--- com.jayway.jsonpath:json-path:2.9.0 (c)
+|    |    +--- org.springframework.retry:spring-retry:2.0.11 (c)
+|    |    +--- org.apache.kafka:kafka-server:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-metadata:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-streams-test-utils:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka_2.13:3.9.0 (c)
+|    |    +--- org.apache.tomcat:tomcat-annotations-api:10.1.34 (c)
+|    |    +--- net.bytebuddy:byte-buddy:1.17.0 (c)
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0 (c)
+|    |    +--- net.bytebuddy:byte-buddy-agent:1.17.0 (c)
+|    |    +--- com.rabbitmq:amqp-client:5.24.0 (c)
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (c)
+|    |    +--- com.couchbase.client:java-client:3.7.7 (c)
+|    |    +--- co.elastic.clients:elasticsearch-java:8.15.5 (c)
+|    |    +--- org.hibernate.orm:hibernate-envers:6.6.6.Final (c)
+|    |    +--- org.neo4j.driver:neo4j-java-driver:5.25.0 (c)
+|    |    +--- org.springframework.ldap:spring-ldap-core:3.3.0-M1 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10 (c)
+|    |    +--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10 (c)
+|    |    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.2 (c)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:3.0.4 (c)
+|    |    +--- org.xmlunit:xmlunit-core:2.10.0 (c)
+|    |    +--- junit:junit:4.13.2 (c)
+|    |    +--- jakarta.activation:jakarta.activation-api:2.1.3 (c)
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4 (c)
+|    |    +--- org.apache.kafka:kafka-storage-api:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-raft:3.9.0 (c)
+|    |    +--- org.apache.kafka:kafka-storage:3.9.0 (c)
+|    |    +--- com.fasterxml:classmate:1.7.0 (c)
+|    |    +--- org.mongodb:bson-record-codec:5.3.1 (c)
+|    |    +--- net.minidev:json-smart:2.5.1 (c)
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5 (c)
+|    |    +--- jakarta.json:jakarta.json-api:2.1.3 (c)
+|    |    +--- com.github.ben-manes.caffeine:caffeine:3.2.0 (c)
+|    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5 (c)
+|    |    \--- org.apache.httpcomponents:httpcore-nio:4.4.16 (c)
+|    +--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.7.0-alpha (c)
+|    +--- org.codehaus.janino:janino:{strictly 3.1.10} -> 3.1.10 (*)
+|    +--- com.vaadin.external.google:android-json:0.0.20131108.vaadin1 (c)
+|    +--- jline:jline:2.11 (c)
+|    +--- net.sf.jopt-simple:jopt-simple:5.0.4 (c)
+|    +--- org.apache.commons:commons-compress:1.25.0 (c)
+|    +--- org.apache.maven.resolver:maven-resolver-connector-basic:1.9.14 (c)
+|    +--- org.apache.maven.resolver:maven-resolver-impl:1.9.14 (c)
+|    +--- org.apache.maven:maven-resolver-provider:3.9.4 (c)
+|    +--- org.apache.maven.resolver:maven-resolver-transport-http:1.9.14 (c)
+|    +--- org.apache.maven.resolver:maven-resolver-api:1.9.14 (c)
+|    +--- org.apache.maven.resolver:maven-resolver-spi:1.9.14 (c)
+|    +--- org.apache.maven.resolver:maven-resolver-util:1.9.14 (c)
+|    +--- org.apache.maven:maven-model-builder:3.9.4 (c)
+|    +--- io.micrometer:context-propagation:1.0.5 -> 1.1.2 (c)
+|    \--- org.apiguardian:apiguardian-api:1.1.2 (c)
++--- project :spring-boot-project:spring-boot-actuator
+|    \--- project :spring-boot-project:spring-boot
+|         +--- org.springframework:spring-core -> 6.2.2
+|         |    \--- org.springframework:spring-jcl:6.2.2
+|         \--- org.springframework:spring-context -> 6.2.2
+|              +--- org.springframework:spring-aop:6.2.2
+|              |    +--- org.springframework:spring-beans:6.2.2
+|              |    |    \--- org.springframework:spring-core:6.2.2 (*)
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-beans:6.2.2 (*)
+|              +--- org.springframework:spring-core:6.2.2 (*)
+|              +--- org.springframework:spring-expression:6.2.2
+|              |    \--- org.springframework:spring-core:6.2.2 (*)
+|              \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1
+|                   \--- io.micrometer:micrometer-commons:1.15.0-M1
++--- project :spring-boot-project:spring-boot-actuator-autoconfigure
+|    +--- project :spring-boot-project:spring-boot-actuator (*)
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- project :spring-boot-project:spring-boot-autoconfigure
+|    |    \--- project :spring-boot-project:spring-boot (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind -> 2.18.2
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    \--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310 -> 2.18.2
+|         +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|         +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|         +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|         \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
++--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-docker-compose
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind -> 2.18.2 (*)
+|    \--- com.fasterxml.jackson.module:jackson-module-parameter-names -> 2.18.2
+|         +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|         +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|         \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
++--- project :spring-boot-project:spring-boot-tools:spring-boot-cli
+|    +--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools
+|    |    +--- org.apache.commons:commons-compress -> 1.25.0
+|    |    \--- org.springframework:spring-core -> 6.2.2 (*)
+|    +--- com.vaadin.external.google:android-json -> 0.0.20131108.vaadin1
+|    +--- jline:jline -> 2.11
+|    +--- net.sf.jopt-simple:jopt-simple -> 5.0.4
+|    +--- org.apache.httpcomponents.client5:httpclient5 -> 5.4.2
+|    |    +--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.3.3
+|    |    |    \--- org.apache.httpcomponents.core5:httpcore5:5.3.3
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- org.slf4j:slf4j-simple -> 2.0.16
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    +--- org.springframework:spring-core -> 6.2.2 (*)
+|    \--- org.springframework.security:spring-security-crypto -> 6.5.0-M1
++--- project :spring-boot-project:spring-boot-tools:spring-boot-loader-tools (*)
++--- project :spring-boot-project:spring-boot-test
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- org.springframework:spring-test -> 6.2.2
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- project :spring-boot-project:spring-boot-test-autoconfigure
+|    +--- project :spring-boot-project:spring-boot (*)
+|    +--- project :spring-boot-project:spring-boot-test (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- project :spring-boot-project:spring-boot-testcontainers
+|    +--- project :spring-boot-project:spring-boot-autoconfigure (*)
+|    \--- org.testcontainers:testcontainers -> 1.20.4
+|         +--- junit:junit:4.13.2
+|         |    \--- org.hamcrest:hamcrest-core:1.3 -> 3.0
+|         |         \--- org.hamcrest:hamcrest:3.0
+|         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- org.apache.commons:commons-compress:1.24.0 -> 1.25.0
+|         +--- org.rnorth.duct-tape:duct-tape:1.0.8
+|         |    \--- org.jetbrains:annotations:17.0.0
+|         +--- com.github.docker-java:docker-java-api:3.4.0
+|         |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.3 -> 2.18.2 (*)
+|         |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|         \--- com.github.docker-java:docker-java-transport-zerodep:3.4.0
+|              +--- com.github.docker-java:docker-java-transport:3.4.0
+|              +--- org.slf4j:slf4j-api:1.7.25 -> 2.0.16
+|              \--- net.java.dev.jna:jna:5.13.0
++--- project :spring-boot-project:spring-boot-devtools
+|    +--- project :spring-boot-project:spring-boot (*)
+|    \--- project :spring-boot-project:spring-boot-autoconfigure (*)
++--- ch.qos.logback:logback-classic -> 1.5.16
+|    +--- ch.qos.logback:logback-core:1.5.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- com.zaxxer:HikariCP -> 6.2.1
+|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-jakarta9 -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    |    +--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    |    +--- org.hdrhistogram:HdrHistogram:2.2.2
+|    |    \--- org.latencyutils:LatencyUtils:2.0.3
+|    +--- io.micrometer:micrometer-commons:1.15.0-M1
+|    \--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
++--- io.micrometer:micrometer-tracing -> 1.5.0-M1
+|    +--- io.micrometer:micrometer-observation:1.15.0-M1 (*)
+|    +--- io.micrometer:context-propagation:1.1.2
+|    \--- aopalliance:aopalliance:1.0
++--- io.micrometer:micrometer-registry-graphite -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-graphite:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         +--- com.rabbitmq:amqp-client:5.23.0 -> 5.24.0
+|         |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.micrometer:micrometer-registry-jmx -> 1.15.0-M1
+|    +--- io.micrometer:micrometer-core:1.15.0-M1 (*)
+|    \--- io.dropwizard.metrics:metrics-jmx:4.2.29
+|         +--- io.dropwizard.metrics:metrics-core:4.2.29 (*)
+|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
++--- io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0 -> 2.7.0-alpha
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.41.0-alpha -> 1.45.0-alpha
+|    |    |    \--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0
+|    |    |         \--- io.opentelemetry:opentelemetry-context:1.46.0
+|    |    +--- io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha
+|    |    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0 (*)
+|    +--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:2.7.0-alpha
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.41.0-alpha -> 1.45.0-alpha (*)
+|    |    +--- io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha
+|    |    \--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.7.0 (*)
+|    \--- io.opentelemetry:opentelemetry-api:1.41.0 -> 1.46.0 (*)
++--- io.projectreactor.netty:reactor-netty-http -> 1.2.2
+|    +--- io.netty:netty-codec-http:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final
+|    |    |    \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-transport:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-resolver:4.1.117.Final
+|    |    |         \--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-codec:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport-native-unix-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-common:4.1.117.Final
+|    |         |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         |    \--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-codec:4.1.117.Final (*)
+|    +--- io.netty:netty-codec-http2:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler:4.1.117.Final (*)
+|    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    +--- io.netty:netty-codec-dns:4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    \--- io.netty:netty-handler:4.1.117.Final (*)
+|    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final
+|    |    \--- io.netty:netty-resolver-dns-classes-macos:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-resolver-dns:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final
+|    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    |    \--- io.netty:netty-transport-classes-epoll:4.1.117.Final
+|    |         +--- io.netty:netty-common:4.1.117.Final
+|    |         +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |         +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |         \--- io.netty:netty-transport-native-unix-common:4.1.117.Final (*)
+|    +--- io.projectreactor.netty:reactor-netty-core:1.2.2
+|    |    +--- io.netty:netty-handler:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-handler-proxy:4.1.116.Final -> 4.1.117.Final
+|    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    +--- io.netty:netty-codec-socks:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-common:4.1.117.Final
+|    |    |    |    +--- io.netty:netty-buffer:4.1.117.Final (*)
+|    |    |    |    +--- io.netty:netty-transport:4.1.117.Final (*)
+|    |    |    |    \--- io.netty:netty-codec:4.1.117.Final (*)
+|    |    |    \--- io.netty:netty-codec-http:4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.116.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.116.Final -> 4.1.117.Final (*)
+|    |    \--- io.projectreactor:reactor-core:3.7.2
+|    |         \--- org.reactivestreams:reactive-streams:1.0.4
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- io.undertow:undertow-core -> 2.3.18.Final
+|    +--- org.jboss.logging:jboss-logging:3.4.3.Final -> 3.6.1.Final
+|    +--- org.jboss.xnio:xnio-api:3.8.16.Final
+|    |    +--- org.wildfly.common:wildfly-common:1.5.4.Final
+|    |    +--- org.wildfly.client:wildfly-client-config:1.0.1.Final
+|    |    |    \--- org.jboss.logging:jboss-logging:3.3.1.Final -> 3.6.1.Final
+|    |    \--- org.jboss.threads:jboss-threads:2.3.6.Final -> 3.5.0.Final
+|    |         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.6.1.Final
+|    |         \--- org.wildfly.common:wildfly-common:1.5.0.Final -> 1.5.4.Final
+|    +--- org.jboss.xnio:xnio-nio:3.8.16.Final
+|    |    \--- org.jboss.xnio:xnio-api:3.8.16.Final (*)
+|    \--- org.jboss.threads:jboss-threads:3.5.0.Final (*)
++--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
++--- jakarta.jms:jakarta.jms-api -> 3.1.0
++--- jakarta.persistence:jakarta.persistence-api -> 3.1.0
++--- jakarta.servlet:jakarta.servlet-api -> 6.0.0
++--- jakarta.validation:jakarta.validation-api -> 3.0.2
++--- org.apache.httpcomponents.client5:httpclient5 -> 5.4.2 (*)
++--- org.apache.commons:commons-dbcp2 -> 2.13.0
+|    +--- org.apache.commons:commons-pool2:2.12.0 -> 2.12.1
+|    \--- jakarta.transaction:jakarta.transaction-api:1.3.3 -> 2.0.1
++--- org.apache.kafka:kafka-streams -> 3.9.0
+|    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- com.fasterxml.jackson.core:jackson-annotations:2.16.2 -> 2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    +--- org.apache.kafka:kafka-clients:3.9.0
+|    |    +--- com.github.luben:zstd-jni:1.5.6-4
+|    |    +--- org.lz4:lz4-java:1.8.0
+|    |    +--- org.xerial.snappy:snappy-java:1.1.10.5
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    \--- org.rocksdb:rocksdbjni:7.9.2
++--- org.apache.logging.log4j:log4j-to-slf4j -> 2.24.3
+|    +--- org.apache.logging.log4j:log4j-api:2.24.3
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.apache.tomcat.embed:tomcat-embed-core -> 10.1.34
+|    \--- org.apache.tomcat:tomcat-annotations-api:10.1.34
++--- org.assertj:assertj-core -> 3.27.3
+|    \--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
++--- org.cache2k:cache2k-spring -> 2.6.1.Final
+|    +--- org.cache2k:cache2k-api:2.6.1.Final
+|    \--- org.cache2k:cache2k-core:2.6.1.Final
+|         \--- org.cache2k:cache2k-api:2.6.1.Final
++--- org.apache.groovy:groovy -> 4.0.25
+|    \--- org.apache.groovy:groovy-bom:4.0.25 (*)
++--- org.glassfish.jersey.containers:jersey-container-servlet-core -> 3.1.10
+|    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    +--- org.glassfish.jersey.core:jersey-common:3.1.10
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- org.glassfish.hk2:osgi-resource-locator:1.0.3
+|    +--- org.glassfish.jersey.core:jersey-server:3.1.10
+|    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    +--- org.glassfish.jersey.core:jersey-client:3.1.10
+|    |    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    |    +--- org.glassfish.jersey.core:jersey-common:3.1.10 (*)
+|    |    |    \--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- jakarta.validation:jakarta.validation-api:3.0.2
+|    \--- jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
++--- org.glassfish.jersey.core:jersey-server -> 3.1.10 (*)
++--- org.hibernate.orm:hibernate-jcache -> 6.6.6.Final
+|    +--- org.hibernate.orm:hibernate-core:6.6.6.Final
+|    |    +--- jakarta.persistence:jakarta.persistence-api:3.1.0
+|    |    +--- jakarta.transaction:jakarta.transaction-api:2.0.1
+|    |    +--- org.jboss.logging:jboss-logging:3.5.0.Final -> 3.6.1.Final
+|    |    +--- org.hibernate.common:hibernate-commons-annotations:7.0.3.Final
+|    |    +--- io.smallrye:jandex:3.2.0
+|    |    +--- com.fasterxml:classmate:1.5.1 -> 1.7.0
+|    |    +--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2
+|    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    +--- org.glassfish.jaxb:jaxb-runtime:4.0.2 -> 4.0.5
+|    |    |    \--- org.glassfish.jaxb:jaxb-core:4.0.5
+|    |    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (*)
+|    |    |         +--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    |         +--- org.eclipse.angus:angus-activation:2.0.2
+|    |    |         |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    |         +--- org.glassfish.jaxb:txw2:4.0.5
+|    |    |         \--- com.sun.istack:istack-commons-runtime:4.1.2
+|    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    \--- org.antlr:antlr4-runtime:4.13.0
+|    +--- javax.cache:cache-api:1.0.0 -> 1.1.1
+|    \--- org.jboss.logging:jboss-logging:3.5.0.Final -> 3.6.1.Final
++--- org.htmlunit:htmlunit -> 4.9.0
+|    +--- org.apache.httpcomponents:httpmime:4.5.14
+|    |    \--- org.apache.httpcomponents:httpclient:4.5.14
+|    |         +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |         \--- commons-codec:commons-codec:1.11 -> 1.18.0
+|    +--- org.htmlunit:htmlunit-core-js:4.9.0
+|    +--- org.htmlunit:neko-htmlunit:4.9.0
+|    +--- org.htmlunit:htmlunit-cssparser:4.9.0
+|    +--- org.htmlunit:htmlunit-xpath:4.9.0
+|    +--- org.htmlunit:htmlunit-csp:4.9.0
+|    +--- org.htmlunit:htmlunit-websocket-client:4.9.0
+|    +--- org.apache.commons:commons-lang3:3.17.0
+|    +--- commons-io:commons-io:2.18.0
+|    +--- commons-codec:commons-codec:1.17.2 -> 1.18.0
+|    \--- org.brotli:dec:0.1.2
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.25
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+|    |    +--- org.jetbrains:annotations:13.0 -> 17.0.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.25 (c)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.25 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.25
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 (*)
++--- org.jooq:jooq -> 3.19.18
+|    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE
+|         \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
++--- org.mockito:mockito-core -> 5.15.2
+|    +--- net.bytebuddy:byte-buddy:1.15.11 -> 1.17.0
+|    +--- net.bytebuddy:byte-buddy-agent:1.15.11 -> 1.17.0
+|    \--- org.objenesis:objenesis:3.3
++--- org.mongodb:mongodb-driver-sync -> 5.3.1
+|    +--- org.mongodb:bson:5.3.1
+|    \--- org.mongodb:mongodb-driver-core:5.3.1
+|         +--- org.mongodb:bson:5.3.1
+|         \--- org.mongodb:bson-record-codec:5.3.1
+|              \--- org.mongodb:bson:5.3.1
++--- org.postgresql:r2dbc-postgresql -> 1.0.7.RELEASE
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- com.ongres.scram:client:2.1
+|    |    \--- com.ongres.scram:common:2.1
+|    |         \--- com.ongres.stringprep:saslprep:1.1
+|    |              \--- com.ongres.stringprep:stringprep:1.1
+|    +--- io.projectreactor:reactor-core:3.5.20 -> 3.7.2 (*)
+|    \--- io.projectreactor.netty:reactor-netty-core:1.1.22 -> 1.2.2 (*)
++--- org.quartz-scheduler:quartz -> 2.5.0
+|    +--- org.slf4j:slf4j-api:2.0.16
+|    \--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (*)
++--- org.slf4j:jul-to-slf4j -> 2.0.16
+|    \--- org.slf4j:slf4j-api:2.0.16
++--- org.springframework:spring-jdbc -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework:spring-jms -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-orm -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    \--- org.springframework:spring-tx:6.2.2 (*)
++--- org.springframework:spring-test -> 6.2.2 (*)
++--- org.springframework:spring-web -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework:spring-webflux -> 6.2.2
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    \--- io.projectreactor:reactor-core:3.7.2 (*)
++--- org.springframework:spring-webmvc -> 6.2.2
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework:spring-websocket -> 6.2.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-web:6.2.2 (*)
++--- org.springframework.amqp:spring-amqp -> 3.2.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework.retry:spring-retry:2.0.11
++--- org.springframework.amqp:spring-rabbit -> 3.2.2
+|    +--- org.springframework.amqp:spring-amqp:3.2.2 (*)
+|    +--- com.rabbitmq:amqp-client:5.22.0 -> 5.24.0 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.batch:spring-batch-core -> 5.2.1
+|    +--- org.springframework.batch:spring-batch-infrastructure:5.2.1
+|    |    +--- org.springframework:spring-core:6.2.1 -> 6.2.2 (*)
+|    |    \--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.springframework:spring-aop:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.1 -> 6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.1 -> 6.2.2 (*)
+|    +--- io.micrometer:micrometer-core:1.14.2 -> 1.15.0-M1 (*)
+|    +--- io.micrometer:micrometer-observation:1.14.2 -> 1.15.0-M1 (*)
+|    \--- org.springframework.data:spring-data-commons:3.4.1 -> 3.4.2
+|         +--- org.springframework:spring-core:6.2.2 (*)
+|         +--- org.springframework:spring-beans:6.2.2 (*)
+|         \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-cassandra -> 4.4.2
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.apache.cassandra:java-driver-core:4.18.0 -> 4.18.1
+|    |    +--- com.datastax.oss:native-protocol:1.5.1
+|    |    +--- io.netty:netty-handler:4.1.94.Final -> 4.1.117.Final (*)
+|    |    +--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    |    +--- com.typesafe:config:1.4.1
+|    |    +--- com.github.jnr:jnr-posix:3.1.15
+|    |    |    +--- com.github.jnr:jnr-ffi:2.2.11
+|    |    |    |    +--- com.github.jnr:jffi:1.3.9
+|    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    +--- org.ow2.asm:asm-commons:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2
+|    |    |    |    |    |    \--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2
+|    |    |    |    |         \--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    +--- org.ow2.asm:asm-util:9.2
+|    |    |    |    |    +--- org.ow2.asm:asm:9.2 -> 9.6
+|    |    |    |    |    +--- org.ow2.asm:asm-tree:9.2 (*)
+|    |    |    |    |    \--- org.ow2.asm:asm-analysis:9.2 (*)
+|    |    |    |    +--- com.github.jnr:jnr-a64asm:1.0.0
+|    |    |    |    \--- com.github.jnr:jnr-x86asm:1.0.2
+|    |    |    \--- com.github.jnr:jnr-constants:0.10.3
+|    |    +--- org.slf4j:slf4j-api:1.7.26 -> 2.0.16
+|    |    +--- io.dropwizard.metrics:metrics-core:4.1.18 -> 4.2.29 (*)
+|    |    +--- org.hdrhistogram:HdrHistogram:2.1.12 -> 2.2.2
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.4 -> 2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 -> 2.18.2 (*)
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- org.apache.cassandra:java-driver-query-builder:4.18.0 -> 4.18.1
+|    |    +--- org.apache.cassandra:java-driver-core:4.18.1 (*)
+|    |    \--- com.datastax.oss:java-driver-shaded-guava:25.1-jre-graal-sub-1
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-couchbase -> 5.4.2
+|    +--- org.springframework:spring-context-support:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- com.couchbase.client:java-client:3.7.7
+|    |    \--- com.couchbase.client:core-io:3.7.7
+|    |         +--- io.projectreactor:reactor-core:3.6.9 -> 3.7.2 (*)
+|    |         +--- org.reactivestreams:reactive-streams:1.0.4
+|    |         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-elasticsearch -> 5.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- co.elastic.clients:elasticsearch-java:8.15.5
+|    |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.15.5
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.5.14 (*)
+|    |    |    +--- org.apache.httpcomponents:httpcore:4.4.13 -> 4.4.16
+|    |    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5
+|    |    |    +--- org.apache.httpcomponents:httpcore-nio:4.4.13 -> 4.4.16
+|    |    |    \--- commons-codec:commons-codec:1.15 -> 1.18.0
+|    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    +--- jakarta.json:jakarta.json-api:2.0.1 -> 2.1.3
+|    |    +--- org.eclipse.parsson:parsson:1.0.5
+|    |    |    \--- jakarta.json:jakarta.json-api:2.0.2 -> 2.1.3
+|    |    \--- io.opentelemetry:opentelemetry-api:1.29.0 -> 1.46.0 (*)
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-envers -> 3.4.2
+|    +--- org.springframework.data:spring-data-jpa:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-orm:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.antlr:antlr4-runtime:4.13.0
+|    |    +--- jakarta.annotation:jakarta.annotation-api:2.0.0 -> 2.1.1
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.hibernate.orm:hibernate-envers:6.6.4.Final -> 6.6.6.Final
+|    |    +--- org.hibernate.orm:hibernate-core:6.6.6.Final (*)
+|    |    +--- org.jboss.logging:jboss-logging:3.5.0.Final -> 3.6.1.Final
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2 (*)
+|    |    +--- org.glassfish.jaxb:jaxb-runtime:4.0.2 -> 4.0.5 (*)
+|    |    +--- org.hibernate.common:hibernate-commons-annotations:7.0.3.Final
+|    |    \--- io.smallrye:jandex:3.2.0
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-jpa -> 3.4.2 (*)
++--- org.springframework.data:spring-data-ldap -> 3.4.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.ldap:spring-ldap-core:3.2.10 -> 3.3.0-M1
+|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- org.springframework:spring-core:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.1.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.1.16 -> 6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-core:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-mongodb -> 4.4.2
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-expression:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.mongodb:mongodb-driver-core:5.2.1 -> 5.3.1 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-neo4j -> 7.4.2
+|    +--- jakarta.transaction:jakarta.transaction-api:2.0.0 -> 2.0.1
+|    +--- org.apiguardian:apiguardian-api:1.1.1 -> 1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl:2024.2.0
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    +--- org.neo4j:neo4j-cypher-dsl-schema-name-support:2024.2.0
+|    +--- org.neo4j.driver:neo4j-java-driver:5.25.0
+|    |    +--- org.reactivestreams:reactive-streams:1.0.4
+|    |    +--- io.netty:netty-handler:4.1.113.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-tcnative-classes:2.0.66.Final -> 2.0.69.Final
+|    |    \--- io.projectreactor:reactor-core:3.6.10 -> 3.7.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-redis -> 3.4.2
+|    +--- org.springframework.data:spring-data-keyvalue:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.2.2
+|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:3.0.1 -> 4.0.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    \--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-context-support:6.2.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.data:spring-data-r2dbc -> 3.4.2
+|    +--- org.springframework.data:spring-data-relational:3.4.2
+|    |    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework.data:spring-data-commons:3.4.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-jdbc:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    +--- org.springframework:spring-r2dbc:6.2.2
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-tx:6.2.2 (*)
+|    |    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    |    \--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.r2dbc:r2dbc-spi:1.0.0.RELEASE (*)
+|    +--- io.projectreactor:reactor-core:3.7.2 (*)
+|    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
++--- org.springframework.graphql:spring-graphql -> 1.3.3
+|    +--- io.micrometer:context-propagation:1.1.2
+|    +--- com.graphql-java:graphql-java:22.3
+|    |    +--- com.graphql-java:java-dataloader:3.3.0
+|    |    |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    \--- org.reactivestreams:reactive-streams:1.0.3 -> 1.0.4
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    \--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
++--- org.springframework.graphql:spring-graphql-test -> 1.3.3
+|    +--- org.springframework.graphql:spring-graphql:1.3.3 (*)
+|    +--- com.graphql-java:graphql-java:22.3 (*)
+|    +--- io.projectreactor:reactor-core:3.6.11 -> 3.7.2 (*)
+|    +--- org.springframework:spring-context:6.1.14 -> 6.2.2 (*)
+|    +--- org.springframework:spring-test:6.1.14 -> 6.2.2 (*)
+|    \--- com.jayway.jsonpath:json-path:2.9.0
+|         +--- net.minidev:json-smart:2.5.0 -> 2.5.1
+|         |    \--- net.minidev:accessors-smart:2.5.1
+|         |         \--- org.ow2.asm:asm:9.6
+|         \--- org.slf4j:slf4j-api:2.0.11 -> 2.0.16
++--- org.springframework.kafka:spring-kafka -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0 (*)
+|    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
++--- org.springframework.kafka:spring-kafka-test -> 3.3.2
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-test:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    +--- org.apache.zookeeper:zookeeper:3.8.4
+|    |    +--- org.apache.zookeeper:zookeeper-jute:3.8.4
+|    |    |    \--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- org.apache.yetus:audience-annotations:0.12.0
+|    |    +--- io.netty:netty-handler:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- io.netty:netty-transport-native-epoll:4.1.105.Final -> 4.1.117.Final (*)
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+|    |    +--- ch.qos.logback:logback-core:1.2.13 -> 1.5.16
+|    |    +--- ch.qos.logback:logback-classic:1.2.13 -> 1.5.16 (*)
+|    |    \--- commons-io:commons-io:2.11.0 -> 2.18.0
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.9.0 (*)
+|    +--- org.apache.kafka:kafka-server:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-metadata:3.9.0
+|    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    |    +--- com.yammer.metrics:metrics-core:2.2.0
+|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.2 -> 2.0.16
+|    |    |    |    +--- net.sf.jopt-simple:jopt-simple:5.0.4
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    |    +--- org.pcollections:pcollections:4.0.1
+|    |    |    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-raft:3.9.0
+|    |    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.2 -> 2.18.2
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    |    \--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-storage:3.9.0
+|    |    |    +--- org.apache.kafka:kafka-storage-api:3.9.0
+|    |    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    |    |    +--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-transaction-coordinator:3.9.0
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- com.github.ben-manes.caffeine:caffeine:2.9.3 -> 3.2.0
+|    |    |    |    +--- org.jspecify:jspecify:1.0.0
+|    |    |    |    \--- com.google.errorprone:error_prone_annotations:2.36.0
+|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    \--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- org.apache.kafka:kafka-group-coordinator:3.9.0
+|    |    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-metadata:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-group-coordinator-api:3.9.0
+|    |    |    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    |    +--- org.apache.kafka:kafka-storage:3.9.0 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.2 -> 2.18.2 (*)
+|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    \--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- org.apache.kafka:kafka-transaction-coordinator:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-raft:3.9.0 (*)
+|    |    +--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- org.apache.kafka:kafka-metadata:3.8.1 -> 3.9.0 (*)
+|    +--- org.apache.kafka:kafka-server-common:3.8.1 -> 3.9.0 (*)
+|    +--- org.apache.kafka:kafka-streams-test-utils:3.8.1 -> 3.9.0
+|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- org.apache.kafka:kafka-streams:3.9.0 (*)
+|    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    +--- org.apache.kafka:kafka_2.13:3.8.1 -> 3.9.0
+|    |    +--- org.apache.kafka:kafka-server-common:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-group-coordinator-api:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-group-coordinator:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-transaction-coordinator:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-metadata:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-storage-api:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-tools-api:3.9.0
+|    |    |    \--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-raft:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-storage:3.9.0 (*)
+|    |    +--- org.apache.kafka:kafka-server:3.9.0 (*)
+|    |    +--- net.sourceforge.argparse4j:argparse4j:0.7.0
+|    |    +--- commons-validator:commons-validator:1.7
+|    |    |    +--- commons-beanutils:commons-beanutils:1.9.4
+|    |    |    |    \--- commons-collections:commons-collections:3.2.2
+|    |    |    +--- commons-digester:commons-digester:2.1
+|    |    |    \--- commons-collections:commons-collections:3.2.2
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.16.2 -> 2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-scala_2.13:2.16.2 -> 2.18.2
+|    |    |    +--- org.scala-lang:scala-library:2.13.15
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    |    |    \--- com.thoughtworks.paranamer:paranamer:2.8
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.16.2 -> 2.18.2
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.2 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.2 -> 2.18.2 (*)
+|    |    +--- net.sf.jopt-simple:jopt-simple:5.0.4
+|    |    +--- org.bitbucket.b_c:jose4j:0.9.4
+|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- com.yammer.metrics:metrics-core:2.2.0 (*)
+|    |    +--- org.scala-lang.modules:scala-collection-compat_2.13:2.10.0
+|    |    |    \--- org.scala-lang:scala-library:2.13.10 -> 2.13.15
+|    |    +--- org.scala-lang.modules:scala-java8-compat_2.13:1.0.2
+|    |    |    \--- org.scala-lang:scala-library:2.13.6 -> 2.13.15
+|    |    +--- org.scala-lang:scala-reflect:2.13.14
+|    |    |    \--- org.scala-lang:scala-library:2.13.14 -> 2.13.15
+|    |    +--- com.typesafe.scala-logging:scala-logging_2.13:3.9.5
+|    |    |    +--- org.scala-lang:scala-library:2.13.8 -> 2.13.15
+|    |    |    +--- org.scala-lang:scala-reflect:2.13.8 -> 2.13.14 (*)
+|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- commons-io:commons-io:2.14.0 -> 2.18.0
+|    |    +--- io.dropwizard.metrics:metrics-core:4.1.12.1 -> 4.2.29 (*)
+|    |    +--- org.apache.zookeeper:zookeeper:3.8.4 (*)
+|    |    +--- commons-cli:commons-cli:1.4
+|    |    +--- org.apache.kafka:kafka-clients:3.9.0 (*)
+|    |    \--- org.scala-lang:scala-library:2.13.14 -> 2.13.15
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4
+|    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    +--- org.opentest4j:opentest4j:1.3.0
+|    |    \--- org.junit.platform:junit-platform-commons:1.11.4
+|    |         \--- org.junit:junit-bom:5.11.4 (*)
+|    \--- org.junit.platform:junit-platform-launcher:1.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         \--- org.junit.platform:junit-platform-engine:1.11.4
+|              +--- org.junit:junit-bom:5.11.4 (*)
+|              +--- org.opentest4j:opentest4j:1.3.0
+|              \--- org.junit.platform:junit-platform-commons:1.11.4 (*)
++--- org.springframework.pulsar:spring-pulsar -> 1.2.2
+|    +--- org.springframework.pulsar:spring-pulsar-cache-provider-caffeine:1.2.2
+|    |    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.apache.pulsar:pulsar-client-all:3.3.4 -> 4.0.2
+|    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    +--- org.apache.pulsar:bouncy-castle-bc:4.0.2
+|    |    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1
+|    |    |    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    |    \--- org.bouncycastle:bcutil-jdk18on:1.78.1
+|    |    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    |    \--- org.bouncycastle:bcprov-ext-jdk18on:1.78.1
+|    |    |         \--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- org.bouncycastle:bcpkix-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcutil-jdk18on:1.78.1 (*)
+|    |    +--- org.bouncycastle:bcprov-jdk18on:1.78.1
+|    |    +--- io.opentelemetry:opentelemetry-api:1.45.0 -> 1.46.0 (*)
+|    |    +--- io.opentelemetry:opentelemetry-context:1.45.0 -> 1.46.0
+|    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.45.0-alpha (*)
+|    |    +--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.17.2 -> 2.18.2 (*)
+|    |    +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2
+|    |    |    +--- org.apache.pulsar:pulsar-client-api:4.0.2
+|    |    |    \--- org.slf4j:slf4j-api:2.0.13 -> 2.0.16
+|    |    \--- org.apache.pulsar:pulsar-package-core:4.0.2
+|    |         +--- org.apache.pulsar:pulsar-client-admin-api:4.0.2 (*)
+|    |         +--- com.google.guava:guava:32.1.2-jre -> 33.3.1-jre
+|    |         |    +--- com.google.guava:failureaccess:1.0.2
+|    |         |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |         |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |         |    +--- org.checkerframework:checker-qual:3.43.0
+|    |         |    +--- com.google.errorprone:error_prone_annotations:2.28.0 -> 2.36.0
+|    |         |    \--- com.google.j2objc:j2objc-annotations:3.0.0
+|    |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    +--- org.springframework:spring-messaging:6.2.2 (*)
+|    +--- org.springframework:spring-tx:6.2.2 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.11
+|    \--- org.springframework.pulsar:spring-pulsar-cache-provider:1.2.2
++--- org.springframework.pulsar:spring-pulsar-reactive -> 1.2.2
+|    +--- com.fasterxml.jackson.core:jackson-core:2.18.2 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.18.2 (*)
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.springframework.pulsar:spring-pulsar:1.2.2 (*)
+|    +--- org.apache.pulsar:pulsar-client-reactive-api:0.5.10
+|    |    +--- org.jctools:jctools-core:3.3.0
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    +--- org.apache.pulsar:pulsar-client-reactive-adapter:0.5.10
+|    |    +--- io.projectreactor:reactor-core:3.6.13 -> 3.7.2 (*)
+|    |    \--- org.slf4j:slf4j-api:2.0.16
+|    \--- org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.5.10
++--- org.springframework.restdocs:spring-restdocs-mockmvc -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.14.0 -> 2.18.2 (*)
+|    |    \--- org.springframework:spring-web:6.1.13 -> 6.2.2 (*)
+|    +--- org.springframework:spring-webmvc:6.1.13 -> 6.2.2 (*)
+|    +--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
+|    \--- jakarta.servlet:jakarta.servlet-api:6.0.0
++--- org.springframework.restdocs:spring-restdocs-restassured -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (*)
+|    +--- io.rest-assured:rest-assured:5.2.1 -> 5.5.0
+|    |    +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|    |    +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25
+|    |    |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|    |    |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|    |    +--- org.apache.httpcomponents:httpclient:4.5.13 -> 4.5.14 (*)
+|    |    +--- org.apache.httpcomponents:httpmime:4.5.13 -> 4.5.14 (*)
+|    |    +--- org.hamcrest:hamcrest:2.2 -> 3.0
+|    |    +--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
+|    |    +--- io.rest-assured:json-path:5.5.0
+|    |    |    +--- org.apache.groovy:groovy-json:4.0.22 -> 4.0.25
+|    |    |    |    +--- org.apache.groovy:groovy-bom:4.0.25 (*)
+|    |    |    |    \--- org.apache.groovy:groovy:4.0.25 (*)
+|    |    |    +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|    |    |    \--- io.rest-assured:rest-assured-common:5.5.0
+|    |    |         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|    |    |         \--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    |    \--- io.rest-assured:xml-path:5.5.0
+|    |         +--- org.apache.groovy:groovy-xml:4.0.22 -> 4.0.25 (*)
+|    |         +--- org.apache.groovy:groovy:4.0.22 -> 4.0.25 (*)
+|    |         +--- io.rest-assured:rest-assured-common:5.5.0 (*)
+|    |         +--- org.apache.commons:commons-lang3:3.11 -> 3.17.0
+|    |         \--- org.ccil.cowan.tagsoup:tagsoup:1.2.1
+|    \--- org.springframework:spring-web:6.1.13 -> 6.2.2 (*)
++--- org.springframework.restdocs:spring-restdocs-webtestclient -> 3.0.3
+|    +--- org.springframework.restdocs:spring-restdocs-core:3.0.3 (*)
+|    +--- org.springframework:spring-test:6.1.13 -> 6.2.2 (*)
+|    \--- org.springframework:spring-webflux:6.1.13 -> 6.2.2 (*)
++--- org.springframework.security:spring-security-config -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-crypto:6.5.0-M1
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- io.micrometer:micrometer-observation:1.14.3 -> 1.15.0-M1 (*)
+|    +--- org.springframework:spring-aop:6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.2.2 (*)
+|    +--- org.springframework:spring-context:6.2.2 (*)
+|    \--- org.springframework:spring-core:6.2.2 (*)
++--- org.springframework.security:spring-security-oauth2-client -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-oauth2-core:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1
+|    |    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    |    +--- org.springframework:spring-core:6.2.2 (*)
+|    |    +--- org.springframework:spring-aop:6.2.2 (*)
+|    |    +--- org.springframework:spring-beans:6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.2.2 (*)
+|    |    +--- org.springframework:spring-expression:6.2.2 (*)
+|    |    \--- org.springframework:spring-web:6.2.2 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- com.nimbusds:oauth2-oidc-sdk:9.43.4
+|         +--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|         +--- com.nimbusds:content-type:2.2
+|         +--- net.minidev:json-smart:[1.3.3,2.4.10] -> 2.5.1 (*)
+|         +--- com.nimbusds:lang-tag:1.7
+|         \--- com.nimbusds:nimbus-jose-jwt:9.37.3
+|              \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
++--- org.springframework.security:spring-security-test -> 6.5.0-M1
+|    +--- org.springframework.security:spring-security-core:6.5.0-M1 (*)
+|    +--- org.springframework.security:spring-security-web:6.5.0-M1 (*)
+|    +--- org.springframework:spring-core:6.2.2 (*)
+|    \--- org.springframework:spring-test:6.2.2 (*)
++--- org.springframework.security:spring-security-web -> 6.5.0-M1 (*)
++--- org.springframework.ws:spring-ws-core -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11
+|    |    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    |    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    |    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4
+|    |    |    +--- org.jvnet.staxex:stax-ex:2.1.0
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.0 -> 2.1.3
+|    |    |    +--- jakarta.activation:jakarta.activation-api:2.1.3
+|    |    |    \--- org.eclipse.angus:angus-activation:2.0.2 (*)
+|    |    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
+|    +--- org.springframework:spring-aop:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-beans:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-oxm:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-web:6.0.16 -> 6.2.2 (*)
+|    +--- org.springframework:spring-webmvc:6.0.16 -> 6.2.2 (*)
+|    +--- jakarta.xml.soap:jakarta.xml.soap-api:3.0.0 -> 3.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0 -> 4.0.2 (*)
+|    +--- org.glassfish.jaxb:jaxb-runtime:4.0.1 -> 4.0.5 (*)
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.springframework.ws:spring-ws-test -> 4.0.11
+|    +--- org.springframework.ws:spring-xml:4.0.11 (*)
+|    +--- org.springframework.ws:spring-ws-core:4.0.11 (*)
+|    +--- org.springframework:spring-context:6.0.16 -> 6.2.2 (*)
+|    +--- xmlunit:xmlunit:1.6
+|    +--- org.xmlunit:xmlunit-core:2.9.0 -> 2.10.0
+|    +--- org.springframework:spring-core:6.0.16 -> 6.2.2 (*)
+|    +--- com.sun.xml.messaging.saaj:saaj-impl:2.0.1 -> 3.0.4 (*)
+|    \--- org.jvnet.staxex:stax-ex:2.0.1 -> 2.1.0 (*)
++--- org.testcontainers:junit-jupiter -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:neo4j -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.testcontainers:mongodb -> 1.20.4
+|    \--- org.testcontainers:testcontainers:1.20.4 (*)
++--- org.junit.jupiter:junit-jupiter -> 5.11.4
+|    +--- org.junit:junit-bom:5.11.4 (*)
+|    +--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|    +--- org.junit.jupiter:junit-jupiter-params:5.11.4
+|    |    +--- org.junit:junit-bom:5.11.4 (*)
+|    |    \--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
+|    \--- org.junit.jupiter:junit-jupiter-engine:5.11.4
+|         +--- org.junit:junit-bom:5.11.4 (*)
+|         +--- org.junit.platform:junit-platform-engine:1.11.4 (*)
+|         \--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
++--- org.yaml:snakeyaml -> 2.3
++--- project :spring-boot-project:spring-boot-tools:spring-boot-test-support
+|    +--- project :spring-boot-project:spring-boot-parent (*)
+|    +--- jakarta.inject:jakarta.inject-api -> 2.0.1
+|    +--- org.apache.maven.resolver:maven-resolver-connector-basic -> 1.9.14
+|    |    +--- org.apache.maven.resolver:maven-resolver-api:1.9.14
+|    |    +--- org.apache.maven.resolver:maven-resolver-spi:1.9.14
+|    |    |    \--- org.apache.maven.resolver:maven-resolver-api:1.9.14
+|    |    +--- org.apache.maven.resolver:maven-resolver-util:1.9.14
+|    |    |    \--- org.apache.maven.resolver:maven-resolver-api:1.9.14
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- org.apache.maven.resolver:maven-resolver-impl -> 1.9.14
+|    |    +--- org.apache.maven.resolver:maven-resolver-api:1.9.14
+|    |    +--- org.apache.maven.resolver:maven-resolver-spi:1.9.14 (*)
+|    |    +--- org.apache.maven.resolver:maven-resolver-named-locks:1.9.14
+|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- org.apache.maven.resolver:maven-resolver-util:1.9.14 (*)
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- org.apache.maven:maven-resolver-provider -> 3.9.4
+|    |    +--- org.apache.maven:maven-model:3.9.4
+|    |    |    \--- org.codehaus.plexus:plexus-utils:3.5.1
+|    |    +--- org.apache.maven:maven-model-builder:3.9.4
+|    |    |    +--- org.codehaus.plexus:plexus-utils:3.5.1
+|    |    |    +--- org.codehaus.plexus:plexus-interpolation:1.26
+|    |    |    +--- org.apache.maven:maven-model:3.9.4 (*)
+|    |    |    +--- org.apache.maven:maven-artifact:3.9.4
+|    |    |    |    +--- org.codehaus.plexus:plexus-utils:3.5.1
+|    |    |    |    \--- org.apache.commons:commons-lang3:3.12.0 -> 3.17.0
+|    |    |    +--- org.apache.maven:maven-builder-support:3.9.4
+|    |    |    \--- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5
+|    |    +--- org.apache.maven:maven-repository-metadata:3.9.4
+|    |    |    \--- org.codehaus.plexus:plexus-utils:3.5.1
+|    |    +--- org.apache.maven.resolver:maven-resolver-api:1.9.14
+|    |    +--- org.apache.maven.resolver:maven-resolver-spi:1.9.14 (*)
+|    |    +--- org.apache.maven.resolver:maven-resolver-util:1.9.14 (*)
+|    |    +--- org.apache.maven.resolver:maven-resolver-impl:1.9.14 (*)
+|    |    \--- org.codehaus.plexus:plexus-utils:3.5.1
+|    +--- org.apache.maven.resolver:maven-resolver-transport-http -> 1.9.14
+|    |    +--- org.apache.maven.resolver:maven-resolver-api:1.9.14
+|    |    +--- org.apache.maven.resolver:maven-resolver-spi:1.9.14 (*)
+|    |    +--- org.apache.maven.resolver:maven-resolver-util:1.9.14 (*)
+|    |    +--- org.apache.httpcomponents:httpclient:4.5.14 (*)
+|    |    +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    +--- org.assertj:assertj-core -> 3.27.3 (*)
+|    +--- org.hamcrest:hamcrest-core -> 3.0 (*)
+|    +--- org.hamcrest:hamcrest-library -> 3.0
+|    |    \--- org.hamcrest:hamcrest-core:3.0 (*)
+|    +--- org.springframework:spring-core -> 6.2.2 (*)
+|    +--- org.springframework:spring-test -> 6.2.2 (*)
+|    \--- org.springframework:spring-core-test -> 6.2.2
+|         +--- com.thoughtworks.qdox:qdox:2.1.0
+|         +--- org.springframework:spring-core:6.2.2 (*)
+|         +--- org.assertj:assertj-core:3.27.2 -> 3.27.3 (*)
+|         \--- org.junit.jupiter:junit-jupiter-api:5.11.4 (*)
++--- org.junit.platform:junit-platform-launcher -> 1.11.4 (*)
++--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-web
+|    +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter
+|    |    +--- project :spring-boot-project:spring-boot (*)
+|    |    +--- project :spring-boot-project:spring-boot-autoconfigure (*)
+|    |    +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-logging
+|    |    |    +--- ch.qos.logback:logback-classic -> 1.5.16 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j -> 2.24.3 (*)
+|    |    |    \--- org.slf4j:jul-to-slf4j -> 2.0.16 (*)
+|    |    +--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
+|    |    +--- org.springframework:spring-core -> 6.2.2 (*)
+|    |    \--- org.yaml:snakeyaml -> 2.3
+|    +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-json
+|    |    +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter (*)
+|    |    +--- org.springframework:spring-web -> 6.2.2 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind -> 2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8 -> 2.18.2 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310 -> 2.18.2 (*)
+|    |    \--- com.fasterxml.jackson.module:jackson-module-parameter-names -> 2.18.2 (*)
+|    +--- project :spring-boot-project:spring-boot-starters:spring-boot-starter-tomcat
+|    |    +--- jakarta.annotation:jakarta.annotation-api -> 2.1.1
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-core -> 10.1.34 (*)
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-el -> 10.1.34
+|    |    \--- org.apache.tomcat.embed:tomcat-embed-websocket -> 10.1.34
+|    |         \--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (*)
+|    +--- org.springframework:spring-web -> 6.2.2 (*)
+|    \--- org.springframework:spring-webmvc -> 6.2.2 (*)
+\--- com.h2database:h2 -> 2.3.232
+
+testRuntimeOnly - Runtime only dependencies for null/test. (n)
++--- org.junit.platform:junit-platform-launcher (n)
++--- project spring-boot-starter-web (n)
++--- com.h2database:h2 (n)
+\--- org.springframework:spring-jdbc (n)
+
+testSlices
+\--- project :spring-boot-project:spring-boot-test-autoconfigure
+
+(c) - A dependency constraint, not a dependency. The dependency affected by the constraint occurs elsewhere in the tree.
+(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.
+
+(n) - A dependency or dependency configuration that cannot be resolved.
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/packages/gradle/src/utils/get-gradle-report.spec.ts
+++ b/packages/gradle/src/utils/get-gradle-report.spec.ts
@@ -73,4 +73,26 @@ describe('processGradleDependencies', () => {
     const dependencies = processGradleDependencies(depFilePath);
     expect(Array.from(dependencies)).toEqual([':utilities']);
   });
+
+  it('should process gradle custom dependencies', () => {
+    const depFilePath = join(
+      __dirname,
+      '..',
+      'utils/__mocks__/gradle-custom-dependencies.txt'
+    );
+    const dependencies = processGradleDependencies(depFilePath);
+    expect(Array.from(dependencies)).toEqual([
+      ':spring-boot-project:spring-boot-parent',
+      ':spring-boot-project:spring-boot-actuator',
+      ':spring-boot-project:spring-boot-actuator-autoconfigure',
+      ':spring-boot-project:spring-boot-autoconfigure',
+      ':spring-boot-project:spring-boot-docker-compose',
+      ':spring-boot-project:spring-boot-tools:spring-boot-cli',
+      ':spring-boot-project:spring-boot-tools:spring-boot-loader-tools',
+      ':spring-boot-project:spring-boot-test',
+      ':spring-boot-project:spring-boot-test-autoconfigure',
+      ':spring-boot-project:spring-boot-testcontainers',
+      ':spring-boot-project:spring-boot-devtools',
+    ]);
+  });
 });

--- a/packages/gradle/src/utils/get-gradle-report.ts
+++ b/packages/gradle/src/utils/get-gradle-report.ts
@@ -424,10 +424,11 @@ export function processGradleDependencies(depsFile: string): Set<string> {
           targetProjectName = dep
             .substring('project '.length)
             .replace(/ \(n\)$/, '')
-            .trim();
+            .trim()
+            .split(' ')?.[0];
         } else if (dep.includes('-> project')) {
           const [_, projectName] = dep.split('-> project');
-          targetProjectName = projectName.trim();
+          targetProjectName = projectName.trim().split(' ')?.[0];
         }
         if (targetProjectName) {
           dependedProjects.add(targetProjectName);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
got this error:
```
 NX   Cannot read properties of undefined (reading '1')

TypeError: Cannot read properties of undefined (reading '1')
    at fileDataDepTarget (/Users/emily/code/tmp/spring-boot/.nx/installation/node_modules/nx/src/config/project-graph.js:13:18)
    at ProjectGraphBuilder.calculateTargetDepsFromFiles (/Users/emily/code/tmp/spring-boot/.nx/installation/node_modules/nx/src/project-graph/project-graph-builder.js:271:74)
```

this happens because the project in the dependency file is in format like `:spring-boot-project:spring-boot-autoconfigure (*)`. need to take out the text after space.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
