### PR TITLE
feat(bundling): use tsconfig.lib.json for rollup.config.ts

### DIFF
--- a/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -1,6 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
+exports[`@nx/rollup/plugin non-root project should create nodes 1`
+] = `
 [
   [
     "mylib/rollup.config.cjs",
@@ -66,7 +67,8 @@ exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
 ]
 `;
 
-exports[`@nx/rollup/plugin non-root project should create nodes 2`] = `
+exports[`@nx/rollup/plugin non-root project should create nodes 2`
+] = `
 [
   [
     "mylib/rollup.config.cts",
@@ -77,7 +79,7 @@ exports[`@nx/rollup/plugin non-root project should create nodes 2`] = `
           "targets": {
             "build": {
               "cache": true,
-              "command": "rollup -c rollup.config.cts --configPlugin @rollup/plugin-typescript",
+              "command": "rollup -c rollup.config.cts --configPlugin typescript={tsconfig:\\'tsconfig.lib.json\\'}",
               "dependsOn": [
                 "^build",
               ],
@@ -132,7 +134,8 @@ exports[`@nx/rollup/plugin non-root project should create nodes 2`] = `
 ]
 `;
 
-exports[`@nx/rollup/plugin root project should create nodes 1`] = `
+exports[`@nx/rollup/plugin root project should create nodes 1`
+] = `
 [
   [
     "rollup.config.cjs",
@@ -197,7 +200,8 @@ exports[`@nx/rollup/plugin root project should create nodes 1`] = `
 ]
 `;
 
-exports[`@nx/rollup/plugin root project should create nodes 2`] = `
+exports[`@nx/rollup/plugin root project should create nodes 2`
+] = `
 [
   [
     "rollup.config.cts",
@@ -208,7 +212,7 @@ exports[`@nx/rollup/plugin root project should create nodes 2`] = `
           "targets": {
             "build": {
               "cache": true,
-              "command": "rollup -c rollup.config.cts --configPlugin @rollup/plugin-typescript",
+              "command": "rollup -c rollup.config.cts --configPlugin typescript={tsconfig:\\'tsconfig.lib.json\\'}",
               "dependsOn": [
                 "^build",
               ],

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -187,9 +187,8 @@ async function buildRollupTarget(
 
   const targets: Record<string, TargetConfiguration> = {};
   targets[options.buildTargetName] = {
-    command: `rollup -c ${basename(configFilePath)}${
-      isTsConfig ? ` --configPlugin ${tsConfigPlugin}` : ''
-    }`,
+    command: `rollup -c ${basename(configFilePath)}${isTsConfig ? " --configPlugin typescript={tsconfig:\'tsconfig.lib.json\'}" : ''
+      }`,
     options: { cwd: projectRoot },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
@@ -250,16 +249,16 @@ function getOutputs(
         const outputPathFromConfig = output.dir
           ? output.dir
           : output.file
-          ? dirname(output.file)
-          : 'dist';
+            ? dirname(output.file)
+            : 'dist';
         const outputPath =
           projectRoot === '.'
             ? joinPathFragments(`{workspaceRoot}`, outputPathFromConfig)
             : joinPathFragments(
-                `{workspaceRoot}`,
-                projectRoot,
-                outputPathFromConfig
-              );
+              `{workspaceRoot}`,
+              projectRoot,
+              outputPathFromConfig
+            );
         outputs.add(outputPath);
       }
     }

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -187,10 +187,11 @@ async function buildRollupTarget(
 
   const targets: Record<string, TargetConfiguration> = {};
   targets[options.buildTargetName] = {
-    command: `rollup -c ${basename(configFilePath)}${isTsConfig
-      ? ` --configPlugin typescript={tsconfig:\\'tsconfig.lib.json\\'}`
-      : ''
-      }`,
+    command: `rollup -c ${basename(configFilePath)}${
+      isTsConfig
+        ? ` --configPlugin typescript={tsconfig:\\'tsconfig.lib.json\\'}`
+        : ''
+    }`,
     options: { cwd: projectRoot },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
@@ -251,16 +252,16 @@ function getOutputs(
         const outputPathFromConfig = output.dir
           ? output.dir
           : output.file
-            ? dirname(output.file)
-            : 'dist';
+          ? dirname(output.file)
+          : 'dist';
         const outputPath =
           projectRoot === '.'
             ? joinPathFragments(`{workspaceRoot}`, outputPathFromConfig)
             : joinPathFragments(
-              `{workspaceRoot}`,
-              projectRoot,
-              outputPathFromConfig
-            );
+                `{workspaceRoot}`,
+                projectRoot,
+                outputPathFromConfig
+              );
         outputs.add(outputPath);
       }
     }

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -187,11 +187,10 @@ async function buildRollupTarget(
 
   const targets: Record<string, TargetConfiguration> = {};
   targets[options.buildTargetName] = {
-    command: `rollup -c ${basename(configFilePath)}${
-      isTsConfig
-        ? ` --configPlugin typescript={tsconfig:\'tsconfig.lib.json\'}`
-        : ''
-    }`,
+    command: `rollup -c ${basename(configFilePath)}${isTsConfig
+      ? ` --configPlugin typescript={tsconfig:\\'tsconfig.lib.json\\'}`
+      : ''
+      }`,
     options: { cwd: projectRoot },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
@@ -252,16 +251,16 @@ function getOutputs(
         const outputPathFromConfig = output.dir
           ? output.dir
           : output.file
-          ? dirname(output.file)
-          : 'dist';
+            ? dirname(output.file)
+            : 'dist';
         const outputPath =
           projectRoot === '.'
             ? joinPathFragments(`{workspaceRoot}`, outputPathFromConfig)
             : joinPathFragments(
-                `{workspaceRoot}`,
-                projectRoot,
-                outputPathFromConfig
-              );
+              `{workspaceRoot}`,
+              projectRoot,
+              outputPathFromConfig
+            );
         outputs.add(outputPath);
       }
     }

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -187,8 +187,11 @@ async function buildRollupTarget(
 
   const targets: Record<string, TargetConfiguration> = {};
   targets[options.buildTargetName] = {
-    command: `rollup -c ${basename(configFilePath)}${isTsConfig ? " --configPlugin typescript={tsconfig:\'tsconfig.lib.json\'}" : ''
-      }`,
+    command: `rollup -c ${basename(configFilePath)}${
+      isTsConfig
+        ? " --configPlugin typescript={tsconfig:'tsconfig.lib.json'}"
+        : ''
+    }`,
     options: { cwd: projectRoot },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
@@ -249,16 +252,16 @@ function getOutputs(
         const outputPathFromConfig = output.dir
           ? output.dir
           : output.file
-            ? dirname(output.file)
-            : 'dist';
+          ? dirname(output.file)
+          : 'dist';
         const outputPath =
           projectRoot === '.'
             ? joinPathFragments(`{workspaceRoot}`, outputPathFromConfig)
             : joinPathFragments(
-              `{workspaceRoot}`,
-              projectRoot,
-              outputPathFromConfig
-            );
+                `{workspaceRoot}`,
+                projectRoot,
+                outputPathFromConfig
+              );
         outputs.add(outputPath);
       }
     }

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -189,7 +189,7 @@ async function buildRollupTarget(
   targets[options.buildTargetName] = {
     command: `rollup -c ${basename(configFilePath)}${
       isTsConfig
-        ? " --configPlugin typescript={tsconfig:'tsconfig.lib.json'}"
+        ? ` --configPlugin typescript={tsconfig:\'tsconfig.lib.json\'}`
         : ''
     }`,
     options: { cwd: projectRoot },


### PR DESCRIPTION
## Current Behavior

Currently when we're using `rollup.config.ts`  rollup is picking up wrong tsconfig. Because of this not everything works as expected:

- `You are using one of Typescript's compiler options 'declaration', 'declarationMap' or 'composite'. In this case 'outDir' or 'declarationDir' must be specified to generate declaration files.` error appears , because lib tsconfig.json doesn't have outputDir at all
- even if we add outDir to `tsconfig.base.json` we'll have another error `[!] (plugin typescript) RollupError: [plugin typescript] @rollup/plugin-typescript TS6377: Cannot write file '/workspaces/abapify-docs/dist/tsconfig.tsbuildinfo' because it will overwrite '.tsbuildinfo' file generated by referenced project '/workspaces/abapify-docs/packages/abap-to-markdown'` 
This happens becase it tries to write all tsbuildinfo files into a root dist folder.

## Expected Behavior
Using rollup.config.ts should just work in a similar way as js|cjs|mjs config work.

## Solution

According to docs:

> This option supports the same syntax as the [--plugin](https://rollupjs.org/command-line-interface/#p-plugin-plugin-plugin) option i.e., you can specify the option multiple times, you can omit the @rollup/plugin- prefix and just write typescript and you can specify plugin options via ={...}.

So it means we can use something like this:
```
rollup -c rollup.config.ts --configPlugin typescript={tsconfig:\'tsconfig.lib.json\'}
```

## Related Issue(s)
Solution is taken from this issue:: https://github.com/rollup/plugins/issues/1713#issuecomment-2201138846



