### PR TITLE
feat(vite): add ajv dev dependency for vite-plugin-dts

### DIFF
--- a/packages/vite/.eslintrc.json
+++ b/packages/vite/.eslintrc.json
@@ -44,7 +44,8 @@
               // we only check if the package is installed
               "eslint",
               // we ensure it is installed and only use it when eslint is installed
-              "@nx/eslint"
+              "@nx/eslint",
+              "ajv"
             ]
           }
         ]

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -37,7 +37,8 @@
     "@nx/js": "file:../js",
     "picomatch": "4.0.2",
     "tsconfig-paths": "^4.1.2",
-    "semver": "^7.6.3"
+    "semver": "^7.6.3",
+    "ajv": "^8.0.0"
   },
   "peerDependencies": {
     "vite": "^5.0.0 || ^6.0.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, when we generate a vite library that uses `vite-plugin-dts` it breaks the project graph and all nx commands fail. 
It happens because the wrong version of `ajv` is being hoisted in `node_modules/ajv` so the expected module path required from `vite-plugin-dts` is not found.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx commands should work out of the box when we generate a library with vite.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
