### PR TITLE
fix(js): use absolute filetorun path

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -404,7 +404,7 @@ function getFileToRun(
       const outputFilePath = interpolate(outputPath, {
         projectName: project.name,
         projectRoot: project.data.root,
-        workspaceRoot: '',
+        workspaceRoot: context.root,
       });
       return path.join(outputFilePath, 'main.js');
     }


### PR DESCRIPTION
Fix a bug introduced in #30087

#### Current Behavior
The `@nx/js` plugins throw an error when the project is served in the project root but not in the workspace root.

#### Expected Behavior
Ensure that `nx run $project:serve` works correctly both in the workspace root and the project root, restoring the previous behavior.

#### Related Issue(s)
Fixes #30087
