### PR TITLE
fix(core): task runner should match on full segments (e.g. foo does not match foo-e2e)

### DIFF
--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -55,6 +55,14 @@ describe('findMatchingProjects', () => {
         tags: [],
       },
     },
+    '@acme/foo-e2e': {
+      name: '@acme/foo-e2e',
+      type: 'lib',
+      data: {
+        root: 'lib/foo-e2e',
+        tags: [],
+      },
+    },
     '@acme/bar': {
       name: '@acme/bar',
       type: 'lib',
@@ -102,6 +110,7 @@ describe('findMatchingProjects', () => {
       'c',
       'nested',
       '@acme/foo',
+      '@acme/foo-e2e',
       '@acme/bar',
       'foo_bar1',
       '@acme/nested/foo',
@@ -115,6 +124,7 @@ describe('findMatchingProjects', () => {
       'c',
       'nested',
       '@acme/foo',
+      '@acme/foo-e2e',
       '@acme/bar',
       'foo_bar1',
       '@acme/nested/foo',
@@ -162,6 +172,7 @@ describe('findMatchingProjects', () => {
       'c',
       'nested',
       '@acme/foo',
+      '@acme/foo-e2e',
       '@acme/bar',
       'foo_bar1',
       '@acme/nested/foo',
@@ -176,7 +187,7 @@ describe('findMatchingProjects', () => {
       projectGraph
     );
     expect(matches).toEqual(expect.arrayContaining(['a', 'b', 'nested']));
-    expect(matches.length).toEqual(7);
+    expect(matches.length).toEqual(8);
   });
 
   it('should expand generic glob patterns for tags', () => {
@@ -202,6 +213,7 @@ describe('findMatchingProjects', () => {
       'a',
       'b',
       '@acme/foo',
+      '@acme/foo-e2e',
       '@acme/bar',
       'foo_bar1',
     ]);
@@ -218,6 +230,7 @@ describe('findMatchingProjects', () => {
       'c',
       'nested',
       '@acme/foo',
+      '@acme/foo-e2e',
       '@acme/bar',
       'foo_bar1',
       '@acme/nested/foo',
@@ -226,6 +239,7 @@ describe('findMatchingProjects', () => {
       'b',
       'nested',
       '@acme/foo',
+      '@acme/foo-e2e',
       '@acme/bar',
       'foo_bar1',
       '@acme/nested/foo',
@@ -236,6 +250,7 @@ describe('findMatchingProjects', () => {
       'b',
       'nested',
       '@acme/foo',
+      '@acme/foo-e2e',
       '@acme/bar',
       'foo_bar1',
       '@acme/nested/foo',
@@ -248,6 +263,9 @@ describe('findMatchingProjects', () => {
       '@acme/foo',
       'foo_bar1',
       '@acme/nested/foo',
+    ]);
+    expect(findMatchingProjects(['foo-e2e'], projectGraph)).toEqual([
+      '@acme/foo-e2e',
     ]);
     expect(findMatchingProjects(['bar'], projectGraph)).toEqual(['@acme/bar']);
     // Case insensitive

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -167,9 +167,9 @@ function addMatchingProjectsByName(
   }
 
   if (!isGlobPattern(pattern.value)) {
-    // Custom regex that is basically \b without underscores, so "foo" pattern matches "foo_bar".
+    // Custom regex that is basically \b but includes hyphens (-) and excludes underscores (_), so "foo" pattern matches "foo_bar" but not "foo-e2e".
     const regex = new RegExp(
-      `(?<![a-zA-Z0-9])${pattern.value}(?![a-zA-Z0-9])`,
+      `(?<![a-zA-Z0-9-])${pattern.value}(?![a-zA-Z0-9-])`,
       'i'
     );
     const matchingProjects = Object.keys(projects).filter((name) =>


### PR DESCRIPTION
This PR fixes project matching such that the name must match on `-` as well. For example, given two projects with the following names:

- `@acme/foo`
- `@acme/foo-e2e`

Running `nx serve foo` shoud match `@acme/foo`. Currently it will error out because it matches both projects.

## Current Behavior
Project names can partially match, so `foo` matches `@acme/foo-e2e`.

## Expected Behavior
Project names must match the segment fully, including `-`, so `foo` does not match `@acme/foo-e2e`, but `foo-e2e` does.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
