### PR TITLE
feat(module-federation): add NxModuleFederationPlugin for inferred usage

### DIFF
--- a/packages/module-federation/rspack.ts
+++ b/packages/module-federation/rspack.ts
@@ -1,2 +1,4 @@
 export * from './src/with-module-federation/rspack/with-module-federation';
 export * from './src/with-module-federation/rspack/with-module-federation-ssr';
+export * from './src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin';
+export * from './src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-dev-server-plugin';

--- a/packages/module-federation/src/plugins/models/index.ts
+++ b/packages/module-federation/src/plugins/models/index.ts
@@ -1,0 +1,11 @@
+import { ModuleFederationConfig } from '../../utils/models';
+
+export interface NxModuleFederationDevServerConfig {
+  host?: string;
+  staticRemotesPort?: number;
+  pathToManifestFile?: string;
+  ssl?: boolean;
+  sslCert?: string;
+  sslKey?: string;
+  parallel?: number;
+}

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-dev-server-plugin.ts
@@ -1,0 +1,108 @@
+import { Compilation, Compiler, RspackPluginInstance } from '@rspack/core';
+import * as pc from 'picocolors';
+import {
+  logger,
+  readCachedProjectGraph,
+  readProjectsConfigurationFromProjectGraph,
+  workspaceRoot,
+} from '@nx/devkit';
+import { ModuleFederationConfig } from '../../../utils/models';
+import { extname, join } from 'path';
+import { existsSync } from 'fs';
+import {
+  buildStaticRemotes,
+  getDynamicMfManifestFile,
+  getRemotes,
+  getStaticRemotes,
+  parseRemotesConfig,
+  startRemoteProxies,
+  startStaticRemotesFileServer,
+} from '../../utils';
+import { NxModuleFederationDevServerConfig } from '../../models';
+
+const PLUGIN_NAME = 'NxModuleFederationDevServerPlugin';
+
+export class NxModuleFederationDevServerPlugin implements RspackPluginInstance {
+  private nxBin = require.resolve('nx/bin/nx');
+
+  constructor(
+    private _options: {
+      config: ModuleFederationConfig;
+      devServerConfig: NxModuleFederationDevServerConfig;
+    }
+  ) {}
+
+  apply(compiler: Compiler) {
+    compiler.hooks.beforeCompile.tapAsync(
+      PLUGIN_NAME,
+      async (params, callback) => {
+        const staticRemotesConfig = await this.setup();
+
+        logger.info(
+          `NX Starting module federation dev-server for ${pc.bold(
+            this._options.config.name
+          )} with ${Object.keys(staticRemotesConfig).length} remotes`
+        );
+
+        const mappedLocationOfRemotes = await buildStaticRemotes(
+          staticRemotesConfig,
+          this._options.devServerConfig,
+          this.nxBin
+        );
+        startStaticRemotesFileServer(
+          staticRemotesConfig,
+          workspaceRoot,
+          this._options.devServerConfig.staticRemotesPort
+        );
+        startRemoteProxies(staticRemotesConfig, mappedLocationOfRemotes, {
+          pathToCert: this._options.devServerConfig.sslCert,
+          pathToKey: this._options.devServerConfig.sslCert,
+        });
+        callback();
+      }
+    );
+  }
+
+  private async setup() {
+    const projectGraph = readCachedProjectGraph();
+    const { projects: workspaceProjects } =
+      readProjectsConfigurationFromProjectGraph(projectGraph);
+    const project = workspaceProjects[this._options.config.name];
+    if (!this._options.devServerConfig.pathToManifestFile) {
+      this._options.devServerConfig.pathToManifestFile =
+        getDynamicMfManifestFile(project, workspaceRoot);
+    } else {
+      const userPathToManifestFile = join(
+        workspaceRoot,
+        this._options.devServerConfig.pathToManifestFile
+      );
+      if (!existsSync(userPathToManifestFile)) {
+        throw new Error(
+          `The provided Module Federation manifest file path does not exist. Please check the file exists at "${userPathToManifestFile}".`
+        );
+      } else if (
+        extname(this._options.devServerConfig.pathToManifestFile) !== '.json'
+      ) {
+        throw new Error(
+          `The Module Federation manifest file must be a JSON. Please ensure the file at ${userPathToManifestFile} is a JSON.`
+        );
+      }
+
+      this._options.devServerConfig.pathToManifestFile = userPathToManifestFile;
+    }
+
+    // TODO(colum): Add method for setting dev remotes to runtime plugin
+    const { remotes, staticRemotePort } = getRemotes(
+      this._options.config,
+      projectGraph,
+      this._options.devServerConfig.pathToManifestFile
+    );
+    this._options.devServerConfig.staticRemotesPort ??= staticRemotePort;
+
+    const remotesConfig = parseRemotesConfig(remotes, projectGraph);
+    const staticRemotesConfig = await getStaticRemotes(
+      remotesConfig.config ?? {}
+    );
+    return staticRemotesConfig ?? {};
+  }
+}

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts
@@ -1,0 +1,66 @@
+import { Compiler, RspackPluginInstance } from '@rspack/core';
+import {
+  ModuleFederationConfig,
+  NxModuleFederationConfigOverride,
+} from '../../../utils/models';
+import { getModuleFederationConfig } from '../../../with-module-federation/rspack/utils';
+import { NxModuleFederationDevServerConfig } from '../../models';
+import { NxModuleFederationDevServerPlugin } from './nx-module-federation-dev-server-plugin';
+
+export class NxModuleFederationPlugin implements RspackPluginInstance {
+  constructor(
+    private _options: {
+      config: ModuleFederationConfig;
+      devServerConfig?: NxModuleFederationDevServerConfig;
+    },
+    private configOverride?: NxModuleFederationConfigOverride
+  ) {}
+
+  // Do nothing
+
+  apply(compiler: Compiler) {
+    if (global.NX_GRAPH_CREATION) {
+      return;
+    }
+
+    // This is required to ensure Module Federation will build the project correctly
+    compiler.options.optimization.runtimeChunk = false;
+
+    const isDevServer = !!process.env['WEBPACK_SERVE'];
+
+    // TODO(colum): Add support for SSR
+    const config = getModuleFederationConfig(this._options.config);
+    const sharedLibraries = config.sharedLibraries;
+    const sharedDependencies = config.sharedDependencies;
+    const mappedRemotes = config.mappedRemotes;
+
+    new (require('@module-federation/enhanced/rspack').ModuleFederationPlugin)({
+      name: this._options.config.name.replace(/-/g, '_'),
+      filename: 'remoteEntry.js',
+      exposes: this._options.config.exposes,
+      remotes: mappedRemotes,
+      shared: {
+        ...(sharedDependencies ?? {}),
+      },
+      ...(this.configOverride ? this.configOverride : {}),
+      runtimePlugins: this.configOverride
+        ? this.configOverride.runtimePlugins ?? []
+        : [],
+      virtualRuntimeEntry: true,
+    }).apply(compiler);
+
+    if (sharedLibraries) {
+      sharedLibraries.getReplacementPlugin().apply(compiler as any);
+    }
+
+    if (isDevServer) {
+      new NxModuleFederationDevServerPlugin({
+        config: this._options.config,
+        devServerConfig: {
+          ...(this._options.devServerConfig ?? {}),
+          host: this._options.devServerConfig?.host ?? 'localhost',
+        },
+      }).apply(compiler);
+    }
+  }
+}

