### PR TITLE
chore(core): fix command info

### DIFF
--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -64,6 +64,7 @@ async function ptyProcess(
   env: Record<string, string>
 ) {
   const terminal = createPseudoTerminal();
+  await terminal.init();
 
   return new Promise<void>((res, rej) => {
     const cp = terminal.runCommand(command, { cwd, jsEnv: env });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

"Printing" the command info before output causes `run-script` to hang and not run. In addition, the screen was cleared.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The command in run-script runs without issues. The screen is not cleared.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
