### PR TITLE
chore(repo): make copy-docs non-cacheable

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -175,9 +175,6 @@
     },
     "sitemap": {
       "cache": true
-    },
-    "copy-docs": {
-      "cache": true
     }
   },
   "plugins": [


### PR DESCRIPTION
The `copy-docs` target takes less than a second to run but is caching 500+ MB of assets. Let's make it non-cacheable since it's not needed anyway.