### PR TITLE
fix(webpack): interpolate process.env more verbosely to reduce bundle size with DefinePlugin

### DIFF
--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -51,10 +51,15 @@ function getClientEnvironment(mode) {
     );
 
   // Stringify all values so we can feed into webpack DefinePlugin
-  const stringified = Object.keys(raw).reduce((env, key) => {
-    env[`process.env.${key}`] = JSON.stringify(raw[key]);
-    return env;
-  }, {});
+  const stringified = Object.keys(raw).reduce(
+    (env, key) => {
+      env[`process.env.${key}`] = JSON.stringify(raw[key]);
+      return env;
+    },
+    // Provide a fallback for process.env itself to handle cases where code
+    // accesses process.env directly (e.g., in Cypress component testing)
+    { 'process.env': '{}' } as Record<string, string>
+  );
 
   return { stringified };
 }

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -51,12 +51,10 @@ function getClientEnvironment(mode) {
     );
 
   // Stringify all values so we can feed into webpack DefinePlugin
-  const stringified = {
-    'process.env': Object.keys(raw).reduce((env, key) => {
-      env[key] = JSON.stringify(raw[key]);
-      return env;
-    }, {}),
-  };
+  const stringified = Object.keys(raw).reduce((env, key) => {
+    env[`process.env.${key}`] = JSON.stringify(raw[key]);
+    return env;
+  }, {});
 
   return { stringified };
 }

--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -421,12 +421,10 @@ function getClientEnvironment(mode?: string) {
     }, {});
 
   // Stringify all values so we can feed into rspack DefinePlugin
-  const stringified = {
-    'process.env': Object.keys(raw).reduce((env, key) => {
-      env[key] = JSON.stringify(raw[key]);
-      return env;
-    }, {}),
-  };
+  const stringified = Object.keys(raw).reduce((env, key) => {
+    env[`process.env.${key}`] = JSON.stringify(raw[key]);
+    return env;
+  }, {});
 
   return { stringified };
 }

--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -421,10 +421,15 @@ function getClientEnvironment(mode?: string) {
     }, {});
 
   // Stringify all values so we can feed into rspack DefinePlugin
-  const stringified = Object.keys(raw).reduce((env, key) => {
-    env[`process.env.${key}`] = JSON.stringify(raw[key]);
-    return env;
-  }, {});
+  const stringified = Object.keys(raw).reduce(
+    (env, key) => {
+      env[`process.env.${key}`] = JSON.stringify(raw[key]);
+      return env;
+    },
+    // Provide a fallback for process.env itself to handle cases where code
+    // accesses process.env directly (e.g., in Cypress component testing)
+    { 'process.env': '{}' } as Record<string, string>
+  );
 
   return { stringified };
 }

--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -78,12 +78,10 @@ function getClientEnvironment(mode?: string) {
     }, {});
 
   // Stringify all values so we can feed into rspack DefinePlugin
-  const stringified = {
-    'process.env': Object.keys(raw).reduce((env, key) => {
-      env[key] = JSON.stringify(raw[key]);
-      return env;
-    }, {}),
-  };
+  const stringified = Object.keys(raw).reduce((env, key) => {
+    env[`process.env.${key}`] = JSON.stringify(raw[key]);
+    return env;
+  }, {});
 
   return { stringified };
 }

--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -78,10 +78,15 @@ function getClientEnvironment(mode?: string) {
     }, {});
 
   // Stringify all values so we can feed into rspack DefinePlugin
-  const stringified = Object.keys(raw).reduce((env, key) => {
-    env[`process.env.${key}`] = JSON.stringify(raw[key]);
-    return env;
-  }, {});
+  const stringified = Object.keys(raw).reduce(
+    (env, key) => {
+      env[`process.env.${key}`] = JSON.stringify(raw[key]);
+      return env;
+    },
+    // Provide a fallback for process.env itself to handle cases where code
+    // accesses process.env directly (e.g., in Cypress component testing)
+    { 'process.env': '{}' } as Record<string, string>
+  );
 
   return { stringified };
 }

--- a/packages/webpack/src/utils/get-client-environment.ts
+++ b/packages/webpack/src/utils/get-client-environment.ts
@@ -19,10 +19,15 @@ export function getClientEnvironment(mode?: string) {
     );
 
   // Stringify all values so we can feed into webpack DefinePlugin
-  const stringified = Object.keys(raw).reduce((env, key) => {
-    env[`process.env.${key}`] = JSON.stringify(raw[key]);
-    return env;
-  }, {});
+  const stringified = Object.keys(raw).reduce(
+    (env, key) => {
+      env[`process.env.${key}`] = JSON.stringify(raw[key]);
+      return env;
+    },
+    // Provide a fallback for process.env itself to handle cases where code
+    // accesses process.env directly (e.g., in Cypress component testing)
+    { 'process.env': '{}' } as Record<string, string>
+  );
 
   return { stringified };
 }

--- a/packages/webpack/src/utils/get-client-environment.ts
+++ b/packages/webpack/src/utils/get-client-environment.ts
@@ -19,12 +19,10 @@ export function getClientEnvironment(mode?: string) {
     );
 
   // Stringify all values so we can feed into webpack DefinePlugin
-  const stringified = {
-    'process.env': Object.keys(raw).reduce((env, key) => {
-      env[key] = JSON.stringify(raw[key]);
-      return env;
-    }, {}),
-  };
+  const stringified = Object.keys(raw).reduce((env, key) => {
+    env[`process.env.${key}`] = JSON.stringify(raw[key]);
+    return env;
+  }, {});
 
   return { stringified };
 }


### PR DESCRIPTION
## Current Behavior
When we prepare ENVs for the DefinePlugin, we are creating the `process.env` object.
For example:
```
// .env
NX_PUBLIC_VALUE1=1
NX_PUBLIC_VALUE2=2
NX_PUBLIC_VALUE3=3
```
As result we will have:
```js
{
   'process.env': {
      "NX_PUBLIC_VALUE1": "1",
      "NX_PUBLIC_VALUE2": "2",
      "NX_PUBLIC_VALUE3": "3"
   }
}
```

As a result, in the final bundle, we will replace process.env with this object.
The issue:
If I use all 3 values in my application DefinePlugin will inject this object 3 times, instead of injecting it once.
It will look like that:
```js
const a = {
      "NX_PUBLIC_VALUE1": "1",
      "NX_PUBLIC_VALUE2": "2",
      "NX_PUBLIC_VALUE3": "3"
}.NX_PUBLIC_VALUE1
const b = {
      "NX_PUBLIC_VALUE1": "1",
      "NX_PUBLIC_VALUE2": "2",
      "NX_PUBLIC_VALUE3": "3"
}.NX_PUBLIC_VALUE2
const c = {
      "NX_PUBLIC_VALUE1": "1",
      "NX_PUBLIC_VALUE2": "2",
      "NX_PUBLIC_VALUE3": "3"
}.NX_PUBLIC_VALUE3
```

## Expected Behavior
DefinePlugin injects values instead of env object in each place
```js
const a = "1"
const b = "2"
const c = "3"
```

## Fixes
- fixed this issue for webpack
- fixed this issue for storybook
- fixed this issue for rspack

TLDR:
now we have object like so:
```js
{
    "process.env.NX_PUBLIC_VALUE1": "1",
    "process.env.NX_PUBLIC_VALUE2": "2",
    "process.env.NX_PUBLIC_VALUE3": "3"
}
```
