### PR TITLE
feat(core): add continuous option to targets for Detox, Expo, and React Native

### DIFF
--- a/packages/detox/src/plugins/plugin.ts
+++ b/packages/detox/src/plugins/plugin.ts
@@ -137,6 +137,7 @@ function buildDetoxTargets(
     },
     [options.startTargetName]: {
       command: `detox start`,
+      continuous: true,
       options: { cwd: projectRoot },
     },
     [options.testTargetName]: {

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -155,17 +155,21 @@ function buildExpoTargets(
   const targets: Record<string, TargetConfiguration> = {
     [options.startTargetName]: {
       executor: `@nx/expo:start`,
+      continuous: true,
     },
     [options.serveTargetName]: {
       command: `expo start --web`,
+      continuous: true,
       options: { cwd: projectRoot, args: ['--clear'] },
     },
     [options.runIosTargetName]: {
       command: `expo run:ios`,
+      continuous: true,
       options: { cwd: projectRoot },
     },
     [options.runAndroidTargetName]: {
       command: `expo run:android`,
+      continuous: true,
       options: { cwd: projectRoot },
     },
     [options.exportTargetName]: {

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -164,6 +164,7 @@ function buildReactNativeTargets(
   const targets: Record<string, TargetConfiguration> = {
     [options.startTargetName]: {
       command: `react-native start`,
+      continuous: true,
       options: { cwd: projectRoot },
     },
     [options.podInstallTargetName]: {
@@ -173,10 +174,12 @@ function buildReactNativeTargets(
     },
     [options.runIosTargetName]: {
       command: `react-native run-ios`,
+      continuous: true,
       options: { cwd: projectRoot },
     },
     [options.runAndroidTargetName]: {
       command: `react-native run-android`,
+      continuous: true,
       options: { cwd: projectRoot },
     },
     [options.buildIosTargetName]: {


### PR DESCRIPTION
Adds continuous support for Detox, Expo and React Native
 
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
