### PR TITLE
fix(module-federation): remove disabling runtimeChunk

### DIFF
--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
@@ -27,7 +27,6 @@ export async function withModuleFederationForSSR(
       },
       optimization: {
         ...(config.optimization ?? {}),
-        runtimeChunk: false,
       },
       resolve: {
         ...(config.resolve ?? {}),

--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
@@ -26,7 +26,6 @@ export async function withModuleFederation(
       },
       optimization: {
         ...(config.optimization ?? {}),
-        runtimeChunk: false,
       },
       resolve: {
         ...(config.resolve ?? {}),

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
@@ -26,7 +26,6 @@ export async function withModuleFederationForSSR(
     };
     config.optimization = {
       ...(config.optimization ?? {}),
-      runtimeChunk: false,
     };
 
     config.plugins.push(

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
@@ -42,7 +42,6 @@ export async function withModuleFederation(
 
     config.optimization = {
       ...(config.optimization ?? {}),
-      runtimeChunk: false,
     };
 
     if (

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
@@ -23,7 +23,6 @@ export async function withModuleFederationForSSR(
     config.output.uniqueName = options.name;
     config.optimization = {
       ...(config.optimization ?? {}),
-      runtimeChunk: false,
     };
 
     config.plugins.push(

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
@@ -27,7 +27,6 @@ export async function withModuleFederation(
     config.output.scriptType = 'text/javascript';
     config.optimization = {
       ...(config.optimization ?? {}),
-      runtimeChunk: false,
     };
 
     if (

--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -177,7 +177,6 @@ function applyNxIndependentConfig(
             },
           }),
         ],
-        runtimeChunk: false,
         concatenateModules: true,
       };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When using Module Federation with an app that defines styles as a separate entry point, HMR fails to update in the browser. Instead of updating automatically, a warning is shown in the console related to a missing chunk. A full-page reload is typically required, which is not the intended behaviour.


## Expected Behavior
<!-- This is the behaviour we should expect with the changes in this PR -->
HMR should work with styles as an entrypoint.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
The default is for `runtimeChunk` is `config.optimization.runtimeChunk = {name: 'runtime'}` it is _not_ the same as `single` but the naming will be the same.

Fixes #9582
