### PR TITLE
fix(core): make project graph lock null-safe

### DIFF
--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -363,7 +363,7 @@ export async function createProjectGraphAndSourceMapsAsync(
     } catch (e) {
       handleProjectGraphError(opts, e);
     } finally {
-      lock.unlock();
+      lock?.unlock();
     }
   } else {
     try {


### PR DESCRIPTION
## Current Behavior
During the creation of the project graph, if there's no lock, an attempt to unlock results in a null pointer.
```
> nx build --configuration=production --output-hashing=none --single-bundle --verbose
 
 
NX   Cannot read properties of null (reading 'unlock')
 
TypeError: Cannot read properties of null (reading 'unlock')
    at createProjectGraphAndSourceMapsAsync (/my_project/node_modules/nx/src/project-graph/project-graph.js:283:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async createProjectGraphAsync (/my_project/node_modules/nx/src/project-graph/project-graph.js:219:39)
    at async Object.runOne (/my_project/node_modules/nx/src/command-line/run/run-one.js:23:26)
    at async handleErrors (/my_project/node_modules/nx/src/utils/handle-errors.js:8:24)
    at async Object.handler (/my_project/node_modules/nx/src/command-line/run/command-object.js:32:26)
```

## Expected Behavior
The project graph creation completes successfully, regardless of whether there's a lock or not.

## Related Issue(s)
Bug was introduced in https://github.com/nrwl/nx/pull/29408
