### PR TITLE
fix(testing): unset `customConditions` when running cypress tasks

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -116,6 +116,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/videos",
@@ -213,6 +216,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/videos",
@@ -325,6 +331,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/videos",
@@ -402,6 +411,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/videos/src-test-cy-ts",

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -262,11 +262,15 @@ async function buildCypressTargets(
 
   const targets: Record<string, TargetConfiguration> = {};
   let metadata: ProjectConfiguration['metadata'];
+  const tsNodeCompilerOptions = JSON.stringify({ customConditions: null });
 
   if ('e2e' in cypressConfig) {
     targets[options.targetName] = {
       command: `cypress run`,
-      options: { cwd: projectRoot },
+      options: {
+        cwd: projectRoot,
+        env: { TS_NODE_COMPILER_OPTIONS: tsNodeCompilerOptions },
+      },
       cache: true,
       inputs: getInputs(namedInputs),
       outputs: getOutputs(projectRoot, cypressConfig, 'e2e'),
@@ -345,6 +349,7 @@ async function buildCypressTargets(
           )}`,
           options: {
             cwd: projectRoot,
+            env: { TS_NODE_COMPILER_OPTIONS: tsNodeCompilerOptions },
           },
           parallelism: false,
           metadata: {
@@ -392,7 +397,10 @@ async function buildCypressTargets(
     // This will not override the e2e target if it is the same
     targets[options.componentTestingTargetName] ??= {
       command: `cypress run --component`,
-      options: { cwd: projectRoot },
+      options: {
+        cwd: projectRoot,
+        env: { TS_NODE_COMPILER_OPTIONS: tsNodeCompilerOptions },
+      },
       cache: true,
       inputs: getInputs(namedInputs),
       outputs: getOutputs(projectRoot, cypressConfig, 'component'),


### PR DESCRIPTION
## Current Behavior

Cypress e2e tasks in a workspace with the `customConditions` TypeScript compiler option set, fail with the error:

```bash
TSError: ⨯ Unable to compile TypeScript:
error TS5098: Option 'customConditions' can only be used when 'moduleResolution' is set to 'node16', 'nodenext', or 'bundler'.
```

This happens because Cypress forces ts-node to use `module: commonjs` and `moduleResolution: node10`, which is not compatible with the `customConditions` TypeScript compiler option.

## Expected Behavior

Cypress e2e tasks in a workspace with the `customConditions` TypeScript compiler option set should work as expected.

## Related Issue(s)

Fixes #
