### PR TITLE
chore(repo): update gh actions version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - name: Fetch Master
         run: git fetch origin master:master
         if: ${{ github.event_name == 'pull_request' }}
-
 
       - name: Set SHAs
         uses: nrwl/nx-set-shas@v4
@@ -73,7 +73,7 @@ jobs:
         run: |
           pids=()
 
-          pnpm nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD &
+          pnpm nx-cloud record -- nx format:check &
           pids+=($!)
 
           pnpm nx-cloud record -- nx sync:check
@@ -85,7 +85,7 @@ jobs:
           pnpm nx run-many -t check-imports check-commit check-lock-files check-codeowners --parallel=1 --no-dte &
           pids+=($!)
 
-          pnpm nx affected --targets=lint,test,build,e2e,e2e-ci --base=$NX_BASE --head=$NX_HEAD &
+          pnpm nx affected --targets=lint,test,build,e2e,e2e-ci &
           pids+=($!)
 
           for pid in "${pids[@]}"; do
@@ -102,16 +102,17 @@ jobs:
       SELECTED_PM: 'npm'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - name: Fetch Master
         run: git fetch origin master:master
         if: ${{ github.event_name == 'pull_request' }}
 
       - name: Restore Homebrew packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             /usr/local/Homebrew
@@ -126,7 +127,7 @@ jobs:
         timeout-minutes: 20
 
       - name: Save Homebrew Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             /usr/local/Homebrew
@@ -151,7 +152,7 @@ jobs:
         uses: nrwl/nx-set-shas@v4
         with:
           main-branch-name: 'master'
-        
+
       - name: Run E2E Tests for macOS
         run: |
           HAS_CHANGED=$(node ./scripts/check-react-native-changes.js $NX_BASE $NX_HEAD);


### PR DESCRIPTION
This PR bumps the versions of `actions/*` GH actions to latest v4.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
