### PR TITLE
chore(repo): mark vite as cacheable

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -97,7 +97,6 @@
     "build-base": {
       "dependsOn": ["^build-base", "build-native"],
       "inputs": ["production", "^production"],
-      "executor": "@nx/js:tsc",
       "options": {
         "outputPath": "build/{projectRoot}",
         "tsConfig": "{projectRoot}/tsconfig.lib.json",


### PR DESCRIPTION
This PR makes sure that `vite:build-base` is cacheable. It's a long-standing issue because vite is the only package using SWC to build, thus the `targetDefaults` using TSC is not being applied. We don't actually need to specify the executor, as `build-base` using `@nx/next:build` (nx-dev) and `@nx/js:swc` (vite) are both cacheable.