### PR TITLE
chore(misc): update .gitignore help link

### DIFF
--- a/packages/nuxt/src/utils/__snapshots__/update-gitignore.spec.ts.snap
+++ b/packages/nuxt/src/utils/__snapshots__/update-gitignore.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`update gitignore should add entries to .gitignore if they do not exist 1`] = `
 "
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
 # compiled output
 dist
@@ -32,7 +32,7 @@ node_modules
 
 exports[`update gitignore should not add duplicate entries to .gitignore if they already exist 1`] = `
 "
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
 # compiled output
 dist

--- a/packages/nuxt/src/utils/update-gitignore.spec.ts
+++ b/packages/nuxt/src/utils/update-gitignore.spec.ts
@@ -13,7 +13,7 @@ describe('update gitignore', () => {
     tree.write(
       '.gitignore',
       `
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
 # compiled output
 dist
@@ -44,7 +44,7 @@ node_modules
     tree.write(
       '.gitignore',
       `
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
 # compiled output
 dist

--- a/packages/workspace/src/generators/new/files-integrated-repo/__dot__gitignore
+++ b/packages/workspace/src/generators/new/files-integrated-repo/__dot__gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
 # compiled output
 dist

--- a/packages/workspace/src/generators/new/files-package-based-repo/__dot__gitignore
+++ b/packages/workspace/src/generators/new/files-package-based-repo/__dot__gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
 # compiled output
 dist

--- a/packages/workspace/src/generators/new/files-root-app/__dot__gitignore
+++ b/packages/workspace/src/generators/new/files-root-app/__dot__gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
 # compiled output
 dist


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Currently when we generate a `.gitignore` file we include a help link to http://help.github.com/ignore-files/ which is no longer a valid url.

## Expected Behavior
It should link to the new help link https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29794
