### PR TITLE
docs(nx-dev): disable WebinarNotifier & remove live event link

### DIFF
--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -109,7 +109,7 @@ export default function CustomApp({
       </Link>
       <Component {...pageProps} />
       {/* <LiveStreamNotifier /> */}
-      <WebinarNotifier />
+      {/*<WebinarNotifier />*/}
 
       {/* Global Site Tag (gtag.js) - Google Analytics */}
       <Script

--- a/nx-dev/ui-enterprise/src/lib/hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/hero.tsx
@@ -33,24 +33,24 @@ export function Hero(): ReactElement {
       </svg>
       <div className="mx-auto max-w-7xl px-6 pb-24 pt-32 lg:flex lg:px-8 lg:pt-56">
         <div className="mx-auto max-w-2xl lg:mx-0 lg:-mt-12 lg:shrink-0">
-          <p>
-            <a
-              href="https://bit.ly/4aRmrRb"
-              title="See live event in details"
-              className="group/event-link inline-flex space-x-6"
-            >
-              <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">
-                Live event
-              </span>
-              <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">
-                <span>Webinar + live Q&A on February 26th</span>
-                <ChevronRightIcon
-                  aria-hidden="true"
-                  className="size-5 transform transition-all group-hover/event-link:translate-x-1"
-                />
-              </span>
-            </a>
-          </p>
+          {/*<p>*/}
+          {/*  <a*/}
+          {/*    href="https://bit.ly/4aRmrRb"*/}
+          {/*    title="See live event in details"*/}
+          {/*    className="group/event-link inline-flex space-x-6"*/}
+          {/*  >*/}
+          {/*    <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">*/}
+          {/*      Live event*/}
+          {/*    </span>*/}
+          {/*    <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">*/}
+          {/*      <span>Webinar + live Q&A on February 26th</span>*/}
+          {/*      <ChevronRightIcon*/}
+          {/*        aria-hidden="true"*/}
+          {/*        className="size-5 transform transition-all group-hover/event-link:translate-x-1"*/}
+          {/*      />*/}
+          {/*    </span>*/}
+          {/*  </a>*/}
+          {/*</p>*/}
           <SectionHeading
             id="get-speed-and-scale"
             as="h1"


### PR DESCRIPTION
Commented out the `WebinarNotifier` component and the live event link section, likely for deprecation or temporary removal.
