### PR TITLE
feat(gradle): set gradle task continuous for bootRun

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -27,6 +27,11 @@ fun processTask(
   val target = mutableMapOf<String, Any?>()
   target["cache"] = true // set cache to be always true
 
+  val continuous = isContinuous(task)
+  if (continuous) {
+    target["continuous"] = true
+  }
+
   // process inputs
   val inputs = getInputsForTask(task, projectRoot, workspaceRoot, externalNodes)
   if (!inputs.isNullOrEmpty()) {
@@ -299,4 +304,8 @@ fun replaceRootInPath(p: String, projectRoot: String, workspaceRoot: String): St
     return path
   }
   return null
+}
+
+fun isContinuous(task: Task): Boolean {
+  return task.name == "bootRun"
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
non of the gradle tasks is set as continuous

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
set only bootRun task as continuous

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