--- a/packages/module-federation/src/plugins/utils/build-static-remotes.ts
+++ b/packages/module-federation/src/plugins/utils/build-static-remotes.ts
@@ -1,0 +1,84 @@
+import { fork } from 'node:child_process';
+import { join } from 'path';
+import { createWriteStream } from 'node:fs';
+import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
+import { workspaceRoot } from '@nx/devkit';
+import { StaticRemoteConfig } from '../../utils';
+import { NxModuleFederationDevServerConfig } from '../models';
+
+export async function buildStaticRemotes(
+  staticRemotesConfig: Record<string, StaticRemoteConfig>,
+  options: NxModuleFederationDevServerConfig,
+  nxBin: string
+) {
+  const remotes = Object.keys(staticRemotesConfig);
+  if (!remotes.length) {
+    return;
+  }
+  const mappedLocationOfRemotes: Record<string, string> = {};
+  for (const app of remotes) {
+    mappedLocationOfRemotes[app] = `http${options.ssl ? 's' : ''}://${
+      options.host
+    }:${options.staticRemotesPort}/${staticRemotesConfig[app].urlSegment}`;
+  }
+
+  await new Promise<void>((res, rej) => {
+    console.log(`NX Building ${remotes.length} static remotes...`);
+    const staticProcess = fork(
+      nxBin,
+      [
+        'run-many',
+        `--target=build`,
+        `--projects=${remotes.join(',')}`,
+        ...(options.parallel ? [`--parallel=${options.parallel}`] : []),
+      ],
+      {
+        cwd: workspaceRoot,
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      }
+    );
+    // File to debug build failures e.g. 2024-01-01T00_00_0_0Z-build.log'
+    const remoteBuildLogFile = join(
+      workspaceDataDirectory,
+      // eslint-disable-next-line
+      `${new Date().toISOString().replace(/[:\.]/g, '_')}-build.log`
+    );
+    const stdoutStream = createWriteStream(remoteBuildLogFile);
+    staticProcess.stdout?.on('data', (data) => {
+      const ANSII_CODE_REGEX =
+        // eslint-disable-next-line no-control-regex
+        /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+      const stdoutString = data.toString().replace(ANSII_CODE_REGEX, '');
+      stdoutStream.write(stdoutString);
+
+      // in addition to writing into the stdout stream, also show error directly in console
+      // so the error is easily discoverable. 'ERROR in' is the key word to search in webpack output.
+      if (stdoutString.includes('ERROR in')) {
+        console.log(stdoutString);
+      }
+
+      if (stdoutString.includes('Successfully ran target build')) {
+        staticProcess.stdout?.removeAllListeners('data');
+        console.info(`NX Built ${remotes.length} static remotes`);
+        res();
+      }
+    });
+    staticProcess.stderr?.on('data', (data) => console.log(data.toString()));
+    staticProcess.once('exit', (code) => {
+      stdoutStream.end();
+      staticProcess.stdout?.removeAllListeners('data');
+      staticProcess.stderr?.removeAllListeners('data');
+      if (code !== 0) {
+        rej(
+          `Remote failed to start. A complete log can be found in: ${remoteBuildLogFile}`
+        );
+      } else {
+        res();
+      }
+    });
+    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
+    process.on('exit', () => staticProcess.kill('SIGTERM'));
+  });
+
+  return mappedLocationOfRemotes;
+}

