### PR TITLE
fix(vite): correct mapping for reportsDirectory when using executors

### DIFF
--- a/e2e/vite/src/vite-legacy.test.ts
+++ b/e2e/vite/src/vite-legacy.test.ts
@@ -87,6 +87,18 @@ describe('Vite Plugin', () => {
           const result = runCLI(`test ${myApp}`);
           expect(result).toContain('Successfully ran target test');
         }, 200_000);
+
+        it('should generate a coverage file specified by the executor', async () => {
+          updateJson(`${myApp}/project.json`, (json) => {
+            json.targets.test.options.reportsDirectory = '../coverage/test-dir';
+            return json;
+          });
+
+          const result = runCLI(`test ${myApp} --coverage`);
+
+          checkFilesExist(`coverage/test-dir/index.html`);
+          expect(result).toContain('Coverage report');
+        }, 200_000);
       });
     });
 

--- a/packages/vite/src/executors/test/lib/utils.ts
+++ b/packages/vite/src/executors/test/lib/utils.ts
@@ -67,15 +67,22 @@ export async function getOptions(
     options: { watch, ...normalizedExtraArgs },
   } = parseCLI(['vitest', ...getOptionsAsArgv(options)]);
 
+  const { reportsDirectory, coverage, ...restNormalizedArgs } =
+    normalizedExtraArgs as Record<string, any>;
+
   const settings = {
     // Explicitly set watch mode to false if not provided otherwise vitest
     // will enable watch mode by default for non CI environments
     watch: watch ?? false,
-    ...normalizedExtraArgs,
+    ...restNormalizedArgs,
     // This should not be needed as it's going to be set in vite.config.ts
     // but leaving it here in case someone did not migrate correctly
     root: resolved.config.root ?? root,
     config: viteConfigPath,
+    coverage: {
+      ...(coverage ?? {}),
+      ...(reportsDirectory && { reportsDirectory }),
+    },
   };
 
   return mergeConfig(resolved?.config?.['test'] ?? {}, settings);


### PR DESCRIPTION
Using vitest whenever we merge configs from executors and the config file. The executors should override the option which has be set inside of the config file.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `reportsDirectory` option which can be set when using `@nx/vite:test` is not override the generated coverage directory path.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When the `@nx/vite:test` executor runs the option `reportsDirectory` should override the option set inside `vite.config`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30223
