### PR TITLE
fix(testing): fix cypress and playwright atomized targetDefaults so they match correctly

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -605,7 +605,7 @@ describe('app', () => {
             },
           ]
         `);
-        expect(nxJson.targetDefaults['e2e-ci--**/*']).toMatchInlineSnapshot(`
+        expect(nxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
           {
             "dependsOn": [
               "^build",

--- a/packages/cypress/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.spec.ts
+++ b/packages/cypress/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.spec.ts
@@ -77,7 +77,7 @@ describe('add-e2e-ci-target-defaults', () => {
         "build": {
           "cache": true,
         },
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
@@ -114,7 +114,7 @@ describe('add-e2e-ci-target-defaults', () => {
         "build": {
           "cache": true,
         },
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "build",
           ],
@@ -165,12 +165,12 @@ describe('add-e2e-ci-target-defaults', () => {
         "build": {
           "cache": true,
         },
-        "cypress:e2e-ci--**/*": {
+        "cypress:e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
         },
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
@@ -220,7 +220,7 @@ describe('add-e2e-ci-target-defaults', () => {
         "build": {
           "cache": true,
         },
-        "cypress:e2e-ci--**/*": {
+        "cypress:e2e-ci--**/**": {
           "dependsOn": [
             "^build",
             "^bundle",

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -17,7 +17,7 @@ describe('target-defaults-utils', () => {
       jest.resetModules();
     });
 
-    it('should add e2e-ci--**/* target default for e2e plugin for specified build target when it does not exist', async () => {
+    it('should add e2e-ci--**/** target default for e2e plugin for specified build target when it does not exist', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
@@ -43,7 +43,7 @@ describe('target-defaults-utils', () => {
 
       // ASSERT
       const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['e2e-ci--**/*']).toMatchInlineSnapshot(`
+      expect(newNxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
         {
           "dependsOn": [
             "^build",
@@ -52,7 +52,7 @@ describe('target-defaults-utils', () => {
       `);
     });
 
-    it('should update existing e2e-ci--**/* target default for e2e plugin for specified build target when it does not exist in dependsOn', async () => {
+    it('should update existing e2e-ci--**/** target default for e2e plugin for specified build target when it does not exist in dependsOn', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
@@ -64,7 +64,7 @@ describe('target-defaults-utils', () => {
         },
       });
       nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['e2e-ci--**/*'] = {
+      nxJson.targetDefaults['e2e-ci--**/**'] = {
         dependsOn: ['^build'],
       };
       updateNxJson(tree, nxJson);
@@ -82,7 +82,7 @@ describe('target-defaults-utils', () => {
 
       // ASSERT
       const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['e2e-ci--**/*']).toMatchInlineSnapshot(`
+      expect(newNxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
         {
           "dependsOn": [
             "^build",
@@ -104,7 +104,7 @@ describe('target-defaults-utils', () => {
         },
       });
       nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['e2e-ci--**/*'] = {
+      nxJson.targetDefaults['e2e-ci--**/**'] = {
         dependsOn: ['^build'],
       };
       updateNxJson(tree, nxJson);
@@ -122,14 +122,14 @@ describe('target-defaults-utils', () => {
 
       // ASSERT
       const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['e2e-ci--**/*']).toMatchInlineSnapshot(`
+      expect(newNxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
         {
           "dependsOn": [
             "^build",
           ],
         }
       `);
-      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/*'])
+      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/**'])
         .toMatchInlineSnapshot(`
         {
           "dependsOn": [
@@ -139,7 +139,7 @@ describe('target-defaults-utils', () => {
       `);
     });
 
-    it('should not add additional e2e-ci--**/* target default for e2e plugin when it already exists with build target', async () => {
+    it('should not add additional e2e-ci--**/** target default for e2e plugin when it already exists with build target', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
@@ -151,7 +151,7 @@ describe('target-defaults-utils', () => {
         },
       });
       nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['e2e-ci--**/*'] = {
+      nxJson.targetDefaults['e2e-ci--**/**'] = {
         dependsOn: ['^build'],
       };
       updateNxJson(tree, nxJson);
@@ -174,7 +174,7 @@ describe('target-defaults-utils', () => {
           "build": {
             "cache": true,
           },
-          "e2e-ci--**/*": {
+          "e2e-ci--**/**": {
             "dependsOn": [
               "^build",
             ],
@@ -290,7 +290,7 @@ describe('target-defaults-utils', () => {
 
       // ASSERT
       const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/*'])
+      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/**'])
         .toMatchInlineSnapshot(`
         {
           "dependsOn": [
@@ -335,7 +335,7 @@ describe('target-defaults-utils', () => {
 
       // ASSERT
       const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/*'])
+      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/**'])
         .toMatchInlineSnapshot(`
         {
           "dependsOn": [
@@ -365,7 +365,7 @@ describe('target-defaults-utils', () => {
 
       // ASSERT
       const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['e2e-ci--**/*']).toMatchInlineSnapshot(`
+      expect(newNxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
         {
           "dependsOn": [
             "^build",

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -81,7 +81,7 @@ export async function addE2eCiTargetDefaults(
       ? 'e2e-ci'
       : (foundPluginForApplication.options as any)?.ciTargetName ?? 'e2e-ci';
 
-  const ciTargetNameGlob = `${ciTargetName}--**/*`;
+  const ciTargetNameGlob = `${ciTargetName}--**/**`;
   nxJson.targetDefaults ??= {};
   const e2eCiTargetDefaults = nxJson.targetDefaults[ciTargetNameGlob];
   if (!e2eCiTargetDefaults) {

--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -295,7 +295,7 @@ describe('app', () => {
 
       // ASSERT
       const nxJson = readNxJson(appTree);
-      expect(nxJson.targetDefaults['e2e-ci--**/*']).toMatchInlineSnapshot(`
+      expect(nxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
         {
           "dependsOn": [
             "^export",
@@ -320,7 +320,7 @@ describe('app', () => {
 
       // ASSERT
       const nxJson = readNxJson(appTree);
-      expect(nxJson.targetDefaults['e2e-ci--**/*']).toMatchInlineSnapshot(`
+      expect(nxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
         {
           "dependsOn": [
             "^export",

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -576,7 +576,7 @@ describe('app', () => {
         e2eTestRunner: 'cypress',
         addPlugin: true,
       });
-      expect(readNxJson(tree).targetDefaults['e2e-ci--**/*'])
+      expect(readNxJson(tree).targetDefaults['e2e-ci--**/**'])
         .toMatchInlineSnapshot(`
         {
           "dependsOn": [
@@ -597,7 +597,7 @@ describe('app', () => {
         e2eTestRunner: 'playwright',
         addPlugin: true,
       });
-      expect(readNxJson(tree).targetDefaults['e2e-ci--**/*'])
+      expect(readNxJson(tree).targetDefaults['e2e-ci--**/**'])
         .toMatchInlineSnapshot(`
         {
           "dependsOn": [

--- a/packages/nuxt/src/generators/application/application.spec.ts
+++ b/packages/nuxt/src/generators/application/application.spec.ts
@@ -163,7 +163,7 @@ describe('app', () => {
               nxJson.plugins.find((p) => p.plugin === '@nx/vite/plugin')
             )
           );
-          expect(nxJson.targetDefaults['e2e-ci--**/*']).toMatchSnapshot();
+          expect(nxJson.targetDefaults['e2e-ci--**/**']).toMatchSnapshot();
         });
       });
 

--- a/packages/playwright/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.spec.ts
+++ b/packages/playwright/src/migrations/update-19-6-0/add-e2e-ci-target-defaults.spec.ts
@@ -77,7 +77,7 @@ describe('add-e2e-ci-target-defaults', () => {
         "build": {
           "cache": true,
         },
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
@@ -144,7 +144,7 @@ export default defineConfig({
         "build": {
           "cache": true,
         },
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
@@ -196,7 +196,7 @@ export default defineConfig({
         "build": {
           "cache": true,
         },
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
@@ -204,7 +204,7 @@ export default defineConfig({
         "lint": {
           "cache": true,
         },
-        "playwright:e2e-ci--**/*": {
+        "playwright:e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
@@ -254,7 +254,7 @@ export default defineConfig({
         "lint": {
           "cache": true,
         },
-        "playwright:e2e-ci--**/*": {
+        "playwright:e2e-ci--**/**": {
           "dependsOn": [
             "^build",
             "^bundle",

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1364,7 +1364,7 @@ describe('app', () => {
     nxJson = readNxJson(tree);
     expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
       {
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
@@ -1393,7 +1393,7 @@ describe('app', () => {
     nxJson = readNxJson(tree);
     expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
       {
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "^build",
           ],
@@ -1430,7 +1430,7 @@ describe('app', () => {
     nxJson = readNxJson(tree);
     expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
       {
-        "e2e-ci--**/*": {
+        "e2e-ci--**/**": {
           "dependsOn": [
             "^build-base",
           ],

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -178,7 +178,7 @@ describe('Remix Application', () => {
         expectTargetsToBeCorrect(tree, '.');
 
         expect(tree.read('e2e/cypress.config.ts', 'utf-8')).toMatchSnapshot();
-        expect(readNxJson(tree).targetDefaults['e2e-ci--**/*'])
+        expect(readNxJson(tree).targetDefaults['e2e-ci--**/**'])
           .toMatchInlineSnapshot(`
           {
             "dependsOn": [
@@ -206,14 +206,14 @@ describe('Remix Application', () => {
       expectTargetsToBeCorrect(tree, '.');
 
       expect(tree.read('e2e/playwright.config.ts', 'utf-8')).toMatchSnapshot();
-      expect(readNxJson(tree).targetDefaults['e2e-ci--**/*'])
+      expect(readNxJson(tree).targetDefaults['e2e-ci--**/**'])
         .toMatchInlineSnapshot(`
-          {
-            "dependsOn": [
-              "^build",
-            ],
-          }
-        `);
+        {
+          "dependsOn": [
+            "^build",
+          ],
+        }
+      `);
     });
   });
 

--- a/packages/vue/src/generators/application/application.spec.ts
+++ b/packages/vue/src/generators/application/application.spec.ts
@@ -59,7 +59,7 @@ describe('application generator', () => {
       tree.read('test-e2e/playwright.config.ts', 'utf-8')
     ).toMatchSnapshot();
     expect(listFiles(tree)).toMatchSnapshot();
-    expect(readNxJson(tree).targetDefaults['e2e-ci--**/*'])
+    expect(readNxJson(tree).targetDefaults['e2e-ci--**/**'])
       .toMatchInlineSnapshot(`
       {
         "dependsOn": [

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -53,7 +53,7 @@ describe('app', () => {
       expect(readProjectConfiguration(tree, 'my-app-e2e').root).toEqual(
         'my-app-e2e'
       );
-      expect(readNxJson(tree).targetDefaults['e2e-ci--**/*'])
+      expect(readNxJson(tree).targetDefaults['e2e-ci--**/**'])
         .toMatchInlineSnapshot(`
         {
           "dependsOn": [


### PR DESCRIPTION
Currently, we provide `targetDefaults` for atomized targets (e.g. `e2e-ci`) with a glob pattern that may not match nested paths.

i.e.

```
"e2e-ci--**/*": {
  "dependsOn": [
    "^build",
  ],
},
```

The `e2e-ci--**/*` pattern should be `e2e-ci--**/**`.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The generated `e2e-ci` pattern in `nx.json` does not match nested paths for split tasks.

## Expected Behavior
The generated `e2e-ci` pattern should apply to all split tasks.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #28842
