### PR TITLE
fix(core): make 'key' parameter optional in register command

### DIFF
--- a/packages/nx/src/command-line/register/command-object.ts
+++ b/packages/nx/src/command-line/register/command-object.ts
@@ -8,7 +8,7 @@ export interface RegisterOptions {
 }
 
 export const yargsRegisterCommand: CommandModule<{}, RegisterOptions> = {
-  command: 'register <key>',
+  command: 'register [key]',
   aliases: ['activate-powerpack'],
   describe: false,
   builder: (yargs) =>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Calling `nx register` requires users to enter a key.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Calling `nx register` should work without having users enter a key.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
