### PR TITLE
docs(gradle): fix link in overview doc

### DIFF
--- a/docs/generated/packages/gradle/documents/overview.md
+++ b/docs/generated/packages/gradle/documents/overview.md
@@ -170,7 +170,7 @@ The `@nx/gradle` plugin will automatically split your testing tasks by test clas
 
 ### Continuous Tasks
 
-Gradle doesn't have a standard way to identify tasks which are [continuous](https://nx-dev-git-docs-gradle-publish-nrwl.vercel.app/reference/project-configuration#continuous), like `bootRun` for serving a Spring Boot project. To ensure Nx handles these continuous tasks correctly, you can explicitly mark them as continuous.
+Gradle doesn't have a standard way to identify tasks which are [continuous](/reference/project-configuration#continuous), like `bootRun` for serving a Spring Boot project. To ensure Nx handles these continuous tasks correctly, you can explicitly mark them as continuous.
 
 {% tabs %}
 {% tab label="nx.json" %}

--- a/docs/shared/packages/gradle/gradle-plugin.md
+++ b/docs/shared/packages/gradle/gradle-plugin.md
@@ -170,7 +170,7 @@ The `@nx/gradle` plugin will automatically split your testing tasks by test clas
 
 ### Continuous Tasks
 
-Gradle doesn't have a standard way to identify tasks which are [continuous](https://nx-dev-git-docs-gradle-publish-nrwl.vercel.app/reference/project-configuration#continuous), like `bootRun` for serving a Spring Boot project. To ensure Nx handles these continuous tasks correctly, you can explicitly mark them as continuous.
+Gradle doesn't have a standard way to identify tasks which are [continuous](/reference/project-configuration#continuous), like `bootRun` for serving a Spring Boot project. To ensure Nx handles these continuous tasks correctly, you can explicitly mark them as continuous.
 
 {% tabs %}
 {% tab label="nx.json" %}


### PR DESCRIPTION
## Current Behavior
The link to Continuous Tasks is pointing to a preview site.

## Expected Behavior
The link should remain on the production site.
