### PR TITLE
fix(core): update ci-workflow generator package manager installation

### DIFF
--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -2074,6 +2074,52 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with yarn should generate github CI config when packageManager is defined in package.json 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - run: corepack enable
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: yarn nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: yarn nx affected -t lint test build
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with yarn should generate github CI config with custom name 1`] = `
 "name: My custom-workflow
 
@@ -4161,6 +4207,52 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: yarn nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: yarn nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with yarn should generate github CI config when packageManager is defined in package.json 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - run: corepack enable
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -174,14 +174,9 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
 
@@ -190,6 +185,12 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
       - run: npx cypress install
@@ -225,14 +226,9 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
 
@@ -241,6 +237,12 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
       - run: npx cypress install
@@ -694,14 +696,9 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
 
@@ -710,6 +707,12 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
@@ -743,14 +746,9 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
 
@@ -759,6 +757,12 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
@@ -978,19 +982,23 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
         with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - run: corepack prepare pnpm@9.8
+          version: 9.8.0
+          run_install: false
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -1024,19 +1032,23 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
         with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - run: corepack prepare pnpm@9.8
+          version: 9.8.0
+          run_install: false
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -1247,19 +1259,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'yarn'
-
-      - run: corepack prepare yarn@1.22
+      - run: corepack prepare 'yarn@1.22'
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -1293,19 +1305,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'yarn'
-
-      - run: corepack prepare yarn@1.22
+      - run: corepack prepare 'yarn@1.22'
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -1521,14 +1533,9 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
 
@@ -1537,6 +1544,12 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
       - run: npx cypress install
@@ -1572,14 +1585,9 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
 
@@ -1588,6 +1596,12 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
       - run: npx cypress install
@@ -2043,14 +2057,9 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
 
@@ -2059,6 +2068,12 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
@@ -2092,14 +2107,9 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
 
@@ -2108,6 +2118,12 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
@@ -2328,19 +2344,23 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
         with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - run: corepack prepare pnpm@9.8
+          version: 9.8.0
+          run_install: false
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -2374,19 +2394,23 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
         with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - run: corepack prepare pnpm@9.8
+          version: 9.8.0
+          run_install: false
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -2598,19 +2622,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'yarn'
-
-      - run: corepack prepare yarn@1.22
+      - run: corepack prepare 'yarn@1.22'
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -2644,19 +2668,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'yarn'
-
-      - run: corepack prepare yarn@1.22
+      - run: corepack prepare 'yarn@1.22'
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -174,17 +174,22 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
       - run: npm ci --legacy-peer-deps
       - run: npx cypress install
@@ -220,17 +225,22 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
       - run: npm ci --legacy-peer-deps
       - run: npx cypress install
@@ -684,17 +694,22 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
@@ -728,17 +743,22 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
@@ -958,22 +978,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-
+      # Cache node_modules
+      - uses: actions/setup-node@v4
         with:
-          version: 9
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: corepack prepare pnpm@9.8
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -1007,22 +1024,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-
+      # Cache node_modules
+      - uses: actions/setup-node@v4
         with:
-          version: 9
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: corepack prepare pnpm@9.8
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
       # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -1233,17 +1247,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'
+
+      - run: corepack prepare yarn@1.22
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -1277,17 +1293,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'
+
+      - run: corepack prepare yarn@1.22
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -1503,17 +1521,22 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
       - run: npm ci --legacy-peer-deps
       - run: npx cypress install
@@ -1549,17 +1572,22 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
       - run: npm ci --legacy-peer-deps
       - run: npx cypress install
@@ -2015,17 +2043,22 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
@@ -2059,17 +2092,22 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
@@ -2290,22 +2328,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-
+      # Cache node_modules
+      - uses: actions/setup-node@v4
         with:
-          version: 9
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: corepack prepare pnpm@9.8
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -2339,22 +2374,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-
+      # Cache node_modules
+      - uses: actions/setup-node@v4
         with:
-          version: 9
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: corepack prepare pnpm@9.8
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -2566,17 +2598,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'
+
+      - run: corepack prepare yarn@1.22
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
@@ -2610,17 +2644,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'
+
+      - run: corepack prepare yarn@1.22
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -959,6 +959,7 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
+
         with:
           version: 9
 
@@ -1007,6 +1008,7 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
+
         with:
           version: 9
 
@@ -2289,6 +2291,7 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
+
         with:
           version: 9
 
