### PR TITLE
feat: expand task ctx by overrides and nx args

### DIFF
--- a/packages/nx/src/project-graph/plugins/public-api.ts
+++ b/packages/nx/src/project-graph/plugins/public-api.ts
@@ -194,12 +194,14 @@ export type PreTasksExecutionContext = {
   readonly nxArgs: NxArgs;
   readonly overrides: Record<string, unknown>;
   readonly workspaceRoot: string;
+  readonly initiatingProject: string | null;
   readonly nxJsonConfiguration: NxJsonConfiguration;
 };
 export type PostTasksExecutionContext = {
   readonly nxArgs: NxArgs;
   readonly overrides: Record<string, unknown>;
   readonly workspaceRoot: string;
+  readonly initiatingProject: string | null;
   readonly nxJsonConfiguration: NxJsonConfiguration;
   readonly taskResults: TaskResults;
 };

--- a/packages/nx/src/project-graph/plugins/public-api.ts
+++ b/packages/nx/src/project-graph/plugins/public-api.ts
@@ -12,6 +12,7 @@ import type { ProjectConfiguration } from '../../config/workspace-json-project-j
 import type { NxJsonConfiguration } from '../../config/nx-json';
 import type { RawProjectGraphDependency } from '../project-graph-builder';
 import type { TaskResults } from '../../tasks-runner/life-cycle';
+import type { NxArgs } from '../../utils/command-line-utils';
 
 /**
  * Context for {@link CreateNodesFunction}
@@ -190,10 +191,14 @@ export type NxPluginV2<TOptions = unknown> = {
 };
 
 export type PreTasksExecutionContext = {
+  readonly nxArgs: NxArgs;
+  readonly overrides: Record<string, unknown>;
   readonly workspaceRoot: string;
   readonly nxJsonConfiguration: NxJsonConfiguration;
 };
 export type PostTasksExecutionContext = {
+  readonly nxArgs: NxArgs;
+  readonly overrides: Record<string, unknown>;
   readonly workspaceRoot: string;
   readonly nxJsonConfiguration: NxJsonConfiguration;
   readonly taskResults: TaskResults;

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -190,6 +190,7 @@ export async function runCommand(
         nxArgs,
         overrides,
         workspaceRoot,
+        initiatingProject,
         nxJsonConfiguration: nxJson,
       });
 
@@ -222,6 +223,7 @@ export async function runCommand(
         overrides,
         taskResults,
         workspaceRoot,
+        initiatingProject,
         nxJsonConfiguration: nxJson,
       });
 

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -187,6 +187,8 @@ export async function runCommand(
     process.env.NX_VERBOSE_LOGGING === 'true',
     async () => {
       await runPreTasksExecution({
+        nxArgs,
+        overrides,
         workspaceRoot,
         nxJsonConfiguration: nxJson,
       });
@@ -216,6 +218,8 @@ export async function runCommand(
         : 0;
 
       await runPostTasksExecution({
+        nxArgs,
+        overrides,
         taskResults,
         workspaceRoot,
         nxJsonConfiguration: nxJson,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx tasks only receive the nx workspace root configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Task lifecycle hooks should be able to run logic depending on the overrides and current nx args.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
