### PR TITLE
fix(core): error message when failing to fetch migrations is no good

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1089,9 +1089,11 @@ async function getPackageMigrationsUsingInstall(
 
     result = { ...migrations, packageGroup, version: packageJson.version };
   } catch (e) {
-    logger.warn(
-      `Unable to fetch migrations for ${packageName}@${packageVersion}: ${e.message}`
-    );
+    output.warn({
+      title: `Failed to fetch migrations for ${packageName}@${packageVersion}`,
+      bodyLines: [e.message],
+    });
+    return {};
   } finally {
     await cleanup();
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
We error when failing to find a package version via the install step, but meant to warn. Additionally, the warning is hard to see.

## Expected Behavior
We don't error when failing to install the package, but the warning is more visible.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
