### PR TITLE
fix(linter): fix generator '@nx/eslint:convert-to-flat-config' on win…

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
@@ -1,6 +1,7 @@
 import { Tree, readJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { convertEslintJsonToFlatConfig } from './json-converter';
+import { EOL } from 'node:os';
 
 describe('convertEslintJsonToFlatConfig', () => {
   let tree: Tree;
@@ -63,7 +64,7 @@ describe('convertEslintJsonToFlatConfig', () => {
         })
       );
 
-      tree.write('.eslintignore', 'node_modules\nsomething/else');
+      tree.write('.eslintignore', `node_modules${EOL}something/else`);
 
       const { content } = convertEslintJsonToFlatConfig(
         tree,
@@ -227,7 +228,7 @@ describe('convertEslintJsonToFlatConfig', () => {
         })
       );
 
-      tree.write('mylib/.eslintignore', 'node_modules\nsomething/else');
+      tree.write('mylib/.eslintignore', `node_modules${EOL}something/else`);
 
       const { content } = convertEslintJsonToFlatConfig(
         tree,
@@ -376,7 +377,7 @@ describe('convertEslintJsonToFlatConfig', () => {
         })
       );
 
-      tree.write('.eslintignore', 'node_modules\nsomething/else');
+      tree.write('.eslintignore', `node_modules${EOL}something/else`);
 
       const { content } = convertEslintJsonToFlatConfig(
         tree,
@@ -537,7 +538,7 @@ describe('convertEslintJsonToFlatConfig', () => {
         })
       );
 
-      tree.write('mylib/.eslintignore', 'node_modules\nsomething/else');
+      tree.write('mylib/.eslintignore', `node_modules${EOL}something/else`);
 
       const { content } = convertEslintJsonToFlatConfig(
         tree,

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -12,6 +12,7 @@ import {
 } from '../../utils/flat-config/ast-utils';
 import { getPluginImport } from '../../utils/eslint-file';
 import { mapFilePath } from '../../utils/flat-config/path-utils';
+import { EOL } from 'node:os';
 
 /**
  * Converts an ESLint JSON config to a flat config.
@@ -185,7 +186,7 @@ export function convertEslintJsonToFlatConfig(
     if (tree.exists(ignorePath)) {
       const patterns = tree
         .read(ignorePath, 'utf-8')
-        .split('\n')
+        .split(EOL)
         .filter((line) => line.length > 0 && line !== 'node_modules')
         .map((path) => mapFilePath(path));
       if (patterns.length > 0) {

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -12,7 +12,6 @@ import {
 } from '../../utils/flat-config/ast-utils';
 import { getPluginImport } from '../../utils/eslint-file';
 import { mapFilePath } from '../../utils/flat-config/path-utils';
-import { EOL } from 'node:os';
 
 /**
  * Converts an ESLint JSON config to a flat config.
@@ -186,7 +185,7 @@ export function convertEslintJsonToFlatConfig(
     if (tree.exists(ignorePath)) {
       const patterns = tree
         .read(ignorePath, 'utf-8')
-        .split(EOL)
+        .split(/\r\n|\r|\n/)
         .filter((line) => line.length > 0 && line !== 'node_modules')
         .map((path) => mapFilePath(path));
       if (patterns.length > 0) {


### PR DESCRIPTION
…dows

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `nx g @nx/eslint:convert-to-flat-config` on windows, the ignores path is not handled correctly. After converting, the path will have the additional `/r`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When running `nx g @nx/eslint:convert-to-flat-config` on windows, the ignores path should be correct.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
NA
