### PR TITLE
fix(core): init should use pr version when specified

### DIFF
--- a/packages/nx/src/command-line/init/init-v1.ts
+++ b/packages/nx/src/command-line/init/init-v1.ts
@@ -30,7 +30,7 @@ export async function initHandler(options: InitArgs) {
   const args = process.argv.slice(3).join(' ');
 
   const version =
-    process.env.NX_VERSION ?? (prerelease(nxVersion) ? 'next' : 'latest');
+    process.env.NX_VERSION ?? (prerelease(nxVersion) ? nxVersion : 'latest');
   if (process.env.NX_VERSION) {
     console.log(`Using version ${process.env.NX_VERSION}`);
   }

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -46,7 +46,7 @@ export interface InitArgs {
 export async function initHandler(options: InitArgs): Promise<void> {
   process.env.NX_RUNNING_NX_INIT = 'true';
   const version =
-    process.env.NX_VERSION ?? (prerelease(nxVersion) ? 'next' : 'latest');
+    process.env.NX_VERSION ?? (prerelease(nxVersion) ? nxVersion : 'latest');
   if (process.env.NX_VERSION) {
     output.log({ title: `Using version ${process.env.NX_VERSION}` });
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
`nx init` always either installs `next` or `latest` versions of Nx. The intent here is that running `npx nx init` should always provide the latest version of Nx, and we added a condition to use `next` if we detected a beta version of Nx was running to facilitate easier testing of RC and beta releases. The full logic to determine which version of Nx to setup is below:

```ts
const version =
    process.env.NX_VERSION ?? (prerelease(nxVersion) ? 'next' : 'latest');
```

The goal here was to avoid hitting the `npx` cache and accidentally creating new workspaces with an older Nx version. This logic falls apart a bit when considering prereleases though, as `npx nx@next init` would always check the tag to make sure its up to date rather than using a cached version. This is the case when providing **_any_** tag to `npx`. 

A bad side effect of the above is that when trying to test PR builds and the like, `nx init` will never setup the PR build when running `npx nx@0.0.0-pr....` opting instead to setup `next`.

## Expected Behavior
Running `npx nx@0.0.0-pr.... init` sets up an nx workspace using the specified PR release.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
