### PR TITLE
feat(graph): add undo migration option when one is pending approval

### DIFF
--- a/graph/client/src/app/console-migrate/migrate.app.tsx
+++ b/graph/client/src/app/console-migrate/migrate.app.tsx
@@ -85,6 +85,13 @@ export function MigrateApp({
     });
   };
 
+  const onUndoMigration = (migration: MigrationDetailsWithId) => {
+    externalApiService.postEvent({
+      type: 'undo-migration',
+      payload: { migration },
+    });
+  };
+
   const onViewImplementation = (migration: MigrationDetailsWithId) => {
     externalApiService.postEvent({
       type: 'view-implementation',
@@ -109,6 +116,7 @@ export function MigrateApp({
       onFinish={onFinish}
       onFileClick={onFileClick}
       onSkipMigration={onSkipMigration}
+      onUndoMigration={onUndoMigration}
       onViewImplementation={onViewImplementation}
       onViewDocumentation={onViewDocumentation}
     ></MigrateUI>

--- a/graph/migrate/src/lib/components/automatic-migration.tsx
+++ b/graph/migrate/src/lib/components/automatic-migration.tsx
@@ -21,6 +21,7 @@ export function AutomaticMigration(props: {
   nxConsoleMetadata: MigrationsJsonMetadata;
   onRunMigration: (migration: MigrationDetailsWithId) => void;
   onSkipMigration: (migration: MigrationDetailsWithId) => void;
+  onUndoMigration: (migration: MigrationDetailsWithId) => void;
   onFileClick: (
     migration: MigrationDetailsWithId,
     file: Omit<FileChange, 'content'>
@@ -87,6 +88,7 @@ export function AutomaticMigration(props: {
       isInit={isInit}
       onRunMigration={props.onRunMigration}
       onSkipMigration={props.onSkipMigration}
+      onUndoMigration={props.onUndoMigration}
       onFileClick={props.onFileClick}
       onViewImplementation={props.onViewImplementation}
       onViewDocumentation={props.onViewDocumentation}

--- a/graph/migrate/src/lib/components/migration-timeline.tsx
+++ b/graph/migrate/src/lib/components/migration-timeline.tsx
@@ -33,6 +33,7 @@ export interface MigrationTimelineProps {
   isInit: boolean;
   onRunMigration: (migration: MigrationDetailsWithId) => void;
   onSkipMigration: (migration: MigrationDetailsWithId) => void;
+  onUndoMigration: (migration: MigrationDetailsWithId) => void;
   onFileClick: (
     migration: MigrationDetailsWithId,
     file: Omit<FileChange, 'content'>
@@ -53,6 +54,7 @@ export function MigrationTimeline({
   currentMigrationHasChanges,
   onRunMigration,
   onSkipMigration,
+  onUndoMigration,
   onFileClick,
   onViewImplementation,
   onViewDocumentation,
@@ -335,17 +337,30 @@ export function MigrationTimeline({
                       )}
 
                       {currentMigrationHasChanges && (
-                        <button
-                          onClick={() => {
-                            toggleMigrationExpanded(currentMigration.id);
-                            onReviewMigration(currentMigration.id);
-                          }}
-                          type="button"
-                          className="flex items-center gap-2 rounded-md border border-blue-500 bg-blue-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-600 dark:border-blue-600 dark:bg-blue-600 hover:dark:bg-blue-700"
-                        >
-                          <CheckIcon className="h-5 w-5" aria-hidden="true" />{' '}
-                          Approve Changes
-                        </button>
+                        <>
+                          <button
+                            onClick={() => {
+                              toggleMigrationExpanded(currentMigration.id);
+                              onUndoMigration(currentMigration);
+                            }}
+                            type="button"
+                            className="flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
+                          >
+                            <XMarkIcon className="h-5 w-5" aria-hidden="true" />{' '}
+                            Undo and Skip
+                          </button>
+                          <button
+                            onClick={() => {
+                              toggleMigrationExpanded(currentMigration.id);
+                              onReviewMigration(currentMigration.id);
+                            }}
+                            type="button"
+                            className="flex items-center gap-2 rounded-md border border-blue-500 bg-blue-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-600 dark:border-blue-600 dark:bg-blue-600 hover:dark:bg-blue-700"
+                          >
+                            <CheckIcon className="h-5 w-5" aria-hidden="true" />{' '}
+                            Approve Changes
+                          </button>
+                        </>
                       )}
                     </div>
                   )}

--- a/graph/migrate/src/lib/migrate.stories.tsx
+++ b/graph/migrate/src/lib/migrate.stories.tsx
@@ -290,6 +290,9 @@ export const PendingApproval: Story = {
     onSkipMigration: (migration) => {
       console.log('skip migration', migration);
     },
+    onUndoMigration: (migration) => {
+      console.log('undo migration', migration);
+    },
     onFileClick: (migration, file) => {
       console.log('file click', migration, file);
     },

--- a/graph/migrate/src/lib/migrate.tsx
+++ b/graph/migrate/src/lib/migrate.tsx
@@ -36,6 +36,7 @@ export interface MigrateUIProps {
     }
   ) => void;
   onSkipMigration: (migration: MigrationDetailsWithId) => void;
+  onUndoMigration: (migration: MigrationDetailsWithId) => void;
   onCancel: () => void;
   onFinish: (squashCommits: boolean) => void;
   onFileClick: (
@@ -188,13 +189,10 @@ export function MigrateUI(props: MigrateUIProps) {
           onRunMigration={(migration) =>
             props.onRunMigration(migration, { createCommits })
           }
-          onSkipMigration={(migration) => props.onSkipMigration(migration)}
-          onViewImplementation={(migration) =>
-            props.onViewImplementation(migration)
-          }
-          onViewDocumentation={(migration) =>
-            props.onViewDocumentation(migration)
-          }
+          onSkipMigration={props.onSkipMigration}
+          onUndoMigration={props.onUndoMigration}
+          onViewImplementation={props.onViewImplementation}
+          onViewDocumentation={props.onViewDocumentation}
           onFileClick={props.onFileClick}
         />
       </div>


### PR DESCRIPTION
This PR adds a button for user to undo a migration that's already been applied and pending approval.

See: https://www.loom.com/share/97286bdc80ea4538af76a914ef8f0f8b

Also, fixes an existing issue where `migrations.json` did not record the correct git sha for each commit.


## Current Behavior
When a migration is pending approval, the only option is to accept it.

## Expected Behavior
Allow user to undo a migration if they don't want the changes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
