### PR TITLE
fix(vue): stories generator using wrong root variable from conf

### DIFF
--- a/packages/vue/src/generators/stories/lib/component-story.ts
+++ b/packages/vue/src/generators/stories/lib/component-story.ts
@@ -23,8 +23,8 @@ export function createComponentStories(
   if (!tsModule) {
     tsModule = ensureTypescript();
   }
-  const proj = getProjects(host).get(project);
-  const sourceRoot = proj.sourceRoot;
+  const projectConfiguration = getProjects(host).get(project);
+  const { root: sourceRoot } = projectConfiguration;
 
   const componentFilePath = joinPathFragments(sourceRoot, componentPath);
 


### PR DESCRIPTION
@nx/vue:stories generator is using property `sourceRoot` from the project configuration which doesn't exist.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `@nx/vue:stories --project=something` you get the following error:

```
NX   The "path" argument must be of type string. Received undefined
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generator should create stories

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30955
