### PR TITLE
fix(release): only error on missing manifestsToUpdate if a project is being directly processed

### DIFF
--- a/packages/nx/src/command-line/release/version/multiple-release-groups.spec.ts
+++ b/packages/nx/src/command-line/release/version/multiple-release-groups.spec.ts
@@ -889,4 +889,140 @@ describe('Multiple Release Groups', () => {
       });
     });
   });
+
+  describe('groups filter', () => {
+    it('should not error if projects in release groups outside of the filtered groups do not have valid manifestsToUpdate', async () => {
+      const {
+        nxReleaseConfig,
+        projectGraph,
+        releaseGroups,
+        releaseGroupToFilteredProjects,
+        filters,
+      } = await createNxReleaseConfigAndPopulateWorkspace(
+        tree,
+        `
+            group1 ({ "projectsRelationship": "fixed" }):
+              - pkg-a@1.0.0 [js]
+            group2 ({ "projectsRelationship": "fixed" }):
+              - pkg-c@2.0.0 [js]
+          `,
+        {
+          version: {
+            conventionalCommits: true,
+            manifestRootsToUpdate: ['{projectRoot}'],
+          },
+        },
+        mockResolveCurrentVersion,
+        {
+          // Only release group1
+          groups: ['group1'],
+        }
+      );
+
+      // Delete the package.json for pkg-c which is outside of the filtered groups. This test is asserting that this does NOT throw an error.
+      tree.delete('pkg-c/package.json');
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'pkg-a') return 'minor';
+          return 'none';
+        }
+      );
+
+      const processor = new ReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        releaseGroups,
+        releaseGroupToFilteredProjects,
+        {
+          dryRun: false,
+          verbose: false,
+          firstRelease: false,
+          preid: undefined,
+          filters,
+        }
+      );
+
+      await processor.init();
+      await processor.processGroups();
+
+      // Called for each project
+      expect(mockResolveVersionActionsForProject).toHaveBeenCalledTimes(2);
+
+      expect(tree.read('pkg-a/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "pkg-a",
+          "version": "1.1.0"
+        }
+        "
+      `);
+    });
+
+    it('should error when projects in release groups outside of the filtered groups do not have valid manifestsToUpdate IF they are required to be processed because of dependencies to groups included in the filtered groups', async () => {
+      const {
+        nxReleaseConfig,
+        projectGraph,
+        releaseGroups,
+        releaseGroupToFilteredProjects,
+        filters,
+      } = await createNxReleaseConfigAndPopulateWorkspace(
+        tree,
+        `
+            group1 ({ "projectsRelationship": "fixed" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "fixed" }):
+              - pkg-c@2.0.0 [js]
+              - pkg-d@2.0.0 [js]
+          `,
+        {
+          version: {
+            conventionalCommits: true,
+            manifestRootsToUpdate: ['{projectRoot}'],
+          },
+        },
+        mockResolveCurrentVersion,
+        {
+          // Only release group2 (but group1 has a dependency on group2)
+          groups: ['group2'],
+        }
+      );
+
+      // Delete the package.json for pkg-c which is outside of the filtered groups. This test is asserting that this DOES throw an error.
+      tree.delete('pkg-c/package.json');
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'pkg-c') return 'patch';
+          return 'none';
+        }
+      );
+
+      const processor = new ReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        releaseGroups,
+        releaseGroupToFilteredProjects,
+        {
+          dryRun: false,
+          verbose: false,
+          firstRelease: false,
+          preid: undefined,
+          filters,
+        }
+      );
+
+      await expect(processor.init()).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+        "The project "pkg-c" does not have a package.json file available in ./pkg-c.
+
+        To fix this you will either need to add a package.json file at that location, or configure "release" within your nx.json to exclude "pkg-c" from the current release group, or amend the "release.version.manifestRootsToUpdate" configuration to point to where the relevant manifest should be.
+
+        It is also possible that the project is being processed because of a dependency relationship between what you are directly versioning and the project/release group, in which case you will need to amend your filters to include all relevant projects and release groups."
+      `);
+    });
+  });
 });

--- a/packages/nx/src/command-line/release/version/test-utils.ts
+++ b/packages/nx/src/command-line/release/version/test-utils.ts
@@ -584,7 +584,8 @@ export async function mockResolveVersionActionsForProjectImplementation(
   tree: Tree,
   releaseGroup: any,
   projectGraphNode: any,
-  finalConfigForProject: FinalConfigForProject
+  finalConfigForProject: FinalConfigForProject,
+  isInProjectsToProcess: boolean
 ) {
   if (
     projectGraphNode.data.release?.versionActions ===
@@ -597,7 +598,7 @@ export async function mockResolveVersionActionsForProjectImplementation(
       finalConfigForProject
     );
     // Initialize the versionActions with all the required manifest paths etc
-    await versionActions.init(tree);
+    await versionActions.init(tree, isInProjectsToProcess);
     return {
       versionActionsPath: exampleRustVersionActions,
       versionActions,
@@ -615,7 +616,7 @@ export async function mockResolveVersionActionsForProjectImplementation(
       finalConfigForProject
     );
     // Initialize the versionActions with all the required manifest paths etc
-    await versionActions.init(tree);
+    await versionActions.init(tree, isInProjectsToProcess);
     return {
       versionActionsPath: exampleNonSemverVersionActions,
       versionActions,
@@ -632,7 +633,7 @@ export async function mockResolveVersionActionsForProjectImplementation(
     finalConfigForProject
   );
   // Initialize the versionActions with all the required manifest paths etc
-  await versionActions.init(tree);
+  await versionActions.init(tree, isInProjectsToProcess);
   return {
     versionActionsPath,
     versionActions: versionActions,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

If filtering by groups or projects, we still validate that all `manifestRootsToUpdate` are valid and in place even for projects which are not captured by those filters (directly and indirectly via dependencies).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We only validate the `manifestRootsToUpdate` that are applicable to the current versioning run, taking the filters into account.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
