### PR TITLE
fix(graph): ensure deps from graph-client->migrate-ui exists so taliwind styles are compiled correctly

### DIFF
--- a/graph/client/src/app/console-migrate/migrate.app.tsx
+++ b/graph/client/src/app/console-migrate/migrate.app.tsx
@@ -3,7 +3,6 @@
 import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
 // nx-ignore-next-line
 import { type FileChange } from 'nx/src/devkit-exports';
-// nx-ignore-next-line
 import { MigrateUI } from '@nx/graph-migrate';
 /* eslint-enable @nx/enforce-module-boundaries */
 

--- a/graph/migrate/src/lib/components/automatic-migration.tsx
+++ b/graph/migrate/src/lib/components/automatic-migration.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @nx/enforce-module-boundaries */
-import { FileChange } from '@nx/devkit';
+import { FileChange } from 'nx/src/devkit-exports';
 import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
 import type { MigrationsJsonMetadata } from 'nx/src/command-line/migrate/migrate-ui-api';
 /* eslint-enable @nx/enforce-module-boundaries */

--- a/graph/migrate/src/lib/components/migration-list.tsx
+++ b/graph/migrate/src/lib/components/migration-list.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @nx/enforce-module-boundaries */
-import { FileChange } from '@nx/devkit';
+import { FileChange } from 'nx/src/devkit-exports';
 import { MigrationsJsonMetadata } from 'nx/src/command-line/migrate/migrate-ui-api';
 import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
 /* eslint-enable @nx/enforce-module-boundaries */

--- a/graph/migrate/src/lib/components/migration-timeline.tsx
+++ b/graph/migrate/src/lib/components/migration-timeline.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @nx/enforce-module-boundaries */
-import { FileChange } from '@nx/devkit';
+import { FileChange } from 'nx/src/devkit-exports';
 import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
 import type { MigrationsJsonMetadata } from 'nx/src/command-line/migrate/migrate-ui-api';
 


### PR DESCRIPTION
This PR removes the `// nx-ignore-next-line` from graph client to the migrate lib import. Without the dep being there, the tailwind styles will not include classes used by migrate UI.


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Styles are broken for migrate UI

## Expected Behavior
Styles should work

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
