### PR TITLE
fix(core): handle nullable `lock` when creating project graph

### DIFF
--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -363,7 +363,7 @@ export async function createProjectGraphAndSourceMapsAsync(
     } catch (e) {
       handleProjectGraphError(opts, e);
     } finally {
-      lock.unlock();
+      lock?.unlock();
     }
   } else {
     try {


### PR DESCRIPTION
## Current Behavior

The project graph construction can throw an error when the lock is not created: https://github.com/nrwl/nx/issues/29821#issuecomment-2653007563.

## Expected Behavior

The project graph construction should correctly handle the nullable lock.

## Related Issue(s)

Fixes #
