### PR TITLE
fix(misc): init should prompt for cloud when using dot nx folder

### DIFF
--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -19,7 +19,7 @@ import type { AddOptions } from './command-object';
 import { normalizeVersionForNxJson } from '../init/implementation/dot-nx/add-nx-scripts';
 import { gte } from 'semver';
 import {
-  installPlugin,
+  runPluginInitGenerator,
   getFailedToInstallPluginErrorMessages,
 } from '../init/configure-plugins';
 
@@ -126,7 +126,7 @@ async function initializePlugin(
   spinner.start();
 
   try {
-    await installPlugin(
+    await runPluginInitGenerator(
       pkgName,
       workspaceRoot,
       updatePackageScripts,

--- a/packages/nx/src/command-line/generate/generator-utils.ts
+++ b/packages/nx/src/command-line/generate/generator-utils.ts
@@ -11,6 +11,7 @@ import {
 } from '../../config/schema-utils';
 import { readJsonFile } from '../../utils/fileutils';
 import { readPluginPackageJson } from '../../project-graph/plugins';
+import { getNxRequirePaths } from '../../utils/installation-directory';
 
 export type GeneratorInformation = {
   resolvedCollectionName: string;
@@ -72,10 +73,7 @@ export function getGeneratorInformation(
       isNxGenerator: !isNgCompat,
       generatorConfiguration: normalizedGeneratorConfiguration,
     };
-  } catch (e) {
-    throw new Error(
-      `Unable to resolve ${collectionName}:${generatorName}.\n${e.message}`
-    );
+  } finally {
   }
 }
 
@@ -93,13 +91,17 @@ export function readGeneratorsJson(
   let generatorsFilePath;
   if (collectionName.endsWith('.json')) {
     generatorsFilePath = require.resolve(collectionName, {
-      paths: root ? [root, __dirname] : [__dirname],
+      paths: root
+        ? [...getNxRequirePaths(root), __dirname]
+        : [...getNxRequirePaths(), __dirname],
     });
   } else {
     const { json: packageJson, path: packageJsonPath } = readPluginPackageJson(
       collectionName,
       projects,
-      root ? [root, __dirname] : [__dirname]
+      root
+        ? [...getNxRequirePaths(root), __dirname]
+        : [...getNxRequirePaths(), __dirname]
     );
     const generatorsFile = packageJson.generators ?? packageJson.schematics;
 

--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -27,7 +27,7 @@ import { mergeRemoteSource } from './utils/merge-remote-source';
 import { minimatch } from 'minimatch';
 import {
   configurePlugins,
-  runPackageManagerInstallPlugins,
+  installPluginPackages,
 } from '../init/configure-plugins';
 import {
   checkCompatibleWithPlugins,
@@ -441,7 +441,7 @@ async function runPluginsInstall(
   let installed = true;
   output.log({ title: 'Installing Plugins' });
   try {
-    runPackageManagerInstallPlugins(workspaceRoot, pmc, plugins);
+    installPluginPackages(workspaceRoot, pmc, plugins);
     await destinationGitClient.amendCommit();
   } catch (e) {
     installed = false;

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -21,6 +21,7 @@ import { printSuccessMessage } from '../../../nx-cloud/generators/connect-to-nx-
 import { repoUsesGithub } from '../../../nx-cloud/utilities/url-shorten';
 import { connectWorkspaceToCloud } from '../../connect/connect-to-nx-cloud';
 import { deduceDefaultBase } from './deduce-default-base';
+import { getRunNxBaseCommand } from '../../../utils/child-process';
 
 export function createNxJsonFile(
   repoRoot: string,
@@ -320,8 +321,12 @@ export function printFinalMessage({
   output.success({
     title: '🎉 Done!',
     bodyLines: [
-      `- Run "${pmc.exec} nx run-many -t build" to run the build target for every project in the workspace. Run it again to replay the cached computation. https://nx.dev/features/cache-task-results`,
-      `- Run "${pmc.exec} nx graph" to see the graph of projects and tasks in your workspace. https://nx.dev/core-features/explore-graph`,
+      `- Run "${getRunNxBaseCommand(
+        pmc
+      )} run-many -t build" to run the build target for every project in the workspace. Run it again to replay the cached computation. https://nx.dev/features/cache-task-results`,
+      `- Run "${getRunNxBaseCommand(
+        pmc
+      )} graph" to see the graph of projects and tasks in your workspace. https://nx.dev/core-features/explore-graph`,
       learnMoreLink ? `- Learn more at ${learnMoreLink}.` : undefined,
     ].filter(Boolean),
   });

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -15,10 +15,7 @@ import {
 import { nxVersion } from '../../utils/versions';
 import { globWithWorkspaceContextSync } from '../../utils/workspace-context';
 import { connectExistingRepoToNxCloudPrompt } from '../connect/connect-to-nx-cloud';
-import {
-  configurePlugins,
-  runPackageManagerInstallPlugins,
-} from './configure-plugins';
+import { configurePlugins, installPluginPackages } from './configure-plugins';
 import { addNxToMonorepo } from './implementation/add-nx-to-monorepo';
 import { addNxToNpmRepo } from './implementation/add-nx-to-npm-repo';
 import { addNxToTurborepo } from './implementation/add-nx-to-turborepo';
@@ -51,30 +48,6 @@ export async function initHandler(options: InitArgs): Promise<void> {
     output.log({ title: `Using version ${process.env.NX_VERSION}` });
   }
 
-  if (!existsSync('package.json') || options.useDotNxInstallation) {
-    if (process.platform !== 'win32') {
-      console.log(
-        'Setting Nx up installation in `.nx`. You can run Nx commands like: `./nx --help`'
-      );
-    } else {
-      console.log(
-        'Setting Nx up installation in `.nx`. You can run Nx commands like: `./nx.bat --help`'
-      );
-    }
-    generateDotNxSetup(version);
-    const nxJson = readNxJson(process.cwd());
-    const { plugins } = await detectPlugins(nxJson, options.interactive);
-    plugins.forEach((plugin) => {
-      runNxSync(`add ${plugin}`, {
-        stdio: 'inherit',
-      });
-    });
-
-    // invokes the wrapper, thus invoking the initial installation process
-    runNxSync('--version', { stdio: 'ignore' });
-    return;
-  }
-
   // TODO(jack): Remove this Angular logic once `@nx/angular` is compatible with inferred targets.
   if (existsSync('angular.json')) {
     await addNxToAngularCliRepo({
@@ -88,10 +61,13 @@ export async function initHandler(options: InitArgs): Promise<void> {
     return;
   }
 
-  const packageJson: PackageJson = readJsonFile('package.json');
+  const _isNonJs = !existsSync('package.json') || options.useDotNxInstallation;
+  const packageJson: PackageJson = _isNonJs
+    ? null
+    : readJsonFile('package.json');
   const _isTurborepo = existsSync('turbo.json');
-  const _isMonorepo = isMonorepo(packageJson);
-  const _isCRA = isCRA(packageJson);
+  const _isMonorepo = _isNonJs ? false : isMonorepo(packageJson);
+  const _isCRA = _isNonJs ? false : isCRA(packageJson);
 
   const learnMoreLink = _isTurborepo
     ? 'https://nx.dev/recipes/adopting-nx/from-turborepo'
@@ -131,6 +107,9 @@ export async function initHandler(options: InitArgs): Promise<void> {
       interactive: options.interactive,
       nxCloud: false,
     });
+  } else if (_isNonJs) {
+    generateDotNxSetup(version);
+    console.log('');
   } else {
     await addNxToNpmRepo({
       interactive: options.interactive,
@@ -166,7 +145,7 @@ export async function initHandler(options: InitArgs): Promise<void> {
 
   output.log({ title: '📦 Installing Nx' });
 
-  runPackageManagerInstallPlugins(repoRoot, pmc, plugins);
+  installPluginPackages(repoRoot, pmc, plugins);
   await configurePlugins(
     plugins,
     updatePackageScripts,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When nx is installed in the `.nx` directory the init flow is substantially different. This changes how some prompting works as well as how plugin installation flows.

## Expected Behavior
The two flows operate in a similar manner.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
