### PR TITLE
fix(nextjs): update default `eslint-config-next` to match Next.js 15

### DIFF
--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxVersion = require('../../package.json').version;
 
 export const nextVersion = '~15.1.4';
 export const next14Version = '~14.2.16';
-export const eslintConfigNextVersion = '14.2.16';
+export const eslintConfigNextVersion = '~15.1.4';
 export const sassVersion = '1.62.1';
 export const lessLoader = '11.1.0';
 export const emotionServerVersion = '11.11.0';


### PR DESCRIPTION
The `create-nx-workspace` command with the Next.js preset currently installs `next@15` but incorrectly adds `eslint-config-next@14`, leading to potential ESLint compatibility issues.

This fix ensures that `eslint-config-next@15` is installed when using Next.js 15.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

### Current Behavior

- `next@~15.1.4` is installed
- `eslint-config-next@14.2.16` is installed

### Expected Behavior

- `next@~15.1.4` is installed
- `eslint-config-next@15.1.4` is installed

### GitHub Repo

https://github.com/tuffz/new-nx-with-preset-nextjs

### Steps to Reproduce

1. Run the following command from the official documentation:
```sh npx create-nx-workspace@latest --preset=next```
2. Open `package.json` and check the installed dependencies

- `next@~15.1.4` is installed
- `eslint-config-next@14.2.16` is installed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30257
