### PR TITLE
fix(core): angular rspack should not prompt for SSG

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -979,8 +979,11 @@ async function determineAngularOptions(
     const reply = await enquirer.prompt<{ ssr: 'Yes' | 'No' }>([
       {
         name: 'ssr',
-        message:
-          'Do you want to enable Server-Side Rendering (SSR) and Static Site Generation (SSG/Prerendering)?',
+        message: `Do you want to enable Server-Side Rendering (SSR)${
+          bundler !== 'rspack'
+            ? ' and Static Site Generation (SSG/Prerendering)?'
+            : '?'
+        }`,
         type: 'autocomplete',
         choices: [{ name: 'Yes' }, { name: 'No' }],
         initial: 1,


### PR DESCRIPTION
## Current Behavior
Create Nx Workspace will prompt for SSG when `Rspack` is chosen as a bundler option for Angular.
SSG is currently not supported by Angular Rspack.

## Expected Behavior
Do not mention SSG when prompting for SSR with Angular Rspack

