### PR TITLE
fix(release): properly terminate case in switch statement

### DIFF
--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -837,6 +837,7 @@ export async function handleNxReleaseConfigError(
         title: `There was an error when resolving the configured changelog renderer at path: ${error.data.workspaceRelativePath}`,
         bodyLines: [nxJsonMessage],
       });
+      break;
     }
     case 'INVALID_CHANGELOG_CREATE_RELEASE_PROVIDER':
       {


### PR DESCRIPTION
This corrects an issue when the changelog renderer is incorrect and shows `Cannot read properties of undefined (reading 'map')`, but it hides the real error message.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
