### PR TITLE
feat(rspack): infer ts-node compiler options in rspack task env when using a typescript config file

### DIFF
--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -12,6 +12,7 @@ describe('@nx/rspack', () => {
   let createNodesFunction = createNodesV2[1];
   let context: CreateNodesContext;
   let tempFs: TempFs;
+  let originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
 
   beforeEach(() => {
     (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(false);
@@ -26,22 +27,120 @@ describe('@nx/rspack', () => {
       },
       workspaceRoot: tempFs.tempDir,
     };
+    process.env.NX_CACHE_PROJECT_GRAPH = 'false';
 
     tempFs.createFileSync(
       'my-app/project.json',
       JSON.stringify({ name: 'my-app' })
     );
     tempFs.createFileSync('my-app/rspack.config.ts', `export default {};`);
+    tempFs.createFileSync('package-lock.json', `{}`);
   });
 
   afterEach(() => {
     jest.resetModules();
     tempFs.cleanup();
+    if (originalCacheProjectGraph !== undefined) {
+      process.env.NX_CACHE_PROJECT_GRAPH = originalCacheProjectGraph;
+    } else {
+      delete process.env.NX_CACHE_PROJECT_GRAPH;
+    }
   });
 
   it('should handle missing lock file', async () => {
+    tempFs.removeFileSync('package-lock.json');
+
     await expect(
       createNodesFunction(['my-app/rspack.config.ts'], {}, context)
     ).resolves.not.toThrow();
+  });
+
+  it('should infer tasks', async () => {
+    await expect(createNodesFunction(['my-app/rspack.config.ts'], {}, context))
+      .resolves.toMatchInlineSnapshot(`
+      [
+        [
+          "my-app/rspack.config.ts",
+          {
+            "projects": {
+              "my-app": {
+                "metadata": {},
+                "root": "my-app",
+                "targets": {
+                  "build": {
+                    "cache": true,
+                    "command": "rspack build",
+                    "dependsOn": [
+                      "^build",
+                    ],
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "@rspack/cli",
+                        ],
+                      },
+                    ],
+                    "options": {
+                      "args": [
+                        "--node-env=production",
+                      ],
+                      "cwd": "my-app",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"Node10","module":"CommonJS"}",
+                      },
+                    },
+                    "outputs": [],
+                  },
+                  "build-deps": {
+                    "dependsOn": [
+                      "^build",
+                    ],
+                  },
+                  "preview": {
+                    "command": "rspack serve",
+                    "options": {
+                      "args": [
+                        "--node-env=production",
+                      ],
+                      "cwd": "my-app",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"Node10","module":"CommonJS"}",
+                      },
+                    },
+                  },
+                  "serve": {
+                    "command": "rspack serve",
+                    "options": {
+                      "args": [
+                        "--node-env=development",
+                      ],
+                      "cwd": "my-app",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"Node10","module":"CommonJS"}",
+                      },
+                    },
+                  },
+                  "serve-static": {
+                    "executor": "@nx/web:file-server",
+                    "options": {
+                      "buildTarget": "build",
+                      "spa": true,
+                    },
+                  },
+                  "watch-deps": {
+                    "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+                    "dependsOn": [
+                      "build-deps",
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ]
+    `);
   });
 });

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -16,7 +16,7 @@ import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-
 import { existsSync, readdirSync } from 'fs';
 import { hashArray, hashFile, hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
-import { dirname, isAbsolute, join, relative, resolve } from 'path';
+import { dirname, extname, isAbsolute, join, relative, resolve } from 'path';
 import { readRspackOptions } from '../utils/read-rspack-options';
 import { resolveUserDefinedRspackConfig } from '../utils/resolve-user-defined-rspack-config';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
@@ -35,7 +35,13 @@ type RspackTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 const pmc = getPackageManagerCommand();
 
 function readTargetsCache(cachePath: string): Record<string, RspackTargets> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
+  try {
+    return process.env.NX_CACHE_PROJECT_GRAPH !== 'false'
+      ? readJsonFile(cachePath)
+      : {};
+  } catch {
+    return {};
+  }
 }
 
 function writeTargetsToCache(
@@ -172,9 +178,25 @@ async function createRspackTargets(
 
   const targets = {};
 
+  const env: NodeJS.ProcessEnv = {};
+  const isTsConfig = ['.ts', '.cts', '.mts'].includes(extname(configFilePath));
+  if (isTsConfig) {
+    // https://rspack.dev/config/#using-ts-node
+    const existingValue = process.env['TS_NODE_COMPILER_OPTIONS'];
+    env['TS_NODE_COMPILER_OPTIONS'] = JSON.stringify({
+      ...(existingValue ? JSON.parse(existingValue) : {}),
+      module: 'CommonJS',
+      moduleResolution: 'Node10',
+    });
+  }
+
   targets[options.buildTargetName] = {
     command: `rspack build`,
-    options: { cwd: projectRoot, args: ['--node-env=production'] },
+    options: {
+      cwd: projectRoot,
+      args: ['--node-env=production'],
+      env,
+    },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
     inputs:
@@ -201,6 +223,7 @@ async function createRspackTargets(
     options: {
       cwd: projectRoot,
       args: ['--node-env=development'],
+      env,
     },
   };
 
@@ -209,6 +232,7 @@ async function createRspackTargets(
     options: {
       cwd: projectRoot,
       args: ['--node-env=production'],
+      env,
     },
   };
 


### PR DESCRIPTION
Infer the relevant ts-node compiler options to support an Rspack config file using TypeScript as per https://rspack.dev/config/#using-ts-node.

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
