### PR TITLE
feat(core)!: drop support for create nodes v1 in favor of only calling create nodes v2

### DIFF
--- a/e2e/plugin/src/nx-plugin.fixtures.ts
+++ b/e2e/plugin/src/nx-plugin.fixtures.ts
@@ -20,7 +20,7 @@ export default async function* execute(
 `;
 
 export const NX_PLUGIN_V2_CONTENTS = `import { basename, dirname } from "path";
-import { CreateNodes, CreateMetadata, ProjectsMetadata } from "@nx/devkit";
+import { CreateNodesV2, CreateMetadata, ProjectsMetadata } from "@nx/devkit";
 
 type PluginOptions = {
     inferredTags: string[]
@@ -38,32 +38,40 @@ export const createMetadata: CreateMetadata = (graph) => {
   return metadata;
 }
 
-export const createNodes: CreateNodes<PluginOptions> = [
-    "**/my-project-file",
-    (f, options, ctx) => {
-        // f = path/to/my/file/my-project-file
-        const root = dirname(f);
-        // root = path/to/my/file
-        const name = basename(root);
-        // name = file
+export const createNodesV2: CreateNodesV2<PluginOptions> = [
+  "**/my-project-file",
+  (files, options, ctx) => {
+    const results = [];
+    for (const f of files) {
+      // f = path/to/my/file/my-project-file
+      const root = dirname(f);
+      // root = path/to/my/file
+      const name = basename(root);
+      // name = file
 
-        return {
-            projects: {
-                [root]: {
-                    root,
-                    name,
-                    targets: {
-                        build: {
-                            executor: "nx:run-commands",
-                            options: {
-                                command: "echo 'custom registered target'",
-                            },
-                        },
-                    },
-                    tags: options.inferredTags
+      results.push([
+        f,
+        {
+          projects: {
+            [root]: {
+              root,
+              name,
+              targets: {
+                build: {
+                  executor: "nx:run-commands",
+                  options: {
+                    command: "echo 'custom registered target'",
+                  },
                 },
+              },
+              tags: options.inferredTags,
             },
-        };
-    },
+          },
+        },
+      ]);
+    }
+    return results;
+  },
 ];
+
 `;

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -8,8 +8,8 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
-import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
-import { createNodes } from '../../plugins/plugin';
+import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
+import { createNodesV2 } from '../../plugins/plugin';
 import { detoxVersion, nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -33,11 +33,11 @@ export async function detoxInitGeneratorInternal(host: Tree, schema: Schema) {
   }
 
   if (schema.addPlugin) {
-    await addPluginV1(
+    await addPlugin(
       host,
       await createProjectGraphAsync(),
       '@nx/detox/plugin',
-      createNodes,
+      createNodesV2,
       {
         buildTargetName: ['build', 'detox:build', 'detox-build'],
         startTargetName: ['start', 'detox:start', 'detox-start'],

--- a/packages/expo/src/generators/init/init.ts
+++ b/packages/expo/src/generators/init/init.ts
@@ -8,8 +8,8 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
-import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
-import { createNodes } from '../../../plugins/plugin';
+import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
+import { createNodesV2 } from '../../../plugins/plugin';
 import {
   expoCliVersion,
   expoVersion,
@@ -36,11 +36,11 @@ export async function expoInitGeneratorInternal(host: Tree, schema: Schema) {
   addGitIgnoreEntry(host);
 
   if (schema.addPlugin) {
-    await addPluginV1(
+    await addPlugin(
       host,
       await createProjectGraphAsync(),
       '@nx/expo/plugin',
-      createNodes,
+      createNodesV2,
       {
         startTargetName: ['start', 'expo:start', 'expo-start'],
         buildTargetName: ['build', 'expo:build', 'expo-build'],

--- a/packages/nuxt/plugin.ts
+++ b/packages/nuxt/plugin.ts
@@ -1,1 +1,5 @@
-export { createNodes, NuxtPluginOptions } from './src/plugins/plugin';
+export {
+  createNodes,
+  createNodesV2,
+  NuxtPluginOptions,
+} from './src/plugins/plugin';

--- a/packages/nuxt/src/generators/init/init.ts
+++ b/packages/nuxt/src/generators/init/init.ts
@@ -1,16 +1,16 @@
 import { createProjectGraphAsync, GeneratorCallback, Tree } from '@nx/devkit';
-import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
+import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
 
-import { createNodes } from '../../plugins/plugin';
+import { createNodesV2 } from '../../plugins/plugin';
 import { InitSchema } from './schema';
 import { updateDependencies } from './lib/utils';
 
 export async function nuxtInitGenerator(host: Tree, schema: InitSchema) {
-  await addPluginV1(
+  await addPlugin(
     host,
     await createProjectGraphAsync(),
     '@nx/nuxt/plugin',
-    createNodes,
+    createNodesV2,
     {
       buildTargetName: ['build', 'nuxt:build', 'nuxt-build'],
       serveTargetName: ['serve', 'nuxt:serve', 'nuxt-serve'],

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -3,6 +3,8 @@ import {
   CreateDependencies,
   CreateNodes,
   CreateNodesContext,
+  createNodesFromFiles,
+  CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
   readJsonFile,
@@ -40,11 +42,6 @@ function writeTargetsToCache() {
   });
 }
 
-export const createDependencies: CreateDependencies = () => {
-  writeTargetsToCache();
-  return [];
-};
-
 export interface NuxtPluginOptions {
   buildTargetName?: string;
   serveTargetName?: string;
@@ -53,6 +50,21 @@ export interface NuxtPluginOptions {
   buildDepsTargetName?: string;
   watchDepsTargetName?: string;
 }
+
+export const createNodesV2: CreateNodesV2<NuxtPluginOptions> = [
+  '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',
+  async (files, options, context) => {
+    //TODO(@nrwl/nx-vue-reviewers): This should batch hashing like our other plugins.
+    const result = await createNodesFromFiles(
+      createNodes[1],
+      files,
+      options,
+      context
+    );
+    writeTargetsToCache();
+    return result;
+  },
+];
 
 export const createNodes: CreateNodes<NuxtPluginOptions> = [
   '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',

--- a/packages/nx/src/adapter/angular-json.ts
+++ b/packages/nx/src/adapter/angular-json.ts
@@ -14,6 +14,17 @@ export const NxAngularJsonPlugin: NxPluginV2 = {
       projects: readAngularJson(ctx.workspaceRoot),
     }),
   ],
+  createNodesV2: [
+    'angular.json',
+    (f, _, ctx) => [
+      [
+        'angular.json',
+        {
+          projects: readAngularJson(ctx.workspaceRoot),
+        },
+      ],
+    ],
+  ],
 };
 
 export default NxAngularJsonPlugin;

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -8,6 +8,8 @@ import {
   CreateDependencies,
   CreateDependenciesContext,
   CreateNodes,
+  createNodesFromFiles,
+  CreateNodesV2,
 } from '../../project-graph/plugins';
 import {
   getLockFileDependencies,
@@ -33,6 +35,13 @@ interface ParsedLockFile {
 }
 
 let parsedLockFile: ParsedLockFile = {};
+
+export const createNodesV2: CreateNodesV2 = [
+  combineGlobPatterns(LOCKFILES),
+  (files, _, context) => {
+    return createNodesFromFiles(createNodes[1], files, _, context);
+  },
+];
 
 export const createNodes: CreateNodes = [
   // Look for all lockfiles

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -59,19 +59,6 @@ export class LoadedNxPlugin {
       this.exclude = pluginDefinition.exclude;
     }
 
-    if (plugin.createNodes && !plugin.createNodesV2) {
-      this.createNodes = [
-        plugin.createNodes[0],
-        (configFiles, context) =>
-          createNodesFromFiles(
-            plugin.createNodes[1],
-            configFiles,
-            this.options,
-            context
-          ).then((results) => results.map((r) => [this.name, r[0], r[1]])),
-      ];
-    }
-
     if (plugin.createNodesV2) {
       this.createNodes = [
         plugin.createNodesV2[0],

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -59,6 +59,12 @@ export class LoadedNxPlugin {
       this.exclude = pluginDefinition.exclude;
     }
 
+    if (plugin.createNodes && !plugin.createNodesV2) {
+      throw new Error(
+        `Plugin ${plugin.name} only provides \`createNodes\` which was removed in Nx 21, it should provide a \`createNodesV2\` implementation.`
+      );
+    }
+
     if (plugin.createNodesV2) {
       this.createNodes = [
         plugin.createNodesV2[0],

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -14,7 +14,7 @@ import {
   readProjectConfigurationsFromRootMap,
   readTargetDefaultsForTarget,
 } from './project-configuration-utils';
-import { NxPluginV2 } from '../plugins';
+import { createNodesFromFiles, NxPluginV2 } from '../plugins';
 import { LoadedNxPlugin } from '../plugins/loaded-nx-plugin';
 import { dirname } from 'path';
 import { isProjectConfigurationsError } from '../error-types';
@@ -1712,63 +1712,81 @@ describe('project-configuration-utils', () => {
     /* A fake plugin that sets `fake-lib` tag to libs. */
     const fakeTagPlugin: NxPluginV2 = {
       name: 'fake-tag-plugin',
-      createNodes: [
+      createNodesV2: [
         'libs/*/project.json',
-        (vitestConfigPath) => {
-          const [_libs, name, _config] = vitestConfigPath.split('/');
-          return {
-            projects: {
-              [name]: {
-                name: name,
-                root: `libs/${name}`,
-                tags: ['fake-lib'],
-              },
+        (vitestConfigPaths) =>
+          createNodesFromFiles(
+            (vitestConfigPath) => {
+              const [_libs, name, _config] = vitestConfigPath.split('/');
+              return {
+                projects: {
+                  [name]: {
+                    name: name,
+                    root: `libs/${name}`,
+                    tags: ['fake-lib'],
+                  },
+                },
+              };
             },
-          };
-        },
+            vitestConfigPaths,
+            null,
+            null
+          ),
       ],
     };
 
     const fakeTargetsPlugin: NxPluginV2 = {
       name: 'fake-targets-plugin',
-      createNodes: [
+      createNodesV2: [
         'libs/*/project.json',
-        (projectJsonPath) => {
-          const root = dirname(projectJsonPath);
-          return {
-            projects: {
-              [root]: {
-                root,
-                targets: {
-                  build: {
-                    executor: 'nx:run-commands',
-                    options: {
-                      command: 'echo {projectName} @ {projectRoot}',
+        (projectJsonPaths) =>
+          createNodesFromFiles(
+            (projectJsonPath) => {
+              const root = dirname(projectJsonPath);
+              return {
+                projects: {
+                  [root]: {
+                    root,
+                    targets: {
+                      build: {
+                        executor: 'nx:run-commands',
+                        options: {
+                          command: 'echo {projectName} @ {projectRoot}',
+                        },
+                      },
                     },
                   },
                 },
-              },
+              };
             },
-          };
-        },
+            projectJsonPaths,
+            null,
+            null
+          ),
       ],
     };
 
     const sameNamePlugin: NxPluginV2 = {
       name: 'same-name-plugin',
-      createNodes: [
+      createNodesV2: [
         'libs/*/project.json',
-        (projectJsonPath) => {
-          const root = dirname(projectJsonPath);
-          return {
-            projects: {
-              [root]: {
-                root,
-                name: 'same-name',
-              },
+        (projectJsonPaths) =>
+          createNodesFromFiles(
+            (projectJsonPath) => {
+              const root = dirname(projectJsonPath);
+              return {
+                projects: {
+                  [root]: {
+                    root,
+                    name: 'same-name',
+                  },
+                },
+              };
             },
-          };
-        },
+            projectJsonPaths,
+            null,
+            null
+          ),
       ],
     };
 

--- a/packages/react-native/src/generators/init/init.ts
+++ b/packages/react-native/src/generators/init/init.ts
@@ -8,8 +8,8 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
-import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
-import { createNodes } from '../../../plugins/plugin';
+import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
+import { createNodesV2 } from '../../../plugins/plugin';
 import {
   nxVersion,
   reactDomVersion,
@@ -39,11 +39,11 @@ export async function reactNativeInitGeneratorInternal(
   schema.addPlugin ??= addPluginDefault;
 
   if (schema.addPlugin) {
-    await addPluginV1(
+    await addPlugin(
       host,
       await createProjectGraphAsync(),
       '@nx/react-native/plugin',
-      createNodes,
+      createNodesV2,
       {
         startTargetName: ['start', 'react-native:start', 'react-native-start'],
         upgradeTargetName: [

--- a/packages/remix/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/remix/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -1,10 +1,10 @@
 import { createProjectGraphAsync, formatFiles, type Tree } from '@nx/devkit';
 import { AggregatedLog } from '@nx/devkit/src/generators/plugin-migrations/aggregate-log-util';
 import {
-  migrateProjectExecutorsToPluginV1,
+  migrateProjectExecutorsToPlugin,
   NoTargetsToMigrateError,
 } from '@nx/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator';
-import { createNodes } from '../../plugins/plugin';
+import { createNodesV2 } from '../../plugins/plugin';
 import { buildPostTargetTransformer } from './lib/build-post-target-transformer';
 import { servePostTargetTransformer } from './lib/serve-post-target-transformer';
 
@@ -16,11 +16,11 @@ interface Schema {
 export async function convertToInferred(tree: Tree, options: Schema) {
   const projectGraph = await createProjectGraphAsync();
   const migrationLogs = new AggregatedLog();
-  const migratedProjects = await migrateProjectExecutorsToPluginV1(
+  const migratedProjects = await migrateProjectExecutorsToPlugin(
     tree,
     projectGraph,
     '@nx/remix/plugin',
-    createNodes,
+    createNodesV2,
     {
       buildTargetName: 'build',
       devTargetName: 'dev',

--- a/packages/rollup/src/generators/init/init.ts
+++ b/packages/rollup/src/generators/init/init.ts
@@ -8,8 +8,8 @@ import {
 } from '@nx/devkit';
 import { nxVersion, rollupVersion } from '../../utils/versions';
 import { Schema } from './schema';
-import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
-import { createNodes } from '../../plugins/plugin';
+import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
+import { createNodesV2 } from '../../plugins/plugin';
 
 export async function rollupInitGenerator(tree: Tree, schema: Schema) {
   let task: GeneratorCallback = () => {};
@@ -34,11 +34,11 @@ export async function rollupInitGenerator(tree: Tree, schema: Schema) {
   }
 
   if (schema.addPlugin) {
-    await addPluginV1(
+    await addPlugin(
       tree,
       await createProjectGraphAsync(),
       '@nx/rollup/plugin',
-      createNodes,
+      createNodesV2,
       {
         buildTargetName: ['build', 'rollup:build', 'rollup-build'],
         buildDepsTargetName: [

--- a/packages/webpack/src/generators/init/init.ts
+++ b/packages/webpack/src/generators/init/init.ts
@@ -6,8 +6,8 @@ import {
   readNxJson,
   Tree,
 } from '@nx/devkit';
-import { addPluginV1 } from '@nx/devkit/src/utils/add-plugin';
-import { createNodes } from '../../plugins/plugin';
+import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
+import { createNodesV2 } from '../../plugins/plugin';
 import { nxVersion, webpackCliVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -23,11 +23,11 @@ export async function webpackInitGeneratorInternal(tree: Tree, schema: Schema) {
   schema.addPlugin ??= addPluginDefault;
 
   if (schema.addPlugin) {
-    await addPluginV1(
+    await addPlugin(
       tree,
       await createProjectGraphAsync(),
       '@nx/webpack/plugin',
-      createNodes,
+      createNodesV2,
       {
         buildTargetName: [
           'build',


### PR DESCRIPTION
BREAKING CHANGE: Plugins will need to migrate to create nodes v2 if they haven't already to stay supported.

## Current Behavior

Currently if a plugin exports only `createNodes`, we adapt it to a `createNodesV2` under the hood and run it. If a plugin exports both, we only run the v2 api.

## Future Behavior

In the future we want `createNodesV2` to become `createNodes`. To facilitate this transition for the duration of Nx 21, `createNodes` will not be invoked. This gives plugin authors time to migrate over to the v2 spec and export it from `createNodes` such that it will be ready to be called in the future.