### PR TITLE
fix(core): exit the command with sigint if it is interrupted

### DIFF
--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -271,7 +271,7 @@ async function runPublishOnProjects(
    * NOTE: Force TUI to be disabled for now.
    */
   process.env.NX_TUI = 'false';
-  const commandResults = await runCommandForTasks(
+  const { taskResults } = await runCommandForTasks(
     projectsWithTarget,
     projectGraph,
     { nxJson },
@@ -289,13 +289,13 @@ async function runPublishOnProjects(
   );
 
   const publishProjectsResult: PublishProjectsResult = {};
-  for (const taskData of Object.values(commandResults)) {
+  for (const taskData of Object.values(taskResults)) {
     publishProjectsResult[taskData.task.target.project] = {
       code: taskData.code,
     };
   }
   await runPostTasksExecution({
-    taskResults: commandResults,
+    taskResults,
     workspaceRoot,
     nxJsonConfiguration: nxJson,
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When tasks are still running but the user exits the TUI, Nx returns exit code 0 (success)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When tasks are still running but the user exits the TUI, Nx returns exit code 130 (SIGINT)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
