### PR TITLE
docs(module-federation): add sections covering continuous tasks change

### DIFF
--- a/docs/shared/concepts/module-federation/module-federation-and-nx.md
+++ b/docs/shared/concepts/module-federation/module-federation-and-nx.md
@@ -113,7 +113,13 @@ The `host` is the entry point and the `remotes` are modules used by the applicat
 
 To support this, as well as to ensure a great local DX, we built our Module Federation support in such a way that when developing locally you should always run `serve` on your `host` application. This will start up your full Module Federation architecture; serving your `host` with `webpack-dev-server` and each `remote` via a single `http-server`. You can learn more about this on our [Nx Module Federation Technical Overview](/concepts/module-federation/nx-module-federation-technical-overview).
 
-When you're working on a specific `remote` application, you should use the `--devRemotes` option to specify the `remote` you are currently developing; e.g. `nx serve host --devRemotes=remote1`. This ensures that the `remote` is served via `webpack-dev-server` allowing for HMR and live reloading.
+With the introduction of Continuous Tasks in Nx 21 when you're working on a specific `remote` application, you now only need to run `nx serve remote` and it will serve the application along with your `host` application.
+
+{% callout type="note" title="Continuous Tasks Support in Module Federation" %}
+This is currently only supported for Rspack Module Federation using the `@nx/rspack/plugin` Inference Plugin.
+{% /callout %}
+
+If you are using Webpack Module Federation, or are not using [Inferred Tasks](/concepts/inferred-tasks), you should use the `--devRemotes` option to specify the `remote` you are currently developing; e.g. `nx serve host --devRemotes=remote1`. This ensures that the `remote` is served via `webpack-dev-server` allowing for HMR and live reloading.
 
 ## Use Cases
 

--- a/docs/shared/concepts/module-federation/nx-module-federation-technical-overview.md
+++ b/docs/shared/concepts/module-federation/nx-module-federation-technical-overview.md
@@ -26,12 +26,25 @@ The executor does the following:
 5. It will run `http-server` at the common directory such that those files are available on the network from a single port.
 6. It will create proxy servers via `express` listening on the ports where each `remote` _should_ be located (as configured in the host's `module-federation.config.ts` or `module-federation.manifest.json` file).
    - These proxy servers will proxy requests from the server to the `http-server` to fetch the correct files as requested by Module Federation.
-7. If the `--devRemotes` option has been passed, it will serve each `dev remote` via `webpack-dev-server` allowing for HMR and live reloading when working on those remotes.
+7. **Only Applicable for Executor Usage**: If the `--devRemotes` option has been passed, it will serve each `dev remote` via `webpack-dev-server` allowing for HMR and live reloading when working on those remotes.
 8. It will serve the `host` via `webpack-dev-server`.
 
 If you prefer diagrams, the one below outlines the above steps.
 
 ![Nx Module Federation Host Serve Flow](/shared/concepts/module-federation/module-federation-host-serve-light.png)
+
+## Using Module Federation with Continuous Tasks
+
+Continuous Tasks are a new feature in Nx 21. Using Rspack Module Federation, you can now use Continuous Tasks to serve your `remotes` and `host` application.
+
+Thanks to the benefits of Continuous Tasks, you no longer need to run `nx serve host --devRemotes=remote` to serve your `host` application with HMR enabled for your remote applications.  
+Instead, you can run `nx serve remote` and it will serve the `remote` along with your `host` application with HMR enabled.
+
+This is a great way to develop your application locally and have a great DX. It also makes it easier to explain to your team how to work with Module Federation as there is no longer any special command required to serve their application.
+
+{% callout type="note" title="Using Continuous Tasks with Webpack Module Federation?" %}
+Webpack Module Federation does not support Continuous Tasks. If you are using Webpack Module Federation, you should use the `--devRemotes` option to specify the `remote` you are currently developing; e.g. `npx nx serve host --devRemotes=remote`.
+{% /callout %}
 
 ## The `NxRuntimeLibraryControlPlugin`
 


### PR DESCRIPTION
## Current Behavior
Module Federation Documentation talks about using `--devRemotes` exclusively for serving remote applications that feature teams are working on.
With Continuous Tasks this is no longer the case

## Expected Behavior
Add section mentioning Continuous Tasks and the change to the `serve` flow
