### PR TITLE
fix(bundling): remove migration always adding sass-embedded

### DIFF
--- a/docs/generated/packages/rspack/migrations/20.5.0-package-updates.json
+++ b/docs/generated/packages/rspack/migrations/20.5.0-package-updates.json
@@ -2,8 +2,7 @@
   "name": "20.5.0-package-updates",
   "version": "20.5.0-beta.4",
   "packages": {
-    "sass-embedded": { "version": "^1.83.4", "alwaysAddToPackageJson": true },
-    "sass-loader": { "version": "^16.0.4", "alwaysAddToPackageJson": true },
+    "sass-loader": { "version": "^16.0.4", "alwaysAddToPackageJson": false },
     "@rspack/core": { "version": "^1.2.2", "alwaysAddToPackageJson": false }
   },
   "aliases": [],

--- a/docs/generated/packages/webpack/migrations/20.5.0-package-updates.json
+++ b/docs/generated/packages/webpack/migrations/20.5.0-package-updates.json
@@ -2,8 +2,7 @@
   "name": "20.5.0-package-updates",
   "version": "20.5.0-beta.3",
   "packages": {
-    "sass-loader": { "version": "^16.0.4", "alwaysAddToPackageJson": false },
-    "sass-embedded": { "version": "^1.83.4", "alwaysAddToPackageJson": true }
+    "sass-loader": { "version": "^16.0.4", "alwaysAddToPackageJson": false }
   },
   "aliases": [],
   "description": "",

--- a/packages/rspack/migrations.json
+++ b/packages/rspack/migrations.json
@@ -98,13 +98,9 @@
     "20.5.0": {
       "version": "20.5.0-beta.4",
       "packages": {
-        "sass-embedded": {
-          "version": "^1.83.4",
-          "alwaysAddToPackageJson": true
-        },
         "sass-loader": {
           "version": "^16.0.4",
-          "alwaysAddToPackageJson": true
+          "alwaysAddToPackageJson": false
         },
         "@rspack/core": {
           "version": "^1.2.2",

--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -42,10 +42,6 @@
         "sass-loader": {
           "version": "^16.0.4",
           "alwaysAddToPackageJson": false
-        },
-        "sass-embedded": {
-          "version": "^1.83.4",
-          "alwaysAddToPackageJson": true
         }
       }
     }


### PR DESCRIPTION
## Current Behavior
There is a migration that always adds `sass-embedded` for Rspack and Webpack for 20.5

## Expected Behavior
`sass-embedded` is already a dependency of Rspack and Webpack and therefore does not need to be added to users package.json - especially as they may not be using it.
