### PR TITLE
fix(core): add keepExistingVersions to jest option to preserve dependency versions

### DIFF
--- a/docs/generated/packages/jest/generators/configuration.json
+++ b/docs/generated/packages/jest/generators/configuration.json
@@ -79,6 +79,12 @@
       "runtimeTsconfigFileName": {
         "type": "string",
         "description": "The name of the project's tsconfig file that includes the runtime source files. If not provided, it will default to `tsconfig.lib.json` for libraries and `tsconfig.app.json` for applications."
+      },
+      "keepExistingVersions": {
+        "type": "boolean",
+        "x-priority": "internal",
+        "description": "Keep existing dependencies versions",
+        "default": true
       }
     },
     "required": [],

--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -71,6 +71,7 @@ function normalizeOptions(
   return {
     ...schemaDefaults,
     ...options,
+    keepExistingVersions: options.keepExistingVersions ?? true,
     rootProject: project.root === '.' || project.root === '',
     isTsSolutionSetup: isUsingTsSolutionSetup(tree),
   };

--- a/packages/jest/src/generators/configuration/lib/ensure-dependencies.ts
+++ b/packages/jest/src/generators/configuration/lib/ensure-dependencies.ts
@@ -44,5 +44,11 @@ export function ensureDependencies(
     devDeps['@swc/jest'] = swcJestVersion;
   }
 
-  return addDependenciesToPackageJson(tree, dependencies, devDeps);
+  return addDependenciesToPackageJson(
+    tree,
+    dependencies,
+    devDeps,
+    undefined,
+    options.keepExistingVersions
+  );
 }

--- a/packages/jest/src/generators/configuration/schema.d.ts
+++ b/packages/jest/src/generators/configuration/schema.d.ts
@@ -30,6 +30,7 @@ export interface JestProjectSchema {
    * @deprecated Use the `setupFile` option instead. It will be removed in Nx v22.
    */
   skipSetupFile?: boolean;
+  keepExistingVersions?: boolean;
 }
 
 export type NormalizedJestProjectSchema = JestProjectSchema & {

--- a/packages/jest/src/generators/configuration/schema.json
+++ b/packages/jest/src/generators/configuration/schema.json
@@ -78,6 +78,12 @@
     "runtimeTsconfigFileName": {
       "type": "string",
       "description": "The name of the project's tsconfig file that includes the runtime source files. If not provided, it will default to `tsconfig.lib.json` for libraries and `tsconfig.app.json` for applications."
+    },
+    "keepExistingVersions": {
+      "type": "boolean",
+      "x-priority": "internal",
+      "description": "Keep existing dependencies versions",
+      "default": true
     }
   },
   "required": []


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, when we use the jest configuration generator it will forcibly update the jest version if the package already exist.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Now, the jest version will be preserved unless the option is passed to update the version.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
