### PR TITLE
fix(angular): remove deprecated standaloneConfig from generators

### DIFF
--- a/docs/generated/packages/angular/generators/application.json
+++ b/docs/generated/packages/angular/generators/application.json
@@ -127,12 +127,6 @@
         "description": "Create an application with stricter type checking and build optimization options.",
         "default": true
       },
-      "standaloneConfig": {
-        "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-        "type": "boolean",
-        "default": true,
-        "x-deprecated": "Nx only supports standaloneConfig"
-      },
       "port": {
         "type": "number",
         "description": "The port at which the remote application should be served."

--- a/docs/generated/packages/angular/generators/host.json
+++ b/docs/generated/packages/angular/generators/host.json
@@ -141,12 +141,6 @@
         "description": "Create an application with stricter type checking and build optimization options.",
         "default": true
       },
-      "standaloneConfig": {
-        "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-        "type": "boolean",
-        "default": true,
-        "x-deprecated": "Nx only supports standaloneConfig"
-      },
       "setParserOptionsProject": {
         "type": "boolean",
         "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",

--- a/docs/generated/packages/angular/generators/library.json
+++ b/docs/generated/packages/angular/generators/library.json
@@ -108,12 +108,6 @@
         "enum": ["eslint", "none"],
         "default": "eslint"
       },
-      "standaloneConfig": {
-        "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-        "type": "boolean",
-        "default": true,
-        "x-deprecated": "Nx only supports standaloneConfig"
-      },
       "compilationMode": {
         "description": "Specifies the compilation mode to use. If not specified, it will default to `partial` for publishable libraries and to `full` for buildable libraries. The `full` value can not be used for publishable libraries.",
         "type": "string",

--- a/docs/generated/packages/angular/generators/remote.json
+++ b/docs/generated/packages/angular/generators/remote.json
@@ -135,12 +135,6 @@
         "description": "Create an application with stricter type checking and build optimization options.",
         "default": true
       },
-      "standaloneConfig": {
-        "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-        "type": "boolean",
-        "default": true,
-        "x-deprecated": "Nx only supports standaloneConfig"
-      },
       "setParserOptionsProject": {
         "type": "boolean",
         "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -20,7 +20,6 @@ export interface Schema {
   e2eTestRunner?: E2eTestRunner;
   backendProject?: string;
   strict?: boolean;
-  standaloneConfig?: boolean;
   port?: number;
   setParserOptionsProject?: boolean;
   skipPackageJson?: boolean;

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -130,12 +130,6 @@
       "description": "Create an application with stricter type checking and build optimization options.",
       "default": true
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "port": {
       "type": "number",
       "description": "The port at which the remote application should be served."

--- a/packages/angular/src/generators/host/schema.d.ts
+++ b/packages/angular/src/generators/host/schema.d.ts
@@ -20,7 +20,6 @@ export interface Schema {
   e2eTestRunner?: E2eTestRunner;
   backendProject?: string;
   strict?: boolean;
-  standaloneConfig?: boolean;
   inlineStyle?: boolean;
   inlineTemplate?: boolean;
   viewEncapsulation?: 'Emulated' | 'Native' | 'None';

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -144,12 +144,6 @@
       "description": "Create an application with stricter type checking and build optimization options.",
       "default": true
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "setParserOptionsProject": {
       "type": "boolean",
       "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",

--- a/packages/angular/src/generators/library/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/library/lib/normalized-schema.ts
@@ -13,7 +13,6 @@ export interface NormalizedSchema {
     buildable?: boolean;
     publishable?: boolean;
     importPath?: string;
-    standaloneConfig?: boolean;
     spec?: boolean;
     commonModule?: boolean;
     routing?: boolean;

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -12,7 +12,6 @@ export interface Schema {
   buildable?: boolean;
   publishable?: boolean;
   importPath?: string;
-  standaloneConfig?: boolean;
   spec?: boolean;
   flat?: boolean;
   commonModule?: boolean;

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -108,12 +108,6 @@
       "enum": ["eslint", "none"],
       "default": "eslint"
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "compilationMode": {
       "description": "Specifies the compilation mode to use. If not specified, it will default to `partial` for publishable libraries and to `full` for buildable libraries. The `full` value can not be used for publishable libraries.",
       "type": "string",

--- a/packages/angular/src/generators/remote/schema.d.ts
+++ b/packages/angular/src/generators/remote/schema.d.ts
@@ -19,7 +19,6 @@ export interface Schema {
   e2eTestRunner?: E2eTestRunner;
   backendProject?: string;
   strict?: boolean;
-  standaloneConfig?: boolean;
   inlineStyle?: boolean;
   inlineTemplate?: boolean;
   viewEncapsulation?: 'Emulated' | 'Native' | 'None';

--- a/packages/angular/src/generators/remote/schema.json
+++ b/packages/angular/src/generators/remote/schema.json
@@ -138,12 +138,6 @@
       "description": "Create an application with stricter type checking and build optimization options.",
       "default": true
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "setParserOptionsProject": {
       "type": "boolean",
       "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",


### PR DESCRIPTION
## Current Behavior
The `standaloneConfig` option has long been deprecated as it is the only behaviour that Nx now provides.
Using it is a no-op.

## Expected Behavior
Remove the `standaloneConfig` option.

