### PR TITLE
fix(angular): fix create config output in convert-to-rspack

### DIFF
--- a/packages/angular/src/generators/convert-to-rspack/lib/create-config.ts
+++ b/packages/angular/src/generators/convert-to-rspack/lib/create-config.ts
@@ -89,7 +89,8 @@ export function createConfig(
         ? `async function (env, argv) { 
         const oldConfig = await baseWebpackConfig;
         const browserConfig = baseConfig[0];
-        return oldConfig(browserConfig);`
+        return oldConfig(browserConfig);
+      }`
         : 'webpackMerge(baseConfig[0], baseWebpackConfig)'
     }
   `


### PR DESCRIPTION
In the new convert-to-rspack generator, when the project’s existing webpack config is a function, create-config’s generated output was missing the closing brace on the exported function.

## Current Behavior
The generated rspack.config.ts from the convert-to-rspack generator was missing the closing brace when the project to convert had its webpack config as a function. 

## Expected Behavior
The generated rspack.config.ts should have valid output.

