### PR TITLE
docs(nx-dev): add Google Tag Manager script

### DIFF
--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -131,6 +131,29 @@ export default function CustomApp({
           `,
         }}
       />
+      <Script
+        id="gtm-script"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','${gaMeasurementId}');
+          `,
+        }}
+      />
+      {/* Google Tag Manager - NoScript */}
+      <noscript>
+        <iframe
+          src={`https://www.googletagmanager.com/ns.html?id=${gaMeasurementId}`}
+          height="0"
+          width="0"
+          style={{ display: 'none', visibility: 'hidden' }}
+        />
+      </noscript>
+
       {/* Apollo.io Embed Code */}
       <Script
         type="text/javascript"


### PR DESCRIPTION
Integrated Google Tag Manager (GTM) with both script and noscript tags for analytics tracking. Ensured the script uses `afterInteractive` loading strategy and includes dynamic `gaMeasurementId` for proper configuration.
