### PR TITLE
docs(nx-dev): remove deprecated RFC references & update link

### DIFF
--- a/nx-dev/ui-remote-cache/src/lib/faq.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/faq.tsx
@@ -76,23 +76,6 @@ export function Faq(): ReactElement {
       ),
     },
     {
-      question: 'How will versioning be handled in the API specification?',
-      answerJson:
-        'Check out our RFC for more details: https://github.com/nrwl/nx/discussions/30548',
-      answerUi: (
-        <p>
-          Check out our RFC for more details:{' '}
-          <Link
-            href="https://github.com/nrwl/nx/discussions/30548"
-            title="See documentation"
-            className="font-semibold"
-          >
-            Nx Custom Self-Hosted Remote Cache
-          </Link>
-        </p>
-      ),
-    },
-    {
       question:
         'What security measures does Nx Cloud offer beyond the official plugins and third party plugins?',
       answerJson:

--- a/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
@@ -227,20 +227,12 @@ export function RemoteCacheSolutions(): ReactElement {
                   </h4>
                 </div>
                 <p className="mt-2 text-sm">
-                  API specs coming soon. See current{' '}
-                  <Link
-                    href="https://github.com/nrwl/nx/discussions/30548"
-                    title="See RFC on GitHub"
-                    className="italic underline"
-                  >
-                    RFC under review
-                  </Link>
-                  .
+                  Create your own custom remote cache server.
                 </p>
 
                 <div className="mt-8">
                   <ButtonLink
-                    href="https://github.com/nrwl/nx/discussions/30548"
+                    href="/recipes/running-tasks/self-hosted-caching#build-your-own-caching-server"
                     aria-describedby="open-api"
                     title="Remote cache api specs"
                     size="default"


### PR DESCRIPTION
Removed outdated references to RFC #30548 in FAQ and remote cache solutions components. Updated the link to point to the relevant documentation on building a custom caching server.
