### PR TITLE
fix(module-federation): enhance remote entry handling with query parameters in paths

### DIFF
--- a/e2e/react/src/module-federation/core.rspack.test.ts
+++ b/e2e/react/src/module-federation/core.rspack.test.ts
@@ -5,6 +5,7 @@ import {
   killPorts,
   killProcessAndPorts,
   newProject,
+  readJson,
   runCLIAsync,
   runCommandUntil,
   runE2ETests,
@@ -227,5 +228,63 @@ describe('React Rspack Module Federation', () => {
         remotePort
       );
     }, 500_000);
+    it('should preserve remotes with query params in the path', async () => {
+      const shell = uniq('shell');
+      const remote1 = uniq('remote1');
+
+      runCLI(
+        `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1} --bundler=rspack --e2eTestRunner=none --style=css --no-interactive --skipFormat`
+      );
+
+      // Update the remote entry to include query params
+      updateFile(`apps/${shell}/module-federation.config.ts`, (content) =>
+        content.replace(
+          `"${remote1}"`,
+          `['${remote1}', 'http://localhost:4201/remoteEntry.js?param=value']`
+        )
+      );
+
+      runCLI(`run ${shell}:build:production`);
+
+      // Check the artifact in dist for the remote
+      const manifestJson = readJson(`dist/apps/${shell}/mf-manifest.json`);
+      const remoteEntry = manifestJson.remotes[0]; // There should be only one remote
+
+      expect(remoteEntry).toBeDefined();
+      expect(remoteEntry.entry).toContain(
+        'http://localhost:4201/remoteEntry.js?param=value'
+      );
+      expect(manifestJson.remotes).toMatchInlineSnapshot(`
+        [
+          {
+            "alias": "${remote1}",
+            "entry": "http://localhost:4201/remoteEntry.js?param=value",
+            "federationContainerName": "${remote1}",
+            "moduleName": "Module",
+          },
+        ]
+      `);
+
+      // Update the remote entry to include new query params without remoteEntry.js
+      updateFile(`apps/${shell}/module-federation.config.ts`, (content) =>
+        content.replace(
+          'http://localhost:4201/remoteEntry.js?param=value',
+          'http://localhost:4201?param=newValue'
+        )
+      );
+
+      runCLI(`run ${shell}:build:production`);
+
+      // Check the artifact in dist for the remote
+      const manifestJsonUpdated = readJson(
+        `dist/apps/${shell}/mf-manifest.json`
+      );
+      const remoteEntryUpdated = manifestJsonUpdated.remotes[0]; // There should be only one remote
+
+      expect(remoteEntryUpdated).toBeDefined();
+      expect(remoteEntryUpdated.entry).toContain(
+        'http://localhost:4201/remoteEntry.js?param=newValue'
+      );
+    });
   });
 });

--- a/e2e/react/src/module-federation/core.webpack.test.ts
+++ b/e2e/react/src/module-federation/core.webpack.test.ts
@@ -5,6 +5,7 @@ import {
   killPorts,
   killProcessAndPorts,
   newProject,
+  readJson,
   runCLIAsync,
   runCommandUntil,
   runE2ETests,
@@ -186,6 +187,65 @@ describe('React Module Federation', () => {
         await killProcessAndPorts(e2eResultsTsNode.pid, readPort(shell));
       }
     }, 500_000);
+
+    it('should preserve remotes with query params in the path', async () => {
+      const shell = uniq('shell');
+      const remote1 = uniq('remote1');
+
+      runCLI(
+        `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1} --bundler=webpack --e2eTestRunner=none --style=css --no-interactive --skipFormat`
+      );
+
+      // Update the remote entry to include query params at the end with remoteEntry in path
+      updateFile(`apps/${shell}/webpack.config.prod.ts`, (content) =>
+        content.replace(
+          `'http://localhost:4201/'`,
+          `'http://localhost:4201/remoteEntry.js?param=value'`
+        )
+      );
+
+      runCLI(`run ${shell}:build:production`);
+
+      // Check the artifact in dist for the remote
+      const manifestJson = readJson(`dist/apps/${shell}/mf-manifest.json`);
+      const remoteEntry = manifestJson.remotes[0];
+
+      expect(remoteEntry).toBeDefined();
+      expect(remoteEntry.entry).toContain(
+        'http://localhost:4201/remoteEntry.js?param=value'
+      );
+      expect(manifestJson.remotes).toMatchInlineSnapshot(`
+        [
+          {
+            "alias": "${remote1}",
+            "entry": "http://localhost:4201/remoteEntry.js?param=value",
+            "federationContainerName": "${remote1}",
+            "moduleName": "Module",
+          },
+        ]
+      `);
+
+      // Update the remote entry to include query params at the end without remoteEntry in path
+      updateFile(`apps/${shell}/webpack.config.prod.ts`, (content) =>
+        content.replace(
+          `'http://localhost:4201/remoteEntry.js?param=value'`,
+          `'http://localhost:4201?param=newValue'`
+        )
+      );
+
+      runCLI(`run ${shell}:build:production`);
+
+      // Check the artifact in dist for the remote
+      const manifestJsonUpdated = readJson(
+        `dist/apps/${shell}/mf-manifest.json`
+      );
+      const remoteEntryUpdated = manifestJsonUpdated.remotes[0]; // There should be only one remote
+
+      expect(remoteEntryUpdated).toBeDefined();
+      expect(remoteEntryUpdated.entry).toContain(
+        'http://localhost:4201/remoteEntry.js?param=newValue'
+      );
+    });
 
     describe('ssr', () => {
       it('should generate host and remote apps with ssr', async () => {

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
@@ -6,7 +6,6 @@ import {
   NxModuleFederationConfigOverride,
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
-import { type ExecutorContext } from '@nx/devkit';
 
 const isVarOrWindow = (libType?: string) =>
   libType === 'var' || libType === 'window';

--- a/packages/react/mf/dynamic-federation.ts
+++ b/packages/react/mf/dynamic-federation.ts
@@ -1,3 +1,5 @@
+import { extname } from 'node:path';
+
 export type ResolveRemoteUrlFunction = (
   remoteName: string
 ) => string | Promise<string>;
@@ -158,12 +160,18 @@ async function loadRemoteContainer(remoteName: string) {
     ? remoteUrlDefinitions[remoteName]
     : await resolveRemoteUrl(remoteName);
 
-  let containerUrl = remoteUrl;
-  if (!remoteUrl.endsWith('.mjs') && !remoteUrl.endsWith('.js')) {
-    containerUrl = `${remoteUrl}${
-      remoteUrl.endsWith('/') ? '' : '/'
-    }remoteEntry.js`;
+  const url = new URL(remoteUrl);
+  const ext = extname(url.pathname);
+
+  const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
+
+  if (needsRemoteEntry) {
+    url.pathname = url.pathname.endsWith('/')
+      ? `${url.pathname}remoteEntry.mjs`
+      : `${url.pathname}/remoteEntry.mjs`;
   }
+
+  const containerUrl = url.href;
 
   const container = await fetchRemoteModule(containerUrl, remoteName);
   await container.init(__webpack_share_scopes__.default);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
In Module Federation apps, when remotes are defined using URLs that include query string or hash fragments (e.g. for cache busting), those params are not preserved after the application is built.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This PR ensures that query strings and hash fragments are preserved when resolving or generating remote URLs. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30602
