### PR TITLE
docs(misc): add canonical urls to website

### DIFF
--- a/nx-dev/nx-dev/app/blog/[slug]/page.tsx
+++ b/nx-dev/nx-dev/app/blog/[slug]/page.tsx
@@ -18,6 +18,9 @@ export async function generateMetadata(
   return {
     title: `${post.title} | Nx Blog`,
     description: post.description,
+    alternates: {
+      canonical: `https://nx.dev/blog/${slug}`,
+    },
     openGraph: {
       url: `https://nx.dev/blog/${slug}`,
       title: post.title,

--- a/nx-dev/nx-dev/app/blog/page.tsx
+++ b/nx-dev/nx-dev/app/blog/page.tsx
@@ -11,6 +11,9 @@ import {
 export const metadata: Metadata = {
   title: 'Nx Blog - Updates from the Nx & Nx Cloud team',
   description: 'Latest news from the Nx & Nx Cloud core team',
+  alternates: {
+    canonical: 'https://nx.dev/blog',
+  },
   openGraph: {
     url: 'https://nx.dev/blog',
     title: 'Nx Blog - Updates from the Nx & Nx Cloud team',

--- a/nx-dev/nx-dev/app/brands/page.tsx
+++ b/nx-dev/nx-dev/app/brands/page.tsx
@@ -10,6 +10,9 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Brands & Guidelines',
+  alternates: {
+    canonical: 'https://nx.dev/brands',
+  },
   description:
     'We’ve created the following guidelines for 3rd party use of our logos, content, and trademarks.',
   openGraph: {

--- a/nx-dev/nx-dev/app/careers/page.tsx
+++ b/nx-dev/nx-dev/app/careers/page.tsx
@@ -7,10 +7,37 @@ import {
 import { DefaultLayout } from '@nx/nx-dev/ui-common';
 
 import { fetchJobsList } from '@nx/nx-dev/data-access-careers/node-only';
+import { Metadata } from 'next';
 
 async function getData() {
   return await fetchJobsList();
 }
+
+export const metadata: Metadata = {
+  title: 'Nx: Careers',
+  alternates: {
+    canonical: 'https://nx.dev/careers',
+  },
+  description:
+    'Make a difference. We build tools helping companies scale and modernize their development practices.',
+  openGraph: {
+    url: 'https://nx.dev/careers',
+    title: 'Nx: Careers',
+    description:
+      'Make a difference. We build tools helping companies scale and modernize their development practices.',
+    images: [
+      {
+        url: 'https://nx.dev/socials/nx-media.png',
+        width: 800,
+        height: 421,
+        alt: 'Nx: Smart Monorepos · Fast CI',
+        type: 'image/jpeg',
+      },
+    ],
+    siteName: 'Nx',
+    type: 'website',
+  },
+};
 
 export default async function CareersPage() {
   const jobs = await getData();

--- a/nx-dev/nx-dev/app/courses/page.tsx
+++ b/nx-dev/nx-dev/app/courses/page.tsx
@@ -8,6 +8,9 @@ export const metadata: Metadata = {
   title: 'Nx Video Courses',
   description:
     'Master Nx with expert-led video courses from the core team. Boost your skills and productivity.',
+  alternates: {
+    canonical: 'https://nx.dev/courses',
+  },
   openGraph: {
     url: 'https://nx.dev/courses',
     title: 'Nx Video Courses',

--- a/nx-dev/nx-dev/app/nx-cloud/page.tsx
+++ b/nx-dev/nx-dev/app/nx-cloud/page.tsx
@@ -20,6 +20,9 @@ export const metadata: Metadata = {
   title: 'Nx Cloud',
   description:
     'Nx Cloud is the end-to-end solution for smart, efficient and maintainable CI.',
+  alternates: {
+    canonical: 'https://nx.dev/nx-cloud',
+  },
   openGraph: {
     url: 'https://nx.dev/nx-cloud',
     title: 'Nx Cloud',

--- a/nx-dev/nx-dev/app/podcast/page.tsx
+++ b/nx-dev/nx-dev/app/podcast/page.tsx
@@ -6,6 +6,9 @@ import { Hero, PodcastList } from '@nx/nx-dev/ui-podcast';
 export const metadata: Metadata = {
   title: 'Nx Podcast - Updates from the Nx & Nx Cloud team',
   description: 'Latest podcasts from the Nx & Nx Cloud core team',
+  alternates: {
+    canonical: 'https://nx.dev/podcast',
+  },
   openGraph: {
     url: 'https://nx.dev/podcast',
     title: 'Nx Podcast - Updates from the Nx & Nx Cloud team',

--- a/nx-dev/nx-dev/app/powerpack/page.tsx
+++ b/nx-dev/nx-dev/app/powerpack/page.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
   title: 'Nx Powerpack',
   description:
     'Nx Powerpack is a suite of paid extensions for the Nx CLI specifically designed for enterprises.',
+  alternates: {
+    canonical: 'https://nx.dev/powerpack',
+  },
   openGraph: {
     url: 'https://nx.dev/powerpack',
     title: 'Nx Powerpack',

--- a/nx-dev/nx-dev/app/pricing/page.tsx
+++ b/nx-dev/nx-dev/app/pricing/page.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
   title: 'Nx Cloud - Available Plans',
   description:
     "Distribute everything, don't waste time waiting on CI. Use Nx Cloud's distributed task execution and caching features to release faster. Save time and money.",
+  alternates: {
+    canonical: 'https://nx.dev/pricing',
+  },
   openGraph: {
     url: 'https://nx.dev/pricing',
     title: 'Nx Cloud - Available Plans',

--- a/nx-dev/nx-dev/app/resources/page.tsx
+++ b/nx-dev/nx-dev/app/resources/page.tsx
@@ -98,6 +98,9 @@ export const metadata: Metadata = {
   title: 'Resources',
   description:
     'Explore Nx resources including tutorials, code examples, podcasts, and more.',
+  alternates: {
+    canonical: 'https://nx.dev/resources',
+  },
   openGraph: {
     url: 'https://nx.dev/resources',
     title: 'Nx Resources',

--- a/nx-dev/nx-dev/app/webinar/page.tsx
+++ b/nx-dev/nx-dev/app/webinar/page.tsx
@@ -6,6 +6,9 @@ import { Hero, WebinarList } from '@nx/nx-dev/ui-webinar';
 export const metadata: Metadata = {
   title: 'Nx Webinar - Updates from the Nx & Nx Cloud team',
   description: 'Latest webinars from the Nx & Nx Cloud core team',
+  alternates: {
+    canonical: 'https://nx.dev/webinar',
+  },
   openGraph: {
     url: 'https://nx.dev/webinar',
     title: 'Nx Webinar - Updates from the Nx & Nx Cloud team',

--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -75,6 +75,7 @@ export default function CustomApp({
         dangerouslySetAllPagesToNoIndex={
           process.env.NEXT_PUBLIC_NO_INDEX === 'true'
         }
+        canonical={'https://nx.dev' + router.asPath.split('?')[0]}
       />
       <Head>
         <meta name="apple-mobile-web-app-title" content="Nx" />


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The docs site doesn't set any canonical URLs, meaning that content can be flagged as duplicate by search engines. Explicitly setting the canonical URL for each page can improve the SEO of the site


