### PR TITLE
fix(linter): install `@eslint/eslintrc` when needed

### DIFF
--- a/packages/eslint/src/generators/utils/eslint-file.spec.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.spec.ts
@@ -227,6 +227,9 @@ module.exports = [
           },
         ];"
       `);
+      const { devDependencies } = readJson(tree, 'package.json');
+      expect(devDependencies['@eslint/compat']).toBeDefined();
+      expect(devDependencies['@eslint/eslintrc']).toBeDefined();
     });
 
     it('should handle mixed multiple incompatible and compatible plugins and add them to extends in the specified order when using eslint v9', () => {
@@ -298,6 +301,9 @@ module.exports = [
           },
         ];"
       `);
+      const { devDependencies } = readJson(tree, 'package.json');
+      expect(devDependencies['@eslint/compat']).toBeDefined();
+      expect(devDependencies['@eslint/eslintrc']).toBeDefined();
     });
 
     it('should not add wrapped plugin for compat in extends when not using eslint v9', () => {

--- a/packages/eslint/src/generators/utils/eslint-file.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.ts
@@ -20,7 +20,11 @@ import {
   useFlatConfig,
 } from '../../utils/flat-config';
 import { getInstalledEslintVersion } from '../../utils/version-utils';
-import { eslint9__eslintVersion, eslintCompat } from '../../utils/versions';
+import {
+  eslint9__eslintVersion,
+  eslintCompat,
+  eslintrcVersion,
+} from '../../utils/versions';
 import {
   addBlockToFlatConfigExport,
   addFlatCompatToFlatConfig,
@@ -421,14 +425,6 @@ export function addExtendsToLintConfig(
         break;
       }
     }
-    // Check the file extension to determine the format of the config if it is .js we look for the export
-    const eslintConfigFormat = fileName.endsWith('.mjs')
-      ? 'mjs'
-      : fileName.endsWith('.cjs')
-      ? 'cjs'
-      : tree.read(fileName, 'utf-8').includes('module.exports')
-      ? 'cjs'
-      : 'mjs';
 
     let shouldImportEslintCompat = false;
     // assume eslint version is 9 if not found, as it's what we'd be generating by default
@@ -489,17 +485,21 @@ export function addExtendsToLintConfig(
     }
     tree.write(fileName, content);
 
+    const devDependencies = {
+      '@eslint/eslintrc': eslintrcVersion,
+    };
+
     if (shouldImportEslintCompat) {
-      return addDependenciesToPackageJson(
-        tree,
-        {},
-        { '@eslint/compat': eslintCompat },
-        undefined,
-        true
-      );
+      devDependencies['@eslint/compat'] = eslintCompat;
     }
 
-    return () => {};
+    return addDependenciesToPackageJson(
+      tree,
+      {},
+      devDependencies,
+      undefined,
+      true
+    );
   } else {
     const plugins = (Array.isArray(plugin) ? plugin : [plugin]).map((p) =>
       typeof p === 'string' ? p : p.name


### PR DESCRIPTION
## Current Behavior

When generating an ESLint configuration that imports from `@eslint/eslintrc`, that package is not installed in the user's workspace.

## Expected Behavior

When generating an ESLint configuration that imports from `@eslint/eslintrc`, that package should be installed in the user's workspace.

## Related Issue(s)

Fixes #29845 
