### PR TITLE
fix(nextjs): accept fileName option to generate page

### DIFF
--- a/packages/next/src/generators/page/page.spec.ts
+++ b/packages/next/src/generators/page/page.spec.ts
@@ -50,6 +50,18 @@ describe('component', () => {
         tree.exists('my-app/pages/posts/[dynamic]/index.module.css')
       ).toBeTruthy();
     });
+  
+    it('should generate component in pages directory using fileName', async () => {
+      await pageGenerator(tree, {
+        name: 'hello',
+        path: 'my-app/pages/hello',
+        fileName: 'foo',
+        style: 'css',
+      });
+
+      expect(tree.exists('my-app/pages/hello/foo.tsx')).toBeTruthy();
+      expect(tree.exists('my-app/pages/hello/foo.module.css')).toBeTruthy();
+    });
   });
 
   describe('app router', () => {
@@ -87,6 +99,22 @@ describe('component', () => {
       const content = tree
         .read(`${appRouterProjectName}/app/posts/[dynamic]/page.tsx`)
         .toString();
+    });
+
+    it('should generate component in app directory using fileName', async () => {
+      await pageGenerator(tree, {
+        name: 'about',
+        path: `${appRouterProjectName}/app/about`,
+        fileName: 'bar',
+        style: 'css',
+      });
+
+      expect(
+        tree.exists(`${appRouterProjectName}/app/about/bar.tsx`)
+      ).toBeTruthy();
+      expect(
+        tree.exists(`${appRouterProjectName}/app/about/bar.module.css`)
+      ).toBeTruthy();
     });
   });
 });

--- a/packages/next/src/generators/page/page.spec.ts
+++ b/packages/next/src/generators/page/page.spec.ts
@@ -50,7 +50,7 @@ describe('component', () => {
         tree.exists('my-app/pages/posts/[dynamic]/index.module.css')
       ).toBeTruthy();
     });
-  
+
     it('should generate component in pages directory using fileName', async () => {
       await pageGenerator(tree, {
         name: 'hello',

--- a/packages/next/src/generators/page/page.ts
+++ b/packages/next/src/generators/page/page.ts
@@ -80,14 +80,16 @@ async function normalizeOptions(host: Tree, options: Schema) {
     }
   }
 
+  const fileName = options.fileName || (isAppRouter ? 'page' : 'index');
   const { project: projectName, filePath } =
     await determineArtifactNameAndDirectoryOptions(host, {
       name: pageSymbolName,
       path: joinPathFragments(
         options.path,
-        isAppRouter ? 'page.tsx' : 'index.tsx'
+        `${fileName}.${options.js ? 'jsx' : 'tsx'}`
       ),
     });
+
   return {
     ...options,
     path: filePath,


### PR DESCRIPTION
## Current Behavior
The `pageGenerator` has the option `fileName`, but it is not affecting anything.

## Expected Behavior
The `pageGenerator` has the option `fileName`, it will define the page file name.
