### PR TITLE
fix(core): add option to use v8 for daemon message serialization to avoid issues when JSON.stringify would fail

### DIFF
--- a/packages/nx/src/command-line/daemon/daemon.ts
+++ b/packages/nx/src/command-line/daemon/daemon.ts
@@ -2,6 +2,7 @@ import type { Arguments } from 'yargs';
 import { DAEMON_OUTPUT_LOG_FILE } from '../../daemon/tmp-dir';
 import { output } from '../../utils/output';
 import { generateDaemonHelpOutput } from '../../daemon/client/generate-help-output';
+import { daemonClient } from '../../daemon/client/client';
 
 export async function daemonHandler(args: Arguments) {
   if (args.start) {

--- a/packages/nx/src/command-line/daemon/daemon.ts
+++ b/packages/nx/src/command-line/daemon/daemon.ts
@@ -2,7 +2,6 @@ import type { Arguments } from 'yargs';
 import { DAEMON_OUTPUT_LOG_FILE } from '../../daemon/tmp-dir';
 import { output } from '../../utils/output';
 import { generateDaemonHelpOutput } from '../../daemon/client/generate-help-output';
-import { daemonClient } from '../../daemon/client/client';
 
 export async function daemonHandler(args: Arguments) {
   if (args.start) {

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
@@ -89,14 +89,18 @@ export function notifyFileWatcherSockets(
         }
 
         if (changedProjects.length > 0 || changedFiles.length > 0) {
-          return handleResult(socket, 'FILE-WATCH-CHANGED', () =>
-            Promise.resolve({
-              description: 'File watch changed',
-              response: JSON.stringify({
-                changedProjects,
-                changedFiles,
+          return handleResult(
+            socket,
+            'FILE-WATCH-CHANGED',
+            () =>
+              Promise.resolve({
+                description: 'File watch changed',
+                response: JSON.stringify({
+                  changedProjects,
+                  changedFiles,
+                }),
               }),
-            })
+            'json'
           );
         }
       })

--- a/packages/nx/src/daemon/server/handle-context-file-data.ts
+++ b/packages/nx/src/daemon/server/handle-context-file-data.ts
@@ -5,7 +5,7 @@ import { HandlerResult } from './server';
 export async function handleContextFileData(): Promise<HandlerResult> {
   const files = await getAllFileDataInContext(workspaceRoot);
   return {
-    response: JSON.stringify(files),
+    response: files,
     description: 'handleContextFileData',
   };
 }

--- a/packages/nx/src/daemon/server/handle-flush-sync-generator-changes-to-disk.ts
+++ b/packages/nx/src/daemon/server/handle-flush-sync-generator-changes-to-disk.ts
@@ -7,7 +7,7 @@ export async function handleFlushSyncGeneratorChangesToDisk(
   const result = await flushSyncGeneratorChangesToDisk(generators);
 
   return {
-    response: JSON.stringify(result),
+    response: result,
     description: 'handleFlushSyncGeneratorChangesToDisk',
   };
 }

--- a/packages/nx/src/daemon/server/handle-get-files-in-directory.ts
+++ b/packages/nx/src/daemon/server/handle-get-files-in-directory.ts
@@ -7,7 +7,7 @@ export async function handleGetFilesInDirectory(
 ): Promise<HandlerResult> {
   const files = await getFilesInDirectoryUsingContext(workspaceRoot, dir);
   return {
-    response: JSON.stringify(files),
+    response: files,
     description: 'handleNxWorkspaceFiles',
   };
 }

--- a/packages/nx/src/daemon/server/handle-get-registered-sync-generators.ts
+++ b/packages/nx/src/daemon/server/handle-get-registered-sync-generators.ts
@@ -5,7 +5,7 @@ export async function handleGetRegisteredSyncGenerators(): Promise<HandlerResult
   const syncGenerators = await getCachedRegisteredSyncGenerators();
 
   return {
-    response: JSON.stringify(syncGenerators),
+    response: syncGenerators,
     description: 'handleGetSyncGeneratorChanges',
   };
 }

--- a/packages/nx/src/daemon/server/handle-get-sync-generator-changes.ts
+++ b/packages/nx/src/daemon/server/handle-get-sync-generator-changes.ts
@@ -18,7 +18,7 @@ export async function handleGetSyncGeneratorChanges(
   );
 
   return {
-    response: JSON.stringify(result),
+    response: result,
     description: 'handleGetSyncGeneratorChanges',
   };
 }

--- a/packages/nx/src/daemon/server/handle-glob.ts
+++ b/packages/nx/src/daemon/server/handle-glob.ts
@@ -11,7 +11,7 @@ export async function handleGlob(
 ): Promise<HandlerResult> {
   const files = await globWithWorkspaceContext(workspaceRoot, globs, exclude);
   return {
-    response: JSON.stringify(files),
+    response: files,
     description: 'handleGlob',
   };
 }
@@ -26,7 +26,7 @@ export async function handleMultiGlob(
     exclude
   );
   return {
-    response: JSON.stringify(files),
+    response: files,
     description: 'handleMultiGlob',
   };
 }

--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -45,8 +45,10 @@ export async function handleHashTasks(payload: {
       payload.runnerOptions
     );
   }
-  const response = JSON.stringify(
-    await storedHasher.hashTasks(payload.tasks, payload.taskGraph, payload.env)
+  const response = await storedHasher.hashTasks(
+    payload.tasks,
+    payload.taskGraph,
+    payload.env
   );
   return {
     response,

--- a/packages/nx/src/daemon/server/handle-nx-workspace-files.ts
+++ b/packages/nx/src/daemon/server/handle-nx-workspace-files.ts
@@ -10,7 +10,7 @@ export async function handleNxWorkspaceFiles(
     projectRootMap
   );
   return {
-    response: JSON.stringify(files),
+    response: files,
     description: 'handleNxWorkspaceFiles',
   };
 }

--- a/packages/nx/src/daemon/server/handle-outputs-tracking.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-tracking.ts
@@ -31,7 +31,7 @@ export async function handleOutputsHashesMatch(payload: {
       payload.data.hash
     );
     return {
-      response: JSON.stringify(res),
+      response: res,
       description: 'outputsHashesMatch',
     };
   } catch (e) {

--- a/packages/nx/src/daemon/server/handle-task-history.ts
+++ b/packages/nx/src/daemon/server/handle-task-history.ts
@@ -14,7 +14,7 @@ export async function handleGetFlakyTasks(hashes: string[]) {
   const taskHistory = getTaskHistory();
   const history = await taskHistory.getFlakyTasks(hashes);
   return {
-    response: JSON.stringify(history),
+    response: history,
     description: 'handleGetFlakyTasks',
   };
 }
@@ -23,7 +23,7 @@ export async function handleGetEstimatedTaskTimings(targets: TaskTarget[]) {
   const taskHistory = getTaskHistory();
   const history = await taskHistory.getEstimatedTaskTimings(targets);
   return {
-    response: JSON.stringify(history),
+    response: history,
     description: 'handleGetEstimatedTaskTimings',
   };
 }

--- a/packages/nx/src/daemon/server/handle-tasks-execution-hooks.ts
+++ b/packages/nx/src/daemon/server/handle-tasks-execution-hooks.ts
@@ -13,7 +13,7 @@ export async function handleRunPreTasksExecution(
   try {
     const envs = await runPreTasksExecution(context);
     return {
-      response: JSON.stringify(envs),
+      response: envs,
       description: 'handleRunPreTasksExecution',
     };
   } catch (e) {

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -4,7 +4,10 @@ import { join } from 'path';
 import { PerformanceObserver } from 'perf_hooks';
 import { hashArray } from '../../hasher/file-hasher';
 import { hashFile } from '../../native';
-import { consumeMessagesFromSocket } from '../../utils/consume-messages-from-socket';
+import {
+  consumeMessagesFromSocket,
+  isJsonMessage,
+} from '../../utils/consume-messages-from-socket';
 import { readJsonFile } from '../../utils/fileutils';
 import { PackageJson } from '../../utils/package-json';
 import { nxVersion } from '../../utils/versions';
@@ -129,6 +132,7 @@ import {
   handleRunPostTasksExecution,
   handleRunPreTasksExecution,
 } from './handle-tasks-execution-hooks';
+import { deserialize, serialize } from 'v8';
 
 let performanceObserver: PerformanceObserver | undefined;
 let workspaceWatcherError: Error | undefined;
@@ -139,7 +143,7 @@ global.NX_DAEMON = true;
 export type HandlerResult = {
   description: string;
   error?: any;
-  response?: string;
+  response?: string | object | boolean;
 };
 
 let numberOfOpenConnections = 0;
@@ -184,7 +188,7 @@ const server = createServer(async (socket) => {
 });
 registerProcessTerminationListeners();
 
-async function handleMessage(socket, data: string) {
+async function handleMessage(socket: Socket, data: string) {
   if (workspaceWatcherError) {
     await respondWithErrorAndExit(
       socket,
@@ -206,8 +210,16 @@ async function handleMessage(socket, data: string) {
 
   const unparsedPayload = data;
   let payload;
+  let mode: 'json' | 'v8' = 'json';
   try {
-    payload = JSON.parse(unparsedPayload);
+    // JSON Message
+    if (isJsonMessage(unparsedPayload)) {
+      payload = JSON.parse(unparsedPayload);
+    } else {
+      // V8 Serialized Message
+      payload = deserialize(Buffer.from(unparsedPayload, 'binary'));
+      mode = 'v8';
+    }
   } catch (e) {
     await respondWithErrorAndExit(
       socket,
@@ -215,106 +227,180 @@ async function handleMessage(socket, data: string) {
       new Error(`Unsupported payload sent to daemon server: ${unparsedPayload}`)
     );
   }
-
   if (payload.type === 'PING') {
-    await handleResult(socket, 'PING', () =>
-      Promise.resolve({ response: JSON.stringify(true), description: 'ping' })
+    await handleResult(
+      socket,
+      'PING',
+      () => Promise.resolve({ response: true, description: 'ping' }),
+      mode
     );
   } else if (payload.type === 'REQUEST_PROJECT_GRAPH') {
-    await handleResult(socket, 'REQUEST_PROJECT_GRAPH', () =>
-      handleRequestProjectGraph()
+    await handleResult(
+      socket,
+      'REQUEST_PROJECT_GRAPH',
+      () => handleRequestProjectGraph(),
+      mode
     );
   } else if (payload.type === 'HASH_TASKS') {
-    await handleResult(socket, 'HASH_TASKS', () => handleHashTasks(payload));
+    await handleResult(
+      socket,
+      'HASH_TASKS',
+      () => handleHashTasks(payload),
+      mode
+    );
   } else if (payload.type === 'PROCESS_IN_BACKGROUND') {
-    await handleResult(socket, 'PROCESS_IN_BACKGROUND', () =>
-      handleProcessInBackground(payload)
+    await handleResult(
+      socket,
+      'PROCESS_IN_BACKGROUND',
+      () => handleProcessInBackground(payload),
+      mode
     );
   } else if (payload.type === 'RECORD_OUTPUTS_HASH') {
-    await handleResult(socket, 'RECORD_OUTPUTS_HASH', () =>
-      handleRecordOutputsHash(payload)
+    await handleResult(
+      socket,
+      'RECORD_OUTPUTS_HASH',
+      () => handleRecordOutputsHash(payload),
+      mode
     );
   } else if (payload.type === 'OUTPUTS_HASHES_MATCH') {
-    await handleResult(socket, 'OUTPUTS_HASHES_MATCH', () =>
-      handleOutputsHashesMatch(payload)
+    await handleResult(
+      socket,
+      'OUTPUTS_HASHES_MATCH',
+      () => handleOutputsHashesMatch(payload),
+      mode
     );
   } else if (payload.type === 'REQUEST_SHUTDOWN') {
-    await handleResult(socket, 'REQUEST_SHUTDOWN', () =>
-      handleRequestShutdown(server, numberOfOpenConnections)
+    await handleResult(
+      socket,
+      'REQUEST_SHUTDOWN',
+      () => handleRequestShutdown(server, numberOfOpenConnections),
+      mode
     );
   } else if (payload.type === 'REGISTER_FILE_WATCHER') {
     registeredFileWatcherSockets.push({ socket, config: payload.config });
   } else if (isHandleGlobMessage(payload)) {
-    await handleResult(socket, GLOB, () =>
-      handleGlob(payload.globs, payload.exclude)
+    await handleResult(
+      socket,
+      GLOB,
+      () => handleGlob(payload.globs, payload.exclude),
+      mode
     );
   } else if (isHandleMultiGlobMessage(payload)) {
-    await handleResult(socket, MULTI_GLOB, () =>
-      handleMultiGlob(payload.globs, payload.exclude)
+    await handleResult(
+      socket,
+      MULTI_GLOB,
+      () => handleMultiGlob(payload.globs, payload.exclude),
+      mode
     );
   } else if (isHandleNxWorkspaceFilesMessage(payload)) {
-    await handleResult(socket, GET_NX_WORKSPACE_FILES, () =>
-      handleNxWorkspaceFiles(payload.projectRootMap)
+    await handleResult(
+      socket,
+      GET_NX_WORKSPACE_FILES,
+      () => handleNxWorkspaceFiles(payload.projectRootMap),
+      mode
     );
   } else if (isHandleGetFilesInDirectoryMessage(payload)) {
-    await handleResult(socket, GET_FILES_IN_DIRECTORY, () =>
-      handleGetFilesInDirectory(payload.dir)
+    await handleResult(
+      socket,
+      GET_FILES_IN_DIRECTORY,
+      () => handleGetFilesInDirectory(payload.dir),
+      mode
     );
   } else if (isHandleContextFileDataMessage(payload)) {
-    await handleResult(socket, GET_CONTEXT_FILE_DATA, () =>
-      handleContextFileData()
+    await handleResult(
+      socket,
+      GET_CONTEXT_FILE_DATA,
+      () => handleContextFileData(),
+      mode
     );
   } else if (isHandleHashGlobMessage(payload)) {
-    await handleResult(socket, HASH_GLOB, () =>
-      handleHashGlob(payload.globs, payload.exclude)
+    await handleResult(
+      socket,
+      HASH_GLOB,
+      () => handleHashGlob(payload.globs, payload.exclude),
+      mode
     );
   } else if (isHandleHashMultiGlobMessage(payload)) {
-    await handleResult(socket, HASH_GLOB, () =>
-      handleHashMultiGlob(payload.globGroups)
+    await handleResult(
+      socket,
+      HASH_GLOB,
+      () => handleHashMultiGlob(payload.globGroups),
+      mode
     );
   } else if (isHandleGetFlakyTasksMessage(payload)) {
-    await handleResult(socket, GET_FLAKY_TASKS, () =>
-      handleGetFlakyTasks(payload.hashes)
+    await handleResult(
+      socket,
+      GET_FLAKY_TASKS,
+      () => handleGetFlakyTasks(payload.hashes),
+      mode
     );
   } else if (isHandleGetEstimatedTaskTimings(payload)) {
-    await handleResult(socket, GET_ESTIMATED_TASK_TIMINGS, () =>
-      handleGetEstimatedTaskTimings(payload.targets)
+    await handleResult(
+      socket,
+      GET_ESTIMATED_TASK_TIMINGS,
+      () => handleGetEstimatedTaskTimings(payload.targets),
+      mode
     );
   } else if (isHandleWriteTaskRunsToHistoryMessage(payload)) {
-    await handleResult(socket, RECORD_TASK_RUNS, () =>
-      handleRecordTaskRuns(payload.taskRuns)
+    await handleResult(
+      socket,
+      RECORD_TASK_RUNS,
+      () => handleRecordTaskRuns(payload.taskRuns),
+      mode
     );
   } else if (isHandleForceShutdownMessage(payload)) {
-    await handleResult(socket, 'FORCE_SHUTDOWN', () =>
-      handleForceShutdown(server)
+    await handleResult(
+      socket,
+      'FORCE_SHUTDOWN',
+      () => handleForceShutdown(server),
+      mode
     );
   } else if (isHandleGetSyncGeneratorChangesMessage(payload)) {
-    await handleResult(socket, GET_SYNC_GENERATOR_CHANGES, () =>
-      handleGetSyncGeneratorChanges(payload.generators)
+    await handleResult(
+      socket,
+      GET_SYNC_GENERATOR_CHANGES,
+      () => handleGetSyncGeneratorChanges(payload.generators),
+      mode
     );
   } else if (isHandleFlushSyncGeneratorChangesToDiskMessage(payload)) {
-    await handleResult(socket, FLUSH_SYNC_GENERATOR_CHANGES_TO_DISK, () =>
-      handleFlushSyncGeneratorChangesToDisk(payload.generators)
+    await handleResult(
+      socket,
+      FLUSH_SYNC_GENERATOR_CHANGES_TO_DISK,
+      () => handleFlushSyncGeneratorChangesToDisk(payload.generators),
+      mode
     );
   } else if (isHandleGetRegisteredSyncGeneratorsMessage(payload)) {
-    await handleResult(socket, GET_REGISTERED_SYNC_GENERATORS, () =>
-      handleGetRegisteredSyncGenerators()
+    await handleResult(
+      socket,
+      GET_REGISTERED_SYNC_GENERATORS,
+      () => handleGetRegisteredSyncGenerators(),
+      mode
     );
   } else if (isHandleUpdateWorkspaceContextMessage(payload)) {
-    await handleResult(socket, UPDATE_WORKSPACE_CONTEXT, () =>
-      handleUpdateWorkspaceContext(
-        payload.createdFiles,
-        payload.updatedFiles,
-        payload.deletedFiles
-      )
+    await handleResult(
+      socket,
+      UPDATE_WORKSPACE_CONTEXT,
+      () =>
+        handleUpdateWorkspaceContext(
+          payload.createdFiles,
+          payload.updatedFiles,
+          payload.deletedFiles
+        ),
+      mode
     );
   } else if (isHandlePreTasksExecutionMessage(payload)) {
-    await handleResult(socket, PRE_TASKS_EXECUTION, () =>
-      handleRunPreTasksExecution(payload.context)
+    await handleResult(
+      socket,
+      PRE_TASKS_EXECUTION,
+      () => handleRunPreTasksExecution(payload.context),
+      mode
     );
   } else if (isHandlePostTasksExecutionMessage(payload)) {
-    await handleResult(socket, POST_TASKS_EXECUTION, () =>
-      handleRunPostTasksExecution(payload.context)
+    await handleResult(
+      socket,
+      POST_TASKS_EXECUTION,
+      () => handleRunPostTasksExecution(payload.context),
+      mode
     );
   } else {
     await respondWithErrorAndExit(
@@ -328,7 +414,8 @@ async function handleMessage(socket, data: string) {
 export async function handleResult(
   socket: Socket,
   type: string,
-  hrFn: () => Promise<HandlerResult>
+  hrFn: () => Promise<HandlerResult>,
+  mode: 'json' | 'v8'
 ) {
   let hr: HandlerResult;
   const startMark = new Date();
@@ -341,11 +428,15 @@ export async function handleResult(
   if (hr.error) {
     await respondWithErrorAndExit(socket, hr.description, hr.error);
   } else {
-    await respondToClient(socket, hr.response, hr.description);
+    const response =
+      typeof hr.response === 'string'
+        ? hr.response
+        : serializeUnserializedResult(hr.response, mode);
+    await respondToClient(socket, response, hr.description);
   }
   const endMark = new Date();
   serverLogger.log(
-    `Handled ${type}. Handling time: ${
+    `Handled ${mode} message ${type}. Handling time: ${
       doneHandlingMark.getTime() - startMark.getTime()
     }. Response time: ${endMark.getTime() - doneHandlingMark.getTime()}.`
   );
@@ -606,4 +697,14 @@ export async function startServer(): Promise<Server> {
       reject(err);
     }
   });
+}
+function serializeUnserializedResult(
+  response: boolean | object,
+  mode: 'json' | 'v8'
+) {
+  if (mode === 'json') {
+    return JSON.stringify(response);
+  } else {
+    return serialize(response).toString('binary');
+  }
 }

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -10,6 +10,7 @@ import {
 } from '../../project-graph/error-types';
 import { removeDbConnections } from '../../utils/db-connection';
 import { cleanupPlugins } from '../../project-graph/plugins/get-plugins';
+import { MESSAGE_END_SEQ } from '../../utils/consume-messages-from-socket';
 
 export const SERVER_INACTIVITY_TIMEOUT_MS = 10800000 as const; // 10800000 ms = 3 hours
 
@@ -98,7 +99,7 @@ export function respondToClient(
     if (description) {
       serverLogger.requestLog(`Responding to the client.`, description);
     }
-    socket.write(`${response}${String.fromCodePoint(4)}`, (err) => {
+    socket.write(response + MESSAGE_END_SEQ, (err) => {
       if (err) {
         console.error(err);
       }

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -10,6 +10,7 @@ import type {
 import type { LoadedNxPlugin } from '../loaded-nx-plugin';
 import type { Serializable } from 'child_process';
 import type { Socket } from 'net';
+import { MESSAGE_END_SEQ } from '../../../utils/consume-messages-from-socket';
 
 export interface PluginWorkerLoadMessage {
   type: 'load';
@@ -250,5 +251,5 @@ export function sendMessageOverSocket(
   socket: Socket,
   message: PluginWorkerMessage | PluginWorkerResult
 ) {
-  socket.write(JSON.stringify(message) + String.fromCodePoint(4));
+  socket.write(JSON.stringify(message) + MESSAGE_END_SEQ);
 }

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -263,7 +263,7 @@ function createWorkerHandler(
         }
       },
       createDependenciesResult: ({ tx, ...result }) => {
-        const { resolver, rejector } = pending.get(tx);
+        const { resolver, rejector } = getPendingPromise(tx, pending);
         if (result.success) {
           resolver(result.dependencies);
         } else if (result.success === false) {
@@ -271,7 +271,7 @@ function createWorkerHandler(
         }
       },
       createNodesResult: ({ tx, ...result }) => {
-        const { resolver, rejector } = pending.get(tx);
+        const { resolver, rejector } = getPendingPromise(tx, pending);
         if (result.success) {
           resolver(result.result);
         } else if (result.success === false) {
@@ -279,7 +279,7 @@ function createWorkerHandler(
         }
       },
       createMetadataResult: ({ tx, ...result }) => {
-        const { resolver, rejector } = pending.get(tx);
+        const { resolver, rejector } = getPendingPromise(tx, pending);
         if (result.success) {
           resolver(result.metadata);
         } else if (result.success === false) {
@@ -287,7 +287,7 @@ function createWorkerHandler(
         }
       },
       preTasksExecutionResult: ({ tx, ...result }) => {
-        const { resolver, rejector } = pending.get(tx);
+        const { resolver, rejector } = getPendingPromise(tx, pending);
         if (result.success) {
           resolver(result.mutations);
         } else if (result.success === false) {
@@ -295,7 +295,7 @@ function createWorkerHandler(
         }
       },
       postTasksExecutionResult: ({ tx, ...result }) => {
-        const { resolver, rejector } = pending.get(tx);
+        const { resolver, rejector } = getPendingPromise(tx, pending);
         if (result.success) {
           resolver();
         } else if (result.success === false) {
@@ -320,6 +320,23 @@ function createWorkerExitHandler(
         )
       );
     }
+  };
+}
+
+function getPendingPromise(tx: string, pending: Map<string, PendingPromise>) {
+  const pendingPromise = pending.get(tx);
+
+  if (!pendingPromise) {
+    throw new Error(
+      `No pending promise found for transaction "${tx}". This may indicate a bug in the plugin pool. Currently pending promises:` +
+        Object.keys(pending).map((t) => `  -  ${t}`)
+    );
+  }
+
+  const { rejector, resolver } = pendingPromise;
+  return {
+    rejector,
+    resolver,
   };
 }
 

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -328,8 +328,8 @@ function getPendingPromise(tx: string, pending: Map<string, PendingPromise>) {
 
   if (!pendingPromise) {
     throw new Error(
-      `No pending promise found for transaction "${tx}". This may indicate a bug in the plugin pool. Currently pending promises:` +
-        Object.keys(pending).map((t) => `  -  ${t}`)
+      `No pending promise found for transaction "${tx}". This may indicate a bug in the plugin pool. Currently pending promises:\n` +
+        Object.keys(pending).map((t) => `  -  ${t}`).join('\n')
     );
   }
 

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -329,7 +329,9 @@ function getPendingPromise(tx: string, pending: Map<string, PendingPromise>) {
   if (!pendingPromise) {
     throw new Error(
       `No pending promise found for transaction "${tx}". This may indicate a bug in the plugin pool. Currently pending promises:\n` +
-        Object.keys(pending).map((t) => `  -  ${t}`).join('\n')
+        Array.from(pending.keys())
+          .map((t) => `  -  ${t}`)
+          .join('\n')
     );
   }
 

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -126,6 +126,8 @@ export class LoadedNxPlugin {
           });
         }
         await plugin.preTasksExecution(this.options, context);
+        // This doesn't revert env changes, as the proxy still updates
+        // originalEnv, rather it removes the proxy.
         process.env = originalEnv;
 
         return updates;

--- a/packages/nx/src/tasks-runner/pseudo-ipc.ts
+++ b/packages/nx/src/tasks-runner/pseudo-ipc.ts
@@ -18,7 +18,10 @@
  */
 
 import { connect, Server, Socket } from 'net';
-import { consumeMessagesFromSocket } from '../utils/consume-messages-from-socket';
+import {
+  consumeMessagesFromSocket,
+  MESSAGE_END_SEQ,
+} from '../utils/consume-messages-from-socket';
 import { Serializable } from 'child_process';
 
 export interface PseudoIPCMessage {
@@ -98,7 +101,7 @@ export class PseudoIPCServer {
         JSON.stringify({ type: 'TO_CHILDREN_FROM_PARENT', message })
       );
       // send EOT to indicate that the message has been fully written
-      socket.write(String.fromCodePoint(4));
+      socket.write(MESSAGE_END_SEQ);
     });
   }
 
@@ -107,7 +110,7 @@ export class PseudoIPCServer {
       socket.write(
         JSON.stringify({ type: 'TO_CHILDREN_FROM_PARENT', id, message })
       );
-      socket.write(String.fromCodePoint(4));
+      socket.write(MESSAGE_END_SEQ);
     });
   }
 
@@ -139,7 +142,7 @@ export class PseudoIPCClient {
       JSON.stringify({ type: 'TO_PARENT_FROM_CHILDREN', message })
     );
     // send EOT to indicate that the message has been fully written
-    this.socket.write(String.fromCodePoint(4));
+    this.socket.write(MESSAGE_END_SEQ);
   }
 
   notifyChildIsReady(id: string) {
@@ -150,7 +153,7 @@ export class PseudoIPCClient {
       } as PseudoIPCMessage)
     );
     // send EOT to indicate that the message has been fully written
-    this.socket.write(String.fromCodePoint(4));
+    this.socket.write(MESSAGE_END_SEQ);
   }
 
   onMessageFromParent(

--- a/packages/nx/src/utils/consume-messages-from-socket.spec.ts
+++ b/packages/nx/src/utils/consume-messages-from-socket.spec.ts
@@ -1,4 +1,7 @@
-import { consumeMessagesFromSocket } from './consume-messages-from-socket';
+import {
+  consumeMessagesFromSocket,
+  MESSAGE_END_SEQ,
+} from './consume-messages-from-socket';
 
 describe('consumeMessagesFromSocket', () => {
   it('should handle messages where every messages is in its own chunk', () => {
@@ -6,8 +9,8 @@ describe('consumeMessagesFromSocket', () => {
     const r = consumeMessagesFromSocket((message) =>
       messages.push(JSON.parse(message))
     );
-    r(JSON.stringify({ one: 1 }) + String.fromCodePoint(4));
-    r(JSON.stringify({ two: 2 }) + String.fromCodePoint(4));
+    r(JSON.stringify({ one: 1 }) + MESSAGE_END_SEQ);
+    r(JSON.stringify({ two: 2 }) + MESSAGE_END_SEQ);
     expect(messages).toEqual([{ one: 1 }, { two: 2 }]);
   });
 
@@ -18,29 +21,29 @@ describe('consumeMessagesFromSocket', () => {
     );
     const message = JSON.stringify({ one: 1 });
     r(message.substring(0, 3));
-    r(message.substring(3) + String.fromCodePoint(4));
+    r(message.substring(3) + MESSAGE_END_SEQ);
     expect(messages).toEqual([{ one: 1 }]);
   });
 
-  // it('should handle messages where multiple messages are in the same chunk', () => {
-  //   const messages = [] as any[];
-  //   const r = consumeMessagesFromSocket((message) =>
-  //     messages.push(JSON.parse(message))
-  //   );
-  //   const message1 = JSON.stringify({ one: 1 });
-  //   const message2 = JSON.stringify({ two: 2 });
-  //   const message3 = JSON.stringify({ three: 3 });
-  //
-  //   r(message1.substring(0, 3));
-  //   r(
-  //     message1.substring(3) +
-  //       String.fromCodePoint(4) +
-  //       message2 +
-  //       String.fromCodePoint(4) +
-  //       message3.substring(0, 3)
-  //   );
-  //   r(message3.substring(3) + String.fromCodePoint(4));
-  //
-  //   expect(messages).toEqual([{ one: 1 }, { two: 2 }, { three: 3 }]);
-  // });
+  it('should handle messages where multiple messages are in the same chunk', () => {
+    const messages = [] as any[];
+    const r = consumeMessagesFromSocket((message) =>
+      messages.push(JSON.parse(message))
+    );
+    const message1 = JSON.stringify({ one: 1 });
+    const message2 = JSON.stringify({ two: 2 });
+    const message3 = JSON.stringify({ three: 3 });
+
+    r(message1.substring(0, 3));
+    r(
+      message1.substring(3) +
+        MESSAGE_END_SEQ +
+        message2 +
+        MESSAGE_END_SEQ +
+        message3.substring(0, 3)
+    );
+    r(message3.substring(3) + MESSAGE_END_SEQ);
+
+    expect(messages).toEqual([{ one: 1 }, { two: 2 }, { three: 3 }]);
+  });
 });

--- a/packages/nx/src/utils/consume-messages-from-socket.ts
+++ b/packages/nx/src/utils/consume-messages-from-socket.ts
@@ -1,12 +1,14 @@
+export const MESSAGE_END_SEQ = 'NX_MSG_END' + String.fromCharCode(4);
+
 export function consumeMessagesFromSocket(callback: (message: string) => void) {
   let message = '';
   return (data) => {
     const chunk = data.toString();
-    if (chunk.codePointAt(chunk.length - 1) === 4) {
-      message += chunk.substring(0, chunk.length - 1);
+    if (chunk.endsWith(MESSAGE_END_SEQ)) {
+      message += chunk.substring(0, chunk.length - MESSAGE_END_SEQ.length);
 
       // Server may send multiple messages in one chunk, so splitting by 0x4
-      const messages = message.split('');
+      const messages = message.split(MESSAGE_END_SEQ);
       for (const splitMessage of messages) {
         callback(splitMessage);
       }
@@ -16,4 +18,18 @@ export function consumeMessagesFromSocket(callback: (message: string) => void) {
       message += chunk;
     }
   };
+}
+
+export function isJsonMessage(message: string): boolean {
+  return (
+    // json objects
+    ['[', '{'].some((prefix) => message.startsWith(prefix)) ||
+    // booleans
+    message === 'true' ||
+    message === 'false' ||
+    // strings
+    (message.startsWith('"') && message.endsWith('"')) ||
+    // numbers
+    /^[0-9]+(.?[0-9]+)?$/.test(message)
+  );
 }

--- a/packages/nx/src/utils/consume-messages-from-socket.ts
+++ b/packages/nx/src/utils/consume-messages-from-socket.ts
@@ -30,6 +30,6 @@ export function isJsonMessage(message: string): boolean {
     // strings
     (message.startsWith('"') && message.endsWith('"')) ||
     // numbers
-    /^[0-9]+(.?[0-9]+)?$/.test(message)
+/^[0-9]+(\\.?[0-9]+)?$/.test(message)
   );
 }

--- a/packages/nx/src/utils/consume-messages-from-socket.ts
+++ b/packages/nx/src/utils/consume-messages-from-socket.ts
@@ -30,6 +30,6 @@ export function isJsonMessage(message: string): boolean {
     // strings
     (message.startsWith('"') && message.endsWith('"')) ||
     // numbers
-/^[0-9]+(\.?[0-9]+)?$/.test(message)
+    /^[0-9]+(\.?[0-9]+)?$/.test(message)
   );
 }

--- a/packages/nx/src/utils/consume-messages-from-socket.ts
+++ b/packages/nx/src/utils/consume-messages-from-socket.ts
@@ -30,6 +30,6 @@ export function isJsonMessage(message: string): boolean {
     // strings
     (message.startsWith('"') && message.endsWith('"')) ||
     // numbers
-/^[0-9]+(\\.?[0-9]+)?$/.test(message)
+/^[0-9]+(\.?[0-9]+)?$/.test(message)
   );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
For really large objects (particularly those containing large strings) JSON.stringify can fail

## Expected Behavior
Daemon serialization doesn't fail for the same strings when setting `NX_USE_V8_SERIALIZER=true`. This should become the default behavior.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
