### PR TITLE
feat(node): generate new apps with continuous: true

### DIFF
--- a/e2e/node/src/node-server.test.ts
+++ b/e2e/node/src/node-server.test.ts
@@ -193,7 +193,9 @@ describe('Node Applications + webpack', () => {
       return config;
     });
 
-    runCLI(`serve ${nodeApp1} --watch=false`);
+    await runCommandUntil(`serve ${nodeApp1} `, (output) =>
+      output.includes('Hello World')
+    );
 
     checkFilesExist(`dist/apps/${nodeApp1}/main.js`);
     checkFilesExist(`dist/apps/${nodeApp2}/main.js`);

--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -223,6 +223,7 @@ describe('app', () => {
                     "buildTarget": "myapp:build:production",
                   },
                 },
+                "continuous": true,
                 "defaultConfiguration": "development",
                 "dependsOn": [
                   "build",

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -56,6 +56,7 @@ describe('application generator', () => {
                 "buildTarget": "my-node-app:build:production",
               },
             },
+            "continuous": true,
             "defaultConfiguration": "development",
             "dependsOn": [
               "build",
@@ -238,6 +239,7 @@ describe('application generator', () => {
                     "buildTarget": "myapp:build:production",
                   },
                 },
+                "continuous": true,
                 "defaultConfiguration": "development",
                 "dependsOn": [
                   "build",

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -51,6 +51,7 @@ describe('app', () => {
                   "buildTarget": "my-node-app:build:production",
                 },
               },
+              "continuous": true,
               "defaultConfiguration": "development",
               "dependsOn": [
                 "build",
@@ -263,6 +264,7 @@ describe('app', () => {
                   "buildTarget": "my-node-app:build:production",
                 },
               },
+              "continuous": true,
               "defaultConfiguration": "development",
               "dependsOn": [
                 "build",
@@ -626,6 +628,7 @@ describe('app', () => {
                     "buildTarget": "myapp:build:production",
                   },
                 },
+                "continuous": true,
                 "defaultConfiguration": "development",
                 "dependsOn": [
                   "build",

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -145,6 +145,7 @@ function getEsBuildConfig(
 
 function getServeConfig(options: NormalizedSchema): TargetConfiguration {
   return {
+    continuous: true,
     executor: '@nx/js:node',
     defaultConfiguration: 'development',
     // Run build, which includes dependency on "^build" by default, so the first run
@@ -290,10 +291,18 @@ function addAppFiles(tree: Tree, options: NormalizedSchema) {
 
 function addProxy(tree: Tree, options: NormalizedSchema) {
   const projectConfig = readProjectConfiguration(tree, options.frontendProject);
-  if (projectConfig.targets && projectConfig.targets.serve) {
+  if (
+    projectConfig.targets &&
+    ['serve', 'dev'].find((t) => !!projectConfig.targets[t])
+  ) {
+    const targetName = ['serve', 'dev'].find((t) => !!projectConfig.targets[t]);
+    projectConfig.targets[targetName].dependsOn = [
+      ...(projectConfig.targets[targetName].dependsOn ?? []),
+      `${options.name}:serve`,
+    ];
     const pathToProxyFile = `${projectConfig.root}/proxy.conf.json`;
-    projectConfig.targets.serve.options = {
-      ...projectConfig.targets.serve.options,
+    projectConfig.targets[targetName].options = {
+      ...projectConfig.targets[targetName].options,
       proxyConfig: pathToProxyFile,
     };
 


### PR DESCRIPTION
## Current Behavior
Node applications rely on the `@nx/js:node` executor to handle serving. 
Unfortunately, it can not be determined if existing usage of the executor is used for a continuous or finite task. 

## Expected Behavior
Generate new node applications with `continuous: true` for their serve targets
