### PR TITLE
fix(rspack): must run type check with @nx/rspack:rspack when skipTypeChecking is false

### DIFF
--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -30,7 +30,7 @@ export default async function* runExecutor(
     normalizedOptions.mode = process.env.NODE_ENV;
   }
 
-  if (normalizedOptions.typeCheck) {
+  if (!normalizedOptions.skipTypeChecking) {
     await executeTypeCheck(normalizedOptions, context);
   }
 

--- a/packages/rspack/src/plugins/utils/plugins/normalize-options.ts
+++ b/packages/rspack/src/plugins/utils/plugins/normalize-options.ts
@@ -82,6 +82,37 @@ export function normalizeOptions(
     );
   }
 
+  // Normalize typeCheck and skipTypeChecking options
+  let normalizedTypeCheck: boolean;
+  let normalizedSkipTypeChecking: boolean;
+
+  if (
+    combinedPluginAndMaybeExecutorOptions.typeCheck !== undefined &&
+    combinedPluginAndMaybeExecutorOptions.skipTypeChecking !== undefined
+  ) {
+    // Both options are provided - use typeCheck as the source of truth
+    normalizedTypeCheck = combinedPluginAndMaybeExecutorOptions.typeCheck;
+    normalizedSkipTypeChecking =
+      !combinedPluginAndMaybeExecutorOptions.typeCheck;
+  } else if (combinedPluginAndMaybeExecutorOptions.typeCheck !== undefined) {
+    // Only typeCheck is provided
+    normalizedTypeCheck = combinedPluginAndMaybeExecutorOptions.typeCheck;
+    normalizedSkipTypeChecking =
+      !combinedPluginAndMaybeExecutorOptions.typeCheck;
+  } else if (
+    combinedPluginAndMaybeExecutorOptions.skipTypeChecking !== undefined
+  ) {
+    // Only skipTypeChecking is provided
+    normalizedSkipTypeChecking =
+      combinedPluginAndMaybeExecutorOptions.skipTypeChecking;
+    normalizedTypeCheck =
+      !combinedPluginAndMaybeExecutorOptions.skipTypeChecking;
+  } else {
+    // Neither option is provided - use defaults
+    normalizedTypeCheck = true;
+    normalizedSkipTypeChecking = false;
+  }
+
   return {
     ...combinedPluginAndMaybeExecutorOptions,
     assets: combinedPluginAndMaybeExecutorOptions.assets
@@ -126,6 +157,7 @@ export function normalizeOptions(
       combinedPluginAndMaybeExecutorOptions.sassImplementation ??
       'sass-embedded',
     scripts: combinedPluginAndMaybeExecutorOptions.scripts ?? [],
+    skipTypeChecking: normalizedSkipTypeChecking,
     sourceMap: combinedPluginAndMaybeExecutorOptions.sourceMap ?? !isProd,
     sourceRoot,
     styles: combinedPluginAndMaybeExecutorOptions.styles ?? [],
@@ -133,6 +165,7 @@ export function normalizeOptions(
       combinedPluginAndMaybeExecutorOptions.subresourceIntegrity ?? false,
     target: combinedPluginAndMaybeExecutorOptions.target ?? 'web',
     targetName,
+    typeCheck: normalizedTypeCheck,
     vendorChunk: combinedPluginAndMaybeExecutorOptions.vendorChunk ?? !isProd,
   };
 }


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
- Create a project that uses @nx/rspack:rspack as build target with SkipTypeChecking set to false.
- Run build target for project.
- Type check has not been run and will not bail in case of any typescript errors

<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- It should run type checking as documented: https://nx.dev/nx-api/rspack/executors/rspack#skiptypechecking
I looked at the webpack executor and there it also runs the type check based on `skipTypeChecking` and not the `typeCheck` alias. So I've adjusted it accordingly for the rspack executor.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31026 
