### PR TITLE
fix(core): update Homebrew cache path to /opt/Homebrew to be consistent with Apple Silicon default path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /usr/local/Homebrew
+            /opt/Homebrew
             ~/Library/Caches/Homebrew
           key: nrwl-nx-homebrew-packages
 
@@ -137,7 +137,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /usr/local/Homebrew
+            /opt/Homebrew
             ~/Library/Caches/Homebrew
           key: nrwl-nx-homebrew-packages
 


### PR DESCRIPTION
Currently, we are caching the wrong path `/usr/local/Homebrew` for homebrew on macos  it should be `/opt/Homebrew`