### PR TITLE
docs(core): add continuous task to task pipeline and project config pages

### DIFF
--- a/docs/shared/concepts/myreactapp.json
+++ b/docs/shared/concepts/myreactapp.json
@@ -29,7 +29,8 @@
         "serve": {
           "options": {
             "cwd": "apps/myreactapp",
-            "command": "vite serve"
+            "command": "vite serve",
+            "continuous": true
           },
           "executor": "nx:run-commands",
           "configurations": {},
@@ -51,7 +52,8 @@
         "serve-static": {
           "executor": "@nx/web:file-server",
           "options": {
-            "buildTarget": "build"
+            "buildTarget": "build",
+            "continuous": true
           },
           "configurations": {}
         },

--- a/docs/shared/migration/adding-to-existing-project.md
+++ b/docs/shared/migration/adding-to-existing-project.md
@@ -169,7 +169,8 @@ nx show project my-workspace --web
         "dev": {
           "options": {
             "cwd": ".",
-            "command": "next dev"
+            "command": "next dev",
+            "continuous": true
           },
           "executor": "nx:run-commands",
           "configurations": {},
@@ -180,7 +181,8 @@ nx show project my-workspace --web
         "start": {
           "options": {
             "cwd": ".",
-            "command": "next start"
+            "command": "next start",
+            "continuous": true
           },
           "dependsOn": ["build"],
           "executor": "nx:run-commands",

--- a/docs/shared/migration/adding-to-monorepo.md
+++ b/docs/shared/migration/adding-to-monorepo.md
@@ -165,7 +165,8 @@ nx show project my-workspace --web
         "dev": {
           "options": {
             "cwd": ".",
-            "command": "next dev"
+            "command": "next dev",
+            "continuous": true
           },
           "executor": "nx:run-commands",
           "configurations": {},
@@ -176,7 +177,8 @@ nx show project my-workspace --web
         "start": {
           "options": {
             "cwd": ".",
-            "command": "next start"
+            "command": "next start",
+            "continuous": true
           },
           "dependsOn": ["build"],
           "executor": "nx:run-commands",

--- a/docs/shared/recipes/running-tasks/convert-to-inferred.md
+++ b/docs/shared/recipes/running-tasks/convert-to-inferred.md
@@ -84,7 +84,8 @@ For example, if we migrated the `@nx/vite` plugin for a single app (i.e. `nx g @
         "serve": {
           "executor": "nx:run-commands",
           "options": {
-            "command": "vite dev"
+            "command": "vite dev",
+            "continuous": true
           }
         },
         "build": {

--- a/docs/shared/recipes/running-tasks/defining-task-pipeline.md
+++ b/docs/shared/recipes/running-tasks/defining-task-pipeline.md
@@ -87,7 +87,23 @@ Or they can be [defined per-project](/reference/project-configuration#dependson)
 {% /tab %}
 {% /tabs %}
 
-## Visualize task dependencies
+## Continuous Task Dependencies
+
+If a task has a dependency that never exits, then the task will never start. To support this scenario, you can mark the dependency as a [continuous task](/reference/project-configuration#continuous). Labeling a task as continuous tells Nx to not wait for the process to exit, and it will be run alongside its dependents.
+
+```json {% fileName="apps/myapp/project.json" %}
+{
+  "targets": {
+    "serve": {
+      "continuous": true
+    }
+  }
+}
+```
+
+The `continuous` option is most useful for running development servers. For example, the `e2e` task depends on a continuous `serve` task that starts the server to be tested againts.
+
+## Visualize Task Dependencies
 
 You can also visualize the actual task graph (alongside the projects) using [Nx graph](/features/explore-graph). This can be useful for debugging purposes.
 

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -527,7 +527,7 @@ configuration above.
 
 ### Continuous
 
-In Nx 21+, tasks that never exit can be configured with `"continuous": true` to prevent their dependent tasks from waiting for task completion. For example, the `e2e` task depends on a continuous `serve` task to ensure that the development server is running.
+In Nx 21+, tasks that never exit (sometimes called long-running processes) can be configured with `"continuous": true` to prevent their dependent tasks from waiting for task completion. For example, the `e2e` task depends on a continuous `serve` task to ensure that the development server is running.
 
 In this example, application's configuration labels the `serve` task as continuous.
 

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -225,6 +225,39 @@ If you are using distributed task execution, tasks will still be run simultaneou
 
 {% /callout %}
 
+### Continuous
+
+In Nx 21+, tasks that never exit can be configured with `"continuous": true` to prevent their dependent tasks from waiting for task completion. For example, the `e2e` task depends on a continuous `serve` task to ensure that the development server is running.
+
+In this example, application's configuration labels the `serve` task as continuous.
+
+```json {% fileName="apps/myapp/project.json" %}
+{
+  "targets": {
+    "serve": {
+      "continuous": true
+    }
+  }
+}
+```
+
+And the E2E project's `e2e` task has a dependency on the `serve` task, which ensures that the server is running when we run the `e2e` task.
+
+```json {% fileName="apps/myapp-e2e/project.json" %}
+{
+  "targets": {
+    "e2e": {
+      "dependsOn": [
+        {
+          "projects": "myapp",
+          "target": "serve"
+        }
+      ]
+    }
+  }
+}
+```
+
 ### Inputs and Named Inputs
 
 Each cacheable task needs to define `inputs` which determine whether the task outputs can be retrieved from the cache or the task needs to be re-run. The `namedInputs` defined in `nx.json` or project level configuration are sets of reusable input definitions.


### PR DESCRIPTION
This PR adds information about `continuous` option for tasks. Also removes references to Nx <16 examples on the project configuration page.

**Preview:**
- https://nx-dev-git-docs-continuous-tasks-nrwl.vercel.app/recipes/running-tasks/defining-task-pipeline#continuous-task-dependencies
  - Add a section on continuous task and links to the project configuration reference page (below)
- https://nx-dev-git-docs-continuous-tasks-nrwl.vercel.app/reference/project-configuration#continuous
  - Add section on continuous task with example of `e2e -> serve` dependency
  - Add a callout on `dependsOn` section for continuous/long-running tasks (long-running is mentioned so it appears in the search)
  - Remove Nx <16 examples

**TODO:**
- [x] Update PDV that show e2e and serve targets