--- a/packages/module-federation/src/plugins/utils/get-dynamic-manifest-file.spec.ts
+++ b/packages/module-federation/src/plugins/utils/get-dynamic-manifest-file.spec.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import { getDynamicMfManifestFile } from './get-dynamic-manifest-file';
+
+describe('getDynamicMfManifestFile', () => {
+  it('should return the correct manifest file', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const manifestFile = getDynamicMfManifestFile(
+      { root: 'myapp', sourceRoot: 'myapp/src' },
+      'my-workspace'
+    );
+
+    expect(manifestFile).toEqual(
+      'my-workspace/myapp/public/module-federation.manifest.json'
+    );
+  });
+
+  it('should return undefined if the manifest file does not exist', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    const manifestFile = getDynamicMfManifestFile(
+      { root: 'myapp', sourceRoot: 'myapp/src' },
+      'my-workspace'
+    );
+
+    expect(manifestFile).toBeUndefined();
+  });
+});

--- a/packages/module-federation/src/plugins/utils/get-dynamic-manifest-file.ts
+++ b/packages/module-federation/src/plugins/utils/get-dynamic-manifest-file.ts
@@ -1,0 +1,23 @@
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { type ProjectConfiguration } from '@nx/devkit';
+
+export function getDynamicMfManifestFile(
+  project: ProjectConfiguration,
+  workspaceRoot: string
+): string | undefined {
+  // {sourceRoot}/assets/module-federation.manifest.json was the generated
+  // path for the manifest file in the past. We now generate the manifest
+  // file at {root}/public/module-federation.manifest.json. This check
+  // ensures that we can still support the old path for backwards
+  // compatibility since old projects may still have the manifest file
+  // at the old path.
+  return [
+    join(workspaceRoot, project.root, 'public/module-federation.manifest.json'),
+    join(
+      workspaceRoot,
+      project.sourceRoot!,
+      'assets/module-federation.manifest.json'
+    ),
+  ].find((path) => existsSync(path));
+}

