### PR TITLE
fix(core): tui summary should not show canceled during run-one because tasks are skipped

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -167,7 +167,7 @@ export function getTuiTerminalSummaryLifeCycle({
         );
       }
       lines = [output.colors.green(lines.join(EOL))];
-    } else if (totalCompletedTasks + stoppedTasks.size === totalTasks) {
+    } else if (inProgressTasks.size === 0) {
       let text = `Ran target ${output.bold(
         targets[0]
       )} for project ${output.bold(initiatingProject)}`;
@@ -190,7 +190,7 @@ export function getTuiTerminalSummaryLifeCycle({
 
       const viewLogs = viewLogsFooterRows(totalFailedTasks);
 
-      lines = [
+      lines.push(
         output.colors.red(
           [
             output.applyNxPrefix(
@@ -209,11 +209,10 @@ export function getTuiTerminalSummaryLifeCycle({
             )}`,
             ...viewLogs,
           ].join(EOL)
-        ),
-      ];
+        )
+      );
     } else {
-      lines = [
-        ...output.getVerticalSeparatorLines('red'),
+      lines.push(
         output.applyNxPrefix(
           'red',
           output.colors.red(
@@ -221,8 +220,8 @@ export function getTuiTerminalSummaryLifeCycle({
               targets[0]
             )} for project ${output.bold(initiatingProject)}`
           ) + output.dim(` (${timeTakenText})`)
-        ),
-      ];
+        )
+      );
     }
 
     // adds some vertical space after the summary to avoid bunching against terminal


### PR DESCRIPTION
## Current Behavior
If a run-one with the tui enabled fails because of a dependant task failing, and some tasks are skipped, the summary acts as if you canceled the run.
<img width="876" alt="image" src="https://github.com/user-attachments/assets/3e61979b-8dfc-4ae3-8612-dc03e3519ac4" />


## Expected Behavior
This behavior is a failure
<img width="876" alt="image" src="https://github.com/user-attachments/assets/e945983a-041a-4a44-adb9-e04a72560b52" />


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
