### PR TITLE
fix(vite): copy assets plugin not copying files in watch mode #30141

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -55,6 +55,7 @@
     "npm-package-arg": "11.0.1",
     "npm-run-path": "^4.0.1",
     "ora": "5.3.0",
+    "picocolors": "^1.1.0",
     "picomatch": "4.0.2",
     "semver": "^7.5.3",
     "source-map-support": "0.5.19",


### PR DESCRIPTION
## Current Behavior
Copy assets plugin for Vite is not copying files in watch mode when those files are changed.

This is due to the path being incorrect after calculation.
There is also no indication to the user that the copy completed at all.

## Expected Behavior
Fix path calculation to allow copy to occur correctly

Output the relative dest of the file after copy completed.

## Related Issue(s)

Fixes #30141
