### PR TITLE
fix(webpack): show webpack chunks when verbose

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -215,7 +215,7 @@ function applyNxIndependentConfig(
     warnings: true,
     errors: true,
     colors: !options.verbose && !options.statsJson,
-    chunks: !options.verbose,
+    chunks: !!options.verbose,
     assets: !!options.verbose,
     chunkOrigins: !!options.verbose,
     chunkModules: !!options.verbose,


### PR DESCRIPTION
The NxAppWebpackPlugin option 'verbose' should show chunk output during webpack build when true, and hide them when false.  It's currently the reverse, causing a lot of console spam during dev, and the hiding the info during ci/cd.

## Current Behavior
Setting the NxAppWebpackPlugin option 'verbose' to false shows chunk output.

<img width="848" alt="chunky" src="https://github.com/user-attachments/assets/4cd5502d-d059-4ace-9e42-28eb160bc1d0" />

## Expected Behavior
Setting the NxAppWebpackPlugin option 'verbose' to false hides chunk output.

