### PR TITLE
cleanup(testing): fix outdated test snapshot in cypress graph plugin tests

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -548,6 +548,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/videos",
@@ -632,6 +635,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/videos/src-test-cy-ts",
@@ -745,6 +751,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/videos",
@@ -822,6 +831,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/videos/src-test-cy-ts",


### PR DESCRIPTION
## Current Behavior

A couple of unit tests for the `@nx/cypress` graph plugin are failing due to outdated snapshots.

## Expected Behavior

The `@nx/cypress` graph plugin tests should succeed. The test snapshots should be updated to match the new behavior.

## Related Issue(s)

Fixes #
