### PR TITLE
docs(misc): remove installation instructions for Nx < 18

### DIFF
--- a/docs/generated/packages/angular/documents/overview.md
+++ b/docs/generated/packages/angular/documents/overview.md
@@ -39,26 +39,11 @@ Make sure to install the `@nx/angular` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/angular` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/angular
 ```
 
 This will install the correct version of `@nx/angular`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/angular` package with your package manager.
-
-```shell
-npm add -D @nx/angular
-```
-
-{% /tab %}
-{% /tabs %}
 
 {% callout type="note" title="Angular Tutorial" %}
 For a full tutorial experience, follow the [Angular Monorepo Tutorial](/getting-started/tutorials/angular-monorepo-tutorial)

--- a/docs/generated/packages/detox/documents/overview.md
+++ b/docs/generated/packages/detox/documents/overview.md
@@ -38,9 +38,6 @@ Make sure to install the `@nx/detox` version that matches the version of `nx` in
 
 In any Nx workspace, you can install `@nx/detox` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/detox
 ```
@@ -80,24 +77,6 @@ The `@nx/detox/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 Once a Detox configuration file has been identified, the targets are created with the name you specify under `buildTargetName`, `startTargetName` or `testTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `build` and `test`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/detox` package with your package manager.
-
-```shell
-npm add -D @nx/detox
-```
-
-### Generating Applications
-
-By default, when creating a mobile application, Nx will use Detox to create the e2e tests project.
-
-```shell
-nx g @nx/react-native:app apps/frontend --e2eTestRunner=deotx
-nx g @nx/expo:app apps/frontend --e2eTestRunner=detox
-```
 
 ## Using Detox
 

--- a/docs/generated/packages/esbuild/documents/overview.md
+++ b/docs/generated/packages/esbuild/documents/overview.md
@@ -22,26 +22,11 @@ Make sure to install the `@nx/esbuild` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/esbuild` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/esbuild
 ```
 
 This will install the correct version of `@nx/esbuild`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/esbuild` package with your package manager.
-
-```shell
-npm add -D @nx/esbuild
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/esbuild Plugin
 

--- a/docs/generated/packages/eslint-plugin/documents/overview.md
+++ b/docs/generated/packages/eslint-plugin/documents/overview.md
@@ -18,26 +18,11 @@ Make sure to install the `@nx/eslint-plugin` version that matches the version of
 
 In any Nx workspace, you can install `@nx/eslint-plugin` by running the following commands if the package is not already installed:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/eslint-plugin
 ```
 
 This will install the correct version of `@nx/eslint-plugin`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/eslint-plugin` package with your package manager.
-
-```shell
-npm add -D @nx/eslint-plugin
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Included plugins
 

--- a/docs/generated/packages/eslint/documents/overview.md
+++ b/docs/generated/packages/eslint/documents/overview.md
@@ -15,9 +15,6 @@ Make sure to install the `@nx/eslint` version that matches the version of `nx` i
 
 In any Nx workspace, you can install `@nx/eslint` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/eslint
 ```
@@ -65,27 +62,6 @@ The `@nx/eslint/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 - The `targetName` option controls the name of the inferred ESLint tasks. The default name is `lint`.
-
-{% /tab %}
-{% tab label="Nx 17" %}
-
-Install the `@nx/eslint` package with your package manager.
-
-```shell {% skipRescope=true %}
-npm add -D @nx/eslint
-```
-
-{% /tab %}
-{% tab label="Nx < 17" %}
-
-Install the `@nx/linter` package with your package manager.
-
-```shell
-npm add -D @nx/linter
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Lint
 

--- a/docs/generated/packages/expo/documents/overview.md
+++ b/docs/generated/packages/expo/documents/overview.md
@@ -23,26 +23,11 @@ Make sure to install the `@nx/expo` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/expo` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/expo
 ```
 
 This will install the correct version of `@nx/expo`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/expo` package with your package manager.
-
-```shell
-npm add -D @nx/expo
-```
-
-{% /tab %}
-{% /tabs %}
 
 ### How @nx/expo Infers Tasks
 

--- a/docs/generated/packages/express/documents/overview.md
+++ b/docs/generated/packages/express/documents/overview.md
@@ -24,26 +24,11 @@ Make sure to install the `@nx/express` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/express` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/express
 ```
 
 This will install the correct version of `@nx/express`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/express` package with your package manager.
-
-```shell
-npm add -D @nx/express
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Recipes
 

