### PR TITLE
fix(js): remove check that ts plugin is used for ts sync generator

### DIFF
--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -95,16 +95,6 @@ describe('syncGenerator()', () => {
     addProject('b', ['a']);
   });
 
-  it('should error if the @nx/js/typescript plugin is not configured in nx.json', async () => {
-    const nxJson = readJson(tree, 'nx.json');
-    nxJson.plugins = nxJson.plugins.filter((p) => p !== '@nx/js/typescript');
-    writeJson(tree, 'nx.json', nxJson);
-
-    await expect(syncGenerator(tree)).rejects.toMatchInlineSnapshot(
-      `[SyncError: The "@nx/js/typescript" plugin is not registered]`
-    );
-  });
-
   it('should error if there is no root tsconfig.json', async () => {
     tree.delete('tsconfig.json');
 

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -61,21 +61,6 @@ type TsconfigInfoCaches = {
 export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
   // Ensure that the plugin has been wired up in nx.json
   const nxJson = readNxJson(tree);
-  const tscPluginConfig:
-    | string
-    | ExpandedPluginConfiguration<TscPluginOptions> = nxJson.plugins.find(
-    (p) => {
-      if (typeof p === 'string') {
-        return p === PLUGIN_NAME;
-      }
-      return p.plugin === PLUGIN_NAME;
-    }
-  );
-  if (!tscPluginConfig) {
-    throw new SyncError(`The "${PLUGIN_NAME}" plugin is not registered`, [
-      `The "${PLUGIN_NAME}" plugin must be added to the "plugins" array in "nx.json" in order to sync the project graph information to the TypeScript configuration files.`,
-    ]);
-  }
 
   const tsconfigInfoCaches: TsconfigInfoCaches = {
     composite: new Map(),

--- a/packages/nx/src/command-line/init/configure-plugins.ts
+++ b/packages/nx/src/command-line/init/configure-plugins.ts
@@ -85,9 +85,11 @@ export async function runPluginInitGenerator(
     });
   } catch {
     // init generator does not exist, so this function should noop
-    output.log({
-      title: `No "init" generator found in ${plugin}. Skipping initialization.`,
-    });
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
+      output.log({
+        title: `No "init" generator found in ${plugin}. Skipping initialization.`,
+      });
+    }
     return;
   }
 }

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -313,8 +313,10 @@ export function markPackageJsonAsNxProject(packageJsonPath: string) {
 
 export function printFinalMessage({
   learnMoreLink,
+  appendLines,
 }: {
   learnMoreLink?: string;
+  appendLines?: string[];
 }): void {
   const pmc = getPackageManagerCommand();
 
@@ -328,6 +330,7 @@ export function printFinalMessage({
         pmc
       )} graph" to see the graph of projects and tasks in your workspace. https://nx.dev/core-features/explore-graph`,
       learnMoreLink ? `- Learn more at ${learnMoreLink}.` : undefined,
+      ...(appendLines ?? []),
     ].filter(Boolean),
   });
 }

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -69,12 +69,6 @@ export async function initHandler(options: InitArgs): Promise<void> {
   const _isMonorepo = _isNonJs ? false : isMonorepo(packageJson);
   const _isCRA = _isNonJs ? false : isCRA(packageJson);
 
-  const learnMoreLink = _isTurborepo
-    ? 'https://nx.dev/recipes/adopting-nx/from-turborepo'
-    : _isMonorepo
-    ? 'https://nx.dev/getting-started/tutorials/npm-workspaces-tutorial'
-    : 'https://nx.dev/recipes/adopting-nx/adding-to-existing-project';
-
   /**
    * Turborepo users must have set up individual scripts already, and we keep the transition as minimal as possible.
    * We log a message during the conversion process in addNxToTurborepo about how they can learn more about the power
@@ -86,7 +80,7 @@ export async function initHandler(options: InitArgs): Promise<void> {
       interactive: options.interactive,
     });
     printFinalMessage({
-      learnMoreLink,
+      learnMoreLink: 'https://nx.dev/recipes/adopting-nx/from-turborepo',
     });
     return;
   }
@@ -160,7 +154,13 @@ export async function initHandler(options: InitArgs): Promise<void> {
   }
 
   printFinalMessage({
-    learnMoreLink,
+    appendLines: _isMonorepo
+      ? [
+          `- Learn how Nx helps manage your TypeScript monorepo at https://nx.dev/features/maintain-ts-monorepos.`,
+        ]
+      : [
+          `- Learn how Nx works with any type of project at https://nx.dev/recipes/adopting-nx/adding-to-existing-project.`,
+        ],
   });
 }
 


### PR DESCRIPTION
This PR ensures that when `@nx/js/typescript` is not used, we do not add `@nx/js:typescript-sync` sync generator to targets such as build, serve, etc.

It resolves issues where `nx init` into a repo that is compatible with TS solution will add the sync generator, even if the plugin is unused. It leads to errors everytime users run a task like build. The error is like this:

```
[@nx/js:typescript-sync] The `@nx/js/typescript` plugin is not registered

...

> Would you like to ignore the sync failures and continue running the task?
Yes
No
```

It makes it confusing for users, especially new users that don't know what sync generators are. They will always run into the error and have to choose to continue despite the failure.

**Note:** In a future follow-up, we could consider adding better info and prompts so we can let users know that Nx also helps keep workspace up to date, and can learn more about it.

## Current Behavior
Users see an error when running `nx add @nx/vite` and then `nx build <project>`.

## Expected Behavior


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
