### PR TITLE
fix(core): properly print errors coming from  js when tui is enabled

### DIFF
--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -282,6 +282,12 @@ impl AppLifeCycle {
 
 #[napi]
 pub fn restore_terminal() -> Result<()> {
+    // Restore the terminal to a clean state
+    if let Ok(mut t) = Tui::new() {
+        if let Err(r) = t.exit() {
+            debug!("Unable to exit Terminal: {:?}", r);
+        }
+    }
     // TODO: Maybe need some additional cleanup here in addition to the tui cleanup performed at the end of the render loop?
     Ok(())
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When the TUI is enabled, JS errors during task running cause the process to exit without printing out information about the error and also leave the terminal in a broken state.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

JS errors are printed before the process exits and the terminal is restored to a good state.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
