### PR TITLE
feat(core): run parallel based on the number of cpu cores

### DIFF
--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -1,6 +1,6 @@
 import * as yargs from 'yargs';
 
-import { withAffectedOptions, withRunManyOptions } from './shared-options';
+import { withAffectedOptions, withRunManyOptions, readParallelFromArgsAndEnv } from './shared-options';
 
 const argv = yargs.default([]);
 
@@ -75,6 +75,45 @@ describe('shared-options', () => {
           maxParallel: 2,
         })
       );
+    });
+  });
+
+  describe('readParallelFromArgsAndEnv', () => {
+    it('default parallel should be 3', () => {
+      const result = readParallelFromArgsAndEnv({parallel: 'true'});
+      expect(result).toEqual(3);
+    });
+
+    it('use maxParallel', () => {
+      const result = readParallelFromArgsAndEnv({parallel:'', maxParallel: '4'});
+      expect(result).toEqual(4);
+    });
+
+    it('use max-parallel', () => {
+      const result = readParallelFromArgsAndEnv({parallel:'', 'max-parallel': '5'});
+      expect(result).toEqual(5);
+    });
+
+    it('should read parallel 6', () => {
+      const result = readParallelFromArgsAndEnv({
+        parallel: '6',
+      });
+      expect(result).toEqual(6);
+    });
+
+    it('0% parallel should be 1', () => {
+      const result = readParallelFromArgsAndEnv({
+        parallel: '0%',
+      });
+      expect(result).toEqual(1);
+    });
+
+
+    it('100% parallel should not be less than 1', () => {
+      const result = readParallelFromArgsAndEnv({
+        parallel: '100%',
+      });
+      expect(result).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -1,4 +1,5 @@
 import { Argv, ParserConfigurationOptions } from 'yargs';
+import { cpus } from 'node:os';
 
 interface ExcludeOptions {
   exclude: string[];
@@ -337,16 +338,26 @@ export function readParallelFromArgsAndEnv(args: { [k: string]: any }) {
     args['parallel'] === 'true' ||
     args['parallel'] === true ||
     args['parallel'] === '' ||
-    // dont require passing --parallel if NX_PARALLEL is set, but allow overriding it
+    // don't require passing --parallel if NX_PARALLEL is set, but allow overriding it
     (process.env.NX_PARALLEL && args['parallel'] === undefined)
   ) {
-    return Number(
+    return concurrency(Number(
       args['maxParallel'] ||
         args['max-parallel'] ||
         process.env.NX_PARALLEL ||
-        3
-    );
+        0.5
+    ));
   } else if (args['parallel'] !== undefined) {
-    return Number(args['parallel']);
+    return concurrency(Number(args['parallel']));
   }
+}
+
+function concurrency(parallel: number) {
+  if (parallel > 0) {
+    if ( parallel < 1) {
+      return Math.floor(cpus().length * parallel);
+    }
+    return parallel;
+  }
+  return 1;
 }


### PR DESCRIPTION
BREAKING CHANGE: default parallel changed from 3 to half of the cpu cores

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
can not specify parallel based on the number of cpu cores. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`--parallel 0.5` means half of the cpu cores. 
`--parallel 3` means exact tasks to run in parallel. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

https://github.com/nrwl/nx/discussions/30238