--- a/docs/generated/packages/jest/documents/overview.md
+++ b/docs/generated/packages/jest/documents/overview.md
@@ -19,26 +19,11 @@ Make sure to install the `@nx/jest` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/jest` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/jest
 ```
 
 This will install the correct version of `@nx/jest`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/jest` package with your package manager.
-
-```shell
-npm add -D @nx/jest
-```
-
-{% /tab %}
-{% /tabs %}
 
 #### Configuring @nx/jest/plugin for both E2E and Unit Tests
 

--- a/docs/generated/packages/js/documents/overview.md
+++ b/docs/generated/packages/js/documents/overview.md
@@ -15,26 +15,11 @@ Make sure to install the `@nx/js` version that matches the version of `nx` in yo
 
 In any Nx workspace, you can install `@nx/js` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/js
 ```
 
 This will install the correct version of `@nx/js`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/js` package with your package manager.
-
-```shell
-npm add -D @nx/js
-```
-
-{% /tab %}
-{% /tabs %}
 
 ### `ts` Preset
 

--- a/docs/generated/packages/nest/documents/overview.md
+++ b/docs/generated/packages/nest/documents/overview.md
@@ -37,26 +37,11 @@ Make sure to install the `@nx/nest` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/nest` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/nest
 ```
 
 This will install the correct version of `@nx/nest`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/nest` package with your package manager.
-
-```shell
-npm add -D @nx/nest
-```
-
-{% /tab %}
-{% /tabs %}
 
 ### Create Applications
 

--- a/docs/generated/packages/node/documents/overview.md
+++ b/docs/generated/packages/node/documents/overview.md
@@ -15,26 +15,11 @@ Make sure to install the `@nx/node` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/node` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/node
 ```
 
 This will install the correct version of `@nx/node`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/node` package with your package manager.
-
-```shell
-npm add -D @nx/node
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/node Plugin
 

--- a/docs/generated/packages/playwright/documents/overview.md
+++ b/docs/generated/packages/playwright/documents/overview.md
@@ -21,9 +21,6 @@ Make sure to install the `@nx/playwright` version that matches the version of `n
 
 In any Nx workspace, you can install `@nx/playwright` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/playwright
 ```
@@ -70,18 +67,6 @@ The `targetName` and `ciTargetName` options control the name of the inferred Pla
 `@nx/playwright/plugin` leverages Nx Atomizer to split your e2e tests into smaller tasks in a fully automated way. This allows for a much more efficient distribution of tasks in CI. You can read more about the Atomizer feature [here](/ci/features/split-e2e-tasks).
 
 If you would like to disable Atomizer for Playwright tasks, set `ciTargetName` to `false`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/playwright` package with your package manager.
-
-```shell {% skipRescope=true %}
-npm add -D @nx/playwright
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## E2E Testing
 

--- a/docs/generated/packages/react/documents/overview.md
+++ b/docs/generated/packages/react/documents/overview.md
@@ -30,26 +30,11 @@ Make sure to install the `@nx/react` version that matches the version of `nx` in
 
 In any Nx workspace, you can install `@nx/react` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/react
 ```
 
 This will install the correct version of `@nx/react`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/react` package with your package manager.
-
-```shell
-npm add -D @nx/react
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/react Plugin
 

--- a/docs/generated/packages/remix/documents/overview.md
+++ b/docs/generated/packages/remix/documents/overview.md
@@ -25,9 +25,6 @@ Make sure to install the `@nx/remix` version that matches the version of `nx` in
 
 In any Nx workspace, you can install `@nx/remix` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/remix
 ```
@@ -67,18 +64,6 @@ The `@nx/remix/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `buildTargetName`, `devTargetName`, `startTargetName` and `typecheckTargetName` options control the names of the inferred Remix tasks. The default names are `build`, `dev`, `start` and `typecheck`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/remix` package with your package manager.
-
-```shell
-npm add -D @nx/remix
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the Remix Plugin
 

--- a/docs/generated/packages/rspack/documents/overview.md
+++ b/docs/generated/packages/rspack/documents/overview.md
@@ -15,9 +15,6 @@ Make sure to install the `@nx/rspack` version that matches the version of `nx` i
 
 In any Nx workspace, you can install `@nx/rspack` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/rspack
 ```
