### PR TITLE
fix(nx-dev): sidebar should not always show angular-rs* links

### DIFF
--- a/nx-dev/ui-common/src/lib/sidebar-container.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar-container.tsx
@@ -81,6 +81,9 @@ export function SidebarContainer({
   // TODO(colum): Remove this angular-rspack modification once we move angular rspack into main repo (when stable).
   const menuWithAngularRspack = useMemo(() => {
     const angularIdx = menu.sections.findIndex((s) => s.id === 'angular');
+    if (angularIdx === -1) {
+      return menu;
+    }
     const sections = [
       ...menu.sections.slice(0, angularIdx),
       angularRspackSection,


### PR DESCRIPTION
## Current Behavior
The `angular-rspack` and `angular-rsbuild` packages links are always shown on the menu after navigating to the API section

## Expected Behavior
The links for these packages should only display on the `API` page

