### PR TITLE
fix(rspack): do not reuse existing ts-node compiler options when inferring tasks

### DIFF
--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -88,7 +88,7 @@ describe('@nx/rspack', () => {
                       ],
                       "cwd": "my-app",
                       "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"Node10","module":"CommonJS","customConditions":null}",
+                        "TS_NODE_COMPILER_OPTIONS": "{"module":"CommonJS","moduleResolution":"Node10","customConditions":null}",
                       },
                     },
                     "outputs": [],
@@ -106,7 +106,7 @@ describe('@nx/rspack', () => {
                       ],
                       "cwd": "my-app",
                       "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"Node10","module":"CommonJS","customConditions":null}",
+                        "TS_NODE_COMPILER_OPTIONS": "{"module":"CommonJS","moduleResolution":"Node10","customConditions":null}",
                       },
                     },
                   },
@@ -118,7 +118,7 @@ describe('@nx/rspack', () => {
                       ],
                       "cwd": "my-app",
                       "env": {
-                        "TS_NODE_COMPILER_OPTIONS": "{"moduleResolution":"Node10","module":"CommonJS","customConditions":null}",
+                        "TS_NODE_COMPILER_OPTIONS": "{"module":"CommonJS","moduleResolution":"Node10","customConditions":null}",
                       },
                     },
                   },

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -182,9 +182,7 @@ async function createRspackTargets(
   const isTsConfig = ['.ts', '.cts', '.mts'].includes(extname(configFilePath));
   if (isTsConfig) {
     // https://rspack.dev/config/#using-ts-node
-    const existingValue = process.env['TS_NODE_COMPILER_OPTIONS'];
     env['TS_NODE_COMPILER_OPTIONS'] = JSON.stringify({
-      ...(existingValue ? JSON.parse(existingValue) : {}),
       module: 'CommonJS',
       moduleResolution: 'Node10',
       customConditions: null,


### PR DESCRIPTION
## Current Behavior

The `@nx/rspack` graph plugin reuses the potentially existing `TS_NODE_COMPILER_OPTIONS` to set the `env` property of the inferred tasks for a TS config file. This is not correct since the env var could have a different value (or not exist at all) when running tasks compared to when the graph plugin runs.

## Expected Behavior

The `@nx/rspack` graph plugin should not reuse any existing `TS_NODE_COMPILER_OPTIONS` when inferring tasks for a TS config file.

## Related Issue(s)

Fixes #
