### PR TITLE
feat(core): stream task output for all tasks except for direct output…

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -1,13 +1,7 @@
-import { Serializable } from 'child_process';
 import * as yargsParser from 'yargs-parser';
 import { ExecutorContext } from '../../config/misc-interfaces';
 import { isTuiEnabled } from '../../tasks-runner/is-tui-enabled';
-import {
-  createPseudoTerminal,
-  PseudoTerminal,
-  PseudoTtyProcess,
-} from '../../tasks-runner/pseudo-terminal';
-import { signalToCode } from '../../utils/exit-codes';
+import { PseudoTerminal } from '../../tasks-runner/pseudo-terminal';
 import {
   ParallelRunningTasks,
   runSingleCommandWithPseudoTerminal,
@@ -141,7 +135,7 @@ export async function runCommands(
     const runningTask = isSingleCommandAndCanUsePseudoTerminal
       ? await runSingleCommandWithPseudoTerminal(normalized, context)
       : options.parallel
-      ? new ParallelRunningTasks(normalized, context, tuiEnabled)
+      ? new ParallelRunningTasks(normalized, context)
       : new SeriallyRunningTasks(normalized, context, tuiEnabled);
     return runningTask;
   } catch (e) {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -17,6 +17,8 @@ export declare class AppLifeCycle {
   endCommand(): void
   __init(doneCallback: () => any): void
   registerRunningTask(taskId: string, parserAndWriter: ExternalObject<[ParserArc, WriterArc]>): void
+  registerRunningTaskWithEmptyParser(taskId: string): void
+  appendTaskOutput(taskId: string, output: string): void
   setTaskStatus(taskId: string, status: TaskStatus): void
   registerForcedShutdownCallback(forcedShutdownCallback: () => any): void
   __setCloudMessage(message: string): Promise<void>

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -242,6 +242,18 @@ impl AppLifeCycle {
     }
 
     #[napi]
+    pub fn register_running_task_with_empty_parser(&mut self, task_id: String) {
+        let mut app = self.app.lock().unwrap();
+        app.register_running_task_with_empty_parser(task_id)
+    }
+
+    #[napi]
+    pub fn append_task_output(&mut self, task_id: String, output: String) {
+        let mut app = self.app.lock().unwrap();
+        app.append_task_output(task_id, output)
+    }
+
+    #[napi]
     pub fn set_task_status(&mut self, task_id: String, status: TaskStatus) {
         let mut app = self.app.lock().unwrap();
         app.set_task_status(task_id, status)

--- a/packages/nx/src/native/tui/pty.rs
+++ b/packages/nx/src/native/tui/pty.rs
@@ -110,11 +110,10 @@ impl PtyInstance {
     }
 
     /// Process output with an existing parser
-    pub fn process_output(parser: &RwLock<Parser>, output: &[u8]) -> io::Result<()> {
-        if let Ok(mut parser_guard) = parser.write() {
+    pub fn process_output(&self, output: &[u8]) {
+        if let Ok(mut parser_guard) = self.parser.write() {
             let normalized = normalize_newlines(output);
-            parser_guard.process(&normalized);
+            parser_guard.process(&normalized)
         }
-        Ok(())
     }
 }

--- a/packages/nx/src/tasks-runner/life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycle.ts
@@ -69,6 +69,10 @@ export interface LifeCycle {
     parserAndWriter: ExternalObject<[any, any]>
   ): void;
 
+  registerRunningTaskWithEmptyParser?(taskId: string): void;
+
+  appendTaskOutput?(taskId: string, output: string): void;
+
   setTaskStatus?(taskId: string, status: NativeTaskStatus): void;
 
   registerForcedShutdownCallback?(callback: () => void): void;
@@ -159,6 +163,22 @@ export class CompositeLifeCycle implements LifeCycle {
     for (let l of this.lifeCycles) {
       if (l.registerRunningTask) {
         l.registerRunningTask(taskId, parserAndWriter);
+      }
+    }
+  }
+
+  registerRunningTaskWithEmptyParser(taskId: string): void {
+    for (let l of this.lifeCycles) {
+      if (l.registerRunningTaskWithEmptyParser) {
+        l.registerRunningTaskWithEmptyParser(taskId);
+      }
+    }
+  }
+
+  appendTaskOutput(taskId: string, output: string): void {
+    for (let l of this.lifeCycles) {
+      if (l.appendTaskOutput) {
+        l.appendTaskOutput(taskId, output);
       }
     }
   }

--- a/packages/nx/src/tasks-runner/running-tasks/running-task.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/running-task.ts
@@ -7,5 +7,7 @@ export abstract class RunningTask {
 
   abstract kill(signal?: NodeJS.Signals | number): Promise<void> | void;
 
+  abstract onOutput?(cb: (output: string) => void): void;
+
   abstract send?(message: Serializable): void;
 }

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -526,12 +526,19 @@ export class TaskOrchestrator {
           root: workspaceRoot, // only root is needed in runCommands
         } as any);
 
-        if (this.tuiEnabled && runningTask instanceof PseudoTtyProcess) {
-          // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
-          this.options.lifeCycle.registerRunningTask(
-            task.id,
-            runningTask.getParserAndWriter()
-          );
+        if (this.tuiEnabled) {
+          if (runningTask instanceof PseudoTtyProcess) {
+            // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
+            this.options.lifeCycle.registerRunningTask(
+              task.id,
+              runningTask.getParserAndWriter()
+            );
+          } else {
+            this.options.lifeCycle.registerRunningTaskWithEmptyParser(task.id);
+            runningTask.onOutput((output) => {
+              this.options.lifeCycle.appendTaskOutput(task.id, output);
+            });
+          }
         }
 
         if (!streamOutput) {
@@ -591,12 +598,19 @@ export class TaskOrchestrator {
         streamOutput
       );
 
-      if (this.tuiEnabled && runningTask instanceof PseudoTtyProcess) {
-        // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
-        this.options.lifeCycle.registerRunningTask(
-          task.id,
-          runningTask.getParserAndWriter()
-        );
+      if (this.tuiEnabled) {
+        if (runningTask instanceof PseudoTtyProcess) {
+          // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
+          this.options.lifeCycle.registerRunningTask(
+            task.id,
+            runningTask.getParserAndWriter()
+          );
+        } else if ('onOutput' in runningTask) {
+          this.options.lifeCycle.registerRunningTaskWithEmptyParser(task.id);
+          runningTask.onOutput((output) => {
+            this.options.lifeCycle.appendTaskOutput(task.id, output);
+          });
+        }
       }
 
       return runningTask;


### PR DESCRIPTION
… tasks

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently, only running tasks which are a PseudoTTYProcess stream outputs to the TUI.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Most running tasks have `onOutput` even if they are not a `PseudoTTYProcess`. This method is used to stream outputs to the TUI. The only sort of running task which does not have this `onOutput` are tasks with direct output... Those remain unhandled.. for now.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
