### PR TITLE
docs(misc): document vim/nvim nx watch issue

### DIFF
--- a/docs/generated/packages/nx/documents/watch.md
+++ b/docs/generated/packages/nx/documents/watch.md
@@ -5,7 +5,7 @@ description: 'Watch for changes within projects, and execute commands.'
 
 # watch
 
-Watch for changes within projects, and execute commands.
+Watch for changes within projects, and execute commands. Please be aware that file saving with Vim/Nvim is only registered the first time if you don't have `nowritebackup` set.
 
 ## Usage
 


### PR DESCRIPTION
If you are using Vim/Nvim and you are saving a file this file is not edited directly. The content is saved to a backup file and after this step the original file gets deleted and the backup file gets renamed. The nx watch command can't handle this at the moment. To help users of this command find this information I propose this documentation change.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
General information and the workaround:
https://github.com/nrwl/nx/issues/22945
Investigation:
https://github.com/nrwl/nx/issues/21734#issuecomment-1962274644

Fixes #
