### PR TITLE
fix(rspack): remove unused plugin-minify

### DIFF
--- a/packages/rspack/src/generators/init/init.ts
+++ b/packages/rspack/src/generators/init/init.ts
@@ -15,7 +15,6 @@ import {
   reactRefreshVersion,
   rspackCoreVersion,
   rspackDevServerVersion,
-  rspackPluginMinifyVersion,
   rspackPluginReactRefreshVersion,
   sassEmbeddedVersion,
   sassLoaderVersion,
@@ -88,7 +87,6 @@ export async function rspackInitGenerator(
   const devDependencies = {
     '@rspack/core': rspackCoreVersion,
     '@rspack/cli': rspackCoreVersion,
-    '@rspack/plugin-minify': rspackPluginMinifyVersion,
     '@rspack/plugin-react-refresh': rspackPluginReactRefreshVersion,
     'react-refresh': reactRefreshVersion,
   };

--- a/packages/rspack/src/utils/versions.ts
+++ b/packages/rspack/src/utils/versions.ts
@@ -2,7 +2,6 @@ export const nxVersion = require('../../package.json').version;
 export const rspackCoreVersion = '1.2.2';
 export const rspackDevServerVersion = '1.0.9';
 
-export const rspackPluginMinifyVersion = '^0.7.5';
 export const rspackPluginReactRefreshVersion = '^1.0.0';
 export const lessLoaderVersion = '~11.1.3';
 export const sassLoaderVersion = '^16.0.4';


### PR DESCRIPTION
## Current Behavior
`@nx/rspack` set ups currently install `@rspack/plugin-minify` which has been deprecated. It is also unused in the configurations that are generated.

## Expected Behavior
Remove unused the unused `@rspack/plugin-minify`

## Related Issue(s)

Fixes #30318
