### PR TITLE
fix(nextjs): bumped to eslintConfigNextVersion to v15

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -3094,6 +3094,16 @@
       }
     },
     "migrations": {
+      "/nx-api/next/migrations/20.7.1-beta.0-package-updates": {
+        "description": "",
+        "file": "generated/packages/next/migrations/20.7.1-beta.0-package-updates.json",
+        "hidden": false,
+        "name": "20.7.1-beta.0-package-updates",
+        "version": "20.7.1-beta.0",
+        "originalFilePath": "/packages/next",
+        "path": "/nx-api/next/migrations/20.7.1-beta.0-package-updates",
+        "type": "migration"
+      },
       "/nx-api/next/migrations/19.0.3-package-updates": {
         "description": "",
         "file": "generated/packages/next/migrations/19.0.3-package-updates.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -3075,6 +3075,16 @@
     "migrations": [
       {
         "description": "",
+        "file": "generated/packages/next/migrations/20.7.1-beta.0-package-updates.json",
+        "hidden": false,
+        "name": "20.7.1-beta.0-package-updates",
+        "version": "20.7.1-beta.0",
+        "originalFilePath": "/packages/next",
+        "path": "next/migrations/20.7.1-beta.0-package-updates",
+        "type": "migration"
+      },
+      {
+        "description": "",
         "file": "generated/packages/next/migrations/19.0.3-package-updates.json",
         "hidden": false,
         "name": "19.0.3-package-updates",

--- a/docs/generated/packages/next/migrations/20.7.1-beta.0-package-updates.json
+++ b/docs/generated/packages/next/migrations/20.7.1-beta.0-package-updates.json
@@ -1,0 +1,17 @@
+{
+  "name": "20.7.1-beta.0-package-updates",
+  "version": "20.7.1-beta.0",
+  "packages": {
+    "eslint-config-next": {
+      "version": "^15.2.4",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/next",
+  "schema": null,
+  "type": "migration"
+}

--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -38,6 +38,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "20.7.1-beta.0": {
+      "version": "20.7.1-beta.0",
+      "packages": {
+        "eslint-config-next": {
+          "version": "^15.2.4",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxVersion = require('../../package.json').version;
 
 export const nextVersion = '~15.1.4';
 export const next14Version = '~14.2.16';
-export const eslintConfigNextVersion = '14.2.16';
+export const eslintConfigNextVersion = '^15.2.4';
 export const sassVersion = '1.62.1';
 export const lessLoader = '11.1.0';
 export const emotionServerVersion = '11.11.0';


### PR DESCRIPTION
Closes #30536

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The current version of eslint-config-next (v14.2.16) has peer dependency conflicts with the latest versions of ESLint (v9.x). This issue causes npm install to fail in projects using eslint-config-next.

## Expected Behavior
`npm install` should succeed without dependency conflicts.

## Related Issue(s)


Fixes #30536
