### PR TITLE
fix(nextjs): add eslint plugin dependencies in application and library generators

### DIFF
--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -99,6 +99,7 @@ export async function addLinting(
       addDependenciesToPackageJson(host, extraEslintDependencies.dependencies, {
         ...extraEslintDependencies.devDependencies,
         'eslint-config-next': eslintConfigNextVersion,
+        '@next/eslint-plugin-next': eslintConfigNextVersion,
       })
     );
   }

--- a/packages/next/src/generators/application/lib/normalize-options.ts
+++ b/packages/next/src/generators/application/lib/normalize-options.ts
@@ -93,6 +93,7 @@ export async function normalizeOptions(
     projectName: appProjectName,
     projectSimpleName: projectNames.projectSimpleName,
     style: options.style || 'css',
+    swc: options.swc ?? true,
     styledModule,
     unitTestRunner: options.unitTestRunner || 'jest',
     importPath,

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -60,6 +60,7 @@ export async function libraryGeneratorInternal(host: Tree, rawOptions: Schema) {
     const devDependencies: Record<string, string> = {};
     if (options.linter === 'eslint') {
       devDependencies['eslint-config-next'] = eslintConfigNextVersion;
+      devDependencies['@next/eslint-plugin-next'] = eslintConfigNextVersion;
     }
 
     if (options.unitTestRunner && options.unitTestRunner !== 'none') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, `eslint-config-next` which is a next package requires `@nx/eslint-plugin-next` 
Also when you create a next application from `create-nx-workspace` you get neither `swc` nor `babelrc` which is unintended.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When you create a next application OOTB with jest and linting they should work without issues.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #26823
