### PR TITLE
fix(testing): ignore test outputs from playwright when linting

### DIFF
--- a/packages/playwright/src/generators/configuration/configuration.spec.ts
+++ b/packages/playwright/src/generators/configuration/configuration.spec.ts
@@ -110,5 +110,27 @@ describe('Playwright e2e configuration', () => {
         "
       `);
     });
+
+    it('should ignore Playwright output files in eslint config if used', async () => {
+      tree.write('eslint.config.mjs', `export default [{ ignores: [] }];`);
+      writeJson(tree, 'apps/myapp/package.json', {
+        name: '@proj/myapp',
+      });
+      writeJson(tree, 'apps/myapp/tsconfig.json', {
+        include: [],
+        files: [],
+        references: [],
+      });
+
+      await configGenerator(tree, {
+        project: '@proj/myapp',
+        linter: 'eslint',
+      });
+
+      expect(tree.read('eslint.config.mjs', 'utf-8')).toMatchInlineSnapshot(`
+        "export default [{ ignores: ['**/test-output'] }];
+        "
+      `);
+    });
   });
 });

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -39,6 +39,7 @@ import type {
   ConfigurationGeneratorSchema,
   NormalizedGeneratorOptions,
 } from './schema';
+import { addIgnoresToLintConfig } from '@nx/eslint/src/generators/utils/eslint-file';
 
 export function configurationGenerator(
   tree: Tree,
@@ -186,7 +187,7 @@ export async function configurationGeneratorInternal(
       writeJson(tree, packageJsonPath, packageJson);
     }
 
-    ignoreTestOutput(tree);
+    ignoreTestOutput(tree, options);
   }
 
   const hasPlugin = readNxJson(tree).plugins?.some((p) =>
@@ -388,7 +389,16 @@ Rename or remove the existing e2e target.`);
   updateProjectConfiguration(tree, options.project, projectConfig);
 }
 
-function ignoreTestOutput(tree: Tree): void {
+function ignoreTestOutput(
+  tree: Tree,
+  options: ConfigurationGeneratorSchema
+): void {
+  // Make sure playwright outputs are not linted.
+  if (options.linter === 'eslint') {
+    addIgnoresToLintConfig(tree, '', ['**/test-output']);
+  }
+
+  // Handle gitignore
   if (!tree.exists('.gitignore')) {
     logger.warn(`Couldn't find a root .gitignore file to update.`);
   }


### PR DESCRIPTION
Currently if Playwright runs with trace on, it'll generate `.js` files in `test-output` folder. Trace is turned on automatically whenever a e2e test retries, or if the user sets `trace: 'on'`, or if `--trace on` is passed to the CLI.

These trace `.js` files are being linted, and is failing the lint task.

## Current Behavior
Lint fails when trace is on

## Expected Behavior

Lint should ignore trace files
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
