### PR TITLE
feat(bundling): add buildLibsFromSource option to @nx/rollup:rollup executor

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -4,15 +4,14 @@
   "schema": {
     "version": 2,
     "outputCapture": "direct-nodejs",
-    "title": "Web Library Rollup Target (Experimental)",
+    "title": "Web Library Rollup Target",
     "description": "Packages a library for different web usages (ESM, CommonJS).",
     "cli": "nx",
     "type": "object",
     "properties": {
       "project": {
         "type": "string",
-        "description": "The path to package.json file.",
-        "x-priority": "important"
+        "description": "The path to package.json file."
       },
       "main": {
         "type": "string",
@@ -148,6 +147,11 @@
         "description": "Additional entry-points to add to exports field in the package.json file.",
         "items": { "type": "string" },
         "x-priority": "important"
+      },
+      "buildLibsFromSource": {
+        "type": "boolean",
+        "description": "Read buildable libraries from source instead of building them separately.",
+        "default": true
       },
       "skipTypeCheck": {
         "type": "boolean",

--- a/packages/rollup/src/executors/rollup/schema.d.ts
+++ b/packages/rollup/src/executors/rollup/schema.d.ts
@@ -15,22 +15,23 @@ export interface Globals {
 export interface RollupExecutorOptions {
   outputPath: string;
   tsConfig: string;
-  allowJs?: boolean;
-  project: string;
   main: string;
-  outputFileName?: string;
-  extractCss?: boolean | string;
-  external?: string[] | 'all' | 'none';
-  rollupConfig?: string | string[];
-  watch?: boolean;
-  assets?: any[];
-  deleteOutputPath?: boolean;
-  format?: ('cjs' | 'esm')[];
-  compiler?: 'babel' | 'tsc' | 'swc';
-  javascriptEnabled?: boolean;
-  generateExportsField?: boolean;
   additionalEntryPoints?: string[];
-  skipTypeCheck?: boolean;
+  allowJs?: boolean;
+  assets?: any[];
   babelUpwardRootMode?: boolean;
+  buildLibsFromSource?: boolean;
+  compiler?: 'babel' | 'tsc' | 'swc';
+  deleteOutputPath?: boolean;
+  external?: string[] | 'all' | 'none';
+  extractCss?: boolean | string;
+  format?: ('cjs' | 'esm')[];
+  generateExportsField?: boolean;
+  javascriptEnabled?: boolean;
+  project?: string;
+  outputFileName?: string;
+  rollupConfig?: string | string[];
+  skipTypeCheck?: boolean;
   skipTypeField?: boolean;
+  watch?: boolean;
 }

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -1,15 +1,14 @@
 {
   "version": 2,
   "outputCapture": "direct-nodejs",
-  "title": "Web Library Rollup Target (Experimental)",
+  "title": "Web Library Rollup Target",
   "description": "Packages a library for different web usages (ESM, CommonJS).",
   "cli": "nx",
   "type": "object",
   "properties": {
     "project": {
       "type": "string",
-      "description": "The path to package.json file.",
-      "x-priority": "important"
+      "description": "The path to package.json file."
     },
     "main": {
       "type": "string",
@@ -137,6 +136,11 @@
         "type": "string"
       },
       "x-priority": "important"
+    },
+    "buildLibsFromSource": {
+      "type": "boolean",
+      "description": "Read buildable libraries from source instead of building them separately.",
+      "default": true
     },
     "skipTypeCheck": {
       "type": "boolean",

--- a/packages/rollup/src/plugins/with-nx/with-nx-options.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx-options.ts
@@ -16,6 +16,10 @@ export interface RollupWithNxPluginOptions {
    */
   babelUpwardRootMode?: boolean;
   /**
+   * Build the libraries from source. Default is `true`.
+   */
+  buildLibsFromSource?: boolean;
+  /**
    * Which compiler to use.
    */
   compiler?: 'babel' | 'tsc' | 'swc';

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -15,6 +15,7 @@ import {
 import {
   calculateProjectBuildableDependencies,
   computeCompilerOptionsPaths,
+  createTmpTsConfig,
   DependentBuildableProjectNode,
 } from '@nx/js/src/utils/buildable-libs-utils';
 import nodeResolve from '@rollup/plugin-node-resolve';
@@ -80,7 +81,15 @@ export function withNx(
   const useBabel = options.compiler === 'babel';
   const useSwc = options.compiler === 'swc';
 
-  const tsConfigPath = joinPathFragments(workspaceRoot, options.tsConfig);
+  const tsConfigPath =
+    options.buildLibsFromSource || global.NX_GRAPH_CREATION
+      ? joinPathFragments(workspaceRoot, options.tsConfig)
+      : createTmpTsConfig(
+          options.tsConfig,
+          workspaceRoot,
+          projectRoot,
+          dependencies
+        );
   const tsConfigFile = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
   const tsConfig = ts.parseJsonConfigFileContent(
     tsConfigFile.config,
@@ -211,7 +220,7 @@ export function withNx(
       // Needed to generate type definitions, even if we're using babel or swc.
       require('rollup-plugin-typescript2')({
         check: !options.skipTypeCheck,
-        tsconfig: options.tsConfig,
+        tsconfig: tsConfigPath,
         tsconfigOverride: {
           compilerOptions: createTsCompilerOptions(
             projectRoot,


### PR DESCRIPTION
Add `buildLibsFromSource` to the `@nx/rollup:rollup` executor to bring it to parity with Webpack/Rspack/Vite. This allows the bundle to point to dist if `buildLibsFromSource: false` is set, which enables incremental builds.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

Note: This only applies to workspaces using tsconfig paths, as that linking mechanism is assumed by `buildLibsFromSource`. For NPM workspaces, whatever is defined in `package.json` exports is used as we use Node resolution in the new setup.

## Current Behavior
`buildLibsFromSource` does not exist

## Expected Behavior
`buildLibsFromSource exists

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
