### PR TITLE
fix(nx-dev): toc should only include headings from the article body

### DIFF
--- a/nx-dev/ui-blog/src/lib/blog-details.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-details.tsx
@@ -100,7 +100,7 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
       </div>
 
       {/* Main grid layout */}
-      <div className="mx-auto max-w-7xl px-4 lg:px-8">
+      <div className="mx-auto max-w-7xl px-4 lg:px-8" data-content-area>
         <div className="relative isolate grid grid-cols-1 gap-8 xl:grid-cols-[200px_minmax(0,1fr)_200px]">
           <div className="hidden min-h-full xl:block">
             {post.metrics && (

--- a/nx-dev/ui-markdoc/src/lib/tags/table-of-contents.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/table-of-contents.component.tsx
@@ -18,8 +18,8 @@ export function TableOfContents({
   const [headings, setHeadings] = useState<TocItem[]>([]);
 
   useEffect(() => {
-    // Find the main content wrapper where markdown content is rendered
-    const content = document.querySelector('[data-document="main"]');
+    // Find the content area where markdown content is rendered
+    const content = document.querySelector('[data-content-area]');
     if (!content) return;
 
     // Get all headings h1-h6 within the content
@@ -42,7 +42,7 @@ export function TableOfContents({
   }, [maxDepth]);
 
   if (headings.length === 0) {
-    return null;
+    return <></>;
   }
 
   return (


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The toc also includes the "More Articles" heading which is out of the scope of the TOC

<img width="802" alt="Screenshot 2025-04-17 at 10 42 35" src="https://github.com/user-attachments/assets/ccdc8775-aa18-4267-aaf0-21d0f07723eb" />


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR fixes it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
