### PR TITLE
feat(nx-dev): allow sampling rate to be configured through env var

### DIFF
--- a/nx-dev/nx-dev/lib/components/frontend-observability.tsx
+++ b/nx-dev/nx-dev/lib/components/frontend-observability.tsx
@@ -2,6 +2,12 @@
 import { useEffect, useRef } from 'react';
 import { getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';
 
+const DEFAULT_SAMPLE_RATE = 0.5;
+let samplingRate = process.env.NEXT_PUBLIC_FARO_SAMPLING_RATE
+  ? parseFloat(process.env.NEXT_PUBLIC_FARO_SAMPLING_RATE)
+  : DEFAULT_SAMPLE_RATE;
+if (isNaN(samplingRate) || samplingRate > 1) samplingRate = DEFAULT_SAMPLE_RATE;
+
 export function FrontendObservability() {
   const initialized = useRef(false);
   useEffect(() => {
@@ -23,6 +29,9 @@ export function FrontendObservability() {
         name: 'Nx Dev',
         version,
         environment,
+      },
+      sessionTracking: {
+        samplingRate,
       },
       instrumentations: [...getWebInstrumentations()],
     });


### PR DESCRIPTION
The current sample rate for Grafana Faro is the default 100% and is currently around $200 for the month. We want to be able to make changes to it without needing code changes. Once this PR is merged, we can just update the env var, and then redeploy.
