### PR TITLE
fix(testing): enforce commonjs module for ts-jest

### DIFF
--- a/e2e/js/src/js-ts-solution.test.ts
+++ b/e2e/js/src/js-ts-solution.test.ts
@@ -67,11 +67,15 @@ describe('JS - TS solution setup', () => {
     );
 
     // add deps, each parent lib imports all child libs
-    const addImports = (parentLib: string) => {
+    const addImports = (parentLib: string, includeRollupChildLib = false) => {
       updateFile(
         `packages/${parentLib}/src/index.ts`,
-        (content) => `export * from '@proj/${esbuildChildLib}';
-export * from '@proj/${rollupChildLib}';
+        (content) => `export * from '@proj/${esbuildChildLib}';${
+          includeRollupChildLib
+            ? `
+export * from '@proj/${rollupChildLib}';`
+            : ''
+        }
 export * from '@proj/${swcChildLib}';
 export * from '@proj/${tscChildLib}';
 export * from '@proj/${viteChildLib}';
@@ -80,7 +84,7 @@ ${content}`
     };
 
     addImports(esbuildParentLib);
-    addImports(rollupParentLib);
+    addImports(rollupParentLib, true);
     addImports(swcParentLib);
     addImports(tscParentLib);
     addImports(viteParentLib);
@@ -88,11 +92,13 @@ ${content}`
     const pm = getSelectedPackageManager();
     if (pm === 'pnpm') {
       // for pnpm we need to add the local packages as dependencies to each consumer package.json
-      const addDeps = (parentLib: string) => {
+      const addDeps = (parentLib: string, includeRollupChildLib = false) => {
         updateJson(`packages/${parentLib}/package.json`, (json) => {
           json.dependencies ??= {};
           json.dependencies[`@proj/${esbuildChildLib}`] = 'workspace:*';
-          json.dependencies[`@proj/${rollupChildLib}`] = 'workspace:*';
+          if (includeRollupChildLib) {
+            json.dependencies[`@proj/${rollupChildLib}`] = 'workspace:*';
+          }
           json.dependencies[`@proj/${swcChildLib}`] = 'workspace:*';
           json.dependencies[`@proj/${tscChildLib}`] = 'workspace:*';
           json.dependencies[`@proj/${viteChildLib}`] = 'workspace:*';
@@ -101,7 +107,7 @@ ${content}`
       };
 
       addDeps(esbuildParentLib);
-      addDeps(rollupParentLib);
+      addDeps(rollupParentLib, true);
       addDeps(swcParentLib);
       addDeps(tscParentLib);
       addDeps(viteParentLib);

--- a/e2e/node/src/node-ts-solution-esbuild.test.ts
+++ b/e2e/node/src/node-ts-solution-esbuild.test.ts
@@ -61,6 +61,7 @@ describe('Node Esbuild Applications', () => {
     updateJson('tsconfig.base.json', (json) => {
       json.compilerOptions.moduleResolution = 'node';
       json.compilerOptions.module = 'esnext';
+      delete json.compilerOptions.customConditions;
       return json;
     });
 

--- a/nx.json
+++ b/nx.json
@@ -245,7 +245,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 5,
+  "bust": 6,
   "defaultBase": "master",
   "conformance": {
     "rules": [

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -27,6 +27,7 @@ export async function jestExecutor(
   process.env['TS_NODE_COMPILER_OPTIONS'] = JSON.stringify({
     ...(existingValue ? JSON.parse(existingValue) : {}),
     moduleResolution: 'Node10',
+    module: 'commonjs',
     customConditions: null,
   });
 

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -98,7 +98,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "options": {
                       "cwd": "proj",
                       "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                       },
                     },
                     "outputs": [
@@ -179,7 +179,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "options": {
                       "cwd": "proj",
                       "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                       },
                     },
                     "outputs": [
@@ -249,7 +249,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "options": {
                       "cwd": "proj",
                       "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                       },
                     },
                     "outputs": [
@@ -318,7 +318,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "options": {
                       "cwd": "proj",
                       "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                       },
                     },
                     "outputs": [
@@ -398,7 +398,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "options": {
                       "cwd": "proj",
                       "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                       },
                     },
                     "outputs": [
@@ -482,7 +482,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "options": {
                         "cwd": "proj",
                         "env": {
-                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                         },
                       },
                       "outputs": [
@@ -552,7 +552,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "options": {
                         "cwd": "proj",
                         "env": {
-                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                         },
                       },
                       "outputs": [
@@ -632,7 +632,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "options": {
                         "cwd": "proj",
                         "env": {
-                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                         },
                       },
                       "outputs": [
@@ -702,7 +702,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "options": {
                         "cwd": "proj",
                         "env": {
-                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                         },
                       },
                       "outputs": [
@@ -782,7 +782,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "options": {
                         "cwd": "proj",
                         "env": {
-                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                         },
                       },
                       "outputs": [
@@ -852,7 +852,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "options": {
                         "cwd": "proj",
                         "env": {
-                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","customConditions":null}",
+                          "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"node10","module":"commonjs","customConditions":null}",
                         },
                       },
                       "outputs": [

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -259,6 +259,7 @@ async function buildJestTargets(
       ? JSON.parse(existingTsNodeCompilerOptions)
       : {}),
     moduleResolution: 'node10',
+    module: 'commonjs',
     customConditions: null,
   });
   const target: TargetConfiguration = (targets[options.targetName] = {


### PR DESCRIPTION
## Current Behavior

The `@nx/jest` graph plugin and the `@nx/jest:jest` executor correctly force the `moduleResolution: node10` to be used by `ts-node` (used by `ts-jest`), but don't force using `module: commonjs`, which can result in issues due to incompatible `module`/`moduleResolution` pair.

## Expected Behavior

The `@nx/jest` graph plugin and the `@nx/jest:jest` executor should force the `moduleResolution: node10` and `module: commonjs` compiler options to be used by `ts-node`.

## Related Issue(s)

Fixes #
