### PR TITLE
fix(nx-dev): fix blog post links

### DIFF
--- a/docs/blog/2024-09-25-evolving-nx.md
+++ b/docs/blog/2024-09-25-evolving-nx.md
@@ -7,9 +7,9 @@ cover_image: /blog/images/evolving-nx/thumbnail.png
 description: Nx's journey from a side project to a tool for millions, including Nx Cloud and Nx Powerpack developments.
 ---
 
-{% callout type="info" title="Update - March 15th, 2025" %}
+{% callout type="info" title="Update - March 31st, 2025" %}
 
-Self-hosted caching is now free for everyone. Read more [in our blog post](todojs) and in our documentation about [remote caching options with Nx](/remote-cache).
+Self-hosted caching is now free for everyone. Read more [in our blog post](/blog/custom-runners-and-self-hosted-caching) and in our documentation about [remote caching options with Nx](/remote-cache).
 
 {% /callout %}
 

--- a/docs/blog/2024-09-25-introducing-nx-powerpack.md
+++ b/docs/blog/2024-09-25-introducing-nx-powerpack.md
@@ -7,9 +7,9 @@ cover_image: /blog/images/introducing-powerpack/thumbnail.png
 description: Introducing Nx Powerpack, a paid extension suite for enterprise use cases, ensuring Nx remains open source and existing features are free.
 ---
 
-{% callout type="info" title="Update - March 15th, 2025" %}
+{% callout type="info" title="Update - March 31st, 2025" %}
 
-Self-hosted caching is now free for everyone. Read more [in our blog post](todojs) and in our documentation about [remote caching options with Nx](/remote-cache).
+Self-hosted caching is now free for everyone. Read more [in our blog post](/blog/custom-runners-and-self-hosted-caching) and in our documentation about [remote caching options with Nx](/remote-cache).
 
 {% /callout %}
 


### PR DESCRIPTION
Currently, links are broken to the latest Remote Caching blog post on these two pages:
- https://nx.dev/blog/evolving-nx
- https://nx.dev/blog/introducing-nx-powerpack
<img width="885" alt="Screenshot 2025-03-31 at 2 39 38 PM" src="https://github.com/user-attachments/assets/2c6b3667-496a-4c40-b3de-8c7e911e4608" />


This PR fixes those and updates the timestamp to the correct date.

