### PR TITLE
fix(module-federation): handle remote output paths

### DIFF
--- a/packages/module-federation/src/plugins/models/index.ts
+++ b/packages/module-federation/src/plugins/models/index.ts
@@ -8,4 +8,10 @@ export interface NxModuleFederationDevServerConfig {
   sslCert?: string;
   sslKey?: string;
   parallel?: number;
+  devRemoteFindOptions?: DevRemoteFindOptions;
+}
+
+export interface DevRemoteFindOptions {
+  retries?: number;
+  retryDelay?: number;
 }

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts
@@ -16,8 +16,6 @@ export class NxModuleFederationPlugin implements RspackPluginInstance {
     private configOverride?: NxModuleFederationConfigOverride
   ) {}
 
-  // Do nothing
-
   apply(compiler: Compiler) {
     if (global.NX_GRAPH_CREATION) {
       return;

--- a/packages/module-federation/src/plugins/utils/get-static-remotes.ts
+++ b/packages/module-federation/src/plugins/utils/get-static-remotes.ts
@@ -1,8 +1,10 @@
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
 import { StaticRemoteConfig } from '../../utils';
+import { DevRemoteFindOptions } from '../models';
 
 export async function getStaticRemotes(
-  remotesConfig: Record<string, StaticRemoteConfig>
+  remotesConfig: Record<string, StaticRemoteConfig>,
+  devRemoteFindOptions?: DevRemoteFindOptions
 ) {
   const remotes = Object.keys(remotesConfig);
   const findStaticRemotesPromises: Promise<string | undefined>[] = [];
@@ -10,8 +12,8 @@ export async function getStaticRemotes(
     findStaticRemotesPromises.push(
       new Promise<string>((resolve, reject) => {
         waitForPortOpen(remotesConfig[remote].port, {
-          retries: 5,
-          retryDelay: 1000,
+          retries: devRemoteFindOptions?.retries ?? 3,
+          retryDelay: devRemoteFindOptions?.retryDelay ?? 1000,
         }).then(
           (res) => {
             resolve(undefined);

--- a/packages/module-federation/src/plugins/utils/parse-remotes-config.ts
+++ b/packages/module-federation/src/plugins/utils/parse-remotes-config.ts
@@ -1,6 +1,7 @@
-import { ProjectGraph } from '@nx/devkit';
-import { StaticRemoteConfig } from '../../utils';
 import { basename, dirname } from 'path';
+import { interpolate } from 'nx/src/devkit-internals';
+import { joinPathFragments, ProjectGraph } from '@nx/devkit';
+import { StaticRemoteConfig } from '../../utils';
 
 export function parseRemotesConfig(
   remotes: string[] | undefined,
@@ -12,11 +13,22 @@ export function parseRemotesConfig(
   }
   const config: Record<string, StaticRemoteConfig> = {};
   for (const app of remotes) {
-    const outputPath =
-      projectGraph.nodes[app].data.targets?.['build']?.options.outputPath ??
-      `${workspaceRoot ? `${workspaceRoot}/` : ''}${
-        projectGraph.nodes[app].data.root
-      }/dist`; // this needs replaced with better logic for finding the output path
+    const projectRoot = projectGraph.nodes[app].data.root;
+    let outputPath = interpolate(
+      projectGraph.nodes[app].data.targets?.['build']?.options?.outputPath ??
+        projectGraph.nodes[app].data.targets?.['build']?.outputs?.[0] ??
+        `${workspaceRoot ? `${workspaceRoot}/` : ''}${
+          projectGraph.nodes[app].data.root
+        }/dist`,
+      {
+        projectName: projectGraph.nodes[app].data.name,
+        projectRoot,
+        workspaceRoot,
+      }
+    );
+    if (outputPath.startsWith(projectRoot)) {
+      outputPath = joinPathFragments(workspaceRoot, outputPath);
+    }
     const basePath = dirname(outputPath);
     const urlSegment = app;
     const port = projectGraph.nodes[app].data.targets?.['serve']?.options.port;


### PR DESCRIPTION
## Current Behavior
`parseRemotesConfig` is naively handling detection of remote output paths needed for standing up the single file server.


## Expected Behavior
Provide better detection of remote output paths that covers inference and executor usage with fallback behaviour
