### PR TITLE
feat(core): migration to remove useLegacyCache from nx.json

### DIFF
--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -327,6 +327,10 @@ Set this to false to disable adding inference plugins when generating new projec
 
 Use the legacy file system cache instead of the db cache
 
+**`Deprecated`**
+
+Use the db cache.
+
 ---
 
 ### workspaceLayout

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -447,6 +447,10 @@ Set this to false to disable adding inference plugins when generating new projec
 
 Use the legacy file system cache instead of the db cache
 
+**`Deprecated`**
+
+Use the db cache.
+
 #### Inherited from
 
 [NxJsonConfiguration](../../devkit/documents/NxJsonConfiguration).[useLegacyCache](../../devkit/documents/NxJsonConfiguration#uselegacycache)

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -3364,6 +3364,16 @@
       }
     },
     "migrations": {
+      "/nx-api/nx/migrations/remove-use-legacy-cache": {
+        "description": "Remove `useLegacyCache` option from nx.json",
+        "file": "generated/packages/nx/migrations/remove-use-legacy-cache.json",
+        "hidden": false,
+        "name": "remove-use-legacy-cache",
+        "version": "21.0.0-beta.11",
+        "originalFilePath": "/packages/nx",
+        "path": "/nx-api/nx/migrations/remove-use-legacy-cache",
+        "type": "migration"
+      },
       "/nx-api/nx/migrations/release-version-config-changes": {
         "description": "Updates release version config based on the breaking changes in Nx v21",
         "file": "generated/packages/nx/migrations/release-version-config-changes.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -3341,6 +3341,16 @@
     ],
     "migrations": [
       {
+        "description": "Remove `useLegacyCache` option from nx.json",
+        "file": "generated/packages/nx/migrations/remove-use-legacy-cache.json",
+        "hidden": false,
+        "name": "remove-use-legacy-cache",
+        "version": "21.0.0-beta.11",
+        "originalFilePath": "/packages/nx",
+        "path": "nx/migrations/remove-use-legacy-cache",
+        "type": "migration"
+      },
+      {
         "description": "Updates release version config based on the breaking changes in Nx v21",
         "file": "generated/packages/nx/migrations/release-version-config-changes.json",
         "hidden": false,

--- a/docs/generated/packages/nx/migrations/remove-use-legacy-cache.json
+++ b/docs/generated/packages/nx/migrations/remove-use-legacy-cache.json
@@ -1,0 +1,13 @@
+{
+  "name": "remove-use-legacy-cache",
+  "version": "21.0.0-beta.11",
+  "description": "Remove `useLegacyCache` option from nx.json",
+  "implementation": "/packages/nx/src/migrations/update-21-0-0/remove-use-legacy-cache.ts",
+  "x-repair-skip": true,
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/nx",
+  "schema": null,
+  "type": "migration",
+  "examplesFile": "#### Remove `useLegacyCache`\n\nRemove `useLegacyCache` option from `nx.json` since it is deprecated.\n\n#### Sample Code Changes\n\nRemove `useLegacyCache` option from `nx.json`.\n\n{% tabs %}\n{% tab label=\"Before\" %}\n\n```json {% fileName=\"nx.json\" %}\n{\n  \"targetDefaults\": {}\n}\n```\n\n{% /tab %}\n{% tab label=\"After\" %}\n\n```json {% fileName=\"nx.json\" %}\n{\n  \"targetDefaults\": {},\n  \"useLegacyCache\": true\n}\n```\n\n{% /tab %}\n{% /tabs %}\n"
+}

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -33,6 +33,12 @@
       "version": "21.0.0-beta.1",
       "description": "Updates release version config based on the breaking changes in Nx v21",
       "implementation": "./src/migrations/update-21-0-0/release-version-config-changes"
+    },
+    "remove-use-legacy-cache": {
+      "version": "21.0.0-beta.11",
+      "description": "Remove `useLegacyCache` option from nx.json",
+      "implementation": "./src/migrations/update-21-0-0/remove-use-legacy-cache",
+      "x-repair-skip": true
     }
   }
 }

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -653,6 +653,7 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
 
   /**
    * Use the legacy file system cache instead of the db cache
+   * @deprecated Use the db cache.
    */
   useLegacyCache?: boolean;
 

