### PR TITLE
feat(core): add filter for git checkouts in generated pipelines and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - name: Fetch Master
         run: git fetch origin master:master
@@ -105,6 +106,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - name: Fetch Master
         run: git fetch origin master:master
@@ -151,7 +153,7 @@ jobs:
         uses: nrwl/nx-set-shas@v4
         with:
           main-branch-name: 'master'
-        
+
       - name: Run E2E Tests for macOS
         run: |
           HAS_CHANGED=$(node ./scripts/check-react-native-changes.js $NX_BASE $NX_HEAD);

--- a/docs/nx-cloud/enterprise/dte/azure-dte.md
+++ b/docs/nx-cloud/enterprise/dte/azure-dte.md
@@ -33,6 +33,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
         persistCredentials: true
 
       - script: npm ci

--- a/docs/nx-cloud/enterprise/dte/github-dte.md
+++ b/docs/nx-cloud/enterprise/dte/github-dte.md
@@ -40,6 +40,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
+          filter: tree:0
 
       - uses: actions/checkout@v4
         name: Checkout [Default Branch]
@@ -47,6 +48,7 @@ jobs:
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
+          filter: tree:0
 
       # Set node/npm/yarn versions using volta
       - uses: volta-cli/action@v4

--- a/docs/nx-cloud/features/split-e2e-tasks.md
+++ b/docs/nx-cloud/features/split-e2e-tasks.md
@@ -427,6 +427,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: pnpm/action-setup@v4
         with:

--- a/docs/nx-cloud/tutorial/github-actions.md
+++ b/docs/nx-cloud/tutorial/github-actions.md
@@ -72,6 +72,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: pnpm/action-setup@v4
         with:
@@ -207,6 +208,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: pnpm/action-setup@v4
         with:

--- a/docs/shared/features/distribute-task-execution.md
+++ b/docs/shared/features/distribute-task-execution.md
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 

--- a/docs/shared/migration/adding-to-existing-project.md
+++ b/docs/shared/migration/adding-to-existing-project.md
@@ -354,6 +354,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
+
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun

--- a/docs/shared/migration/adding-to-monorepo.md
+++ b/docs/shared/migration/adding-to-monorepo.md
@@ -373,6 +373,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
+
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -176,6 +176,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
+
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun

--- a/docs/shared/monorepo-ci-azure.md
+++ b/docs/shared/monorepo-ci-azure.md
@@ -33,6 +33,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
         persistCredentials: true
 
       # Set Azure Devops CLI default settings

--- a/docs/shared/monorepo-ci-github-actions.md
+++ b/docs/shared/monorepo-ci-github-actions.md
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
+
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/docs/shared/recipes/nx-release/publish-in-ci-cd.md
+++ b/docs/shared/recipes/nx-release/publish-in-ci-cd.md
@@ -134,6 +134,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/docs/shared/tutorials/angular-monorepo.md
+++ b/docs/shared/tutorials/angular-monorepo.md
@@ -1289,6 +1289,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
+
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun

--- a/docs/shared/tutorials/gradle.md
+++ b/docs/shared/tutorials/gradle.md
@@ -350,6 +350,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/docs/shared/tutorials/react-monorepo.md
+++ b/docs/shared/tutorials/react-monorepo.md
@@ -1124,6 +1124,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/docs/shared/tutorials/typescript-packages.md
+++ b/docs/shared/tutorials/typescript-packages.md
@@ -453,6 +453,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
+
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun

--- a/packages/gradle/src/generators/ci-workflow/__snapshots__/generator.spec.ts.snap
+++ b/packages/gradle/src/generators/ci-workflow/__snapshots__/generator.spec.ts.snap
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -140,6 +141,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/packages/gradle/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml.template
+++ b/packages/gradle/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml.template
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -26,6 +26,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -170,6 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -215,6 +217,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -267,6 +270,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -416,6 +420,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v1
@@ -457,6 +462,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v1
@@ -536,6 +542,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -674,6 +681,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -717,6 +725,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -796,6 +805,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -945,6 +955,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -992,6 +1003,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -1077,6 +1089,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -1215,6 +1228,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -1258,6 +1272,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -1337,6 +1352,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -1482,6 +1498,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -1527,6 +1544,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -1579,6 +1597,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -1729,6 +1748,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v1
@@ -1770,6 +1790,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v1
@@ -1849,6 +1870,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -1988,6 +2010,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -2031,6 +2054,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -2110,6 +2134,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -2260,6 +2285,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -2307,6 +2333,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -2392,6 +2419,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'
@@ -2531,6 +2559,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud
@@ -2574,6 +2603,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       # This enables task distribution via Nx Cloud

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -334,6 +334,7 @@ describe('CI Workflow generator', () => {
             steps:
               - uses: actions/checkout@v4
                 with:
+                  filter: tree:0
                   fetch-depth: 0
 
               # This enables task distribution via Nx Cloud
@@ -429,6 +430,7 @@ describe('CI Workflow generator', () => {
             steps:
               - checkout: self
                 fetchDepth: 0
+                fetchFilter: tree:0
               # Set Azure Devops CLI default settings
               - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
                 displayName: 'Set default Azure DevOps organization and project'

--- a/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
@@ -23,6 +23,7 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+        fetchFilter: tree:0
       # Set Azure Devops CLI default settings
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: 'Set default Azure DevOps organization and project'

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -16,7 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          filter: tree:0
           fetch-depth: 0
+
       <% if(packageManager == 'pnpm'){ %>
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
This PR adds Git filter `tree:0` to Azure and GitHub pipelines to avoid fetching the full history content because of the affected command.

The change is made to:
- `ci-workflow` generator in `workspace` project for Azure and GitHub
- `ci-workflow` generator in `gradle` project for GitHub
- this repo's  main pipeline -`ci.yaml`
- all documentation occurrences where fetch depth 0 is used on Azure or GitHub

More info on reasoning here: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
