### PR TITLE
chore(module-federation): disable test that is causing agents to run …

### DIFF
--- a/e2e/react/src/module-federation/ssr.rspack.test.ts
+++ b/e2e/react/src/module-federation/ssr.rspack.test.ts
@@ -13,7 +13,8 @@ import {
 import { readPort, runCLI } from './utils';
 
 describe('React Rspack SSR Module Federation', () => {
-  describe('ssr', () => {
+  // TODO: @columferry please investigate why this test cauess agents to run out of memory
+  xdescribe('ssr', () => {
     beforeEach(() => {
       newProject({ packages: ['@nx/react'] });
     });


### PR DESCRIPTION
…out of memory

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Many pipelines are stuck because this task is causing agents to run out of memory.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This test is disabled so that pipelines can complete.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
