### PR TITLE
fix(nest): fix library generator

### DIFF
--- a/packages/nest/src/generators/library/lib/add-project.ts
+++ b/packages/nest/src/generators/library/lib/add-project.ts
@@ -11,6 +11,7 @@ export function addProject(tree: Tree, options: NormalizedOptions): void {
   }
 
   const project = readProjectConfiguration(tree, options.projectName);
+  project.targets ??= {};
   project.targets.build = {
     executor: '@nx/js:tsc',
     outputs: ['{options.outputPath}'],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Nest library generator fails because `readProjectConfiguration` is not returning targets property:
```
 NX  Generating @nx/nest:library


 NX   Cannot set properties of undefined (setting 'build')

Pass --verbose to see the stacktrace.


 *  The terminal process "/bin/zsh '-l', '-c', 'npx nx generate @nx/nest:library --directory=packages/backend/feature-typeahead --buildable=true --linter=eslint --unitTestRunner=jest --controller=true --importPath=@listing-experience/feature-typeahead --name=feature-typeahead --service=true --tags=type:lib,scope:nest --no-interactive --dry-run'" terminated with exit code: 1. 
 *  Terminal will be reused by tasks, press any key to close it. 
 ```

## Expected Behavior
The library should be generated without issues
