### PR TITLE
fix(release): ensure tags for version match stable variant before prerelease

### DIFF
--- a/e2e/release/src/release-tag-pattern.test.ts
+++ b/e2e/release/src/release-tag-pattern.test.ts
@@ -57,6 +57,36 @@ describe('nx release releaseTagPattern', () => {
 
   afterEach(() => cleanupProject());
 
+  it('should prefer stable versions over prereleases', async () => {
+    updateJson<NxJsonConfiguration>('nx.json', (nxJson) => {
+      nxJson.release = {
+        releaseTagPattern: 'v{version}',
+        version: {
+          conventionalCommits: true,
+        },
+      };
+      return nxJson;
+    });
+
+    // Tag the existing commit as a prerelease
+    await runCommandAsync(`git tag -a v1.0.0-beta.1 -m "v1.0.0-beta.1"`);
+
+    // Resolve that prerelease as the current version
+    expect(runCLI(`release version -d`)).toContain(
+      `Resolved the current version as 1.0.0-beta.1 from git tag "v1.0.0-beta.1"`
+    );
+
+    // Make a new commit and tag it as a stable version
+    await runCommandAsync(`echo "Hello" > README.md`);
+    await runCommandAsync(`git add README.md`);
+    await runCommandAsync(`git commit -m "chore: update README.md"`);
+    await runCommandAsync(`git tag -a v1.0.0 -m "v1.0.0"`);
+
+    expect(runCLI(`release version -d`)).toContain(
+      `Resolved the current version as 1.0.0 from git tag "v1.0.0"`
+    );
+  });
+
   describe('releaseTagPatternCheckAllBranchesWhen', () => {
     it('should check the current branch first, and then fall back to all branches by default/when not specified', async () => {
       updateJson<NxJsonConfiguration>('nx.json', (nxJson) => {

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -85,7 +85,14 @@ export async function getLatestGitTagForPattern(
     }
   }
 
-  const defaultGitArgs = ['tag', '--sort', '-v:refname'];
+  const defaultGitArgs = [
+    // Apply git config to take version suffixes into account when sorting, e.g. 1.0.0 is newer than 1.0.0-beta.1
+    '-c',
+    'versionsort.suffix=-',
+    'tag',
+    '--sort',
+    '-v:refname',
+  ];
 
   try {
     let tags: string[];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Versions with a `-suffix` (prereleases) would be matched before ones without (stable) releases for the same version number.

E.g. `v1.0.0-beta.1` would be matched before `v1.0.0` even though based on the lifecycle of development, `v1.0.0` would be the latest release.

This is shown by the included e2e test which failed before this change, and passes after it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The included e2e test passes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #27577
