### PR TITLE
fix(angular): use latest version of @analogjs/vitest-angular #30423

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -5609,6 +5609,16 @@
       }
     },
     "migrations": {
+      "/nx-api/vite/migrations/20.7.1-package-updates": {
+        "description": "",
+        "file": "generated/packages/vite/migrations/20.7.1-package-updates.json",
+        "hidden": false,
+        "name": "20.7.1-package-updates",
+        "version": "20.7.1-beta.0",
+        "originalFilePath": "/packages/vite",
+        "path": "/nx-api/vite/migrations/20.7.1-package-updates",
+        "type": "migration"
+      },
       "/nx-api/vite/migrations/update-20-5-0-update-resolve-conditions": {
         "description": "Update resolve.conditions to include defaults that are no longer provided by Vite.",
         "file": "generated/packages/vite/migrations/update-20-5-0-update-resolve-conditions.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -5576,6 +5576,16 @@
     ],
     "migrations": [
       {
+        "description": "",
+        "file": "generated/packages/vite/migrations/20.7.1-package-updates.json",
+        "hidden": false,
+        "name": "20.7.1-package-updates",
+        "version": "20.7.1-beta.0",
+        "originalFilePath": "/packages/vite",
+        "path": "vite/migrations/20.7.1-package-updates",
+        "type": "migration"
+      },
+      {
         "description": "Update resolve.conditions to include defaults that are no longer provided by Vite.",
         "file": "generated/packages/vite/migrations/update-20-5-0-update-resolve-conditions.json",
         "hidden": false,

--- a/docs/generated/packages/vite/migrations/20.7.1-package-updates.json
+++ b/docs/generated/packages/vite/migrations/20.7.1-package-updates.json
@@ -1,0 +1,21 @@
+{
+  "name": "20.7.1-package-updates",
+  "version": "20.7.1-beta.0",
+  "packages": {
+    "@analogjs/vite-plugin-angular": {
+      "version": "~1.14.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@analogjs/vitest-angular": {
+      "version": "~1.14.1",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/vite",
+  "schema": null,
+  "type": "migration"
+}

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -52,6 +52,19 @@
     }
   },
   "packageJsonUpdates": {
+    "20.7.1": {
+      "version": "20.7.1-beta.0",
+      "packages": {
+        "@analogjs/vite-plugin-angular": {
+          "version": "~1.14.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@analogjs/vitest-angular": {
+          "version": "~1.14.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
     "20.5.0": {
       "version": "20.5.0-beta.3",
       "packages": {

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -12,7 +12,7 @@ export const happyDomVersion = '~9.20.3';
 export const edgeRuntimeVmVersion = '~3.0.2';
 export const jitiVersion = '2.4.2';
 
-export const analogVitestAngular = '~1.10.0';
+export const analogVitestAngular = '~1.14.1';
 
 // Coverage providers
 export const vitestCoverageV8Version = '^3.0.5';


### PR DESCRIPTION
## Current Behavior
The version of `@analogjs/vitest-angular` and `@analogjs/vite-plugin-angular` that is installed is `1.10.0`
The latest version is `1.14.1`.

## Expected Behavior
Upgrade to the latest version of the packages.

## Related Issue(s)

Fixes #30423
