### PR TITLE
fix(core): reset should clear cloud light client

### DIFF
--- a/packages/nx/src/nx-cloud/update-manager.ts
+++ b/packages/nx/src/nx-cloud/update-manager.ts
@@ -152,7 +152,7 @@ export async function verifyOrUpdateNxCloudClient(
   };
 }
 
-function getBundleInstallDefaultLocation() {
+export function getBundleInstallDefaultLocation() {
   const legacyPath = join(
     workspaceRoot,
     'node_modules',

--- a/packages/nx/src/nx-cloud/utilities/client.ts
+++ b/packages/nx/src/nx-cloud/utilities/client.ts
@@ -15,13 +15,20 @@ export async function getCloudClient(options: CloudTaskRunnerOptions) {
   nxCloudClient.configureLightClientRequire()(paths);
 
   return {
-    invoke: (command: string) => {
+    invoke: (command: string, exit = true) => {
       if (command in nxCloudClient.commands) {
         nxCloudClient.commands[command]()
-          .then(() => process.exit(0))
+          .then(() => {
+            if (exit) {
+              process.exit(0);
+            }
+          })
           .catch((e) => {
             console.error(e);
-            process.exit(1);
+            if (exit) {
+              process.exit(1);
+            }
+            throw e;
           });
       } else {
         throw new UnknownCommandError(


### PR DESCRIPTION
## Current Behavior
Calling `nx reset` doesn't remove the currently installed cloud light client bundle. Additionally, it creates a .nx/cache/cloud directory even if it doesn't have cloud installed.

## Expected Behavior
Calling `nx reset` doesn't remove the currently installed cloud light client bundle

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
