### PR TITLE
cleanup(js): fix outdated unit test snapshot

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1242,7 +1242,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "cwd": "libs/my-lib",
                     },
                     "outputs": [
-                      "{projectRoot}/dist",
+                      "{projectRoot}/dist/**/*.d.ts",
+                      "{projectRoot}/dist/tsconfig.tsbuildinfo",
                     ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",


### PR DESCRIPTION
Updates a unit test snapshot that got out of date when multiple PRs were merged close to each other without rebasing the last one.

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
