### PR TITLE
fix(react): only add release config for publishable librarires

### DIFF
--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -249,7 +249,7 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
     tasks.push(componentTask);
   }
 
-  if (options.publishable || options.buildable) {
+  if (options.publishable) {
     const projectConfiguration = readProjectConfiguration(host, options.name);
     if (options.isUsingTsSolutionConfig) {
       await addReleaseConfigForTsSolution(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a library that is not published but has a build step, then release targets, verdaccio and nx release are configured

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When a library is only built, but not published, none of the release setup is done

