### PR TITLE
fix(gradle): specify idle timeout for gradle batch runner

### DIFF
--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
@@ -27,9 +27,20 @@ fun runTasksInParallel(
   val errorStream = ByteArrayOutputStream()
 
   val args = buildList {
-    addAll(listOf("--info", "--continue", "--parallel", "--build-cache"))
+    // --info is for terminal per task
+    // --continue is for continue running tasks if one failed in a batch
+    // --parallel and --build-cache are for performance
+    // -Dorg.gradle.daemon.idletimeout=10000 is to kill daemon after 10 seconds
+    addAll(
+        listOf(
+            "--info",
+            "--continue",
+            "--parallel",
+            "--build-cache",
+            "-Dorg.gradle.daemon.idletimeout=10000"))
     addAll(additionalArgs.split(" ").filter { it.isNotBlank() })
   }
+  logger.info("🏳️ Args: ${args.joinToString(", ")}")
 
   val taskNames = tasks.values.map { it.taskName }.distinct()
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -60,7 +60,9 @@ private fun getTestClassNameIfAnnotated(file: File): String? {
   return file
       .takeIf { it.exists() }
       ?.readText()
-      ?.takeIf { it.contains("@Test") || it.contains("@TestTemplate") }
+      ?.takeIf {
+        it.contains("@Test") || it.contains("@TestTemplate") || it.contains("@ParameterizedTest")
+      }
       ?.let { content ->
         val className = classDeclarationRegex.find(content)?.groupValues?.getOrNull(1)
         return if (className != null && !className.startsWith("Fake")) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
there is no idle timeout set for gradle, by default is 3 hours.
when running gradle in DTE, it seems to run into memory issue. Even through using tooling api, the connection is closed when batch is done, but i think the gradle daemon is still active in the background. when running the next batch, it is going to start a new gradle daemon and i got an error like
```
Starting a Gradle Daemon, 2 busy and 200 stopped Daemons could not be reused, use --status for details
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
add idle timeout for 10s.
this inline command will make gradle daemon to stop itself after 10s.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
