### PR TITLE
chore(repo): publish for freebsd in canary and pr releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -294,14 +294,12 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-        if: ${{ github.event_name != 'schedule' && !github.event.inputs.pr }}
         with:
           repository: ${{ needs.resolve-required-data.outputs.repo }}
           ref: ${{ needs.resolve-required-data.outputs.ref }}
 
       - name: Build
         id: build
-        if: ${{ github.event_name != 'schedule' && !github.event.inputs.pr }}
         uses: cross-platform-actions/action@v0.25.0
         env:
           DEBUG: napi:*
@@ -343,7 +341,6 @@ jobs:
             echo "COMPLETE"
 
       - name: Upload artifact
-        if: ${{ github.event_name != 'schedule' && !github.event.inputs.pr }}
         uses: actions/upload-artifact@v4
         with:
           name: bindings-freebsd


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

FreeBSD artifacts are not published as part of PR and canary releases because it was unstable. Now it seems it's pretty stable though.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

FreeBSD artifacts are published as part of PR and canary releases. Those releases can be used in this repo (which requires FreeBSD) support.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
