### PR TITLE
fix(vite): ensure paths with explicit extensions are resolved #29948

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -254,6 +254,19 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
           importPath.replace(normalizedImport, joinedPath),
           options.extensions
         );
+
+        if (
+          resolvedFile === undefined &&
+          options.extensions.some((ext) => importPath.endsWith(ext))
+        ) {
+          const foundExtension = options.extensions.find((ext) =>
+            importPath.endsWith(ext)
+          );
+          const pathWithoutExtension = importPath
+            .replace(normalizedImport, joinedPath)
+            .slice(0, -foundExtension.length);
+          resolvedFile = findFile(pathWithoutExtension, options.extensions);
+        }
       }
     }
 


### PR DESCRIPTION
## Current Behavior
When TS Path Mappings are combined with an explicit extension of the build outcome of a file, the `nxViteTsPaths` plugin cannot resolve the file. 

e.g.

```ts

import {something} from '@mylib/file.js';


// tsconfig paths

"@mylib/*": ["mylib/src/*"]
```

In this case, we fallback to the file system to try find the file, and we do it by adding extensions to the end of the path.

e.g.

```ts
@mylib/file.js.js
@mylib/file.js.ts
@mylib/file.js.mts
etc
```

## Expected Behavior
Perform the usual logic first to try find the file in the file system.

If the file is still not resolved AND the path ends with an `extname` that we support in `options.extensions`, strip the extension from the path and try append the different extensions again and resolve against the filesystem.

This allows for the case where someone has a file in their file system that _is_ `file.js.js` to be resolve via `@mylib/file.js` as well as when the explicit path is provided.


## Related Issues

Fixes #29948
