### PR TITLE
cleanup(angular): update `ng-packagr` nested import paths

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/entry-point.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/entry-point.ts
@@ -1,18 +1,36 @@
-import {
-  type DestinationFiles,
+import type {
+  DestinationFiles,
   NgEntryPoint as NgEntryPointBase,
 } from 'ng-packagr/lib/ng-package/entry-point/entry-point';
+import type { NgPackageConfig } from 'ng-packagr/ng-package.schema';
 import { dirname } from 'node:path';
+import { getNgPackagrVersionInfo } from '../../../../utilities/ng-packagr/ng-packagr-version';
+import { importNgPackagrPath } from '../../../../utilities/ng-packagr/package-imports';
 
-export class NgEntryPoint extends NgEntryPointBase {
-  /**
-   * Point the FESM2022 files to the ESM2022 files.
-   */
-  public override get destinationFiles(): DestinationFiles {
-    const result = super.destinationFiles;
-    result.fesm2022 = result.esm2022;
-    result.fesm2022Dir = dirname(result.esm2022);
+export function createNgEntryPoint(
+  packageJson: Record<string, any>,
+  ngPackageJson: NgPackageConfig,
+  basePath: string,
+  secondaryData?: Record<string, any>
+): NgEntryPointBase {
+  const { major: ngPackagrMajorVersion } = getNgPackagrVersionInfo();
 
-    return result;
+  const { NgEntryPoint: NgEntryPointBase } = importNgPackagrPath<
+    typeof import('ng-packagr/lib/ng-package/entry-point/entry-point')
+  >('ng-packagr/lib/ng-package/entry-point/entry-point', ngPackagrMajorVersion);
+
+  class NgEntryPoint extends NgEntryPointBase {
+    /**
+     * Point the FESM2022 files to the ESM2022 files.
+     */
+    public override get destinationFiles(): DestinationFiles {
+      const result = super.destinationFiles;
+      result.fesm2022 = result.esm2022;
+      result.fesm2022Dir = dirname(result.esm2022);
+
+      return result;
+    }
   }
+
+  return new NgEntryPoint(packageJson, ngPackageJson, basePath, secondaryData);
 }

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.di.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.di.ts
@@ -1,13 +1,27 @@
-import {
-  TransformProvider,
-  provideTransform,
-} from 'ng-packagr/lib/graph/transform.di';
-import { WRITE_BUNDLES_TRANSFORM_TOKEN } from 'ng-packagr/lib/ng-package/entry-point/write-bundles.di';
-import { OPTIONS_TOKEN } from 'ng-packagr/lib/ng-package/options.di';
+import type { TransformProvider } from 'ng-packagr/lib/graph/transform.di';
+import { getNgPackagrVersionInfo } from '../../../../utilities/ng-packagr/ng-packagr-version';
+import { importNgPackagrPath } from '../../../../utilities/ng-packagr/package-imports';
 import { writeBundlesTransform } from './write-bundles.transform';
 
-export const WRITE_BUNDLES_TRANSFORM: TransformProvider = provideTransform({
-  provide: WRITE_BUNDLES_TRANSFORM_TOKEN,
-  useFactory: writeBundlesTransform,
-  deps: [OPTIONS_TOKEN],
-});
+export function getWriteBundlesTransformProvider(): TransformProvider {
+  const { major: ngPackagrMajorVersion } = getNgPackagrVersionInfo();
+
+  const { provideTransform } = importNgPackagrPath<
+    typeof import('ng-packagr/lib/graph/transform.di')
+  >('ng-packagr/lib/graph/transform.di', ngPackagrMajorVersion);
+  const { WRITE_BUNDLES_TRANSFORM_TOKEN } = importNgPackagrPath<
+    typeof import('ng-packagr/lib/ng-package/entry-point/write-bundles.di')
+  >(
+    'ng-packagr/lib/ng-package/entry-point/write-bundles.di',
+    ngPackagrMajorVersion
+  );
+  const { OPTIONS_TOKEN } = importNgPackagrPath<
+    typeof import('ng-packagr/lib/ng-package/options.di')
+  >('ng-packagr/lib/ng-package/options.di', ngPackagrMajorVersion);
+
+  return provideTransform({
+    provide: WRITE_BUNDLES_TRANSFORM_TOKEN,
+    useFactory: writeBundlesTransform,
+    deps: [OPTIONS_TOKEN],
+  });
+}

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-packagr.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-packagr.ts
@@ -1,15 +1,18 @@
-import { NgPackagr, ngPackagr } from 'ng-packagr';
+import { type NgPackagr, ngPackagr } from 'ng-packagr';
 
 export async function getNgPackagrInstance(): Promise<NgPackagr> {
-  const { WRITE_BUNDLES_TRANSFORM } = await import(
+  const { getWriteBundlesTransformProvider } = await import(
     './ng-package/entry-point/write-bundles.di.js'
   );
-  const { STYLESHEET_PROCESSOR } = await import(
+  const { getStylesheetProcessorFactoryProvider } = await import(
     '../../utilities/ng-packagr/stylesheet-processor.di.js'
   );
 
   const packagr = ngPackagr();
-  packagr.withProviders([WRITE_BUNDLES_TRANSFORM, STYLESHEET_PROCESSOR]);
+  packagr.withProviders([
+    getWriteBundlesTransformProvider(),
+    getStylesheetProcessorFactoryProvider(),
+  ]);
 
   return packagr;
 }

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ng-packagr.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ng-packagr.ts
@@ -1,11 +1,11 @@
-import { NgPackagr, ngPackagr } from 'ng-packagr';
+import { type NgPackagr, ngPackagr } from 'ng-packagr';
 
 export async function getNgPackagrInstance(): Promise<NgPackagr> {
-  const { STYLESHEET_PROCESSOR } = await import(
+  const { getStylesheetProcessorFactoryProvider } = await import(
     '../../utilities/ng-packagr/stylesheet-processor.di.js'
   );
 
   const packagr = ngPackagr();
-  packagr.withProviders([STYLESHEET_PROCESSOR]);
+  packagr.withProviders([getStylesheetProcessorFactoryProvider()]);
   return packagr;
 }

--- a/packages/angular/src/executors/utilities/ng-packagr/ng-packagr-version.ts
+++ b/packages/angular/src/executors/utilities/ng-packagr/ng-packagr-version.ts
@@ -1,0 +1,13 @@
+import {
+  getInstalledPackageVersionInfo,
+  type VersionInfo,
+} from '../angular-version-utils';
+
+let ngPackagrVersionInfo: VersionInfo | undefined;
+export function getNgPackagrVersionInfo(): VersionInfo {
+  if (!ngPackagrVersionInfo) {
+    ngPackagrVersionInfo = getInstalledPackageVersionInfo('ng-packagr');
+  }
+
+  return ngPackagrVersionInfo;
+}

--- a/packages/angular/src/executors/utilities/ng-packagr/package-imports.ts
+++ b/packages/angular/src/executors/utilities/ng-packagr/package-imports.ts
@@ -1,0 +1,12 @@
+export function importNgPackagrPath<T>(
+  path: string,
+  ngPackagrMajorVersion: number
+): T {
+  let finalPath = path;
+
+  if (ngPackagrMajorVersion >= 20 && !path.startsWith('ng-packagr/src/')) {
+    finalPath = path.replace(/^ng-packagr\//, 'ng-packagr/src/');
+  }
+
+  return require(finalPath);
+}

--- a/packages/angular/src/executors/utilities/ng-packagr/pre-v19/stylesheet-processor.ts
+++ b/packages/angular/src/executors/utilities/ng-packagr/pre-v19/stylesheet-processor.ts
@@ -16,7 +16,7 @@ import { getTailwindConfigPath } from '../tailwindcss';
 import { workspaceRoot } from '@nx/devkit';
 import type { PostcssConfiguration } from 'ng-packagr/lib/styles/postcss-configuration';
 import { gt, gte } from 'semver';
-import { getInstalledPackageVersionInfo } from '../../angular-version-utils';
+import { getNgPackagrVersionInfo } from '../ng-packagr-version';
 
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
 const maxThreads =
@@ -91,8 +91,7 @@ export class StylesheetProcessor {
 
     const browserslistData = browserslist(undefined, { path: this.basePath });
 
-    const { version: ngPackagrVersion } =
-      getInstalledPackageVersionInfo('ng-packagr');
+    const { version: ngPackagrVersion } = getNgPackagrVersionInfo();
     let tailwindConfigPath: string | undefined;
     let postcssConfiguration: PostcssConfiguration | undefined;
     if (gte(ngPackagrVersion, '18.0.0')) {
@@ -212,8 +211,7 @@ export class AsyncStylesheetProcessor {
 
     const browserslistData = browserslist(undefined, { path: this.basePath });
 
-    const { version: ngPackagrVersion } =
-      getInstalledPackageVersionInfo('ng-packagr');
+    const { version: ngPackagrVersion } = getNgPackagrVersionInfo();
     let postcssConfiguration: PostcssConfiguration | undefined;
     if (ngPackagrVersion === '17.2.0') {
       const {

--- a/packages/angular/src/executors/utilities/ng-packagr/stylesheet-processor.di.ts
+++ b/packages/angular/src/executors/utilities/ng-packagr/stylesheet-processor.di.ts
@@ -1,27 +1,37 @@
 import type { FactoryProvider } from 'injection-js';
-import { STYLESHEET_PROCESSOR_TOKEN } from 'ng-packagr/lib/styles/stylesheet-processor.di';
-import { getInstalledPackageVersionInfo } from '../angular-version-utils';
+import { getNgPackagrVersionInfo } from './ng-packagr-version';
+import { importNgPackagrPath } from './package-imports';
 
-export const STYLESHEET_PROCESSOR: FactoryProvider = {
-  provide: STYLESHEET_PROCESSOR_TOKEN,
-  useFactory: () => {
-    const { major: ngPackagrMajorVersion, version: ngPackagrVersion } =
-      getInstalledPackageVersionInfo('ng-packagr');
+export function getStylesheetProcessorFactoryProvider(): FactoryProvider {
+  const { major: ngPackagrMajorVersion, version: ngPackagrVersion } =
+    getNgPackagrVersionInfo();
 
-    if (ngPackagrMajorVersion >= 19) {
-      const { StylesheetProcessor } = require('./v19+/stylesheet-processor');
-      return StylesheetProcessor;
-    }
+  const { STYLESHEET_PROCESSOR_TOKEN } = importNgPackagrPath<
+    typeof import('ng-packagr/lib/styles/stylesheet-processor.di')
+  >('ng-packagr/lib/styles/stylesheet-processor.di', ngPackagrMajorVersion);
 
-    if (ngPackagrVersion !== '17.2.0') {
-      const { StylesheetProcessor } = require('./pre-v19/stylesheet-processor');
-      return StylesheetProcessor;
-    }
+  return {
+    provide: STYLESHEET_PROCESSOR_TOKEN,
+    useFactory: () => {
+      if (ngPackagrMajorVersion >= 19) {
+        const {
+          getStylesheetProcessor,
+        } = require('./v19+/stylesheet-processor');
+        return getStylesheetProcessor();
+      }
 
-    const {
-      AsyncStylesheetProcessor,
-    } = require('./pre-v19/stylesheet-processor');
-    return AsyncStylesheetProcessor;
-  },
-  deps: [],
-};
+      if (ngPackagrVersion !== '17.2.0') {
+        const {
+          StylesheetProcessor,
+        } = require('./pre-v19/stylesheet-processor');
+        return StylesheetProcessor;
+      }
+
+      const {
+        AsyncStylesheetProcessor,
+      } = require('./pre-v19/stylesheet-processor');
+      return AsyncStylesheetProcessor;
+    },
+    deps: [],
+  };
+}

--- a/packages/angular/src/executors/utilities/ng-packagr/v19+/stylesheet-processor.ts
+++ b/packages/angular/src/executors/utilities/ng-packagr/v19+/stylesheet-processor.ts
@@ -5,71 +5,94 @@
  * - Add the project root to the search directories.
  */
 
-import browserslist from 'browserslist';
-import { NgPackageEntryConfig } from 'ng-packagr/ng-entrypoint.schema';
-import { ComponentStylesheetBundler } from 'ng-packagr/lib/styles/component-stylesheets';
-import {
-  generateSearchDirectories,
-  getTailwindConfig,
-  loadPostcssConfiguration,
-} from 'ng-packagr/lib/styles/postcss-configuration';
 import { workspaceRoot } from '@nx/devkit';
+import browserslist from 'browserslist';
+import type { NgPackageEntryConfig } from 'ng-packagr/ng-entrypoint.schema';
+import { getNgPackagrVersionInfo } from '../ng-packagr-version';
+import { importNgPackagrPath } from '../package-imports';
 
 export enum CssUrl {
   inline = 'inline',
   none = 'none',
 }
 
-export class StylesheetProcessor extends ComponentStylesheetBundler {
-  constructor(
-    protected readonly projectBasePath: string,
-    protected readonly basePath: string,
-    protected readonly cssUrl?: CssUrl,
-    protected readonly includePaths?: string[],
-    protected readonly sass?: NgPackageEntryConfig['lib']['sass'],
-    protected readonly cacheDirectory?: string | false,
-    protected readonly watch?: boolean
-  ) {
-    // By default, browserslist defaults are too inclusive
-    // https://github.com/browserslist/browserslist/blob/83764ea81ffaa39111c204b02c371afa44a4ff07/index.js#L516-L522
-    // We change the default query to browsers that Angular support.
-    // https://angular.io/guide/browser-support
-    (browserslist.defaults as string[]) = [
-      'last 2 Chrome versions',
-      'last 1 Firefox version',
-      'last 2 Edge major versions',
-      'last 2 Safari major versions',
-      'last 2 iOS major versions',
-      'Firefox ESR',
-    ];
+export function getStylesheetProcessor(): new (
+  projectBasePath: string,
+  basePath: string,
+  cssUrl?: CssUrl,
+  includePaths?: string[],
+  sass?: NgPackageEntryConfig['lib']['sass'],
+  cacheDirectory?: string | false,
+  watch?: boolean
+) => {
+  [key: string]: any;
+} {
+  const { major: ngPackagrMajorVersion } = getNgPackagrVersionInfo();
 
-    const browserslistData = browserslist(undefined, { path: basePath });
-    let searchDirs = generateSearchDirectories([projectBasePath]);
-    const postcssConfiguration = loadPostcssConfiguration(searchDirs);
-    // (nx-specific): we support loading the TailwindCSS config from the root of the workspace
-    searchDirs = generateSearchDirectories([projectBasePath, workspaceRoot]);
+  const { ComponentStylesheetBundler } = importNgPackagrPath<
+    typeof import('ng-packagr/lib/styles/component-stylesheets')
+  >('ng-packagr/lib/styles/component-stylesheets', ngPackagrMajorVersion);
+  const {
+    generateSearchDirectories,
+    getTailwindConfig,
+    loadPostcssConfiguration,
+  } = importNgPackagrPath<
+    typeof import('ng-packagr/lib/styles/postcss-configuration')
+  >('ng-packagr/lib/styles/postcss-configuration', ngPackagrMajorVersion);
 
-    super(
-      {
-        cacheDirectory: cacheDirectory,
-        postcssConfiguration: postcssConfiguration,
-        tailwindConfiguration: postcssConfiguration
-          ? undefined
-          : getTailwindConfig(searchDirs, projectBasePath),
-        sass: sass as any,
-        workspaceRoot: projectBasePath,
-        cssUrl: cssUrl,
-        target: transformSupportedBrowsersToTargets(browserslistData),
-        includePaths: includePaths,
-      },
-      'css',
-      watch
-    );
+  class StylesheetProcessor extends ComponentStylesheetBundler {
+    constructor(
+      protected readonly projectBasePath: string,
+      protected readonly basePath: string,
+      protected readonly cssUrl?: CssUrl,
+      protected readonly includePaths?: string[],
+      protected readonly sass?: NgPackageEntryConfig['lib']['sass'],
+      protected readonly cacheDirectory?: string | false,
+      protected readonly watch?: boolean
+    ) {
+      // By default, browserslist defaults are too inclusive
+      // https://github.com/browserslist/browserslist/blob/83764ea81ffaa39111c204b02c371afa44a4ff07/index.js#L516-L522
+      // We change the default query to browsers that Angular support.
+      // https://angular.io/guide/browser-support
+      (browserslist.defaults as string[]) = [
+        'last 2 Chrome versions',
+        'last 1 Firefox version',
+        'last 2 Edge major versions',
+        'last 2 Safari major versions',
+        'last 2 iOS major versions',
+        'Firefox ESR',
+      ];
+
+      const browserslistData = browserslist(undefined, { path: basePath });
+      let searchDirs = generateSearchDirectories([projectBasePath]);
+      const postcssConfiguration = loadPostcssConfiguration(searchDirs);
+      // (nx-specific): we support loading the TailwindCSS config from the root of the workspace
+      searchDirs = generateSearchDirectories([projectBasePath, workspaceRoot]);
+
+      super(
+        {
+          cacheDirectory: cacheDirectory,
+          postcssConfiguration: postcssConfiguration,
+          tailwindConfiguration: postcssConfiguration
+            ? undefined
+            : getTailwindConfig(searchDirs, projectBasePath),
+          sass: sass as any,
+          workspaceRoot: projectBasePath,
+          cssUrl: cssUrl,
+          target: transformSupportedBrowsersToTargets(browserslistData),
+          includePaths: includePaths,
+        },
+        'css',
+        watch
+      );
+    }
+
+    destroy(): void {
+      void super.dispose();
+    }
   }
 
-  destroy(): void {
-    void super.dispose();
-  }
+  return StylesheetProcessor;
 }
 
 function transformSupportedBrowsersToTargets(


### PR DESCRIPTION
Update the nested import paths from `ng-packagr` to handle the different paths in the upcoming Angular v20.

We must update and release `@nx/angular` and update the Nx repo with the new version to handle the path changes in the upcoming `ng-packagr` v20 before updating the version in the Angular v20 branch. Otherwise, a compilation error is thrown when building the v20 branch because the installed `@nx/angular` version does not support the new paths needed in `ng-packagr` v20.