### PR TITLE
chore(core): fix docs release script for single version

### DIFF
--- a/scripts/release-docs.ts
+++ b/scripts/release-docs.ts
@@ -11,11 +11,14 @@ const currentVersion = process.env.GITHUB_REF_NAME || '';
 console.log(`Comparing ${currentVersion} to npm versions`);
 
 const majorVersion = major(currentVersion);
-const releasedVersions: string[] = JSON.parse(
+let releasedVersions: string[] = JSON.parse(
   execSync(`npm show nx@^${majorVersion} version --json`, {
     windowsHide: false,
   }).toString()
 );
+if (typeof releasedVersions === 'string') {
+  releasedVersions = [releasedVersions];
+}
 
 const latestVersion = maxSatisfying(releasedVersions, `^${majorVersion}`);
 


### PR DESCRIPTION
Fixes an issue with the docs release script when there is only one version in a particular major version.

The `npm show [version] --json` command normally returns an array of strings, but if there is only one version returned, it tries to be helpful by returning a string instead. This fix normalizes that behavior.