### PR TITLE
feat(core): remove usage of `cli` property from migration definitions

### DIFF
--- a/packages/nx/src/command-line/repair/repair.ts
+++ b/packages/nx/src/command-line/repair/repair.ts
@@ -14,7 +14,6 @@ export async function repair(
         if (!skip) {
           agg.push({
             package: 'nx',
-            cli: 'nx',
             name,
             description: migration.description,
             version: migration.version,

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -69,7 +69,6 @@ export type PackageJsonUpdates = {
 export interface MigrationsJsonEntry {
   version: string;
   description?: string;
-  cli?: string;
   implementation?: string;
   factory?: string;
   requires?: Record<string, string>;


### PR DESCRIPTION
Removes the usage of the `cli` property from migration definitions.

BREAKING CHANGE: The `cli` property from migration generator definitions is no longer used. The CLI to run the migration generator will be identified based on whether the definition is contained in `generators` (Nx) or `schematics` (Angular CLI).