### PR TITLE
fix(gradle): fix gradle tests

### DIFF
--- a/e2e/gradle/src/gradle-import.test.ts
+++ b/e2e/gradle/src/gradle-import.test.ts
@@ -16,7 +16,7 @@ import { join } from 'path';
 import { createGradleProject } from './utils/create-gradle-project';
 import { createFileSync } from 'fs-extra';
 
-xdescribe('Nx Import Gradle', () => {
+describe('Nx Import Gradle', () => {
   const tempImportE2ERoot = join(e2eCwd, 'nx-import');
   beforeAll(() => {
     newProject({
@@ -72,31 +72,34 @@ xdescribe('Nx Import Gradle', () => {
     const source = '.';
     const directory = 'projects/gradle-app-kotlin';
 
-    runCLI(
-      `import ${remote} ${directory} --ref ${ref} --source ${source} --no-interactive`,
-      {
-        verbose: true,
-      }
-    );
+    try {
+      runCLI(
+        `import ${remote} ${directory} --ref ${ref} --source ${source} --no-interactive`,
+        {
+          verbose: true,
+        }
+      );
 
-    checkFilesExist(
-      `${directory}/settings.gradle.kts`,
-      `${directory}/build.gradle.kts`,
-      `${directory}/gradlew`,
-      `${directory}/gradlew.bat`
-    );
-    const nxJson = readJson('nx.json');
-    const gradlePlugin = nxJson.plugins.find(
-      (plugin) => plugin.plugin === '@nx/gradle'
-    );
-    expect(gradlePlugin).toBeDefined();
-    expect(() => {
-      runCLI(`show projects`);
-      runCLI('build kotlin-app');
-    }).not.toThrow();
-
-    runCommand(`git add .`);
-    runCommand(`git commit -am 'import kotlin project'`);
+      checkFilesExist(
+        `${directory}/settings.gradle.kts`,
+        `${directory}/build.gradle.kts`,
+        `${directory}/gradlew`,
+        `${directory}/gradlew.bat`
+      );
+      const nxJson = readJson('nx.json');
+      const gradlePlugin = nxJson.plugins.find(
+        (plugin) => plugin.plugin === '@nx/gradle'
+      );
+      expect(gradlePlugin).toBeDefined();
+      expect(() => {
+        runCLI(`show projects`);
+        runCLI('build kotlin-app');
+      }).not.toThrow();
+    } finally {
+      // Cleanup
+      runCommand(`git add .`);
+      runCommand(`git commit -am 'import kotlin project'`);
+    }
   });
 
   it('should be able to import a groovy gradle app', () => {
@@ -123,33 +126,36 @@ xdescribe('Nx Import Gradle', () => {
     const source = '.';
     const directory = 'projects/gradle-app-groovy';
 
-    runCLI(
-      `import ${remote} ${directory} --ref ${ref} --source ${source} --no-interactive`,
-      {
-        verbose: true,
-      }
-    );
-    runCLI(`g @nx/gradle:init --no-interactive`);
+    try {
+      runCLI(
+        `import ${remote} ${directory} --ref ${ref} --source ${source} --no-interactive`,
+        {
+          verbose: true,
+        }
+      );
+      runCLI(`g @nx/gradle:init --no-interactive`);
 
-    checkFilesExist(
-      `${directory}/build.gradle`,
-      `${directory}/settings.gradle`,
-      `${directory}/gradlew`,
-      `${directory}/gradlew.bat`
-    );
-    const nxJson = readJson('nx.json');
-    const gradlePlugin = nxJson.plugins.find(
-      (plugin) => plugin.plugin === '@nx/gradle'
-    );
-    gradlePlugin.exclude = [];
-    updateJson('nx.json', () => nxJson);
-    expect(() => {
-      runCLI(`show projects`);
-      runCLI('build groovy-app');
-    }).not.toThrow();
-
-    runCommand(`git add .`);
-    runCommand(`git commit -am 'import groovy project'`);
+      checkFilesExist(
+        `${directory}/build.gradle`,
+        `${directory}/settings.gradle`,
+        `${directory}/gradlew`,
+        `${directory}/gradlew.bat`
+      );
+      const nxJson = readJson('nx.json');
+      const gradlePlugin = nxJson.plugins.find(
+        (plugin) => plugin.plugin === '@nx/gradle'
+      );
+      gradlePlugin.exclude = [];
+      updateJson('nx.json', () => nxJson);
+      expect(() => {
+        runCLI(`show projects`);
+        runCLI('build groovy-app');
+      }).not.toThrow();
+    } finally {
+      // Cleanup
+      runCommand(`git add .`);
+      runCommand(`git commit -am 'import groovy project'`);
+    }
   });
 });
 

--- a/e2e/gradle/src/gradle.test.ts
+++ b/e2e/gradle/src/gradle.test.ts
@@ -45,7 +45,7 @@ describe('Gradle', () => {
         expect(buildOutput).toContain(':utilities:classes');
       });
 
-      xit('should track dependencies for new app', () => {
+      it('should track dependencies for new app', () => {
         if (type === 'groovy') {
           createFile(
             `app2/build.gradle`,

--- a/e2e/gradle/src/utils/create-gradle-project.ts
+++ b/e2e/gradle/src/utils/create-gradle-project.ts
@@ -80,7 +80,7 @@ export function createGradleProject(
 
   e2eConsoleLogger(
     execSync(
-      `${gradleCommand} :project-graph:publishToMavenLocal -x :project-graph:signNxProjectGraphPluginPluginMarkerMavenPublication -x :project-graph:signPluginMavenPublication -x :project-graph:publishNxProjectGraphPluginPluginMarkerMavenPublicationToMavenLocal -x :project-graph:publishPluginMavenPublicationToMavenLocal`,
+      `${gradleCommand} :project-graph:publishToMavenLocal -PskipSign=true`,
       {
         cwd: `${__dirname}/../../../..`,
       }

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -108,13 +108,17 @@ afterEvaluate {
       }
     }
   }
-}
 
-signing {
-  afterEvaluate {
-    sign(publishing.publications["pluginMaven"])
-    sign(publishing.publications["nxProjectGraphPluginPluginMarkerMaven"])
+  val skipSign = project.findProperty("skipSign") == "true"
+  if (!skipSign) {
+    signing {
+      sign(publishing.publications["pluginMaven"])
+      sign(publishing.publications["nxProjectGraphPluginPluginMarkerMaven"])
+    }
   }
+
+  // Even if signing plugin was applied, we can prevent the sign tasks from running
+  tasks.withType<Sign>().configureEach { onlyIf { !skipSign } }
 }
 
 tasks.test { useJUnitPlatform() }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
currently, because it requires to sign locally, so i thought run command like
`:project-graph:publishToMavenLocal -x :project-graph:signNxProjectGraphPluginPluginMarkerMavenPublication -x :project-graph:signPluginMavenPublication -x :project-graph:publishNxProjectGraphPluginPluginMarkerMavenPublicationToMavenLocal -x :project-graph:publishPluginMavenPublicationToMavenLocal` would publish the plugin locally, but it actually does not. it does not throw an error, but does not do anything at all.
so for e2e tests, it is actually pulling the latest published gradle plugin from maven rather than test local code, hence the e2e errors.

also, currently project graph build for java version 21, we change it to java 17 to be used by ocean repo.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
change the command to `./gradlew :project-graph:publishToMavenLocal -PskipSign=true` and not apply signing when skip sign is true, so this should be able to publish plugin to local repository.

work with java 17

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
