### PR TITLE
fix(core): wait for exit before getting terminal output

### DIFF
--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
@@ -182,18 +182,11 @@ export class NodeChildProcessWithDirectOutput implements RunningTask {
   }
 
   async getResults(): Promise<{ code: number; terminalOutput: string }> {
-    const terminalOutput = this.getTerminalOutput();
-    if (this.exited) {
-      return Promise.resolve({
-        code: this.exitCode,
-        terminalOutput,
-      });
+    if (!this.exited) {
+      await this.waitForExit();
     }
-    await this.waitForExit();
-    return Promise.resolve({
-      code: this.exitCode,
-      terminalOutput,
-    });
+    const terminalOutput = this.getTerminalOutput();
+    return { code: this.exitCode, terminalOutput };
   }
 
   waitForExit() {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

An error is occurring where it cannot find the terminal output for a task. Turns out this is because it is trying to get terminal output basically immediately after the task has started instead of after it has exited.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Terminal output is retrieved after the task has exited. At this point, terminal output is available.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
