### PR TITLE
feat(vite): infer continuous tasks for dev

### DIFF
--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -123,6 +123,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
             },
             "dev": {
               "command": "vite",
+              "continuous": true,
               "metadata": {
                 "description": "Starts Vite dev server",
                 "help": {
@@ -143,6 +144,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
             },
             "my-serve": {
               "command": "vite",
+              "continuous": true,
               "metadata": {
                 "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                 "description": "Starts Vite dev server",
@@ -164,6 +166,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
             },
             "preview-site": {
               "command": "vite preview",
+              "continuous": true,
               "dependsOn": [
                 "build-something",
               ],
@@ -186,6 +189,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
               },
             },
             "serve-static": {
+              "continuous": true,
               "executor": "@nx/web:file-server",
               "options": {
                 "buildTarget": "build-something",
@@ -257,6 +261,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             },
             "dev": {
               "command": "vite",
+              "continuous": true,
               "metadata": {
                 "description": "Starts Vite dev server",
                 "help": {
@@ -277,6 +282,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             },
             "preview": {
               "command": "vite preview",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -300,6 +306,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             },
             "serve": {
               "command": "vite",
+              "continuous": true,
               "metadata": {
                 "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                 "description": "Starts Vite dev server",
@@ -320,6 +327,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               },
             },
             "serve-static": {
+              "continuous": true,
               "executor": "@nx/web:file-server",
               "options": {
                 "buildTarget": "build",

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -389,6 +389,7 @@ describe('@nx/vite/plugin', () => {
                     },
                     "dev": {
                       "command": "vite",
+                      "continuous": true,
                       "metadata": {
                         "description": "Starts Vite dev server",
                         "help": {
@@ -409,6 +410,7 @@ describe('@nx/vite/plugin', () => {
                     },
                     "preview": {
                       "command": "vite preview",
+                      "continuous": true,
                       "dependsOn": [
                         "build",
                       ],
@@ -432,6 +434,7 @@ describe('@nx/vite/plugin', () => {
                     },
                     "serve": {
                       "command": "vite",
+                      "continuous": true,
                       "metadata": {
                         "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                         "description": "Starts Vite dev server",
@@ -452,6 +455,7 @@ describe('@nx/vite/plugin', () => {
                       },
                     },
                     "serve-static": {
+                      "continuous": true,
                       "executor": "@nx/web:file-server",
                       "options": {
                         "buildTarget": "build",

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -354,6 +354,7 @@ async function buildTarget(
 
 function serveTarget(projectRoot: string, isUsingTsSolutionSetup: boolean) {
   const targetConfig: TargetConfiguration = {
+    continuous: true,
     command: `vite`,
     options: {
       cwd: joinPathFragments(projectRoot),
@@ -381,6 +382,7 @@ function serveTarget(projectRoot: string, isUsingTsSolutionSetup: boolean) {
 
 function previewTarget(projectRoot: string, buildTargetName) {
   const targetConfig: TargetConfiguration = {
+    continuous: true,
     command: `vite preview`,
     dependsOn: [buildTargetName],
     options: {
@@ -445,6 +447,7 @@ function serveStaticTarget(
   isUsingTsSolutionSetup: boolean
 ) {
   const targetConfig: TargetConfiguration = {
+    continuous: true,
     executor: '@nx/web:file-server',
     options: {
       buildTarget: `${options.buildTargetName}`,


### PR DESCRIPTION
## Current Behavior
The `dev`, `serve`, `preview` and `serve-static` targets inferred by the `@nx/vite/plugin` do not infer `continuous:true` indicating to Nx that these tasks are continuous.


## Expected Behavior
Infer `continuous: true` for the serve-like targets for Vite.
