### PR TITLE
chore(nx-dev): ignore the `public` directory in the eslint configuration

### DIFF
--- a/nx-dev/nx-dev/.eslintrc.json
+++ b/nx-dev/nx-dev/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*", "**/.next"]
+  "ignorePatterns": ["!**/*", "**/.next", "public"]
 }


### PR DESCRIPTION
## Current Behavior

The `nx-dev:lint` task is processing the `public` directory. That directory is meant to contain assets that ESLint shouldn't process. It results in extra time being spent linting the project, and it could result in some errors due to linting some generated output that's copied there (e.g. `documentation` and `tutorials` directories).

## Expected Behavior

The `nx-dev:lint` task should not process the `public` directory.

## Related Issue(s)

Fixes #
