### PR TITLE
feat: add devDependencies support & regex ignored dependencies to `@nx/dependency-checks`

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -122,7 +122,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -189,7 +189,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -247,9 +247,9 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {
+      [{
         ignoredFiles: ['{projectRoot}/vite.config.ts'],
-      },
+      }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -293,7 +293,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -356,7 +356,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { ignoredDependencies: ['external1'] },
+      [{ ignoredDependencies: ['external1'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -400,7 +400,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { ignoredDependencies: ['external1'] },
+      [{ ignoredDependencies: ['external1'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -444,7 +444,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { ignoredDependencies: ['external1'] },
+      [{ ignoredDependencies: ['external1'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -489,7 +489,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -561,7 +561,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -618,7 +618,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -679,7 +679,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { buildTargets: ['notbuild'] },
+      [{ buildTargets: ['notbuild'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -735,7 +735,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { checkMissingDependencies: false },
+      [{ checkMissingDependencies: false }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -791,7 +791,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { ignoredDependencies: ['external2'] },
+      [{ ignoredDependencies: ['external2'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -851,7 +851,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -923,7 +923,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1002,7 +1002,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1081,7 +1081,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1160,7 +1160,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { checkObsoleteDependencies: false },
+      [{ checkObsoleteDependencies: false }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1213,7 +1213,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { ignoredDependencies: ['unneeded'] },
+      [{ ignoredDependencies: ['unneeded'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1264,7 +1264,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1349,7 +1349,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { checkVersionMismatches: false },
+      [{ checkVersionMismatches: false }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1406,7 +1406,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { ignoredDependencies: ['external1'] },
+      [{ ignoredDependencies: ['external1'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1506,7 +1506,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1564,7 +1564,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1615,7 +1615,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1662,7 +1662,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1725,7 +1725,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1788,7 +1788,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      {},
+      [{}],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1844,7 +1844,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { runtimeHelpers: ['@swc/helpers'] },
+      [{ runtimeHelpers: ['@swc/helpers'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1900,7 +1900,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      { runtimeHelpers: ['@swc/helpers'] },
+      [{ runtimeHelpers: ['@swc/helpers'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1933,6 +1933,73 @@ describe('Dependency checks (eslint)', () => {
     );
     expect(failures.length).toEqual(0);
   });
+
+  it('should enforce dev-only dependencies when using multiple config objects', () => {
+    const packageJson = {
+      name: '@mycompany/liba',
+      dependencies: {
+        external1: '^16.0.0',
+      },
+      devDependencies: {
+      },
+    };
+
+    const fileSys = {
+      './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+      './libs/liba/src/index.ts': '',
+      './libs/liba/src/index.spec.ts': '',
+      './package.json': JSON.stringify(rootPackageJson, null, 2),
+    };
+    vol.fromJSON(fileSys, '/root');
+
+    const failures = runRule(
+      [
+        {
+          ignoredFiles: ['**/*.spec.ts'],
+        },
+        {
+          ignoredFiles: ['**/!(*.spec.ts)'],
+          production: false,
+        }
+      ] as Options,
+      `/root/libs/liba/package.json`,
+      JSON.stringify(packageJson, null, 2),
+      {
+        nodes: {
+          liba: {
+            name: 'liba',
+            type: 'lib',
+            data: {
+              root: 'libs/liba',
+              targets: {
+                build: {},
+              },
+            },
+          },
+        },
+        externalNodes,
+        dependencies: {
+          liba: [
+            { source: 'liba', target: 'npm:external1', type: 'static' },
+            { source: 'liba', target: 'npm:external2', type: 'static' },
+          ],
+        },
+      },
+      {
+        liba: [
+          createFile(`libs/liba/src/main.ts`, ['npm:external1']),
+          createFile(`libs/liba/src/main.spec.ts`, ['npm:external2']),
+          createFile(`libs/liba/package.json`, ['npm:external1']),
+        ],
+      }
+    );
+    expect(failures.length).toEqual(1);
+    expect(failures[0].message).toMatchInlineSnapshot(`
+      "The "liba" project uses the following packages, but they are missing from "devDependencies":
+          - external2"
+    `);
+    expect(failures[0].line).toEqual(6);
+  });
 });
 
 function createFile(f: string, deps?: FileDataDependency[]): FileData {
@@ -1950,7 +2017,7 @@ linter.defineParser('jsonc-eslint-parser', jsoncParser as any);
 linter.defineRule(dependencyChecksRuleName, dependencyChecks as any);
 
 function runRule(
-  ruleArguments: Options[0],
+  ruleArguments: Options,
   filePath: string,
   content: string,
   projectGraph: ProjectGraph,
@@ -1965,7 +2032,7 @@ function runRule(
   const config = {
     ...baseConfig,
     rules: {
-      [dependencyChecksRuleName]: ['error', ruleArguments],
+      [dependencyChecksRuleName]: ['error', ...ruleArguments],
     },
   };
 

--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -28,6 +28,7 @@ jest.mock('nx/src/utils/workspace-root', () => ({
 
 const rootPackageJson = {
   dependencies: {
+    '@types/external1': '~16.1.2',
     external1: '~16.1.2',
     external2: '^5.2.0',
     external3: '1.0.0',
@@ -356,7 +357,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      [{ ignoredDependencies: ['external1'] }],
+      [{ ignoredDependencies: ['external1', '@types/*'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -374,12 +375,18 @@ describe('Dependency checks (eslint)', () => {
         },
         externalNodes,
         dependencies: {
-          liba: [{ source: 'liba', target: 'npm:external1', type: 'static' }],
+          liba: [
+            { source: 'liba', target: 'npm:external1', type: 'static' },
+            { source: 'liba', target: 'npm:@types/external1', type: 'static' },
+          ],
         },
       },
       {
         liba: [
-          createFile(`libs/liba/src/main.ts`, ['npm:external1']),
+          createFile(`libs/liba/src/main.ts`, [
+            'npm:external1',
+            'npm:@types/external1',
+          ]),
           createFile(`libs/liba/package.json`),
         ],
       }
@@ -791,7 +798,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      [{ ignoredDependencies: ['external2'] }],
+      [{ ignoredDependencies: ['external2', '@types/*'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -801,7 +808,6 @@ describe('Dependency checks (eslint)', () => {
             type: 'lib',
             data: {
               root: 'libs/liba',
-
               targets: {
                 build: {},
               },
@@ -813,6 +819,7 @@ describe('Dependency checks (eslint)', () => {
           liba: [
             { source: 'liba', target: 'npm:external1', type: 'static' },
             { source: 'liba', target: 'npm:external2', type: 'static' },
+            { source: 'liba', target: 'npm:@types/react', type: 'static' },
           ],
         },
       },
@@ -821,10 +828,12 @@ describe('Dependency checks (eslint)', () => {
           createFile(`libs/liba/src/main.ts`, [
             'npm:external1',
             'npm:external2',
+            'npm:@types/react',
           ]),
           createFile(`libs/liba/package.json`, [
             'npm:external1',
             'npm:external2',
+            'npm:@types/react',
           ]),
         ],
       }
@@ -1202,6 +1211,7 @@ describe('Dependency checks (eslint)', () => {
       },
       peerDependencies: {
         unneeded: '>= 16 < 18',
+        '@types/unneeded': '^18.0.0',
       },
     };
 
@@ -1213,7 +1223,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      [{ ignoredDependencies: ['unneeded'] }],
+      [{ ignoredDependencies: ['unneeded', '@types/*'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1240,6 +1250,7 @@ describe('Dependency checks (eslint)', () => {
           createFile(`libs/liba/package.json`, [
             'npm:external1',
             'npm:unneeded',
+            'npm:@types/unneeded',
           ]),
         ],
       }
@@ -1393,6 +1404,7 @@ describe('Dependency checks (eslint)', () => {
     const packageJson = {
       name: '@mycompany/liba',
       dependencies: {
+        '@types/external1': '~16.0.0',
         external1: '~16.0.0',
         external2: '^1.0.0',
       },
@@ -1406,7 +1418,7 @@ describe('Dependency checks (eslint)', () => {
     vol.fromJSON(fileSys, '/root');
 
     const failures = runRule(
-      [{ ignoredDependencies: ['external1'] }],
+      [{ ignoredDependencies: ['external1', '@types/*'] }],
       `/root/libs/liba/package.json`,
       JSON.stringify(packageJson, null, 2),
       {
@@ -1427,6 +1439,7 @@ describe('Dependency checks (eslint)', () => {
           liba: [
             { source: 'liba', target: 'npm:external1', type: 'static' },
             { source: 'liba', target: 'npm:external2', type: 'static' },
+            { source: 'liba', target: 'npm:@types/external1', type: 'static' },
           ],
         },
       },
@@ -1435,10 +1448,12 @@ describe('Dependency checks (eslint)', () => {
           createFile(`libs/liba/src/main.ts`, [
             'npm:external1',
             'npm:external2',
+            'npm:@types/external1',
           ]),
           createFile(`libs/liba/package.json`, [
             'npm:external1',
             'npm:external2',
+            'npm:@types/external1',
           ]),
         ],
       }
@@ -1447,7 +1462,7 @@ describe('Dependency checks (eslint)', () => {
     expect(failures[0].message).toMatchInlineSnapshot(
       `"The version specifier does not contain the installed version of "external2" package: 5.5.6."`
     );
-    expect(failures[0].line).toEqual(5);
+    expect(failures[0].line).toEqual(6);
   });
 
   it('should require tslib if @nx/js:tsc executor', () => {

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -49,8 +49,9 @@ export default ESLintUtils.RuleCreator(
       description: `Checks dependencies in project's package.json for version mismatches`,
     },
     fixable: 'code',
-    schema: [
-      {
+    schema: {
+      type: 'array',
+      items: {
         type: 'object',
         properties: {
           buildTargets: { type: 'array', items: { type: 'string' } },
@@ -66,7 +67,7 @@ export default ESLintUtils.RuleCreator(
         },
         additionalProperties: false,
       },
-    ],
+    },
     messages: {
       missingDependency: `The "{{projectName}}" project uses the following packages, but they are missing from "{{section}}":{{packageNames}}`,
       obsoleteDependency: `The "{{packageName}}" package is not used by "{{projectName}}" project.`,

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -151,12 +151,16 @@ export default ESLintUtils.RuleCreator(
 
       const rootPackageJsonDeps = getAllDependencies(rootPackageJson);
 
+      function includesMatch(value: string, arr: string[]): boolean {
+        return arr.some(pattern => new RegExp(pattern).test(value));
+      }
+
       function validateMissingDependencies(node: AST.JSONProperty) {
         if (!checkMissingDependencies) {
           return;
         }
         const missingDeps = expectedDependencyNames.filter(
-          (d) => !projPackageJsonDeps[d] && !ignoredDependencies.includes(d)
+          (d) => !includesMatch(d, Object.keys(projPackageJsonDeps)) && !includesMatch(d, ignoredDependencies)
         );
 
         if (missingDeps.length) {
@@ -282,7 +286,7 @@ export default ESLintUtils.RuleCreator(
       ) {
         if (
           !expectedDependencyNames.length ||
-          !expectedDependencyNames.some((d) => !ignoredDependencies.includes(d))
+          !expectedDependencyNames.some((d) => !includesMatch(d, ignoredDependencies))
         ) {
           return;
         }
@@ -336,7 +340,7 @@ export default ESLintUtils.RuleCreator(
           const packageName = (node.key as any).value;
           const packageRange = (node.value as any).value;
 
-          if (ignoredDependencies.includes(packageName)) {
+          if (includesMatch(packageName, ignoredDependencies)) {
             return;
           }
 

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -151,16 +151,12 @@ export default ESLintUtils.RuleCreator(
 
       const rootPackageJsonDeps = getAllDependencies(rootPackageJson);
 
-      function includesMatch(value: string, arr: string[]): boolean {
-        return arr.some(pattern => new RegExp(pattern).test(value));
-      }
-
       function validateMissingDependencies(node: AST.JSONProperty) {
         if (!checkMissingDependencies) {
           return;
         }
         const missingDeps = expectedDependencyNames.filter(
-          (d) => !includesMatch(d, Object.keys(projPackageJsonDeps)) && !includesMatch(d, ignoredDependencies)
+          (d) => !projPackageJsonDeps[d] && !ignoredDependencies.some(p => new RegExp(p).test(d))
         );
 
         if (missingDeps.length) {
@@ -286,7 +282,7 @@ export default ESLintUtils.RuleCreator(
       ) {
         if (
           !expectedDependencyNames.length ||
-          !expectedDependencyNames.some((d) => !includesMatch(d, ignoredDependencies))
+          !expectedDependencyNames.some((d) => !ignoredDependencies.some(p => new RegExp(p).test(d)))
         ) {
           return;
         }
@@ -340,7 +336,7 @@ export default ESLintUtils.RuleCreator(
           const packageName = (node.key as any).value;
           const packageRange = (node.value as any).value;
 
-          if (includesMatch(packageName, ignoredDependencies)) {
+          if (ignoredDependencies.some(p => new RegExp(p).test(packageName))) {
             return;
           }
 


### PR DESCRIPTION
This (non-breaking) PR adds support for multiple configuration objects as well as a `production` flag to the `dependency-checks` eslint rule. This is similar to how https://knip.dev/features/production-mode works.

With this change, it is now possible to enforce presence of `devDependencies` for dev-only files, e.g. `.spec`, like so:

```jsonc
// ...
"@nx/dependency-checks": ["error", 
  { "ignoredFiles": ["**/*.spec.ts"] }, 
  { "production": false, "ignoredFiles": ["**/!(*.spec.ts)"] }
]
```

Furthermore, this PR also adds capability to match dependencies via regex pattern in the `ignoredDependencies`.
## Current Behavior
<!-- This is the behavior we have today -->
It is impossible to enforce dev-only dependencies.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30614 