@@ -60,18 +57,6 @@ The `@nx/rspack/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `buildTargetName`, `previewTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Rspack tasks. The default names are `build`, `preview`, `serve` and `serve-static`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/rspack` package with your package manager.
-
-```shell
-npm add -D @nx/rspack
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using @nx/rspack
 

--- a/docs/generated/packages/storybook/documents/overview.md
+++ b/docs/generated/packages/storybook/documents/overview.md
@@ -17,9 +17,6 @@ Make sure to install the `@nx/storybook` version that matches the version of `nx
 
 In any Nx workspace, you can install `@nx/storybook` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/storybook
 ```
@@ -62,18 +59,6 @@ The `@nx/storybook/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `builtStorybookTargetName`, `serveStorybookTargetName`, `testStorybookTargetName` and `staticStorybookTargetName` options control the names of the inferred Storybook tasks. The default names are `build-storybook`, `storybook`, `test-storybook` and `static-storybook`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/storybook` package with your package manager.
-
-```shell
-npm add -D @nx/storybook
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using Storybook
 

--- a/docs/generated/packages/vite/documents/overview.md
+++ b/docs/generated/packages/vite/documents/overview.md
@@ -32,17 +32,8 @@ Make sure to install the `@nx/vite` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/vite` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/vite
-```
-
-You can also pass the `--setupPathsPlugin` flag to add [`nxViteTsPaths` plugin](/recipes/vite/configure-vite#typescript-paths), so your projects can use workspace libraries.
-
-```shell {% skipRescope=true %}
-nx add @nx/vite --setupPathsPlugin
 ```
 
 This will install the correct version of `@nx/vite`.
@@ -90,18 +81,6 @@ The `@nx/vite/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `buildTargetName`, `previewTargetName`, `testTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Vite tasks. The default names are `build`, `preview`, `test`, `serve` and `serve-static`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/vite` package with your package manager.
-
-```shell
-npm add -D @nx/vite
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using @nx/vite
 

--- a/docs/generated/packages/vue/documents/overview.md
+++ b/docs/generated/packages/vue/documents/overview.md
@@ -19,26 +19,11 @@ Make sure to install the `@nx/vue` version that matches the version of `nx` in y
 
 In any Nx workspace, you can install `@nx/vue` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/vue
 ```
 
 This will install the correct version of `@nx/vue`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/vue` package with your package manager.
-
-```shell {% skipRescope=true %}
-npm add -D @nx/vue
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/vue Plugin
 

--- a/docs/generated/packages/web/documents/overview.md
+++ b/docs/generated/packages/web/documents/overview.md
@@ -23,26 +23,11 @@ Make sure to install the `@nx/web` version that matches the version of `nx` in y
 
 In any Nx workspace, you can install `@nx/web` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/web
 ```
 
 This will install the correct version of `@nx/web`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/web` package with your package manager.
-
-```shell
-npm add -D @nx/web
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/web Plugin
 

--- a/docs/generated/packages/webpack/documents/overview.md
+++ b/docs/generated/packages/webpack/documents/overview.md
@@ -33,9 +33,6 @@ Make sure to install the `@nx/webpack` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/webpack` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/webpack
 ```
@@ -76,18 +73,6 @@ The `@nx/webpack/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `buildTargetName`, `previewTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Webpack tasks. The default names are `build`, `preview`, `serve` and `serve-static`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/webpack` package with your package manager.
-
-```shell
-npm add -D @nx/webpack
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Generate a new project using Webpack
 

--- a/docs/shared/packages/angular/angular-plugin.md
+++ b/docs/shared/packages/angular/angular-plugin.md
@@ -39,26 +39,11 @@ Make sure to install the `@nx/angular` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/angular` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/angular
 ```
 
 This will install the correct version of `@nx/angular`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/angular` package with your package manager.
-
-```shell
-npm add -D @nx/angular
-```
-
-{% /tab %}
-{% /tabs %}
 
 {% callout type="note" title="Angular Tutorial" %}
 For a full tutorial experience, follow the [Angular Monorepo Tutorial](/getting-started/tutorials/angular-monorepo-tutorial)

