### PR TITLE
chore(repo): cleanup nx setup around lint-lockfile

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -119,14 +119,7 @@
       }
     },
     "lint": {
-      "dependsOn": [
-        "build-native",
-        "^build-native",
-        "@nx/nx-source:lint-pnpm-lock"
-      ]
-    },
-    "lint-pnpm-lock": {
-      "cache": true
+      "dependsOn": ["build-native", "^build-native"]
     },
     "e2e": {
       "cache": true,

--- a/project.json
+++ b/project.json
@@ -70,6 +70,15 @@
         "{workspaceRoot}/docs/external-generated",
         "{workspaceRoot}/docs/generated"
       ]
+    },
+    "lint": {
+      "dependsOn": ["@nx/nx-source:lint-pnpm-lock"],
+      "cache": true,
+      "inputs": ["{projectRoot}/pnpm-lock.yaml"]
+    },
+    "lint-pnpm-lock": {
+      "cache": true,
+      "inputs": ["{projectRoot}/pnpm-lock.yaml"]
     }
   }
 }


### PR DESCRIPTION
## Current Behavior
We use `targetDefaults` to define things for `lint-lockfile`, but `lint-lockfile` is only on root project. Doing this means all lint tasks in the repo depend on it, which isn't necessary.

## Expected Behavior
Only the root project lint task depends on `lint-lockfile`, and `lint-lockfile`s only input is the lockfile itself.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
