### PR TITLE
fix(core): error when restoring http cache with no outputs

### DIFF
--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -301,9 +301,26 @@ impl NxCache {
             &outputs_path,
             &self.workspace_root
         );
-        let sz = _copy(outputs_path, &self.workspace_root)?;
+        let sz = _copy(outputs_path, &self.workspace_root);
 
-        Ok(sz)
+        match sz {
+            Err(e) => {
+                let kind = underlying_io_error_kind(&e);
+                match kind {
+                    Some(std::io::ErrorKind::NotFound) => {
+                        trace!("No artifacts to copy: {:?}", e);
+                        Ok(0)
+                    }
+                    _ => {
+                        return Err(anyhow::anyhow!("Error copying files from cache: {:?}", e));
+                    }
+                }
+            }
+            Ok(sz) => {
+                trace!("Copied {} bytes from cache", sz);
+                Ok(sz)
+            }
+        }
     }
 
     #[napi]
@@ -406,4 +423,14 @@ where
             }
         }
     }
+}
+
+// From: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#example-1
+fn underlying_io_error_kind(error: &anyhow::Error) -> Option<std::io::ErrorKind> {
+    for cause in error.chain() {
+        if let Some(io_error) = cause.downcast_ref::<std::io::Error>() {
+            return Some(io_error.kind());
+        }
+    }
+    None
 }


### PR DESCRIPTION
## Current Behavior
When restoring remote cache results that did not have any outputs, but the outputs array itself was not empty and using the http remote cache there is an OS Error hit with no such file or directory. This stems from the `_copy` call on a non-existant path.

## Expected Behavior
We don't try to copy a non-existant path

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30733
