### PR TITLE
chore(repo): remove `bun`'s workaround to make it work with verdaccio

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -341,51 +341,6 @@ export function runCreateWorkspace(
     command += ` --prefix=${prefix}`;
   }
 
-  if (packageManager === 'bun') {
-    /**
-     * `bunx` does not seem to work well at all with custom registries, I tried many combinations of flags and config files.
-     *
-     * The only viable workaround currently seems to be to write a package.json and a bunfig.toml in the e2e directory,
-     * install create-nx-workspace using `bun install` (which _does_ seem to respect the registry settings), and _then_
-     * run `bunx create-nx-workspace` (but without the version number added with @{version}).
-     */
-    writeFileSync(
-      join(cwd, 'bunfig.toml'),
-      // Also set up a dedicated cache directory to hopefully avoid conflicts with the global cache
-      `
-[install]
-cache = ".bun-cache"
-registry = "${registry}"
-`.trim()
-    );
-    writeFileSync(
-      join(cwd, 'package.json'),
-      `
-{
-  "private": true,
-  "name": "only-here-to-make-bunx-happy"
-}
-    `
-    );
-    const output = execSync('bun install create-nx-workspace', {
-      cwd,
-      stdio: 'pipe',
-      env: {
-        CI: 'true',
-        ...process.env,
-      },
-      encoding: 'utf-8',
-    });
-    const publishedVersion = getPublishedVersion();
-    // Ensure that it installed the version published for the e2e tests
-    if (!output.includes(publishedVersion)) {
-      console.error(output);
-      throw new Error(
-        `bunx create-nx-workspace did not install the version published for the e2e tests: ${publishedVersion}, in ${cwd}`
-      );
-    }
-  }
-
   try {
     const create = execSync(`${command}${isVerbose() ? ' --verbose' : ''}`, {
       cwd,
@@ -406,32 +361,10 @@ registry = "${registry}"
       });
     }
 
-    if (packageManager === 'bun') {
-      // We also have to add an explicit bunfig.toml in the workspace itself as bun does not seem to use the setting applied by the local registry logic
-      // (via `npm set config registry`), unlike all other package managers.
-      updateFile(
-        'bunfig.toml',
-        `
-[install]
-registry = { url = "${registry}", token = "secretVerdaccioToken" }
-`.trim()
-      );
-    }
-
     return create;
   } catch (e) {
     logError(`Original command: ${command}`, `${e.stdout}\n\n${e.stderr}`);
     throw e;
-  } finally {
-    // Clean up files related to bun workarounds
-    if (packageManager === 'bun') {
-      removeSync(join(cwd, 'bunfig.toml'));
-      removeSync(join(cwd, 'package.json'));
-      removeSync(join(cwd, '.bun-cache'));
-      removeSync(join(cwd, 'node_modules'));
-      removeSync(join(cwd, 'bun.lock'));
-      removeSync(join(cwd, 'bun.lockb'));
-    }
   }
 }
 


### PR DESCRIPTION
This workaround is no longer necessary once is merged #30459.

Until then, some e2e tests should still  fail due to bun publish errors (which is normal).
The  PR will be converted to final, once the previous is merged to master

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
See #30459

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

See #30459
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
