### PR TITLE
fix(vite): ensure nxCopyAssetsPlugin outputs assets to correct location #28786

### DIFF
--- a/packages/vite/plugins/nx-copy-assets.plugin.ts
+++ b/packages/vite/plugins/nx-copy-assets.plugin.ts
@@ -31,7 +31,9 @@ export function nxCopyAssetsPlugin(_assets: (string | AssetGlob)[]): Plugin {
       handler = new CopyAssetsHandler({
         rootDir: workspaceRoot,
         projectDir: config.root,
-        outputDir: join(config.root, config.build.outDir),
+        outputDir: config.build.outDir.startsWith(config.root)
+          ? config.build.outDir
+          : join(config.root, config.build.outDir),
         assets,
       });
       if (this.meta.watchMode && isDaemonEnabled()) {


### PR DESCRIPTION
## Current Behavior
The `nxCopyAssetsPlugin` from `@nx/vite` does not output the asset files to the correct location. 
It prepends the `rootDir` even when the `outDir` in the `vite.config` resolves to contain the `rootDir`.

## Expected Behavior
Only prepend the `rootDir` when it does not already exist

## Related Issue(s)

Fixes #28786
