### PR TITLE
fix(core): q should exit tui immediately if all tasks complete

### DIFF
--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -146,9 +146,11 @@ impl CountdownPopup {
         let content = vec![
             Line::from(vec![
                 Span::styled("• Press ", Style::default().fg(Color::DarkGray)),
-                Span::styled("any key", Style::default().fg(Color::Cyan)),
+                Span::styled("q to exit immediately ", Style::default().fg(Color::Cyan)),
+                Span::styled("or ", Style::default().fg(Color::DarkGray)),
+                Span::styled("any other key ", Style::default().fg(Color::Cyan)),
                 Span::styled(
-                    " to keep the TUI running and interactively explore the results.",
+                    "to keep the TUI running and interactively explore the results.",
                     Style::default().fg(Color::DarkGray),
                 ),
             ]),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`q` **always** triggers the exit countdown (designed to prevent accidental exits which are super annoying)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`q` exits immediately if all the tasks are complete and only triggers the exit countdown if at least one task is in progress. Also documents the fact that a second `q` will exit immediately and override the countdown which was already supported.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
