### PR TITLE
fix(core): prioritize --output-style flag over tui env vars

### DIFF
--- a/packages/nx/src/tasks-runner/is-tui-enabled.spec.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.spec.ts
@@ -1,5 +1,4 @@
 import { withEnvironmentVariables } from '../internal-testing-utils/with-environment';
-import { logger } from '../utils/logger';
 import { shouldUseTui } from './is-tui-enabled';
 
 describe('shouldUseTui', () => {
@@ -139,26 +138,4 @@ describe('shouldUseTui', () => {
         }
       ));
   });
-
-  it('should warn if the TUI is enabled but not supported', () =>
-    withEnvironmentVariables(
-      {
-        NX_TUI: 'true',
-        CI: 'false',
-      },
-      () => {
-        const spy = jest.spyOn(logger, 'warn').mockImplementationOnce(() => {});
-        process.stderr.isTTY = false;
-
-        expect(shouldUseTui({}, {}, false)).toBe(false);
-
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy.mock.calls[0]).toMatchInlineSnapshot(`
-          [
-            "The current environment is not capable of displaying the TUI. Falling back to \`dynamic-legacy\` output style.",
-          ]
-        `);
-        process.stderr.isTTY = true;
-      }
-    ));
 });

--- a/packages/nx/src/tasks-runner/is-tui-enabled.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.ts
@@ -34,15 +34,6 @@ export function shouldUseTui(
     skipCapabilityCheck || (process.stderr.isTTY && isUnicodeSupported());
 
   if (!isCapable) {
-    if (shouldUseTui(nxJson, nxArgs, true)) {
-      // The current environment is not capable of displaying the TUI, but the user has
-      // specified that they want to use it. This is likely a mistake, so we log a warning.
-      // NOTE: isCI, isWindows, and IS_WASM are not part of the capability check
-      // and as such would return false in the second check, and therefore not warn.
-      logger.warn(
-        'The current environment is not capable of displaying the TUI. Falling back to `dynamic-legacy` output style.'
-      );
-    }
     return false;
   }
 


### PR DESCRIPTION
## Current Behavior
Specifying `--output-style=static`  does nothing if `NX_TUI=true` is set on your system.

## Expected Behavior
Specifying `--output-style=static` disables the tui. Additionally, if the use attempts to enable the tui but it would not be supported in the current environment, they get a warning that explains why they are not seeing it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
