### PR TITLE
fix(core): align createNodesFromFiles options type with createNodes callback

### DIFF
--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -12,7 +12,7 @@ export async function createNodesFromFiles<T = unknown>(
     idx: number
   ) => CreateNodesResult | Promise<CreateNodesResult>,
   configFiles: readonly string[],
-  options: T,
+  options: T | undefined,
   context: CreateNodesContextV2
 ) {
   const results: Array<[file: string, value: CreateNodesResult]> = [];


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
type of `option` from `createNodes()` callback does not match type of `option` of `createNodesFromFiles`. Change was introduced in 20.5.0 by #29935.

A workaround in 20.5.0 is to get a type by using `Parameters<typeof createNodesFromFiles<MyOptions>>[0]`. Before 20.5.0 you could use `CreateNodesFunction<MyOptions>` when you wanted to type your _createNodes_ function. Of course you could pass an arrow function, but I think many plugin authors use a separate function.

## Expected Behavior
They should have the same types or there should be a public type of the `createNodes()` callback, so that users have better dx.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
