### PR TITLE
fix(core): use deprecated tag on workspace

### DIFF
--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -246,7 +246,7 @@ export interface ExecutorContext {
   taskGraph?: TaskGraph;
 
   /**
-   * Deprecated. Use projectsConfigurations or nxJsonConfiguration
+   * @deprecated Use projectsConfigurations or nxJsonConfiguration
    * The full workspace configuration
    * @todo(vsavkin): remove after v17
    */


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Workspace says it is deprecated in the comment but does not use the `@deprecated` tag identifier.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Using the `@deprecated` tag allows tooling, like https://typescript-eslint.io/rules/no-deprecated/ , to easily identify code that will be removed.   Many code editors will also strikethrough if it has been marked with the deprecated tag.

| before | after |
|--------|-------|
|  <img width="1032" alt="Screenshot 2025-03-11 at 8 09 58 AM" src="https://github.com/user-attachments/assets/4adf741c-7072-4723-af46-6f83b8e473e9" />     |    <img width="969" alt="Screenshot 2025-03-11 at 8 08 44 AM" src="https://github.com/user-attachments/assets/56e9bde3-db80-4bd5-b61b-449cf557c37b" />   |


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30517
