### PR TITLE
fix(js): handle when there are no package manager workspaces' patterns

### DIFF
--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -230,7 +230,8 @@ export async function addProjectToTsSolutionWorkspace(
   let pattern = projectDir;
   if (baseDir !== '.') {
     const patterns = getPackageManagerWorkspacesPatterns(tree);
-    const projectsBefore = await globAsync(tree, patterns);
+    const projectsBefore =
+      patterns.length > 0 ? await globAsync(tree, patterns) : [];
     patterns.push(`${baseDir}/*/package.json`);
     const projectsAfter = await globAsync(tree, patterns);
 


### PR DESCRIPTION
## Current Behavior

The helper to add a project to the package manager workspaces' configuration doesn't handle correctly when there are no patterns and this results in the error `Invalid glob pattern` being thrown.

## Expected Behavior

The helper to add a project to the package manager workspaces' configuration should handle when there are no patterns.

## Related Issue(s)

Fixes #
