### PR TITLE
feat(nuxt): enable continuous tasks

### DIFF
--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -30,6 +30,7 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
           ],
         },
         "acme-serve-static": {
+          "continuous": true,
           "executor": "@nx/web:file-server",
           "options": {
             "buildTarget": "acme-build-static",
@@ -68,6 +69,7 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
         },
         "my-serve": {
           "command": "nuxt dev",
+          "continuous": true,
           "options": {
             "cwd": "my-app",
           },
@@ -144,11 +146,13 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
         },
         "serve": {
           "command": "nuxt dev",
+          "continuous": true,
           "options": {
             "cwd": ".",
           },
         },
         "serve-static": {
+          "continuous": true,
           "executor": "@nx/web:file-server",
           "options": {
             "buildTarget": "build-static",

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -182,6 +182,7 @@ function serveTarget(projectRoot: string) {
     options: {
       cwd: projectRoot,
     },
+    continuous: true,
   };
 
   return targetConfig;
@@ -189,6 +190,7 @@ function serveTarget(projectRoot: string) {
 
 function serveStaticTarget(options: NuxtPluginOptions) {
   const targetConfig: TargetConfiguration = {
+    continuous: true,
     executor: '@nx/web:file-server',
     options: {
       buildTarget: `${options.buildStaticTargetName}`,


### PR DESCRIPTION
## Current Behavior
The tasks inferred by the `@nx/nuxt/plugin` do not set `continuous:true` for serve-like tasks.

## Expected Behavior
The tasks should be correctly inferred with `continuous:true`.
