### PR TITLE
fix(remix): Bump version to handle manifest warning changes

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -4919,6 +4919,16 @@
       }
     },
     "migrations": {
+      "/nx-api/remix/migrations/20.7.1-beta.0-package-updates": {
+        "description": "",
+        "file": "generated/packages/remix/migrations/20.7.1-beta.0-package-updates.json",
+        "hidden": false,
+        "name": "20.7.1-beta.0-package-updates",
+        "version": "20.7.1-beta.0",
+        "originalFilePath": "/packages/remix",
+        "path": "/nx-api/remix/migrations/20.7.1-beta.0-package-updates",
+        "type": "migration"
+      },
       "/nx-api/remix/migrations/20.1.0-package-updates": {
         "description": "",
         "file": "generated/packages/remix/migrations/20.1.0-package-updates.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -4892,6 +4892,16 @@
     "migrations": [
       {
         "description": "",
+        "file": "generated/packages/remix/migrations/20.7.1-beta.0-package-updates.json",
+        "hidden": false,
+        "name": "20.7.1-beta.0-package-updates",
+        "version": "20.7.1-beta.0",
+        "originalFilePath": "/packages/remix",
+        "path": "remix/migrations/20.7.1-beta.0-package-updates",
+        "type": "migration"
+      },
+      {
+        "description": "",
         "file": "generated/packages/remix/migrations/20.1.0-package-updates.json",
         "hidden": false,
         "name": "20.1.0-package-updates",

--- a/docs/generated/packages/remix/migrations/20.7.1-beta.0-package-updates.json
+++ b/docs/generated/packages/remix/migrations/20.7.1-beta.0-package-updates.json
@@ -1,0 +1,74 @@
+{
+  "name": "20.7.1-beta.0-package-updates",
+  "version": "20.7.1-beta.0",
+  "packages": {
+    "@remix-run/node": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/react": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/serve": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/dev": { "version": "^2.16.1", "alwaysAddToPackageJson": false },
+    "@remix-run/css-bundle": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/eslint-config": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/server-runtime": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/testing": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/express": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/cloudflare": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/cloudflare-pages": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/cloudflare-workers": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/architect": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/deno": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/route-config": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@remix-run/fs-routes": {
+      "version": "^2.16.1",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/remix",
+  "schema": null,
+  "type": "migration"
+}

--- a/packages/remix/migrations.json
+++ b/packages/remix/migrations.json
@@ -200,6 +200,75 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "20.7.1-beta.0": {
+      "version": "20.7.1-beta.0",
+      "packages": {
+        "@remix-run/node": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/react": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/serve": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/dev": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/css-bundle": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/eslint-config": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/server-runtime": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/testing": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/express": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/cloudflare": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/cloudflare-pages": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/cloudflare-workers": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/architect": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/deno": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/route-config": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@remix-run/fs-routes": {
+          "version": "^2.16.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -482,15 +482,15 @@ describe('Remix Application', () => {
       expect(packageJson).toMatchInlineSnapshot(`
         {
           "dependencies": {
-            "@remix-run/node": "^2.15.0",
-            "@remix-run/react": "^2.15.0",
-            "@remix-run/serve": "^2.15.0",
+            "@remix-run/node": "^2.16.1",
+            "@remix-run/react": "^2.16.1",
+            "@remix-run/serve": "^2.16.1",
             "isbot": "^4.4.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
           },
           "devDependencies": {
-            "@remix-run/dev": "^2.15.0",
+            "@remix-run/dev": "^2.16.1",
             "@types/react": "^18.2.0",
             "@types/react-dom": "^18.2.0",
           },
@@ -699,15 +699,15 @@ describe('Remix Application', () => {
       expect(readJson(tree, 'apps/myapp/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {
-            "@remix-run/node": "^2.15.0",
-            "@remix-run/react": "^2.15.0",
-            "@remix-run/serve": "^2.15.0",
+            "@remix-run/node": "^2.16.1",
+            "@remix-run/react": "^2.16.1",
+            "@remix-run/serve": "^2.16.1",
             "isbot": "^4.4.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
           },
           "devDependencies": {
-            "@remix-run/dev": "^2.15.0",
+            "@remix-run/dev": "^2.16.1",
             "@types/react": "^18.2.0",
             "@types/react-dom": "^18.2.0",
           },

--- a/packages/remix/src/generators/init/init.spec.ts
+++ b/packages/remix/src/generators/init/init.spec.ts
@@ -18,13 +18,13 @@ describe('Remix Init Generator', () => {
     const pkgJson = readJson(tree, 'package.json');
     expect(pkgJson.dependencies).toMatchInlineSnapshot(`
       {
-        "@remix-run/serve": "^2.15.0",
+        "@remix-run/serve": "^2.16.1",
       }
     `);
     expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
       {
         "@nx/web": "0.0.1",
-        "@remix-run/dev": "^2.15.0",
+        "@remix-run/dev": "^2.16.1",
       }
     `);
 
@@ -72,13 +72,13 @@ describe('Remix Init Generator', () => {
       const pkgJson = readJson(tree, 'package.json');
       expect(pkgJson.dependencies).toMatchInlineSnapshot(`
         {
-          "@remix-run/serve": "^2.15.0",
+          "@remix-run/serve": "^2.16.1",
         }
       `);
       expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
         {
           "@nx/web": "0.0.1",
-          "@remix-run/dev": "^2.15.0",
+          "@remix-run/dev": "^2.16.1",
         }
       `);
     });

--- a/packages/remix/src/utils/versions.ts
+++ b/packages/remix/src/utils/versions.ts
@@ -2,7 +2,7 @@ import { readJson, Tree } from '@nx/devkit';
 
 export const nxVersion = require('../../package.json').version;
 
-export const remixVersion = '^2.15.0';
+export const remixVersion = '^2.16.1';
 export const isbotVersion = '^4.4.0';
 export const reactVersion = '^18.2.0';
 export const reactDomVersion = '^18.2.0';


### PR DESCRIPTION
Bump version to 2.16.1 or greater to handle remix manifest warning inside the terminal if users are on 2.16.0

```shell
6:23:37 PM [vite] (client) warning: Failed to resolve "remix:manifest" from /Users/tmac/tmp/thing/node_modules/.vite/deps/@remix-run_react.js?v=5ceadf52. 
An id should be written. Did you pass a URL?
````
