### PR TITLE
fix(core): do not clone screen on every render loop of the TUI

### DIFF
--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -254,8 +254,8 @@ impl<'a> TerminalPane<'a> {
             | TaskStatus::RemoteCache => Color::Green,
             TaskStatus::Failure => Color::Red,
             TaskStatus::Skipped => Color::Yellow,
-            TaskStatus::InProgress | TaskStatus::Shared=> Color::LightCyan,
-            TaskStatus::NotStarted | TaskStatus::Stopped=> Color::DarkGray,
+            TaskStatus::InProgress | TaskStatus::Shared => Color::LightCyan,
+            TaskStatus::NotStarted | TaskStatus::Stopped => Color::DarkGray,
         })
     }
 
@@ -420,7 +420,7 @@ impl<'a> StatefulWidget for TerminalPane<'a> {
                         ScrollbarState::default()
                     };
 
-                    let pseudo_term = PseudoTerminal::new(&screen).block(block);
+                    let pseudo_term = PseudoTerminal::new(&*screen).block(block);
                     Widget::render(pseudo_term, area, buf);
 
                     // Only render scrollbar if needed


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Everytime the TUI is rendered with a terminal pane opened, we clone the screen. This cloning is resource intensive as we would be creating a new screen every couple of milliseconds.
 
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This has changes so that we can pass a reference to the screen to be used in places where its needed. This avoids the cloning the screen.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
