### PR TITLE
feat(webpack): add continuous inference support

### DIFF
--- a/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -59,6 +59,7 @@ exports[`@nx/webpack/plugin should create nodes 1`] = `
             },
             "my-serve": {
               "command": "webpack-cli serve",
+              "continuous": true,
               "metadata": {
                 "description": "Starts Webpack dev server",
                 "help": {
@@ -85,6 +86,7 @@ exports[`@nx/webpack/plugin should create nodes 1`] = `
             },
             "preview-site": {
               "command": "webpack-cli serve",
+              "continuous": true,
               "metadata": {
                 "description": "Starts Webpack dev server in production mode",
                 "help": {
@@ -110,6 +112,7 @@ exports[`@nx/webpack/plugin should create nodes 1`] = `
               },
             },
             "serve-static": {
+              "continuous": true,
               "dependsOn": [
                 "build-something",
               ],

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -217,6 +217,7 @@ async function createWebpackTargets(
   };
 
   targets[options.serveTargetName] = {
+    continuous: true,
     command: `webpack-cli serve`,
     options: {
       cwd: projectRoot,
@@ -237,6 +238,7 @@ async function createWebpackTargets(
   };
 
   targets[options.previewTargetName] = {
+    continuous: true,
     command: `webpack-cli serve`,
     options: {
       cwd: projectRoot,
@@ -257,6 +259,7 @@ async function createWebpackTargets(
   };
 
   targets[options.serveStaticTargetName] = {
+    continuous: true,
     dependsOn: [options.buildTargetName],
     executor: '@nx/web:file-server',
     options: {


### PR DESCRIPTION
## Current Behavior
Webpack Inference Plugin does not currently infer `continuous` for `serve, preview, serve-static` targets.

## Expected Behavior
Webpack Inference Plugin correctly infers `continuous: true`
