### PR TITLE
fix(core): only register forced shutdown when tui is enabled

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -129,12 +129,16 @@ export class TaskOrchestrator {
 
     await Promise.race([
       Promise.all(threads),
-      new Promise((resolve) => {
-        this.options.lifeCycle.registerForcedShutdownCallback(() => {
-          // The user force quit the TUI with ctrl+c, so proceed onto cleanup
-          resolve(undefined);
-        });
-      }),
+      ...(this.tuiEnabled
+        ? [
+            new Promise((resolve) => {
+              this.options.lifeCycle.registerForcedShutdownCallback(() => {
+                // The user force quit the TUI with ctrl+c, so proceed onto cleanup
+                resolve(undefined);
+              });
+            }),
+          ]
+        : []),
     ]);
 
     performance.mark('task-execution:end');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The `registerForcedShutdownCallback` lifecycle hook does not exist if the TUI is not enabled as it is not on CI. But Nx tries to invoke it anyways so it  causes an error in CI: https://github.com/nrwl/nx/actions/runs/14471341199/job/40585817051?pr=30710#step:11:31

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `registerForcedShutdownCallback` is only utilized when the TUI is enabled so it will not be invoked on CI where it does not exist.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
