### PR TITLE
fix(core): resolve subpath patterns in package exports correctly when constructing graph

### DIFF
--- a/docs/generated/devkit/ProjectGraphProjectNode.md
+++ b/docs/generated/devkit/ProjectGraphProjectNode.md
@@ -8,7 +8,7 @@ A node describing a project in a workspace
 
 - [data](../../devkit/documents/ProjectGraphProjectNode#data): ProjectConfiguration & Object
 - [name](../../devkit/documents/ProjectGraphProjectNode#name): string
-- [type](../../devkit/documents/ProjectGraphProjectNode#type): "app" | "e2e" | "lib"
+- [type](../../devkit/documents/ProjectGraphProjectNode#type): "lib" | "app" | "e2e"
 
 ## Properties
 
@@ -28,4 +28,4 @@ Additional metadata about a project
 
 ### type
 
-• **type**: `"app"` \| `"e2e"` \| `"lib"`
+• **type**: `"lib"` \| `"app"` \| `"e2e"`

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1091,6 +1091,10 @@ describe('TargetProjectLocator', () => {
       ${{ '.': 'dist/index.js' }}                                  | ${'@org/pkg1'}
       ${{ './subpath': './dist/subpath.js' }}                      | ${'@org/pkg1/subpath'}
       ${{ './*': './dist/*.js' }}                                  | ${'@org/pkg1/subpath'}
+      ${{ './*': './dist/*.js' }}                                  | ${'@org/pkg1/subpath/extra-path'}
+      ${{ './*': './dist/foo/*/index.js' }}                        | ${'@org/pkg1/foo/subpath'}
+      ${{ './*': './dist/foo/*/index.js' }}                        | ${'@org/pkg1/foo/subpath/extra-path'}
+      ${{ './features/*.js': './dist/features/*.js' }}             | ${'@org/pkg1/features/some-file.js'}
       ${{ import: './dist/index.js', default: './dist/index.js' }} | ${'@org/pkg1'}
     `(
       'should find "$importPath" as "pkg1" project when exports="$exports"',
@@ -1130,6 +1134,10 @@ describe('TargetProjectLocator', () => {
       ${{ '.': 'dist/index.js' }}                                  | ${'@org/pkg1'}
       ${{ './subpath': './dist/subpath.js' }}                      | ${'@org/pkg1/subpath'}
       ${{ './*': './dist/*.js' }}                                  | ${'@org/pkg1/subpath'}
+      ${{ './*': './dist/*.js' }}                                  | ${'@org/pkg1/subpath/extra-path'}
+      ${{ './*': './dist/foo/*/index.js' }}                        | ${'@org/pkg1/foo/subpath'}
+      ${{ './*': './dist/foo/*/index.js' }}                        | ${'@org/pkg1/foo/subpath/extra-path'}
+      ${{ './features/*.js': './dist/features/*.js' }}             | ${'@org/pkg1/features/some-file.js'}
       ${{ import: './dist/index.js', default: './dist/index.js' }} | ${'@org/pkg1'}
     `(
       'should not find "$importPath" as "pkg1" project when exports="$exports" and isInPackageManagerWorkspaces is false',
@@ -1168,8 +1176,8 @@ describe('TargetProjectLocator', () => {
       ${undefined}                                                 | ${'@org/pkg1'}
       ${{}}                                                        | ${'@org/pkg1'}
       ${{ '.': 'dist/index.js' }}                                  | ${'@org/pkg1/subpath'}
+      ${{ './subpath/*': 'dist/subpath/*.js' }}                    | ${'@org/pkg1/foo'}
       ${{ './subpath': './dist/subpath.js' }}                      | ${'@org/pkg1/subpath/extra-path'}
-      ${{ './*': './dist/*.js' }}                                  | ${'@org/pkg1/subpath/extra-path'}
       ${{ './feature': null }}                                     | ${'@org/pkg1/feature'}
       ${{ import: './dist/index.js', default: './dist/index.js' }} | ${'@org/pkg1/subpath'}
     `(


### PR DESCRIPTION
## Current Behavior

When a package has a subpath pattern like the following:

```json
{
  "exports": {
    "./*": {
      "types": "./dist/lib/*/index.d.ts",
      "import": "./dist/lib/*/index.js",
      "default": "./dist/lib/*/index.js"
    }
  }
}
```

When constructing the graph the project is not picked as a dependency of others projects that import from the package using a path that matches that subpath pattern. This is currently happening because the current resolution is wrongly using `minimatch` to match those patterns instead of the [Node.js spec for resolving subpath patterns](https://nodejs.org/docs/latest-v22.x/api/esm.html#resolution-algorithm-specification).

## Expected Behavior

Subpath patterns should be processed after the [Node.js spec](https://nodejs.org/docs/latest-v22.x/api/esm.html#resolution-algorithm-specification) and the graph should pick up dependencies when used.

## Related Issue(s)

Fixes #30342 
