### PR TITLE
fix(linter): remove empty entry in typescript eslint flat config

### DIFF
--- a/packages/eslint-plugin/src/flat-configs/typescript.ts
+++ b/packages/eslint-plugin/src/flat-configs/typescript.ts
@@ -30,7 +30,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['**/*.ts', '**/*.tsx', , '**/*.cts', '**/*.mts'],
+    files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
     rules: {
       '@typescript-eslint/explicit-member-accessibility': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',


### PR DESCRIPTION
## Current Behavior

The `flat/typescript` config contains a config block with the `files` containing an invalid empty entry.

## Expected Behavior

The `flat/typescript` config should be correct.

## Related Issue(s)

Fixes #30725 
