### PR TITLE
feat(core): update getTouchedProjectsFromLockFile to detect which projects were changed from pnpm lock file diff

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.spec.ts
@@ -1,10 +1,17 @@
 import { ProjectGraph } from '../../../../config/project-graph';
 import { WholeFileChange } from '../../../../project-graph/file-utils';
-import { getTouchedProjectsFromLockFile } from './lock-file-changes';
+import {
+  getTouchedProjectsFromLockFile,
+  PNPM_LOCK_FILES,
+} from './lock-file-changes';
+import { TempFs } from '../../../../internal-testing-utils/temp-fs';
+import { JsonDiffType } from '../../../../utils/json-diff';
+// const tempFs = new TempFs('lock-file-changes-test');
 
 describe('getTouchedProjectsFromLockFile', () => {
   let graph: ProjectGraph;
   let allNodes = [];
+  let tempFs: TempFs;
 
   beforeEach(() => {
     graph = {
@@ -71,6 +78,98 @@ describe('getTouchedProjectsFromLockFile', () => {
           graph.nodes
         );
         expect(result).toEqual(allNodes);
+      });
+    });
+  });
+
+  PNPM_LOCK_FILES.forEach((lockFile) => {
+    describe(`"${lockFile} with projectsAffectedByDependencyUpdates set to auto"`, () => {
+      beforeAll(async () => {
+        tempFs = new TempFs('lock-file-changes-test');
+        await tempFs.createFiles({
+          './nx.json': JSON.stringify({
+            pluginsConfig: {
+              '@nx/js': {
+                projectsAffectedByDependencyUpdates: 'auto',
+              },
+            },
+          }),
+        });
+      });
+
+      afterAll(() => {
+        tempFs.cleanup();
+      });
+
+      it(`should not return changes when "${lockFile}" is not touched`, () => {
+        const result = getTouchedProjectsFromLockFile(
+          [
+            {
+              file: 'source.ts',
+              hash: 'some-hash',
+              getChanges: () => [new WholeFileChange()],
+            },
+          ],
+          graph.nodes
+        );
+        expect(result).toEqual([]);
+      });
+
+      it(`should not return changes when whole lock file "${lockFile}" is changed`, () => {
+        const result = getTouchedProjectsFromLockFile(
+          [
+            {
+              file: lockFile,
+              hash: 'some-hash',
+              getChanges: () => [new WholeFileChange()],
+            },
+          ],
+          graph.nodes
+        );
+        expect(result).toEqual([]);
+      });
+
+      it(`should return only changed projects when "${lockFile}" is touched`, () => {
+        const result = getTouchedProjectsFromLockFile(
+          [
+            {
+              file: lockFile,
+              hash: 'some-hash',
+              getChanges: () => [
+                {
+                  type: JsonDiffType.Modified,
+                  path: [
+                    'importers',
+                    'libs/proj1',
+                    'dependencies',
+                    'some-external-package',
+                    'version',
+                  ],
+                  value: {
+                    lhs: '0.0.1',
+                    rhs: '0.0.2',
+                  },
+                },
+                {
+                  type: JsonDiffType.Added,
+                  path: [
+                    'importers',
+                    'apps/app1',
+                    'devDependencies',
+                    'some-other-external-package',
+                    'version',
+                  ],
+                  value: {
+                    lhs: undefined,
+                    rhs: '4.0.1',
+                  },
+                },
+              ],
+            },
+          ],
+          graph.nodes
+        );
+        expect(result).toEqual(['proj1', 'app1']);
       });
     });
   });

--- a/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.spec.ts
@@ -6,7 +6,6 @@ import {
 } from './lock-file-changes';
 import { TempFs } from '../../../../internal-testing-utils/temp-fs';
 import { JsonDiffType } from '../../../../utils/json-diff';
