### PR TITLE
fix(vite): add logic to prevent overwriting generated package.json

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -203,9 +203,9 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
       if (isUsingTsSolutionSetup()) return;
       const outDir = options.dir || 'dist';
       const src = resolve(projectRoot, 'package.json');
-      if (existsSync(src)) {
-        const dest = join(outDir, 'package.json');
+      const dest = join(outDir, 'package.json');
 
+      if (existsSync(src) && !existsSync(dest)) {
         try {
           copyFileSync(src, dest);
         } catch (err) {


### PR DESCRIPTION
The nxViteTsPaths plugin currently always copys the package.json file at the end of the build and does not check if the file was generated from the build process. This adds logic to check if the package.json file already exists in the dist path before copying to prevent overwriting generated files.

Closes #30312

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
nxViteTsPaths always copies package.json at end of build.

## Expected Behavior
nxViteTsPaths only copies package.json at end of build if package.json not generated during build.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30312
