### PR TITLE
feat(rspack): add continous inference support

### DIFF
--- a/packages/rsbuild/src/plugins/plugin.spec.ts
+++ b/packages/rsbuild/src/plugins/plugin.spec.ts
@@ -116,6 +116,7 @@ describe('@nx/rsbuild', () => {
                   },
                   "dev-serve": {
                     "command": "rsbuild dev",
+                    "continuous": true,
                     "options": {
                       "args": [
                         "--mode=development",
@@ -131,6 +132,7 @@ describe('@nx/rsbuild', () => {
                   },
                   "preview-serve": {
                     "command": "rsbuild preview",
+                    "continuous": true,
                     "dependsOn": [
                       "build-something",
                       "^build-something",

--- a/packages/rsbuild/src/plugins/plugin.ts
+++ b/packages/rsbuild/src/plugins/plugin.ts
@@ -187,6 +187,7 @@ async function createRsbuildTargets(
   };
 
   targets[options.devTargetName] = {
+    continuous: true,
     command: `rsbuild dev`,
     options: {
       cwd: projectRoot,
@@ -195,6 +196,7 @@ async function createRsbuildTargets(
   };
 
   targets[options.previewTargetName] = {
+    continuous: true,
     command: `rsbuild preview`,
     dependsOn: [`${options.buildTargetName}`, `^${options.buildTargetName}`],
     options: {

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -195,6 +195,7 @@ async function createRspackTargets(
   };
 
   targets[options.serveTargetName] = {
+    continuous: true,
     command: `rspack serve`,
     options: {
       cwd: projectRoot,
@@ -203,6 +204,7 @@ async function createRspackTargets(
   };
 
   targets[options.previewTargetName] = {
+    continuous: true,
     command: `rspack serve`,
     options: {
       cwd: projectRoot,
@@ -211,6 +213,7 @@ async function createRspackTargets(
   };
 
   targets[options.serveStaticTargetName] = {
+    continuous: true,
     executor: '@nx/web:file-server',
     options: {
       buildTarget: options.buildTargetName,


### PR DESCRIPTION
## Current Behavior
Rspack and Rsbuild Inference Plugins do not infer `continuous` for serve tasks.

## Expected Behavior
Correctly infer `continuous` true.
