### PR TITLE
fix(devkit): enhance pkg require errors and rescue a failing generator

### DIFF
--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -29,6 +29,9 @@ const NON_SEMVER_TAGS = {
   legacy: -2,
 };
 
+const ERR_REQUIRE_ESM = 'ERR_REQUIRE_ESM';
+export const ERR_MODULE_NOT_FOUND = 'MODULE_NOT_FOUND';
+
 function filterExistingDependencies(
   dependencies: Record<string, string>,
   existingAltDependencies: Record<string, string>
@@ -455,6 +458,7 @@ export function ensurePackage<T extends any = any>(
 ): T {
   let pkg: string;
   let requiredVersion: string;
+  let errorCode: string;
   if (typeof pkgOrTree === 'string') {
     pkg = pkgOrTree;
     requiredVersion = requiredVersionOrPackage;
@@ -471,18 +475,20 @@ export function ensurePackage<T extends any = any>(
   try {
     return require(pkg);
   } catch (e) {
-    if (e.code === 'ERR_REQUIRE_ESM') {
+    errorCode = e.code;
+    if (errorCode === ERR_REQUIRE_ESM) {
       // The package is installed, but is an ESM package.
       // The consumer of this function can import it as needed.
       return null;
-    } else if (e.code !== 'MODULE_NOT_FOUND') {
+    } else if (errorCode !== ERR_MODULE_NOT_FOUND) {
       throw e;
     }
   }
 
   if (process.env.NX_DRY_RUN && process.env.NX_DRY_RUN !== 'false') {
     throw new Error(
-      'NOTE: This generator does not support --dry-run. If you are running this in Nx Console, it should execute fine once you hit the "Generate" button.\n'
+      `NOTE: This generator does not support --dry-run for ${pkgOrTree}. If you are running this in Nx Console, it should execute fine once you hit the "Generate" button.\n`, 
+      { 'cause': errorCode }
     );
   }
 
@@ -529,7 +535,7 @@ export function ensurePackage<T extends any = any>(
 
     return result;
   } catch (e) {
-    if (e.code === 'ERR_REQUIRE_ESM') {
+    if (e.code === ERR_REQUIRE_ESM) {
       // The package is installed, but is an ESM package.
       // The consumer of this function can import it as needed.
       packageMapCache.set(pkg, null);

--- a/packages/next/src/generators/application/lib/add-e2e.ts
+++ b/packages/next/src/generators/application/lib/add-e2e.ts
@@ -11,6 +11,7 @@ import { webStaticServeGenerator } from '@nx/web';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { nxVersion } from '../../../utils/versions';
 import { NormalizedSchema } from './normalize-options';
+import { ERR_MODULE_NOT_FOUND } from '@nx/devkit/src/utils/package-json';
 
 export async function addE2e(host: Tree, options: NormalizedSchema) {
   const nxJson = readNxJson(host);
@@ -88,9 +89,17 @@ export async function addE2e(host: Tree, options: NormalizedSchema) {
 
     return e2eTask;
   } else if (options.e2eTestRunner === 'playwright') {
-    const { configurationGenerator } = ensurePackage<
-      typeof import('@nx/playwright')
-    >('@nx/playwright', nxVersion);
+    let playwrightPkg: typeof import('@nx/playwright');
+    try {
+      playwrightPkg = ensurePackage<
+        typeof playwrightPkg
+      >('@nx/playwright', nxVersion);
+    }
+    catch (e) {
+      if (e instanceof Error && e.cause === ERR_MODULE_NOT_FOUND) {
+        console.log("NOTE: @nx/playwright couldn't be found in this project's dependencies and will be installed once you remove the \"dryRun\" flag (or once you hit the \"Generate\" button if you are running this in Nx Console)")
+      }
+    }
 
     const packageJson: PackageJson = {
       name: options.e2eProjectName,
@@ -121,7 +130,7 @@ export async function addE2e(host: Tree, options: NormalizedSchema) {
       );
     }
 
-    const e2eTask = await configurationGenerator(host, {
+    const e2eTask = await playwrightPkg.configurationGenerator(host, {
       rootProject: options.rootProject,
       project: options.e2eProjectName,
       skipFormat: true,


### PR DESCRIPTION
_Please __note__ that this change affects both `next` and `devkit` packages. I've decided to attribute it to the one with the broader impact (`devkit`)._

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
On a new nx monorepo, when you install `@nx/next` and run: 

```
yarn nx generate @nx/next:application --directory=test-app --name=test-app --no-interactive --dry-run
```

the command fails, even though without the `dryRun` flag it passes. Due to the error, the `dryRun` output is obscured and there's no obvious reason for it.

## Expected Behavior

The proper `dryRun` output is printed and a warning message informs that playwright will be installed once not in a `dryRun` mode

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30184 
