### PR TITLE
fix(devkit): support pnpm catalogs

### DIFF
--- a/packages/devkit/src/utils/semver.ts
+++ b/packages/devkit/src/utils/semver.ts
@@ -11,6 +11,10 @@ export function checkAndCleanWithSemver(
     return newVersion;
   }
 
+  if (version.startsWith('~') || version.startsWith('^')) {
+    newVersion = version.substring(1);
+  }
+
   if (!valid(newVersion)) {
     throw new Error(
       `The package.json lists a version of ${pkgName} that Nx is unable to validate - (${version})`

--- a/packages/devkit/src/utils/semver.ts
+++ b/packages/devkit/src/utils/semver.ts
@@ -6,12 +6,9 @@ export function checkAndCleanWithSemver(
 ): string {
   let newVersion = version;
 
-  if (valid(newVersion)) {
+  const isPnpmCatalog = newVersion.startsWith('catalog:');
+  if (valid(newVersion) || isPnpmCatalog) {
     return newVersion;
-  }
-
-  if (version.startsWith('~') || version.startsWith('^')) {
-    newVersion = version.substring(1);
   }
 
   if (!valid(newVersion)) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx generate plugin` throws the following error if a package like typescript is using the PNPM catalog feature in the package.json:

>  NX   The package.json lists a version of typescript that Nx is unable to validate - (catalog:my-catalog)

```json
"typescript": "catalog:my-catalog",
```

This is due too the semver validation that fails with the catalog.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If I am using a pnpm catalog, the package dependency should not be checked for a valid semver.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30035
