### PR TITLE
docs(angular): update angular rspack docs to reflect recent updates

### DIFF
--- a/docs/blog/2025-03-19-using-angular-with-rspack.md
+++ b/docs/blog/2025-03-19-using-angular-with-rspack.md
@@ -206,14 +206,14 @@ Given that the primary goal for Angular Rspack is to provide a faster build syst
 
 The following are known limitations and missing features of Angular Rspack:
 
-- Static Site Generation (SSG) is not supported.
-- Angular's built-in support for Internationalization (i18n) is not supported.
+- Static Site Generation (SSG) is not supported. _**UPDATE**: As of Angular Rspack version 20.9, SSG is supported._
+- Angular's built-in support for Internationalization (i18n) is not supported. _**UPDATE**: As of Angular Rspack version 20.8, i18n is supported._
 - Server Routing is not supported - still experimental in Angular currently.
 - App Engine APIs are not supported - still experimental in Angular currently.
 - Optimization is not currently 1:1 with Angular's optimization - however, there are still great optimizations that are made.
   - Styles optimization for `inline-critical` and `remove-special-comments` are not yet implemented.
   - Inlining of fonts is not yet implemented.
-- Web Workers are not fully supported.
+- Web Workers are not fully supported. _**UPDATE**: As of Angular Rspack version 20.8, Web Workers are supported._
 - Hot Module Replacement (HMR) is partially supported.
 
 If you have any other missing features or limitations, please [let us know](https://github.com/nrwl/angular-rspack/issues/new).

--- a/docs/blog/2025-04-14-scaffold-angular-rspack-applications.md
+++ b/docs/blog/2025-04-14-scaffold-angular-rspack-applications.md
@@ -131,6 +131,9 @@ It’s been great to see the progress on Angular Rspack so far, but it’s not d
 - Static Site Generation (SSG) support
 - and more!
 
+**[UPDATE - 2025-04-25]** - We've released version 20.8 of Angular Rspack that includes support for i18n.
+**[UPDATE - 2025-05-06]** - We've released version 20.9 of Angular Rspack that includes support for SSG.
+
 Stay tuned to our socials to stay up to date on the latest Angular Rspack news!
 
 - 🧠 [**Nx Docs**](/getting-started/intro)

--- a/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
+++ b/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
@@ -53,5 +53,6 @@ Below is a reference table that matches versions of [Angular Rspack](/recipes/an
 
 | Angular Rspack | Angular     | Nx                  |
 | -------------- | ----------- | ------------------- |
+| ~20.8.0        | **~19.2.0** | >= 20.8.1 <= latest |
 | ~20.7.0        | **~19.2.0** | >= 20.8.1 <= latest |
 | ~20.6.0        | **~19.2.0** | >= 20.6.0 <= latest |

--- a/docs/shared/guides/angular-rspack/introduction.md
+++ b/docs/shared/guides/angular-rspack/introduction.md
@@ -39,13 +39,11 @@ Please not that Angular Rspack support is still experimental and is not yet cons
 
 The following are known limitations and missing features of Angular Rspack:
 
-- Static Site Generation (SSG) is not supported.
 - Server Routing is not supported - still experimental in Angular currently.
 - App Engine APIs are not supported - still experimental in Angular currently.
 - Optimization is not currently 1:1 with Angular's optimization - however, there are still great optimizations that are made.
   - Styles optimization for `inline-critical` and `remove-special-comments` are not yet implemented.
   - Inlining of fonts is not yet implemented.
-- Web Workers are not fully supported.
 - Hot Module Replacement (HMR) is partially supported.
 
 If you have any other missing features or limitations, please [let us know](https://github.com/nrwl/angular-rspack/issues/new).

--- a/docs/shared/packages/angular/angular-nx-version-matrix.md
+++ b/docs/shared/packages/angular/angular-nx-version-matrix.md
@@ -53,5 +53,6 @@ Below is a reference table that matches versions of [Angular Rspack](/recipes/an
 
 | Angular Rspack | Angular     | Nx                  |
 | -------------- | ----------- | ------------------- |
+| ~20.8.0        | **~19.2.0** | >= 20.8.1 <= latest |
 | ~20.7.0        | **~19.2.0** | >= 20.8.1 <= latest |
 | ~20.6.0        | **~19.2.0** | >= 20.6.0 <= latest |


### PR DESCRIPTION
## Current Behavior
The docs on Angular Rspack's supported features are outdated

## Expected Behavior
Update the supported features for Angular Rspack
