### PR TITLE
chore(repo): set concurrency group for macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
@@ -102,6 +106,7 @@ jobs:
 
   main-macos:
     runs-on: macos-latest
+    
     env:
       NX_E2E_CI_CACHE_KEY: e2e-github-macos
       NX_PERF_LOGGING: 'false'


### PR DESCRIPTION

## Current Behavior
macos ci runs are not cancelled on new CI push

## Expected Behavior
macos ci runs are cancelled on new CI push

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
