### PR TITLE
chore(repo): disable failing gradle test

### DIFF
--- a/e2e/gradle/src/gradle.test.ts
+++ b/e2e/gradle/src/gradle.test.ts
@@ -43,7 +43,7 @@ describe('Gradle', () => {
         );
       });
 
-      it('should track dependencies for new app', () => {
+      xit('should track dependencies for new app', () => {
         if (type === 'groovy') {
           createFile(
             `app2/build.gradle`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

This test is failing on `master`

https://staging.nx.app/runs/kfcEGEM9Nk?utm_source=pull-request&utm_medium=comment

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The test has been disabled for now.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
