### PR TITLE
docs(core): fix package manager workspaces' patterns in typescript project linking concept page

### DIFF
--- a/docs/shared/concepts/typescript-project-linking.md
+++ b/docs/shared/concepts/typescript-project-linking.md
@@ -48,7 +48,7 @@ The configuration for package manager workspaces varies based on which package m
 
 ```json {% fileName="package.json" %}
 {
-  "workspaces": ["apps/**", "packages/**"]
+  "workspaces": ["apps/*", "packages/*"]
 }
 ```
 
@@ -69,7 +69,7 @@ If you want to reference a local library project with its own `build` task, you 
 
 ```json {% fileName="package.json" %}
 {
-  "workspaces": ["apps/**", "packages/**"]
+  "workspaces": ["apps/*", "packages/*"]
 }
 ```
 
@@ -90,7 +90,7 @@ If you want to reference a local library project with its own `build` task, you 
 
 ```json {% fileName="package.json" %}
 {
-  "workspaces": ["apps/**", "packages/**"]
+  "workspaces": ["apps/*", "packages/*"]
 }
 ```
 
@@ -111,8 +111,8 @@ If you want to reference a local library project with its own `build` task, you 
 
 ```yaml {% fileName="pnpm-workspace.yaml" %}
 packages:
-  - 'apps/**'
-  - 'packages/**'
+  - 'apps/*'
+  - 'packages/*'
 ```
 
 Defining the `packages` property in the root `pnpm-workspaces.yaml` file lets pnpm know to look for project `package.json` files in the specified folders. With this configuration in place, all the dependencies for the individual projects will be installed in the root `node_modules` folder when `pnpm install` is run in the root folder.


### PR DESCRIPTION
## Current Behavior

The "Typescript Project Linking" concept page shows package manager workspaces' patterns like `apps/**`. While this could be correct, it's not what Nx generators will generate, and it can result in some nested and non-expected directories being matched (e.g., fixtures).

## Expected Behavior

The "Typescript Project Linking" concept page should show package manager workspaces' patterns like `apps/*` so it's aligned with what Nx generators will generate. It would be a safer example, so it doesn't match potentially undesired directories.

## Related Issue(s)

Fixes #
