### PR TITLE
fix(core): skip vt100 parsing if tui disabled

### DIFF
--- a/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
+++ b/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
@@ -110,7 +110,9 @@ impl PseudoTerminal {
                     trace!("Quiet: {}", quiet);
                     debug!("Read {} bytes", len);
                     if let Ok(mut parser) = parser_clone.write() {
-                        parser.process(&buf[..len]);
+                        if is_within_nx_tui {
+                            parser.process(&buf[..len]);
+                        }
 
                         if !quiet {
                             let mut logged_interrupted_error = false;


### PR DESCRIPTION
## Current Behavior
nx@21.0.0-rc.2 is failing on circle ci because it registers as a tty

## Expected Behavior
We don't deal with vt100 unless in the tui, which doesn't happen on ci

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
