### PR TITLE
fix(webpack): add extension alias support for handling ESM libs

### DIFF
--- a/e2e/react/src/react-webpack.test.ts
+++ b/e2e/react/src/react-webpack.test.ts
@@ -10,7 +10,7 @@ import {
   updateFile,
 } from '@nx/e2e/utils';
 
-describe('Build React applications and libraries with Vite', () => {
+describe('Build React applications and libraries with Webpack', () => {
   beforeAll(() => {
     newProject({
       packages: ['@nx/react'],

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -26,6 +26,10 @@ const IGNORED_WEBPACK_WARNINGS = [
   /could not find any license/i,
 ];
 
+const extensionAlias = {
+  '.js': ['.ts', '.js'],
+  '.mjs': ['.mts', '.mjs'],
+};
 const extensions = ['.ts', '.tsx', '.mjs', '.js', '.jsx'];
 const mainFields = ['module', 'main'];
 
@@ -356,6 +360,10 @@ function applyNxDependentConfig(
   config.resolve = {
     ...config.resolve,
     extensions: [...(config?.resolve?.extensions ?? []), ...extensions],
+    extensionAlias: {
+      ...(config.resolve?.extensionAlias ?? {}),
+      ...extensionAlias,
+    },
     alias: {
       ...(config.resolve?.alias ?? {}),
       ...(options.fileReplacements?.reduce(


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, if you have a webpack application that uses out NxWebpackAppPlugin and has a non-buildable lib that has exports with extension enabled for example:`export * from './lib/lib8446520.js';`. 
The app fails to build.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When using webpack and including libraries that contain extension it should resolve.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30492
