### PR TITLE
feat(core): add enter and q keybindings

### DIFF
--- a/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
+++ b/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
@@ -5,7 +5,6 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode},
     tty::IsTty,
 };
-use itertools::Itertools;
 use napi::bindgen_prelude::*;
 use portable_pty::{CommandBuilder, NativePtySystem, PtyPair, PtySize, PtySystem};
 use std::io::stdout;

--- a/packages/nx/src/native/tui/components/help_popup.rs
+++ b/packages/nx/src/native/tui/components/help_popup.rs
@@ -91,7 +91,7 @@ impl HelpPopup {
         let keybindings = vec![
             // Misc
             ("?", "Toggle this popup"),
-            ("<ctrl>+c", "Quit the TUI"),
+            ("q or <ctrl>+c", "Quit the TUI"),
             ("", ""),
             // Navigation
             ("↑ or k", "Navigate/scroll task output up"),
@@ -106,6 +106,8 @@ impl HelpPopup {
             ("<esc>", "Clear filter"),
             ("", ""),
             // Output Controls
+            ("<enter>", "Open and focus terminal for task"),
+            ("<esc>", "Set focus back to task list"),
             ("<space>", "Quick toggle a single output pane"),
             ("b", "Toggle task list visibility"),
             ("1", "Pin task to be shown in output pane 1"),
@@ -166,12 +168,7 @@ impl HelpPopup {
                         let mut spans = Vec::new();
 
                         // Calculate the total visible length (excluding color codes)
-                        let visible_length = if key_parts.len() > 1 {
-                            key_parts.iter().map(|s| s.len()).sum::<usize>() + 2
-                        // for alignment
-                        } else {
-                            key.len()
-                        };
+                        let visible_length = key.chars().count();
 
                         // Add each key part with the appropriate styling
                         for (i, part) in key_parts.iter().enumerate() {
@@ -188,7 +185,7 @@ impl HelpPopup {
                         }
 
                         // Add padding to align all descriptions
-                        let padding = " ".repeat(11usize.saturating_sub(visible_length));
+                        let padding = " ".repeat(14usize.saturating_sub(visible_length));
                         spans.push(Span::raw(padding));
 
                         // Add the separator and description

--- a/packages/nx/src/native/tui/components/help_text.rs
+++ b/packages/nx/src/native/tui/components/help_text.rs
@@ -36,7 +36,7 @@ impl HelpText {
             // Show minimal hint
             let hint = vec![
                 Span::styled("quit: ", base_style.fg(Color::DarkGray)),
-                Span::styled("<ctrl>+c", base_style.fg(Color::Cyan)),
+                Span::styled("q", base_style.fg(Color::Cyan)),
                 Span::styled("  ", base_style.fg(Color::DarkGray)),
                 Span::styled("help: ", base_style.fg(Color::DarkGray)),
                 Span::styled("?  ", base_style.fg(Color::Cyan)),
@@ -53,7 +53,7 @@ impl HelpText {
             // Show full shortcuts
             let shortcuts = vec![
                 Span::styled("quit: ", base_style.fg(Color::DarkGray)),
-                Span::styled("<ctrl>+c", base_style.fg(Color::Cyan)),
+                Span::styled("q", base_style.fg(Color::Cyan)),
                 Span::styled("  ", base_style.fg(Color::DarkGray)),
                 Span::styled("help: ", base_style.fg(Color::DarkGray)),
                 Span::styled("?", base_style.fg(Color::Cyan)),
@@ -70,8 +70,8 @@ impl HelpText {
                 Span::styled(" or ", base_style.fg(Color::DarkGray)),
                 Span::styled("2", base_style.fg(Color::Cyan)),
                 Span::styled("  ", base_style.fg(Color::DarkGray)),
-                Span::styled("focus output: ", base_style.fg(Color::DarkGray)),
-                Span::styled("<tab>", base_style.fg(Color::Cyan)),
+                Span::styled("show output: ", base_style.fg(Color::DarkGray)),
+                Span::styled("<enter>", base_style.fg(Color::Cyan)),
             ];
 
             f.render_widget(

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::{any::Any, io};
 use vt100_ctt::Parser;
 
-use crate::native::tui::utils::{is_cache_hit, normalize_newlines, sort_task_items};
+use crate::native::tui::utils::{normalize_newlines, sort_task_items};
 use crate::native::tui::{
     action::Action, app::Focus, components::Component, pty::PtyInstance, utils,
 };
@@ -965,6 +965,16 @@ impl TasksList {
             task_item.update_status(status);
             self.sort_tasks();
         }
+        for (i, data) in self.terminal_pane_data.iter_mut().enumerate() {
+            if self.pane_tasks.as_ref()[i].clone().is_some_and(|id| id == task_id) {
+                let in_progress = status == TaskStatus::InProgress;
+                data.can_be_interactive = in_progress;
+                if !in_progress {
+                    data.set_interactive(false);
+                }
+            }
+        }
+        
     }
 
     pub fn end_tasks(&mut self, task_results: Vec<TaskResult>) {
@@ -2068,7 +2078,7 @@ impl Component for TasksList {
                             {
                                 let mut terminal_pane_data = &mut self.terminal_pane_data[1];
                                 terminal_pane_data.is_continuous = task.continuous;
-                                terminal_pane_data.is_cache_hit = is_cache_hit(task.status);
+                                // terminal_pane_data.is_cache_hit = is_cache_hit(task.status);
 
                                 let mut has_pty = false;
                                 if let Some(pty) = self.pty_instances.get(task_name) {
@@ -2111,7 +2121,7 @@ impl Component for TasksList {
                         if let Some(task) = self.tasks.iter_mut().find(|t| t.name == *task_name) {
                             let mut terminal_pane_data = &mut self.terminal_pane_data[pane_idx];
                             terminal_pane_data.is_continuous = task.continuous;
-                            terminal_pane_data.is_cache_hit = is_cache_hit(task.status);
+                            // terminal_pane_data.is_cache_hit = is_cache_hit(task.status);
 
                             let mut has_pty = false;
                             if let Some(pty) = self.pty_instances.get(task_name) {
@@ -2153,7 +2163,7 @@ impl Component for TasksList {
                             {
                                 let mut terminal_pane_data = &mut self.terminal_pane_data[pane_idx];
                                 terminal_pane_data.is_continuous = task.continuous;
-                                terminal_pane_data.is_cache_hit = is_cache_hit(task.status);
+                                // terminal_pane_data.is_cache_hit = is_cache_hit(task.status);
 
                                 let mut has_pty = false;
                                 if let Some(pty) = self.pty_instances.get(task_name) {

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -723,6 +723,13 @@ impl TasksList {
     }
 
     /// Returns true if the currently focused pane is in interactive mode.
+    pub fn set_interactive_mode(&mut self, interactive: bool) {
+        if let Focus::MultipleOutput(pane_idx) = self.focus {
+            self.terminal_pane_data[pane_idx].set_interactive(interactive);
+        }
+    }
+
+    /// Returns true if the currently focused pane is in interactive mode.
     pub fn is_interactive_mode(&self) -> bool {
         match self.focus {
             Focus::MultipleOutput(pane_idx) => self.terminal_pane_data[pane_idx].is_interactive(),

--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -21,7 +21,7 @@ pub struct TerminalPaneData {
     pub pty: Option<Arc<PtyInstance>>,
     pub is_interactive: bool,
     pub is_continuous: bool,
-    pub is_cache_hit: bool,
+    pub can_be_interactive: bool,
 }
 
 impl TerminalPaneData {
@@ -30,7 +30,7 @@ impl TerminalPaneData {
             pty: None,
             is_interactive: false,
             is_continuous: false,
-            is_cache_hit: false,
+            can_be_interactive: false,
         }
     }
 
@@ -91,8 +91,8 @@ impl TerminalPaneData {
                     }
                     return Ok(());
                 }
-                // Handle 'i' to enter interactive mode for non cache hit tasks
-                KeyCode::Char('i') if !self.is_cache_hit && !self.is_interactive => {
+                // Handle 'i' to enter interactive mode for in progress tasks
+                KeyCode::Char('i') if self.can_be_interactive && !self.is_interactive => {
                     self.set_interactive(true);
                     return Ok(());
                 }
@@ -426,7 +426,7 @@ impl<'a> StatefulWidget for TerminalPane<'a> {
                     }
 
                     // Show interactive/readonly status for focused, non-cache hit, tasks
-                    if state.is_focused && !pty_data.is_cache_hit {
+                    if state.task_status == TaskStatus::InProgress && state.is_focused {
                         // Bottom right status
                         let bottom_text = if self.is_currently_interactive() {
                             Line::from(vec![

--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -96,15 +96,6 @@ impl TerminalPaneData {
                     self.set_interactive(true);
                     return Ok(());
                 }
-                // Handle Ctrl+Z to exit interactive mode
-                KeyCode::Char('z')
-                    if key.modifiers == KeyModifiers::CONTROL
-                        && !self.is_cache_hit
-                        && self.is_interactive =>
-                {
-                    self.set_interactive(false);
-                    return Ok(());
-                }
                 // Only send input to PTY if we're in interactive mode
                 _ if self.is_interactive => match key.code {
                     KeyCode::Char(c) => {

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -202,11 +202,7 @@ impl AppLifeCycle {
                 // Handle events using our Tui abstraction
                 if let Some(event) = tui.next().await {
                     if let Ok(mut app) = app_mutex.lock() {
-                        if let Ok(true) = app.handle_event(event, &action_tx) {
-                            tui.exit().ok();
-                            app.call_done_callback();
-                            break;
-                        }
+                        let _ = app.handle_event(event, &action_tx);
 
                         // Check if we should quit based on the timer
                         if let Some(quit_time) = app.quit_at {

--- a/packages/nx/src/native/tui/utils.rs
+++ b/packages/nx/src/native/tui/utils.rs
@@ -32,13 +32,6 @@ pub fn normalize_newlines(input: &[u8]) -> Vec<u8> {
     output
 }
 
-pub fn is_cache_hit(status: TaskStatus) -> bool {
-    matches!(
-        status,
-        TaskStatus::LocalCacheKeptExisting | TaskStatus::LocalCache | TaskStatus::RemoteCache
-    )
-}
-
 /// Sorts a list of TaskItems with a stable, total ordering.
 ///
 /// The sort order is:

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -680,6 +680,12 @@ export class TaskOrchestrator {
 
       this.runningContinuousTasks.set(task.id, runningTask);
       runningTask.onExit(() => {
+        if (this.tuiEnabled) {
+          this.options.lifeCycle.setTaskStatus(
+            task.id,
+            NativeTaskStatus.Stopped
+          );
+        }
         this.runningContinuousTasks.delete(task.id);
       });
 
@@ -744,6 +750,9 @@ export class TaskOrchestrator {
     this.runningContinuousTasks.set(task.id, childProcess);
 
     childProcess.onExit(() => {
+      if (this.tuiEnabled) {
+        this.options.lifeCycle.setTaskStatus(task.id, NativeTaskStatus.Stopped);
+      }
       this.runningTasksService.removeRunningTask(task.id);
       this.runningContinuousTasks.delete(task.id);
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The TUI is missing some standard keybindings:

Q to quit
Enter to show task output

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Q now triggers a confirmation to exit. Because Q is close to 1, users might often accidentally hit Q so this gives them a chance to cancel the exit.
Enter will show the task output.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