-// const tempFs = new TempFs('lock-file-changes-test');
 
 describe('getTouchedProjectsFromLockFile', () => {
   let graph: ProjectGraph;

--- a/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.ts
@@ -1,9 +1,23 @@
 import { readNxJson } from '../../../../config/configuration';
 import { TouchedProjectLocator } from '../../../../project-graph/affected/affected-project-graph-models';
-import { WholeFileChange } from '../../../../project-graph/file-utils';
-import { JsonChange } from '../../../../utils/json-diff';
+import {
+  FileChange,
+  WholeFileChange,
+} from '../../../../project-graph/file-utils';
+import { isJsonChange, JsonChange } from '../../../../utils/json-diff';
 import { jsPluginConfig as readJsPluginConfig } from '../../utils/config';
 import { findMatchingProjects } from '../../../../utils/find-matching-projects';
+import { ProjectGraphProjectNode } from '../../../../config/project-graph';
+
+export const PNPM_LOCK_FILES = ['pnpm-lock.yaml', 'pnpm-lock.yml'];
+
+const ALL_LOCK_FILES = [
+  ...PNPM_LOCK_FILES,
+  'package-lock.json',
+  'yarn.lock',
+  'bun.lockb',
+  'bun.lock',
+];
 
 export const getTouchedProjectsFromLockFile: TouchedProjectLocator<
   WholeFileChange | JsonChange
@@ -11,8 +25,18 @@ export const getTouchedProjectsFromLockFile: TouchedProjectLocator<
   const nxJson = readNxJson();
   const { projectsAffectedByDependencyUpdates } = readJsPluginConfig(nxJson);
 
+  const changedLockFile = fileChanges.find((f) =>
+    ALL_LOCK_FILES.includes(f.file)
+  );
+
   if (projectsAffectedByDependencyUpdates === 'auto') {
-    return [];
+    const changedProjectPaths =
+      getProjectPathsAffectedByDependencyUpdates(changedLockFile);
+    const changedProjectNames = getProjectsNamesFromPaths(
+      projectGraphNodes,
+      changedProjectPaths
+    );
+    return changedProjectNames;
   } else if (Array.isArray(projectsAffectedByDependencyUpdates)) {
     return findMatchingProjects(
       projectsAffectedByDependencyUpdates,
@@ -20,17 +44,57 @@ export const getTouchedProjectsFromLockFile: TouchedProjectLocator<
     );
   }
 
-  const lockFiles = [
-    'package-lock.json',
-    'yarn.lock',
-    'pnpm-lock.yaml',
-    'pnpm-lock.yml',
-    'bun.lockb',
-    'bun.lock',
-  ];
-
-  if (fileChanges.some((f) => lockFiles.includes(f.file))) {
+  if (changedLockFile) {
     return Object.values(projectGraphNodes).map((p) => p.name);
   }
   return [];
 };
+
+/**
+ * For pnpm projects, check lock file for changes to importers and return the project paths that have changes.
+ */
+const getProjectPathsAffectedByDependencyUpdates = (
+  changedLockFile?: FileChange<WholeFileChange | JsonChange>
+): string[] => {
+  if (!changedLockFile) {
+    return [];
+  }
+  const changedProjectPaths = new Set<string>();
+  if (PNPM_LOCK_FILES.includes(changedLockFile.file)) {
+    for (const change of changedLockFile.getChanges()) {
+      if (
+        isJsonChange(change) &&
+        change.path[0] === 'importers' &&
+        change.path[1] !== undefined
+      ) {
+        changedProjectPaths.add(change.path[1]);
+      }
+    }
+  }
+  return Array.from(changedProjectPaths);
+};
+
+const getProjectsNamesFromPaths = (
+  projectGraphNodes: Record<string, ProjectGraphProjectNode>,
+  projectPaths: string[]
+): string[] => {
+  const lookup = new RootPathLookup(projectGraphNodes);
+  return projectPaths.map((path) => {
+    return lookup.findNodeNameByRoot(path);
+  });
+};
+
+class RootPathLookup {
+  private rootToNameMap: Map<string, string>;
+
+  constructor(nodes: Record<string, ProjectGraphProjectNode>) {
+    this.rootToNameMap = new Map();
+    Object.entries(nodes).forEach(([name, node]) => {
+      this.rootToNameMap.set(node.data.root, name);
+    });
+  }
+
+  findNodeNameByRoot(root: string): string | undefined {
+    return this.rootToNameMap.get(root);
+  }
+}

--- a/packages/nx/src/project-graph/file-utils.ts
+++ b/packages/nx/src/project-graph/file-utils.ts
@@ -76,6 +76,16 @@ export function calculateFileChanges(
             } catch (e) {
               return [new WholeFileChange()];
             }
+          case '.yml':
+          case '.yaml':
+            const { load } = require('@zkochan/js-yaml');
+            try {
+              const atBase = readFileAtRevision(f, nxArgs.base);
+              const atHead = readFileAtRevision(f, nxArgs.head);
+              return jsonDiff(load(atBase), load(atHead));
+            } catch (e) {
+              return [new WholeFileChange()];
+            }
           default:
             return [new WholeFileChange()];
         }


### PR DESCRIPTION
…jects were changed from pnpm lock file diff

Closes #29986

## Current Behavior

Nx projects that use pnpm catalogs cannot take advantage of the  `projectsAffectedByDependencyUpdates` `“auto”` setting because updating catalog versions does not touch project files.

## Expected Behavior

When `projectsAffectedByDependencyUpdates` is set to `“auto”`, updating a catalog dependency version should result in all projects that use it getting marked as affected.

A catalog version update and the affected projects can be detected from a changed pnpm lock file. This PR updates the `getTouchedProjectsFromLockFile` logic to check the lock file for pnpm monorepos.

Example pnpm lock file diff after catalog dependency update:

```diff
# pnpm-lock.yaml

# ...

catalogs:
  default:
    '@aws-sdk/client-s3':
-      specifier: ^3.535.0
-      version: 3.535.0
+      specifier: ^3.797.0
+      version: 3.797.0

importers:

  apps/app1:
    dependencies:
      '@aws-sdk/client-s3':
        specifier: 'catalog:'
-        version: 3.535.0
+        version: 3.797.0

# ...
```

## Related Issue(s)

https://github.com/nrwl/nx/issues/29986

Fixes #29986
