### PR TITLE
fix(vite): allow force ignore of logs from nxViteTsPaths plugin #29320

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -24,8 +24,8 @@ import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-
 export interface nxViteTsPathsOptions {
   /**
    * Enable debug logging
-   * If set to 'force-ignore', it will always ignore the debug logging even when `--verbose` or `NX_VERBOSE_LOGGING` is set to true.
-   * @default false
+   * If set to false, it will always ignore the debug logging even when `--verbose` or `NX_VERBOSE_LOGGING` is set to true.
+   * @default undefined
    **/
   debug?: boolean;
   /**

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -224,11 +224,7 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
   }
 
   function logIt(...msg: any[]) {
-    const shouldLog =
-      options?.debug === false
-        ? false
-        : process.env.NX_VERBOSE_LOGGING === 'true' || options?.debug;
-    if (shouldLog) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true' && options?.debug !== false) {
       console.debug('\n[Nx Vite TsPaths]', ...msg);
     }
   }

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -24,6 +24,7 @@ import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-
 export interface nxViteTsPathsOptions {
   /**
    * Enable debug logging
+   * If set to 'force-ignore', it will always ignore the debug logging even when `--verbose` or `NX_VERBOSE_LOGGING` is set to true.
    * @default false
    **/
   debug?: boolean;
@@ -223,7 +224,11 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
   }
 
   function logIt(...msg: any[]) {
-    if (process.env.NX_VERBOSE_LOGGING === 'true' || options?.debug) {
+    const shouldLog =
+      options?.debug === false
+        ? false
+        : process.env.NX_VERBOSE_LOGGING === 'true' || options?.debug;
+    if (shouldLog) {
       console.debug('\n[Nx Vite TsPaths]', ...msg);
     }
   }


### PR DESCRIPTION
## Current Behavior
When Vite build is run where:
- `nxViteTsPaths` plugin is enabled
- `--verbose` or `NX_VERBOSE_LOGGING=true` is set

The resulting logs can be quite noisy.

## Expected Behavior
When `debug` is explicitly set to false, ignore logs even when `--verbose` is passed.

Usage:

```ts
nxViteTsPaths({ debug: false })
```

## Related Issue(s)

Fixes #29320 