@@ -2337,6 +2340,7 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
+
         with:
           version: 9
 

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -321,7 +321,123 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with bun should generate azure CI config when packageManager is set to \${packageManager} in package.json 1`] = `
+"name: CI
+
+trigger:
+  - main
+pr:
+  - main
+
+variables:
+  CI: 'true'
+  \${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(System.PullRequest.PullRequestNumber)
+    TARGET_BRANCH: $[replace(variables['System.PullRequest.TargetBranch'],'refs/heads/','origin/')]
+    BASE_SHA: $(git merge-base $(TARGET_BRANCH) HEAD)
+  \${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(Build.SourceBranchName)
+    BASE_SHA: $(git rev-parse HEAD~1)
+  HEAD_SHA: $(git rev-parse HEAD)
+
+jobs:
+  - job: main
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        fetchFilter: tree:0
+      # Set Azure Devops CLI default settings
+      - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
+        displayName: 'Set default Azure DevOps organization and project'
+      # Get last successfull commit from Azure Devops CLI
+      - bash: |
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          if [ -z "$LAST_SHA" ]
+          then
+            echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
+          else
+            echo "Last successful commit SHA: $LAST_SHA"
+            echo "##vso[task.setvariable variable=BASE_SHA]$LAST_SHA"
+          fi
+        displayName: 'Get last successful commit SHA'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      - script: npm install --prefix=$HOME/.local -g Bun
+        displayName: Install Bun
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - script: bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - script: bun install --no-cache
+      - script: git branch --track main origin/main
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - script: bun nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - script: bun nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with bun should generate bitbucket pipelines config 1`] = `
+"image: node:20
+
+clone:
+  depth: full
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Build and test affected apps on Pull Requests'
+          script:
+            - export NX_BRANCH=$BITBUCKET_PR_ID
+
+            - npm install --prefix=$HOME/.local -g bun
+
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Uncomment this line to enable task distribution
+            # - bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - bun install --no-cache
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # bun nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - bun nx affected --base=origin/main -t lint test build
+
+  branches:
+    main:
+      - step:
+          name: 'Build and test affected apps on "main" branch changes'
+          script:
+            - export NX_BRANCH=$BITBUCKET_BRANCH
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            - bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - npm install --prefix=$HOME/.local -g bun
+
+            - bun install --no-cache
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # - bun nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - bun nx affected -t lint test build --base=HEAD~1
+"
+`;
+
+exports[`CI Workflow generator connected to nxCloud with bun should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
 "image: node:20
 
 clone:
@@ -413,7 +529,90 @@ workflows:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with bun should generate circleci CI config when packageManager is set to bun in package.json 1`] = `
+"version: 2.1
+
+orbs:
+  nx: nrwl/nx@1.6.2
+
+jobs:
+  main:
+    docker:
+      - image: cimg/node:lts-browsers
+    steps:
+      - checkout
+
+      - run:
+          name: Install Bun
+          command: npm install --prefix=$HOME/.local -g bun
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: bun install --no-cache
+      - nx/set-shas:
+          main-branch-name: 'main'
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: bun nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: bun nx affected -t lint test build
+
+workflows:
+  version: 2
+
+  ci:
+    jobs:
+      - main
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with bun should generate github CI config 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: bun install --no-cache
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: bun nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: bun nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator connected to nxCloud with bun should generate github CI config when packageManager is defined in package.json 1`] = `
 "name: CI
 
 on:
@@ -590,7 +789,116 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with npm should generate azure CI config when packageManager is set to \${packageManager} in package.json 1`] = `
+"name: CI
+
+trigger:
+  - main
+pr:
+  - main
+
+variables:
+  CI: 'true'
+  \${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(System.PullRequest.PullRequestNumber)
+    TARGET_BRANCH: $[replace(variables['System.PullRequest.TargetBranch'],'refs/heads/','origin/')]
+    BASE_SHA: $(git merge-base $(TARGET_BRANCH) HEAD)
+  \${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(Build.SourceBranchName)
+    BASE_SHA: $(git rev-parse HEAD~1)
+  HEAD_SHA: $(git rev-parse HEAD)
+
+jobs:
+  - job: main
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        fetchFilter: tree:0
+      # Set Azure Devops CLI default settings
+      - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
+        displayName: 'Set default Azure DevOps organization and project'
+      # Get last successfull commit from Azure Devops CLI
+      - bash: |
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          if [ -z "$LAST_SHA" ]
+          then
+            echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
+          else
+            echo "Last successful commit SHA: $LAST_SHA"
+            echo "##vso[task.setvariable variable=BASE_SHA]$LAST_SHA"
+          fi
+        displayName: 'Get last successful commit SHA'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - script: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - script: npm ci --legacy-peer-deps
+      - script: git branch --track main origin/main
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - script: npx nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with npm should generate bitbucket pipelines config 1`] = `
+"image: node:20
+
+clone:
+  depth: full
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Build and test affected apps on Pull Requests'
+          script:
+            - export NX_BRANCH=$BITBUCKET_PR_ID
+
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Uncomment this line to enable task distribution
+            # - npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - npm ci --legacy-peer-deps
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # npx nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - npx nx affected --base=origin/main -t lint test build
+
+  branches:
+    main:
+      - step:
+          name: 'Build and test affected apps on "main" branch changes'
+          script:
+            - export NX_BRANCH=$BITBUCKET_BRANCH
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            - npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - npm ci --legacy-peer-deps
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # - npx nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - npx nx affected -t lint test build --base=HEAD~1
+"
+`;
+
+exports[`CI Workflow generator connected to nxCloud with npm should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
 "image: node:20
 
 clone:
@@ -674,7 +982,94 @@ workflows:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with npm should generate circleci CI config when packageManager is set to npm in package.json 1`] = `
+"version: 2.1
+
+orbs:
+  nx: nrwl/nx@1.6.2
+
+jobs:
+  main:
+    docker:
+      - image: cimg/node:lts-browsers
+    steps:
+      - checkout
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: npm ci --legacy-peer-deps
+      - nx/set-shas:
+          main-branch-name: 'main'
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: npx nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: npx nx affected -t lint test build
+
+workflows:
+  version: 2
+
+  ci:
+    jobs:
+      - main
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with npm should generate github CI config 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci --legacy-peer-deps
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: npx nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: npx nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator connected to nxCloud with npm should generate github CI config when packageManager is defined in package.json 1`] = `
 "name: CI
 
 on:
@@ -868,7 +1263,123 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with pnpm should generate azure CI config when packageManager is set to \${packageManager} in package.json 1`] = `
+"name: CI
+
+trigger:
+  - main
+pr:
+  - main
+
+variables:
+  CI: 'true'
+  \${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(System.PullRequest.PullRequestNumber)
+    TARGET_BRANCH: $[replace(variables['System.PullRequest.TargetBranch'],'refs/heads/','origin/')]
+    BASE_SHA: $(git merge-base $(TARGET_BRANCH) HEAD)
+  \${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(Build.SourceBranchName)
+    BASE_SHA: $(git rev-parse HEAD~1)
+  HEAD_SHA: $(git rev-parse HEAD)
+
+jobs:
+  - job: main
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        fetchFilter: tree:0
+      # Set Azure Devops CLI default settings
+      - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
+        displayName: 'Set default Azure DevOps organization and project'
+      # Get last successfull commit from Azure Devops CLI
+      - bash: |
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          if [ -z "$LAST_SHA" ]
+          then
+            echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
+          else
+            echo "Last successful commit SHA: $LAST_SHA"
+            echo "##vso[task.setvariable variable=BASE_SHA]$LAST_SHA"
+          fi
+        displayName: 'Get last successful commit SHA'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      - script: npm install --prefix=$HOME/.local -g pnpm@8
+        displayName: Install PNPM
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - script: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - script: pnpm install --frozen-lockfile
+      - script: git branch --track main origin/main
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - script: pnpm exec nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - script: pnpm exec nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with pnpm should generate bitbucket pipelines config 1`] = `
+"image: node:20
+
+clone:
+  depth: full
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Build and test affected apps on Pull Requests'
+          script:
+            - export NX_BRANCH=$BITBUCKET_PR_ID
+
+            - npm install --prefix=$HOME/.local -g pnpm@8
+
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Uncomment this line to enable task distribution
+            # - pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - pnpm install --frozen-lockfile
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # pnpm exec nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - pnpm exec nx affected --base=origin/main -t lint test build
+
+  branches:
+    main:
+      - step:
+          name: 'Build and test affected apps on "main" branch changes'
+          script:
+            - export NX_BRANCH=$BITBUCKET_BRANCH
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            - pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - npm install --prefix=$HOME/.local -g pnpm@8
+
+            - pnpm install --frozen-lockfile
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # - pnpm exec nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - pnpm exec nx affected -t lint test build --base=HEAD~1
+"
+`;
+
+exports[`CI Workflow generator connected to nxCloud with pnpm should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
 "image: node:20
 
 clone:
@@ -960,6 +1471,47 @@ workflows:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with pnpm should generate circleci CI config when packageManager is set to pnpm in package.json 1`] = `
+"version: 2.1
+
+orbs:
+  nx: nrwl/nx@1.6.2
+
+jobs:
+  main:
+    docker:
+      - image: cimg/node:lts-browsers
+    steps:
+      - checkout
+
+      - run:
+          name: Install PNPM
+          command: npm install --prefix=$HOME/.local -g pnpm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: pnpm install --frozen-lockfile
+      - nx/set-shas:
+          main-branch-name: 'main'
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: pnpm exec nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: pnpm exec nx affected -t lint test build
+
+workflows:
+  version: 2
+
+  ci:
+    jobs:
+      - main
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with pnpm should generate github CI config 1`] = `
 "name: CI
 
@@ -986,6 +1538,55 @@ jobs:
         name: Install pnpm
         with:
           version: 9.8.0
+          run_install: false
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: pnpm exec nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: pnpm exec nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator connected to nxCloud with pnpm should generate github CI config when packageManager is defined in package.json 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
           run_install: false
 
       # This enables task distribution via Nx Cloud
@@ -1153,7 +1754,116 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with yarn should generate azure CI config when packageManager is set to \${packageManager} in package.json 1`] = `
+"name: CI
+
+trigger:
+  - main
+pr:
+  - main
+
+variables:
+  CI: 'true'
+  \${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(System.PullRequest.PullRequestNumber)
+    TARGET_BRANCH: $[replace(variables['System.PullRequest.TargetBranch'],'refs/heads/','origin/')]
+    BASE_SHA: $(git merge-base $(TARGET_BRANCH) HEAD)
+  \${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(Build.SourceBranchName)
+    BASE_SHA: $(git rev-parse HEAD~1)
+  HEAD_SHA: $(git rev-parse HEAD)
+
+jobs:
+  - job: main
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        fetchFilter: tree:0
+      # Set Azure Devops CLI default settings
+      - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
+        displayName: 'Set default Azure DevOps organization and project'
+      # Get last successfull commit from Azure Devops CLI
+      - bash: |
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          if [ -z "$LAST_SHA" ]
+          then
+            echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
+          else
+            echo "Last successful commit SHA: $LAST_SHA"
+            echo "##vso[task.setvariable variable=BASE_SHA]$LAST_SHA"
+          fi
+        displayName: 'Get last successful commit SHA'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - script: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - script: yarn install --frozen-lockfile
+      - script: git branch --track main origin/main
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - script: yarn nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with yarn should generate bitbucket pipelines config 1`] = `
+"image: node:20
+
+clone:
+  depth: full
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Build and test affected apps on Pull Requests'
+          script:
+            - export NX_BRANCH=$BITBUCKET_PR_ID
+
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Uncomment this line to enable task distribution
+            # - yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - yarn install --frozen-lockfile
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # yarn nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - yarn nx affected --base=origin/main -t lint test build
+
+  branches:
+    main:
+      - step:
+          name: 'Build and test affected apps on "main" branch changes'
+          script:
+            - export NX_BRANCH=$BITBUCKET_BRANCH
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            - yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - yarn install --frozen-lockfile
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # - yarn nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - yarn nx affected -t lint test build --base=HEAD~1
+"
+`;
+
+exports[`CI Workflow generator connected to nxCloud with yarn should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
 "image: node:20
 
 clone:
@@ -1237,6 +1947,43 @@ workflows:
 "
 `;
 
+exports[`CI Workflow generator connected to nxCloud with yarn should generate circleci CI config when packageManager is set to yarn in package.json 1`] = `
+"version: 2.1
+
+orbs:
+  nx: nrwl/nx@1.6.2
+
+jobs:
+  main:
+    docker:
+      - image: cimg/node:lts-browsers
+    steps:
+      - checkout
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: yarn install --frozen-lockfile
+      - nx/set-shas:
+          main-branch-name: 'main'
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: yarn nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: yarn nx affected -t lint test build
+
+workflows:
+  version: 2
+
+  ci:
+    jobs:
+      - main
+"
+`;
+
 exports[`CI Workflow generator connected to nxCloud with yarn should generate github CI config 1`] = `
 "name: CI
 
@@ -1259,7 +2006,51 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - run: corepack prepare 'yarn@1.22'
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: yarn nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: yarn nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator connected to nxCloud with yarn should generate github CI config when packageManager is defined in package.json 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - run: corepack enable
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -1304,8 +2095,6 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-
-      - run: corepack prepare 'yarn@1.22'
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -1680,7 +2469,124 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator not connected to nxCloud with bun should generate azure CI config when packageManager is set to \${packageManager} in package.json 1`] = `
+"name: CI
+
+trigger:
+  - main
+pr:
+  - main
+
+variables:
+  CI: 'true'
+  \${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(System.PullRequest.PullRequestNumber)
+    TARGET_BRANCH: $[replace(variables['System.PullRequest.TargetBranch'],'refs/heads/','origin/')]
+    BASE_SHA: $(git merge-base $(TARGET_BRANCH) HEAD)
+  \${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(Build.SourceBranchName)
+    BASE_SHA: $(git rev-parse HEAD~1)
+  HEAD_SHA: $(git rev-parse HEAD)
+
+jobs:
+  - job: main
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        fetchFilter: tree:0
+      # Set Azure Devops CLI default settings
+      - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
+        displayName: 'Set default Azure DevOps organization and project'
+      # Get last successfull commit from Azure Devops CLI
+      - bash: |
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          if [ -z "$LAST_SHA" ]
+          then
+            echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
+          else
+            echo "Last successful commit SHA: $LAST_SHA"
+            echo "##vso[task.setvariable variable=BASE_SHA]$LAST_SHA"
+          fi
+        displayName: 'Get last successful commit SHA'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      - script: npm install --prefix=$HOME/.local -g Bun
+        displayName: Install Bun
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - script: bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - script: bun install --no-cache
+      - script: git branch --track main origin/main
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - script: bun nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - script: bun nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+"
+`;
+
 exports[`CI Workflow generator not connected to nxCloud with bun should generate bitbucket pipelines config 1`] = `
+"image: node:20
+
+clone:
+  depth: full
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Build and test affected apps on Pull Requests'
+          script:
+            - export NX_BRANCH=$BITBUCKET_PR_ID
+
+            - npm install --prefix=$HOME/.local -g bun
+
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+            # - bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - bun install --no-cache
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # bun nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - bun nx affected --base=origin/main -t lint test build
+
+  branches:
+    main:
+      - step:
+          name: 'Build and test affected apps on "main" branch changes'
+          script:
+            - export NX_BRANCH=$BITBUCKET_BRANCH
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Connect your workspace by running "nx connect" and uncomment this
+            # - bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - npm install --prefix=$HOME/.local -g bun
+
+            - bun install --no-cache
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # - bun nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - bun nx affected -t lint test build --base=HEAD~1
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with bun should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
 "image: node:20
 
 clone:
@@ -1773,7 +2679,90 @@ workflows:
 "
 `;
 
+exports[`CI Workflow generator not connected to nxCloud with bun should generate circleci CI config when packageManager is set to bun in package.json 1`] = `
+"version: 2.1
+
+orbs:
+  nx: nrwl/nx@1.6.2
+
+jobs:
+  main:
+    docker:
+      - image: cimg/node:lts-browsers
+    steps:
+      - checkout
+
+      - run:
+          name: Install Bun
+          command: npm install --prefix=$HOME/.local -g bun
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: bun install --no-cache
+      - nx/set-shas:
+          main-branch-name: 'main'
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: bun nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: bun nx affected -t lint test build
+
+workflows:
+  version: 2
+
+  ci:
+    jobs:
+      - main
+"
+`;
+
 exports[`CI Workflow generator not connected to nxCloud with bun should generate github CI config 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: bunx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: bun install --no-cache
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: bun nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: bun nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with bun should generate github CI config when packageManager is defined in package.json 1`] = `
 "name: CI
 
 on:
@@ -1950,7 +2939,117 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator not connected to nxCloud with npm should generate azure CI config when packageManager is set to \${packageManager} in package.json 1`] = `
+"name: CI
+
+trigger:
+  - main
+pr:
+  - main
+
+variables:
+  CI: 'true'
+  \${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(System.PullRequest.PullRequestNumber)
+    TARGET_BRANCH: $[replace(variables['System.PullRequest.TargetBranch'],'refs/heads/','origin/')]
+    BASE_SHA: $(git merge-base $(TARGET_BRANCH) HEAD)
+  \${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(Build.SourceBranchName)
+    BASE_SHA: $(git rev-parse HEAD~1)
+  HEAD_SHA: $(git rev-parse HEAD)
+
+jobs:
+  - job: main
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        fetchFilter: tree:0
+      # Set Azure Devops CLI default settings
+      - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
+        displayName: 'Set default Azure DevOps organization and project'
+      # Get last successfull commit from Azure Devops CLI
+      - bash: |
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          if [ -z "$LAST_SHA" ]
+          then
+            echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
+          else
+            echo "Last successful commit SHA: $LAST_SHA"
+            echo "##vso[task.setvariable variable=BASE_SHA]$LAST_SHA"
+          fi
+        displayName: 'Get last successful commit SHA'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - script: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - script: npm ci --legacy-peer-deps
+      - script: git branch --track main origin/main
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - script: npx nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+"
+`;
+
 exports[`CI Workflow generator not connected to nxCloud with npm should generate bitbucket pipelines config 1`] = `
+"image: node:20
+
+clone:
+  depth: full
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Build and test affected apps on Pull Requests'
+          script:
+            - export NX_BRANCH=$BITBUCKET_PR_ID
+
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+            # - npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - npm ci --legacy-peer-deps
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # npx nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - npx nx affected --base=origin/main -t lint test build
+
+  branches:
+    main:
+      - step:
+          name: 'Build and test affected apps on "main" branch changes'
+          script:
+            - export NX_BRANCH=$BITBUCKET_BRANCH
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Connect your workspace by running "nx connect" and uncomment this
+            # - npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - npm ci --legacy-peer-deps
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # - npx nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - npx nx affected -t lint test build --base=HEAD~1
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with npm should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
 "image: node:20
 
 clone:
@@ -2035,7 +3134,94 @@ workflows:
 "
 `;
 
+exports[`CI Workflow generator not connected to nxCloud with npm should generate circleci CI config when packageManager is set to npm in package.json 1`] = `
+"version: 2.1
+
+orbs:
+  nx: nrwl/nx@1.6.2
+
+jobs:
+  main:
+    docker:
+      - image: cimg/node:lts-browsers
+    steps:
+      - checkout
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: npm ci --legacy-peer-deps
+      - nx/set-shas:
+          main-branch-name: 'main'
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: npx nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: npx nx affected -t lint test build
+
+workflows:
+  version: 2
+
+  ci:
+    jobs:
+      - main
+"
+`;
+
 exports[`CI Workflow generator not connected to nxCloud with npm should generate github CI config 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci --legacy-peer-deps
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: npx nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: npx nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with npm should generate github CI config when packageManager is defined in package.json 1`] = `
 "name: CI
 
 on:
@@ -2229,7 +3415,124 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator not connected to nxCloud with pnpm should generate azure CI config when packageManager is set to \${packageManager} in package.json 1`] = `
+"name: CI
+
+trigger:
+  - main
+pr:
+  - main
+
+variables:
+  CI: 'true'
+  \${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(System.PullRequest.PullRequestNumber)
+    TARGET_BRANCH: $[replace(variables['System.PullRequest.TargetBranch'],'refs/heads/','origin/')]
+    BASE_SHA: $(git merge-base $(TARGET_BRANCH) HEAD)
+  \${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(Build.SourceBranchName)
+    BASE_SHA: $(git rev-parse HEAD~1)
+  HEAD_SHA: $(git rev-parse HEAD)
+
+jobs:
+  - job: main
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        fetchFilter: tree:0
+      # Set Azure Devops CLI default settings
+      - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
+        displayName: 'Set default Azure DevOps organization and project'
+      # Get last successfull commit from Azure Devops CLI
+      - bash: |
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          if [ -z "$LAST_SHA" ]
+          then
+            echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
+          else
+            echo "Last successful commit SHA: $LAST_SHA"
+            echo "##vso[task.setvariable variable=BASE_SHA]$LAST_SHA"
+          fi
+        displayName: 'Get last successful commit SHA'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      - script: npm install --prefix=$HOME/.local -g pnpm@8
+        displayName: Install PNPM
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - script: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - script: pnpm install --frozen-lockfile
+      - script: git branch --track main origin/main
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - script: pnpm exec nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - script: pnpm exec nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+"
+`;
+
 exports[`CI Workflow generator not connected to nxCloud with pnpm should generate bitbucket pipelines config 1`] = `
+"image: node:20
+
+clone:
+  depth: full
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Build and test affected apps on Pull Requests'
+          script:
+            - export NX_BRANCH=$BITBUCKET_PR_ID
+
+            - npm install --prefix=$HOME/.local -g pnpm@8
+
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+            # - pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - pnpm install --frozen-lockfile
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # pnpm exec nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - pnpm exec nx affected --base=origin/main -t lint test build
+
+  branches:
+    main:
+      - step:
+          name: 'Build and test affected apps on "main" branch changes'
+          script:
+            - export NX_BRANCH=$BITBUCKET_BRANCH
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Connect your workspace by running "nx connect" and uncomment this
+            # - pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - npm install --prefix=$HOME/.local -g pnpm@8
+
+            - pnpm install --frozen-lockfile
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # - pnpm exec nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - pnpm exec nx affected -t lint test build --base=HEAD~1
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with pnpm should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
 "image: node:20
 
 clone:
@@ -2322,6 +3625,47 @@ workflows:
 "
 `;
 
+exports[`CI Workflow generator not connected to nxCloud with pnpm should generate circleci CI config when packageManager is set to pnpm in package.json 1`] = `
+"version: 2.1
+
+orbs:
+  nx: nrwl/nx@1.6.2
+
+jobs:
+  main:
+    docker:
+      - image: cimg/node:lts-browsers
+    steps:
+      - checkout
+
+      - run:
+          name: Install PNPM
+          command: npm install --prefix=$HOME/.local -g pnpm@8
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: pnpm install --frozen-lockfile
+      - nx/set-shas:
+          main-branch-name: 'main'
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: pnpm exec nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: pnpm exec nx affected -t lint test build
+
+workflows:
+  version: 2
+
+  ci:
+    jobs:
+      - main
+"
+`;
+
 exports[`CI Workflow generator not connected to nxCloud with pnpm should generate github CI config 1`] = `
 "name: CI
 
@@ -2348,6 +3692,55 @@ jobs:
         name: Install pnpm
         with:
           version: 9.8.0
+          run_install: false
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: pnpm exec nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: pnpm exec nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with pnpm should generate github CI config when packageManager is defined in package.json 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
           run_install: false
 
       # This enables task distribution via Nx Cloud
@@ -2515,7 +3908,117 @@ jobs:
 "
 `;
 
+exports[`CI Workflow generator not connected to nxCloud with yarn should generate azure CI config when packageManager is set to \${packageManager} in package.json 1`] = `
+"name: CI
+
+trigger:
+  - main
+pr:
+  - main
+
+variables:
+  CI: 'true'
+  \${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(System.PullRequest.PullRequestNumber)
+    TARGET_BRANCH: $[replace(variables['System.PullRequest.TargetBranch'],'refs/heads/','origin/')]
+    BASE_SHA: $(git merge-base $(TARGET_BRANCH) HEAD)
+  \${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    NX_BRANCH: $(Build.SourceBranchName)
+    BASE_SHA: $(git rev-parse HEAD~1)
+  HEAD_SHA: $(git rev-parse HEAD)
+
+jobs:
+  - job: main
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        fetchFilter: tree:0
+      # Set Azure Devops CLI default settings
+      - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
+        displayName: 'Set default Azure DevOps organization and project'
+      # Get last successfull commit from Azure Devops CLI
+      - bash: |
+          LAST_SHA=$(az pipelines build list --branch $(Build.SourceBranchName) --definition-ids $(System.DefinitionId) --result succeeded --top 1 --query "[0].triggerInfo.\\"ci.sourceSha\\"")
+          if [ -z "$LAST_SHA" ]
+          then
+            echo "Last successful commit not found. Using fallback 'HEAD~1': $BASE_SHA"
+          else
+            echo "Last successful commit SHA: $LAST_SHA"
+            echo "##vso[task.setvariable variable=BASE_SHA]$LAST_SHA"
+          fi
+        displayName: 'Get last successful commit SHA'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - script: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - script: yarn install --frozen-lockfile
+      - script: git branch --track main origin/main
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - script: yarn nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint test build
+"
+`;
+
 exports[`CI Workflow generator not connected to nxCloud with yarn should generate bitbucket pipelines config 1`] = `
+"image: node:20
+
+clone:
+  depth: full
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Build and test affected apps on Pull Requests'
+          script:
+            - export NX_BRANCH=$BITBUCKET_PR_ID
+
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+            # - yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - yarn install --frozen-lockfile
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # yarn nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - yarn nx affected --base=origin/main -t lint test build
+
+  branches:
+    main:
+      - step:
+          name: 'Build and test affected apps on "main" branch changes'
+          script:
+            - export NX_BRANCH=$BITBUCKET_BRANCH
+            # This enables task distribution via Nx Cloud
+            # Run this command as early as possible, before dependencies are installed
+            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+            # Connect your workspace by running "nx connect" and uncomment this
+            # - yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+            - yarn install --frozen-lockfile
+
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # - yarn nx-cloud record -- echo Hello World
+            # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+            - yarn nx affected -t lint test build --base=HEAD~1
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with yarn should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
 "image: node:20
 
 clone:
@@ -2600,6 +4103,43 @@ workflows:
 "
 `;
 
+exports[`CI Workflow generator not connected to nxCloud with yarn should generate circleci CI config when packageManager is set to yarn in package.json 1`] = `
+"version: 2.1
+
+orbs:
+  nx: nrwl/nx@1.6.2
+
+jobs:
+  main:
+    docker:
+      - image: cimg/node:lts-browsers
+    steps:
+      - checkout
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: yarn install --frozen-lockfile
+      - nx/set-shas:
+          main-branch-name: 'main'
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: yarn nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: yarn nx affected -t lint test build
+
+workflows:
+  version: 2
+
+  ci:
+    jobs:
+      - main
+"
+`;
+
 exports[`CI Workflow generator not connected to nxCloud with yarn should generate github CI config 1`] = `
 "name: CI
 
@@ -2622,7 +4162,51 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - run: corepack prepare 'yarn@1.22'
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
+      - uses: nrwl/nx-set-shas@v4
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - run: yarn nx-cloud record -- echo Hello World
+      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
+      - run: yarn nx affected -t lint test build
+"
+`;
+
+exports[`CI Workflow generator not connected to nxCloud with yarn should generate github CI config when packageManager is defined in package.json 1`] = `
+"name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - run: corepack enable
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -2667,8 +4251,6 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-
-      - run: corepack prepare 'yarn@1.22'
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -174,12 +174,6 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
-
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
@@ -225,12 +219,6 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -1041,12 +1029,6 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
-
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
@@ -1091,12 +1073,6 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
-
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
@@ -1140,12 +1116,6 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -2074,52 +2044,6 @@ jobs:
 "
 `;
 
-exports[`CI Workflow generator connected to nxCloud with yarn should generate github CI config when packageManager is defined in package.json 1`] = `
-"name: CI
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-permissions:
-  actions: read
-  contents: read
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          filter: tree:0
-          fetch-depth: 0
-
-      - run: corepack enable
-
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'yarn'
-
-      - run: yarn install --frozen-lockfile
-      - uses: nrwl/nx-set-shas@v4
-
-      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
-      # - run: yarn nx-cloud record -- echo Hello World
-      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
-      - run: yarn nx affected -t lint test build
-"
-`;
-
 exports[`CI Workflow generator connected to nxCloud with yarn should generate github CI config with custom name 1`] = `
 "name: My custom-workflow
 
@@ -2368,12 +2292,6 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
-
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
@@ -2419,12 +2337,6 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -3239,12 +3151,6 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
-
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
@@ -3289,12 +3195,6 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
-
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
@@ -3338,12 +3238,6 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-
-      ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -4207,52 +4101,6 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: yarn nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'yarn'
-
-      - run: yarn install --frozen-lockfile
-      - uses: nrwl/nx-set-shas@v4
-
-      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
-      # - run: yarn nx-cloud record -- echo Hello World
-      # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
-      - run: yarn nx affected -t lint test build
-"
-`;
-
-exports[`CI Workflow generator not connected to nxCloud with yarn should generate github CI config when packageManager is defined in package.json 1`] = `
-"name: CI
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-permissions:
-  actions: read
-  contents: read
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          filter: tree:0
-          fetch-depth: 0
-
-      - run: corepack enable
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -337,14 +337,9 @@ describe('CI Workflow generator', () => {
                   filter: tree:0
                   fetch-depth: 0
 
-              # Cache node_modules
-              - uses: actions/setup-node@v4
-                with:
-                  node-version: 20
-                  cache: 'npm'
-
-              ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+              ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
               ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+              ## When we upgrade to node 22.5.1 this can be removed.
               - name: Downgrade npm to 8.x
                 run: npm install -g npm@8
 
@@ -353,6 +348,12 @@ describe('CI Workflow generator', () => {
               # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
               # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
               # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+              # Cache node_modules
+              - uses: actions/setup-node@v4
+                with:
+                  node-version: 20
+                  cache: 'npm'
 
               - run: npm ci --legacy-peer-deps
               - uses: nrwl/nx-set-shas@v4

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -109,13 +109,48 @@ describe('CI Workflow generator', () => {
           ).toMatchSnapshot();
         });
 
+        it('should generate github CI config when packageManager is defined in package.json', async () => {
+          updateJson(tree, 'package.json', (json) => ({
+            ...json,
+            packageManager: `${packageManager}@latest`,
+          }));
+
+          await ciWorkflowGenerator(tree, { ci: 'github', name: 'CI' });
+
+          expect(
+            tree.read('.github/workflows/ci.yml', 'utf-8')
+          ).toMatchSnapshot();
+        });
+
         it('should generate circleci CI config', async () => {
           await ciWorkflowGenerator(tree, { ci: 'circleci', name: 'CI' });
 
           expect(tree.read('.circleci/config.yml', 'utf-8')).toMatchSnapshot();
         });
 
+        it(`should generate circleci CI config when packageManager is set to ${packageManager} in package.json`, async () => {
+          updateJson(tree, 'package.json', (json) => ({
+            ...json,
+            packageManager: `${packageManager}@latest`,
+          }));
+
+          await ciWorkflowGenerator(tree, { ci: 'circleci', name: 'CI' });
+
+          expect(tree.read('.circleci/config.yml', 'utf-8')).toMatchSnapshot();
+        });
+
         it('should generate azure CI config', async () => {
+          await ciWorkflowGenerator(tree, { ci: 'azure', name: 'CI' });
+
+          expect(tree.read('azure-pipelines.yml', 'utf-8')).toMatchSnapshot();
+        });
+
+        it('should generate azure CI config when packageManager is set to ${packageManager} in package.json', async () => {
+          updateJson(tree, 'package.json', (json) => ({
+            ...json,
+            packageManager: `${packageManager}@latest`,
+          }));
+
           await ciWorkflowGenerator(tree, { ci: 'azure', name: 'CI' });
 
           expect(tree.read('azure-pipelines.yml', 'utf-8')).toMatchSnapshot();
@@ -133,6 +168,22 @@ describe('CI Workflow generator', () => {
         });
 
         it('should generate bitbucket pipelines config', async () => {
+          await ciWorkflowGenerator(tree, {
+            ci: 'bitbucket-pipelines',
+            name: 'CI',
+          });
+
+          expect(
+            tree.read('bitbucket-pipelines.yml', 'utf-8')
+          ).toMatchSnapshot();
+        });
+
+        it('should generate bitbucket pipelines config when packageManager is set to ${packageManager} in package.json', async () => {
+          updateJson(tree, 'package.json', (json) => ({
+            ...json,
+            packageManager: `${packageManager}@latest`,
+          }));
+
           await ciWorkflowGenerator(tree, {
             ci: 'bitbucket-pipelines',
             name: 'CI',

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -337,17 +337,22 @@ describe('CI Workflow generator', () => {
                   filter: tree:0
                   fetch-depth: 0
 
-              # This enables task distribution via Nx Cloud
-              # Run this command as early as possible, before dependencies are installed
-              # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-              # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-              # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
               # Cache node_modules
               - uses: actions/setup-node@v4
                 with:
                   node-version: 20
                   cache: 'npm'
+
+              ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1
+              ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+              - name: Downgrade npm to 8.x
+                run: npm install -g npm@8
+
+              # This enables task distribution via Nx Cloud
+              # Run this command as early as possible, before dependencies are installed
+              # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+              # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+              # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
               - run: npm ci --legacy-peer-deps
               - uses: nrwl/nx-set-shas@v4

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -388,12 +388,6 @@ describe('CI Workflow generator', () => {
                   filter: tree:0
                   fetch-depth: 0
 
-              ## NPM versions that are > v8 has a npm error \`Exit handler never called\` which has been solved in Node 22.5.1
-              ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-              ## When we upgrade to node 22.5.1 this can be removed.
-              - name: Downgrade npm to 8.x
-                run: npm install -g npm@8
-
               # This enables task distribution via Nx Cloud
               # Run this command as early as possible, before dependencies are installed
               # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
@@ -52,6 +52,7 @@ interface Substitutes {
   hasPlaywright: boolean;
   tmpl: '';
   connectedToCloud: boolean;
+  hasPnpmVersion: boolean;
 }
 
 function normalizeOptions(options: Schema, tree: Tree): Substitutes {
@@ -72,6 +73,8 @@ function normalizeOptions(options: Schema, tree: Tree): Substitutes {
   } catch {}
 
   const packageJson = readJson(tree, 'package.json');
+  // check if packagejson has packagemanager and its pnpm
+  const packageManagerPrefixPnpm = packageJson?.pnpm?.packageManager;
   const allDependencies = {
     ...packageJson.dependencies,
     ...packageJson.devDependencies,
@@ -92,6 +95,8 @@ function normalizeOptions(options: Schema, tree: Tree): Substitutes {
     packageManagerPrefix,
     packageManagerPreInstallPrefix,
     mainBranch: deduceDefaultBase(),
+    hasPnpmVersion:
+      packageManagerPrefixPnpm && !!packageManagerPrefixPnpm?.split('@')[1],
     hasCypress,
     hasE2E,
     hasPlaywright,

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
@@ -52,7 +52,7 @@ interface Substitutes {
   hasPlaywright: boolean;
   tmpl: '';
   connectedToCloud: boolean;
-  hasPnpmVersion: boolean;
+  packageManagerVersion: string;
 }
 
 function normalizeOptions(options: Schema, tree: Tree): Substitutes {
@@ -73,8 +73,6 @@ function normalizeOptions(options: Schema, tree: Tree): Substitutes {
   } catch {}
 
   const packageJson = readJson(tree, 'package.json');
-  // check if packagejson has packagemanager and its pnpm
-  const packageManagerPrefixPnpm = packageJson?.pnpm?.packageManager;
   const allDependencies = {
     ...packageJson.dependencies,
     ...packageJson.devDependencies,
@@ -95,8 +93,7 @@ function normalizeOptions(options: Schema, tree: Tree): Substitutes {
     packageManagerPrefix,
     packageManagerPreInstallPrefix,
     mainBranch: deduceDefaultBase(),
-    hasPnpmVersion:
-      packageManagerPrefixPnpm && !!packageManagerPrefixPnpm?.split('@')[1],
+    packageManagerVersion: packageJson?.packageManager?.split('@')[1],
     hasCypress,
     hasE2E,
     hasPlaywright,

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -24,18 +24,18 @@ jobs:
         with:
           bun-version: latest
       <% } else if (packageManager == 'npm'){ %>
-      ## NPM versions that are > v8 has a npm error `Exit handler never called` which has been solved in Node 22.5.1 
+      ## NPM versions that are > v8 has a npm error `Exit handler never called` which has been solved in Node 22.5.1
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
       ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
-      <% } else if(packageManager === 'yarn'){ %>
-      - run: <%- packageManagerVersion ? 'corepack enable' : "corepack prepare 'yarn@1.22'" %>
+      <% } else if (packageManager === 'yarn' && packageManagerVersion) { %>
+      - run: corepack enable
       <% } else if(packageManager ==='pnpm'){ %>
       - uses: pnpm/action-setup@v4
         name: Install pnpm
-        with:
-          version: <%- packageManagerVersion ? packageManagerVersion : '9.8.0' %>
+        with:<% if (!packageManagerVersion) { %>
+          version: 9.8.0<% } %>
           run_install: false
       <% } %>
       # This enables task distribution via Nx Cloud

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -19,11 +19,14 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      <% if(packageManager == 'pnpm'){ %>
+      <% if(packageManager === 'pnpm'){ %>
       - uses: pnpm/action-setup@v4
+      <% if(!hasPnpmVersion){ %>
         with:
           version: 9
+        <% } %>
       <% } %>
+
       <% if(packageManager == 'bun'){ %>
       - uses: oven-sh/setup-bun@v1
         with:

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -18,34 +18,39 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-      <% if(packageManager != 'bun'){ %>
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: '<%= packageManager %>'
-       <% } %>
-      <% if(packageManager == 'bun'){ %>
+
+      <% if(packageManager === 'bun'){ %>
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
       <% } else if (packageManager == 'npm'){ %>
-      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1 
+      ## NPM versions that are > v8 has a npm error `Exit handler never called` which has been solved in Node 22.5.1 
       ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      ## When we upgrade to node 22.5.1 this can be removed.
       - name: Downgrade npm to 8.x
         run: npm install -g npm@8
-      <% } else if(packageManagerVersion){ %>
-      - run: corepack enable
-      <% } else { %>
-      - run: corepack prepare <%- packageManager === 'pnpm' ? 'pnpm@9.8' : 'yarn@1.22' -%>
+      <% } else if(packageManager === 'yarn'){ %>
+      - run: <%- packageManagerVersion ? 'corepack enable' : "corepack prepare 'yarn@1.22'" %>
+      <% } else if(packageManager ==='pnpm'){ %>
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: <%- packageManagerVersion ? packageManagerVersion : '9.8.0' %>
+          run_install: false
       <% } %>
-
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       <% if (connectedToCloud) { %># Uncomment this line to enable task distribution<% } else { %># Connect your workspace by running "nx connect" and uncomment this line to enable task distribution<% } %>
       # - run: <%= packageManagerPreInstallPrefix %> nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="<% if(hasE2E){ %>e2e-ci<% } else { %>build<% } %>"
 
+      <% if(packageManager !== 'bun'){ %>
+      # Cache node_modules
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: '<%= packageManager %>'
+       <% } %>
       - run: <%= packageManagerInstall %><% if(hasCypress){ %>
       - run: <%= packageManagerPrefix %> cypress install<% } %><% if(hasPlaywright){ %>
       - run: <%= packageManagerPrefix %> playwright install --with-deps<% } %>

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -23,12 +23,6 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      <% } else if (packageManager == 'npm'){ %>
-      ## NPM versions that are > v8 has a npm error `Exit handler never called` which has been solved in Node 22.5.1
-      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
-      ## When we upgrade to node 22.5.1 this can be removed.
-      - name: Downgrade npm to 8.x
-        run: npm install -g npm@8
       <% } else if (packageManager === 'yarn' && packageManagerVersion) { %>
       - run: corepack enable
       <% } else if(packageManager ==='pnpm'){ %>

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -18,19 +18,26 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-
-      <% if(packageManager === 'pnpm'){ %>
-      - uses: pnpm/action-setup@v4
-      <% if(!hasPnpmVersion){ %>
+      <% if(packageManager != 'bun'){ %>
+      # Cache node_modules
+      - uses: actions/setup-node@v4
         with:
-          version: 9
-        <% } %>
-      <% } %>
-
+          node-version: 20
+          cache: '<%= packageManager %>'
+       <% } %>
       <% if(packageManager == 'bun'){ %>
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
+      <% } else if (packageManager == 'npm'){ %>
+      ## NPM versions that are > v8 has an issue which has been solved in Node 22.5.1 
+      ## Since we are still on node 20 pin the npm version so that we can install ref: https://github.com/npm/cli/issues/7639
+      - name: Downgrade npm to 8.x
+        run: npm install -g npm@8
+      <% } else if(packageManagerVersion){ %>
+      - run: corepack enable
+      <% } else { %>
+      - run: corepack prepare <%- packageManager === 'pnpm' ? 'pnpm@9.8' : 'yarn@1.22' -%>
       <% } %>
 
       # This enables task distribution via Nx Cloud
@@ -39,13 +46,6 @@ jobs:
       <% if (connectedToCloud) { %># Uncomment this line to enable task distribution<% } else { %># Connect your workspace by running "nx connect" and uncomment this line to enable task distribution<% } %>
       # - run: <%= packageManagerPreInstallPrefix %> nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="<% if(hasE2E){ %>e2e-ci<% } else { %>build<% } %>"
 
-      <% if(packageManager != 'bun'){ %>
-      # Cache node_modules
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: '<%= packageManager %>'
-       <% } %>
       - run: <%= packageManagerInstall %><% if(hasCypress){ %>
       - run: <%= packageManagerPrefix %> cypress install<% } %><% if(hasPlaywright){ %>
       - run: <%= packageManagerPrefix %> playwright install --with-deps<% } %>


### PR DESCRIPTION
This pull request updates the CI workflow configuration to replace the use of `pnpm/action-setup` with `corepack enable` for package manager setup. 

- NPM versions greater than 8 has an error which has been [fixed in Node 22.5.1](https://github.com/npm/cli/issues/7639), since we are still using Node 20 we need to pin the installed npm version to 8.
- Now we are conditionally handling different package managers based on how the repo has been configured.
Should the repository specify the package manager's version for `pnpm` and `yarn` those versions will be respected, else it will fallback to a `9.8` for `pnpm` and `1.22` for `yarn`.