### PR TITLE
fix(core): Update React,Vue and Node generators applications for CNW

### DIFF
--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -850,7 +850,7 @@ async function normalizeOptions(
   }
 
   if (options.publishable) {
-    if (!options.importPath) {
+    if (!isUsingTsSolutionConfig && !options.importPath) {
       throw new Error(
         `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
       );

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -64,7 +64,11 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
 
   const options = await normalizeOptions(host, schema);
 
-  if (options.publishable === true && !schema.importPath) {
+  if (
+    options.publishable === true &&
+    !options.isUsingTsSolutionConfig &&
+    !schema.importPath
+  ) {
     throw new Error(
       `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
     );

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -91,7 +91,7 @@ async function createPreset(tree: Tree, options: Schema) {
     const bundler = options.bundler ?? 'vite';
 
     return reactApplicationGenerator(tree, {
-      name: options.workspaces ? undefined : options.name,
+      name: options.name,
       directory: '.',
       style: options.style,
       linter: options.linter,
@@ -128,7 +128,7 @@ async function createPreset(tree: Tree, options: Schema) {
       '/vue');
 
     return vueApplicationGenerator(tree, {
-      name: options.workspaces ? undefined : options.name,
+      name: options.name,
       directory: '.',
       style: options.style,
       linter: options.linter,
@@ -143,7 +143,7 @@ async function createPreset(tree: Tree, options: Schema) {
       '/nuxt');
 
     return nuxtApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       style: options.style,
       linter: options.linter,
@@ -175,7 +175,7 @@ async function createPreset(tree: Tree, options: Schema) {
       '/next');
 
     return nextApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       style: options.style,
       linter: options.linter,
@@ -209,7 +209,7 @@ async function createPreset(tree: Tree, options: Schema) {
       '/web');
 
     return webApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       style: options.style,
       linter: options.linter,
@@ -223,7 +223,7 @@ async function createPreset(tree: Tree, options: Schema) {
       '/nest');
 
     return nestApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       linter: options.linter,
       e2eTestRunner: options.e2eTestRunner ?? 'jest',
@@ -238,7 +238,7 @@ async function createPreset(tree: Tree, options: Schema) {
       applicationGenerator: expressApplicationGenerator,
     } = require('@nx' + '/express');
     return expressApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       linter: options.linter,
       e2eTestRunner: options.e2eTestRunner ?? 'jest',
@@ -252,7 +252,7 @@ async function createPreset(tree: Tree, options: Schema) {
     const { reactNativeApplicationGenerator } = require('@nx' +
       '/react-native');
     return reactNativeApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       linter: options.linter,
       e2eTestRunner: options.e2eTestRunner ?? 'detox',
@@ -267,7 +267,7 @@ async function createPreset(tree: Tree, options: Schema) {
   } else if (options.preset === Preset.Expo) {
     const { expoApplicationGenerator } = require('@nx' + '/expo');
     return expoApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       linter: options.linter,
       e2eTestRunner: options.e2eTestRunner ?? 'detox',

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -67,7 +67,7 @@ async function createPreset(tree: Tree, options: Schema) {
       '/react');
 
     return reactApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       style: options.style,
       linter: options.linter,
@@ -91,7 +91,7 @@ async function createPreset(tree: Tree, options: Schema) {
     const bundler = options.bundler ?? 'vite';
 
     return reactApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: '.',
       style: options.style,
       linter: options.linter,
@@ -111,7 +111,7 @@ async function createPreset(tree: Tree, options: Schema) {
       '/vue');
 
     return vueApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       style: options.style,
       linter: options.linter,
@@ -128,7 +128,7 @@ async function createPreset(tree: Tree, options: Schema) {
       '/vue');
 
     return vueApplicationGenerator(tree, {
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: '.',
       style: options.style,
       linter: options.linter,
@@ -302,7 +302,7 @@ async function createPreset(tree: Tree, options: Schema) {
     const bundler = options.bundler === 'webpack' ? 'webpack' : 'esbuild';
     return nodeApplicationGenerator(tree, {
       bundler,
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: '.',
       linter: options.linter,
       standaloneConfig: options.standaloneConfig,
@@ -319,7 +319,7 @@ async function createPreset(tree: Tree, options: Schema) {
     const bundler = options.bundler === 'webpack' ? 'webpack' : 'esbuild';
     return nodeApplicationGenerator(tree, {
       bundler,
-      name: options.name,
+      name: options.workspaces ? undefined : options.name,
       directory: join('apps', options.name),
       linter: options.linter,
       framework: options.framework,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
- Currently, when we create a React, Vue or Node app we add the app name inside `package.json` under the nx 
```
{
  "name": "@myworkspace/acme",
  "version": "0.0.1",
  "private": true,
  "nx": {
    "name": "acme"
  }
}

```

- When we create a publishable library using React/JS generator inside a ts project references workspace the `--importPath` option.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- Since the original intention is not known we should not automatically add this to the project's `package.json`
- `importPath` option should not be required when using ts project references.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
For workspaces that are not using TS project references the result remains unchanged.

Fixes #