--- a/docs/shared/packages/detox/detox-plugin.md
+++ b/docs/shared/packages/detox/detox-plugin.md
@@ -38,9 +38,6 @@ Make sure to install the `@nx/detox` version that matches the version of `nx` in
 
 In any Nx workspace, you can install `@nx/detox` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/detox
 ```
@@ -80,24 +77,6 @@ The `@nx/detox/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 Once a Detox configuration file has been identified, the targets are created with the name you specify under `buildTargetName`, `startTargetName` or `testTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `build` and `test`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/detox` package with your package manager.
-
-```shell
-npm add -D @nx/detox
-```
-
-### Generating Applications
-
-By default, when creating a mobile application, Nx will use Detox to create the e2e tests project.
-
-```shell
-nx g @nx/react-native:app apps/frontend --e2eTestRunner=deotx
-nx g @nx/expo:app apps/frontend --e2eTestRunner=detox
-```
 
 ## Using Detox
 

--- a/docs/shared/packages/esbuild/esbuild-plugin.md
+++ b/docs/shared/packages/esbuild/esbuild-plugin.md
@@ -22,26 +22,11 @@ Make sure to install the `@nx/esbuild` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/esbuild` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/esbuild
 ```
 
 This will install the correct version of `@nx/esbuild`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/esbuild` package with your package manager.
-
-```shell
-npm add -D @nx/esbuild
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/esbuild Plugin
 

--- a/docs/shared/packages/eslint/eslint-plugin.md
+++ b/docs/shared/packages/eslint/eslint-plugin.md
@@ -18,26 +18,11 @@ Make sure to install the `@nx/eslint-plugin` version that matches the version of
 
 In any Nx workspace, you can install `@nx/eslint-plugin` by running the following commands if the package is not already installed:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/eslint-plugin
 ```
 
 This will install the correct version of `@nx/eslint-plugin`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/eslint-plugin` package with your package manager.
-
-```shell
-npm add -D @nx/eslint-plugin
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Included plugins
 

--- a/docs/shared/packages/eslint/eslint.md
+++ b/docs/shared/packages/eslint/eslint.md
@@ -15,9 +15,6 @@ Make sure to install the `@nx/eslint` version that matches the version of `nx` i
 
 In any Nx workspace, you can install `@nx/eslint` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/eslint
 ```
@@ -65,27 +62,6 @@ The `@nx/eslint/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 - The `targetName` option controls the name of the inferred ESLint tasks. The default name is `lint`.
-
-{% /tab %}
-{% tab label="Nx 17" %}
-
-Install the `@nx/eslint` package with your package manager.
-
-```shell {% skipRescope=true %}
-npm add -D @nx/eslint
-```
-
-{% /tab %}
-{% tab label="Nx < 17" %}
-
-Install the `@nx/linter` package with your package manager.
-
-```shell
-npm add -D @nx/linter
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Lint
 

--- a/docs/shared/packages/expo/expo-plugin.md
+++ b/docs/shared/packages/expo/expo-plugin.md
@@ -23,26 +23,11 @@ Make sure to install the `@nx/expo` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/expo` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/expo
 ```
 
 This will install the correct version of `@nx/expo`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/expo` package with your package manager.
-
-```shell
-npm add -D @nx/expo
-```
-
-{% /tab %}
-{% /tabs %}
 
 ### How @nx/expo Infers Tasks
 

--- a/docs/shared/packages/express/express-plugin.md
+++ b/docs/shared/packages/express/express-plugin.md
@@ -24,26 +24,11 @@ Make sure to install the `@nx/express` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/express` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/express
 ```
 
 This will install the correct version of `@nx/express`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/express` package with your package manager.
-
-```shell
-npm add -D @nx/express
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Recipes
 

--- a/docs/shared/packages/jest/jest-plugin.md
+++ b/docs/shared/packages/jest/jest-plugin.md
@@ -19,26 +19,11 @@ Make sure to install the `@nx/jest` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/jest` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/jest
 ```
 
 This will install the correct version of `@nx/jest`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/jest` package with your package manager.
-
-```shell
-npm add -D @nx/jest
-```
-
-{% /tab %}
-{% /tabs %}
 
 #### Configuring @nx/jest/plugin for both E2E and Unit Tests
 

--- a/docs/shared/packages/js/js-plugin.md
+++ b/docs/shared/packages/js/js-plugin.md
@@ -15,26 +15,11 @@ Make sure to install the `@nx/js` version that matches the version of `nx` in yo
 
 In any Nx workspace, you can install `@nx/js` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/js
 ```
 
 This will install the correct version of `@nx/js`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/js` package with your package manager.
-
-```shell
-npm add -D @nx/js
-```
-
-{% /tab %}
-{% /tabs %}
 
 ### `ts` Preset
 

