### PR TITLE
chore(repo): assign proper outputs to build targets

### DIFF
--- a/packages/angular/project.json
+++ b/packages/angular/project.json
@@ -58,13 +58,9 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/angular"],
       "dependsOn": ["build-ng", "build-base", "^build"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js angular",
-        "parallel": false
-      }
+      "outputs": ["{workspaceRoot}/build/packages/angular/README.md"],
+      "command": "node ./scripts/copy-readme.js angular"
     }
   },
   "implicitDependencies": []

--- a/packages/create-nx-plugin/project.json
+++ b/packages/create-nx-plugin/project.json
@@ -46,7 +46,10 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/create-nx-plugin"],
+      "outputs": [
+        "{workspaceRoot}/build/packages/create-nx-plugin/bin/create-nx-plugin.js",
+        "{workspaceRoot}/build/packages/create-nx-plugin/README.md"
+      ],
       "options": {
         "commands": [
           {

--- a/packages/create-nx-workspace/project.json
+++ b/packages/create-nx-workspace/project.json
@@ -46,7 +46,10 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/create-nx-workspace"],
+      "outputs": [
+        "{workspaceRoot}/build/packages/create-nx-workspace/bin/create-nx-workspace.js",
+        "{workspaceRoot}/build/packages/create-nx-workspace/README.md"
+      ],
       "options": {
         "commands": [
           {

--- a/packages/cypress/project.json
+++ b/packages/cypress/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/cypress"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js cypress"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/cypress/README.md"],
+      "command": "node ./scripts/copy-readme.js cypress"
     }
   }
 }

--- a/packages/detox/project.json
+++ b/packages/detox/project.json
@@ -43,11 +43,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/detox"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js detox"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/detox/README.md"],
+      "command": "node ./scripts/copy-readme.js detox"
     }
   }
 }

--- a/packages/devkit/project.json
+++ b/packages/devkit/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/devkit"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js devkit"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/devkit/README.md"],
+      "command": "node ./scripts/copy-readme.js devkit"
     }
   }
 }

--- a/packages/esbuild/project.json
+++ b/packages/esbuild/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/esbuild"],
-      "options": {
-        "commands": ["node ./scripts/copy-readme.js esbuild"]
-      }
+      "outputs": ["{workspaceRoot}/build/packages/esbuild/README.md"],
+      "commands": ["node ./scripts/copy-readme.js esbuild"]
     }
   }
 }

--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -45,11 +45,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/eslint-plugin"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js eslint-plugin"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/eslint-plugin/README.md"],
+      "command": "node ./scripts/copy-readme.js eslint-plugin"
     }
   }
 }

--- a/packages/eslint/project.json
+++ b/packages/eslint/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/eslint"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js eslint"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/eslint/README.md"],
+      "command": "node ./scripts/copy-readme.js eslint"
     }
   },
   "implicitDependencies": ["eslint-plugin"]

--- a/packages/expo/project.json
+++ b/packages/expo/project.json
@@ -45,11 +45,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/expo"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js expo"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/expo/README.md"],
+      "command": "node ./scripts/copy-readme.js expo"
     }
   },
   "tags": []

--- a/packages/express/project.json
+++ b/packages/express/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/express"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js express"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/express/README.md"],
+      "command": "node ./scripts/copy-readme.js express"
     }
   },
   "implicitDependencies": ["node"]

--- a/packages/gradle/project.json
+++ b/packages/gradle/project.json
@@ -51,11 +51,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/gradle"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js gradle"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/gradle/README.md"],
+      "command": "node ./scripts/copy-readme.js gradle"
     }
   },
   "tags": []

--- a/packages/jest/project.json
+++ b/packages/jest/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/jest"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js jest"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/jest/README.md"],
+      "command": "node ./scripts/copy-readme.js jest"
     }
   }
 }

--- a/packages/js/project.json
+++ b/packages/js/project.json
@@ -45,11 +45,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/js"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js js"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/js/README.md"],
+      "command": "node ./scripts/copy-readme.js js"
     }
   },
   "tags": []

--- a/packages/module-federation/project.json
+++ b/packages/module-federation/project.json
@@ -49,7 +49,7 @@
     },
     "build": {
       "command": "node ./scripts/copy-readme.js module-federation",
-      "outputs": ["{workspaceRoot}/build/packages/module-federation"]
+      "outputs": ["{workspaceRoot}/build/packages/module-federation/README.md"]
     }
   }
 }

--- a/packages/nest/project.json
+++ b/packages/nest/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/nest"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js nest"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/nest/README.md"],
+      "command": "node ./scripts/copy-readme.js nest"
     }
   },
   "implicitDependencies": ["node", "eslint"]

--- a/packages/next/project.json
+++ b/packages/next/project.json
@@ -49,11 +49,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/next"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js next"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/next/README.md"],
+      "command": "node ./scripts/copy-readme.js next"
     }
   }
 }

--- a/packages/node/project.json
+++ b/packages/node/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/node"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js node"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/node/README.md"],
+      "command": "node ./scripts/copy-readme.js node"
     }
   }
 }

