### PR TITLE
fix(testing): remove dependency on @nx/vite and @nx/webpack from @nx/playwright

### DIFF
--- a/packages/playwright/.eslintrc.json
+++ b/packages/playwright/.eslintrc.json
@@ -29,7 +29,13 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": ["nx", "typescript", "@playwright/test"]
+            "ignoredDependencies": [
+              "nx",
+              "typescript",
+              "@playwright/test",
+              "@nx/webpack",
+              "@nx/vite"
+            ]
           }
         ]
       }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -37,8 +37,6 @@
     "@phenomnomnominal/tsquery": "~5.0.1",
     "@nx/devkit": "file:../devkit",
     "@nx/eslint": "file:../eslint",
-    "@nx/webpack": "file:../webpack",
-    "@nx/vite": "file:../vite",
     "@nx/js": "file:../js",
     "tslib": "^2.3.0",
     "minimatch": "9.0.3"

--- a/packages/playwright/src/migrations/update-19-6-0/use-serve-static-preview-for-command.ts
+++ b/packages/playwright/src/migrations/update-19-6-0/use-serve-static-preview-for-command.ts
@@ -15,8 +15,6 @@ import type { ConfigurationResult } from 'nx/src/project-graph/utils/project-con
 import { LoadedNxPlugin } from 'nx/src/project-graph/plugins/loaded-nx-plugin';
 import { retrieveProjectConfigurations } from 'nx/src/project-graph/utils/retrieve-workspace-files';
 import { ProjectConfigurationsError } from 'nx/src/project-graph/error-types';
-import { createNodesV2 as webpackCreateNodesV2 } from '@nx/webpack/src/plugins/plugin';
-import { createNodesV2 as viteCreateNodesV2 } from '@nx/vite/plugin';
 import type { Node } from 'typescript';
 
 export default async function (tree: Tree) {
@@ -129,8 +127,11 @@ export default async function (tree: Tree) {
           ? 'serveStaticTargetName'
           : 'previewTargetName',
         projectToMigrate.configFileType === 'webpack'
-          ? webpackCreateNodesV2
-          : viteCreateNodesV2
+          ? (
+              require('@nx/webpack/plugin') as typeof import('@nx/webpack/plugin')
+            ).createNodesV2
+          : (require('@nx/vite/plugin') as typeof import('@nx/vite/plugin'))
+              .createNodesV2
       )) ??
       getServeStaticLikeTarget(
         tree,


### PR DESCRIPTION

Dependency on @nx/vite and @nx/webpack is used for a single migration and results in vite being installed in webpack only workspaces when using --legacy-peer-deps
