### PR TITLE
fix(js): improve the `@nx/js/typescript` plugin performance

### DIFF
--- a/docs/generated/devkit/createNodesFromFiles.md
+++ b/docs/generated/devkit/createNodesFromFiles.md
@@ -10,12 +10,12 @@
 
 #### Parameters
 
-| Name          | Type                                                                       |
-| :------------ | :------------------------------------------------------------------------- |
-| `createNodes` | [`CreateNodesFunction`](../../devkit/documents/CreateNodesFunction)\<`T`\> |
-| `configFiles` | readonly `string`[]                                                        |
-| `options`     | `T`                                                                        |
-| `context`     | [`CreateNodesContextV2`](../../devkit/documents/CreateNodesContextV2)      |
+| Name          | Type                                                                                                                                                                                                                                                                                                     |
+| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createNodes` | (`projectConfigurationFile`: `string`, `options`: `T`, `context`: [`CreateNodesContext`](../../devkit/documents/CreateNodesContext), `idx`: `number`) => [`CreateNodesResult`](../../devkit/documents/CreateNodesResult) \| `Promise`\<[`CreateNodesResult`](../../devkit/documents/CreateNodesResult)\> |
+| `configFiles` | readonly `string`[]                                                                                                                                                                                                                                                                                      |
+| `options`     | `T`                                                                                                                                                                                                                                                                                                      |
+| `context`     | [`CreateNodesContextV2`](../../devkit/documents/CreateNodesContextV2)                                                                                                                                                                                                                                    |
 
 #### Returns
 

--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -1,11 +1,17 @@
 import {
+  CreateNodesContext,
   CreateNodesContextV2,
   CreateNodesFunction,
   CreateNodesResult,
 } from './public-api';
 import { AggregateCreateNodesError } from '../error-types';
 export async function createNodesFromFiles<T = unknown>(
-  createNodes: CreateNodesFunction<T>,
+  createNodes: (
+    projectConfigurationFile: string,
+    options: T | undefined,
+    context: CreateNodesContext,
+    idx: number
+  ) => CreateNodesResult | Promise<CreateNodesResult>,
   configFiles: readonly string[],
   options: T,
   context: CreateNodesContextV2
@@ -14,12 +20,17 @@ export async function createNodesFromFiles<T = unknown>(
   const errors: Array<[file: string, error: Error]> = [];
 
   await Promise.all(
-    configFiles.map(async (file) => {
+    configFiles.map(async (file, idx) => {
       try {
-        const value = await createNodes(file, options, {
-          ...context,
-          configFiles,
-        });
+        const value = await createNodes(
+          file,
+          options,
+          {
+            ...context,
+            configFiles,
+          },
+          idx
+        );
         if (value) {
           results.push([file, value] as const);
         }


### PR DESCRIPTION
Improve the perf of the `@nx/js/typescript` plugin both in cold and warm scenarios. The main changes done are:

- Batch some processing to do it once instead of doing it per config file (avoids some duplicated processing)
- Use a custom TS host to read tsconfig files to reduce I/O operations
- Cache tsconfig files' reads

Benchmark results in a repo with 656 TS projects:

```
# Before the changes

Cold (NX_CACHE_PROJECT_GRAPH=false): ~2285 ms
Warm (NX_CACHE_PROJECT_GRAPH=true): ~2142 ms

# After the changes

Cold (NX_CACHE_PROJECT_GRAPH=false): ~597 ms
Warm (NX_CACHE_PROJECT_GRAPH=true): ~220 ms
```

Note: Once https://github.com/nrwl/nx/pull/29935 is merged. I'll send another change to batch the file hashes.

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
