### PR TITLE
fix(rspack): remote applications e2e setup incorrectly #30273

### DIFF
--- a/packages/module-federation/src/utils/get-remotes-for-host.ts
+++ b/packages/module-federation/src/utils/get-remotes-for-host.ts
@@ -78,7 +78,8 @@ export function getRemotes(
   skipRemotes: string[],
   config: ModuleFederationConfig,
   context: ModuleFederationExecutorContext,
-  pathToManifestFile?: string
+  pathToManifestFile?: string,
+  defaultStaticServerPort?: number
 ) {
   const collectedRemotes = new Set<string>();
   const { remotes, dynamicRemotes } = extractRemoteProjectsFromConfig(
@@ -139,17 +140,18 @@ export function getRemotes(
   const remotePorts = [...devServeRemotes, ...staticDynamicRemotes].map(
     (r) => context.projectGraph.nodes[r].data.targets['serve'].options.port
   );
+  const maxPortForRemotes = Math.max(
+    ...([
+      ...remotePorts,
+      ...staticRemotes.map(
+        (r) => context.projectGraph.nodes[r].data.targets['serve'].options.port
+      ),
+    ] as number[])
+  );
   const staticRemotePort =
-    Math.max(
-      ...([
-        ...remotePorts,
-        ...staticRemotes.map(
-          (r) =>
-            context.projectGraph.nodes[r].data.targets['serve'].options.port
-        ),
-      ] as number[])
-    ) +
-    (remotesToSkip.size + 1);
+    staticRemotes.length === 0 && remotePorts.length === 0
+      ? defaultStaticServerPort
+      : maxPortForRemotes + (remotesToSkip.size + 1);
 
   return {
     staticRemotes,

--- a/packages/react/src/generators/application/lib/add-e2e.ts
+++ b/packages/react/src/generators/application/lib/add-e2e.ts
@@ -40,7 +40,7 @@ export async function addE2e(
     e2eCiWebServerCommand: `${getPackageManagerCommand().exec} nx run ${
       options.projectName
     }:serve-static`,
-    e2eCiBaseUrl: `http://localhost:4200`,
+    e2eCiBaseUrl: `http://localhost:${options.devServerPort ?? 4200}`,
     e2eDevServerTarget: `${options.projectName}:serve`,
   };
 

--- a/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -266,6 +266,10 @@ export default async function* moduleFederationStaticServer(
     'react'
   );
 
+  const defaultStaticServerPort =
+    context.projectGraph.nodes[context.projectName].data.targets?.['serve']
+      ?.options?.port ?? 8081;
+
   const remotes = getRemotes(
     [],
     options.serveOptions.skipRemotes,
@@ -275,7 +279,8 @@ export default async function* moduleFederationStaticServer(
       projectGraph: context.projectGraph,
       root: context.root,
     },
-    options.pathToManifestFile
+    options.pathToManifestFile,
+    defaultStaticServerPort
   );
 
   const staticRemotesConfig = parseStaticRemotesConfig(


### PR DESCRIPTION
## Current Behavior
The remote applications that are generated with an e2e project that is incorrectly set up.
There is also an issue in the `@nx/rspack:module-federation-static-server` where the `staticRemotesPort` is incorrectly calculated when the remote has no nested remotes.

## Expected Behavior
Fix the issue in the executor for calculating the staticRemotesPort to ensure it is a valid port.
Ensure the correct port is set in the e2e config file

## Related Issue(s)

Fixes #30273
