### PR TITLE
fix(core): Disable the macOS job to prevent PRs from being blocked by its long runtime.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,11 +175,12 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - name: Run E2E Tests for macOS
-        run: |
-          HAS_CHANGED=$(node ./scripts/check-react-native-changes.js $NX_BASE $NX_HEAD);
-          if $HAS_CHANGED; then
-            pnpm nx affected -t e2e-macos-local --parallel=1 --base=$NX_BASE --head=$NX_HEAD
-          else
-            echo "Skip E2E tests for macOS as there are no changes in React Native projects."
-          fi
+## TODO(nicholas): Uncomment when we have a working setup that passes on MacOS and Linux
+      # - name: Run E2E Tests for macOS
+      #   run: |
+      #     HAS_CHANGED=$(node ./scripts/check-react-native-changes.js $NX_BASE $NX_HEAD);
+      #     if $HAS_CHANGED; then
+      #       pnpm nx affected -t e2e-macos-local --parallel=1 --base=$NX_BASE --head=$NX_HEAD
+      #     else
+      #       echo "Skip E2E tests for macOS as there are no changes in React Native projects."
+      #     fi


### PR DESCRIPTION
MacOs CI job is taking a lot longer than expected and it blocks PRs statues from being generated.

We should keep working on it so it can be re-enabled.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
