### PR TITLE
fix(angular): include `@angular/google-maps` in package updates

### DIFF
--- a/docs/generated/packages/angular/migrations/20.2.0-package-updates.json
+++ b/docs/generated/packages/angular/migrations/20.2.0-package-updates.json
@@ -37,6 +37,10 @@
       "alwaysAddToPackageJson": false
     },
     "@angular/cdk": { "version": "~19.0.0", "alwaysAddToPackageJson": false },
+    "@angular/google-maps": {
+      "version": "~19.0.0",
+      "alwaysAddToPackageJson": false
+    },
     "ng-packagr": { "version": "~19.0.0", "alwaysAddToPackageJson": false },
     "zone.js": { "version": "~0.15.0", "alwaysAddToPackageJson": false }
   },

--- a/docs/generated/packages/angular/migrations/20.4.0-package-updates.json
+++ b/docs/generated/packages/angular/migrations/20.4.0-package-updates.json
@@ -37,6 +37,10 @@
       "alwaysAddToPackageJson": false
     },
     "@angular/cdk": { "version": "~19.1.0", "alwaysAddToPackageJson": false },
+    "@angular/google-maps": {
+      "version": "~19.1.0",
+      "alwaysAddToPackageJson": false
+    },
     "ng-packagr": { "version": "~19.1.0", "alwaysAddToPackageJson": false }
   },
   "aliases": [],

--- a/docs/generated/packages/angular/migrations/20.5.0-package-updates.json
+++ b/docs/generated/packages/angular/migrations/20.5.0-package-updates.json
@@ -37,6 +37,10 @@
       "alwaysAddToPackageJson": false
     },
     "@angular/cdk": { "version": "~19.2.1", "alwaysAddToPackageJson": false },
+    "@angular/google-maps": {
+      "version": "~19.2.1",
+      "alwaysAddToPackageJson": false
+    },
     "ng-packagr": { "version": "~19.2.0", "alwaysAddToPackageJson": false }
   },
   "aliases": [],

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1341,6 +1341,10 @@
           "version": "~19.0.0",
           "alwaysAddToPackageJson": false
         },
+        "@angular/google-maps": {
+          "version": "~19.0.0",
+          "alwaysAddToPackageJson": false
+        },
         "ng-packagr": {
           "version": "~19.0.0",
           "alwaysAddToPackageJson": false
@@ -1537,6 +1541,10 @@
           "version": "~19.1.0",
           "alwaysAddToPackageJson": false
         },
+        "@angular/google-maps": {
+          "version": "~19.1.0",
+          "alwaysAddToPackageJson": false
+        },
         "ng-packagr": {
           "version": "~19.1.0",
           "alwaysAddToPackageJson": false
@@ -1595,6 +1603,10 @@
           "alwaysAddToPackageJson": false
         },
         "@angular/cdk": {
+          "version": "~19.2.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/google-maps": {
           "version": "~19.2.1",
           "alwaysAddToPackageJson": false
         },

--- a/scripts/angular-support-upgrades/build-migrations.ts
+++ b/scripts/angular-support-upgrades/build-migrations.ts
@@ -42,6 +42,7 @@ async function addMigrationPackageGroup(
         '@angular/core',
         '@angular/material',
         '@angular/cdk',
+        '@angular/google-maps',
         '@angular/ssr',
         '@angular/pwa',
         '@angular/build',

--- a/scripts/angular-support-upgrades/fetch-versions-from-registry.ts
+++ b/scripts/angular-support-upgrades/fetch-versions-from-registry.ts
@@ -30,7 +30,7 @@ const packagesToUpdate: PackageSpec[] = [
   },
   {
     main: '@angular/material',
-    children: ['@angular/cdk'],
+    children: ['@angular/cdk', '@angular/google-maps'],
   },
   'ng-packagr',
 ];


### PR DESCRIPTION
## Current Behavior

The `@angular/google-maps` package version is not updated when running `nx migrate`.

## Expected Behavior

The `@angular/google-maps` package version should be updated when running `nx migrate`.

## Related Issue(s)

Fixes #30523 
