### PR TITLE
fix(angular): convert-to-rspack should ensure zone.js is not treated as local file

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`app --minimal should generate a correct setup when --bundler=rspack and
   "index": "./src/index.html",
   "browser": "./src/main.ts",
   "polyfills": [
-    "./zone.js"
+    "zone.js"
   ],
   "tsConfig": "./tsconfig.app.json",
   "assets": [
@@ -162,7 +162,7 @@ exports[`app --minimal should generate a correct setup when --bundler=rspack inc
   "index": "./src/index.html",
   "browser": "./src/main.ts",
   "polyfills": [
-    "./zone.js"
+    "zone.js"
   ],
   "tsConfig": "./tsconfig.app.json",
   "assets": [

--- a/packages/angular/src/generators/convert-to-rspack/convert-to-rspack.ts
+++ b/packages/angular/src/generators/convert-to-rspack/convert-to-rspack.ts
@@ -111,6 +111,10 @@ const PATH_NORMALIZER = {
   polyfills: (tree: Tree, paths: string | string[], root: string) => {
     const normalizedPaths: string[] = [];
     const normalizeFn = (path: string) => {
+      if (path.startsWith('zone.js')) {
+        normalizedPaths.push(path);
+        return;
+      }
       try {
         const resolvedPath = require.resolve(path, {
           paths: [join(workspaceRoot, 'node_modules')],


### PR DESCRIPTION
## Current Behavior
The `@nx/angular:convert-to-rspack` relies on `require.resolve` to check if entries listed in the `polyfills` array is an npm package.
However, in some circumstances such as generating a new app, `zone.js` is not yet installed and therefore require.resolve will not resolve the package.

## Expected Behavior
Ensure that `zone.js` is special cased as it is a polyfill that is always needed to be treated as a package.
This is also the only polyfill that is set during generation of an app and therefore is the only package that should run into this issue.


