### PR TITLE
fix(core): include nx version in native file cache

### DIFF
--- a/packages/nx/src/native/native-file-cache-location.ts
+++ b/packages/nx/src/native/native-file-cache-location.ts
@@ -2,12 +2,13 @@ import { tmpdir, userInfo } from 'os';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { workspaceRoot } from '../utils/workspace-root';
+import { nxVersion } from '../utils/versions';
 
 export function getNativeFileCacheLocation() {
   if (process.env.NX_NATIVE_FILE_CACHE_DIRECTORY) {
     return process.env.NX_NATIVE_FILE_CACHE_DIRECTORY;
   } else {
-    const hash = createHash('sha256').update(workspaceRoot);
+    const hash = createHash('sha256').update(workspaceRoot).update(nxVersion);
 
     try {
       hash.update(userInfo().username);


### PR DESCRIPTION
## Current Behavior
The native file cache doesn't check NX_VERSION when determining its key

## Expected Behavior
The native cache is invalidated when updating Nx

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30940
Fixes #29184
