### PR TITLE
fix(core): explicitly cleanup forked process task runner

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -359,7 +359,7 @@ class RunningNodeProcess implements RunningTask {
 
   kill(signal?: NodeJS.Signals): Promise<void> {
     return new Promise<void>((res, rej) => {
-      if (process.platform === 'win32' || process.platform === 'darwin') {
+      if (process.platform === 'win32') {
         if (this.childProcess.kill(signal)) {
           res();
         } else {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1004,6 +1004,7 @@ export class TaskOrchestrator {
   // endregion utils
 
   private async cleanup() {
+    this.forkedProcessTaskRunner.cleanup();
     await Promise.all([
       ...Array.from(this.runningContinuousTasks).map(async ([taskId, t]) => {
         try {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Forked process task runner cleanup is not explicitly invoked.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Forked process task runner cleanup is explicitly invoked.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
