### PR TITLE
fix(module-federation): the module federation package depends on rspack

### DIFF
--- a/packages/module-federation/package.json
+++ b/packages/module-federation/package.json
@@ -30,14 +30,12 @@
     "@nx/web": "file:../web",
     "picocolors": "^1.1.0",
     "webpack": "^5.88.0",
+    "@rspack/core": "^1.1.5",
     "@module-federation/enhanced": "^0.9.0",
     "@module-federation/node": "^2.6.26",
     "@module-federation/sdk": "^0.9.0",
     "express": "^4.21.2",
     "http-proxy-middleware": "^3.0.3"
-  },
-  "peerDependencies": {
-    "@rspack/core": "^1.1.5"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"


### PR DESCRIPTION
## Current Behavior
The `@nx/module-federation` depends on the `@rspack/core` package but it is currently only set as a `peerDep` meaning users need to install the package manually.

## Expected Behavior
As the package depends on `@rspack/core`, make sure it is set as a dependency

## Related Issue(s)

Fixes #30307
