### PR TITLE
fix(react): mark react-router dev/start targets as continuous

### DIFF
--- a/packages/react/src/plugins/__snapshots__/router-plugin.spec.ts.snap
+++ b/packages/react/src/plugins/__snapshots__/router-plugin.spec.ts.snap
@@ -41,12 +41,14 @@ exports[`@nx/react/react-router-plugin React Router should create nodes by defau
             },
             "dev": {
               "command": "react-router dev",
+              "continuous": true,
               "options": {
                 "cwd": "acme",
               },
             },
             "start": {
               "command": "react-router-serve build/server/index.js",
+              "continuous": true,
               "dependsOn": [
                 "build",
               ],
@@ -139,6 +141,7 @@ exports[`@nx/react/react-router-plugin React Router should create nodes without 
             },
             "dev": {
               "command": "react-router dev",
+              "continuous": true,
               "options": {
                 "cwd": "acme",
               },

--- a/packages/react/src/plugins/router-plugin.ts
+++ b/packages/react/src/plugins/router-plugin.ts
@@ -270,6 +270,7 @@ async function getBuildPaths(reactRouterConfig, isLibMode: boolean) {
 
 async function devTarget(projectRoot: string, isUsingTsSolutionSetup: boolean) {
   const devTarget: TargetConfiguration = {
+    continuous: true,
     command: 'react-router dev',
     options: { cwd: projectRoot },
   };
@@ -292,6 +293,7 @@ async function startTarget(
       : serverBuildPath;
 
   const startTarget: TargetConfiguration = {
+    continuous: true,
     dependsOn: [buildTargetName],
     command: `react-router-serve ${serverPath}`,
     options: { cwd: projectRoot },


### PR DESCRIPTION
This PR marks dev/start from `@nx/react/router-plugin` as continuous. Otherwise, running e2e will hang.

Repro: 
- `npx create-nx-workspace@next org --preset=react-monorepo --appName=demo --e2eTestRunner=playwright` and pick RR For SSR
- Run `nx e2e demo-e2e`




## Current Behavior
<!-- This is the behavior we have today -->

e2e hangs because dev does not finish, and it is not marked as continuous

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
dev and start from RR should work with e2e

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