--- a/packages/module-federation/src/plugins/utils/get-remotes.spec.ts
+++ b/packages/module-federation/src/plugins/utils/get-remotes.spec.ts
@@ -1,0 +1,104 @@
+import { ProjectGraph } from '@nx/devkit';
+import { getRemotes } from './get-remotes';
+import * as _config_1 from '../../utils';
+import * as fs from 'fs';
+
+jest.mock('../../utils');
+
+describe('getRemotes', () => {
+  const mfConfig = {
+    name: 'my-app',
+    exposes: {
+      './my-app': './src/app/index.ts',
+    },
+    remotes: ['my-app-remote1', 'my-app-remote2'],
+  };
+
+  const remote1Config = {
+    name: 'my-app-remote1',
+    exposes: {
+      './my-app-remote1': './src/remote-entry.ts',
+    },
+  };
+
+  const remote2Config = {
+    name: 'my-app-remote2',
+    exposes: {
+      './my-app-remote2': './src/remote-entry.ts',
+    },
+  };
+
+  const projectGraph: ProjectGraph = {
+    nodes: {
+      'my-app-remote1': {
+        type: 'app',
+        name: 'my-app-remote-1',
+        data: {
+          root: 'my-app-remote1',
+          sourceRoot: 'my-app-remote1/src',
+          targets: {
+            serve: {
+              options: {
+                port: 4201,
+              },
+            },
+          },
+        },
+      },
+      'my-app-remote2': {
+        type: 'app',
+        name: 'my-app-remote-2',
+        data: {
+          root: 'my-app-remote2',
+          sourceRoot: 'my-app-remote2/src',
+          targets: {
+            serve: {
+              options: {
+                port: 4202,
+              },
+            },
+          },
+        },
+      },
+      'my-app': {
+        type: 'app',
+        name: 'my-app',
+        data: {
+          root: 'my-app',
+          sourceRoot: 'my-app/src',
+          targets: {
+            serve: {
+              options: {
+                port: 4200,
+              },
+            },
+          },
+        },
+      },
+    },
+    dependencies: {},
+  };
+
+  it('should return remotes', () => {
+    // ARRANGE
+    const mfConfigSpy = jest
+      .spyOn(_config_1, 'getModuleFederationConfig')
+      .mockImplementation((tsConfig, workspaceRoot, projectRoot) => {
+        if (projectRoot === 'my-app') {
+          return mfConfig;
+        } else if (projectRoot === 'my-app-remote1') {
+          return remote1Config;
+        } else if (projectRoot === 'my-app-remote2') {
+          return remote2Config;
+        }
+      });
+    const fsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    // ACT
+    const remotes = getRemotes(mfConfig, projectGraph);
+
+    // ASSERT
+    expect(remotes.remotes).toEqual(['my-app-remote1', 'my-app-remote2']);
+    expect(remotes.staticRemotePort).toEqual(4203);
+  });
+});

