### PR TITLE
fix(core): handle skipped tasks and trigger finished state

### DIFF
--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -254,6 +254,8 @@ export interface NxWorkspaceFilesExternals {
   allWorkspaceFiles: ExternalObject<Array<FileData>>
 }
 
+export declare export declare function parseTaskStatus(stringStatus: string): TaskStatus
+
 export interface Project {
   root: string
   namedInputs?: Record<string, Array<JsInputs>>

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -388,6 +388,7 @@ module.exports.getTransformableOutputs = nativeBinding.getTransformableOutputs
 module.exports.hashArray = nativeBinding.hashArray
 module.exports.hashFile = nativeBinding.hashFile
 module.exports.IS_WASM = nativeBinding.IS_WASM
+module.exports.parseTaskStatus = nativeBinding.parseTaskStatus
 module.exports.remove = nativeBinding.remove
 module.exports.restoreTerminal = nativeBinding.restoreTerminal
 module.exports.TaskStatus = nativeBinding.TaskStatus

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -182,7 +182,6 @@ impl App {
         &mut self,
         task_id: String,
         parser_and_writer: External<(ParserArc, WriterArc)>,
-        task_status: TaskStatus,
     ) {
         if let Some(tasks_list) = self
             .components
@@ -190,7 +189,7 @@ impl App {
             .find_map(|c| c.as_any_mut().downcast_mut::<TasksList>())
         {
             tasks_list.create_and_register_pty_instance(&task_id, parser_and_writer);
-            tasks_list.update_task_status(task_id.clone(), task_status);
+            tasks_list.set_task_status(task_id.clone(), TaskStatus::InProgress);
         }
     }
 
@@ -203,7 +202,7 @@ impl App {
             let (_, parser_and_writer) = TasksList::create_empty_parser_and_noop_writer();
 
             tasks_list.create_and_register_pty_instance(&task_id, parser_and_writer);
-            tasks_list.update_task_status(task_id.clone(), TaskStatus::InProgress);
+            tasks_list.set_task_status(task_id.clone(), TaskStatus::InProgress);
             let _ = tasks_list.handle_resize(None);
         }
     }

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -238,7 +238,7 @@ impl AppLifeCycle {
         parser_and_writer: External<(ParserArc, WriterArc)>,
     ) {
         let mut app = self.app.lock().unwrap();
-        app.register_running_task(task_id, parser_and_writer, TaskStatus::InProgress)
+        app.register_running_task(task_id, parser_and_writer)
     }
 
     #[napi]

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -10,6 +10,7 @@ import { runCommands } from '../executors/run-commands/run-commands.impl';
 import { getTaskDetails, hashTask } from '../hasher/hash-task';
 import { TaskHasher } from '../hasher/task-hasher';
 import {
+  parseTaskStatus,
   RunningTasksService,
   TaskDetails,
   TaskStatus as NativeTaskStatus,
@@ -878,6 +879,10 @@ export class TaskOrchestrator {
     for (const { taskId, status } of taskResults) {
       if (this.completedTasks[taskId] === undefined) {
         this.completedTasks[taskId] = status;
+
+        if (this.tuiEnabled) {
+          this.options.lifeCycle.setTaskStatus(taskId, parseTaskStatus(status));
+        }
 
         if (status === 'failure' || status === 'skipped') {
           if (this.bail) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When tasks are skipped due to a dependent task's failure, the TUI does not recognize that the command is concluded and leaves the user in a confusing state where Nx seems like it is still waiting for tasks.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When tasks are skipped due to a dependent task's failure, the TUI shows that the command has concluded.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
