### PR TITLE
fix(core): tui should not exit when underlying process is cancelled

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -220,7 +220,7 @@ export class ForkedProcessTaskRunner {
     });
 
     p.onExit((code) => {
-      if (code > 128) {
+      if (!this.tuiEnabled && code > 128) {
         process.exit(code);
       }
       this.pseudoTerminals.delete(pseudoTerminal);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Entire TUI exits when any process exits with a SIGINT

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

TUI stays alive when a process exits with a SIGINT

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
