### PR TITLE
fix(core): fix local registry not being considered when using `bun` p…

### DIFF
--- a/packages/js/src/plugins/jest/start-local-registry.ts
+++ b/packages/js/src/plugins/jest/start-local-registry.ts
@@ -49,24 +49,28 @@ export function startLocalRegistry({
         );
 
         const registry = `http://${listenAddress}:${port}`;
+        const authToken = 'secretVerdaccioToken';
 
         console.log(`Local registry started on ${registry}`);
 
         process.env.npm_config_registry = registry;
         execSync(
-          `npm config set //${listenAddress}:${port}/:_authToken "secretVerdaccioToken" --ws=false`,
+          `npm config set //${listenAddress}:${port}/:_authToken "${authToken}" --ws=false`,
           {
             windowsHide: false,
           }
         );
 
+        // bun
+        process.env.BUN_CONFIG_REGISTRY = registry;
+        process.env.BUN_CONFIG_TOKEN = authToken;
         // yarnv1
         process.env.YARN_REGISTRY = registry;
         // yarnv2
         process.env.YARN_NPM_REGISTRY_SERVER = registry;
         process.env.YARN_UNSAFE_HTTP_WHITELIST = listenAddress;
 
-        console.log('Set npm and yarn config registry to ' + registry);
+        console.log('Set npm, bun, and yarn config registry to ' + registry);
 
         resolve(() => {
           childProcess.kill();


### PR DESCRIPTION
…ackage manager

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When using `bun` package manager,  the local registry url set when starting `verdaccio` is ignored by bun, which continues to point to default NPM registry, which in return causes an error when trying to publish package
```
> nx run common:nx-release-publish

bun publish error:
error: missing authentication (run `bunx npm login`)
```
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Verdaccio should work when using `bun` pm

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
