### PR TITLE
fix(vite): ensure test target dependency is not duplicated

### DIFF
--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -171,7 +171,9 @@ getTestBed().initTestEnvironment(
     nxJson.targetDefaults ??= {};
     nxJson.targetDefaults[testTarget] ??= {};
     nxJson.targetDefaults[testTarget].dependsOn ??= [];
-    nxJson.targetDefaults[testTarget].dependsOn = Array.from(new Set([...nxJson.targetDefaults[testTarget].dependsOn, "^build" ]));
+    nxJson.targetDefaults[testTarget].dependsOn = Array.from(
+      new Set([...nxJson.targetDefaults[testTarget].dependsOn, '^build'])
+    );
     updateNxJson(tree, nxJson);
   }
 

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -171,7 +171,7 @@ getTestBed().initTestEnvironment(
     nxJson.targetDefaults ??= {};
     nxJson.targetDefaults[testTarget] ??= {};
     nxJson.targetDefaults[testTarget].dependsOn ??= [];
-    nxJson.targetDefaults[testTarget].dependsOn.push('^build');
+    nxJson.targetDefaults[testTarget].dependsOn = Array.from(new Set([...nxJson.targetDefaults[testTarget].dependsOn, "^build" ]));
     updateNxJson(tree, nxJson);
   }
 


### PR DESCRIPTION



<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Every time the vitest generator was run a new duplicate '^build' dependency was added to the target defaults for the test task.

## Expected Behavior
No duplicate entries added!

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30288
