### PR TITLE
feat(module-federation): add continuous tasks support to react rspack

### DIFF
--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -220,6 +220,14 @@ export async function remoteGenerator(host: Tree, schema: Schema) {
     );
   }
 
+  if (options.host && options.bundler === 'rspack') {
+    const projectConfig = readProjectConfiguration(host, options.projectName);
+    projectConfig.targets.serve ??= {};
+    projectConfig.targets.serve.dependsOn ??= [];
+    projectConfig.targets.serve.dependsOn.push(`${options.host}:serve`);
+    updateProjectConfiguration(host, options.projectName, projectConfig);
+  }
+
   if (options.host && options.dynamic) {
     const hostConfig = readProjectConfiguration(host, schema.host);
     const pathToMFManifest = joinPathFragments(


### PR DESCRIPTION
## Current Behavior
Continuous tasks are not set up for React Rspack Module Federation Remote projects.
This is important because `--dev-remotes` is no longer supported with Crystal Module Federation usage.

## Expected Behavior
Add Continuous Tasks support for React Rspack Module Federation Remote Projects.
This replaces the need for `nx serve shell --dev-remotes=remote1`.

Instead, the command is simply `nx serve remote1` and continuous tasks means that the `shell:serve` task is executed correctly.