--- a/packages/module-federation/src/plugins/utils/get-remotes.ts
+++ b/packages/module-federation/src/plugins/utils/get-remotes.ts
@@ -1,0 +1,106 @@
+import { logger, ProjectGraph, workspaceRoot } from '@nx/devkit';
+import { getModuleFederationConfig, ModuleFederationConfig } from '../../utils';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export function getRemotes(
+  config: ModuleFederationConfig,
+  projectGraph: ProjectGraph,
+  pathToManifestFile?: string
+) {
+  const collectedRemotes = new Set<string>();
+  const { remotes, dynamicRemotes } = extractRemoteProjectsFromConfig(
+    config,
+    pathToManifestFile
+  );
+  remotes.forEach((r) =>
+    collectRemoteProjects(r, collectedRemotes, projectGraph)
+  );
+
+  // With dynamic remotes, the manifest file may contain the names with `_` due to MF limitations on naming
+  // The project graph might contain these names with `-` rather than `_`. Check for both.
+  // This can occur after migration of existing remotes past Nx 19.8
+  let normalizedDynamicRemotes = dynamicRemotes.map((r) => {
+    if (projectGraph.nodes[r.replace(/_/g, '-')]) {
+      return r.replace(/_/g, '-');
+    }
+    return r;
+  });
+  const knownDynamicRemotes = normalizedDynamicRemotes.filter(
+    (r) => projectGraph.nodes[r]
+  );
+
+  const remotePorts = [...collectedRemotes, ...knownDynamicRemotes].map(
+    (r) => projectGraph.nodes[r].data.targets['serve'].options.port
+  );
+  const staticRemotePort = Math.max(...([...remotePorts] as number[])) + 1;
+
+  return {
+    remotes: Array.from(collectedRemotes),
+    remotePorts,
+    staticRemotePort,
+  };
+}
+
+function extractRemoteProjectsFromConfig(
+  config: ModuleFederationConfig,
+  pathToManifestFile?: string
+) {
+  const remotes = [];
+  const dynamicRemotes = [];
+  if (pathToManifestFile && existsSync(pathToManifestFile)) {
+    const moduleFederationManifestJson = readFileSync(
+      pathToManifestFile,
+      'utf-8'
+    );
+
+    if (moduleFederationManifestJson) {
+      // This should have shape of
+      // {
+      //   "remoteName": "remoteLocation",
+      // }
+      const parsedManifest = JSON.parse(moduleFederationManifestJson);
+      if (
+        Object.keys(parsedManifest).every(
+          (key) =>
+            typeof key === 'string' && typeof parsedManifest[key] === 'string'
+        )
+      ) {
+        dynamicRemotes.push(...Object.keys(parsedManifest));
+      }
+    }
+  }
+  const staticRemotes =
+    config.remotes?.map((r) => (Array.isArray(r) ? r[0] : r)) ?? [];
+  remotes.push(...staticRemotes);
+  return { remotes, dynamicRemotes };
+}
+
+function collectRemoteProjects(
+  remote: string,
+  collected: Set<string>,
+  projectGraph: ProjectGraph
+) {
+  const remoteProject = projectGraph.nodes[remote]?.data;
+  if (!projectGraph.nodes[remote] || collected.has(remote)) {
+    return;
+  }
+
+  collected.add(remote);
+
+  const remoteProjectRoot = remoteProject.root;
+  let remoteProjectTsConfig = ['tsconfig.app.json', 'tsconfig.json']
+    .map((p) => join(workspaceRoot, remoteProjectRoot, p))
+    .find((p) => existsSync(p));
+  const remoteProjectConfig = getModuleFederationConfig(
+    remoteProjectTsConfig,
+    workspaceRoot,
+    remoteProjectRoot
+  );
+  const { remotes: remoteProjectRemotes } =
+    extractRemoteProjectsFromConfig(remoteProjectConfig);
+
+  remoteProjectRemotes.forEach((r) =>
+    collectRemoteProjects(r, collected, projectGraph)
+  );
+}

--- a/packages/module-federation/src/plugins/utils/get-static-remotes.ts
+++ b/packages/module-federation/src/plugins/utils/get-static-remotes.ts
@@ -1,0 +1,34 @@
+import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import { StaticRemoteConfig } from '../../utils';
+
+export async function getStaticRemotes(
+  remotesConfig: Record<string, StaticRemoteConfig>
+) {
+  const remotes = Object.keys(remotesConfig);
+  const findStaticRemotesPromises: Promise<string | undefined>[] = [];
+  for (const remote of remotes) {
+    findStaticRemotesPromises.push(
+      new Promise<string>((resolve, reject) => {
+        waitForPortOpen(remotesConfig[remote].port, {
+          retries: 5,
+          retryDelay: 1000,
+        }).then(
+          (res) => {
+            resolve(undefined);
+          },
+          (rej) => {
+            resolve(remote);
+          }
+        );
+      })
+    );
+  }
+  const staticRemoteNames = (
+    await Promise.all(findStaticRemotesPromises)
+  ).filter(Boolean);
+  let staticRemotesConfig: Record<string, StaticRemoteConfig> = {};
+  for (const remote of staticRemoteNames) {
+    staticRemotesConfig[remote] = remotesConfig[remote];
+  }
+  return staticRemotesConfig;
+}

