### PR TITLE
fix(core): fix typescript dependency calculation

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -64,7 +64,7 @@ export function buildExplicitTypeScriptDependencies(
   }
 
   for (const [project, fileData] of Object.entries(
-    ctx.fileMap.projectFileMap
+    ctx.filesToProcess.projectFileMap
   )) {
     filesToProcess[project] ??= [];
     for (const { file } of fileData) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx checks every typescript file whenever 1 file is touched.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx reuses results from files which are not touched and only recalculates those that are touched.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
