### PR TITLE
fix(core): copy native file atomically to avoid hanging graph creation

### DIFF
--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 
 import type { ChangelogRenderOptions } from '../../release/changelog-renderer';
-import { validReleaseVersionPrefixes } from '../command-line/release/version';
+import type { validReleaseVersionPrefixes } from '../command-line/release/version';
 import { readJsonFile } from '../utils/fileutils';
 import type { PackageManager } from '../utils/package-manager';
 import { workspaceRoot } from '../utils/workspace-root';

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { NxJsonConfiguration, readNxJson } from '../../config/nx-json';
-import { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
 import { toProjectName } from '../../config/to-project-name';
 import { readJsonFile, readYamlFile } from '../../utils/fileutils';
 import { combineGlobPatterns } from '../../utils/globs';

--- a/packages/nx/src/project-graph/plugins/load-resolved-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/load-resolved-plugin.ts
@@ -1,6 +1,6 @@
 import type { PluginConfiguration } from '../../config/nx-json';
 import { LoadedNxPlugin } from './loaded-nx-plugin';
-import { NxPlugin } from './public-api';
+import type { NxPlugin } from './public-api';
 
 export async function loadResolvedNxPluginAsync(
   pluginConfiguration: PluginConfiguration,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When copying the native file out of node_modules into tmp from multiple processes (aka plugin workers)... this can result in Node deadlocking.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Copying the native file out of node_modules into tmp from multiple processes will first copy to unique places in `/tmp` but then atomically rename to the final location where it is still loaded from.

This at least fixes a flaky test in `nx:test` where the explicit dependencies tests were timing out after 35 seconds

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
