### PR TITLE
docs(nx-dev): remove unused external script loader

### DIFF
--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -16,30 +16,6 @@ export default function CustomApp({
 }: AppProps): JSX.Element {
   const router = useRouter();
   const gaMeasurementId = 'UA-88380372-10';
-  // RB2B ---------
-  const SCRIPT_ID = 'external-js-script';
-  const SCRIPT_BASE_URL = 'https://s3-us-west-2.amazonaws.com/b2bjsstore/b/';
-  const SCRIPT_KEY = '0NW1GH7YJ4O4'; //
-  const SCRIPT_URL = `${SCRIPT_BASE_URL}${SCRIPT_KEY}/${SCRIPT_KEY}.js.gz`;
-  useEffect(() => {
-    const handleRouteChange = () => {
-      const existingScript = document.getElementById(SCRIPT_ID);
-      if (existingScript) {
-        existingScript.remove();
-      }
-      const script = document.createElement('script');
-      script.id = SCRIPT_ID;
-      script.src = SCRIPT_URL;
-      script.async = true;
-      document.body.appendChild(script);
-    };
-    router.events.on('routeChangeComplete', handleRouteChange);
-    handleRouteChange();
-    return () => {
-      router.events.off('routeChangeComplete', handleRouteChange);
-    };
-  }, [router.events, SCRIPT_URL]);
-  // ---------
 
   useEffect(() => {
     const handleRouteChange = (url: URL) =>


### PR DESCRIPTION
Removed the external JS script loader for a third-party B2B script as it is no longer required. This simplifies the `_app.tsx` file and avoids unnecessary script management during route changes.