### PR TITLE
fix(js): use uuid when generating tmp tsconfig

### DIFF
--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -19,6 +19,7 @@ import { output } from 'nx/src/utils/output';
 import { dirname, join, relative, extname, resolve } from 'path';
 import type * as ts from 'typescript';
 import { readTsConfigPaths } from './typescript/ts-config';
+import { randomUUID } from 'crypto';
 
 function isBuildable(target: string, node: ProjectGraphProjectNode): boolean {
   return (
@@ -443,7 +444,7 @@ export function createTmpTsConfig(
     'tmp',
     projectRoot,
     process.env.NX_TASK_TARGET_TARGET ?? 'build',
-    'tsconfig.generated.json'
+    `tsconfig.generated.${randomUUID()}.json`
   );
   if (tsconfigPath === tmpTsConfigPath) {
     return tsconfigPath;

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -80,13 +80,14 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
       projectRoot = config.root;
       const projectRootFromWorkspaceRoot = relative(workspaceRoot, projectRoot);
       let foundTsConfigPath = getTsConfig(
-        join(
-          workspaceRoot,
-          'tmp',
-          projectRootFromWorkspaceRoot,
-          process.env.NX_TASK_TARGET_TARGET ?? 'build',
-          'tsconfig.generated.json'
-        )
+        process.env.NX_TSCONFIG_PATH ??
+          join(
+            workspaceRoot,
+            'tmp',
+            projectRootFromWorkspaceRoot,
+            process.env.NX_TASK_TARGET_TARGET ?? 'build',
+            'tsconfig.generated.json'
+          )
       );
       if (!foundTsConfigPath) {
         throw new Error(stripIndents`Unable to find a tsconfig in the workspace! 


### PR DESCRIPTION
## Current Behavior
When multiple processes/tasks are running in parallel for a single project that produce tmp tsconfig files for buildable libraries, they can clobber each other.
 

## Expected Behavior
Ensure the config file is generated with a unique id to prevent clobbering
