### PR TITLE
fix(core): ensure rust code is able to handle null terminal outputs

### DIFF
--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -18,7 +18,7 @@ use crate::native::utils::Normalize;
 #[derive(Default, Clone, Debug)]
 pub struct CachedResult {
     pub code: i16,
-    pub terminal_output: String,
+    pub terminal_output: Option<String>,
     pub outputs_path: String,
     pub size: Option<i64>,
 }
@@ -117,7 +117,7 @@ impl NxCache {
 
                     Ok(CachedResult {
                         code,
-                        terminal_output,
+                        terminal_output: Some(terminal_output),
                         outputs_path: task_dir.to_normalized_string(),
                         size: Some(size),
                     })
@@ -182,7 +182,7 @@ impl NxCache {
             &hash,
             &result.outputs_path
         );
-        let terminal_output = result.terminal_output.clone();
+        let terminal_output = result.terminal_output.clone().unwrap_or(String::from(""));
         let mut size = terminal_output.len() as i64;
         if let Some(outputs) = outputs {
             if outputs.len() > 0 && result.code == 0 {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -111,7 +111,7 @@ export declare class WorkspaceContext {
 
 export interface CachedResult {
   code: number
-  terminalOutput: string
+  terminalOutput?: string
   outputsPath: string
   size?: number
 }

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -131,6 +131,7 @@ export class DbCache {
     if (res) {
       return {
         ...res,
+        terminalOutput: res.terminalOutput ?? '',
         remote: false,
       };
     }
@@ -147,6 +148,7 @@ export class DbCache {
 
         return {
           ...res,
+          terminalOutput: res.terminalOutput ?? '',
           remote: true,
         };
       } else {


### PR DESCRIPTION
## Current Behavior
Somewhere in the ts side we are passing a value as null for terminal outputs. The rust code bails when this happens.

## Expected Behavior
The rust side is able to handle it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
