### PR TITLE
fix(nextjs): ensure `eslint-config-next` matches Next.js 14 and 15 versions

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -647,6 +647,49 @@ describe('app', () => {
         `);
       });
 
+      it('should install eslint-config-next@15 when generating a new Next.js application in an empty Nx workspace', async () => {
+        const name = uniq();
+        await applicationGenerator(tree, {
+          directory: name,
+          style: 'css',
+        });
+
+        const packageJson = readJson(tree, '/package.json');
+        expect(packageJson).toMatchObject({
+          devDependencies: {
+            'eslint-config-next': '^15.2.4',
+            '@next/eslint-plugin-next': '^15.2.4',
+          },
+        });
+      });
+
+      it('should install eslint-config-next@14 when an existing Next.js 14 project is detected', async () => {
+        tree.write(
+          '/package.json',
+          JSON.stringify({
+            name: '@proj/source',
+            dependencies: {
+              next: '~14.2.16',
+            },
+            devDependencies: {},
+          })
+        );
+
+        const name = uniq();
+        await applicationGenerator(tree, {
+          directory: name,
+          style: 'css',
+        });
+
+        const packageJson = readJson(tree, '/package.json');
+        expect(packageJson).toMatchObject({
+          devDependencies: {
+            'eslint-config-next': '~14.2.26',
+            '@next/eslint-plugin-next': '~14.2.26',
+          },
+        });
+      });
+
       it('should add .eslintrc.json and dependencies', async () => {
         await applicationGenerator(tree, {
           directory: 'myapp',

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -15,7 +15,7 @@ import {
   isEslintConfigSupported,
   updateOverrideInLintConfig,
 } from '@nx/eslint/src/generators/utils/eslint-file';
-import { eslintConfigNextVersion } from '../../../utils/versions';
+import { getEslintConfigNextDependenciesVersionsToInstall } from '../../../utils/version-utils';
 import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
 
 export async function addLinting(
@@ -98,6 +98,9 @@ export async function addLinting(
   }
 
   if (!options.skipPackageJson) {
+    const eslintConfigNextVersion =
+      await getEslintConfigNextDependenciesVersionsToInstall(host);
+
     tasks.push(
       addDependenciesToPackageJson(host, extraEslintDependencies.dependencies, {
         ...extraEslintDependencies.devDependencies,

--- a/packages/next/src/utils/version-utils.ts
+++ b/packages/next/src/utils/version-utils.ts
@@ -4,11 +4,18 @@ import {
   getDependencyVersionFromPackageJson,
 } from '@nx/devkit';
 import { clean, coerce, major } from 'semver';
-import { next14Version, nextVersion } from './versions';
+import {
+  nextVersion,
+  next14Version,
+  eslintConfigNext14Version,
+  eslintConfigNextVersion,
+} from './versions';
 
 type NextDependenciesVersions = {
   next: string;
 };
+
+type EslintConfigNextVersion = string;
 
 export async function getNextDependenciesVersionsToInstall(
   tree: Tree,
@@ -22,6 +29,16 @@ export async function getNextDependenciesVersionsToInstall(
     return {
       next: nextVersion,
     };
+  }
+}
+
+export async function getEslintConfigNextDependenciesVersionsToInstall(
+  tree: Tree
+): Promise<EslintConfigNextVersion> {
+  if (await isNext14(tree)) {
+    return eslintConfigNext14Version;
+  } else {
+    return eslintConfigNextVersion;
   }
 }
 

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -3,6 +3,7 @@ export const nxVersion = require('../../package.json').version;
 export const nextVersion = '~15.2.4';
 export const next14Version = '~14.2.26';
 export const eslintConfigNextVersion = '^15.2.4';
+export const eslintConfigNext14Version = '~14.2.26';
 export const sassVersion = '1.62.1';
 export const lessLoader = '11.1.0';
 export const emotionServerVersion = '11.11.0';


### PR DESCRIPTION
This PR builds on the previous fix that ensured `eslint-config-next` was correctly installed when using Next.js 15. #30258 

Now, the logic has been further refined to dynamically determine the installed Next.js version and install the corresponding `eslint-config-next` version accordingly.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

### Current Behavior

- `next@~15.1.4` is installed
- `eslint-config-next@14.2.16` is installed (incorrect for Next.js 15)

### Expected Behavior

If Next.js 15 is detected -> eslint-config-next@15.1.4 is installed
If Next.js 14 is detected -> eslint-config-next@14.2.16 is installed

### GitHub Repo

https://github.com/tuffz/new-nx-with-preset-nextjs

### Steps to Reproduce

1. Run the following command from the official documentation:
`npx create-nx-workspace@latest --preset=next`
3. Open `package.json` and check the installed dependencies

- `next@~15.1.4` is installed
- `eslint-config-next@14.2.16` is installed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30257 (& #30258)