### PR TITLE
feat(remix)!: remove deprecated static-serve target name from inferred targets

### DIFF
--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -242,21 +242,6 @@ function getStartTargetConfig(options: NextPluginOptions, projectRoot: string) {
   return targetConfig;
 }
 
-function getStaticServeTargetConfig(options: NextPluginOptions) {
-  const targetConfig: TargetConfiguration = {
-    executor: '@nx/web:file-server',
-    options: {
-      buildTarget: options.buildTargetName,
-      staticFilePath: '{projectRoot}/out',
-      port: 3000,
-      // Routes are found correctly with serve-static
-      spa: false,
-    },
-  };
-
-  return targetConfig;
-}
-
 async function getOutputs(projectRoot, nextConfig) {
   let dir = '.next';
   const { PHASE_PRODUCTION_BUILD } = require('next/constants');

--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -31,6 +31,9 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
         },
         "acme-serve-static": {
           "continuous": true,
+          "dependsOn": [
+            "acme-build-static",
+          ],
           "executor": "@nx/web:file-server",
           "options": {
             "buildTarget": "acme-build-static",
@@ -153,6 +156,9 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
         },
         "serve-static": {
           "continuous": true,
+          "dependsOn": [
+            "build-static",
+          ],
           "executor": "@nx/web:file-server",
           "options": {
             "buildTarget": "build-static",

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -190,6 +190,7 @@ function serveTarget(projectRoot: string) {
 
 function serveStaticTarget(options: NuxtPluginOptions) {
   const targetConfig: TargetConfiguration = {
+    dependsOn: [`${options.buildStaticTargetName}`],
     continuous: true,
     executor: '@nx/web:file-server',
     options: {

--- a/packages/remix/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/remix/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -246,7 +246,7 @@ describe('Remix - Convert To Inferred', () => {
           devTargetName: 'custom-dev',
           startTargetName: 'start',
           typecheckTargetName: 'typecheck',
-          staticServeTargetName: 'static-serve',
+          serveStaticTargetName: 'serve-static',
         },
       });
       updateNxJson(tree, nxJson);

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -65,16 +65,6 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
                 "cwd": "my-app",
               },
             },
-            "static-serve": {
-              "command": "remix-serve build/index.js",
-              "continuous": true,
-              "dependsOn": [
-                "build",
-              ],
-              "options": {
-                "cwd": "my-app",
-              },
-            },
             "tsc": {
               "cache": true,
               "command": "tsc --noEmit",
@@ -176,16 +166,6 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
               },
             },
             "start": {
-              "command": "remix-serve build/index.js",
-              "continuous": true,
-              "dependsOn": [
-                "build",
-              ],
-              "options": {
-                "cwd": "my-app",
-              },
-            },
-            "static-serve": {
               "command": "remix-serve build/index.js",
               "continuous": true,
               "dependsOn": [
@@ -300,16 +280,6 @@ exports[`@nx/remix/plugin Remix Classic Compiler root project should create node
                 "cwd": ".",
               },
             },
-            "static-serve": {
-              "command": "remix-serve build/index.js",
-              "continuous": true,
-              "dependsOn": [
-                "build",
-              ],
-              "options": {
-                "cwd": ".",
-              },
-            },
             "typecheck": {
               "cache": true,
               "command": "tsc --noEmit",
@@ -403,16 +373,6 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
               },
             },
             "start": {
-              "command": "remix-serve build/server/index.js",
-              "continuous": true,
-              "dependsOn": [
-                "build",
-              ],
-              "options": {
-                "cwd": "my-app",
-              },
-            },
-            "static-serve": {
               "command": "remix-serve build/server/index.js",
               "continuous": true,
               "dependsOn": [
@@ -517,16 +477,6 @@ exports[`@nx/remix/plugin Remix Vite Compiler root project should create nodes 1
               },
             },
             "start": {
-              "command": "remix-serve build/server/index.js",
-              "continuous": true,
-              "dependsOn": [
-                "build",
-              ],
-              "options": {
-                "cwd": ".",
-              },
-            },
-            "static-serve": {
               "command": "remix-serve build/server/index.js",
               "continuous": true,
               "dependsOn": [

--- a/packages/remix/src/plugins/plugin.spec.ts
+++ b/packages/remix/src/plugins/plugin.spec.ts
@@ -96,7 +96,6 @@ module.exports = {
             devTargetName: 'dev',
             startTargetName: 'start',
             typecheckTargetName: 'typecheck',
-            staticServeTargetName: 'static-serve',
           },
           context
         );
@@ -160,7 +159,6 @@ module.exports = {
             devTargetName: 'dev',
             startTargetName: 'start',
             typecheckTargetName: 'tsc',
-            staticServeTargetName: 'static-serve',
           },
           context
         );
@@ -182,7 +180,6 @@ module.exports = {
             devTargetName: 'dev',
             startTargetName: 'start',
             typecheckTargetName: 'tsc',
-            staticServeTargetName: 'static-serve',
           },
           context
         );
@@ -347,7 +344,6 @@ module.exports = {
             devTargetName: 'dev',
             startTargetName: 'start',
             typecheckTargetName: 'typecheck',
-            staticServeTargetName: 'static-serve',
           },
           context
         );
@@ -419,7 +415,6 @@ module.exports = {
             devTargetName: 'dev',
             startTargetName: 'start',
             typecheckTargetName: 'tsc',
-            staticServeTargetName: 'static-serve',
           },
           context
         );

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -33,11 +33,6 @@ export interface RemixPluginOptions {
   typecheckTargetName?: string;
   buildDepsTargetName?: string;
   watchDepsTargetName?: string;
-
-  /**
-   * @deprecated Use serveStaticTargetName instead. This option will be removed in Nx 21.
-   */
-  staticServeTargetName?: string;
   serveStaticTargetName?: string;
 }
 
@@ -206,14 +201,6 @@ async function buildRemixTargets(
     isUsingTsSolutionSetup
   );
   targets[options.startTargetName] = startTarget(
-    projectRoot,
-    serverBuildPath,
-    options.buildTargetName,
-    remixCompiler,
-    isUsingTsSolutionSetup
-  );
-  // TODO(colum): Remove for Nx 21
-  targets[options.staticServeTargetName] = startTarget(
     projectRoot,
     serverBuildPath,
     options.buildTargetName,
@@ -451,8 +438,6 @@ function normalizeOptions(options: RemixPluginOptions) {
   options.devTargetName ??= 'dev';
   options.startTargetName ??= 'start';
   options.typecheckTargetName ??= 'typecheck';
-  // TODO(colum): remove for Nx 21
-  options.staticServeTargetName ??= 'static-serve';
   options.serveStaticTargetName ??= 'serve-static';
 
   return options;

--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -126,6 +126,9 @@ describe('@nx/rspack', () => {
                   },
                   "serve-static": {
                     "continuous": true,
+                    "dependsOn": [
+                      "build",
+                    ],
                     "executor": "@nx/web:file-server",
                     "options": {
                       "buildTarget": "build",

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -238,6 +238,7 @@ async function createRspackTargets(
   };
 
   targets[options.serveStaticTargetName] = {
+    dependsOn: [`${options.buildTargetName}`],
     continuous: true,
     executor: '@nx/web:file-server',
     options: {

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -104,6 +104,9 @@ describe('@nx/storybook/plugin', () => {
                   },
                   "static-storybook": {
                     "continuous": true,
+                    "dependsOn": [
+                      "build-storybook",
+                    ],
                     "executor": "@nx/web:file-server",
                     "options": {
                       "buildTarget": "build-storybook",
@@ -187,6 +190,9 @@ describe('@nx/storybook/plugin', () => {
                   },
                   "static-storybook": {
                     "continuous": true,
+                    "dependsOn": [
+                      "build-storybook",
+                    ],
                     "executor": "@nx/web:file-server",
                     "options": {
                       "buildTarget": "build-storybook",
@@ -268,6 +274,9 @@ describe('@nx/storybook/plugin', () => {
                   },
                   "static-storybook": {
                     "continuous": true,
+                    "dependsOn": [
+                      "build-storybook",
+                    ],
                     "executor": "@nx/web:file-server",
                     "options": {
                       "buildTarget": "build-storybook",

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -313,6 +313,7 @@ function serveStaticTarget(
   projectRoot: string
 ) {
   const targetConfig: TargetConfiguration = {
+    dependsOn: [`${options.buildStorybookTargetName}`],
     continuous: true,
     executor: '@nx/web:file-server',
     options: {


### PR DESCRIPTION
This commit also contains various changes to ensure serve-static tasks depend on their build.

BREAKING CHANGE: Remove deprecated static-serve target name from Remix Inferred Tasks in favour of serve-static.
