### PR TITLE
fix(core): NX_PLUGIN_NO_TIMEOUTS should also remove timeout on plugin worker connection

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -217,14 +217,16 @@ const server = createServer((socket) => {
 
 server.listen(socketPath);
 
-setTimeout(() => {
-  if (!connected) {
-    console.error(
-      'The plugin worker is exiting as it was not connected to within 5 seconds.'
-    );
-    process.exit(1);
-  }
-}, 5000).unref();
+if (process.env.NX_PLUGIN_NO_TIMEOUTS !== 'true') {
+  setTimeout(() => {
+    if (!connected) {
+      console.error(
+        'The plugin worker is exiting as it was not connected to within 5 seconds.'
+      );
+      process.exit(1);
+    }
+  }, 5000).unref();
+}
 
 const exitHandler = (exitCode: number) => () => {
   server.close();


### PR DESCRIPTION
## Current Behavior
Setting `NX_PLUGIN_NO_TIMEOUTS ` does not remove the timeout for initial connection to the plugin worker

## Expected Behavior
Setting `NX_PLUGIN_NO_TIMEOUTS ` does remove the timeout for initial connection to the plugin worker

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