--- a/packages/nx/src/migrations/update-21-0-0/remove-use-legacy-cache.md
+++ b/packages/nx/src/migrations/update-21-0-0/remove-use-legacy-cache.md
@@ -1,0 +1,29 @@
+#### Remove `useLegacyCache`
+
+Remove `useLegacyCache` option from `nx.json` since it is deprecated.
+
+#### Sample Code Changes
+
+Remove `useLegacyCache` option from `nx.json`.
+
+{% tabs %}
+{% tab label="Before" %}
+
+```json {% fileName="nx.json" %}
+{
+  "targetDefaults": {}
+}
+```
+
+{% /tab %}
+{% tab label="After" %}
+
+```json {% fileName="nx.json" %}
+{
+  "targetDefaults": {},
+  "useLegacyCache": true
+}
+```
+
+{% /tab %}
+{% /tabs %}

--- a/packages/nx/src/migrations/update-21-0-0/remove-use-legacy-cache.spec.ts
+++ b/packages/nx/src/migrations/update-21-0-0/remove-use-legacy-cache.spec.ts
@@ -1,0 +1,38 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { Tree } from '../../generators/tree';
+
+import update from './remove-use-legacy-cache';
+import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
+
+describe('remove useLegacyCache', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should remove `useLegacyCache` from nx.json', async () => {
+    updateNxJson(tree, {
+      ...readNxJson(tree),
+      useLegacyCache: true,
+    });
+
+    await update(tree);
+
+    expect(readNxJson(tree)).toMatchInlineSnapshot(`
+      {
+        "affected": {
+          "defaultBase": "main",
+        },
+        "targetDefaults": {
+          "build": {
+            "cache": true,
+          },
+          "lint": {
+            "cache": true,
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/nx/src/migrations/update-21-0-0/remove-use-legacy-cache.ts
+++ b/packages/nx/src/migrations/update-21-0-0/remove-use-legacy-cache.ts
@@ -1,0 +1,14 @@
+import { Tree } from '../../generators/tree';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
+import { NxJsonConfiguration } from '../../config/nx-json';
+
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree) as NxJsonConfiguration;
+  if (!nxJson) return;
+  if ('useLegacyCache' in nxJson) {
+    delete nxJson['useLegacyCache'];
+    updateNxJson(tree, nxJson);
+    await formatChangedFilesWithPrettierIfAvailable(tree);
+  }
+}

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -40,6 +40,7 @@ export type TaskWithCachedResult = { task: Task; cachedResult: CachedResult };
 export function dbCacheEnabled(nxJson: NxJsonConfiguration = readNxJson()) {
   // If the user has explicitly disabled the db cache, we can warn...
   if (
+    // TODO(v22): Remove fs cache option
     nxJson.useLegacyCache ||
     process.env.NX_DISABLE_DB === 'true' ||
     process.env.NX_DB_CACHE === 'false'
@@ -59,7 +60,7 @@ export function dbCacheEnabled(nxJson: NxJsonConfiguration = readNxJson()) {
       readMoreLink += '#nxrejectunknownlocalcache';
     }
     logger.warn(
-      `Nx is configured to use the legacy cache. This cache will be removed in Nx 21. Read more at ${readMoreLink}.`
+      `Nx is configured to use the legacy cache. This cache will be removed in Nx 22. Read more at ${readMoreLink}.`
     );
     return false;
   }


### PR DESCRIPTION
This PR adds a migration to remove the `useLegacyCache` option that we added in Nx 20. It also marks the option as deprecated and set for removal in Nx 22.