### PR TITLE
fix(core): tui summary should show cancelled when interrupting dev server

### DIFF
--- a/packages/nx/src/tasks-runner/task-graph-utils.ts
+++ b/packages/nx/src/tasks-runner/task-graph-utils.ts
@@ -192,3 +192,37 @@ class NonParallelTaskDependsOnContinuousTasksError extends Error {
     this.name = 'NonParallelTaskDependsOnContinuousTasksError';
   }
 }
+
+export function getLeafTasks(taskGraph: TaskGraph): Set<string> {
+  const reversed = reverseTaskGraph(taskGraph);
+  const leafTasks = new Set<string>();
+  for (const [taskId, dependencies] of Object.entries(reversed.dependencies)) {
+    if (dependencies.length === 0) {
+      leafTasks.add(taskId);
+    }
+  }
+
+  return leafTasks;
+}
+
+function reverseTaskGraph(taskGraph: TaskGraph): TaskGraph {
+  const reversed = {
+    tasks: taskGraph.tasks,
+    dependencies: Object.fromEntries(
+      Object.entries(taskGraph.tasks).map(([taskId]) => [taskId, []])
+    ),
+  } as TaskGraph;
+  for (const [taskId, dependencies] of Object.entries(taskGraph.dependencies)) {
+    for (const dependency of dependencies) {
+      reversed.dependencies[dependency].push(taskId);
+    }
+  }
+  for (const [taskId, dependencies] of Object.entries(
+    taskGraph.continuousDependencies
+  )) {
+    for (const dependency of dependencies) {
+      reversed.dependencies[dependency].push(taskId);
+    }
+  }
+  return reversed;
+}


### PR DESCRIPTION
## Current Behavior
Interrupting a serve task with `Control + C` displays a "Success" message, which isn't quite accurate.

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/b7e7086d-2725-4c65-b1f6-9f8a5db5196a" />


## Expected Behavior
Interrupting a serve task displays a "Cancelled" message

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/698e6e43-a376-473a-ab4f-7d514026ff02" />


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
