### PR TITLE
fix(core): annotate daemon logs w/ nx version

### DIFF
--- a/packages/nx/src/daemon/server/logger.spec.ts
+++ b/packages/nx/src/daemon/server/logger.spec.ts
@@ -1,5 +1,10 @@
 import { serverLogger } from './logger';
 
+jest.mock('../../utils/versions', () => ({
+  ...jest.requireActual('../../utils/versions'),
+  nxVersion: 'NX_VERSION',
+}));
+
 describe('serverLogger', () => {
   let consoleLogSpy: jest.SpyInstance;
 
@@ -18,20 +23,23 @@ describe('serverLogger', () => {
     const testCases = [
       {
         inputs: ['foobar'],
-        expectedLog: '[NX Daemon Server] - 2021-10-11T17:18:45.980Z - foobar',
+        expectedLog:
+          '[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - foobar',
       },
       {
         inputs: ['foo', 'bar'],
-        expectedLog: '[NX Daemon Server] - 2021-10-11T17:18:45.980Z - foo bar',
+        expectedLog:
+          '[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - foo bar',
       },
       {
         inputs: [1, 2],
-        expectedLog: '[NX Daemon Server] - 2021-10-11T17:18:45.980Z - 1 2',
+        expectedLog:
+          '[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - 1 2',
       },
       {
         inputs: [{ some: 'object' }, ['an', 'array']],
         expectedLog:
-          '[NX Daemon Server] - 2021-10-11T17:18:45.980Z - {"some":"object"} ["an","array"]',
+          '[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - {"some":"object"} ["an","array"]',
       },
     ];
 
@@ -52,11 +60,11 @@ describe('serverLogger', () => {
       serverLogger.log('Server stopped');
       // prettier-ignore
       expect(consoleLogSpy.mock.calls).toEqual([
-        ['[NX Daemon Server] - 2021-10-11T17:18:45.980Z - Server started'],
-        ['[NX Daemon Server] - 2021-10-11T17:18:45.980Z - [WATCHER]: Watching started'],
-        ['[NX Daemon Server] - 2021-10-11T17:18:45.980Z - [REQUEST]: A request has come in'],
-        ['[NX Daemon Server] - 2021-10-11T17:18:45.980Z - [WATCHER]: Watching stopped'],
-        ['[NX Daemon Server] - 2021-10-11T17:18:45.980Z - Server stopped'],
+        ['[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - Server started'],
+        ['[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - [WATCHER]: Watching started'],
+        ['[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - [REQUEST]: A request has come in'],
+        ['[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - [WATCHER]: Watching stopped'],
+        ['[NX vNX_VERSION Daemon Server] - 2021-10-11T17:18:45.980Z - Server stopped'],
       ]);
     });
   });

--- a/packages/nx/src/daemon/server/logger.ts
+++ b/packages/nx/src/daemon/server/logger.ts
@@ -8,6 +8,8 @@
  * logical hierarchy/grouping.
  */
 
+import { nxVersion } from '../../utils/versions';
+
 class ServerLogger {
   log(...s: unknown[]) {
     console.log(
@@ -33,7 +35,7 @@ class ServerLogger {
   }
 
   private formatLogMessage(message: string) {
-    return `[NX Daemon Server] - ${this.getNow()} - ${message}`;
+    return `[NX v${nxVersion} Daemon Server] - ${this.getNow()} - ${message}`;
   }
 
   private getNow() {


### PR DESCRIPTION
## Current Behavior
Daemon log is annotated by time only

## Expected Behavior
Daemon log is annotated by time and nx version

```
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.417Z - Started listening on: /tmp/c31c3bdb2db26a7fdd62/d.sock
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.419Z - [WATCHER]: Subscribed to changes within: /tmp/testing/test-daemon-shutdown (native)
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.421Z - Established a connection. Number of open connections: 1
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.423Z - Closed a connection. Number of open connections: 0
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.694Z - Time taken for 'Load Nx Plugin: /tmp/testing/test-daemon-shutdown/node_modules/nx/src/plugins/project-json/build-nodes/project-json' 172.34599799999998ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.704Z - Time taken for 'Load Nx Plugin: /tmp/testing/test-daemon-shutdown/node_modules/nx/src/plugins/package-json' 182.822698ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.710Z - Time taken for 'loadDefaultNxPlugins' 189.074698ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.747Z - [REQUEST]: Updated workspace context based on watched changes, recomputing project graph...
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.747Z - [REQUEST]: 
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.747Z - [REQUEST]: 
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.751Z - Time taken for 'loadSpecifiedNxPlugins' 226.801397ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.931Z - Time taken for 'build-project-configs' 171.525398ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.932Z - Time taken for '@nx/js/typescript:createDependencies' 1.57650000000001ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.956Z - [SYNC]: collect registered sync generators
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:40.957Z - Time taken for 'total execution time for createProjectGraph()' 25.567300000000046ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:45.422Z - [WATCHER]: Stopping the watcher for /tmp/testing/test-daemon-shutdown (sources)
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:45.422Z - [WATCHER]: Stopping the watcher for /tmp/testing/test-daemon-shutdown (outputs)
[NX v20.5.0 Daemon Server] - 2025-03-04T21:07:45.424Z - Server stopped because: "5000ms of inactivity"
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.567Z - Started listening on: /tmp/c31c3bdb2db26a7fdd62/d.sock
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.570Z - [WATCHER]: Subscribed to changes within: /tmp/testing/test-daemon-shutdown (native)
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.574Z - Established a connection. Number of open connections: 1
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.575Z - Closed a connection. Number of open connections: 0
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.824Z - Time taken for 'Load Nx Plugin: /tmp/testing/test-daemon-shutdown/node_modules/nx/src/plugins/js' 151.981699ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.838Z - Time taken for 'Load Nx Plugin: /tmp/testing/test-daemon-shutdown/node_modules/nx/src/plugins/project-json/build-nodes/project-json' 165.931999ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.839Z - Time taken for 'loadDefaultNxPlugins' 167.35379900000004ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.856Z - [REQUEST]: Updated workspace context based on watched changes, recomputing project graph...
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.856Z - [REQUEST]: 
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.856Z - [REQUEST]: 
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.864Z - Time taken for 'loadSpecifiedNxPlugins' 184.725799ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.879Z - Time taken for 'build-project-configs' 9.32310000000001ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.880Z - Time taken for '@nx/js/typescript:createDependencies' 1.6195999999999913ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.886Z - [SYNC]: collect registered sync generators
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:04.886Z - Time taken for 'total execution time for createProjectGraph()' 9.240700000000004ms
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:09.575Z - [WATCHER]: Stopping the watcher for /tmp/testing/test-daemon-shutdown (sources)
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:09.575Z - [WATCHER]: Stopping the watcher for /tmp/testing/test-daemon-shutdown (outputs)
[NX v20.5.0 Daemon Server] - 2025-03-04T21:08:09.577Z - Server stopped because: "5000ms of inactivity"
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
