### PR TITLE
fix(js): infer `typecheck` task for buildable libraries with tsc

### DIFF
--- a/e2e/js/src/js-ts-solution.test.ts
+++ b/e2e/js/src/js-ts-solution.test.ts
@@ -132,16 +132,19 @@ ${content}`
 
     // check typecheck
     expect(runCLI(`typecheck ${esbuildParentLib}`)).toContain(
-      `Successfully ran target typecheck for project @proj/${esbuildParentLib} and 4 tasks it depends on`
+      `Successfully ran target typecheck for project @proj/${esbuildParentLib} and 5 tasks it depends on`
     );
     expect(runCLI(`typecheck ${rollupParentLib}`)).toContain(
-      `Successfully ran target typecheck for project @proj/${rollupParentLib} and 4 tasks it depends on`
+      `Successfully ran target typecheck for project @proj/${rollupParentLib} and 5 tasks it depends on`
     );
     expect(runCLI(`typecheck ${swcParentLib}`)).toContain(
-      `Successfully ran target typecheck for project @proj/${swcParentLib} and 4 tasks it depends on`
+      `Successfully ran target typecheck for project @proj/${swcParentLib} and 5 tasks it depends on`
+    );
+    expect(runCLI(`typecheck ${tscParentLib}`)).toContain(
+      `Successfully ran target typecheck for project @proj/${tscParentLib} and 5 tasks it depends on`
     );
     expect(runCLI(`typecheck ${viteParentLib}`)).toContain(
-      `Successfully ran target typecheck for project @proj/${viteParentLib} and 4 tasks it depends on`
+      `Successfully ran target typecheck for project @proj/${viteParentLib} and 5 tasks it depends on`
     );
 
     // check lint

--- a/e2e/node/src/node-ts-solution.test.ts
+++ b/e2e/node/src/node-ts-solution.test.ts
@@ -106,6 +106,7 @@ describe('Node Applications', () => {
     expect(() => runCLI(`lint ${nodelib}`)).not.toThrow();
     expect(() => runCLI(`test ${nodelib}`)).not.toThrow();
     expect(() => runCLI(`build ${nodelib}`)).not.toThrow();
+    expect(() => runCLI(`typecheck ${nodelib}`)).not.toThrow();
 
     const p = await runCommandUntil(
       `serve ${nodeapp}`,

--- a/e2e/plugin/src/nx-plugin-ts-solution.test.ts
+++ b/e2e/plugin/src/nx-plugin-ts-solution.test.ts
@@ -47,6 +47,9 @@ describe('Nx Plugin (TS solution)', () => {
     expect(runCLI(`lint @proj/${plugin}`)).toContain(
       `Successfully ran target lint for project @proj/${plugin}`
     );
+    expect(runCLI(`typecheck @proj/${plugin}`)).toContain(
+      `Successfully ran target typecheck for project @proj/${plugin}`
+    );
     expect(runCLI(`build @proj/${plugin}`)).toContain(
       `Successfully ran target build for project @proj/${plugin}`
     );

--- a/e2e/vite/src/vite-ts-solution.test.ts
+++ b/e2e/vite/src/vite-ts-solution.test.ts
@@ -106,7 +106,7 @@ ${content}`
 
     // check typecheck
     expect(runCLI(`typecheck ${reactApp}`)).toContain(
-      `Successfully ran target typecheck for project @proj/${reactApp} and 5 tasks it depends on`
+      `Successfully ran target typecheck for project @proj/${reactApp} and 6 tasks it depends on`
     );
   }, 300_000);
 });

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -2347,24 +2347,6 @@ describe('lib', () => {
       ]);
     });
 
-    it('should add nx.addTypecheckTarget to tsconfig.json when using tsc to build to avoid duplicated typechecks', async () => {
-      await libraryGenerator(tree, {
-        ...defaultOptions,
-        useProjectJson: false,
-        directory: 'my-ts-lib',
-        bundler: 'tsc',
-        unitTestRunner: 'none',
-        linter: 'none',
-      });
-
-      expect(readJson(tree, 'my-ts-lib/tsconfig.json').nx)
-        .toMatchInlineSnapshot(`
-        {
-          "addTypecheckTarget": false,
-        }
-      `);
-    });
-
     it('should set "nx.name" in package.json when the user provides a name that is different than the package name and "useProjectJson" is "false"', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -1057,12 +1057,6 @@ function createProjectTsConfigs(
         json.references.push({
           path: './tsconfig.lib.json',
         });
-        // If using `tsc` to build, then we do not want a typecheck target that duplicates the work, since both run `tsc`.
-        // This applies to `@nx/js/typescript` plugin only.
-        if (options.bundler === 'tsc') {
-          json['nx'] ??= {};
-          json['nx'].addTypecheckTarget = false;
-        }
         return json;
       });
     } else {
@@ -1073,12 +1067,6 @@ function createProjectTsConfigs(
         include: [],
         references: [{ path: './tsconfig.lib.json' }],
       };
-      // If using `tsc` to build, then we do not want a typecheck target that duplicates the work, since both run `tsc`.
-      // This applies to `@nx/js/typescript` plugin only.
-      if (options.bundler === 'tsc') {
-        tsconfig['nx'] ??= {};
-        tsconfig['nx'].addTypecheckTarget = false;
-      }
       writeJson(
         tree,
         joinPathFragments(options.projectRoot, 'tsconfig.json'),

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -466,9 +466,6 @@ describe('NxPlugin Plugin Generator', () => {
           "extends": "../tsconfig.base.json",
           "files": [],
           "include": [],
-          "nx": {
-            "addTypecheckTarget": false,
-          },
           "references": [
             {
               "path": "./tsconfig.lib.json",


### PR DESCRIPTION
## Current Behavior

Buildable libraries using `tsc` for `build` don't get a `typecheck` task, which results in test files not being type-checked.

## Expected Behavior

The `typecheck` task should be inferred, and test files should be type-checked.

## Related Issue(s)

Fixes #
