### PR TITLE
fix(react): migration for babel supports configs that do not use @nx/react/babel

### DIFF
--- a/packages/react/src/migrations/update-21-0-0/update-babel-loose.spec.ts
+++ b/packages/react/src/migrations/update-21-0-0/update-babel-loose.spec.ts
@@ -50,4 +50,21 @@ describe('update-babel-loose migration', () => {
     const content = tree.read(filePath, 'utf-8');
     expect(content).toBe('invalid json content');
   });
+
+  it('should work when @nx/react/babel is not present', async () => {
+    const filePath = '.babelrc';
+    tree.write(filePath, '{ "preset": [] } }');
+
+    await updateBabelLoose(tree);
+
+    let content = tree.read(filePath, 'utf-8');
+    expect(content).toMatch('{ "preset": [] } }');
+
+    tree.write(filePath, '{}');
+
+    await updateBabelLoose(tree);
+
+    content = tree.read(filePath, 'utf-8');
+    expect(content).toMatch('{}');
+  });
 });

--- a/packages/react/src/migrations/update-21-0-0/update-babel-loose.ts
+++ b/packages/react/src/migrations/update-21-0-0/update-babel-loose.ts
@@ -10,11 +10,11 @@ export default async function updateBabelLoose(tree: Tree) {
     if (!path.endsWith('.babelrc')) return;
     try {
       updateJson(tree, path, (babelConfig) => {
-        if (!Array.isArray(babelConfig.presets)) return;
+        if (!Array.isArray(babelConfig.presets)) return babelConfig;
         const ourPreset = babelConfig.presets.find(
           (p) => Array.isArray(p) && p[0] === '@nx/react/babel'
         );
-        if (!ourPreset || !ourPreset[1]) return;
+        if (!ourPreset || !ourPreset[1]) return babelConfig;
         const options = ourPreset[1];
         if (options['classProperties']?.loose !== undefined) {
           options.loose = options['classProperties'].loose;


### PR DESCRIPTION
This PR fixes an issue where the updated `.babelrc` is undefined if the `@nx/react/babel` preset is missing.