### PR TITLE
fix(nx-dev): remove OTel-based tracing for now to remove local dev erros

### DIFF
--- a/nx-dev/nx-dev/lib/components/frontend-observability.tsx
+++ b/nx-dev/nx-dev/lib/components/frontend-observability.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useEffect, useRef } from 'react';
 import { getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';
-import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 export function FrontendObservability() {
   const initialized = useRef(false);
@@ -25,10 +24,7 @@ export function FrontendObservability() {
         version,
         environment,
       },
-      instrumentations: [
-        ...getWebInstrumentations(),
-        new TracingInstrumentation(),
-      ],
+      instrumentations: [...getWebInstrumentations()],
     });
   }, []);
   return null;


### PR DESCRIPTION
Locally, when running `nx serve-docs nx-dev`, you'll see errors coming from `/blog` URLs due to instrumentation problems. This is caused by the `@grafana/faro-web-tracing` packages as soon as it is imported in an app router environment.

We don't need it for now, so we can just remove it. It means that we will be missing tracing on HTTP requests like XHRs, but we still get performance metrics and error reporting.

## Current Behavior
See errors in logs during development

## Expected Behavior
No errors in logs

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
