### PR TITLE
docs(core): remove include command from nx-graph

### DIFF
--- a/docs/generated/cli/graph.md
+++ b/docs/generated/cli/graph.md
@@ -47,12 +47,6 @@ Show the graph where every node is either an ancestor or a descendant of todos-f
  nx graph --focus=todos-feature-main
 ```
 
-Include project-one and project-two in the project graph:
-
-```shell
- nx graph --include=project-one,project-two
-```
-
 Exclude project-one and project-two from the project graph:
 
 ```shell

--- a/docs/generated/packages/nx/documents/dep-graph.md
+++ b/docs/generated/packages/nx/documents/dep-graph.md
@@ -47,12 +47,6 @@ Show the graph where every node is either an ancestor or a descendant of todos-f
  nx graph --focus=todos-feature-main
 ```
 
-Include project-one and project-two in the project graph:
-
-```shell
- nx graph --include=project-one,project-two
-```
-
 Exclude project-one and project-two from the project graph:
 
 ```shell

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -169,10 +169,6 @@ export const examples: Record<string, Example[]> = {
         'Show the graph where every node is either an ancestor or a descendant of todos-feature-main',
     },
     {
-      command: 'graph --include=project-one,project-two',
-      description: 'Include project-one and project-two in the project graph',
-    },
-    {
       command: 'graph --exclude=project-one,project-two',
       description: 'Exclude project-one and project-two from the project graph',
     },


### PR DESCRIPTION
When we run `nx graph --help` we see that the `--include` commands is not available. 
So the docs should also reflect the current options.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30212
