### PR TITLE
feat(rspack): use ts-checker-rspack-plugin instead of fork-ts-checker-webpack-plugin

### DIFF
--- a/packages/rspack/.eslintrc.json
+++ b/packages/rspack/.eslintrc.json
@@ -49,7 +49,8 @@
               "@module-federation/sdk",
               "@module-federation/enhanced",
               "css-loader",
-              "webpack"
+              "webpack",
+              "ts-checker-rspack-plugin"
             ]
           }
         ]

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -37,7 +37,7 @@
     "css-loader": "^6.4.0",
     "enquirer": "~2.3.6",
     "express": "^4.21.2",
-    "fork-ts-checker-webpack-plugin": "7.2.13",
+    "ts-checker-rspack-plugin": "^1.1.1",
     "http-proxy-middleware": "^3.0.3",
     "less-loader": "11.1.0",
     "license-webpack-plugin": "^4.0.2",

--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -235,14 +235,14 @@ function applyNxDependentConfig(
 
   // New TS Solution already has a typecheck target
   if (!options?.skipTypeChecking && !isUsingTsSolution) {
-    const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+    const { TsCheckerRspackPlugin } = require('ts-checker-rspack-plugin');
     plugins.push(
-      new ForkTsCheckerWebpackPlugin({
+      new TsCheckerRspackPlugin({
         typescript: {
           configFile: path.isAbsolute(tsConfig)
             ? tsConfig
             : path.join(options.root, tsConfig),
-          memoryLimit: options.memoryLimit || 2018,
+          memoryLimit: options.memoryLimit || 8192, // default memory limit is 8192
         },
       })
     );


### PR DESCRIPTION
## Current Behavior
Our Rspack support currently leverages `fork-ts-checker-webpack-plugin` to handle typechecking during build.

## Expected Behavior
Switch to using `ts-checker-rspack-plugin` for better memory management and typecheck support.
