### PR TITLE
chore(repo): ensure nx build does not run with other tasks

### DIFF
--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -106,6 +106,7 @@
       "command": "echo hi"
     },
     "build": {
+      "parallelism": false,
       "dependsOn": ["^build-client", "build-base", "build-native"],
       "inputs": [
         "production",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx:build` has `build/packages/nx` as an output. At the same time, `build-base` tasks which depend on Nx.. are compiling based on `build/pacakges/nx`. When `nx:build` is being restored from cache.. `build/packages/nx` gets deleted.. and then restored. While it is deleted, `tsc` tasks are unable to find modules from `nx`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This isn't necessarily the correct solution, but `nx:build` will no longer support parallelism ensuring that it does not get restored from the cache while other `build-base` `tsc` tasks are running. The proper fix is to fix the outputs of `nx:build` to be more specific about the files that it is actually modifying.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