--- a/packages/module-federation/src/plugins/utils/index.ts
+++ b/packages/module-federation/src/plugins/utils/index.ts
@@ -1,0 +1,7 @@
+export * from './build-static-remotes';
+export * from './get-dynamic-manifest-file';
+export * from './get-remotes';
+export * from './get-static-remotes';
+export * from './parse-remotes-config';
+export * from './start-remote-proxies';
+export * from './start-static-remotes-file-server';

--- a/packages/module-federation/src/plugins/utils/parse-remotes-config.spec.ts
+++ b/packages/module-federation/src/plugins/utils/parse-remotes-config.spec.ts
@@ -1,0 +1,66 @@
+import { parseRemotesConfig } from './parse-remotes-config';
+import { ProjectGraph } from '@nx/devkit';
+
+describe('parseRemotesConfig', () => {
+  it('should parse remotes config', () => {
+    // ARRANGE
+    const remotes = ['my-app-remote1', 'my-app-remote2'];
+    const projectGraph: ProjectGraph = {
+      nodes: {
+        'my-app-remote1': {
+          type: 'app',
+          name: 'my-app-remote-1',
+          data: {
+            root: 'my-app-remote1',
+            sourceRoot: 'my-app-remote1/src',
+            targets: {
+              serve: {
+                options: {
+                  port: 4201,
+                },
+              },
+            },
+          },
+        },
+        'my-app-remote2': {
+          type: 'app',
+          name: 'my-app-remote-2',
+          data: {
+            root: 'my-app-remote2',
+            sourceRoot: 'my-app-remote2/src',
+            targets: {
+              serve: {
+                options: {
+                  port: 4202,
+                },
+              },
+            },
+          },
+        },
+      },
+      dependencies: {},
+    };
+
+    // ACT
+    const parsedRemotesConfig = parseRemotesConfig(remotes, '', projectGraph);
+
+    // ASSERT
+    expect(parsedRemotesConfig).toEqual({
+      config: {
+        'my-app-remote1': {
+          basePath: 'my-app-remote1',
+          outputPath: 'my-app-remote1/dist',
+          urlSegment: 'my-app-remote1',
+          port: 4201,
+        },
+        'my-app-remote2': {
+          basePath: 'my-app-remote2',
+          outputPath: 'my-app-remote2/dist',
+          urlSegment: 'my-app-remote2',
+          port: 4202,
+        },
+      },
+      remotes: ['my-app-remote1', 'my-app-remote2'],
+    });
+  });
+});

