### PR TITLE
fix(core): don't display fork script path in tui

### DIFF
--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -89,12 +89,12 @@ export declare class RunningTasksService {
 
 export declare class RustPseudoTerminal {
   constructor()
-  runCommand(command: string, commandDir?: string | undefined | null, jsEnv?: Record<string, string> | undefined | null, execArgv?: Array<string> | undefined | null, quiet?: boolean | undefined | null, tty?: boolean | undefined | null): ChildProcess
+  runCommand(command: string, commandDir?: string | undefined | null, jsEnv?: Record<string, string> | undefined | null, execArgv?: Array<string> | undefined | null, quiet?: boolean | undefined | null, tty?: boolean | undefined | null, commandLabel?: string | undefined | null): ChildProcess
   /**
    * This allows us to run a pseudoterminal with a fake node ipc channel
    * this makes it possible to be backwards compatible with the old implementation
    */
-  fork(id: string, forkScript: string, pseudoIpcPath: string, commandDir: string | undefined | null, jsEnv: Record<string, string> | undefined | null, execArgv: Array<string> | undefined | null, quiet: boolean): ChildProcess
+  fork(id: string, forkScript: string, pseudoIpcPath: string, commandDir: string | undefined | null, jsEnv: Record<string, string> | undefined | null, execArgv: Array<string> | undefined | null, quiet: boolean, commandLabel?: string | undefined | null): ChildProcess
 }
 
 export declare class TaskDetails {

--- a/packages/nx/src/native/pseudo_terminal/mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/mac.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use tracing::trace;
+use watchexec::command;
 
 use super::child_process::ChildProcess;
 use super::os;
@@ -31,9 +32,17 @@ impl RustPseudoTerminal {
         exec_argv: Option<Vec<String>>,
         quiet: Option<bool>,
         tty: Option<bool>,
+        command_label: Option<String>,
     ) -> napi::Result<ChildProcess> {
-        self.pseudo_terminal
-            .run_command(command, command_dir, js_env, exec_argv, quiet, tty)
+        self.pseudo_terminal.run_command(
+            command,
+            command_dir,
+            js_env,
+            exec_argv,
+            quiet,
+            tty,
+            command_label,
+        )
     }
 
     /// This allows us to run a pseudoterminal with a fake node ipc channel
@@ -48,6 +57,7 @@ impl RustPseudoTerminal {
         js_env: Option<HashMap<String, String>>,
         exec_argv: Option<Vec<String>>,
         quiet: bool,
+        command_label: Option<String>,
     ) -> napi::Result<ChildProcess> {
         let command = format!(
             "node {} {} {}",
@@ -64,6 +74,7 @@ impl RustPseudoTerminal {
             exec_argv,
             Some(quiet),
             Some(true),
+            command_label,
         )
     }
 }

--- a/packages/nx/src/native/pseudo_terminal/non_mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/non_mac.rs
@@ -34,7 +34,7 @@ impl RustPseudoTerminal {
         tty: Option<bool>,
     ) -> napi::Result<ChildProcess> {
         self.pseudo_terminal
-            .run_command(command, command_dir, js_env, exec_argv, quiet, tty)
+            .run_command(command, command_dir, js_env, exec_argv, quiet, tty, None)
     }
 
     /// This allows us to run a pseudoterminal with a fake node ipc channel
@@ -49,6 +49,7 @@ impl RustPseudoTerminal {
         js_env: Option<HashMap<String, String>>,
         exec_argv: Option<Vec<String>>,
         quiet: bool,
+        command_label: Option<String>,
     ) -> napi::Result<ChildProcess> {
         let command = format!(
             "node {} {} {}",
@@ -65,6 +66,7 @@ impl RustPseudoTerminal {
             exec_argv,
             Some(quiet),
             Some(true),
+            command_label,
         )
     }
 }

--- a/packages/nx/src/native/pseudo_terminal/non_mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/non_mac.rs
@@ -32,9 +32,17 @@ impl RustPseudoTerminal {
         exec_argv: Option<Vec<String>>,
         quiet: Option<bool>,
         tty: Option<bool>,
+        command_label: Option<String>,
     ) -> napi::Result<ChildProcess> {
-        self.pseudo_terminal
-            .run_command(command, command_dir, js_env, exec_argv, quiet, tty, None)
+        self.pseudo_terminal.run_command(
+            command,
+            command_dir,
+            js_env,
+            exec_argv,
+            quiet,
+            tty,
+            command_label,
+        )
     }
 
     /// This allows us to run a pseudoterminal with a fake node ipc channel

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -203,6 +203,7 @@ export class ForkedProcessTaskRunner {
       execArgv: process.execArgv,
       jsEnv: env,
       quiet: !streamOutput,
+      commandLabel: `nx run ${task.id}`,
     });
 
     p.send({

--- a/packages/nx/src/tasks-runner/pseudo-terminal.ts
+++ b/packages/nx/src/tasks-runner/pseudo-terminal.ts
@@ -106,11 +106,13 @@ export class PseudoTerminal {
       execArgv,
       jsEnv,
       quiet,
+      commandLabel,
     }: {
       cwd?: string;
       execArgv?: string[];
       jsEnv?: Record<string, string>;
       quiet?: boolean;
+      commandLabel?: string;
     }
   ) {
     if (!this.initialized) {
@@ -125,7 +127,8 @@ export class PseudoTerminal {
         cwd,
         jsEnv,
         execArgv,
-        quiet
+        quiet,
+        commandLabel
       ),
       id,
       this.pseudoIPC


### PR DESCRIPTION
## Current Behavior
The tui displays the path to the fork script in the pty pane

## Expected Behavior
The tui displays a command that would be "close enough" to what is being ran in the pty pane

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
