### PR TITLE
docs(core): declarationMaps -> declarationMap typo fix

### DIFF
--- a/docs/shared/concepts/typescript-project-linking.md
+++ b/docs/shared/concepts/typescript-project-linking.md
@@ -133,7 +133,7 @@ The root `tsconfig.base.json` should contain a `compilerOptions` property and no
     // Required compiler options
     "composite": true,
     "declaration": true,
-    "declarationMaps": true
+    "declarationMap": true
     // Other options...
   }
 }


### PR DESCRIPTION
Just fixing a typo in a docs.

declarationMaps -> [declarationMap](https://www.typescriptlang.org/tsconfig/#declarationMap)