### PR TITLE
feat(core): allow disabling output streaming with NX_STREAM_OUTPUT

### DIFF
--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -558,6 +558,7 @@ export function shouldStreamOutput(
   // For now, disable streaming output on the JS side when running the TUI
   if (isTuiEnabled()) return false;
   if (process.env.NX_STREAM_OUTPUT === 'true') return true;
+  if (process.env.NX_STREAM_OUTPUT === 'false') return false;
   if (longRunningTask(task)) return true;
   if (task.target.project === initiatingProject) return true;
   return false;


### PR DESCRIPTION
Previously NX_STREAM_OUTPUT only influenced the streaming behavior if it were set to 'true', this ensures the negated case is also handled