--- a/packages/nuxt/project.json
+++ b/packages/nuxt/project.json
@@ -54,7 +54,7 @@
     },
     "build": {
       "command": "node ./scripts/copy-readme.js nuxt",
-      "outputs": ["{workspaceRoot}/build/packages/nuxt"]
+      "outputs": ["{workspaceRoot}/build/packages/nuxt/README.md"]
     }
   }
 }

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -106,7 +106,6 @@
       "command": "echo hi"
     },
     "build": {
-      "parallelism": false,
       "dependsOn": ["^build-client", "build-base", "build-native"],
       "inputs": [
         "production",
@@ -116,7 +115,12 @@
         }
       ],
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/nx"],
+      "outputs": [
+        "{workspaceRoot}/build/packages/nx/**/*.{node,wasm,js,mjs,cjs}",
+        "{workspaceRoot}/build/packages/nx/src/core/graph",
+        "{workspaceRoot}/build/packages/nx/bin/nx.js",
+        "{workspaceRoot}/build/packages/nx/README.md"
+      ],
       "options": {
         "commands": [
           {

--- a/packages/playwright/project.json
+++ b/packages/playwright/project.json
@@ -5,11 +5,8 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/playwright"],
-      "options": {
-        "commands": ["node ./scripts/copy-readme.js playwright"]
-      }
+      "outputs": ["{workspaceRoot}/build/packages/playwright/README.md"],
+      "commands": ["node ./scripts/copy-readme.js playwright"]
     },
     "build-base": {
       "executor": "@nx/js:tsc",

--- a/packages/plugin/project.json
+++ b/packages/plugin/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/plugin"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js plugin"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/plugin/README.md"],
+      "command": "node ./scripts/copy-readme.js plugin"
     }
   }
 }

--- a/packages/react-native/project.json
+++ b/packages/react-native/project.json
@@ -39,11 +39,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/react-native"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js react-native"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/react-native/README.md"],
+      "command": "node ./scripts/copy-readme.js react-native"
     }
   }
 }

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -54,11 +54,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/react"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js react"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/react/README.md"],
+      "command": "node ./scripts/copy-readme.js react"
     }
   }
 }

--- a/packages/remix/project.json
+++ b/packages/remix/project.json
@@ -6,7 +6,7 @@
   "targets": {
     "build": {
       "command": "node ./scripts/copy-readme.js remix",
-      "outputs": ["{workspaceRoot}/build/packages/remix"]
+      "outputs": ["{workspaceRoot}/build/packages/remix/README.md"]
     },
     "build-base": {
       "executor": "@nx/js:tsc",

--- a/packages/rollup/project.json
+++ b/packages/rollup/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/rollup"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js rollup"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/rollup/README.md"],
+      "command": "node ./scripts/copy-readme.js rollup"
     }
   }
 }

--- a/packages/rsbuild/project.json
+++ b/packages/rsbuild/project.json
@@ -49,7 +49,7 @@
     },
     "build": {
       "command": "node ./scripts/copy-readme.js rsbuild",
-      "outputs": ["{workspaceRoot}/build/packages/rsbuild"]
+      "outputs": ["{workspaceRoot}/build/packages/rsbuild/README.md"]
     }
   }
 }

--- a/packages/rspack/project.json
+++ b/packages/rspack/project.json
@@ -5,11 +5,8 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/rspack"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js rspack"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/rspack/README.md"],
+      "command": "node ./scripts/copy-readme.js rspack"
     },
     "build-base": {
       "dependsOn": ["^build-base"],

--- a/packages/storybook/project.json
+++ b/packages/storybook/project.json
@@ -54,11 +54,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/storybook"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js storybook"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/storybook/README.md"],
+      "command": "node ./scripts/copy-readme.js storybook"
     }
   }
 }

--- a/packages/vite/project.json
+++ b/packages/vite/project.json
@@ -49,11 +49,8 @@
       "outputs": ["{options.outputPath}"]
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/vite"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js vite"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/vite/README.md"],
+      "command": "node ./scripts/copy-readme.js vite"
     }
   }
 }

--- a/packages/vue/project.json
+++ b/packages/vue/project.json
@@ -54,7 +54,7 @@
     },
     "build": {
       "command": "node ./scripts/copy-readme.js vue",
-      "outputs": ["{workspaceRoot}/build/packages/vue"]
+      "outputs": ["{workspaceRoot}/build/packages/vue/README.md"]
     }
   }
 }

--- a/packages/web/project.json
+++ b/packages/web/project.json
@@ -49,11 +49,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/web"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js web"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/web/README.md"],
+      "command": "node ./scripts/copy-readme.js web"
     }
   }
 }

--- a/packages/webpack/project.json
+++ b/packages/webpack/project.json
@@ -44,11 +44,8 @@
       }
     },
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/build/packages/webpack"],
-      "options": {
-        "command": "node ./scripts/copy-readme.js webpack"
-      }
+      "outputs": ["{workspaceRoot}/build/packages/webpack/README.md"],
+      "command": "node ./scripts/copy-readme.js webpack"
     }
   }
 }

--- a/packages/workspace/project.json
+++ b/packages/workspace/project.json
@@ -74,7 +74,7 @@
       }
     },
     "build": {
-      "outputs": ["{workspaceRoot}/build/packages/workspace"],
+      "outputs": ["{workspaceRoot}/build/packages/workspace/README.md"],
       "command": "node ./scripts/copy-readme.js workspace"
     },
     "add-extra-dependencies": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx:build` cannot be run in parallel with any other tasks. It was an improper fix for an issue we were facing in our task graph. This is also not workable if any continuous tasks are running.. which I want `local-registry` to be running while things are built.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The proper outputs are set on `build` targets. Most of them only need `README.md` as the output. `nx`, `create-nx-workspace`, and `create-nx-plugin` are different and need a few more files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
