### PR TITLE
feat(core): bump devkit support range and remove some deprecated APIs

### DIFF
--- a/docs/generated/devkit/readNxJson.md
+++ b/docs/generated/devkit/readNxJson.md
@@ -1,15 +1,5 @@
 # Function: readNxJson
 
-▸ **readNxJson**(): [`NxJsonConfiguration`](../../devkit/documents/NxJsonConfiguration) \| `null`
-
-#### Returns
-
-[`NxJsonConfiguration`](../../devkit/documents/NxJsonConfiguration) \| `null`
-
-**`Deprecated`**
-
-You must pass a [Tree](../../devkit/documents/Tree). This will be removed in Nx 21.
-
 ▸ **readNxJson**(`tree`): [`NxJsonConfiguration`](../../devkit/documents/NxJsonConfiguration) \| `null`
 
 Reads nx.json

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -38,7 +38,7 @@
     "enquirer": "~2.3.6"
   },
   "peerDependencies": {
-    "nx": ">= 19 <= 21"
+    "nx": ">= 20 <= 22"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nx/src/command-line/format/command-object.ts
+++ b/packages/nx/src/command-line/format/command-object.ts
@@ -43,7 +43,7 @@ function withFormatOptions(yargs: Argv): Argv {
       describe: `Ensure the workspace's tsconfig compilerOptions.paths are sorted. Warning: This will cause comments in the tsconfig to be lost.`,
       type: 'boolean',
       /**
-       * TODO(v21): Stop sorting tsconfig paths by default, paths are now less common/important
+       * TODO(v22): Stop sorting tsconfig paths by default, paths are now less common/important
        * in Nx workspace setups, and the sorting causes comments to be lost.
        */
       default: true,

--- a/packages/nx/src/command-line/report/report.ts
+++ b/packages/nx/src/command-line/report/report.ts
@@ -453,39 +453,11 @@ export function findRegisteredPluginsBeingUsed(nxJson: NxJsonConfiguration) {
 export function findInstalledPackagesWeCareAbout() {
   const packagesWeMayCareAbout: Record<string, string> = {};
   // TODO (v20): Remove workaround for hiding @nrwl packages when matching @nx package is found.
-  const packageChangeMap: Record<string, string> = {
-    '@nrwl/nx-plugin': '@nx/plugin',
-    '@nx/plugin': '@nrwl/nx-plugin',
-    '@nrwl/eslint-plugin-nx': '@nx/eslint-plugin',
-    '@nx/eslint-plugin': '@nrwl/eslint-plugin-nx',
-    '@nrwl/nx-cloud': 'nx-cloud',
-  };
 
   for (const pkg of packagesWeCareAbout) {
     const v = readPackageVersion(pkg);
     if (v) {
-      // If its a @nrwl scoped package, keep the version if there is no
-      // corresponding @nx scoped package, or it has a different version.
-      if (pkg.startsWith('@nrwl/')) {
-        const otherPackage =
-          packageChangeMap[pkg] ?? pkg.replace('@nrwl/', '@nx/');
-        const otherVersion = packagesWeMayCareAbout[otherPackage];
-        if (!otherVersion || v !== otherVersion) {
-          packagesWeMayCareAbout[pkg] = v;
-        }
-        // If its a @nx scoped package, always keep the version, and
-        // remove the corresponding @nrwl scoped package if it exists.
-      } else if (pkg.startsWith('@nx/')) {
-        const otherPackage =
-          packageChangeMap[pkg] ?? pkg.replace('@nx/', '@nrwl/');
-        const otherVersion = packagesWeMayCareAbout[otherPackage];
-        if (otherVersion && v === otherVersion) {
-          delete packagesWeMayCareAbout[otherPackage];
-        }
-        packagesWeMayCareAbout[pkg] = v;
-      } else {
-        packagesWeMayCareAbout[pkg] = v;
-      }
+      packagesWeMayCareAbout[pkg] = v;
     }
   }
 

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -1,23 +1,11 @@
 import { workspaceRoot } from '../../utils/workspace-root';
-import { dirname, relative } from 'path';
-import { getFullOsSocketPath } from '../socket-utils';
+import { relative } from 'path';
 import { handleServerProcessTermination } from './shutdown-utils';
 import { Server } from 'net';
 import { normalizePath } from '../../utils/path';
-import {
-  getAlwaysIgnore,
-  getIgnoredGlobs,
-  getIgnoreObject,
-} from '../../utils/ignore';
-import { platform } from 'os';
 import { getDaemonProcessIdSync, serverProcessJsonPath } from '../cache';
 import type { WatchEvent } from '../../native';
 import { openSockets } from './server';
-
-const ALWAYS_IGNORE = [
-  ...getAlwaysIgnore(workspaceRoot),
-  getFullOsSocketPath(),
-];
 
 export type FileWatcherCallback = (
   err: Error | string | null,

--- a/packages/nx/src/generators/utils/nx-json.ts
+++ b/packages/nx/src/generators/utils/nx-json.ts
@@ -4,30 +4,19 @@ import type { NxJsonConfiguration } from '../../config/nx-json';
 import type { Tree } from '../tree';
 
 import { readJson, updateJson } from './json';
-import { readNxJson as readNxJsonFromDisk } from '../../config/nx-json';
-
-/**
- * @deprecated You must pass a {@link Tree}. This will be removed in Nx 21.
- */
-export function readNxJson(): NxJsonConfiguration | null;
-export function readNxJson(tree: Tree): NxJsonConfiguration | null;
 
 /**
  * Reads nx.json
  */
-export function readNxJson(tree?: Tree): NxJsonConfiguration | null {
-  if (tree) {
-    if (!tree.exists('nx.json')) {
-      return null;
-    }
-    let nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-    if (nxJson.extends) {
-      nxJson = { ...readNxJsonExtends(tree, nxJson.extends), ...nxJson };
-    }
-    return nxJson;
-  } else {
-    return readNxJsonFromDisk();
+export function readNxJson(tree: Tree): NxJsonConfiguration | null {
+  if (!tree.exists('nx.json')) {
+    return null;
   }
+  let nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+  if (nxJson.extends) {
+    nxJson = { ...readNxJsonExtends(tree, nxJson.extends), ...nxJson };
+  }
+  return nxJson;
 }
 
 /**

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -1,47 +1,6 @@
-import { readFileSync } from 'node:fs';
 import ignore from 'ignore';
 import { readFileIfExisting } from './fileutils';
-import { joinPathFragments } from './path';
 import { workspaceRoot } from './workspace-root';
-
-/**
- * An array of glob patterns that should always be ignored.
- */
-export const ALWAYS_IGNORE = getAlwaysIgnore();
-
-export function getIgnoredGlobs(
-  root: string = workspaceRoot,
-  prependRoot: boolean = true
-) {
-  const files = ['.gitignore', '.nxignore'];
-  if (prependRoot) {
-    return [
-      ...getAlwaysIgnore(root),
-      ...files.flatMap((f) =>
-        getIgnoredGlobsFromFile(joinPathFragments(root, f), root)
-      ),
-    ];
-  } else {
-    return [
-      ...getAlwaysIgnore(),
-      ...files.flatMap((f) =>
-        getIgnoredGlobsFromFile(joinPathFragments(root, f))
-      ),
-    ];
-  }
-}
-
-export function getAlwaysIgnore(root?: string) {
-  const paths = [
-    'node_modules',
-    '**/node_modules',
-    '.git',
-    '.nx',
-    '.vscode',
-    '.yarn/cache',
-  ];
-  return root ? paths.map((x) => joinPathFragments(root, x)) : paths;
-}
 
 export function getIgnoreObject(
   root: string = workspaceRoot
@@ -50,29 +9,4 @@ export function getIgnoreObject(
   ig.add(readFileIfExisting(`${root}/.gitignore`));
   ig.add(readFileIfExisting(`${root}/.nxignore`));
   return ig;
-}
-
-function getIgnoredGlobsFromFile(file: string, root?: string): string[] {
-  try {
-    const results = [];
-    const contents = readFileSync(file, 'utf-8');
-    const lines = contents.split('\n');
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('#')) {
-        continue;
-      } else if (trimmed.startsWith('/')) {
-        if (root) {
-          results.push(joinPathFragments(root, trimmed));
-        } else {
-          results.push(joinPathFragments('.', trimmed));
-        }
-      } else {
-        results.push(trimmed);
-      }
-    }
-    return results;
-  } catch (e) {
-    return [];
-  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

BREAKING CHANGE

The `readNxJson` signature which did not require a `Tree` to be passed in was marked as deprecated in Nx 20 and is now removed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
