### PR TITLE
fix(bundling): Lock webpack version to be compatible with @angular-devkit

### DIFF
--- a/docs/generated/packages/webpack/migrations/20.7.1-package-updates.json
+++ b/docs/generated/packages/webpack/migrations/20.7.1-package-updates.json
@@ -2,7 +2,7 @@
   "name": "20.7.1-package-updates",
   "version": "20.7.1-beta.0",
   "packages": {
-    "webpack": { "version": "^5.98.0", "alwaysAddToPackageJson": false },
+    "webpack": { "version": "5.98.0", "alwaysAddToPackageJson": false },
     "webpack-dev-server": {
       "version": "^5.2.1",
       "alwaysAddToPackageJson": false

--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -49,7 +49,7 @@
       "version": "20.7.1-beta.0",
       "packages": {
         "webpack": {
-          "version": "^5.98.0",
+          "version": "5.98.0",
           "alwaysAddToPackageJson": false
         },
         "webpack-dev-server": {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -62,7 +62,7 @@
     "ts-loader": "^9.3.1",
     "tsconfig-paths-webpack-plugin": "4.0.0",
     "tslib": "^2.3.0",
-    "webpack": "^5.98.0",
+    "webpack": "5.98.0",
     "webpack-dev-server": "^5.2.1",
     "webpack-node-externals": "^3.0.0",
     "webpack-subresource-integrity": "^5.1.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, when we have `^` it forces an update to webpack version `5.99.x` which is incompatible at the moment with `@angular-devkit` which is locked to webpack version `5.98.0`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx should be compatible with the migration provided by it's own package `@nx/webpack`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
