### PR TITLE
fix(core): fail nx release cli when publish step fails

### DIFF
--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -364,7 +364,14 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     }
 
     if (shouldPublish) {
-      await releasePublish(args);
+      const publishResults = await releasePublish(args);
+      const allExitOk = Object.values(publishResults).every(
+        (result) => result.code === 0
+      );
+      if (!allExitOk) {
+        // When a publish target fails, we want to fail the nx release CLI
+        process.exit(1);
+      }
     } else {
       output.logSingleLine('Skipped publishing packages.');
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `nx release` and a publish targets fails, the cli is not failing

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The cli exists with a code 1 when a publish target fails

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31069
