### PR TITLE
fix(core): make hash_array resilient to None values

### DIFF
--- a/packages/nx/src/native/hasher.rs
+++ b/packages/nx/src/native/hasher.rs
@@ -13,8 +13,8 @@ pub fn hash_array(input: Vec<Option<String>>) -> String {
         if s.is_none() {
             trace!("Encountered None value in hash_array input: {:?}", input);
         }
-        s.as_ref()
-    }).map(|s| s.as_str()).collect::<Vec<_>>().join(",");
+        s.as_deref()
+    }).collect::<Vec<_>>().join(",");
     let content = joined.as_bytes();
     hash(content)
 }

--- a/packages/nx/src/native/hasher.rs
+++ b/packages/nx/src/native/hasher.rs
@@ -8,8 +8,13 @@ pub fn hash(content: &[u8]) -> String {
 }
 
 #[napi]
-pub fn hash_array(input: Vec<String>) -> String {
-    let joined = input.join(",");
+pub fn hash_array(input: Vec<Option<String>>) -> String {
+    let joined = input.iter().filter_map(|s| {
+        if s.is_none() {
+            trace!("Encountered None value in hash_array input: {:?}", input);
+        }
+        s.as_ref()
+    }).map(|s| s.as_str()).collect::<Vec<_>>().join(",");
     let content = joined.as_bytes();
     hash(content)
 }
@@ -36,7 +41,7 @@ pub fn hash_file_path<P: AsRef<Path>>(path: P) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::native::hasher::hash_file;
+    use crate::native::hasher::{hash_file, hash_array};
     use assert_fs::prelude::*;
     use assert_fs::TempDir;
 
@@ -71,5 +76,12 @@ mod tests {
         let content = hash_file(test_file_path);
 
         assert_eq!(content.unwrap(), "6193209363630369380");
+    }
+
+    #[test]
+    fn it_hashes_an_array() {
+        // Resilient to None values (e.g. null values passed from the JS side)
+        let content = hash_array(vec![Some("foo".to_string()), None, Some("bar".to_string())]);
+        assert_eq!(content, "10292076446133652019");
     }
 }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -173,7 +173,7 @@ export declare export function getFilesForOutputs(directory: string, entries: Ar
 
 export declare export function getTransformableOutputs(outputs: Array<string>): Array<string>
 
-export declare export function hashArray(input: Array<string>): string
+export declare export function hashArray(input: Array<string | undefined | null>): string
 
 export interface HashDetails {
   value: string

--- a/packages/nx/src/native/tasks/hashers/hash_external.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_external.rs
@@ -37,8 +37,8 @@ pub fn hash_all_externals<S: AsRef<str>>(
 ) -> Result<String> {
     let hashes = sorted_externals
         .iter()
-        .map(|name| hash_external(name.as_ref(), externals, Arc::clone(&cache)))
-        .collect::<Result<Vec<_>>>()?;
+        .map(|name| hash_external(name.as_ref(), externals, Arc::clone(&cache)).map(Some))
+        .collect::<Result<Vec<Option<String>>>>()?;
     Ok(hash_array(hashes))
 }
 

--- a/packages/nx/src/native/tasks/hashers/hash_task_output.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_task_output.rs
@@ -16,5 +16,5 @@ pub fn hash_task_output(workspace_root: &str, glob: &str, outputs: &[String]) ->
         .filter(|file| glob.is_match(file))
         .filter_map(|file| hash_file(Path::new(workspace_root).join(file).to_str().expect("path contains invalid utf-8").to_owned()))
         .collect::<Vec<_>>();
-    Ok(hash_array(hashes))
+    Ok(hash_array(hashes.into_iter().map(Some).collect()))
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

If `null`/`undefined` is given to `hashArray` we end up with an unclear napi-rs error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The underlying `hash_array` on the rust side is resilient to `None` values, and can therefore handle when `null`/`undefined` are passed through from the JS side.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to #29429 
