### PR TITLE
chore(misc): remove Node.js 18 version from nightly matrix

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -26,20 +26,15 @@ jobs:
           - macos-latest
           - windows-latest
         node_version:
-          - 18
           - 20
           - 22
           # - 23
         exclude:
           # run just node v20 on macos and windows
           - os: macos-latest
-            node_version: 18
-          - os: macos-latest
             node_version: 22
           # - os: macos-latest
           #   node_version: 23
-          - os: windows-latest
-            node_version: 18
           - os: windows-latest
             node_version: 22
           # - os: windows-latest

--- a/.github/workflows/nightly/process-matrix.ts
+++ b/.github/workflows/nightly/process-matrix.ts
@@ -56,7 +56,7 @@ const matrixData: MatrixData = {
   ],
   nodeTLS: 20,
   setup: [
-    { os: 'ubuntu-latest', os_name: 'Linux', os_timeout: 60, package_managers: ['npm', 'pnpm', 'yarn'], node_versions: [18, 20, 22], excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo'] },
+    { os: 'ubuntu-latest', os_name: 'Linux', os_timeout: 60, package_managers: ['npm', 'pnpm', 'yarn'], node_versions: [20, 22], excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo'] },
     { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: [20] },
     { os: 'windows-latest', os_name: 'WinOS', os_timeout: 180, package_managers: ['npm'], node_versions: [20], excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo'] }
   ]


### PR DESCRIPTION
This PR updates our nightly test configuration to align with the current Node.js ecosystem.

Node.js v18 has reached end-of-life, so we're updating our nightly tests to ensure compatibility with actively maintained Node.js versions.