### PR TITLE
fix(webpack): allow baseHref to not be set #30291

### DIFF
--- a/packages/rspack/src/plugins/utils/loaders/stylesheet-loaders.ts
+++ b/packages/rspack/src/plugins/utils/loaders/stylesheet-loaders.ts
@@ -123,7 +123,7 @@ function postcssOptionsCreator(
         ? []
         : [
             PostcssCliResources({
-              baseHref: options.baseHref,
+              baseHref: options.baseHref ? options.baseHref : undefined,
               deployUrl: options.deployUrl,
               loader,
               filename: `[name]${hashFormat.file}.[ext]`,

--- a/packages/rspack/src/plugins/utils/models.ts
+++ b/packages/rspack/src/plugins/utils/models.ts
@@ -64,7 +64,7 @@ export interface NxAppRspackPluginOptions {
   /**
    * Set <base href> for the resulting index.html.
    */
-  baseHref?: string;
+  baseHref?: string | false;
   /**
    * Build the libraries from source. Default is `true`.
    */

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-web-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-web-config.ts
@@ -61,7 +61,7 @@ export function applyWebConfig(
         sri: options.subresourceIntegrity,
         outputPath: path.basename(options.index),
         indexPath: path.join(options.root, options.index),
-        baseHref: options.baseHref,
+        baseHref: options.baseHref !== false ? options.baseHref : undefined,
         deployUrl: options.deployUrl,
         scripts: options.scripts,
         styles: options.styles,

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/stylesheet-loaders.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/stylesheet-loaders.ts
@@ -124,7 +124,7 @@ function postcssOptionsCreator(
         ? []
         : [
             PostcssCliResources({
-              baseHref: options.baseHref,
+              baseHref: options.baseHref ? options.baseHref : undefined,
               deployUrl: options.deployUrl,
               loader,
               filename: `[name]${hashFormat.file}.[ext]`,

--- a/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
@@ -65,7 +65,7 @@ export interface NxAppWebpackPluginOptions {
   /**
    * Set <base href> for the resulting index.html.
    */
-  baseHref?: string;
+  baseHref?: string | false;
   /**
    * Build the libraries from source. Default is `true`.
    */


### PR DESCRIPTION
## Current Behavior
The `NxAppWebpackPlugin` and `NxAppRspackPlugin` both always set `<base href="` even when it is set to undefined.

## Expected Behavior
If `baseHref` is set to false, do not set `<base href`.

## Related Issues
#30291

