### PR TITLE
fix(angular): update ng-packagr-lite executor adjustments to handle destination file changes

### DIFF
--- a/e2e/angular/src/tailwind.test.ts
+++ b/e2e/angular/src/tailwind.test.ts
@@ -180,7 +180,7 @@ describe('Tailwind support', () => {
       const builtComponentContent = readFile(
         isPublishable
           ? `dist/${lib}/fesm2022/${project}-${lib}.mjs`
-          : `dist/${lib}/esm2022/lib/foo.component.mjs`
+          : `dist/${lib}/esm2022/lib/foo.component.js`
       );
       let expectedStylesRegex = new RegExp(
         `styles: \\[\\"\\.custom\\-btn(\\[_ngcontent\\-%COMP%\\])?{margin:${libSpacing.md};padding:${libSpacing.sm}}(\\\\n)?\\"\\]`

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/entry-point.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/entry-point.ts
@@ -3,16 +3,20 @@ import type {
   NgEntryPoint as NgEntryPointBase,
 } from 'ng-packagr/src/lib/ng-package/entry-point/entry-point';
 import type { NgPackageConfig } from 'ng-packagr/src/ng-package.schema';
-import { dirname } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { getNgPackagrVersionInfo } from '../../../../utilities/ng-packagr/ng-packagr-version';
 import { importNgPackagrPath } from '../../../../utilities/ng-packagr/package-imports';
+
+export type NgEntryPointType = NgEntryPointBase & {
+  primaryDestinationPath?: string;
+};
 
 export function createNgEntryPoint(
   packageJson: Record<string, any>,
   ngPackageJson: NgPackageConfig,
   basePath: string,
   secondaryData?: Record<string, any>
-): NgEntryPointBase {
+): NgEntryPointType {
   const { major: ngPackagrMajorVersion } = getNgPackagrVersionInfo();
 
   const { NgEntryPoint: NgEntryPointBase } = importNgPackagrPath<
@@ -22,16 +26,92 @@ export function createNgEntryPoint(
     ngPackagrMajorVersion
   );
 
-  class NgEntryPoint extends NgEntryPointBase {
-    /**
-     * Point the FESM2022 files to the ESM2022 files.
-     */
-    public override get destinationFiles(): DestinationFiles {
-      const result = super.destinationFiles;
-      result.fesm2022 = result.esm2022;
-      result.fesm2022Dir = dirname(result.esm2022);
+  if (ngPackagrMajorVersion < 20) {
+    class NgEntryPoint extends NgEntryPointBase {
+      /**
+       * Point the FESM2022 files to the ESM2022 files.
+       */
+      public override get destinationFiles(): DestinationFiles {
+        const result = super.destinationFiles;
+        result.fesm2022 = result.esm2022;
+        result.fesm2022Dir = dirname(result.esm2022);
 
-      return result;
+        return result;
+      }
+    }
+
+    return new NgEntryPoint(
+      packageJson,
+      ngPackageJson,
+      basePath,
+      secondaryData
+    );
+  }
+
+  const { ensureUnixPath } = importNgPackagrPath<
+    typeof import('ng-packagr/src/lib/utils/path')
+  >('ng-packagr/src/lib/utils/path', ngPackagrMajorVersion);
+
+  class NgEntryPoint extends NgEntryPointBase {
+    constructor(
+      public readonly packageJson: Record<string, any>,
+      public readonly ngPackageJson: NgPackageConfig,
+      public readonly basePath: string,
+      private readonly _secondaryData?: Record<string, any>
+    ) {
+      super(packageJson, ngPackageJson, basePath, _secondaryData);
+    }
+
+    public get primaryDestinationPath(): string {
+      return (
+        this._secondaryData?.primaryDestinationPath ?? this.destinationPath
+      );
+    }
+
+    public get destinationFiles(): DestinationFiles {
+      let primaryDestPath = this.destinationPath;
+      let secondaryDir = '';
+
+      if (this._secondaryData) {
+        primaryDestPath = this._secondaryData.primaryDestinationPath;
+        secondaryDir = relative(
+          primaryDestPath,
+          this._secondaryData.destinationPath
+        );
+      }
+
+      const flatModuleFile = this.flatModuleFile;
+      const pathJoinWithDest = (...paths: string[]) =>
+        join(primaryDestPath, ...paths);
+
+      return {
+        directory: ensureUnixPath(secondaryDir),
+        declarations: pathJoinWithDest(
+          'tmp-typings',
+          secondaryDir,
+          `${flatModuleFile}.d.ts`
+        ),
+        // changed to use esm2022
+        declarationsBundled: pathJoinWithDest(
+          'esm2022',
+          secondaryDir,
+          `${flatModuleFile}.d.ts`
+        ),
+        declarationsDir: pathJoinWithDest(secondaryDir),
+        esm2022: pathJoinWithDest(
+          'tmp-esm2022',
+          secondaryDir,
+          `${flatModuleFile}.js`
+        ),
+        // changed to use esm2022
+        fesm2022: pathJoinWithDest(
+          'esm2022',
+          secondaryDir,
+          `${flatModuleFile}.js`
+        ),
+        // changed to use esm2022
+        fesm2022Dir: pathJoinWithDest('esm2022'),
+      };
     }
   }
 

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -10,10 +10,10 @@
 import type { NgEntryPoint } from 'ng-packagr/src/lib/ng-package/entry-point/entry-point';
 import type { NgPackagrOptions } from 'ng-packagr/src/lib/ng-package/options.di';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import { getNgPackagrVersionInfo } from '../../../../utilities/ng-packagr/ng-packagr-version';
 import { importNgPackagrPath } from '../../../../utilities/ng-packagr/package-imports';
-import { createNgEntryPoint } from './entry-point';
+import { createNgEntryPoint, type NgEntryPointType } from './entry-point';
 
 export const writeBundlesTransform = (_options: NgPackagrOptions) => {
   const { major: ngPackagrMajorVersion } = getNgPackagrVersionInfo();
@@ -41,9 +41,13 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
         entry.data.destinationFiles = entryPoint.destinationFiles;
 
         for (const [path, outputCache] of entry.cache.outputCache.entries()) {
+          const normalizedPath = normalizeEsm2022Path(path, entryPoint);
           // write the outputs to the file system
-          await mkdir(dirname(path), { recursive: true });
-          await writeFile(path, outputCache.content);
+          await mkdir(dirname(normalizedPath), { recursive: true });
+          await writeFile(normalizedPath, outputCache.content);
+        }
+        if (!entry.cache.outputCache.size && entryPoint.isSecondaryEntryPoint) {
+          await mkdir(entryPoint.destinationPath, { recursive: true });
         }
       } else if (isPackage(entry)) {
         entry.data = new NgPackage(
@@ -61,7 +65,26 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
   });
 };
 
-function toCustomNgEntryPoint(entryPoint: NgEntryPoint): NgEntryPoint {
+function normalizeEsm2022Path(
+  path: string,
+  entryPoint: NgEntryPointType
+): string {
+  if (!entryPoint.primaryDestinationPath) {
+    return path;
+  }
+
+  if (path.startsWith(join(entryPoint.primaryDestinationPath, 'tmp-esm2022'))) {
+    return path.replace('tmp-esm2022', 'esm2022');
+  }
+
+  if (path.startsWith(join(entryPoint.primaryDestinationPath, 'tmp-typings'))) {
+    return path.replace('tmp-typings', 'esm2022');
+  }
+
+  return path;
+}
+
+function toCustomNgEntryPoint(entryPoint: NgEntryPoint): NgEntryPointType {
   return createNgEntryPoint(
     entryPoint.packageJson,
     entryPoint.ngPackageJson,


### PR DESCRIPTION
Update the `@nx/angular:ng-packagr-lite` executor to handle changes to destination files made in the upstream `ng-packagr` package.
