### PR TITLE
fix(angular): directory type is not optional

### DIFF
--- a/packages/angular/src/generators/ngrx-feature-store/schema.d.ts
+++ b/packages/angular/src/generators/ngrx-feature-store/schema.d.ts
@@ -2,7 +2,7 @@ export interface Schema {
   name: string;
   minimal: boolean;
   parent: string;
-  directory?: string;
+  directory: string;
   route?: string;
   barrels?: boolean;
   facade?: boolean;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `directory` option for the ngrx feature store generator is currently marked as optional. With that, if you try to run the generator and do not pass a directory, it will throw an error.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`directory` needs to be a required option. The Nx Console already handles this by pre-populating the option, this just adjusts things appropriately for those not using the console, or calling the generator programatically. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
