### PR TITLE
fix(nx-dev): update markdoc component to exclude h1 headers

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/tags/table-of-contents.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/table-of-contents.component.tsx
@@ -23,7 +23,7 @@ export function TableOfContents({
     if (!content) return;
 
     // Get all headings h1-h6 within the content
-    const headingElements = content.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    const headingElements = content.querySelectorAll('h2, h3, h4, h5, h6');
 
     const items: TocItem[] = Array.from(headingElements)
       .map((heading) => {
@@ -54,7 +54,7 @@ export function TableOfContents({
         {headings.map((heading) => (
           <li
             key={heading.id}
-            style={{ paddingLeft: `${(heading.level - 1) * 1}rem` }}
+            style={{ paddingLeft: `${(heading.level - 2) * 1}rem` }}
           >
             <a
               href={`#${heading.id}`}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now the TOC component embedded in blog posts also visualizes the h1 header which is the blog title. That shouldn't happen.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Rather it should just show the article headlines, which are h2 etc... Like this
<img width="836" alt="image" src="https://github.com/user-attachments/assets/b5ba1837-9a53-4f0c-8d86-09439b05e15b" />


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
