### PR TITLE
fix(bundling): fix esbuild to work with ts project references

### DIFF
--- a/e2e/node/src/node-ts-solution-esbuild.test.ts
+++ b/e2e/node/src/node-ts-solution-esbuild.test.ts
@@ -1,0 +1,76 @@
+import { names } from '@nx/devkit';
+import {
+  cleanupProject,
+  getPackageManagerCommand,
+  getSelectedPackageManager,
+  newProject,
+  runCLI,
+  runCommand,
+  uniq,
+  updateFile,
+  updateJson,
+} from '@nx/e2e/utils';
+
+let originalEnvPort;
+
+describe('Node Applications', () => {
+  beforeAll(() => {
+    originalEnvPort = process.env.PORT;
+    newProject({
+      preset: 'ts',
+    });
+  });
+
+  afterAll(() => {
+    process.env.PORT = originalEnvPort;
+    cleanupProject();
+  });
+
+  it('it should generate an app that cosumes a non-buildable ts library', () => {
+    const nodeapp = uniq('nodeapp');
+    const lib = uniq('lib');
+    const port = getRandomPort();
+    process.env.PORT = `${port}`;
+
+    runCLI(
+      `generate @nx/node:app apps/${nodeapp} --port=${port} --bundler=esbuild --linter=none --e2eTestRunner=none --unitTestRunner=none`
+    );
+
+    runCLI(
+      `generate @nx/js:lib packages/${lib} --bundler=none --e2eTestRunner=none --unitTestRunner=none`
+    );
+
+    updateFile(
+      `apps/${nodeapp}/src/main.ts`,
+      (content) => `import { ${names(lib).propertyName} } from '@proj/${lib}';
+      
+      console.log(${names(lib).propertyName}());
+
+      ${content}
+      `
+    );
+
+    const pm = getSelectedPackageManager();
+    if (pm === 'pnpm') {
+      updateJson(`apps/${nodeapp}/package.json`, (json) => {
+        json.dependencies ??= {};
+        json.dependencies[`@proj/${lib}`] = 'workspace:*';
+        return json;
+      });
+
+      const pmc = getPackageManagerCommand({ packageManager: pm });
+      runCommand(pmc.install);
+    }
+
+    runCLI('sync');
+
+    // check build
+    expect(runCLI(`build ${nodeapp}`)).toContain(
+      `Successfully ran target build for project @proj/${nodeapp}`
+    );
+  });
+});
+
+function getRandomPort() {
+  return Math.floor(1000 + Math.random() * 7000);
+}

--- a/packages/js/src/plugins/typescript/util.ts
+++ b/packages/js/src/plugins/typescript/util.ts
@@ -1,7 +1,16 @@
 import { readJsonFile, type TargetConfiguration } from '@nx/devkit';
 import { existsSync } from 'node:fs';
+import { dirname, extname, isAbsolute, relative, resolve } from 'node:path';
 import { type PackageManagerCommands } from 'nx/src/utils/package-manager';
 import { join } from 'path';
+import { type ParsedCommandLine } from 'typescript';
+
+export type ParsedTsconfigData = Pick<
+  ParsedCommandLine,
+  'options' | 'projectReferences' | 'raw'
+> & {
+  extendedConfigFile: { filePath: string; externalPackage?: string } | null;
+};
 
 /**
  * Allow uses that use incremental builds to run `nx watch-deps` to continuously build all dependencies.
@@ -38,4 +47,95 @@ export function addBuildAndWatchDepsTargets(
       command: `${pmc.exec} nx watch --projects ${projectName} --includeDependentProjects -- ${pmc.exec} nx ${buildDepsTargetName} ${projectName}`,
     };
   }
+}
+
+export function isValidPackageJsonBuildConfig(
+  tsConfig: ParsedTsconfigData,
+  workspaceRoot: string,
+  projectRoot: string
+): boolean {
+  const resolvedProjectPath = isAbsolute(projectRoot)
+    ? relative(workspaceRoot, projectRoot)
+    : projectRoot;
+  const packageJsonPath = join(
+    workspaceRoot,
+    resolvedProjectPath,
+    'package.json'
+  );
+  if (!existsSync(packageJsonPath)) {
+    // If the package.json file does not exist.
+    // Assume it's valid because it would be using `project.json` instead.
+    return true;
+  }
+  const packageJson = readJsonFile(packageJsonPath);
+
+  const outDir = tsConfig.options.outFile
+    ? dirname(tsConfig.options.outFile)
+    : tsConfig.options.outDir;
+  const resolvedOutDir = outDir
+    ? resolve(workspaceRoot, resolvedProjectPath, outDir)
+    : undefined;
+
+  const isPathSourceFile = (path: string): boolean => {
+    if (resolvedOutDir) {
+      const pathToCheck = resolve(workspaceRoot, resolvedProjectPath, path);
+      return !pathToCheck.startsWith(resolvedOutDir);
+    }
+
+    const ext = extname(path);
+    // Check that the file extension is a TS file extension. As the source files are in the same directory as the output files.
+    return ['.ts', '.tsx', '.cts', '.mts'].includes(ext);
+  };
+
+  // Checks if the value is a path within the `src` directory.
+  const containsInvalidPath = (
+    value: string | Record<string, string>
+  ): boolean => {
+    if (typeof value === 'string') {
+      return isPathSourceFile(value);
+    } else if (typeof value === 'object') {
+      return Object.entries(value).some(([currentKey, subValue]) => {
+        // Skip types field
+        if (currentKey === 'types') {
+          return false;
+        }
+        if (typeof subValue === 'string') {
+          return isPathSourceFile(subValue);
+        }
+        return false;
+      });
+    }
+    return false;
+  };
+
+  const exports = packageJson?.exports;
+
+  // Check the `.` export if `exports` is defined.
+  if (exports) {
+    if (typeof exports === 'string') {
+      return !isPathSourceFile(exports);
+    }
+    if (typeof exports === 'object' && '.' in exports) {
+      return !containsInvalidPath(exports['.']);
+    }
+
+    // Check other exports if `.` is not defined or valid.
+    for (const key in exports) {
+      if (key !== '.' && containsInvalidPath(exports[key])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // If `exports` is not defined, fallback to `main` and `module` fields.
+  const buildPaths = ['main', 'module'];
+  for (const field of buildPaths) {
+    if (packageJson[field] && isPathSourceFile(packageJson[field])) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -108,9 +108,10 @@ export function assertNotUsingTsSolutionSetup(
 }
 
 export function findRuntimeTsConfigName(
-  tree: Tree,
-  projectRoot: string
+  projectRoot: string,
+  tree?: Tree
 ): string | null {
+  tree ??= new FsTree(workspaceRoot, false);
   if (tree.exists(joinPathFragments(projectRoot, 'tsconfig.app.json')))
     return 'tsconfig.app.json';
   if (tree.exists(joinPathFragments(projectRoot, 'tsconfig.lib.json')))

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -235,7 +235,7 @@ export function createStorybookTsconfigFile(
   };
 
   if (useTsSolution) {
-    const runtimeConfig = findRuntimeTsConfigName(tree, projectRoot);
+    const runtimeConfig = findRuntimeTsConfigName(projectRoot, tree);
     if (runtimeConfig) {
       storybookTsConfig.references ??= [];
       storybookTsConfig.references.push({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
If we are using `esbuild` as our bundler and ts project references (`--workspaces`) local libraries are not building are not resolved in the build artifacts.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When using ts project references with esbuild all types libraries (buildable / non-buildable) should work out of the box.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
