### PR TITLE
fix(core): pass the project graph into the batch instead of recreating

### DIFF
--- a/packages/nx/src/tasks-runner/batch/batch-messages.ts
+++ b/packages/nx/src/tasks-runner/batch/batch-messages.ts
@@ -1,5 +1,6 @@
 import type { TaskResult } from '../../config/misc-interfaces';
 import type { TaskGraph } from '../../config/task-graph';
+import type { ProjectGraph } from '../../config/project-graph';
 
 export enum BatchMessageType {
   RunTasks,
@@ -21,6 +22,7 @@ export interface BatchTaskResult {
 export interface RunTasksMessage {
   type: BatchMessageType.RunTasks;
   executorName: string;
+  projectGraph: ProjectGraph;
   batchTaskGraph: TaskGraph;
   fullTaskGraph: TaskGraph;
 }

--- a/packages/nx/src/tasks-runner/batch/run-batch.ts
+++ b/packages/nx/src/tasks-runner/batch/run-batch.ts
@@ -9,14 +9,12 @@ import { workspaceRoot } from '../../utils/workspace-root';
 import { combineOptionsForExecutor } from '../../utils/params';
 import { TaskGraph } from '../../config/task-graph';
 import { ExecutorContext } from '../../config/misc-interfaces';
-import {
-  createProjectGraphAsync,
-  readProjectsConfigurationFromProjectGraph,
-} from '../../project-graph/project-graph';
+import { readProjectsConfigurationFromProjectGraph } from '../../project-graph/project-graph';
 import { readNxJson } from '../../config/configuration';
 import { isAsyncIterator } from '../../utils/async-iterator';
 import { getExecutorInformation } from '../../command-line/run/executor-utils';
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import { ProjectGraph } from '../../config/project-graph';
 
 function getBatchExecutor(
   executorName: string,
@@ -33,11 +31,11 @@ function getBatchExecutor(
 
 async function runTasks(
   executorName: string,
+  projectGraph: ProjectGraph,
   batchTaskGraph: TaskGraph,
   fullTaskGraph: TaskGraph
 ) {
   const input: Record<string, any> = {};
-  const projectGraph = await createProjectGraphAsync();
   const projectsConfigurations =
     readProjectsConfigurationFromProjectGraph(projectGraph);
   const nxJsonConfiguration = readNxJson();
@@ -116,6 +114,7 @@ process.on('message', async (message: BatchMessage) => {
     case BatchMessageType.RunTasks: {
       const results = await runTasks(
         message.executorName,
+        message.projectGraph,
         message.batchTaskGraph,
         message.fullTaskGraph
       );

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -20,6 +20,7 @@ import {
   PseudoTerminal,
 } from './pseudo-terminal';
 import { signalToCode } from '../utils/exit-codes';
+import { ProjectGraph } from '../config/project-graph';
 
 const forkScript = join(__dirname, './fork.js');
 
@@ -47,6 +48,7 @@ export class ForkedProcessTaskRunner {
   // TODO: vsavkin delegate terminal output printing
   public forkProcessForBatch(
     { executorName, taskGraph: batchTaskGraph }: Batch,
+    projectGraph: ProjectGraph,
     fullTaskGraph: TaskGraph,
     env: NodeJS.ProcessEnv
   ) {
@@ -113,6 +115,7 @@ export class ForkedProcessTaskRunner {
         p.send({
           type: BatchMessageType.RunTasks,
           executorName,
+          projectGraph,
           batchTaskGraph,
           fullTaskGraph,
         });

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -326,6 +326,7 @@ export class TaskOrchestrator {
     try {
       const results = await this.forkedProcessTaskRunner.forkProcessForBatch(
         batch,
+        this.projectGraph,
         this.taskGraph,
         env
       );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Running a batch executor recreates the project graph

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The project graph is passed in when running a batch executor so that it doesn't have to get recreated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
