### PR TITLE
feat(storybook): infer continuous tasks for storybook serve and serve-static

### DIFF
--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -97,11 +97,13 @@ describe('@nx/storybook/plugin', () => {
                   },
                   "serve-storybook": {
                     "command": "storybook dev",
+                    "continuous": true,
                     "options": {
                       "cwd": "my-app",
                     },
                   },
                   "static-storybook": {
+                    "continuous": true,
                     "executor": "@nx/web:file-server",
                     "options": {
                       "buildTarget": "build-storybook",
@@ -175,6 +177,7 @@ describe('@nx/storybook/plugin', () => {
                     ],
                   },
                   "serve-storybook": {
+                    "continuous": true,
                     "executor": "@storybook/angular:start-storybook",
                     "options": {
                       "browserTarget": "my-ng-app:build-storybook",
@@ -183,6 +186,7 @@ describe('@nx/storybook/plugin', () => {
                     },
                   },
                   "static-storybook": {
+                    "continuous": true,
                     "executor": "@nx/web:file-server",
                     "options": {
                       "buildTarget": "build-storybook",
@@ -257,11 +261,13 @@ describe('@nx/storybook/plugin', () => {
                   },
                   "serve-storybook": {
                     "command": "storybook dev",
+                    "continuous": true,
                     "options": {
                       "cwd": "my-react-lib",
                     },
                   },
                   "static-storybook": {
+                    "continuous": true,
                     "executor": "@nx/web:file-server",
                     "options": {
                       "buildTarget": "build-storybook",

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -277,6 +277,7 @@ function serveTarget(
 ) {
   if (frameworkIsAngular) {
     return {
+      continuous: true,
       executor: '@storybook/angular:start-storybook',
       options: {
         configDir: `${dirname(configFilePath)}`,
@@ -286,6 +287,7 @@ function serveTarget(
     };
   } else {
     return {
+      continuous: true,
       command: `storybook dev`,
       options: { cwd: projectRoot },
     };
@@ -311,6 +313,7 @@ function serveStaticTarget(
   projectRoot: string
 ) {
   const targetConfig: TargetConfiguration = {
+    continuous: true,
     executor: '@nx/web:file-server',
     options: {
       buildTarget: `${options.buildStorybookTargetName}`,


### PR DESCRIPTION
## Current Behavior
The `@nx/storybook/plugin` does not set `continuous:true` for serve-like targets.

## Expected Behavior
The plugin should correctly set `continuous: true` for `serve` and `serve-static`.
