### PR TITLE
fix(core): disable tui when CI=true

### DIFF
--- a/packages/nx/src/tasks-runner/is-tui-enabled.spec.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.spec.ts
@@ -1,0 +1,60 @@
+describe('isTuiEnabled', () => {
+  let originalTuiEnv: string | undefined;
+  let originalCIEnv: string | undefined;
+  let isTuiEnabled: typeof import('./is-tui-enabled').isTuiEnabled;
+  beforeEach(async () => {
+    jest.resetModules();
+    isTuiEnabled = await import('./is-tui-enabled').then((m) => m.isTuiEnabled);
+    originalTuiEnv = process.env.NX_TUI;
+    originalCIEnv = process.env.CI;
+    process.env.CI = 'false';
+    delete process.env.NX_TUI;
+  });
+
+  afterEach(() => {
+    if (originalTuiEnv) {
+      process.env.NX_TUI = originalTuiEnv;
+    } else {
+      delete process.env.NX_TUI;
+    }
+    if (originalCIEnv) {
+      process.env.CI = originalCIEnv;
+    } else {
+      delete process.env.CI;
+    }
+  });
+
+  it('should return true by default', () => {
+    // default  is false  in nx.json
+    expect(isTuiEnabled({}, true)).toBe(true);
+  });
+
+  it('should return true if the TUI is enabled', () => {
+    process.env.NX_TUI = 'true';
+    expect(isTuiEnabled({}, true)).toBe(true);
+  });
+
+  it('should return false if the TUI is disabled', () => {
+    process.env.NX_TUI = 'false';
+    expect(isTuiEnabled({}, true)).toBe(false);
+  });
+
+  it('should return false in CI', () => {
+    process.env.CI = 'true';
+    expect(isTuiEnabled({}, true)).toBe(false);
+  });
+
+  it('should return true if TUI is enabled in CI', () => {
+    process.env.NX_TUI = 'true';
+    process.env.CI = 'true';
+    expect(isTuiEnabled({}, true)).toBe(true);
+  });
+
+  it('should return true if the TUI is enabled in nx.json', () => {
+    expect(isTuiEnabled({ tui: { enabled: true } }, true)).toBe(true);
+  });
+
+  it('should return false if the TUI is disabled in nx.json', () => {
+    expect(isTuiEnabled({ tui: { enabled: false } }, true)).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When `CI=true`, the TUI is still enabled by default.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When `CI=true`, the TUI is disabled unless it is explicitly enabled with `NX_TUI=true`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