--- a/docs/shared/packages/nest/nest-plugin.md
+++ b/docs/shared/packages/nest/nest-plugin.md
@@ -37,26 +37,11 @@ Make sure to install the `@nx/nest` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/nest` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/nest
 ```
 
 This will install the correct version of `@nx/nest`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/nest` package with your package manager.
-
-```shell
-npm add -D @nx/nest
-```
-
-{% /tab %}
-{% /tabs %}
 
 ### Create Applications
 

--- a/docs/shared/packages/node/node-plugin.md
+++ b/docs/shared/packages/node/node-plugin.md
@@ -15,26 +15,11 @@ Make sure to install the `@nx/node` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/node` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/node
 ```
 
 This will install the correct version of `@nx/node`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/node` package with your package manager.
-
-```shell
-npm add -D @nx/node
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/node Plugin
 

--- a/docs/shared/packages/playwright/playwright-plugin.md
+++ b/docs/shared/packages/playwright/playwright-plugin.md
@@ -21,9 +21,6 @@ Make sure to install the `@nx/playwright` version that matches the version of `n
 
 In any Nx workspace, you can install `@nx/playwright` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/playwright
 ```
@@ -70,18 +67,6 @@ The `targetName` and `ciTargetName` options control the name of the inferred Pla
 `@nx/playwright/plugin` leverages Nx Atomizer to split your e2e tests into smaller tasks in a fully automated way. This allows for a much more efficient distribution of tasks in CI. You can read more about the Atomizer feature [here](/ci/features/split-e2e-tasks).
 
 If you would like to disable Atomizer for Playwright tasks, set `ciTargetName` to `false`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/playwright` package with your package manager.
-
-```shell {% skipRescope=true %}
-npm add -D @nx/playwright
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## E2E Testing
 

--- a/docs/shared/packages/react/react-plugin.md
+++ b/docs/shared/packages/react/react-plugin.md
@@ -30,26 +30,11 @@ Make sure to install the `@nx/react` version that matches the version of `nx` in
 
 In any Nx workspace, you can install `@nx/react` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/react
 ```
 
 This will install the correct version of `@nx/react`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/react` package with your package manager.
-
-```shell
-npm add -D @nx/react
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/react Plugin
 

--- a/docs/shared/packages/remix/remix-plugin.md
+++ b/docs/shared/packages/remix/remix-plugin.md
@@ -25,9 +25,6 @@ Make sure to install the `@nx/remix` version that matches the version of `nx` in
 
 In any Nx workspace, you can install `@nx/remix` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/remix
 ```
@@ -67,18 +64,6 @@ The `@nx/remix/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `buildTargetName`, `devTargetName`, `startTargetName` and `typecheckTargetName` options control the names of the inferred Remix tasks. The default names are `build`, `dev`, `start` and `typecheck`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/remix` package with your package manager.
-
-```shell
-npm add -D @nx/remix
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the Remix Plugin
 

--- a/docs/shared/packages/rspack/rspack-plugin.md
+++ b/docs/shared/packages/rspack/rspack-plugin.md
@@ -15,9 +15,6 @@ Make sure to install the `@nx/rspack` version that matches the version of `nx` i
 
 In any Nx workspace, you can install `@nx/rspack` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/rspack
 ```
@@ -60,18 +57,6 @@ The `@nx/rspack/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `buildTargetName`, `previewTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Rspack tasks. The default names are `build`, `preview`, `serve` and `serve-static`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/rspack` package with your package manager.
-
-```shell
-npm add -D @nx/rspack
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using @nx/rspack
 

--- a/docs/shared/packages/storybook/plugin-overview.md
+++ b/docs/shared/packages/storybook/plugin-overview.md
@@ -17,9 +17,6 @@ Make sure to install the `@nx/storybook` version that matches the version of `nx
 
 In any Nx workspace, you can install `@nx/storybook` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/storybook
 ```
@@ -62,18 +59,6 @@ The `@nx/storybook/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `builtStorybookTargetName`, `serveStorybookTargetName`, `testStorybookTargetName` and `staticStorybookTargetName` options control the names of the inferred Storybook tasks. The default names are `build-storybook`, `storybook`, `test-storybook` and `static-storybook`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/storybook` package with your package manager.
-
-```shell
-npm add -D @nx/storybook
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using Storybook
 

