### PR TITLE
fix(core): Update nightly tests to work with continuous local-registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /opt/Homebrew
+            /opt/homebrew
             ~/Library/Caches/Homebrew
           key: nrwl-nx-homebrew-packages
 
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /opt/Homebrew
+            /opt/homebrew
             ~/Library/Caches/Homebrew
           key: nrwl-nx-homebrew-packages
 

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -12,12 +12,13 @@ export default async function (globalConfig: Config.ConfigGlobals) {
       process.env.NX_VERBOSE_LOGGING === 'true' || !!globalConfig.verbose;
 
     /**
-     * For e2e-ci & macos-local-e2e we populate the verdaccio storage up front, but for other workflows we need
+     * For e2e-ci, e2e-local and macos-local-e2e we populate the verdaccio storage up front, but for other workflows we need
      * to run the full local release process before running tests.
      */
-    const requiresLocalRelease =
-      !process.env.NX_TASK_TARGET_TARGET?.startsWith('e2e-ci') &&
-      !process.env.NX_TASK_TARGET_TARGET?.startsWith('e2e-macos-local');
+    const prefixes = ['e2e-ci', 'e2e-macos-local', 'e2e-local'];
+    const requiresLocalRelease = !prefixes.some((prefix) =>
+      process.env.NX_TASK_TARGET_TARGET?.startsWith(prefix)
+    );
 
     const listenAddress = 'localhost';
     const port = process.env.NX_LOCAL_REGISTRY_PORT ?? '4873';

--- a/nx.json
+++ b/nx.json
@@ -128,7 +128,11 @@
     },
     "e2e-local": {
       "cache": true,
-      "inputs": ["e2eInputs", "^production"]
+      "inputs": ["e2eInputs", "^production"],
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry"
+      ]
     },
     "e2e-ci": {
       "inputs": ["e2eInputs", "^production"]


### PR DESCRIPTION
Currently, when the Nightly E2E Matrix job is ran it gets stuck at:
```
Waiting for Local registry to start on http://localhost:4873...
Waiting for Local registry to start on http://localhost:4873...
Waiting for Local registry to start on http://localhost:4873...
Waiting for Local registry to start on http://localhost:4873...
Waiting for Local registry to start on http://localhost:4873...
Waiting for Local registry to start on http://localhost:4873...
```

Which blocks other jobs and they will be queued for an unnecessary long period.
![image](https://github.com/user-attachments/assets/bc9e0993-423b-4fb6-9fa0-4e4a1d0a5bb7)

This change should ensure that the local-registry is ran first before attempting to run the test suite.

Results: https://github.com/nrwl/nx/actions/runs/14799474928/job/41554727471 
No longer hanging.