### PR TITLE
fix(core): handle windows drive letter in a case-insensitive manner when normalizing paths

### DIFF
--- a/packages/nx/src/utils/path.spec.ts
+++ b/packages/nx/src/utils/path.spec.ts
@@ -3,6 +3,7 @@ import { joinPathFragments, normalizePath } from './path';
 describe('normalizePath', () => {
   it('should remove drive letters', () => {
     expect(normalizePath('C:\\some\\path')).toEqual('/some/path');
+    expect(normalizePath('c:\\some\\path')).toEqual('/some/path');
   });
 
   it('should use unix style path separators', () => {

--- a/packages/nx/src/utils/path.ts
+++ b/packages/nx/src/utils/path.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { workspaceRoot } from './workspace-root';
 
 function removeWindowsDriveLetter(osSpecificPath: string): string {
-  return osSpecificPath.replace(/^[A-Z]:/, '');
+  return osSpecificPath.replace(/^[a-zA-Z]:/, '');
 }
 
 /**


### PR DESCRIPTION
## Current Behavior

The Windows drive letter in paths could have different casing in certain circumstances. The `normalizePath` helper only considers it as PascalCase, which can result in issues when the path drive letter is actually in lowercase.

## Expected Behavior

The `normalizePath` should correctly handle the Windows drive letter regardless of the casing.

## Related Issue(s)

Fixes #28798 
