### PR TITLE
chore(repo): enforce clippy

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,1 @@
-pnpm check-lock-files
-pnpm pretty-quick --check
-NX_TUI=false pnpm nx format-native nx
-NX_TUI=false pnpm nx lint-native nx
-pnpm check-commit
-pnpm documentation
+pnpm nx prepush --parallel 8 --tuiAutoExit 0

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "commit": "czg",
     "check-commit": "node ./scripts/commit-lint.js",
     "check-format": "nx format:check --all",
+    "check-format:quick": "pretty-quick --check",
     "check-imports": "node ./scripts/check-imports.js",
     "check-lock-files": "node ./scripts/check-lock-files.js",
     "check-documentation-map": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/map-link-checker.ts",
@@ -407,6 +408,7 @@
       "echo",
       "check-commit",
       "check-format",
+      "check-format:quick",
       "check-imports",
       "check-lock-files",
       "check-codeowners"

--- a/project.json
+++ b/project.json
@@ -74,6 +74,9 @@
         "{workspaceRoot}/docs/generated"
       ]
     },
+    "check-format:quick": {
+      "parallelism": false
+    },
     "lint": {
       "dependsOn": ["@nx/nx-source:lint-pnpm-lock"],
       "cache": true,
@@ -82,6 +85,16 @@
     "lint-pnpm-lock": {
       "cache": true,
       "inputs": ["{projectRoot}/pnpm-lock.yaml"]
+    },
+    "prepush": {
+      "dependsOn": [
+        "nx:format-native",
+        "nx:lint-native",
+        "documentation",
+        "check-commit",
+        "check-format:quick",
+        "check-lock-files"
+      ]
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Clippy is not enforced in CI

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Clippy is enforced in CI and is run in the prepush hooks.

Also, I made the prepush hooks all 1 `nx run-many` command so it makes use of parallel instead of running sequentially. And I made the TUI auto exit for the prepush.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
