### PR TITLE
fix(core): update fork task runner so it propagates exit signals

### DIFF
--- a/packages/nx/src/tasks-runner/fork.ts
+++ b/packages/nx/src/tasks-runner/fork.ts
@@ -1,6 +1,7 @@
 import { fork, Serializable } from 'child_process';
 import { join } from 'path';
 import { PseudoIPCClient } from './pseudo-ipc';
+import { signalToCode } from '../utils/exit-codes';
 
 const pseudoIPCPath = process.argv[2];
 const forkId = process.argv[3];
@@ -34,4 +35,19 @@ process.on('message', (message: Serializable) => {
 childProcess.on('exit', (code) => {
   pseudoIPC.close();
   process.exit(code);
+});
+
+// Terminate the child process when exiting
+process.on('exit', () => {
+  childProcess.kill();
+});
+process.on('SIGINT', () => {
+  childProcess.kill('SIGTERM');
+  process.exit(signalToCode('SIGINT'));
+});
+process.on('SIGTERM', () => {
+  childProcess.kill('SIGTERM');
+});
+process.on('SIGHUP', () => {
+  childProcess.kill('SIGTERM');
 });


### PR DESCRIPTION
This is a fix when using the TUI `forked process-task-runner`. The `SIGINT` and other signals are not handled, which causes the underlying process (in this case `run-executor`) to be left hanging.

## Current Behavior
TUI leaves processes hanging when using `forked-process-task-runner`

## Expected Behavior

TUI should kill processes
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
