### PR TITLE
Add support for eslint-config-prettier v10 to disable stylistic eslint rules that would conflict with prettier

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://nx.dev",
   "peerDependencies": {
     "@typescript-eslint/parser": "^6.13.2 || ^7.0.0 || ^8.0.0",
-    "eslint-config-prettier": "^9.0.0"
+    "eslint-config-prettier": "^9.0.0 || ^10.0.0"
   },
   "peerDependenciesMeta": {
     "eslint-config-prettier": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Currently `@nx/eslint-plugin` has an optional peer dependency on eslint-config-prettier@9. 

## Expected Behavior
`@nx/eslint-plugin` should also allow `eslint-config-prettier@10` since that release has brought support for stylistic eslint rules and it still works with eslint 9.

https://github.com/prettier/eslint-config-prettier/releases/tag/v10.0.0

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Didn't log an issue. Let me know if an issue is required.
