### PR TITLE
fix(core): ensure the terminal is restored when cloud exits

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -23,6 +23,13 @@ import { daemonClient } from '../src/daemon/client/client';
 import { removeDbConnections } from '../src/utils/db-connection';
 import { signalToCode } from '../src/utils/exit-codes';
 
+// In case Nx Cloud forcibly exits while the TUI is running, ensure the terminal is restored etc.
+process.on('exit', (...args) => {
+  if (typeof globalThis.tuiOnProcessExit === 'function') {
+    globalThis.tuiOnProcessExit(...args);
+  }
+});
+
 function main() {
   if (
     process.argv[2] !== 'report' &&

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -255,29 +255,36 @@ async function getTerminalOutputLifeCycle(
       console.log = createPatchedConsoleMethod(originalConsoleLog);
       console.error = createPatchedConsoleMethod(originalConsoleError);
 
+      globalThis.tuiOnProcessExit = () => {
+        restoreTerminal();
+        // Revert the patched methods
+        process.stdout.write = originalStdoutWrite;
+        process.stderr.write = originalStderrWrite;
+        console.log = originalConsoleLog;
+        console.error = originalConsoleError;
+        process.stdout.write('\n');
+        // Print the intercepted Nx Cloud logs
+        for (const log of interceptedNxCloudLogs) {
+          const logString = log.toString().trimStart();
+          process.stdout.write(logString);
+          if (logString) {
+            process.stdout.write('\n');
+          }
+        }
+      };
+
       renderIsDone = new Promise<void>((resolve) => {
         appLifeCycle.__init(() => {
           resolve();
         });
-      })
-        .then(() => {
-          restoreTerminal();
-        })
-        .finally(() => {
-          // Revert the patched methods
-          process.stdout.write = originalStdoutWrite;
-          process.stderr.write = originalStderrWrite;
-          console.log = originalConsoleLog;
-          console.error = originalConsoleError;
-          // Print the intercepted Nx Cloud logs
-          for (const log of interceptedNxCloudLogs) {
-            const logString = log.toString().trimStart();
-            process.stdout.write(logString);
-            if (logString) {
-              process.stdout.write('\n');
-            }
-          }
-        });
+      }).finally(() => {
+        restoreTerminal();
+        // Revert the patched methods
+        process.stdout.write = originalStdoutWrite;
+        process.stderr.write = originalStderrWrite;
+        console.log = originalConsoleLog;
+        console.error = originalConsoleError;
+      });
     }
 
     return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

If Nx Cloud calls process.exit(1) while the TUI is running the terminal gets left in a bad state and cloud logs are swallowed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The terminal is restored and cloud logs are printed to the user.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
