### PR TITLE
fix(core): handle package manager workspaces configuration in move generator

### DIFF
--- a/packages/detox/src/generators/application/application.ts
+++ b/packages/detox/src/generators/application/application.ts
@@ -60,7 +60,7 @@ export async function detoxApplicationGeneratorInternal(
   );
 
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(host, options.e2eProjectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.e2eProjectRoot);
   }
 
   sortPackageJsonFields(host, options.e2eProjectRoot);

--- a/packages/expo/src/generators/application/application.ts
+++ b/packages/expo/src/generators/application/application.ts
@@ -65,7 +65,7 @@ export async function expoApplicationGeneratorInternal(
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isTsSolutionSetup) {
-    addProjectToTsSolutionWorkspace(host, options.appProjectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.appProjectRoot);
   }
 
   const lintTask = await addLinting(host, {

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -70,7 +70,7 @@ export async function expoLibraryGeneratorInternal(
   }
 
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(host, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.projectRoot);
   }
 
   const initTask = await init(host, { ...options, skipFormat: true });

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -2303,6 +2303,28 @@ describe('lib', () => {
       );
     });
 
+    it('should add the project root to the package manager workspaces config when a more generic pattern would match other projects that were not previously included', async () => {
+      tree.write(
+        'not-included-dir/some-other-project-not-included/package.json',
+        '{}'
+      );
+
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'not-included-dir/my-lib',
+        bundler: 'tsc',
+        unitTestRunner: 'none',
+        linter: 'none',
+      });
+
+      expect(readJson(tree, 'package.json').workspaces).toContain(
+        'not-included-dir/my-lib'
+      );
+      expect(readJson(tree, 'package.json').workspaces).not.toContain(
+        'not-included-dir/*'
+      );
+    });
+
     it('should not add a pattern for a project that already matches an existing pattern', async () => {
       updateJson(tree, 'package.json', (json) => {
         json.workspaces = ['packages/**'];

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -100,18 +100,18 @@ export async function libraryGeneratorInternal(
   );
   const options = await normalizeOptions(tree, schema);
 
-  // If we are using the new TS solution
-  // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
-  if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.projectRoot);
-  }
-
   createFiles(tree, options);
 
   await configureProject(tree, options);
 
   if (!options.skipPackageJson) {
     tasks.push(addProjectDependencies(tree, options));
+  }
+
+  // If we are using the new TS solution
+  // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
+  if (options.isUsingTsSolutionConfig) {
+    await addProjectToTsSolutionWorkspace(tree, options.projectRoot);
   }
 
   if (options.bundler === 'rollup') {

--- a/packages/js/src/utils/package-manager-workspaces.ts
+++ b/packages/js/src/utils/package-manager-workspaces.ts
@@ -25,7 +25,16 @@ export function getProjectPackageManagerWorkspaceState(
     return 'no-workspaces';
   }
 
-  const patterns = getGlobPatternsFromPackageManagerWorkspaces(
+  const patterns = getPackageManagerWorkspacesPatterns(tree);
+  const isIncluded = patterns.some((p) =>
+    picomatch(p)(join(projectRoot, 'package.json'))
+  );
+
+  return isIncluded ? 'included' : 'excluded';
+}
+
+export function getPackageManagerWorkspacesPatterns(tree: Tree): string[] {
+  return getGlobPatternsFromPackageManagerWorkspaces(
     tree.root,
     (path) => readJson(tree, path, { expectComments: true }),
     (path) => {
@@ -35,11 +44,6 @@ export function getProjectPackageManagerWorkspaceState(
     },
     (path) => tree.exists(path)
   );
-  const isIncluded = patterns.some((p) =>
-    picomatch(p)(join(projectRoot, 'package.json'))
-  );
-
-  return isIncluded ? 'included' : 'excluded';
 }
 
 export function isUsingPackageManagerWorkspaces(tree: Tree): boolean {

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -73,7 +73,7 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isTsSolutionSetup) {
-    addProjectToTsSolutionWorkspace(host, options.appProjectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.appProjectRoot);
   }
 
   const e2eTask = await addE2e(host, options);

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -168,7 +168,7 @@ export async function libraryGeneratorInternal(host: Tree, rawOptions: Schema) {
   );
 
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(host, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.projectRoot);
   }
 
   sortPackageJsonFields(host, options.projectRoot);

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -516,7 +516,7 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.appProjectRoot);
+    await addProjectToTsSolutionWorkspace(tree, options.appProjectRoot);
   }
 
   updateTsConfigOptions(tree, options);

--- a/packages/node/src/generators/e2e-project/e2e-project.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.ts
@@ -259,7 +259,7 @@ export async function e2eProjectGeneratorInternal(
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(host, options.e2eProjectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.e2eProjectRoot);
   }
 
   if (!options.skipFormat) {

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -57,7 +57,7 @@ export async function libraryGeneratorInternal(tree: Tree, schema: Schema) {
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(tree, options.projectRoot);
   }
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -151,7 +151,7 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.appProjectRoot);
+    await addProjectToTsSolutionWorkspace(tree, options.appProjectRoot);
   }
 
   tasks.push(

--- a/packages/plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.ts
@@ -258,7 +258,7 @@ export async function e2eProjectGeneratorInternal(host: Tree, schema: Schema) {
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isTsSolutionSetup) {
-    addProjectToTsSolutionWorkspace(host, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.projectRoot);
   }
 
   if (!options.skipFormat) {

--- a/packages/react-native/src/generators/application/application.ts
+++ b/packages/react-native/src/generators/application/application.ts
@@ -69,7 +69,7 @@ export async function reactNativeApplicationGeneratorInternal(
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isTsSolutionSetup) {
-    addProjectToTsSolutionWorkspace(host, options.appProjectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.appProjectRoot);
   }
 
   const lintTask = await addLinting(host, {

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -88,7 +88,7 @@ export async function reactNativeLibraryGeneratorInternal(
   }
 
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(host, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.projectRoot);
   }
 
   const lintTask = await addLinting(host, {

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -72,12 +72,6 @@ export async function applicationGeneratorInternal(
 
   const options = await normalizeOptions(tree, schema);
 
-  // If we are using the new TS solution
-  // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
-  if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.appProjectRoot);
-  }
-
   showPossibleWarnings(tree, options);
 
   const initTask = await reactInitGenerator(tree, {
@@ -114,6 +108,12 @@ export async function applicationGeneratorInternal(
 
   await createApplicationFiles(tree, options);
   addProject(tree, options);
+
+  // If we are using the new TS solution
+  // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
+  if (options.isUsingTsSolutionConfig) {
+    await addProjectToTsSolutionWorkspace(tree, options.appProjectRoot);
+  }
 
   if (options.style === 'tailwind') {
     const twTask = await setupTailwindGenerator(tree, {

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -62,7 +62,7 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
   const options = await normalizeOptions(host, schema);
 
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(host, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.projectRoot);
   }
 
   if (options.publishable === true && !schema.importPath) {

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -85,7 +85,7 @@ export async function remixApplicationGeneratorInternal(
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(tree, options.projectRoot);
   }
 
   if (!options.isUsingTsSolutionConfig) {

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -30,7 +30,7 @@ export async function remixLibraryGeneratorInternal(
   const options = await normalizeOptions(tree, schema);
 
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(tree, options.projectRoot);
   }
 
   const jsInitTask = await jsInitGenerator(tree, {

--- a/packages/vue/src/generators/application/application.ts
+++ b/packages/vue/src/generators/application/application.ts
@@ -56,7 +56,7 @@ export async function applicationGeneratorInternal(
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.appProjectRoot);
+    await addProjectToTsSolutionWorkspace(tree, options.appProjectRoot);
   }
 
   const nxJson = readNxJson(tree);

--- a/packages/vue/src/generators/library/library.ts
+++ b/packages/vue/src/generators/library/library.ts
@@ -56,7 +56,7 @@ export async function libraryGeneratorInternal(tree: Tree, schema: Schema) {
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(tree, options.projectRoot);
+    await addProjectToTsSolutionWorkspace(tree, options.projectRoot);
   }
 
   if (options.isUsingTsSolutionConfig) {

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -301,7 +301,7 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
   const options = await normalizeOptions(host, schema);
 
   if (options.isUsingTsSolutionConfig) {
-    addProjectToTsSolutionWorkspace(host, options.appProjectRoot);
+    await addProjectToTsSolutionWorkspace(host, options.appProjectRoot);
   }
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -42,7 +42,9 @@
     "chalk": "^4.1.0",
     "enquirer": "~2.3.6",
     "tslib": "^2.3.0",
-    "yargs-parser": "21.1.1"
+    "yargs-parser": "21.1.1",
+    "picomatch": "4.0.2",
+    "@zkochan/js-yaml": "0.0.7"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -39,12 +39,12 @@
   },
   "dependencies": {
     "@nx/devkit": "file:../devkit",
+    "@zkochan/js-yaml": "0.0.7",
     "chalk": "^4.1.0",
     "enquirer": "~2.3.6",
-    "tslib": "^2.3.0",
-    "yargs-parser": "21.1.1",
     "picomatch": "4.0.2",
-    "@zkochan/js-yaml": "0.0.7"
+    "tslib": "^2.3.0",
+    "yargs-parser": "21.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -248,6 +248,25 @@ describe('move', () => {
     `);
   });
 
+  it('should add the project root to the package manager workspaces config when a more generic pattern would match other projects that were not previously included', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.workspaces = ['libs/*'];
+      return json;
+    });
+    await libraryGenerator(tree, { directory: 'libs/lib1' });
+    // extra project that's not part of the package manager workspaces
+    await libraryGenerator(tree, { directory: 'packages/some-package' });
+
+    await moveGenerator(tree, {
+      projectName: 'lib1',
+      destination: 'packages/lib1',
+      updateImportPath: true,
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.workspaces).toStrictEqual(['libs/*', 'packages/lib1']);
+  });
+
   it('should not add new destination to the package manager workspaces config when it was not previously included', async () => {
     updateJson(tree, 'package.json', (json) => {
       json.workspaces = ['apps/*'];

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -1,13 +1,22 @@
-import 'nx/src/internal-testing-utils/mock-project-graph';
-
 import {
+  detectPackageManager,
   readJson,
   readProjectConfiguration,
   Tree,
+  updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { moveGenerator } from './move';
+
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: jest.fn().mockImplementation(async () => ({
+    nodes: {},
+    dependencies: {},
+  })),
+  detectPackageManager: jest.fn(),
+}));
 
 // nx-ignore-next-line
 const { libraryGenerator } = require('@nx/js');
@@ -16,6 +25,9 @@ describe('move', () => {
   let tree: Tree;
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    (detectPackageManager as jest.Mock).mockImplementation((...args) =>
+      jest.requireActual('@nx/devkit').detectPackageManager(...args)
+    );
   });
 
   it('should update jest config when moving down directories', async () => {
@@ -194,5 +206,75 @@ describe('move', () => {
     expect(myLibNewConfig.targets.foo.options.cwd).toEqual('packages/lib1');
     // check that the project.json file is not present
     expect(tree.exists('packages/lib1/project.json')).toBeFalsy();
+  });
+
+  it('should add new destination to the package manager workspaces config when it does not match any existing pattern and it was previously included', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.workspaces = ['libs/*'];
+      return json;
+    });
+    await libraryGenerator(tree, { directory: 'libs/lib1' });
+
+    await moveGenerator(tree, {
+      projectName: 'lib1',
+      destination: 'packages/lib1',
+      updateImportPath: true,
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.workspaces).toStrictEqual(['libs/*', 'packages/*']);
+  });
+
+  it('should add new destination to the pnpm workspaces config when it does not match any existing pattern and it was previously included', async () => {
+    (detectPackageManager as jest.Mock).mockReturnValue('pnpm');
+    tree.write(
+      'pnpm-workspace.yaml',
+      `packages:
+- 'libs/*'`
+    );
+    await libraryGenerator(tree, { directory: 'libs/lib1' });
+
+    await moveGenerator(tree, {
+      projectName: 'lib1',
+      destination: 'packages/lib1',
+      updateImportPath: true,
+    });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "packages:
+        - 'libs/*'
+        - 'packages/*'
+      "
+    `);
+  });
+
+  it('should not add new destination to the package manager workspaces config when it was not previously included', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.workspaces = ['apps/*'];
+      return json;
+    });
+    await libraryGenerator(tree, { directory: 'libs/lib1' });
+
+    await moveGenerator(tree, {
+      projectName: 'lib1',
+      destination: 'packages/lib1',
+      updateImportPath: true,
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.workspaces).toStrictEqual(['apps/*']);
+  });
+
+  it('should not configure package manager workspaces if it was not previously configured', async () => {
+    await libraryGenerator(tree, { directory: 'libs/lib1' });
+
+    await moveGenerator(tree, {
+      projectName: 'lib1',
+      destination: 'packages/lib1',
+      updateImportPath: true,
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.workspaces).toBeUndefined();
   });
 });

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -80,7 +80,7 @@ export async function moveGenerator(tree: Tree, rawSchema: Schema) {
       // the new destination is not included in the package manager workspaces
       // so we need to add it and run a package install to ensure the symlink
       // is created
-      addProjectToTsSolutionWorkspace(tree, schema.destination);
+      await addProjectToTsSolutionWorkspace(tree, schema.destination);
       task = () => installPackagesTask(tree, true);
     }
   }

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -1,11 +1,20 @@
 import {
   formatFiles,
+  installPackagesTask,
   readProjectConfiguration,
   removeProjectConfiguration,
-  Tree,
+  type GeneratorCallback,
+  type Tree,
 } from '@nx/devkit';
+import { isProjectIncludedInPackageManagerWorkspaces } from '../../utilities/package-manager-workspaces';
+import { addProjectToTsSolutionWorkspace } from '../../utilities/typescript/ts-solution-setup';
 import { checkDestination } from './lib/check-destination';
 import { createProjectConfigurationInNewDestination } from './lib/create-project-configuration-in-new-destination';
+import {
+  maybeExtractJestConfigBase,
+  maybeExtractTsConfigBase,
+  maybeMigrateEslintConfigIfRootProject,
+} from './lib/extract-base-configs';
 import { moveProjectFiles } from './lib/move-project-files';
 import { normalizeSchema } from './lib/normalize-schema';
 import { runAngularPlugin } from './lib/run-angular-plugin';
@@ -20,15 +29,14 @@ import { updatePackageJson } from './lib/update-package-json';
 import { updateProjectRootFiles } from './lib/update-project-root-files';
 import { updateReadme } from './lib/update-readme';
 import { updateStorybookConfig } from './lib/update-storybook-config';
-import {
-  maybeMigrateEslintConfigIfRootProject,
-  maybeExtractJestConfigBase,
-  maybeExtractTsConfigBase,
-} from './lib/extract-base-configs';
 import { Schema } from './schema';
 
 export async function moveGenerator(tree: Tree, rawSchema: Schema) {
   let projectConfig = readProjectConfiguration(tree, rawSchema.projectName);
+  const wasIncludedInWorkspaces = isProjectIncludedInPackageManagerWorkspaces(
+    tree,
+    projectConfig.root
+  );
   const schema = await normalizeSchema(tree, rawSchema, projectConfig);
   checkDestination(tree, schema, rawSchema.destination);
 
@@ -61,8 +69,28 @@ export async function moveGenerator(tree: Tree, rawSchema: Schema) {
 
   await runAngularPlugin(tree, schema);
 
+  let task: GeneratorCallback;
+  if (wasIncludedInWorkspaces) {
+    // check if the new destination is included in the package manager workspaces
+    const isIncludedInWorkspaces = isProjectIncludedInPackageManagerWorkspaces(
+      tree,
+      schema.destination
+    );
+    if (!isIncludedInWorkspaces) {
+      // the new destination is not included in the package manager workspaces
+      // so we need to add it and run a package install to ensure the symlink
+      // is created
+      addProjectToTsSolutionWorkspace(tree, schema.destination);
+      task = () => installPackagesTask(tree, true);
+    }
+  }
+
   if (!schema.skipFormat) {
     await formatFiles(tree);
+  }
+
+  if (task) {
+    return task;
   }
 }
 

--- a/packages/workspace/src/utilities/package-manager-workspaces.ts
+++ b/packages/workspace/src/utilities/package-manager-workspaces.ts
@@ -12,7 +12,13 @@ export function isProjectIncludedInPackageManagerWorkspaces(
     return false;
   }
 
-  const patterns = getGlobPatternsFromPackageManagerWorkspaces(
+  const patterns = getPackageManagerWorkspacesPatterns(tree);
+
+  return patterns.some((p) => picomatch(p)(join(projectRoot, 'package.json')));
+}
+
+export function getPackageManagerWorkspacesPatterns(tree: Tree): string[] {
+  return getGlobPatternsFromPackageManagerWorkspaces(
     tree.root,
     (path) => readJson(tree, path, { expectComments: true }),
     (path) => {
@@ -22,8 +28,6 @@ export function isProjectIncludedInPackageManagerWorkspaces(
     },
     (path) => tree.exists(path)
   );
-
-  return patterns.some((p) => picomatch(p)(join(projectRoot, 'package.json')));
 }
 
 export function isUsingPackageManagerWorkspaces(tree: Tree): boolean {

--- a/packages/workspace/src/utilities/package-manager-workspaces.ts
+++ b/packages/workspace/src/utilities/package-manager-workspaces.ts
@@ -1,0 +1,45 @@
+import { detectPackageManager, readJson, type Tree } from '@nx/devkit';
+import { join } from 'node:path/posix';
+import { getGlobPatternsFromPackageManagerWorkspaces } from 'nx/src/plugins/package-json';
+import { PackageJson } from 'nx/src/utils/package-json';
+import picomatch = require('picomatch');
+
+export function isProjectIncludedInPackageManagerWorkspaces(
+  tree: Tree,
+  projectRoot: string
+): boolean {
+  if (!isUsingPackageManagerWorkspaces(tree)) {
+    return false;
+  }
+
+  const patterns = getGlobPatternsFromPackageManagerWorkspaces(
+    tree.root,
+    (path) => readJson(tree, path, { expectComments: true }),
+    (path) => {
+      const content = tree.read(path, 'utf-8');
+      const { load } = require('@zkochan/js-yaml');
+      return load(content, { filename: path });
+    },
+    (path) => tree.exists(path)
+  );
+
+  return patterns.some((p) => picomatch(p)(join(projectRoot, 'package.json')));
+}
+
+export function isUsingPackageManagerWorkspaces(tree: Tree): boolean {
+  return isWorkspacesEnabled(tree);
+}
+
+export function isWorkspacesEnabled(tree: Tree): boolean {
+  const packageManager = detectPackageManager(tree.root);
+  if (packageManager === 'pnpm') {
+    return tree.exists('pnpm-workspace.yaml');
+  }
+
+  // yarn and npm both use the same 'workspaces' property in package.json
+  if (tree.exists('package.json')) {
+    const packageJson = readJson<PackageJson>(tree, 'package.json');
+    return !!packageJson?.workspaces;
+  }
+  return false;
+}


### PR DESCRIPTION
## Current Behavior

Moving a project included in the package manager workspaces setup to a new destination that's not matched by that configuration results in the project not included in the package manager workspaces setup.

## Expected Behavior

Moving a project included in the package manager workspaces setup to a new destination that's not matched by that configuration should result in the new destination included in the workspaces setup.

## Related Issue(s)

Fixes #
