### PR TITLE
feat: Liberate Remote Cache

### DIFF
--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -416,6 +416,15 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
     libsDir?: string;
     appsDir?: string;
   };
+
+  /**
+   * Remote Cache configuration
+   */
+  remoteCache?: {
+    provider?: string;
+    options?: any;
+  };
+
   /**
    * @deprecated Custom task runners will be replaced by a new API starting with Nx 21. More info: https://nx.dev/deprecated/custom-tasks-runner
    * Available Task Runners for Nx to use

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -235,49 +235,24 @@ export class DbCache {
         // old nx cloud instance
         return await RemoteCacheV2.fromCacheV1(this.options.nxCloudRemoteCache);
       }
-    } else {
+    } else if (nxJson.remoteCache?.provider) {
       return (
-        (await this.getS3Cache()) ??
-        (await this.getSharedCache()) ??
-        (await this.getGcsCache()) ??
-        (await this.getAzureCache()) ??
+        (await this.resolveRemoteCache(nxJson.remoteCache?.provider, nxJson.remoteCache?.options)) ??
         null
       );
     }
+
+    return null;
   }
 
-  private async getS3Cache(): Promise<RemoteCacheV2 | null> {
-    const cache = await this.resolveRemoteCache('@nx/s3-cache');
-    if (cache) return cache;
-    return this.resolveRemoteCache('@nx/powerpack-s3-cache');
-  }
-
-  private async getSharedCache(): Promise<RemoteCacheV2 | null> {
-    const cache = await this.resolveRemoteCache('@nx/shared-fs-cache');
-    if (cache) return cache;
-    return this.resolveRemoteCache('@nx/powerpack-shared-fs-cache');
-  }
-
-  private async getGcsCache(): Promise<RemoteCacheV2 | null> {
-    const cache = await this.resolveRemoteCache('@nx/gcs-cache');
-    if (cache) return cache;
-    return this.resolveRemoteCache('@nx/powerpack-gcs-cache');
-  }
-
-  private async getAzureCache(): Promise<RemoteCacheV2 | null> {
-    const cache = await this.resolveRemoteCache('@nx/azure-cache');
-    if (cache) return cache;
-    return this.resolveRemoteCache('@nx/powerpack-azure-cache');
-  }
-
-  private async resolveRemoteCache(pkg: string): Promise<RemoteCacheV2 | null> {
+  private async resolveRemoteCache(pkg: string, options: any = {}): Promise<RemoteCacheV2 | null> {
     let getRemoteCache = null;
     try {
       getRemoteCache = (await import(this.resolvePackage(pkg))).getRemoteCache;
     } catch {
       return null;
     }
-    return getRemoteCache();
+    return getRemoteCache(options);
   }
 
   private resolvePackage(pkg: string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
NX allows only specific NX packages to provide RemoteCacheV2 API, forcing users to agree on licensing or (in the future) implement own Cache Service.

## Expected Behavior

Users can specify package of their choice that provides RemoteCacheV2 API without forcing them to implementing Cache Service or agreeing on licensing.

## Motivation

https://nx.dev/blog/custom-runners-and-self-hosted-caching

> Our commitment is that no major open-source feature or API will be replaced with a non-open-source alternative. Some features will inevitably become obsolete over time, but when that happens, we will provide clear deprecation notices and migration strategies. Nx will continue to evolve, but removing an old API will never be a means to move users toward a paid feature.

> We will keep developing Nx Cloud and other premium offerings for teams that need enterprise-scale solutions, but we remain focused on a strong open-source foundation that allows teams to use and scale Nx without requiring paid features.

> Nx open-source remains a primary focus for us as a company.

## Related Issue(s)

Fixes: https://github.com/nrwl/nx/discussions/30548
