### PR TITLE
fix(vue): upgrade vite plugin vue to v5 to avoid install errors

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -5839,6 +5839,16 @@
       }
     },
     "migrations": {
+      "/nx-api/vue/migrations/20.7.1-package-updates": {
+        "description": "",
+        "file": "generated/packages/vue/migrations/20.7.1-package-updates.json",
+        "hidden": false,
+        "name": "20.7.1-package-updates",
+        "version": "20.7.1-beta.0",
+        "originalFilePath": "/packages/vue",
+        "path": "/nx-api/vue/migrations/20.7.1-package-updates",
+        "type": "migration"
+      },
       "/nx-api/vue/migrations/19.4.3-package-updates": {
         "description": "",
         "file": "generated/packages/vue/migrations/19.4.3-package-updates.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -5806,6 +5806,16 @@
     "migrations": [
       {
         "description": "",
+        "file": "generated/packages/vue/migrations/20.7.1-package-updates.json",
+        "hidden": false,
+        "name": "20.7.1-package-updates",
+        "version": "20.7.1-beta.0",
+        "originalFilePath": "/packages/vue",
+        "path": "vue/migrations/20.7.1-package-updates",
+        "type": "migration"
+      },
+      {
+        "description": "",
         "file": "generated/packages/vue/migrations/19.4.3-package-updates.json",
         "hidden": false,
         "name": "19.4.3-package-updates",

--- a/docs/generated/packages/vue/migrations/20.7.1-package-updates.json
+++ b/docs/generated/packages/vue/migrations/20.7.1-package-updates.json
@@ -1,0 +1,20 @@
+{
+  "name": "20.7.1-package-updates",
+  "version": "20.7.1-beta.0",
+  "packages": {
+    "vue": { "version": "^3.5.13", "alwaysAddToPackageJson": false },
+    "vue-tsc": { "version": "^2.2.8", "alwaysAddToPackageJson": false },
+    "vue-router": { "version": "^4.5.0", "alwaysAddToPackageJson": false },
+    "@vitejs/plugin-vue": {
+      "version": "^5.2.3",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/vue",
+  "schema": null,
+  "type": "migration"
+}

--- a/packages/vue/migrations.json
+++ b/packages/vue/migrations.json
@@ -1,6 +1,27 @@
 {
   "generators": {},
   "packageJsonUpdates": {
+    "20.7.1": {
+      "version": "20.7.1-beta.0",
+      "packages": {
+        "vue": {
+          "version": "^3.5.13",
+          "alwaysAddToPackageJson": false
+        },
+        "vue-tsc": {
+          "version": "^2.2.8",
+          "alwaysAddToPackageJson": false
+        },
+        "vue-router": {
+          "version": "^4.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@vitejs/plugin-vue": {
+          "version": "^5.2.3",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
     "19.4.3": {
       "version": "19.4.3-beta.0",
       "packages": {

--- a/packages/vue/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/vue/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`init should add vue dependencies 1`] = `
 {
   "dependencies": {
-    "vue": "^3.3.4",
+    "vue": "^3.5.13",
   },
   "devDependencies": {
     "@nx/vue": "0.0.1",

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -157,7 +157,7 @@ export default defineConfig(() => ({
 exports[`library should add vue, vite and vitest to package.json 1`] = `
 {
   "dependencies": {
-    "vue": "^3.3.4",
+    "vue": "^3.5.13",
   },
   "devDependencies": {
     "@nx/cypress": "0.0.1",
@@ -174,12 +174,12 @@ exports[`library should add vue, vite and vitest to package.json 1`] = `
     "@types/node": "18.16.9",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
-    "@vitejs/plugin-vue": "^4.5.0",
+    "@vitejs/plugin-vue": "^5.2.3",
     "@vitest/coverage-v8": "^3.0.5",
     "@vitest/ui": "^3.0.0",
     "@vue/eslint-config-prettier": "7.1.0",
     "@vue/eslint-config-typescript": "^11.0.3",
-    "@vue/test-utils": "^2.4.1",
+    "@vue/test-utils": "^2.4.6",
     "eslint": "~8.57.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-vue": "^9.16.1",
@@ -189,7 +189,7 @@ exports[`library should add vue, vite and vitest to package.json 1`] = `
     "typescript": "~5.7.2",
     "vite": "^6.0.0",
     "vitest": "^3.0.0",
-    "vue-tsc": "^2.0.0",
+    "vue-tsc": "^2.2.8",
   },
   "name": "@proj/source",
 }

--- a/packages/vue/src/utils/versions.ts
+++ b/packages/vue/src/utils/versions.ts
@@ -1,13 +1,13 @@
 export const nxVersion = require('../../package.json').version;
 
 // vue core
-export const vueVersion = '^3.3.4';
-export const vueTscVersion = '^2.0.0';
-export const vueRouterVersion = '^4.2.4';
+export const vueVersion = '^3.5.13';
+export const vueTscVersion = '^2.2.8';
+export const vueRouterVersion = '^4.5.0';
 
 // test deps
-export const vueTestUtilsVersion = '^2.4.1';
-export const vitePluginVueVersion = '^4.5.0';
+export const vueTestUtilsVersion = '^2.4.6';
+export const vitePluginVueVersion = '^5.2.3';
 
 // linting deps
 export const vueEslintConfigPrettierVersion = '7.1.0';


### PR DESCRIPTION
## Current Behavior
After the migration to Vite 6 - The `@vitejs/plugin-vue` was not updated to v5.
This has led to an incorrect peer dependency.

## Expected Behavior
Upgrade `@vitejs/plugin-vue` to version 5 to remove peer dependency issues

## Related Issue(s)

Fixes #30326

