### PR TITLE
fix(graph): fix target details header tooltips in collapsed state

### DIFF
--- a/graph/ui-project-details/src/lib/target-configuration-details-header/target-configuration-details-header.tsx
+++ b/graph/ui-project-details/src/lib/target-configuration-details-header/target-configuration-details-header.tsx
@@ -163,15 +163,14 @@ export const TargetConfigurationDetailsHeader = ({
         <div className="flex items-center gap-2">
           <CopyToClipboardButton
             text={JSON.stringify(targetConfiguration, null, 2)}
-            tooltipText={!isCollasped ? 'Copy Target' : undefined}
+            tooltipText="Copy Target"
             tooltipAlignment="right"
             className="rounded-md bg-inherit p-1 text-sm text-slate-600 ring-1 ring-inset ring-slate-400/40 hover:bg-slate-200 dark:text-slate-300 dark:ring-slate-400/30 dark:hover:bg-slate-700/60"
           />
           {onViewInTaskGraph && (
             <button
               className="rounded-md bg-inherit p-1 text-sm text-slate-600 ring-1 ring-inset ring-slate-400/40 hover:bg-slate-200 dark:text-slate-300 dark:ring-slate-400/30 dark:hover:bg-slate-700/60"
-              // TODO: fix tooltip overflow in collapsed state
-              data-tooltip={isCollasped ? false : 'View in Task Graph'}
+              data-tooltip="View in Task Graph"
               data-tooltip-align-right
               onClick={(e) => {
                 e.stopPropagation();
@@ -185,8 +184,7 @@ export const TargetConfigurationDetailsHeader = ({
           {onRunTarget && (
             <span
               className="rounded-md bg-inherit p-1 text-sm text-slate-600 ring-1 ring-inset ring-slate-400/40 hover:bg-slate-200 dark:text-slate-300 dark:ring-slate-400/30 dark:hover:bg-slate-700/60"
-              // TODO: fix tooltip overflow in collapsed state
-              data-tooltip={isCollasped ? false : 'Run Target'}
+              data-tooltip="Run Target"
               data-tooltip-align-right
             >
               <PlayIcon


### PR DESCRIPTION
I couldn't find any visual issues with the tooltips anymore, in collapsed or open state. The click listener order has been fixed as well.
So let's just always show the tooltips.