### PR TITLE
fix(release): adding option to skip formatting in release

### DIFF
--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -998,7 +998,9 @@ To fix this you will either need to add a package.json file at that location, or
      * Ensure that formatting is applied so that version bump diffs are as minimal as possible
      * within the context of the user's workspace.
      */
-    await formatFiles(tree);
+    if (!options.skipFormat) {
+      await formatFiles(tree);
+    }
 
     // Return the version data so that it can be leveraged by the overall version command
     return {

--- a/packages/js/src/generators/release-version/schema.json
+++ b/packages/js/src/generators/release-version/schema.json
@@ -61,6 +61,11 @@
     "installIgnoreScripts": {
       "type": "boolean",
       "description": "Whether to ignore install lifecycle scripts when updating the lock file with an install command."
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Whether to skip formatting files with Prettier after updating version information.",
+      "default": false
     }
   },
   "required": ["projects", "projectGraph", "releaseGroup"]

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -45,6 +45,7 @@ export type VersionOptions = NxReleaseArgs &
     preid?: string;
     stageChanges?: boolean;
     generatorOptionsOverrides?: Record<string, unknown>;
+    skipFormat?: boolean;
   };
 
 export type ChangelogOptions = NxReleaseArgs &
@@ -88,6 +89,7 @@ export type ReleaseOptions = NxReleaseArgs &
     yes?: boolean;
     preid?: VersionOptions['preid'];
     skipPublish?: boolean;
+    skipFormat?: boolean;
   };
 
 export type VersionPlanArgs = {
@@ -204,6 +206,12 @@ const releaseCommand: CommandModule<NxReleaseArgs, ReleaseOptions> = {
         description:
           'Skip publishing by automatically answering no to the confirmation prompt for publishing.',
       })
+      .option('skip-format', {
+        type: 'boolean',
+        describe:
+          'Skip formatting files with Prettier after updating version information.',
+        default: false,
+      })
       .check((argv) => {
         if (argv.yes !== undefined && argv.skipPublish !== undefined) {
           throw new Error(
@@ -247,6 +255,12 @@ const versionCommand: CommandModule<NxReleaseArgs, VersionOptions> = {
             type: 'boolean',
             describe:
               'Whether or not to stage the changes made by this command. Useful when combining this command with changelog generation.',
+          })
+          .option('skip-format', {
+            type: 'boolean',
+            describe:
+              'Skip formatting files with Prettier after updating version information.',
+            default: false,
           })
       )
     ),

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -101,6 +101,11 @@ export interface ReleaseVersionGeneratorSchema {
    * still present in the package.json.
    */
   preserveLocalDependencyProtocols?: boolean;
+  
+  /**
+   * Whether to skip formatting files with Prettier after updating version information.
+   */
+  skipFormat?: boolean;
 }
 
 export interface NxReleaseVersionResult {


### PR DESCRIPTION
## Current Behavior
Cannot skip prettier on `nx release`

## Expected Behavior
Should be able to skip prettier for those of us using biome

## Related Issue(s)

Fixes #
https://github.com/nrwl/nx/issues/30403