### PR TITLE
fix(core): change to use init generator during import

### DIFF
--- a/e2e/webpack/src/__snapshots__/webpack.legacy.test.ts.snap
+++ b/e2e/webpack/src/__snapshots__/webpack.legacy.test.ts.snap
@@ -85,15 +85,15 @@ exports[`Webpack Plugin (legacy) ConvertConfigToWebpackPlugin, should convert wi
         }
       }
     },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
     "test": {
       "executor": "@nx/vite:test",
       "outputs": ["{options.reportsDirectory}"],
       "options": {
         "reportsDirectory": "../coverage/app3224373"
       }
-    },
-    "lint": {
-      "executor": "@nx/eslint:lint"
     },
     "serve-static": {
       "executor": "@nx/web:file-server",

--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -111,29 +111,15 @@ async function initializePlugin(
   options: AddOptions,
   nxJson: NxJsonConfiguration
 ): Promise<void> {
-  const parsedCommandArgs: { [key: string]: any } = yargsParser(
-    options.__overrides_unparsed__,
-    {
-      configuration: {
-        'parse-numbers': false,
-        'parse-positional-numbers': false,
-        'dot-notation': false,
-        'camel-case-expansion': false,
-      },
-    }
-  );
-
-  if (coreNxPluginVersions.has(pkgName)) {
-    parsedCommandArgs.keepExistingVersions = true;
-
-    if (
-      options.updatePackageScripts ||
+  let updatePackageScripts = false;
+  if (
+    coreNxPluginVersions.has(pkgName) &&
+    (options.updatePackageScripts ||
       (options.updatePackageScripts === undefined &&
         nxJson.useInferencePlugins !== false &&
-        process.env.NX_ADD_PLUGINS !== 'false')
-    ) {
-      parsedCommandArgs.updatePackageScripts = true;
-    }
+        process.env.NX_ADD_PLUGINS !== 'false'))
+  ) {
+    updatePackageScripts = true;
   }
 
   const spinner = ora(`Initializing ${pkgName}...`);
@@ -143,8 +129,8 @@ async function initializePlugin(
     await installPlugin(
       pkgName,
       workspaceRoot,
-      options.verbose,
-      parsedCommandArgs
+      updatePackageScripts,
+      options.verbose
     );
   } catch (e) {
     spinner.fail();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
- call init generator using implementationFactory, causing issue because schema.json file isnt respected, and then NX_INTERACTIVE is never set to true

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- change back to run init command

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
