### PR TITLE
use StreamingTargetPlugin instead of @module-federation/enhanced when running MFE in SSR mode

### DIFF
--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
@@ -25,9 +25,9 @@ export async function withModuleFederationForSSR(
       ...(config.optimization ?? {}),
       runtimeChunk: false,
     };
-
+    
     config.plugins.push(
-      new (require('@module-federation/enhanced').ModuleFederationPlugin)(
+      new (require('@module-federation/node').StreamingTargetPlugin)(
         {
           name: options.name.replace(/-/g, '_'),
           filename: 'remoteEntry.js',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
@nrwl/nx-pipelines-reviewers This PR addresses issues encountered when using Module Federation with Server-Side Rendering (SSR) in new Micro Frontend (MFE) workspaces created following the Nx documentation (https://nx.dev/recipes/react/module-federation-with-ssr).

Currently, creating a new MFE workspace results in the following errors:

#### 1)  The error below occurs due to the server attempting to directly load modules using @module-federation/enhanced, which is designed for browser environments and cannot fetch remote modules on the server.
```
[Error: ENOENT: no such file or directory, open '/server/__federation_expose_Module.js'
while loading "./Module" from 28] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/server/__federation_expose_Module.js'
}
```
#### 2) the error below arises when attempting to hardcode the remoteEntry.js file path in the ModuleFederationConfig, indicating a problem with how remote entries are handled in SSR.
```
Error: [ Federation Runtime ]: remoteEntryExports is undefined 
 {
  "alias": "checkout",
  "name": "checkout",
  "entry": "http://localhost:4202/remoteEntry.js",
  "shareScope": "default",
  "type": "global",
  "entryGlobalName": "checkout"
}
```

This PR resolves these issues by utilizing the StreamingTargetPlugin from @module-federation/node within withModuleFederationForSSR. This approach enables remote module loading during SSR, ensuring proper loading on the server-side.  Remote modules are now correctly loaded in SSR mode, without errors, though re-rendering still occurs on the client if you don't hydrate root.

## Expected Behavior
When using Server-Side Rendering (SSR) with Module Federation, remote modules must be loaded by the server.  Currently, this process fails, resulting in errors and a fallback to browser-side loading, which defeats the purpose of SSR. This PR corrects this behavior.

