### PR TITLE
feat(misc): set a `development` conditional export for buildable libraries when using the ts solution setup

### DIFF
--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -167,6 +167,9 @@ function updatePackageJson(
       esbuildOptions,
     } = mergedTarget.options;
 
+    // the file must exist in the TS solution setup
+    const tsconfigBase = readJson(tree, 'tsconfig.base.json');
+
     // can't use the declarationRootDir as rootDir because it only affects the typings,
     // not the runtime entry point
     packageJson = getUpdatedPackageJsonContent(packageJson, {
@@ -186,6 +189,10 @@ function updatePackageJson(
       outputFileExtensionForEsm: getOutExtension('esm', {
         userDefinedBuildOptions: esbuildOptions,
       }),
+      skipDevelopmentExports:
+        !tsconfigBase.compilerOptions?.customConditions?.includes(
+          'development'
+        ),
     });
 
     if (declarationRootDir !== dirname(main)) {

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -467,6 +467,7 @@ describe('lib', () => {
         compilerOptions: {
           composite: true,
           declaration: true,
+          customConditions: ['development'],
         },
       });
       writeJson(appTree, 'tsconfig.json', {
@@ -630,13 +631,14 @@ describe('lib', () => {
         {
           "exports": {
             ".": {
-              "default": "./src/index.ts",
-              "import": "./src/index.ts",
+              "default": "./dist/index.cjs.js",
+              "development": "./src/index.ts",
+              "import": "./dist/index.esm.js",
               "types": "./dist/index.esm.d.ts",
             },
             "./package.json": "./package.json",
           },
-          "main": "./src/index.ts",
+          "main": "./dist/index.cjs.js",
           "module": "./dist/index.esm.js",
           "name": "@proj/my-lib",
           "peerDependencies": {
@@ -647,6 +649,25 @@ describe('lib', () => {
           "version": "0.0.1",
         }
       `);
+    });
+
+    it('should not set the "development" condition in exports when it does not exist in tsconfig.base.json', async () => {
+      updateJson(appTree, 'tsconfig.base.json', (json) => {
+        delete json.compilerOptions.customConditions;
+        return json;
+      });
+
+      await expoLibraryGenerator(appTree, {
+        ...defaultSchema,
+        buildable: true,
+        strict: false,
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      expect(
+        readJson(appTree, 'my-lib/package.json').exports['.']
+      ).not.toHaveProperty('development');
     });
 
     it('should set "nx.name" in package.json when the user provides a name that is different than the package name', async () => {

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -295,6 +295,15 @@ function createFiles(host: Tree, options: NormalizedSchema) {
 function determineEntryFields(
   options: NormalizedSchema
 ): Pick<PackageJson, 'main' | 'types' | 'exports'> {
+  if (
+    options.buildable ||
+    options.publishable ||
+    !options.isUsingTsSolutionConfig
+  ) {
+    // For buildable libraries, the entries are configured by the bundler (i.e. Rollup).
+    return undefined;
+  }
+
   return {
     main: options.js ? './src/index.js' : './src/index.ts',
     types: options.js ? './src/index.js' : './src/index.ts',

--- a/packages/js/src/generators/init/files/ts-solution/tsconfig.base.json__tmpl__
+++ b/packages/js/src/generators/init/files/ts-solution/tsconfig.base.json__tmpl__
@@ -17,6 +17,7 @@
     "noUnusedLocals": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2022"
+    "target": "es2022",
+    "customConditions": ["development"]
   }
 }

--- a/packages/js/src/generators/init/init.spec.ts
+++ b/packages/js/src/generators/init/init.spec.ts
@@ -208,7 +208,8 @@ describe('js init generator', () => {
           "noUnusedLocals": true,
           "skipLibCheck": true,
           "strict": true,
-          "target": "es2022"
+          "target": "es2022",
+          "customConditions": ["development"]
         }
       }
       "

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1817,6 +1817,7 @@ describe('lib', () => {
         compilerOptions: {
           composite: true,
           declaration: true,
+          customConditions: ['development'],
         },
       });
       writeJson(tree, 'tsconfig.json', {
@@ -1954,6 +1955,7 @@ describe('lib', () => {
           "exports": {
             ".": {
               "default": "./dist/index.js",
+              "development": "./src/index.ts",
               "import": "./dist/index.js",
               "types": "./dist/index.d.ts",
             },
@@ -1987,6 +1989,7 @@ describe('lib', () => {
           "exports": {
             ".": {
               "default": "./dist/index.js",
+              "development": "./src/index.ts",
               "import": "./dist/index.js",
               "types": "./dist/index.d.ts",
             },
@@ -2427,6 +2430,27 @@ describe('lib', () => {
 
       expect(readJson(tree, 'my-lib/project.json').name).toBe('my-lib');
       expect(readJson(tree, 'my-lib/package.json').nx).toBeUndefined();
+    });
+
+    it('should not set the "development" condition in exports when it does not exist in tsconfig.base.json', async () => {
+      updateJson(tree, 'tsconfig.base.json', (json) => {
+        delete json.compilerOptions.customConditions;
+        return json;
+      });
+
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        name: 'my-lib',
+        useProjectJson: true,
+        bundler: 'tsc',
+        addPlugin: true,
+        skipFormat: true,
+      });
+
+      expect(
+        readJson(tree, 'my-lib/package.json').exports['.']
+      ).not.toHaveProperty('development');
     });
   });
 });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -10,6 +10,7 @@ import {
   names,
   offsetFromRoot,
   ProjectConfiguration,
+  readJson,
   readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
@@ -631,6 +632,9 @@ function createFiles(tree: Tree, options: NormalizedLibraryGeneratorOptions) {
         options.isUsingTsSolutionConfig &&
         !['none', 'rollup', 'vite'].includes(options.bundler)
       ) {
+        // the file must exist in the TS solution setup
+        const tsconfigBase = readJson(tree, 'tsconfig.base.json');
+
         return getUpdatedPackageJsonContent(updatedPackageJson, {
           main: join(options.projectRoot, 'src/index.ts'),
           outputPath: joinPathFragments(options.projectRoot, 'dist'),
@@ -639,6 +643,10 @@ function createFiles(tree: Tree, options: NormalizedLibraryGeneratorOptions) {
           generateExportsField: true,
           packageJsonPath,
           format: ['esm'],
+          skipDevelopmentExports:
+            !tsconfigBase.compilerOptions?.customConditions?.includes(
+              'development'
+            ),
         });
       }
 
@@ -664,6 +672,8 @@ function createFiles(tree: Tree, options: NormalizedLibraryGeneratorOptions) {
       options.isUsingTsSolutionConfig &&
       !['none', 'rollup', 'vite'].includes(options.bundler)
     ) {
+      const tsconfigBase = readJson(tree, 'tsconfig.base.json');
+
       packageJson = getUpdatedPackageJsonContent(packageJson, {
         main: join(options.projectRoot, 'src/index.ts'),
         outputPath: joinPathFragments(options.projectRoot, 'dist'),
@@ -672,6 +682,10 @@ function createFiles(tree: Tree, options: NormalizedLibraryGeneratorOptions) {
         generateExportsField: true,
         packageJsonPath,
         format: ['esm'],
+        skipDevelopmentExports:
+          !tsconfigBase.compilerOptions?.customConditions?.includes(
+            'development'
+          ),
       });
     }
 

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -325,6 +325,11 @@ function updatePackageJson(
       version: '0.0.1',
     };
   }
+
+  // the file must exist in the TS solution setup, which is the only case this
+  // function is called
+  const tsconfigBase = readJson(tree, 'tsconfig.base.json');
+
   packageJson = getUpdatedPackageJsonContent(packageJson, {
     main,
     outputPath,
@@ -333,6 +338,8 @@ function updatePackageJson(
     packageJsonPath,
     rootDir,
     format,
+    skipDevelopmentExports:
+      !tsconfigBase.compilerOptions?.customConditions?.includes('development'),
   });
   writeJson(tree, packageJsonPath, packageJson);
 }

--- a/packages/js/src/plugins/typescript/util.ts
+++ b/packages/js/src/plugins/typescript/util.ts
@@ -95,8 +95,8 @@ export function isValidPackageJsonBuildConfig(
       return isPathSourceFile(value);
     } else if (typeof value === 'object') {
       return Object.entries(value).some(([currentKey, subValue]) => {
-        // Skip types field
-        if (currentKey === 'types') {
+        // Skip types and development conditions
+        if (currentKey === 'types' || currentKey === 'development') {
           return false;
         }
         if (typeof subValue === 'string') {

--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -157,6 +157,7 @@ describe('getUpdatedPackageJsonContent', () => {
         version: '0.0.1',
         exports: {
           '.': {
+            development: './src/index.ts',
             default: './src/index.js',
             import: './src/index.js',
             types: './src/index.d.ts',
@@ -190,6 +191,7 @@ describe('getUpdatedPackageJsonContent', () => {
         type: 'commonjs',
         exports: {
           '.': {
+            development: './src/index.ts',
             default: './src/index.cjs',
             types: './src/index.d.ts',
           },
@@ -228,15 +230,28 @@ describe('getUpdatedPackageJsonContent', () => {
         version: '0.0.1',
         exports: {
           '.': {
+            development: './src/index.ts',
             default: './src/index.js',
             types: './src/index.d.ts',
           },
-          './foo': './src/foo.js',
-          './bar': './src/bar.js',
+          './foo': {
+            development: './src/foo.ts',
+            default: './src/foo.js',
+          },
+          './bar': {
+            development: './src/bar.ts',
+            default: './src/bar.js',
+          },
           './package.json': './package.json',
           './migrations.json': './migrations.json',
-          './feature': './feature/index.js',
-          './feature/index': './feature/index.js',
+          './feature': {
+            development: './feature/index.ts',
+            default: './feature/index.js',
+          },
+          './feature/index': {
+            development: './feature/index.ts',
+            default: './feature/index.js',
+          },
         },
       });
 
@@ -269,15 +284,32 @@ describe('getUpdatedPackageJsonContent', () => {
         version: '0.0.1',
         exports: {
           '.': {
+            development: './src/index.ts',
             default: './src/index.js',
             import: './src/index.js',
             types: './src/index.d.ts',
           },
-          './foo': './src/foo.js',
-          './bar': './src/bar.js',
+          './foo': {
+            development: './src/foo.ts',
+            import: './src/foo.js',
+            default: './src/foo.js',
+          },
+          './bar': {
+            development: './src/bar.ts',
+            import: './src/bar.js',
+            default: './src/bar.js',
+          },
           './package.json': './package.json',
-          './feature': './feature/index.js',
-          './feature/index': './feature/index.js',
+          './feature': {
+            development: './feature/index.ts',
+            import: './feature/index.js',
+            default: './feature/index.js',
+          },
+          './feature/index': {
+            development: './feature/index.ts',
+            import: './feature/index.js',
+            default: './feature/index.js',
+          },
         },
       });
 
@@ -310,23 +342,28 @@ describe('getUpdatedPackageJsonContent', () => {
         version: '0.0.1',
         exports: {
           '.': {
+            development: './src/index.ts',
             import: './src/index.js',
             default: './src/index.cjs',
             types: './src/index.d.ts',
           },
           './foo': {
+            development: './src/foo.ts',
             import: './src/foo.js',
             default: './src/foo.cjs',
           },
           './bar': {
+            development: './src/bar.ts',
             import: './src/bar.js',
             default: './src/bar.cjs',
           },
           './feature': {
+            development: './feature/index.ts',
             import: './feature/index.js',
             default: './feature/index.cjs',
           },
           './feature/index': {
+            development: './feature/index.ts',
             import: './feature/index.js',
             default: './feature/index.cjs',
           },
@@ -364,6 +401,7 @@ describe('getUpdatedPackageJsonContent', () => {
       version: '0.0.1',
       exports: {
         '.': {
+          development: './src/index.ts',
           import: './src/index.js',
           default: './src/index.cjs',
           types: './src/index.d.ts',
@@ -400,6 +438,7 @@ describe('getUpdatedPackageJsonContent', () => {
       type: 'module',
       exports: {
         '.': {
+          development: './src/index.ts',
           default: './src/index.cjs',
           types: './src/index.d.ts',
         },
@@ -432,6 +471,7 @@ describe('getUpdatedPackageJsonContent', () => {
       type: 'commonjs',
       exports: {
         '.': {
+          development: './src/index.ts',
           default: './src/index.js',
           types: './src/index.d.ts',
         },

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -133,6 +133,7 @@ describe('next library', () => {
         compilerOptions: {
           composite: true,
           declaration: true,
+          customConditions: ['development'],
         },
       });
       writeJson(tree, 'tsconfig.json', {
@@ -262,6 +263,109 @@ describe('next library', () => {
           ],
         }
       `);
+    });
+
+    it('should create a correct package.json for buildable libraries', async () => {
+      await libraryGenerator(tree, {
+        directory: 'mylib',
+        linter: Linter.EsLint,
+        skipFormat: true,
+        skipTsConfig: false,
+        unitTestRunner: 'jest',
+        style: 'css',
+        component: false,
+        useProjectJson: false,
+        buildable: true,
+      });
+
+      expect(tree.read('mylib/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "@proj/mylib",
+          "version": "0.0.1",
+          "type": "module",
+          "main": "./dist/index.esm.js",
+          "module": "./dist/index.esm.js",
+          "types": "./dist/index.esm.d.ts",
+          "exports": {
+            "./package.json": "./package.json",
+            ".": {
+              "development": "./src/index.ts",
+              "types": "./dist/index.esm.d.ts",
+              "import": "./dist/index.esm.js",
+              "default": "./dist/index.esm.js"
+            }
+          },
+          "nx": {
+            "targets": {
+              "lint": {
+                "executor": "@nx/eslint:lint"
+              },
+              "build": {
+                "executor": "@nx/rollup:rollup",
+                "outputs": [
+                  "{options.outputPath}"
+                ],
+                "options": {
+                  "outputPath": "dist/mylib",
+                  "tsConfig": "mylib/tsconfig.lib.json",
+                  "project": "mylib/package.json",
+                  "entryFile": "mylib/src/index.ts",
+                  "external": [
+                    "react",
+                    "react-dom",
+                    "react/jsx-runtime"
+                  ],
+                  "rollupConfig": "@nx/react/plugins/bundle-rollup",
+                  "compiler": "babel",
+                  "assets": [
+                    {
+                      "glob": "mylib/README.md",
+                      "input": ".",
+                      "output": "."
+                    }
+                  ]
+                }
+              },
+              "test": {
+                "executor": "@nx/jest:jest",
+                "outputs": [
+                  "{projectRoot}/test-output/jest/coverage"
+                ],
+                "options": {
+                  "jestConfig": "mylib/jest.config.ts"
+                }
+              }
+            },
+            "sourceRoot": "mylib/src",
+            "projectType": "library",
+            "tags": []
+          }
+        }
+        "
+      `);
+    });
+
+    it('should not set the "development" condition in exports when it does not exist in tsconfig.base.json', async () => {
+      updateJson(tree, 'tsconfig.base.json', (json) => {
+        delete json.compilerOptions.customConditions;
+        return json;
+      });
+
+      await libraryGenerator(tree, {
+        directory: 'mylib',
+        linter: Linter.EsLint,
+        skipFormat: true,
+        skipTsConfig: false,
+        unitTestRunner: 'jest',
+        style: 'css',
+        component: false,
+        useProjectJson: false,
+        buildable: true,
+      });
+
+      expect(
+        readJson(tree, 'mylib/package.json').exports['.']
+      ).not.toHaveProperty('development');
     });
 
     it('should set "nx.name" in package.json when the user provides a name that is different than the package name', async () => {

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -339,6 +339,7 @@ describe('NxPlugin Plugin Generator', () => {
         compilerOptions: {
           composite: true,
           declaration: true,
+          customConditions: ['development'],
         },
       });
       writeJson(tree, 'tsconfig.json', {
@@ -447,6 +448,7 @@ describe('NxPlugin Plugin Generator', () => {
           "exports": {
             ".": {
               "default": "./dist/index.js",
+              "development": "./src/index.ts",
               "import": "./dist/index.js",
               "types": "./dist/index.d.ts",
             },
@@ -530,6 +532,25 @@ describe('NxPlugin Plugin Generator', () => {
           ],
         }
       `);
+    });
+
+    it('should not set the "development" condition in exports when it does not exist in tsconfig.base.json', async () => {
+      updateJson(tree, 'tsconfig.base.json', (json) => {
+        delete json.compilerOptions.customConditions;
+        return json;
+      });
+
+      await pluginGenerator(
+        tree,
+        getSchema({
+          e2eTestRunner: 'jest',
+          skipFormat: true,
+        })
+      );
+
+      expect(
+        readJson(tree, 'my-plugin/package.json').exports['.']
+      ).not.toHaveProperty('development');
     });
 
     it('should set "nx.name" in package.json when the user provides a name that is different than the package name and "useProjectJson" is "false"', async () => {

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -78,13 +78,13 @@ export async function reactNativeLibraryGeneratorInternal(
 
   createFiles(host, options);
 
+  if (options.isUsingTsSolutionConfig) {
+    await addProjectToTsSolutionWorkspace(host, options.projectRoot);
+  }
+
   const addProjectTask = await addProject(host, options);
   if (addProjectTask) {
     tasks.push(addProjectTask);
-  }
-
-  if (options.isUsingTsSolutionConfig) {
-    await addProjectToTsSolutionWorkspace(host, options.projectRoot);
   }
 
   const lintTask = await addLinting(host, {
@@ -296,6 +296,15 @@ function createFiles(host: Tree, options: NormalizedSchema) {
 function determineEntryFields(
   options: NormalizedSchema
 ): Pick<PackageJson, 'main' | 'types' | 'exports'> {
+  if (
+    options.buildable ||
+    options.publishable ||
+    !options.isUsingTsSolutionConfig
+  ) {
+    // For buildable libraries, the entries are configured by the bundler (i.e. Rollup).
+    return undefined;
+  }
+
   return {
     main: options.js ? './src/index.js' : './src/index.ts',
     types: options.js ? './src/index.js' : './src/index.ts',

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -939,6 +939,7 @@ module.exports = withNx(
         compilerOptions: {
           composite: true,
           declaration: true,
+          customConditions: ['development'],
         },
       });
       writeJson(tree, 'tsconfig.json', {
@@ -1246,6 +1247,7 @@ module.exports = withNx(
           "exports": {
             ".": {
               "default": "./dist/index.esm.js",
+              "development": "./src/index.ts",
               "import": "./dist/index.esm.js",
               "types": "./dist/index.esm.d.ts",
             },
@@ -1263,6 +1265,27 @@ module.exports = withNx(
           "version": "0.0.1",
         }
       `);
+    });
+
+    it('should not set the "development" condition in exports when it does not exist in tsconfig.base.json', async () => {
+      updateJson(tree, 'tsconfig.base.json', (json) => {
+        delete json.compilerOptions.customConditions;
+        return json;
+      });
+
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        bundler: 'rollup',
+        directory: 'libs/mylib',
+        publishable: true,
+        importPath: '@acme/mylib',
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      expect(
+        readJson(tree, 'libs/mylib/package.json').exports['.']
+      ).not.toHaveProperty('development');
     });
 
     it('should add project to workspaces when using TS solution', async () => {

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -181,6 +181,9 @@ function updatePackageJson(
       ({ main, outputPath } = mergedTarget.options);
     }
 
+    // the file must exist in the TS solution setup
+    const tsconfigBase = readJson(tree, 'tsconfig.base.json');
+
     packageJson = getUpdatedPackageJsonContent(packageJson, {
       main,
       outputPath,
@@ -191,6 +194,10 @@ function updatePackageJson(
       format: options.format ?? ['esm'],
       outputFileExtensionForCjs: '.cjs.js',
       outputFileExtensionForEsm: '.esm.js',
+      skipDevelopmentExports:
+        !tsconfigBase.compilerOptions?.customConditions?.includes(
+          'development'
+        ),
     });
 
     // rollup has a specific declaration file generation not handled by the util above,

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -219,6 +219,10 @@ function updatePackageJson(
     const rootDir = join(project.root, 'src');
     const outputPath = joinPathFragments(project.root, 'dist');
 
+    // the file must exist in the TS solution setup, which is the only case this
+    // function is called
+    const tsconfigBase = readJson(tree, 'tsconfig.base.json');
+
     packageJson = getUpdatedPackageJsonContent(packageJson, {
       main,
       outputPath,
@@ -227,6 +231,10 @@ function updatePackageJson(
       generateExportsField: true,
       packageJsonPath,
       format: ['esm'],
+      skipDevelopmentExports:
+        !tsconfigBase.compilerOptions?.customConditions?.includes(
+          'development'
+        ),
     });
   }
 

--- a/packages/vue/src/generators/library/lib/determine-entry-fields.ts
+++ b/packages/vue/src/generators/library/lib/determine-entry-fields.ts
@@ -4,25 +4,23 @@ import type { NormalizedSchema } from '../schema';
 export function determineEntryFields(
   options: NormalizedSchema
 ): Pick<PackageJson, 'module' | 'types' | 'exports'> {
-  if (options.bundler === 'none') {
-    return {
-      module: options.js ? './src/index.js' : './src/index.ts',
-      types: options.js ? './src/index.js' : './src/index.ts',
-      exports: {
-        '.': options.js
-          ? './src/index.js'
-          : {
-              types: './src/index.ts',
-              import: './src/index.ts',
-              default: './src/index.ts',
-            },
-        './package.json': './package.json',
-      },
-    };
+  if (options.bundler !== 'none' || !options.isUsingTsSolutionConfig) {
+    // for buildable libraries, the entries are configured by the bundler
+    return undefined;
   }
 
   return {
-    module: './dist/index.mjs',
-    types: './dist/index.d.ts',
+    module: options.js ? './src/index.js' : './src/index.ts',
+    types: options.js ? './src/index.js' : './src/index.ts',
+    exports: {
+      '.': options.js
+        ? './src/index.js'
+        : {
+            types: './src/index.ts',
+            import: './src/index.ts',
+            default: './src/index.ts',
+          },
+      './package.json': './package.json',
+    },
   };
 }

--- a/packages/vue/src/generators/library/library.spec.ts
+++ b/packages/vue/src/generators/library/library.spec.ts
@@ -521,6 +521,7 @@ module.exports = [
         compilerOptions: {
           composite: true,
           declaration: true,
+          customConditions: ['development'],
         },
       });
       writeJson(tree, 'tsconfig.json', {
@@ -584,6 +585,39 @@ module.exports = [
           "exports",
           "nx",
         ]
+      `);
+      expect(tree.read('my-lib/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "@proj/my-lib",
+          "version": "0.0.1",
+          "module": "./src/index.ts",
+          "types": "./src/index.ts",
+          "exports": {
+            ".": {
+              "types": "./src/index.ts",
+              "import": "./src/index.ts",
+              "default": "./src/index.ts"
+            },
+            "./package.json": "./package.json"
+          },
+          "nx": {
+            "targets": {
+              "lint": {
+                "executor": "@nx/eslint:lint"
+              },
+              "test": {
+                "executor": "@nx/vite:test",
+                "outputs": [
+                  "{options.reportsDirectory}"
+                ],
+                "options": {
+                  "reportsDirectory": "../coverage/my-lib"
+                }
+              }
+            }
+          }
+        }
+        "
       `);
       expect(readJson(tree, 'my-lib/tsconfig.json')).toMatchInlineSnapshot(`
         {
@@ -688,6 +722,60 @@ module.exports = [
           ],
         }
       `);
+    });
+
+    it('should create a correct package.json for buildable libraries', async () => {
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        setParserOptionsProject: true,
+        linter: 'eslint',
+        addPlugin: true,
+        useProjectJson: false,
+        bundler: 'vite',
+        skipFormat: true,
+      });
+
+      expect(tree.read('my-lib/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "@proj/my-lib",
+          "version": "0.0.1",
+          "type": "module",
+          "main": "./dist/index.js",
+          "module": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "exports": {
+            "./package.json": "./package.json",
+            ".": {
+              "development": "./src/index.ts",
+              "types": "./dist/index.d.ts",
+              "import": "./dist/index.js",
+              "default": "./dist/index.js"
+            }
+          }
+        }
+        "
+      `);
+    });
+
+    it('should not set the "development" condition in exports when it does not exist in tsconfig.base.json', async () => {
+      updateJson(tree, 'tsconfig.base.json', (json) => {
+        delete json.compilerOptions.customConditions;
+        return json;
+      });
+
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        setParserOptionsProject: true,
+        linter: 'eslint',
+        addPlugin: true,
+        useProjectJson: false,
+        bundler: 'vite',
+        skipFormat: true,
+      });
+
+      expect(
+        readJson(tree, 'my-lib/package.json').exports['.']
+      ).not.toHaveProperty('development');
     });
 
     it('should set "nx.name" in package.json when the user provides a name that is different than the package name', async () => {


### PR DESCRIPTION
Update library generators to set a `development` conditional export for buildable libraries' `package.json` files and set the 
`customConditions` compiler options in `tsconfig.base.json`. This will only be done for workspaces using the TS solution setup.

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
