### PR TITLE
fix(testing): use correct server process reference when killing the server in the cypress preset

### DIFF
--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -94,7 +94,7 @@ function startWebServer(webServerCommand: string) {
     } else {
       return new Promise<void>((res, rej) => {
         if (process.platform === 'win32' || process.platform === 'darwin') {
-          if (this.childProcess.kill()) {
+          if (serverProcess.kill()) {
             res();
           } else {
             rej('Unable to kill process');


### PR DESCRIPTION
## Current Behavior

Cypress e2e tasks fail when trying to kill the web server with:

```bash
TypeError: Cannot read properties of undefined (reading 'childProcess')
    at /<repo path>/node_modules/@nx/cypress/plugins/cypress-preset.js:65:30
    ...
```

## Expected Behavior

Cypress e2e tasks should not fail when trying to kill the web server.

## Related Issue(s)

Fixes #
