### PR TITLE
cleanup(vue): migrate to picomatch

### DIFF
--- a/packages/vue/.eslintrc.json
+++ b/packages/vue/.eslintrc.json
@@ -4,7 +4,15 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "name": "minimatch",
+            "message": "Please use `picomatch` instead."
+          }
+        ]
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,7 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "minimatch": "9.0.3",
+    "picomatch": "^4.0.2",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",

--- a/packages/vue/src/generators/stories/stories.ts
+++ b/packages/vue/src/generators/stories/stories.ts
@@ -13,7 +13,7 @@ import {
 import { basename, join } from 'path';
 import { nxVersion } from '../../utils/versions';
 import { createComponentStories } from './lib/component-story';
-import { minimatch } from 'minimatch';
+import picomatch = require('picomatch');
 
 export interface StorybookStoriesSchema {
   project: string;
@@ -43,7 +43,7 @@ export async function createAllStories(
     visitNotIgnoredFiles(tree, p, (path) => {
       // Ignore private files starting with "_".
       if (basename(path).startsWith('_')) return;
-      if (ignorePaths?.some((pattern) => minimatch(path, pattern))) return;
+      if (ignorePaths?.some((pattern) => picomatch(pattern)(path))) return;
       if (path.endsWith('.vue')) {
         // Let's see if the .stories.* file exists
         const ext = path.slice(path.lastIndexOf('.'));


### PR DESCRIPTION
Migrates the `vue` package to use `picomatch` for the single case of globbing it does.

