### PR TITLE
feat(js): infer continuous for watch-deps task

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -2164,6 +2164,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                 },
                 "watch-deps": {
                   "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                  "continuous": true,
                   "dependsOn": [
                     "build-deps",
                   ],
@@ -2318,6 +2319,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                 },
                 "watch-deps": {
                   "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                  "continuous": true,
                   "dependsOn": [
                     "build-deps",
                   ],

--- a/packages/js/src/plugins/typescript/util.ts
+++ b/packages/js/src/plugins/typescript/util.ts
@@ -34,6 +34,7 @@ export function addBuildAndWatchDepsTargets(
       dependsOn: ['^build'],
     };
     targets[options.watchDepsTargetName ?? 'watch-deps'] = {
+      continuous: true,
       dependsOn: [buildDepsTargetName],
       command: `${pmc.exec} nx watch --projects ${projectName} --includeDependentProjects -- ${pmc.exec} nx ${buildDepsTargetName} ${projectName}`,
     };

--- a/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -64,6 +64,7 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],
@@ -140,6 +141,7 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects next --includeDependentProjects -- npx nx build-deps next",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],

--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -74,6 +74,7 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
         },
         "watch-deps": {
           "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+          "continuous": true,
           "dependsOn": [
             "build-deps",
           ],
@@ -158,6 +159,7 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
         },
         "watch-deps": {
           "command": "npx nx watch --projects nuxt --includeDependentProjects -- npx nx build-deps nuxt",
+          "continuous": true,
           "dependsOn": [
             "build-deps",
           ],

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -107,6 +107,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
             },
             "watch-deps": {
               "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],
@@ -226,6 +227,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
             },
             "watch-deps": {
               "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],
@@ -452,6 +454,7 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
             },
             "watch-deps": {
               "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],

--- a/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -54,6 +54,7 @@ exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects mylib --includeDependentProjects -- npx nx build-deps mylib",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],
@@ -120,6 +121,7 @@ exports[`@nx/rollup/plugin non-root project should create nodes 2`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects mylib --includeDependentProjects -- npx nx build-deps mylib",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],
@@ -185,6 +187,7 @@ exports[`@nx/rollup/plugin root project should create nodes 1`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects mylib --includeDependentProjects -- npx nx build-deps mylib",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],
@@ -250,6 +253,7 @@ exports[`@nx/rollup/plugin root project should create nodes 2`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects mylib --includeDependentProjects -- npx nx build-deps mylib",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],

--- a/packages/rsbuild/src/plugins/plugin.spec.ts
+++ b/packages/rsbuild/src/plugins/plugin.spec.ts
@@ -144,6 +144,7 @@ describe('@nx/rsbuild', () => {
                   },
                   "watch-deps": {
                     "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+                    "continuous": true,
                     "dependsOn": [
                       "build-deps",
                     ],

--- a/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -84,6 +84,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects vite --includeDependentProjects -- npx nx build-deps vite",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],

--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -84,6 +84,7 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
             },
             "watch-deps": {
               "command": "npx nx watch --projects vite --includeDependentProjects -- npx nx build-deps vite",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],

--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -55,6 +55,7 @@ exports[`@nx/vite/plugin Library mode should exclude serve and preview targets w
             },
             "watch-deps": {
               "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],
@@ -193,6 +194,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -460,6 +460,7 @@ describe('@nx/vite/plugin', () => {
                     },
                     "watch-deps": {
                       "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                      "continuous": true,
                       "dependsOn": [
                         "build-deps",
                       ],

--- a/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -121,6 +121,7 @@ exports[`@nx/webpack/plugin should create nodes 1`] = `
             },
             "watch-deps": {
               "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "continuous": true,
               "dependsOn": [
                 "build-deps",
               ],


### PR DESCRIPTION
## Current Behavior
The `@nx/js` plugin exposes a helper to generate `build-deps` and `watch-deps` tasks for inference plugins.
It does not currently infer `continuous` for the `watch-deps` task.

## Expected Behavior
Ensure `watch-deps` is infered with `continuous: true`
