### PR TITLE
feat(core): allow customizing the location of the plugin e2e project

### DIFF
--- a/docs/generated/packages/plugin/generators/plugin.json
+++ b/docs/generated/packages/plugin/generators/plugin.json
@@ -71,6 +71,10 @@
         "description": "Test runner to use for end to end (E2E) tests.",
         "default": "none"
       },
+      "e2eRootDirectory": {
+        "type": "string",
+        "description": "A root directory where the end to end (E2E) project is placed."
+      },
       "standaloneConfig": {
         "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
         "type": "boolean",

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -325,6 +325,19 @@ describe('NxPlugin Plugin Generator', () => {
       const projects = getProjects(tree);
       expect(projects.has('my-plugin-e2e')).toBe(false);
     });
+
+    it('should place the e2e project in a root directory', async () => {
+      await pluginGenerator(
+        tree,
+        getSchema({
+          name: 'my-plugin',
+          e2eRootDirectory: 'e2e',
+        })
+      );
+
+      const projectE2e = readProjectConfiguration(tree, 'my-plugin-e2e');
+      expect(projectE2e.root).toEqual('e2e/my-plugin-e2e');
+    });
   });
 
   describe('TS solution setup', () => {

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -146,7 +146,9 @@ export async function pluginGeneratorInternal(host: Tree, schema: Schema) {
     tasks.push(
       await e2eProjectGenerator(host, {
         pluginName: options.projectName,
-        projectDirectory: options.projectDirectory,
+        projectDirectory: options.e2eRootDirectory
+          ? `${options.e2eRootDirectory}/${options.projectDirectory}`
+          : options.projectDirectory,
         pluginOutputPath: joinPathFragments(
           'dist',
           options.rootProject ? options.projectName : options.projectRoot

--- a/packages/plugin/src/generators/plugin/schema.d.ts
+++ b/packages/plugin/src/generators/plugin/schema.d.ts
@@ -8,6 +8,7 @@ export interface Schema {
   skipFormat?: boolean; // default is false
   skipLintChecks?: boolean; // default is false
   e2eTestRunner?: 'jest' | 'none';
+  e2eRootDirectory?: string;
   tags?: string;
   unitTestRunner?: 'jest' | 'vitest' | 'none';
   linter?: Linter | LinterType;

--- a/packages/plugin/src/generators/plugin/schema.json
+++ b/packages/plugin/src/generators/plugin/schema.json
@@ -71,6 +71,10 @@
       "description": "Test runner to use for end to end (E2E) tests.",
       "default": "none"
     },
+    "e2eRootDirectory": {
+      "type": "string",
+      "description": "A root directory where the end to end (E2E) project is placed."
+    },
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a new plugin with `@nx/plugin` and with e2e tests,  the  e2e project is located in the same folder as the plugin project itself.

This is fine when the plugin project is located at workspace root, but feels "weird" when the plugin is located in a sub directory (for e.g inside a `packages/my-plugin` folder). People may want to group e2e project inside a `e2e` folder.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Allow customizing where to put the -e2e project, and default to the same folder as the plugin

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
