### PR TITLE
docs(nx-dev): add Nx Cloud terms link in footer

### DIFF
--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -13,6 +13,7 @@ const navigation = {
     { name: 'App', href: 'https://cloud.nx.app' },
     { name: 'Docs', href: '/ci/intro/ci-with-nx' },
     { name: 'Pricing', href: '/pricing' },
+    { name: 'Terms', href: 'https://cloud.nx.app/terms' },
   ],
   solutions: [
     { name: 'Nx', href: 'https://nx.dev' },


### PR DESCRIPTION
before: no link to nx cloud terms in footer

after: 
make terms easier to find for people by adding a link in the docs footer
![WKMac 2025-05-07T13-54-56](https://github.com/user-attachments/assets/74c618c1-aa0b-4c98-8a69-fad2fb5f1f3c)

