### PR TITLE
feat(core): add --bundler=rspack option to angular stack cnw

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -69,7 +69,7 @@ interface AngularArguments extends BaseArguments {
   standaloneApi: boolean;
   unitTestRunner: 'none' | 'jest' | 'vitest';
   e2eTestRunner: 'none' | 'cypress' | 'playwright';
-  bundler: 'webpack' | 'esbuild';
+  bundler: 'webpack' | 'rspack' | 'esbuild';
   ssr: boolean;
   serverRouting: boolean;
   prefix: string;
@@ -869,7 +869,7 @@ async function determineAngularOptions(
   let appName: string;
   let unitTestRunner: undefined | 'none' | 'jest' | 'vitest' = undefined;
   let e2eTestRunner: undefined | 'none' | 'cypress' | 'playwright' = undefined;
-  let bundler: undefined | 'webpack' | 'esbuild' = undefined;
+  let bundler: undefined | 'webpack' | 'rspack' | 'esbuild' = undefined;
   let ssr: undefined | boolean = undefined;
   let serverRouting: undefined | boolean = undefined;
 
@@ -928,6 +928,10 @@ async function determineAngularOptions(
           {
             name: 'esbuild',
             message: 'esbuild [ https://esbuild.github.io/ ]',
+          },
+          {
+            name: 'rspack',
+            message: 'Rspack [ https://rspack.dev/ ]',
           },
           {
             name: 'webpack',


### PR DESCRIPTION
## Current Behavior
There is currently no way to generate an Angular Rspack app when creating a new Nx Workspace.

## Expected Behavior
Add support for `--bundler=rspack` in `create-nx-workspace` including adding `Rspack` as a prompt option when asking for bundler.

