### PR TITLE
fix(webpack): enable legacy decorators and metadata in base config for compatibility

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -424,6 +424,8 @@ function applyNxDependentConfig(
               tsx: true,
             },
             transform: {
+              legacyDecorator: true,
+              decoratorMetadata: true,
               react: {
                 runtime: 'automatic',
                 pragma: 'React.createElement',

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
@@ -20,6 +20,8 @@ export function createLoaderFromCompiler(
               tsx: true,
             },
             transform: {
+              legacyDecorator: true,
+              decoratorMetadata: true,
               react: {
                 runtime: 'automatic',
               },


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
This PR fixes a runtime error in our NestJS application:

```
TypeError: Cannot read properties of undefined (reading 'get')
```
The root cause was that services were not being injected correctly due to missing metadata reflection, which NestJS relies on for its dependency injection system to resolve services.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We now fully support NestJS's DI system by adding:

```ts
transform: {
  legacyDecorator: true,
  decoratorMetadata: true,
}
```
This restores proper behavior, and services are injected as expected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29136
