### PR TITLE
feat(rspack): infer continuous for serve tasks

### DIFF
--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -195,6 +195,7 @@ async function createRspackTargets(
   };
 
   targets[options.serveTargetName] = {
+    continuous: true,
     command: `rspack serve`,
     options: {
       cwd: projectRoot,
@@ -203,6 +204,7 @@ async function createRspackTargets(
   };
 
   targets[options.previewTargetName] = {
+    continuous: true,
     command: `rspack serve`,
     options: {
       cwd: projectRoot,
@@ -211,6 +213,7 @@ async function createRspackTargets(
   };
 
   targets[options.serveStaticTargetName] = {
+    continuous: true,
     executor: '@nx/web:file-server',
     options: {
       buildTarget: options.buildTargetName,


### PR DESCRIPTION
## Current Behavior
The `serve` and `preview` tasks that are inferred by Rspack do not currently set `continuous: true`.


## Expected Behavior
Ensure `continuous: true` is set by the Rspack inferrence plugin.
