### PR TITLE
fix(core): migrate-ui-api should always use its own migrate module

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate-ui-api.ts
+++ b/packages/nx/src/command-line/migrate/migrate-ui-api.ts
@@ -1,11 +1,10 @@
 import { execSync } from 'child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import type { MigrationDetailsWithId } from '../../config/misc-interfaces';
 import type { FileChange } from '../../generators/tree';
 import {
   getImplementationPath as getMigrationImplementationPath,
-  nxCliPath,
   readMigrationCollection,
 } from './migrate';
 
@@ -131,21 +130,10 @@ export async function runSingleMigration(
       encoding: 'utf-8',
     }).trim();
 
-    const cliPath = nxCliPath(workspacePath);
-    const updatedMigrateLocation = resolve(
-      cliPath,
-      '..',
-      '..',
-      'nx',
-      'src',
-      'command-line',
-      'migrate',
-      'migrate.js'
-    );
-
-    const updatedMigrateModule: typeof import('./migrate') = await import(
-      updatedMigrateLocation
-    );
+    // For Migrate UI, this current module is loaded either from:
+    // 1. The CLI path to the migrated modules. The version of Nx is of the user's choosing. This may or may not have the new migrate API, so Console will check that `runSingleMigration` exists before using it.
+    // 2. Bundled into Console, so the version is fixed to what we build Console with.
+    const updatedMigrateModule = await import('./migrate.js');
 
     const fileChanges = await updatedMigrateModule.runNxOrAngularMigration(
       workspacePath,


### PR DESCRIPTION
This PR fixes an issue if the user is not updated to an Nx version that provides the new Migrate UI API, then it will load the run version and error out.

<img width="2672" alt="Screenshot 2025-04-17 at 10 18 45 AM" src="https://github.com/user-attachments/assets/2720922b-6ef5-4162-a3f1-d1ccedb60acd" />

The fix is to always use the local `migrate.js` module.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
Migrate UI is broken if the migrated version does not have the new API

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Migrate UI should always work

Fixes #
