### PR TITLE
fix(vite): environments api support in executor

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -58,6 +58,12 @@
       "skipPackageManager": {
         "type": "boolean",
         "description": "Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option."
+      },
+      "useEnvironmentsApi": {
+        "alias": "app",
+        "type": "boolean",
+        "description": "Use the new Environments API for building multiple environments at once. Only works with Vite 6.0.0 or higher.",
+        "default": false
       }
     },
     "definitions": {},

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -9,4 +9,5 @@ export interface ViteBuildExecutorOptions {
   skipTypeCheck?: boolean;
   tsConfig?: string;
   watch?: boolean;
+  useEnvironmentsApi?: boolean;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -67,6 +67,12 @@
     "skipPackageManager": {
       "type": "boolean",
       "description": "Do not add a `packageManager` entry to the generated package.json file. Only works in conjunction with `generatePackageJson` option."
+    },
+    "useEnvironmentsApi": {
+      "alias": "app",
+      "type": "boolean",
+      "description": "Use the new Environments API for building multiple environments at once. Only works with Vite 6.0.0 or higher.",
+      "default": false
     }
   },
   "definitions": {},


### PR DESCRIPTION
## Current Behavior
`@nx/vite:build` executor does not support Vite 6 Environments API

## Expected Behavior
`@nx/vite:build` executor builds all environments when Vite 6 is detected
