### PR TITLE
fix(linter): restore package update group for `@typescript-eslint/eslint-plugin` requirement

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -1698,6 +1698,16 @@
         "path": "/nx-api/eslint/migrations/20.4.0-typescript-eslint-package-updates",
         "type": "migration"
       },
+      "/nx-api/eslint/migrations/20.4.0-@typescript-eslint-package-updates": {
+        "description": "",
+        "file": "generated/packages/eslint/migrations/20.4.0-@typescript-eslint-package-updates.json",
+        "hidden": false,
+        "name": "20.4.0-@typescript-eslint-package-updates",
+        "version": "20.4.0-beta.1",
+        "originalFilePath": "/packages/eslint",
+        "path": "/nx-api/eslint/migrations/20.4.0-@typescript-eslint-package-updates",
+        "type": "migration"
+      },
       "/nx-api/eslint/migrations/add-file-extensions-to-overrides": {
         "description": "Update ESLint flat config to include .cjs, .mjs, .cts, and .mts files in overrides (if needed)",
         "file": "generated/packages/eslint/migrations/add-file-extensions-to-overrides.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1687,6 +1687,16 @@
         "type": "migration"
       },
       {
+        "description": "",
+        "file": "generated/packages/eslint/migrations/20.4.0-@typescript-eslint-package-updates.json",
+        "hidden": false,
+        "name": "20.4.0-@typescript-eslint-package-updates",
+        "version": "20.4.0-beta.1",
+        "originalFilePath": "/packages/eslint",
+        "path": "eslint/migrations/20.4.0-@typescript-eslint-package-updates",
+        "type": "migration"
+      },
+      {
         "description": "Update ESLint flat config to include .cjs, .mjs, .cts, and .mts files in overrides (if needed)",
         "file": "generated/packages/eslint/migrations/add-file-extensions-to-overrides.json",
         "hidden": false,

--- a/docs/generated/packages/eslint/migrations/20.4.0-@typescript-eslint-package-updates.json
+++ b/docs/generated/packages/eslint/migrations/20.4.0-@typescript-eslint-package-updates.json
@@ -1,0 +1,30 @@
+{
+  "name": "20.4.0-@typescript-eslint-package-updates",
+  "version": "20.4.0-beta.1",
+  "requires": { "@typescript-eslint/eslint-plugin": ">8.0.0 <8.19.0" },
+  "packages": {
+    "typescript-eslint": { "version": "^8.19.0" },
+    "@typescript-eslint/eslint-plugin": { "version": "^8.19.0" },
+    "@typescript-eslint/parser": { "version": "^8.19.0" },
+    "@typescript-eslint/utils": { "version": "^8.19.0" },
+    "@typescript-eslint/rule-tester": {
+      "version": "^8.19.0",
+      "alwaysAddToPackageJson": false
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "^8.19.0",
+      "alwaysAddToPackageJson": false
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "^8.19.0",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/eslint",
+  "schema": null,
+  "type": "migration"
+}

--- a/packages/eslint/migrations.json
+++ b/packages/eslint/migrations.json
@@ -150,6 +150,38 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "20.4.0-@typescript-eslint": {
+      "version": "20.4.0-beta.1",
+      "requires": {
+        "@typescript-eslint/eslint-plugin": ">8.0.0 <8.19.0"
+      },
+      "packages": {
+        "typescript-eslint": {
+          "version": "^8.19.0"
+        },
+        "@typescript-eslint/eslint-plugin": {
+          "version": "^8.19.0"
+        },
+        "@typescript-eslint/parser": {
+          "version": "^8.19.0"
+        },
+        "@typescript-eslint/utils": {
+          "version": "^8.19.0"
+        },
+        "@typescript-eslint/rule-tester": {
+          "version": "^8.19.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "^8.19.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "^8.19.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Restores a package update group with a `requires` entry to handle workspaces using `@typescript-eslint/eslint-plugin` and not `typescript-eslint`.

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
