### PR TITLE
docs(core): update webinar status based on date

### DIFF
--- a/nx-dev/ui-webinar/src/lib/webinar-list-item.tsx
+++ b/nx-dev/ui-webinar/src/lib/webinar-list-item.tsx
@@ -45,9 +45,9 @@ export function WebinarListItem({ webinar, episode }: WebinarListItemProps) {
       <p className="my-2">{webinar.description}</p>
       <Link href={link} prefetch={false}>
         <span className="my-4 text-balance text-slate-500 sm:w-8/12 dark:text-white">
-          {webinar.status === 'Past - Gated'
-            ? 'Sign up to view the recording'
-            : 'Watch the recording'}
+          {webinar.status === 'Past - Ungated'
+            ? 'Watch the recording'
+            : 'Sign up to view the recording'}
         </span>
       </Link>
     </div>

--- a/nx-dev/ui-webinar/src/lib/webinar-list.tsx
+++ b/nx-dev/ui-webinar/src/lib/webinar-list.tsx
@@ -1,10 +1,8 @@
 import { WebinarDataEntry } from '@nx/nx-dev/data-access-documents/node-only';
-import { BlogAuthors, BlogEntry } from '@nx/nx-dev/ui-blog';
-import { WebinarListItem } from './webinar-list-item';
 import { CallToAction } from '@nx/nx-dev/ui-markdoc';
 import Image from 'next/image';
 import Link from 'next/link';
-import { ButtonLink } from '@nx/nx-dev/ui-common';
+import { WebinarListItem } from './webinar-list-item';
 
 export interface WebinarListProps {
   webinars: WebinarDataEntry[];
@@ -20,7 +18,9 @@ export function WebinarList({ webinars }: WebinarListProps): JSX.Element {
   ) : (
     <div className="mx-auto max-w-7xl px-8">
       {webinars
-        .filter((w) => w.status === 'Upcoming')
+        .filter(
+          (w) => w.status === 'Upcoming' && new Date(w.date) >= new Date()
+        )
         .map((webinar, index) => {
           const authorsList = (
             webinar.authors.length > 1
@@ -82,7 +82,9 @@ export function WebinarList({ webinars }: WebinarListProps): JSX.Element {
       </div>
       <div>
         {webinars
-          .filter((w) => w.status !== 'Upcoming')
+          .filter(
+            (w) => w.status !== 'Upcoming' || new Date(w.date) < new Date()
+          )
           .map((w, index) => (
             <WebinarListItem key={w.slug} webinar={w} episode={index + 1} />
           ))}


### PR DESCRIPTION
Treats the webinar date as more important than the webinar status.  So an "upcoming" webinar that has a date in the past will not display as upcoming.