### PR TITLE
feat(module-federation): add webpack module federation crystal plugin

### DIFF
--- a/packages/module-federation/src/plugins/models/index.ts
+++ b/packages/module-federation/src/plugins/models/index.ts
@@ -1,5 +1,3 @@
-import { ModuleFederationConfig } from '../../utils/models';
-
 export interface NxModuleFederationDevServerConfig {
   host?: string;
   staticRemotesPort?: number;

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-dev-server-plugin.ts
@@ -1,0 +1,127 @@
+import {
+  Compilation,
+  Compiler,
+  DefinePlugin,
+  WebpackPluginInstance,
+} from 'webpack';
+import * as pc from 'picocolors';
+import {
+  logger,
+  readCachedProjectGraph,
+  readProjectsConfigurationFromProjectGraph,
+  workspaceRoot,
+} from '@nx/devkit';
+import { ModuleFederationConfig } from '../../../utils/models';
+import { extname, join } from 'path';
+import { existsSync } from 'fs';
+import {
+  buildStaticRemotes,
+  getDynamicMfManifestFile,
+  getRemotes,
+  getStaticRemotes,
+  parseRemotesConfig,
+  startRemoteProxies,
+  startStaticRemotesFileServer,
+} from '../../utils';
+import { NxModuleFederationDevServerConfig } from '../../models';
+
+const PLUGIN_NAME = 'NxModuleFederationDevServerPlugin';
+
+export class NxModuleFederationDevServerPlugin
+  implements WebpackPluginInstance
+{
+  private nxBin = require.resolve('nx/bin/nx');
+
+  constructor(
+    private _options: {
+      config: ModuleFederationConfig;
+      devServerConfig: NxModuleFederationDevServerConfig;
+    }
+  ) {}
+
+  apply(compiler: Compiler) {
+    compiler.hooks.beforeCompile.tapAsync(
+      PLUGIN_NAME,
+      async (params, callback) => {
+        const staticRemotesConfig = await this.setup();
+
+        logger.info(
+          `NX Starting module federation dev-server for ${pc.bold(
+            this._options.config.name
+          )} with ${Object.keys(staticRemotesConfig).length} remotes`
+        );
+
+        const mappedLocationOfRemotes = await buildStaticRemotes(
+          staticRemotesConfig,
+          this._options.devServerConfig,
+          this.nxBin
+        );
+        startStaticRemotesFileServer(
+          staticRemotesConfig,
+          workspaceRoot,
+          this._options.devServerConfig.staticRemotesPort
+        );
+        startRemoteProxies(staticRemotesConfig, mappedLocationOfRemotes, {
+          pathToCert: this._options.devServerConfig.sslCert,
+          pathToKey: this._options.devServerConfig.sslCert,
+        });
+
+        new DefinePlugin({
+          'process.env.NX_MF_DEV_REMOTES': process.env.NX_MF_DEV_REMOTES,
+        }).apply(compiler);
+        callback();
+      }
+    );
+  }
+
+  private async setup() {
+    const projectGraph = readCachedProjectGraph();
+    const { projects: workspaceProjects } =
+      readProjectsConfigurationFromProjectGraph(projectGraph);
+    const project = workspaceProjects[this._options.config.name];
+    if (!this._options.devServerConfig.pathToManifestFile) {
+      this._options.devServerConfig.pathToManifestFile =
+        getDynamicMfManifestFile(project, workspaceRoot);
+    } else {
+      const userPathToManifestFile = join(
+        workspaceRoot,
+        this._options.devServerConfig.pathToManifestFile
+      );
+      if (!existsSync(userPathToManifestFile)) {
+        throw new Error(
+          `The provided Module Federation manifest file path does not exist. Please check the file exists at "${userPathToManifestFile}".`
+        );
+      } else if (
+        extname(this._options.devServerConfig.pathToManifestFile) !== '.json'
+      ) {
+        throw new Error(
+          `The Module Federation manifest file must be a JSON. Please ensure the file at ${userPathToManifestFile} is a JSON.`
+        );
+      }
+
+      this._options.devServerConfig.pathToManifestFile = userPathToManifestFile;
+    }
+
+    const { remotes, staticRemotePort } = getRemotes(
+      this._options.config,
+      projectGraph,
+      this._options.devServerConfig.pathToManifestFile
+    );
+    this._options.devServerConfig.staticRemotesPort ??= staticRemotePort;
+
+    const remotesConfig = parseRemotesConfig(
+      remotes,
+      workspaceRoot,
+      projectGraph
+    );
+    const staticRemotesConfig = await getStaticRemotes(
+      remotesConfig.config ?? {}
+    );
+    const devRemotes = remotes.filter((r) => !staticRemotesConfig[r]);
+    process.env.NX_MF_DEV_REMOTES = JSON.stringify([
+      ...(devRemotes.length > 0 ? devRemotes : []),
+      project.name,
+    ]);
+    return staticRemotesConfig ?? {};
+  }
+}

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-dev-server-plugin.ts
@@ -63,7 +63,7 @@ export class NxModuleFederationDevServerPlugin
         );
         startRemoteProxies(staticRemotesConfig, mappedLocationOfRemotes, {
           pathToCert: this._options.devServerConfig.sslCert,
-          pathToKey: this._options.devServerConfig.sslCert,
+          pathToKey: this._options.devServerConfig.sslKey,
         });
 
         new DefinePlugin({

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-plugin.ts
@@ -1,0 +1,66 @@
+import { Compiler, WebpackPluginInstance } from 'webpack';
+import {
+  ModuleFederationConfig,
+  NxModuleFederationConfigOverride,
+} from '../../../utils/models';
+import { getModuleFederationConfig } from '../../../with-module-federation/rspack/utils';
+import { NxModuleFederationDevServerConfig } from '../../models';
+import { NxModuleFederationDevServerPlugin } from './nx-module-federation-dev-server-plugin';
+
+export class NxModuleFederationPlugin implements WebpackPluginInstance {
+  constructor(
+    private _options: {
+      config: ModuleFederationConfig;
+      devServerConfig?: NxModuleFederationDevServerConfig;
+    },
+    private configOverride?: NxModuleFederationConfigOverride
+  ) {}
+
+  apply(compiler: Compiler) {
+    if (global.NX_GRAPH_CREATION) {
+      return;
+    }
+
+    // This is required to ensure Module Federation will build the project correctly
+    compiler.options.optimization.runtimeChunk = false;
+
+    const isDevServer = !!process.env['WEBPACK_SERVE'];
+
+    // TODO(colum): Add support for SSR
+    const config = getModuleFederationConfig(this._options.config);
+    const sharedLibraries = config.sharedLibraries;
+    const sharedDependencies = config.sharedDependencies;
+    const mappedRemotes = config.mappedRemotes;
+
+    new (require('@module-federation/enhanced/webpack').ModuleFederationPlugin)(
+      {
+        name: this._options.config.name.replace(/-/g, '_'),
+        filename: 'remoteEntry.js',
+        exposes: this._options.config.exposes,
+        remotes: mappedRemotes,
+        shared: {
+          ...(sharedDependencies ?? {}),
+        },
+        ...(this.configOverride ? this.configOverride : {}),
+        runtimePlugins: this.configOverride
+          ? this.configOverride.runtimePlugins ?? []
+          : [],
+        virtualRuntimeEntry: true,
+      }
+    ).apply(compiler);
+
+    if (sharedLibraries) {
+      sharedLibraries.getReplacementPlugin().apply(compiler as any);
+    }
+
+    if (isDevServer) {
+      new NxModuleFederationDevServerPlugin({
+        config: this._options.config,
+        devServerConfig: {
+          ...(this._options.devServerConfig ?? {}),
+          host: this._options.devServerConfig?.host ?? 'localhost',
+        },
+      }).apply(compiler);
+    }
+  }
+}

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-ssr-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-ssr-dev-server-plugin.ts
@@ -1,0 +1,191 @@
+import {
+  Compilation,
+  Compiler,
+  DefinePlugin,
+  WebpackPluginInstance,
+} from 'webpack';
+import * as pc from 'picocolors';
+import {
+  logger,
+  readCachedProjectGraph,
+  readProjectsConfigurationFromProjectGraph,
+  workspaceRoot,
+} from '@nx/devkit';
+import { ModuleFederationConfig } from '../../../utils/models';
+import { dirname, extname, join } from 'path';
+import { existsSync } from 'fs';
+import {
+  buildStaticRemotes,
+  getDynamicMfManifestFile,
+  getRemotes,
+  getStaticRemotes,
+  parseRemotesConfig,
+  startRemoteProxies,
+  startStaticRemotesFileServer,
+} from '../../utils';
+import { NxModuleFederationDevServerConfig } from '../../models';
+import { ChildProcess, fork } from 'node:child_process';
+
+const PLUGIN_NAME = 'NxModuleFederationSSRDevServerPlugin';
+
+export class NxModuleFederationSSRDevServerPlugin
+  implements WebpackPluginInstance
+{
+  private devServerProcess: ChildProcess | undefined;
+  private nxBin = require.resolve('nx/bin/nx');
+
+  constructor(
+    private _options: {
+      config: ModuleFederationConfig;
+      devServerConfig?: NxModuleFederationDevServerConfig;
+    }
+  ) {
+    this._options.devServerConfig ??= {
+      host: 'localhost',
+    };
+  }
+
+  apply(compiler: Compiler) {
+    const isDevServer = process.env['WEBPACK_SERVE'];
+    if (!isDevServer) {
+      return;
+    }
+    compiler.hooks.watchRun.tapAsync(
+      PLUGIN_NAME,
+      async (compiler, callback) => {
+        compiler.hooks.beforeCompile.tapAsync(
+          PLUGIN_NAME,
+          async (params, callback) => {
+            const staticRemotesConfig = await this.setup(compiler);
+
+            logger.info(
+              `NX Starting module federation dev-server for ${pc.bold(
+                this._options.config.name
+              )} with ${Object.keys(staticRemotesConfig).length} remotes`
+            );
+
+            const mappedLocationOfRemotes = await buildStaticRemotes(
+              staticRemotesConfig,
+              this._options.devServerConfig,
+              this.nxBin
+            );
+            startStaticRemotesFileServer(
+              staticRemotesConfig,
+              workspaceRoot,
+              this._options.devServerConfig.staticRemotesPort
+            );
+            startRemoteProxies(
+              staticRemotesConfig,
+              mappedLocationOfRemotes,
+              {
+                pathToCert: this._options.devServerConfig.sslCert,
+                pathToKey: this._options.devServerConfig.sslKey,
+              },
+              true
+            );
+
+            new DefinePlugin({
+              'process.env.NX_MF_DEV_REMOTES': process.env.NX_MF_DEV_REMOTES,
+            }).apply(compiler);
+
+            await this.startServer(compiler);
+
+            callback();
+          }
+        );
+        callback();
+      }
+    );
+  }
+
+  private async startServer(compiler: Compiler) {
+    compiler.hooks.done.tapAsync(PLUGIN_NAME, async (_, callback) => {
+      const serverPath = join(
+        compiler.options.output.path,
+        (compiler.options.output.filename as string) ?? 'server.js'
+      );
+      if (this.devServerProcess) {
+        await new Promise<void>((res) => {
+          this.devServerProcess.on('exit', () => {
+            res();
+          });
+          this.devServerProcess.kill('SIGKILL');
+          this.devServerProcess = undefined;
+        });
+      }
+
+      if (!existsSync(serverPath)) {
+        for (let retries = 0; retries < 10; retries++) {
+          await new Promise<void>((res) => setTimeout(res, 200));
+          if (existsSync(serverPath)) {
+            break;
+          }
+        }
+        if (!existsSync(serverPath)) {
+          throw new Error(`Could not find server bundle at ${serverPath}.`);
+        }
+      }
+
+      this.devServerProcess = fork(serverPath);
+      process.on('exit', () => {
+        this.devServerProcess?.kill('SIGKILL');
+      });
+      process.on('SIGINT', () => {
+        this.devServerProcess?.kill('SIGKILL');
+      });
+      callback();
+    });
+  }
+
+  private async setup(compiler: Compiler) {
+    const projectGraph = readCachedProjectGraph();
+    const { projects: workspaceProjects } =
+      readProjectsConfigurationFromProjectGraph(projectGraph);
+    const project = workspaceProjects[this._options.config.name];
+    if (!this._options.devServerConfig.pathToManifestFile) {
+      this._options.devServerConfig.pathToManifestFile =
+        getDynamicMfManifestFile(project, workspaceRoot);
+    } else {
+      const userPathToManifestFile = join(
+        workspaceRoot,
+        this._options.devServerConfig.pathToManifestFile
+      );
+      if (!existsSync(userPathToManifestFile)) {
+        throw new Error(
+          `The provided Module Federation manifest file path does not exist. Please check the file exists at "${userPathToManifestFile}".`
+        );
+      } else if (
+        extname(this._options.devServerConfig.pathToManifestFile) !== '.json'
+      ) {
+        throw new Error(
+          `The Module Federation manifest file must be a JSON. Please ensure the file at ${userPathToManifestFile} is a JSON.`
+        );
+      }
+
+      this._options.devServerConfig.pathToManifestFile = userPathToManifestFile;
+    }
+
+    const { remotes, staticRemotePort } = getRemotes(
+      this._options.config,
+      projectGraph,
+      this._options.devServerConfig.pathToManifestFile
+    );
+    this._options.devServerConfig.staticRemotesPort ??= staticRemotePort;
+
+    const remotesConfig = parseRemotesConfig(
+      remotes,
+      workspaceRoot,
+      projectGraph,
+      true
+    );
+    const staticRemotesConfig = await getStaticRemotes(
+      remotesConfig.config ?? {}
+    );
+    const devRemotes = remotes.filter((r) => !staticRemotesConfig[r]);
+    process.env.NX_MF_DEV_REMOTES = JSON.stringify([
+      ...(devRemotes.length > 0 ? devRemotes : []),
+      project.name,
+    ]);
+    return staticRemotesConfig ?? {};
+  }
+}

--- a/packages/module-federation/webpack.ts
+++ b/packages/module-federation/webpack.ts
@@ -1,2 +1,4 @@
 export * from './src/with-module-federation/webpack/with-module-federation';
 export * from './src/with-module-federation/webpack/with-module-federation-ssr';
+export * from './src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-plugin';
+export * from './src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-dev-server-plugin';

--- a/packages/module-federation/webpack.ts
+++ b/packages/module-federation/webpack.ts
@@ -2,3 +2,4 @@ export * from './src/with-module-federation/webpack/with-module-federation';
 export * from './src/with-module-federation/webpack/with-module-federation-ssr';
 export * from './src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-plugin';
 export * from './src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-dev-server-plugin';
+export * from './src/plugins/nx-module-federation-plugin/webpack/nx-module-federation-ssr-dev-server-plugin';


### PR DESCRIPTION
## Current Behavior
The `NxModuleFederationPlugin` and `NxModuleFederationDevServerPlugin` do not exist for Webpack.

## Expected Behavior
Add the plugins for Webpack to allow for Crystal module federation support with webpack applications.

## Blocked by
https://github.com/module-federation/core/issues/3529
