### PR TITLE
fix(repo): don't cancel running jobs on master when new branch merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.event.type, 'push')}}
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}


### PR DESCRIPTION
## Current Behavior
Concurrency cancels runs on master which results in it being harder to diagnose which commit broke main's CI

## Expected Behavior
Runs on master do not cancel previous runs

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