--- a/docs/shared/packages/vite/vite-plugin.md
+++ b/docs/shared/packages/vite/vite-plugin.md
@@ -32,17 +32,8 @@ Make sure to install the `@nx/vite` version that matches the version of `nx` in 
 
 In any Nx workspace, you can install `@nx/vite` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/vite
-```
-
-You can also pass the `--setupPathsPlugin` flag to add [`nxViteTsPaths` plugin](/recipes/vite/configure-vite#typescript-paths), so your projects can use workspace libraries.
-
-```shell {% skipRescope=true %}
-nx add @nx/vite --setupPathsPlugin
 ```
 
 This will install the correct version of `@nx/vite`.
@@ -90,18 +81,6 @@ The `@nx/vite/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `buildTargetName`, `previewTargetName`, `testTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Vite tasks. The default names are `build`, `preview`, `test`, `serve` and `serve-static`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/vite` package with your package manager.
-
-```shell
-npm add -D @nx/vite
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using @nx/vite
 

--- a/docs/shared/packages/vue/vue-plugin.md
+++ b/docs/shared/packages/vue/vue-plugin.md
@@ -19,26 +19,11 @@ Make sure to install the `@nx/vue` version that matches the version of `nx` in y
 
 In any Nx workspace, you can install `@nx/vue` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/vue
 ```
 
 This will install the correct version of `@nx/vue`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/vue` package with your package manager.
-
-```shell {% skipRescope=true %}
-npm add -D @nx/vue
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/vue Plugin
 

--- a/docs/shared/packages/web/web-plugin.md
+++ b/docs/shared/packages/web/web-plugin.md
@@ -23,26 +23,11 @@ Make sure to install the `@nx/web` version that matches the version of `nx` in y
 
 In any Nx workspace, you can install `@nx/web` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/web
 ```
 
 This will install the correct version of `@nx/web`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/web` package with your package manager.
-
-```shell
-npm add -D @nx/web
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Using the @nx/web Plugin
 

--- a/docs/shared/packages/webpack/plugin-overview.md
+++ b/docs/shared/packages/webpack/plugin-overview.md
@@ -33,9 +33,6 @@ Make sure to install the `@nx/webpack` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/webpack` by running the following command:
 
-{% tabs %}
-{% tab label="Nx 18+" %}
-
 ```shell {% skipRescope=true %}
 nx add @nx/webpack
 ```
@@ -76,18 +73,6 @@ The `@nx/webpack/plugin` is configured in the `plugins` array in `nx.json`.
 ```
 
 The `buildTargetName`, `previewTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Webpack tasks. The default names are `build`, `preview`, `serve` and `serve-static`.
-
-{% /tab %}
-{% tab label="Nx < 18" %}
-
-Install the `@nx/webpack` package with your package manager.
-
-```shell
-npm add -D @nx/webpack
-```
-
-{% /tab %}
-{% /tabs %}
 
 ## Generate a new project using Webpack
 

--- a/docs/shared/recipes/ci-deployment.md
+++ b/docs/shared/recipes/ci-deployment.md
@@ -13,10 +13,6 @@ Additionally, we should generate pruned lock file according to the generated `pa
 
 Nx offers two varieties of Webpack plugin which can be used to generate `package.json`.
 
-{% tabs %}
-
-{% tab label="Nx 18+" %}
-
 ## Basic Plugin Configuration
 
 `@nx/webpack/plugin` plugin is compatible with a conventional webpack configuration setup which offers a smooth integration with the Webpack CLI.
@@ -69,23 +65,6 @@ module.exports = {
   ],
 };
 ```
-
-{% /tab %}
-
-{% tab label="Nx < 18" %}
-
-## Supported executors
-
-The `@nx/webpack:webpack` executor supports the `generatePackageJson` flag which generates both `package.json` as well as the lock file.
-
-Some executors automatically generate output `package.json` and the lock file generation is supported using the `generateLockfile` flag:
-
-- `@nx/js:swc`
-- `@nx/js:tsc`
-- `@nx/next:build`
-
-{% /tab %}
-{% /tabs %}
 
 ## Programmatic usage
 


### PR DESCRIPTION
This PR removes installation instructions for Nx < 18 since it has fallen out of support window. Users can always `npm install <plugin>` as usual if they are on an unsupported Nx version, but the docs will assume `nx add` moving forward.

The changes are on the plugin overview page: https://nx-dev-git-docs-remove-nx-pre-18-install-nrwl.vercel.app/nx-api