### PR TITLE
cleanup(vite): migrate to `picomatch`

### DIFF
--- a/packages/vite/.eslintrc.json
+++ b/packages/vite/.eslintrc.json
@@ -4,7 +4,15 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "name": "minimatch",
+            "message": "Please use `picomatch` instead."
+          }
+        ]
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -35,8 +35,8 @@
     "@swc/helpers": "~0.5.0",
     "enquirer": "~2.3.6",
     "@nx/js": "file:../js",
+    "picomatch": "4.0.2",
     "tsconfig-paths": "^4.1.2",
-    "minimatch": "9.0.3",
     "semver": "^7.6.3"
   },
   "peerDependencies": {

--- a/packages/vite/src/migrations/update-20-5-0/update-resolve-conditions.ts
+++ b/packages/vite/src/migrations/update-20-5-0/update-resolve-conditions.ts
@@ -1,6 +1,6 @@
 import { formatFiles, visitNotIgnoredFiles, type Tree } from '@nx/devkit';
 import { tsquery } from '@phenomnomnominal/tsquery';
-import { minimatch } from 'minimatch';
+import picomatch = require('picomatch');
 
 const REMIX_IMPORT_SELECTOR =
   'ImportDeclaration:has(StringLiteral[value=@remix-run/dev]),CallExpression:has(Identifier[name=require]) StringLiteral[value=@remix-run/dev]';
@@ -24,7 +24,7 @@ export default async function (tree: Tree) {
   const viteFiles = [];
 
   visitNotIgnoredFiles(tree, '', (filePath) => {
-    if (minimatch(filePath, '**/vite.*config*.{js,ts,mjs,mts,cjs,cts}')) {
+    if (picomatch('**/vite.*config*.{js,ts,mjs,mts,cjs,cts}')(filePath)) {
       viteFiles.push(filePath);
     }
   });

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -25,7 +25,7 @@ import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { getLockFileName } from '@nx/js';
 import { loadViteDynamicImport } from '../utils/executor-utils';
 import { hashObject } from 'nx/src/hasher/file-hasher';
-import { minimatch } from 'minimatch';
+import picomatch = require('picomatch');
 import { isUsingTsSolutionSetup as _isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
 
@@ -119,7 +119,7 @@ export const createNodesV2: CreateNodesV2<VitePluginOptions> = [
 
           const tsConfigFiles =
             siblingFiles.filter((p) =>
-              minimatch(p, 'tsconfig*{.json,.*.json}')
+              picomatch('tsconfig*{.json,.*.json}')(p)
             ) ?? [];
 
           const hasReactRouterConfig = siblingFiles.some((configFile) => {
@@ -192,7 +192,7 @@ export const createNodes: CreateNodes<VitePluginOptions> = [
     }
 
     const tsConfigFiles =
-      siblingFiles.filter((p) => minimatch(p, 'tsconfig*{.json,.*.json}')) ??
+      siblingFiles.filter((p) => picomatch('tsconfig*{.json,.*.json}')(p)) ??
       [];
 
     const hasReactRouterConfig = siblingFiles.some((configFile) => {


### PR DESCRIPTION
Migrates glob matching to use `picomatch` like we've done elsewhere.
