### PR TITLE
fix(vite): update worker configuration in generator to follow Vite's …

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -699,7 +699,7 @@ export default defineConfig(() => ({
   plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   test: {
     name: 'my-app',

--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -209,7 +209,7 @@ export default defineConfig(() => ({
   plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   test: {
     name: 'my-app',
@@ -578,7 +578,7 @@ export default defineConfig(() => ({
   plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   test: {
     name: 'myApp',

--- a/packages/react-native/src/generators/web-configuration/files/base-vite/vite.config.mts__tmpl__
+++ b/packages/react-native/src/generators/web-configuration/files/base-vite/vite.config.mts__tmpl__
@@ -72,6 +72,6 @@ export default defineConfig({
   plugins: [react(), nxViteTsPaths()],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
 });

--- a/packages/react/src/generators/application/__snapshots__/application.legacy.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.legacy.spec.ts.snap
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../dist/my-vite-app',

--- a/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -292,7 +292,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../dist/my-app',
@@ -367,7 +367,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../dist/my-app',
@@ -436,7 +436,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../dist/my-app',
@@ -500,7 +500,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../dist/my-app',
@@ -668,7 +668,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../dist/my-app',

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1106,7 +1106,7 @@ describe('app', () => {
           ],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //   plugins: () => [ nxViteTsPaths() ],
           // },
           build: {
             outDir: '../dist/my-app',
@@ -1904,7 +1904,7 @@ describe('app', () => {
           plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //   plugins: () => [ nxViteTsPaths() ],
           // },
           build: {
             outDir: '../dist/my-app',
@@ -2046,7 +2046,7 @@ describe('app', () => {
           plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //   plugins: () => [ nxViteTsPaths() ],
           // },
           build: {
             outDir: '../dist/my-app',

--- a/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -13,7 +13,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md']), ],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   test: {
     'name': 'my-lib',
@@ -110,7 +110,7 @@ export default defineConfig(() => ({
   ],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   // Configuration for building your library.
   // See: https://vite.dev/guide/build.html#library-mode

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -258,7 +258,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   test: {
     setupFiles: ['test-setup.ts'],
@@ -464,7 +464,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   test: {
     setupFiles: ['test-setup.ts'],

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -22,7 +22,7 @@ export default defineConfig(() => ({
   ],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   // Configuration for building your library.
   // See: https://vite.dev/guide/build.html#library-mode
@@ -200,7 +200,7 @@ export default defineConfig(() => ({
   ],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   // Configuration for building your library.
   // See: https://vite.dev/guide/build.html#library-mode
@@ -253,7 +253,7 @@ export default defineConfig(() => ({
   ],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   // Configuration for building your library.
   // See: https://vite.dev/guide/build.html#library-mode
@@ -318,7 +318,7 @@ export default defineConfig(() => ({
   ],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   // Configuration for building your library.
   // See: https://vite.dev/guide/build.html#library-mode
@@ -380,7 +380,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../../dist/apps/my-test-react-app',
@@ -433,7 +433,7 @@ export default defineConfig(() => ({
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../../dist/apps/my-test-web-app',
@@ -487,7 +487,7 @@ export default defineConfig(() => ({
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   build: {
     outDir: '../../dist/apps/my-test-react-app',

--- a/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -195,7 +195,7 @@ export default defineConfig({
 
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
 
   build: {

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -30,7 +30,7 @@ export default defineConfig(() => ({
   plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   test: {
     name: 'my-test-angular-app',

--- a/packages/vite/src/utils/generator-utils.spec.ts
+++ b/packages/vite/src/utils/generator-utils.spec.ts
@@ -152,7 +152,7 @@ describe('generator utils', () => {
           plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md']), dts({ entryRoot: 'src', tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'), pathsToAliases: false })],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //   plugins: () => [ nxViteTsPaths() ],
           // },
           // Configuration for building your library.
           // See: https://vite.dev/guide/build.html#library-mode
@@ -235,7 +235,7 @@ describe('generator utils', () => {
           plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //   plugins: () => [ nxViteTsPaths() ],
           // },
           build: {
             outDir: '../dist/myproj',

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -526,7 +526,7 @@ ${
   // },`
     : `  // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },`;
 
   const cacheDir = `cacheDir: '${normalizedJoinPaths(

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -239,7 +239,7 @@ ${
   // },`
     : `  // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },`;
 
   const cacheDir = `cacheDir: '${normalizedJoinPaths(

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -116,7 +116,7 @@ export default defineConfig(() => ({
   plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.
   // worker: {
-  //  plugins: [ nxViteTsPaths() ],
+  //   plugins: () => [ nxViteTsPaths() ],
   // },
   test: {
     name: 'test',

--- a/packages/workspace/src/generators/preset/preset.spec.ts
+++ b/packages/workspace/src/generators/preset/preset.spec.ts
@@ -144,7 +144,7 @@ describe('preset', () => {
         plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
         // Uncomment this if you are using workers.
         // worker: {
-        //  plugins: [ nxViteTsPaths() ],
+        //   plugins: () => [ nxViteTsPaths() ],
         // },
         build: {
           outDir: '../../dist/apps/vue-preset-monorepo',
@@ -300,7 +300,7 @@ describe('preset', () => {
         plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
         // Uncomment this if you are using workers.
         // worker: {
-        //  plugins: [ nxViteTsPaths() ],
+        //   plugins: () => [ nxViteTsPaths() ],
         // },
         build: {
           outDir: './dist/react-standalone-preset-vite',
@@ -357,7 +357,7 @@ describe('preset', () => {
         plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
         // Uncomment this if you are using workers.
         // worker: {
-        //  plugins: [ nxViteTsPaths() ],
+        //   plugins: () => [ nxViteTsPaths() ],
         // },
         build: {
           outDir: './dist/vue-standalone-preset',


### PR DESCRIPTION
…new convention

## Current Behavior

Currently, the @nx/vite plugin generates a `vite.config.ts` file where the worker configuration is commented out, but uses the old format:

```ts
// worker: {
//  plugins: [ nxViteTsPaths() ],
// }
```

If uncomment, this format triggers a warning from Vite, as the worker configuration should now be a function that returns an array of plugins. While Vite automatically converts the old format for compatibility, it is not ideal to rely on this behavior.

## Expected Behavior

With the changes in this PR, the @nx/vite plugin will generate a Vite configuration where the worker configuration follows the new convention, avoiding warnings and ensuring compatibility with future versions of Vite. The updated configuration will look like this:

```ts
// worker: {
//  plugins: () => [ nxViteTsPaths() ],
// }
```

This change ensures that the generated configuration aligns with Vite's recommended practices and eliminates unnecessary warnings.