### PR TITLE
fix(core): handle null outputs in native cache

### DIFF
--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -175,7 +175,7 @@ impl NxCache {
         &self,
         hash: String,
         result: CachedResult,
-        outputs: Vec<String>,
+        outputs: Option<Vec<String>>,
     ) -> anyhow::Result<()> {
         trace!(
             "applying remote cache results: {:?} ({})",
@@ -184,9 +184,12 @@ impl NxCache {
         );
         let terminal_output = result.terminal_output.clone();
         let mut size = terminal_output.len() as i64;
-        if outputs.len() > 0 && result.code == 0 {
-            size += try_and_retry(|| self.copy_files_from_cache(result.clone(), outputs.clone()))?;
-        };
+        if let Some(outputs) = outputs {
+            if outputs.len() > 0 && result.code == 0 {
+                size +=
+                    try_and_retry(|| self.copy_files_from_cache(result.clone(), outputs.clone()))?;
+            };
+        }
         write(self.get_task_outputs_path(hash.clone()), terminal_output)?;
 
         let code: i16 = result.code;

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -40,7 +40,7 @@ export declare class NxCache {
   constructor(workspaceRoot: string, cachePath: string, dbConnection: ExternalObject<NxDbConnection>, linkTaskDetails?: boolean | undefined | null, maxCacheSize?: number | undefined | null)
   get(hash: string): CachedResult | null
   put(hash: string, terminalOutput: string, outputs: Array<string>, code: number): void
-  applyRemoteCacheResults(hash: string, result: CachedResult, outputs: Array<string>): void
+  applyRemoteCacheResults(hash: string, result: CachedResult, outputs?: Array<string> | undefined | null): void
   getTaskOutputsPath(hash: string): string
   getCacheSize(): number
   copyFilesFromCache(cachedResult: CachedResult, outputs: Array<string>): number


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
`cache.rs` expects outputs to always be an array

## Expected Behavior
`cache.rs` is able to handle null

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
