### PR TITLE
fix(js): apps preset should add typescript package as required by @nx/js and other plugings

### DIFF
--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -20,7 +20,11 @@ async function createPreset(tree: Tree, options: Schema) {
     nxJson.useInferencePlugins !== false;
 
   if (options.preset === Preset.Apps) {
-    return;
+    const { initGenerator } = require('@nx' + '/js');
+    return initGenerator(tree, {
+      formatter: options.formatter,
+      addTsPlugin: false,
+    });
   } else if (options.preset === Preset.AngularMonorepo) {
     const {
       applicationGenerator: angularApplicationGenerator,


### PR DESCRIPTION
If you run `npx create-nx-worspace --preset=apps`, subsequent generators may fail because `typescript` is not installed.

For example,

```shell
npx create-nx-worspace org --preset=apps
cd org
npx nx g @nx/js:lib libs/test --bundler rollup
```

This wil fail with:

```
NX   Cannot find module 'typescript'

Require stack:
- /private/var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/tmp-7791-J66v4FxF119x/node_modules/@nx/rollup/src/plugins/with-nx/with-nx.js
- /private/var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/tmp-7791-J66v4FxF119x/node_modules/@nx/rollup/src/executors/rollup/rollup.impl.js
- /private/var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/tmp-7791-J66v4FxF119x/node_modules/@nx/rollup/index.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/@nx/devkit/src/utils/package-json.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/@nx/devkit/src/generators/to-js.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/@nx/devkit/public-api.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/@nx/devkit/index.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/@nx/js/src/generators/library/library.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/nx/src/config/schema-utils.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/nx/src/command-line/run/executor-utils.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/nx/src/devkit-internals.js
- /private/tmp/nx-e2e/nx/proj6114869/node_modules/nx/src/utils/assert-workspace-validity.js
- ...
```
See: https://app.warp.dev/block/bnmcGjuu5Ox6WlGAtbrCNO
## Current Behavior
Preset `apps` does not install the required `typescript` package.

## Expected Behavior
Preset `apps` installs the required `typescript` package.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
