### PR TITLE
fix(vite): prevent asset copying when NX_GRAPH_CREATION is enabled

### DIFF
--- a/packages/vite/plugins/nx-copy-assets.plugin.ts
+++ b/packages/vite/plugins/nx-copy-assets.plugin.ts
@@ -1,6 +1,6 @@
 import { join, relative } from 'node:path';
 import type { Plugin, ResolvedConfig } from 'vite';
-import { joinPathFragments, workspaceRoot } from '@nx/devkit';
+import { isDaemonEnabled, joinPathFragments, workspaceRoot } from '@nx/devkit';
 import { AssetGlob } from '@nx/js/src/utils/assets/assets';
 import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
 
@@ -8,6 +8,8 @@ export function nxCopyAssetsPlugin(_assets: (string | AssetGlob)[]): Plugin {
   let config: ResolvedConfig;
   let handler: CopyAssetsHandler;
   let dispose: () => void;
+
+  if (global.NX_GRAPH_CREATION) return;
 
   return {
     name: 'nx-copy-assets-plugin',
@@ -32,7 +34,7 @@ export function nxCopyAssetsPlugin(_assets: (string | AssetGlob)[]): Plugin {
         outputDir: join(config.root, config.build.outDir),
         assets,
       });
-      if (this.meta.watchMode) {
+      if (this.meta.watchMode && isDaemonEnabled()) {
         dispose = await handler.watchAndProcessOnAssetChange();
       }
     },


### PR DESCRIPTION
This PR includes updates to the `nxCopyAssetsPlugin` function in the `packages/vite/plugins/nx-copy-assets.plugin.ts` file to improve asset handling and daemon integration. 

The most important changes include adding a check for `NX_GRAPH_CREATION`.

Additionally, it also contains a check to ensure that before attempting to watch for file changes the daemon should be available.
