### PR TITLE
fix(core): use process#kill instead of tree-kill for windows and macos

### DIFF
--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -93,12 +93,20 @@ function startWebServer(webServerCommand: string) {
       }
     } else {
       return new Promise<void>((res, rej) => {
-        treeKill(serverProcess.pid, (err) => {
-          if (err) {
-            rej(err);
+        if (process.platform === 'win32' || process.platform === 'darwin') {
+          if (this.childProcess.kill()) {
+            res();
+          } else {
+            rej('Unable to kill process');
           }
-          res();
-        });
+        } else {
+          treeKill(serverProcess.pid, (err) => {
+            if (err) {
+              rej(err);
+            }
+            res();
+          });
+        }
       });
     }
   };

--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -359,13 +359,21 @@ class RunningNodeProcess implements RunningTask {
 
   kill(signal?: NodeJS.Signals | number): Promise<void> {
     return new Promise<void>((res, rej) => {
-      treeKill(this.childProcess.pid, signal, (err) => {
-        if (err) {
-          rej(err);
-        } else {
+      if (process.platform === 'win32' || process.platform === 'darwin') {
+        if (this.childProcess.kill(signal)) {
           res();
+        } else {
+          rej('Unable to kill process');
         }
-      });
+      } else {
+        treeKill(this.childProcess.pid, signal, (err) => {
+          if (err) {
+            rej(err);
+          } else {
+            res();
+          }
+        });
+      }
     });
   }
 


### PR DESCRIPTION
Prefer `process#kill` instead of `tree-kill` for Mac and Windows. This fixes an issue on Windows where the `taskkill` is unsuccessful.

## Current Behavior
Windows does not always run successfully

## Expected Behavior
Windows runs successfully

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