--- a/packages/module-federation/src/plugins/utils/parse-remotes-config.ts
+++ b/packages/module-federation/src/plugins/utils/parse-remotes-config.ts
@@ -1,9 +1,10 @@
-import { ProjectGraph, workspaceRoot } from '@nx/devkit';
+import { ProjectGraph } from '@nx/devkit';
 import { StaticRemoteConfig } from '../../utils';
 import { basename, dirname } from 'path';
 
 export function parseRemotesConfig(
   remotes: string[] | undefined,
+  workspaceRoot: string,
   projectGraph: ProjectGraph
 ) {
   if (!remotes?.length) {
@@ -12,11 +13,13 @@ export function parseRemotesConfig(
   const config: Record<string, StaticRemoteConfig> = {};
   for (const app of remotes) {
     const outputPath =
-      projectGraph.nodes[app].data.targets?.['build'].options.outputPath ??
-      `${workspaceRoot}/${projectGraph.nodes[app].data.root}/dist`; // this needs replaced with better logic for finding the output path
+      projectGraph.nodes[app].data.targets?.['build']?.options.outputPath ??
+      `${workspaceRoot ? `${workspaceRoot}/` : ''}${
+        projectGraph.nodes[app].data.root
+      }/dist`; // this needs replaced with better logic for finding the output path
     const basePath = dirname(outputPath);
     const urlSegment = app;
-    const port = projectGraph.nodes[app].data.targets?.['serve'].options.port;
+    const port = projectGraph.nodes[app].data.targets?.['serve']?.options.port;
     config[app] = { basePath, outputPath, urlSegment, port };
   }
 

--- a/packages/module-federation/src/plugins/utils/parse-remotes-config.ts
+++ b/packages/module-federation/src/plugins/utils/parse-remotes-config.ts
@@ -1,0 +1,24 @@
+import { ProjectGraph, workspaceRoot } from '@nx/devkit';
+import { StaticRemoteConfig } from '../../utils';
+import { basename, dirname } from 'path';
+
+export function parseRemotesConfig(
+  remotes: string[] | undefined,
+  projectGraph: ProjectGraph
+) {
+  if (!remotes?.length) {
+    return { remotes: [], config: undefined };
+  }
+  const config: Record<string, StaticRemoteConfig> = {};
+  for (const app of remotes) {
+    const outputPath =
+      projectGraph.nodes[app].data.targets?.['build'].options.outputPath ??
+      `${workspaceRoot}/${projectGraph.nodes[app].data.root}/dist`; // this needs replaced with better logic for finding the output path
+    const basePath = dirname(outputPath);
+    const urlSegment = app;
+    const port = projectGraph.nodes[app].data.targets?.['serve'].options.port;
+    config[app] = { basePath, outputPath, urlSegment, port };
+  }
+
+  return { remotes, config };
+}

--- a/packages/module-federation/src/plugins/utils/start-remote-proxies.ts
+++ b/packages/module-federation/src/plugins/utils/start-remote-proxies.ts
@@ -1,0 +1,52 @@
+import { StaticRemoteConfig } from '../../utils';
+import { existsSync, readFileSync } from 'fs';
+import { Express } from 'express';
+
+export function startRemoteProxies(
+  staticRemotesConfig: Record<string, StaticRemoteConfig>,
+  mappedLocationsOfRemotes: Record<string, string>,
+  sslOptions?: {
+    pathToCert: string;
+    pathToKey: string;
+  }
+) {
+  const { createProxyMiddleware } = require('http-proxy-middleware');
+  const express = require('express');
+  let sslCert: Buffer | undefined;
+  let sslKey: Buffer | undefined;
+  if (sslOptions && sslOptions.pathToCert && sslOptions.pathToKey) {
+    if (existsSync(sslOptions.pathToCert) && existsSync(sslOptions.pathToKey)) {
+      sslCert = readFileSync(sslOptions.pathToCert);
+      sslKey = readFileSync(sslOptions.pathToKey);
+    } else {
+      console.warn(
+        `Encountered SSL options in project.json, however, the certificate files do not exist in the filesystem. Using http.`
+      );
+      console.warn(
+        `Attempted to find '${sslOptions.pathToCert}' and '${sslOptions.pathToKey}'.`
+      );
+    }
+  }
+  const http = require('http');
+  const https = require('https');
+
+  const remotes = Object.keys(staticRemotesConfig);
+  console.log(`NX Starting static remotes proxies...`);
+  for (const app of remotes) {
+    const appConfig = staticRemotesConfig[app];
+    const expressProxy: Express = express();
+    expressProxy.use(
+      createProxyMiddleware({
+        target: mappedLocationsOfRemotes[app],
+        changeOrigin: true,
+        secure: sslCert ? false : undefined,
+      })
+    );
+    const proxyServer = (sslCert ? https : http)
+      .createServer({ cert: sslCert, key: sslKey }, expressProxy)
+      .listen(appConfig.port);
+    process.on('SIGTERM', () => proxyServer.close());
+    process.on('exit', () => proxyServer.close());
+  }
+  console.info(`NX Static remotes proxies started successfully`);
+}

--- a/packages/module-federation/src/plugins/utils/start-static-remotes-file-server.ts
+++ b/packages/module-federation/src/plugins/utils/start-static-remotes-file-server.ts
@@ -1,0 +1,63 @@
+import { join, resolve } from 'path';
+import { cpSync } from 'fs';
+import { fork } from 'node:child_process';
+import { StaticRemoteConfig } from '../../utils';
+import { workspaceRoot } from '@nx/devkit';
+import { readModulePackageJson } from 'nx/src/devkit-internals';
+
+export function startStaticRemotesFileServer(
+  staticRemotesConfig: Record<string, StaticRemoteConfig>,
+  root: string,
+  staticRemotesPort: number
+) {
+  const remotes = Object.keys(staticRemotesConfig);
+  if (!remotes || remotes.length === 0) {
+    return;
+  }
+  let shouldMoveToCommonLocation = false;
+  const commonOutputDirectory = join(workspaceRoot, 'tmp/static-remotes');
+  for (const app of remotes) {
+    const remoteConfig = staticRemotesConfig[app];
+    if (remoteConfig) {
+      cpSync(
+        remoteConfig.outputPath,
+        join(commonOutputDirectory, remoteConfig.urlSegment),
+        {
+          force: true,
+          recursive: true,
+        }
+      );
+    }
+  }
+
+  const { path: pathToHttpServerPkgJson, packageJson } = readModulePackageJson(
+    'http-server',
+    module.paths
+  );
+  const pathToHttpServerBin = (packageJson.bin! as Record<string, string>)[
+    'http-server'
+  ] as string;
+  const pathToHttpServer = resolve(
+    pathToHttpServerPkgJson.replace('package.json', ''),
+    pathToHttpServerBin
+  );
+  const httpServerProcess = fork(
+    pathToHttpServer,
+    [
+      commonOutputDirectory!,
+      `-p=${staticRemotesPort}`,
+      `-a=localhost`,
+      `--cors`,
+    ],
+    {
+      stdio: 'pipe',
+      cwd: root,
+      env: {
+        FORCE_COLOR: 'true',
+        ...process.env,
+      },
+    }
+  );
+  process.on('SIGTERM', () => httpServerProcess.kill('SIGTERM'));
+  process.on('exit', () => httpServerProcess.kill('SIGTERM'));
+}

--- a/packages/module-federation/src/with-module-federation/rspack/utils.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/utils.ts
@@ -55,19 +55,14 @@ export function getFunctionDeterminateRemoteUrl(isServer = false) {
   };
 }
 
-export async function getModuleFederationConfig(
+export function getModuleFederationConfig(
   mfConfig: ModuleFederationConfig,
   options: {
     isServer: boolean;
     determineRemoteUrl?: (remote: string) => string;
   } = { isServer: false }
 ) {
-  let projectGraph: ProjectGraph;
-  try {
-    projectGraph = readCachedProjectGraph();
-  } catch (e) {
-    projectGraph = await createProjectGraphAsync();
-  }
+  const projectGraph = readCachedProjectGraph();
 
   const project = projectGraph.nodes[mfConfig.name]?.data;
 

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
@@ -14,7 +14,7 @@ export async function withModuleFederationForSSR(
   }
 
   const { sharedLibraries, sharedDependencies, mappedRemotes } =
-    await getModuleFederationConfig(options, {
+    getModuleFederationConfig(options, {
       isServer: true,
     });
 

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
@@ -26,7 +26,7 @@ export async function withModuleFederation(
   }
 
   const { sharedDependencies, sharedLibraries, mappedRemotes } =
-    await getModuleFederationConfig(options);
+    getModuleFederationConfig(options);
   const isGlobal = isVarOrWindow(options.library?.type);
 
   return function makeConfig(


### PR DESCRIPTION
## Current Behaviour
Currently, Module Federation with Nx is forced to use executors to provide the best DX.

## Expected Behaviour
As part of the transition to inferred targets, we will need Rspack plugins that replicates the DX provided by our executors.
Add `NxModuleFederationPlugin` and `NxModuleFederationDevServerPlugin` to handle this.