### PR TITLE
docs(angular): fix typo in dynamic mfe section

### DIFF
--- a/docs/shared/recipes/module-federation/dynamic-mfe-angular.md
+++ b/docs/shared/recipes/module-federation/dynamic-mfe-angular.md
@@ -440,9 +440,9 @@ There are 3 steps involved with this:
 
 Perhaps one of the easiest methods of fetching the Remote Definitions at runtime is to store them in a JSON file that can be present in each environment. The Host application then only has to make a GET request to the JSON file.
 
-We'll start by creating this file. Add a `module-federation.manifest.json` file to the `src/public/` folder in our **Dashboard** application with the following content:
+We'll start by creating this file. Add a `module-federation.manifest.json` file to the `public/` folder in our **Dashboard** application with the following content:
 
-```json {% fileName="apps/dashboard/src/public/module-federation.manifest.json" %}
+```json {% fileName="apps/dashboard/public/module-federation.manifest.json" %}
 {
   "login": "http://localhost:4201"
 }


### PR DESCRIPTION
The documentation currently states:  
> "Add a `module-federation.manifest.json` file to the `src/public/` folder in our Dashboard application..."  

However, the correct location for the file is `public/` and **not** `src/public/`. This could lead to confusion when implementing the example, as the folder structure may differ.  

So I fixed it to public/

This issue was reported here: [Issue #30020](https://github.com/nrwl/nx/issues/30020).  
