### PR TITLE
chore(repo): remove vite paths plugin from our own Storybook files

### DIFF
--- a/graph/migrate/.storybook/main.ts
+++ b/graph/migrate/.storybook/main.ts
@@ -1,8 +1,5 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 import type { StorybookConfig } from '@storybook/react-vite';
-
-// nx-ignore-next-line
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
@@ -16,7 +13,7 @@ const config: StorybookConfig = {
 
   viteFinal: async (config) =>
     mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
+      plugins: [],
     }),
 
   docs: {},

--- a/graph/ui-code-block/.storybook/main.ts
+++ b/graph/ui-code-block/.storybook/main.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 import type { StorybookConfig } from '@storybook/react-vite';
 import { mergeConfig } from 'vite';
-// nx-ignore-next-line
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
@@ -15,7 +13,7 @@ const config: StorybookConfig = {
 
   viteFinal: async (config) =>
     mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
+      plugins: [],
     }),
 };
 

--- a/graph/ui-project-details/.storybook/main.ts
+++ b/graph/ui-project-details/.storybook/main.ts
@@ -1,8 +1,5 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 import type { StorybookConfig } from '@storybook/react-vite';
-
-// nx-ignore-next-line
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
@@ -16,7 +13,7 @@ const config: StorybookConfig = {
 
   viteFinal: async (config) =>
     mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
+      plugins: [],
     }),
 
   docs: {},


### PR DESCRIPTION
This PR fixes an issue that blocks FreeBSD release for some reason.

When we use the `@nx/vite/plugins/nx-tsconfig-paths.plugin` plugin and both `CI=1` and `NX_PREFER_TS_NODE=true` are set, then the graph fails to compute. For example, running this will error out:

```shell
CI=1 NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false NX_PREFER_TS_NODE=true nx report
```

The error is like this:

```shell
⚠️ Unable to construct project graph.
Failed to process project graph.
     - graph/migrate/.storybook/main.ts: TypeError: Cannot set property level of [object Object] which has only a getter
      at Object.<anonymous> (/Users/jack/projects/nx/packages/nx/src/utils/output.ts:38:23)
      at Module._compile (node:internal/modules/cjs/loader:1554:14)
      at Module.m._compile (/Users/jack/projects/nx/node_modules/.pnpm/ts-node@10.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@types+node@20.16.10_typescript@5.7.3/node_modules/ts-node/src/index.ts:1618:23)
      at node:internal/modules/cjs/loader:1706:10
      at Object.require.extensions.<computed> [as .ts] (/Users/jack/projects/nx/node_modules/.pnpm/ts-node@10.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@types+node@20.16.10_typescript@5.7.3/node_modules/ts-node/src/index.ts:1621:12)
      at Module.load (node:internal/modules/cjs/loader:1289:32)
      at Function._load (node:internal/modules/cjs/loader:1108:12)
      at TracingChannel.traceSync (node:diagnostics_channel:322:14)
      at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
      at Module.require (node:internal/modules/cjs/loader:1311:12)
   - graph/ui-code-block/.storybook/main.ts: TypeError: Cannot set property level of [object Object] which has only a getter
      at Object.<anonymous> (/Users/jack/projects/nx/packages/nx/src/utils/output.ts:38:23)
      at Module._compile (node:internal/modules/cjs/loader:1554:14)
      at Module.m._compile (/Users/jack/projects/nx/node_modules/.pnpm/ts-node@10.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@types+node@20.16.10_typescript@5.7.3/node_modules/ts-node/src/index.ts:1618:23)
      at node:internal/modules/cjs/loader:1706:10
      at Object.require.extensions.<computed> [as .ts] (/Users/jack/projects/nx/node_modules/.pnpm/ts-node@10.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@types+node@20.16.10_typescript@5.7.3/node_modules/ts-node/src/index.ts:1621:12)
      at Module.load (node:internal/modules/cjs/loader:1289:32)
      at Function._load (node:internal/modules/cjs/loader:1108:12)
      at TracingChannel.traceSync (node:diagnostics_channel:322:14)
      at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
      at Module.require (node:internal/modules/cjs/loader:1311:12)
   - graph/ui-project-details/.storybook/main.ts: TypeError: Cannot set property level of [object Object] which has only a getter
      at Object.<anonymous> (/Users/jack/projects/nx/packages/nx/src/utils/output.ts:38:23)
      at Module._compile (node:internal/modules/cjs/loader:1554:14)
      at Module.m._compile (/Users/jack/projects/nx/node_modules/.pnpm/ts-node@10.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@types+node@20.16.10_typescript@5.7.3/node_modules/ts-node/src/index.ts:1618:23)
      at node:internal/modules/cjs/loader:1706:10
      at Object.require.extensions.<computed> [as .ts] (/Users/jack/projects/nx/node_modules/.pnpm/ts-node@10.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@types+node@20.16.10_typescript@5.7.3/node_modules/ts-node/src/index.ts:1621:12)
      at Module.load (node:internal/modules/cjs/loader:1289:32)
      at Function._load (node:internal/modules/cjs/loader:1108:12)
      at TracingChannel.traceSync (node:diagnostics_channel:322:14)
      at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
      at Module.require (node:internal/modules/cjs/loader:1311:12)
```

This is an issue for us only because we are pointing `@nx/vite/plugins/nx-tsconfig-paths.plugin` to source. Normally, this would already be in JS, and not need to go through `ts-node` or SWC. 

I'm unsure what the exact cause is. There was nothing obvious in how we register `ts-node`, and nothing in `ts-node` to suggest different behavior with `CI=1`.

## Current Behavior
FreeBSD release is blocked

See: https://github.com/nrwl/nx/actions/runs/14500499978/job/40678818950

## Expected Behavior
FreeBSD release works

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
