### PR TITLE
fix(core): handle nx config in package.json in move generator

### DIFF
--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
@@ -3,6 +3,7 @@ import {
   joinPathFragments,
   ProjectConfiguration,
   Tree,
+  updateProjectConfiguration,
 } from '@nx/devkit';
 import { NormalizedSchema } from '../schema';
 
@@ -81,6 +82,11 @@ export function createProjectConfigurationInNewDestination(
     );
   }
 
-  // Create a new project with the root replaced
-  addProjectConfiguration(tree, schema.newProjectName, newProject);
+  if (schema.isNxConfiguredInPackageJson) {
+    // Update the existing project configuration in the package.json
+    updateProjectConfiguration(tree, schema.newProjectName, newProject);
+  } else {
+    // Create a new project with the root replaced
+    addProjectConfiguration(tree, schema.newProjectName, newProject);
+  }
 }

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -4,13 +4,10 @@ import {
   readJson,
   readProjectConfiguration,
   Tree,
-  updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { moveGenerator } from './move';
-// nx-ignore-next-line
-const { applicationGenerator } = require('@nx/react');
 
 // nx-ignore-next-line
 const { libraryGenerator } = require('@nx/js');
@@ -72,8 +69,9 @@ describe('move', () => {
       destination: 'shared/two',
     });
 
+    // check that the project.json file is present
+    expect(tree.exists('shared/two/project.json')).toBeTruthy();
     const myLibNewConfig = readProjectConfiguration(tree, 'two');
-
     expect(myLibNewConfig.targets.custom.options.buildTarget).toEqual(
       'two:build:production'
     );
@@ -83,6 +81,8 @@ describe('move', () => {
     expect(myLibNewConfig.targets.custom.options.irrelevantTarget).toEqual(
       'my-lib:build:production'
     );
+    // check that the package.json does not have nx config
+    expect(readJson(tree, 'shared/two/package.json').nx).toBeUndefined();
   });
 
   it('should update jest config when moving up directories', async () => {
@@ -144,5 +144,55 @@ describe('move', () => {
     });
 
     expect(tree.exists('tsconfig.base.json')).toBeFalsy();
+  });
+
+  it('should correctly update the nx configuration when it is located in the package.json file', async () => {
+    await libraryGenerator(tree, {
+      directory: 'libs/lib1',
+      useProjectJson: false,
+      skipFormat: true,
+    });
+    updateProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      targets: {
+        foo: {
+          command: 'echo "foo"',
+          options: {
+            cwd: 'libs/lib1',
+          },
+        },
+      },
+    });
+
+    await moveGenerator(tree, {
+      projectName: 'lib1',
+      destination: 'packages/lib1',
+      updateImportPath: true,
+      skipFormat: true,
+    });
+
+    // check that the nx config in the package.json is correct
+    const packageJson = readJson(tree, 'packages/lib1/package.json');
+    expect(packageJson.nx).toMatchInlineSnapshot(`
+      {
+        "name": "lib1",
+        "projectType": "library",
+        "sourceRoot": "packages/lib1/src",
+        "targets": {
+          "foo": {
+            "command": "echo "foo"",
+            "options": {
+              "cwd": "packages/lib1",
+            },
+          },
+        },
+      }
+    `);
+    // check that we read the project configuration with the updated paths from the package.json
+    const myLibNewConfig = readProjectConfiguration(tree, 'lib1');
+    expect(myLibNewConfig.sourceRoot).toEqual('packages/lib1/src');
+    expect(myLibNewConfig.targets.foo.options.cwd).toEqual('packages/lib1');
+    // check that the project.json file is not present
+    expect(tree.exists('packages/lib1/project.json')).toBeFalsy();
   });
 });

--- a/packages/workspace/src/generators/move/schema.d.ts
+++ b/packages/workspace/src/generators/move/schema.d.ts
@@ -9,4 +9,5 @@ export interface Schema {
 
 export interface NormalizedSchema extends Schema {
   relativeToRootDestination: string;
+  isNxConfiguredInPackageJson?: boolean;
 }


### PR DESCRIPTION
## Current Behavior

When the Nx configuration is in `package.json#nx` and not in `project.json`, the move generator creates a `project.json` file in the new destination.

## Expected Behavior

When the Nx configuration is in `package.json#nx` and not in `project.json`, the move generator should not create a `project.json` file in the new destination and should update the `nx` entry in the `package.json` file.

## Related Issue(s)

Fixes #
