### PR TITLE
Revert "feat(core): add --bundler=rspack option to angular stack cnw (#30629)"

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -69,7 +69,7 @@ interface AngularArguments extends BaseArguments {
   standaloneApi: boolean;
   unitTestRunner: 'none' | 'jest' | 'vitest';
   e2eTestRunner: 'none' | 'cypress' | 'playwright';
-  bundler: 'webpack' | 'rspack' | 'esbuild';
+  bundler: 'webpack' | 'esbuild';
   ssr: boolean;
   serverRouting: boolean;
   prefix: string;
@@ -869,7 +869,7 @@ async function determineAngularOptions(
   let appName: string;
   let unitTestRunner: undefined | 'none' | 'jest' | 'vitest' = undefined;
   let e2eTestRunner: undefined | 'none' | 'cypress' | 'playwright' = undefined;
-  let bundler: undefined | 'webpack' | 'rspack' | 'esbuild' = undefined;
+  let bundler: undefined | 'webpack' | 'esbuild' = undefined;
   let ssr: undefined | boolean = undefined;
   let serverRouting: undefined | boolean = undefined;
 
@@ -928,10 +928,6 @@ async function determineAngularOptions(
           {
             name: 'esbuild',
             message: 'esbuild [ https://esbuild.github.io/ ]',
-          },
-          {
-            name: 'rspack',
-            message: 'Rspack [ https://rspack.dev/ ]',
           },
           {
             name: 'webpack',


### PR DESCRIPTION
This reverts commit 64030f55b5b5dcdbf5a3572be67aa8b72ca19789.

## Current Behavior
CNW with Angular Rspack does not set up Workspace with TS Proj Ref

## Expected Behavior
Eventually, CNW with Angular Rspack should setup Workspace with TS Proj Ref - revert this change until then