### PR TITLE
fix(nx-dev): adjust alignment on the pricing addon descriptions

### DIFF
--- a/nx-dev/ui-pricing/src/lib/plans-display.tsx
+++ b/nx-dev/ui-pricing/src/lib/plans-display.tsx
@@ -105,7 +105,7 @@ export function PlansDisplay(): ReactElement {
                       </Link>
                     </span>
                   </li>
-                  <li className="flex items-start justify-start gap-x-2 py-2.5">
+                  <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
                       className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
@@ -178,28 +178,28 @@ export function PlansDisplay(): ReactElement {
                 <li className="py-2.5">
                   <span className="font-medium">Included for free</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
                   />
                   <span>5 active contributors¹</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
                   />
                   <span>50,000 monthly credits</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
                   />
                   <span>10 concurrent CI connections</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
@@ -220,7 +220,7 @@ export function PlansDisplay(): ReactElement {
                     AI integrations
                   </Link>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
@@ -230,21 +230,21 @@ export function PlansDisplay(): ReactElement {
                 <li className="py-2.5">
                   <span className="font-medium">Add-ons</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
                   />
                   <span>$19 per active contributor¹ / month</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
                   />
                   <span>$5.50 per 10,000 credits</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
@@ -297,21 +297,21 @@ export function PlansDisplay(): ReactElement {
                 <li className="py-2.5">
                   <span className="font-medium">Includes</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
                   />
                   <span>Volume discounts on credits available</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
                   />
                   <span>White glove onboarding</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
@@ -335,7 +335,7 @@ export function PlansDisplay(): ReactElement {
                     : a suite of premium extensions for the Nx CLI
                   </span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
@@ -344,7 +344,7 @@ export function PlansDisplay(): ReactElement {
                     Work hand-in-hand with the Nx team for continual improvement
                   </span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
@@ -354,14 +354,14 @@ export function PlansDisplay(): ReactElement {
                     self-contained, on-prem
                   </span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
                   />
                   <span>SSO / SAML Login</span>
                 </li>
-                <li className="flex items-start justify-start gap-x-2 py-2.5">
+                <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
                     className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"


### PR DESCRIPTION

## Current Behavior

Right now the alignment on the add-on descriptions is off with the plus icon in front

![image](https://github.com/user-attachments/assets/9e77d488-1ea1-4b43-b5db-2f7c632a8ff5)

![image](https://github.com/user-attachments/assets/52b429b0-3415-464f-8427-aaf9a4dcd59a)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

this PR adjusts it

![image](https://github.com/user-attachments/assets/1a2c545b-91f7-4d7b-be12-f95431b40e94)

![image](https://github.com/user-attachments/assets/2cba35d5-3677-40ad-a8c0-c1888f974733)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
