### PR TITLE
docs(nx-cloud): add gradle references

### DIFF
--- a/docs/nx-cloud/features/split-e2e-tasks.md
+++ b/docs/nx-cloud/features/split-e2e-tasks.md
@@ -54,6 +54,13 @@ nx add @nx/jest
 ```
 
 {% /tab %}
+{% tab label="Gradle" %}
+
+```shell {% skipRescope=true %}
+nx add @nx/gradle
+```
+
+{% /tab %}
 {% /tabs %}
 
 This command will register the appropriate plugin in the `plugins` array of `nx.json`.
@@ -75,6 +82,7 @@ If you are already using the `@nx/cypress`, `@nx/playwright`, or `@nx/jest` plug
 - [Configure Cypress Task Splitting](/nx-api/cypress#nxcypress-configuration)
 - [Configure Playwright Task Splitting](/nx-api/playwright#nxplaywright-configuration)
 - [Configure Jest Task Splitting](/nx-api/jest#splitting-e2e-tests)
+- [Configure Gradle Testing Task Splitting](/nx-api/gradle#splitting-tests)
 
 ## Verify Automated Task Splitting Works
 


### PR DESCRIPTION
Update references in "task splitting" to link the Gradle testing task splitting.