### PR TITLE
fix(core): write keybindings with control to terminal panes in intera…

### DIFF
--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -98,6 +98,10 @@ impl TerminalPaneData {
                 }
                 // Only send input to PTY if we're in interactive mode
                 _ if self.is_interactive => match key.code {
+                    KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        let ascii_code = (c as u8) - 0x60;
+                        pty_mut.write_input(&[ascii_code])?;
+                    }
                     KeyCode::Char(c) => {
                         pty_mut.write_input(c.to_string().as_bytes())?;
                     }


### PR DESCRIPTION
…ctive mode

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Ctrl Keybindings are not sent to terminal panes when it's interactive mode, only single key presses are sent.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Ctrl Keybindings are sent to the terminal panes when it is in interactive mode. This means that editors like `nano` and `nvim` somewhat work in interactive mode. The rendering is still broken right now but the keypresses work. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
