### PR TITLE
fix(core): only add keep existing versions if init generator supports it

### DIFF
--- a/packages/nx/src/command-line/init/configure-plugins.ts
+++ b/packages/nx/src/command-line/init/configure-plugins.ts
@@ -47,17 +47,28 @@ export async function installPlugin(
   pmc: PackageManagerCommands = getPackageManagerCommand()
 ): Promise<void> {
   try {
-    getGeneratorInformation(plugin, 'init', workspaceRoot, {});
-    execSync(
-      `${pmc.exec} nx g ${plugin}:init --keepExistingVersions ${
-        updatePackageScripts ? '--updatePackageScripts' : ''
-      } ${verbose ? '--verbose' : ''}`,
-      {
-        stdio: [0, 1, 2],
-        cwd: repoRoot,
-        windowsHide: false,
-      }
+    const { schema } = getGeneratorInformation(
+      plugin,
+      'init',
+      workspaceRoot,
+      {}
     );
+
+    let command = `${pmc.exec} nx g ${plugin}:init ${
+      verbose ? '--verbose' : ''
+    }`;
+
+    if (!!schema.properties['keepExistingVersions']) {
+      command += ` --keepExistingVersions`;
+    }
+    if (updatePackageScripts && !!schema.properties['updatePackageScripts']) {
+      command += ` --updatePackageScripts`;
+    }
+    execSync(command, {
+      stdio: [0, 1, 2],
+      cwd: repoRoot,
+      windowsHide: false,
+    });
   } catch {
     // init generator does not exist, so this function should noop
     output.log({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx plugins which do not support `keepExistingPackages` fail to initialize via `nx init` or `nx add`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx plugins which do not support `keepExistingPackages` initializes properly via `nx init` and `nx add`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
