### PR TITLE
fix(core): add registerExitHandler utility

### DIFF
--- a/packages/detox/src/executors/build/build.impl.ts
+++ b/packages/detox/src/executors/build/build.impl.ts
@@ -45,7 +45,6 @@ export function runCliBuild(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/detox/src/executors/test/test.impl.ts
+++ b/packages/detox/src/executors/test/test.impl.ts
@@ -66,7 +66,6 @@ function runCliTest(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -173,7 +173,7 @@ export async function* esbuildExecutor(
           })
         );
 
-        registerCleanupCallback(() => {
+        process.once('exit', () => {
           assetsResult?.stop();
           packageJsonResult?.stop();
           disposeFns.forEach((fn) => fn());
@@ -267,19 +267,6 @@ async function runTypeCheck(
   }
 
   return { errors, warnings };
-}
-
-function registerCleanupCallback(callback: () => void) {
-  const wrapped = () => {
-    callback();
-    process.off('SIGINT', wrapped);
-    process.off('SIGTERM', wrapped);
-    process.off('exit', wrapped);
-  };
-
-  process.on('SIGINT', wrapped);
-  process.on('SIGTERM', wrapped);
-  process.on('exit', wrapped);
 }
 
 export default esbuildExecutor;

--- a/packages/expo/src/executors/build-list/build-list.impl.ts
+++ b/packages/expo/src/executors/build-list/build-list.impl.ts
@@ -52,7 +52,6 @@ export function runCliBuildList(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     let output = '';
     childProcess.stdout.on('data', (message) => {

--- a/packages/expo/src/executors/build/build.impl.ts
+++ b/packages/expo/src/executors/build/build.impl.ts
@@ -68,7 +68,6 @@ function runCliBuild(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/expo/src/executors/export/export.impl.ts
+++ b/packages/expo/src/executors/export/export.impl.ts
@@ -48,7 +48,6 @@ function exportAsync(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/expo/src/executors/prebuild/prebuild.impl.ts
+++ b/packages/expo/src/executors/prebuild/prebuild.impl.ts
@@ -55,7 +55,6 @@ export function prebuildAsync(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/expo/src/executors/run/run.impl.ts
+++ b/packages/expo/src/executors/run/run.impl.ts
@@ -70,7 +70,6 @@ function runCliRun(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/expo/src/executors/start/start.impl.ts
+++ b/packages/expo/src/executors/start/start.impl.ts
@@ -56,7 +56,6 @@ function startAsync(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/expo/src/executors/submit/submit.impl.ts
+++ b/packages/expo/src/executors/submit/submit.impl.ts
@@ -47,7 +47,6 @@ function runCliSubmit(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/expo/src/executors/update/update.impl.ts
+++ b/packages/expo/src/executors/update/update.impl.ts
@@ -47,7 +47,6 @@ function runCliUpdate(
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
 
     childProcess.on('error', (err) => {
       reject(err);

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -28,6 +28,7 @@ import { compileSwc, compileSwcWatch } from '../../utils/swc/compile-swc';
 import { getSwcrcPath } from '../../utils/swc/get-swcrc-path';
 import { generateTmpSwcrc } from '../../utils/swc/inline';
 import { isUsingTsSolutionSetup } from '../../utils/typescript/ts-solution-setup';
+import { registerExitHandler } from 'nx/src/utils/signals';
 
 function normalizeOptions(
   options: SwcExecutorOptions,
@@ -186,8 +187,8 @@ export async function* swcExecutor(
 
   if (options.watch) {
     let disposeFn: () => void;
-    process.on('SIGINT', () => disposeFn());
-    process.on('SIGTERM', () => disposeFn());
+    registerExitHandler('SIGINT', (s) => disposeFn());
+    registerExitHandler('SIGTERM', (s) => disposeFn());
 
     return yield* compileSwcWatch(context, options, async () => {
       const assetResult = await copyAssets(options, context);

--- a/packages/js/src/executors/tsc/tsc.batch-impl.ts
+++ b/packages/js/src/executors/tsc/tsc.batch-impl.ts
@@ -27,6 +27,7 @@ import {
   watchTaskProjectsPackageJsonFileChanges,
 } from './lib/batch';
 import { createEntryPoints } from '../../utils/package-json/create-entry-points';
+import { registerExitHandler } from 'nx/src/utils/signals';
 
 export async function* tscBatchExecutor(
   taskGraph: TaskGraph,
@@ -150,13 +151,12 @@ export async function* tscBatchExecutor(
         }
       );
 
-    const handleTermination = async (exitCode: number) => {
+    const handleTermination = async () => {
       watchAssetsChangesDisposer();
       watchProjectsChangesDisposer();
-      process.exit(exitCode);
     };
-    process.on('SIGINT', () => handleTermination(128 + 2));
-    process.on('SIGTERM', () => handleTermination(128 + 15));
+    registerExitHandler('SIGINT', (s) => handleTermination());
+    registerExitHandler('SIGTERM', (s) => handleTermination());
 
     return yield* mapAsyncIterable(typescriptCompilation, async (iterator) => {
       // drain the iterator, we don't use the results

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -24,6 +24,7 @@ import { watchForSingleFileChanges } from '../../utils/watch-for-single-file-cha
 import { getCustomTrasformersFactory, normalizeOptions } from './lib';
 import { readTsConfig } from '../../utils/typescript/ts-config';
 import { createEntryPoints } from '../../utils/package-json/create-entry-points';
+import { registerExitHandler } from 'nx/src/utils/signals';
 
 export function determineModuleFormatFromTsConfig(
   absolutePathToTsConfig: string
@@ -169,14 +170,13 @@ export async function* tscExecutor(
           )
       );
     }
-    const handleTermination = async (exitCode: number) => {
+    const handleTermination = async () => {
       await typescriptCompilation.close();
       disposeWatchAssetChanges();
       disposePackageJsonChanges?.();
-      process.exit(exitCode);
     };
-    process.on('SIGINT', () => handleTermination(128 + 2));
-    process.on('SIGTERM', () => handleTermination(128 + 15));
+    registerExitHandler('SIGINT', (s) => handleTermination());
+    registerExitHandler('SIGTERM', (s) => handleTermination());
   }
 
   return yield* typescriptCompilation.iterator;

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -57,9 +57,6 @@ export async function verdaccioExecutor(
     }
   };
   process.on('exit', processExitListener);
-  process.on('SIGTERM', processExitListener);
-  process.on('SIGINT', processExitListener);
-  process.on('SIGHUP', processExitListener);
 
   try {
     await startVerdaccio(options, context.root);

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -229,8 +229,6 @@ export async function* compileSwcWatch(
       swcWatcher.stdout.on('data', stdoutOnData);
       swcWatcher.stderr.on('data', stderrOnData);
 
-      process.on('SIGINT', processOnExit);
-      process.on('SIGTERM', processOnExit);
       process.on('exit', processOnExit);
 
       swcWatcher.on('exit', watcherOnExit);

--- a/packages/module-federation/src/executors/utils/build-static-remotes.ts
+++ b/packages/module-federation/src/executors/utils/build-static-remotes.ts
@@ -87,7 +87,6 @@ export async function buildStaticRemotes(
         res();
       }
     });
-    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
     process.on('exit', () => staticProcess.kill('SIGTERM'));
   });
 

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-ssr-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-ssr-dev-server-plugin.ts
@@ -130,9 +130,6 @@ export class NxModuleFederationSSRDevServerPlugin
       process.on('exit', () => {
         this.devServerProcess?.kill('SIGKILL');
       });
-      process.on('SIGINT', () => {
-        this.devServerProcess?.kill('SIGKILL');
-      });
       callback();
     });
   }

--- a/packages/module-federation/src/plugins/utils/build-static-remotes.ts
+++ b/packages/module-federation/src/plugins/utils/build-static-remotes.ts
@@ -76,7 +76,6 @@ export async function buildStaticRemotes(
         res();
       }
     });
-    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
     process.on('exit', () => staticProcess.kill('SIGTERM'));
   });
 

--- a/packages/module-federation/src/plugins/utils/start-remote-proxies.ts
+++ b/packages/module-federation/src/plugins/utils/start-remote-proxies.ts
@@ -55,7 +55,6 @@ export function startRemoteProxies(
     const proxyServer = (sslCert ? https : http)
       .createServer({ cert: sslCert, key: sslKey }, expressProxy)
       .listen(appConfig.port);
-    process.on('SIGTERM', () => proxyServer.close());
     process.on('exit', () => proxyServer.close());
   }
   console.info(`NX Static remotes proxies started successfully`);

--- a/packages/module-federation/src/plugins/utils/start-static-remotes-file-server.ts
+++ b/packages/module-federation/src/plugins/utils/start-static-remotes-file-server.ts
@@ -58,6 +58,5 @@ export function startStaticRemotesFileServer(
       },
     }
   );
-  process.on('SIGTERM', () => httpServerProcess.kill('SIGTERM'));
   process.on('exit', () => httpServerProcess.kill('SIGTERM'));
 }

--- a/packages/module-federation/src/utils/start-remote-proxies.ts
+++ b/packages/module-federation/src/utils/start-remote-proxies.ts
@@ -41,7 +41,6 @@ export function startRemoteProxies(
     const proxyServer = (sslCert ? https : http)
       .createServer({ cert: sslCert, key: sslKey }, expressProxy)
       .listen(staticRemotesConfig.config[app].port);
-    process.on('SIGTERM', () => proxyServer.close());
     process.on('exit', () => proxyServer.close());
   }
   logger.info(`NX Static remotes proxies started successfully`);

--- a/packages/module-federation/src/utils/start-ssr-remote-proxies.ts
+++ b/packages/module-federation/src/utils/start-ssr-remote-proxies.ts
@@ -58,7 +58,6 @@ export function startSsrRemoteProxies(
     const proxyServer = (sslCert ? https : http)
       .createServer({ cert: sslCert, key: sslKey }, expressProxy)
       .listen(staticRemotesConfig.config[app].port);
-    process.on('SIGTERM', () => proxyServer.close());
     process.on('exit', () => proxyServer.close());
   }
   logger.info(`Nx SSR Static remotes proxies started successfully`);

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -82,9 +82,6 @@ export default async function* serveExecutor(
         }
       };
       process.on('exit', () => killServer());
-      process.on('SIGINT', () => killServer());
-      process.on('SIGTERM', () => killServer());
-      process.on('SIGHUP', () => killServer());
 
       await waitForPortOpen(options.port, { host: options.hostname });
 

--- a/packages/nx/bin/run-executor.ts
+++ b/packages/nx/bin/run-executor.ts
@@ -1,6 +1,9 @@
 import { appendFileSync, openSync, writeFileSync } from 'fs';
-import { Target, run } from '../src/command-line/run/run';
 import { TaskGraph } from '../src/config/task-graph';
+
+import { Target, run } from '../src/command-line/run/run';
+
+import '../src/utils/signals';
 
 if (process.env.NX_TERMINAL_OUTPUT_PATH) {
   setUpOutputWatching(

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -57,6 +57,7 @@ import { ConfigurationSourceMaps } from '../../project-graph/utils/project-confi
 import { createTaskHasher } from '../../hasher/create-task-hasher';
 import { ProjectGraphError } from '../../project-graph/error-types';
 import { isNxCloudUsed } from '../../utils/nx-cloud-utils';
+import { registerExitHandler } from '../../utils/signals';
 
 export interface GraphError {
   message: string;
@@ -667,14 +668,18 @@ async function startServer(
     }
   });
 
-  const handleTermination = async (exitCode: number) => {
+  const handleTermination = async () => {
     if (unregisterFileWatcher) {
       unregisterFileWatcher();
     }
-    process.exit(exitCode);
   };
-  process.on('SIGINT', () => handleTermination(128 + 2));
-  process.on('SIGTERM', () => handleTermination(128 + 15));
+
+  registerExitHandler('SIGINT', () => {
+    handleTermination();
+  });
+  registerExitHandler('SIGTERM', () => {
+    handleTermination();
+  });
 
   return new Promise<{ app: Server; url: URL }>((res) => {
     app.listen(port, host, () => {

--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -7,7 +7,7 @@ import {
   PseudoTtyProcess,
 } from '../../tasks-runner/pseudo-terminal';
 import { getPackageManagerCommand } from '../../utils/package-manager';
-import { signalToCode } from '../../utils/exit-codes';
+import { registerExitHandler } from '../../utils/signals';
 
 export interface RunScriptOptions {
   script: string;
@@ -84,16 +84,6 @@ async function ptyProcess(
   });
 }
 
-// TODO: This only works because pseudo terminal registers signal handlers first but we need a service to handle this
-process.on('SIGHUP', () => {
-  cp.kill('SIGHUP');
-  process.exit(signalToCode('SIGHUP'));
-});
-process.on('SIGTERM', () => {
-  cp.kill('SIGTERM');
-  process.exit(signalToCode('SIGTERM'));
-});
-process.on('SIGINT', () => {
-  cp.kill('SIGINT');
-  process.exit(signalToCode('SIGINT'));
-});
+registerExitHandler('SIGINT', () => cp.kill('SIGINT'));
+registerExitHandler('SIGTERM', () => cp.kill('SIGTERM'));
+registerExitHandler('SIGHUP', () => cp.kill('SIGHUP'));

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -9,6 +9,7 @@ import { Task } from '../../config/task-graph';
 import { prettyTime } from './pretty-time';
 import { formatFlags, formatTargetsAndProjects } from './formatting-utils';
 import { viewLogsFooterRows } from './view-logs-utils';
+import { registerExitHandler } from '../../utils/signals';
 
 const LEFT_PAD = `   `;
 const SPACER = `  `;
@@ -54,10 +55,9 @@ export async function createRunManyDynamicOutputRenderer({
     }
   }
 
-  process.on('exit', () => clearRenderInterval());
-  process.on('SIGINT', () => clearRenderInterval());
-  process.on('SIGTERM', () => clearRenderInterval());
-  process.on('SIGHUP', () => clearRenderInterval());
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP', 'exit'] as const) {
+    registerExitHandler(signal, () => clearRenderInterval());
+  }
 
   const lifeCycle = {} as Partial<LifeCycle>;
   const isVerbose = overrides.verbose === true;

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
@@ -8,6 +8,7 @@ import { prettyTime } from './pretty-time';
 import { Task } from '../../config/task-graph';
 import { formatFlags, formatTargetsAndProjects } from './formatting-utils';
 import { viewLogsFooterRows } from './view-logs-utils';
+import { registerExitHandler } from '../../utils/signals';
 
 const LEFT_PAD = `   `;
 const SPACER = `  `;
@@ -65,10 +66,7 @@ export async function createRunOneDynamicOutputRenderer({
     }
   }
 
-  process.on('exit', () => clearRenderInterval());
-  process.on('SIGINT', () => clearRenderInterval());
-  process.on('SIGTERM', () => clearRenderInterval());
-  process.on('SIGHUP', () => clearRenderInterval());
+  registerExitHandler('exit', () => clearRenderInterval());
 
   const lifeCycle = {} as Partial<LifeCycle>;
 

--- a/packages/nx/src/tasks-runner/pseudo-terminal.ts
+++ b/packages/nx/src/tasks-runner/pseudo-terminal.ts
@@ -4,19 +4,21 @@ import { getForkedProcessOsSocketPath } from '../daemon/socket-utils';
 import { ChildProcess, IS_WASM, RustPseudoTerminal } from '../native';
 import { PseudoIPCServer } from './pseudo-ipc';
 import { RunningTask } from './running-tasks/running-task';
+import { registerExitHandler } from '../utils/signals';
 
 // Register single event listeners for all pseudo-terminal instances
 const pseudoTerminalShutdownCallbacks: Array<(s?: NodeJS.Signals) => void> = [];
-process.on('SIGINT', () => {
+
+registerExitHandler('SIGINT', () => {
   pseudoTerminalShutdownCallbacks.forEach((cb) => cb('SIGINT'));
 });
-process.on('SIGTERM', () => {
+registerExitHandler('SIGTERM', () => {
   pseudoTerminalShutdownCallbacks.forEach((cb) => cb('SIGTERM'));
 });
-process.on('SIGHUP', () => {
+registerExitHandler('SIGHUP', () => {
   pseudoTerminalShutdownCallbacks.forEach((cb) => cb('SIGHUP'));
 });
-process.on('exit', () => {
+registerExitHandler('exit', () => {
   pseudoTerminalShutdownCallbacks.forEach((cb) => cb());
 });
 

--- a/packages/nx/src/utils/exit-codes.ts
+++ b/packages/nx/src/utils/exit-codes.ts
@@ -14,3 +14,16 @@ export function signalToCode(signal: NodeJS.Signals): number {
       return 128;
   }
 }
+
+export function codeToSignal(code: number): NodeJS.Signals {
+  switch (code) {
+    case 128 + 1:
+      return 'SIGHUP';
+    case 128 + 2:
+      return 'SIGINT';
+    case 128 + 15:
+      return 'SIGTERM';
+    default:
+      return 'SIGKILL';
+  }
+}

--- a/packages/nx/src/utils/signals.ts
+++ b/packages/nx/src/utils/signals.ts
@@ -1,0 +1,59 @@
+import { signalToCode } from './exit-codes';
+
+const exitEvents = [
+  'SIGINT',
+  'SIGTERM',
+  'SIGQUIT',
+  'SIGHUP',
+  'SIGKILL',
+  'exit',
+] as const;
+type ExitEvent = (typeof exitEvents)[number];
+
+const signalHandlers: Partial<
+  Record<
+    ExitEvent,
+    Array<(signalOrCode: string | number) => void | Promise<void>>
+  >
+> = {};
+const registeredHandlers = new Set<string>();
+
+export function registerExitHandler(
+  event: 'exit',
+  cb: (code: number) => any | Promise<any>
+);
+export function registerExitHandler<T extends Omit<ExitEvent, 'exit'>>(
+  event: T,
+  cb: (signal: T) => any | Promise<any>
+);
+export function registerExitHandler<T extends ExitEvent>(
+  event: T,
+  cb: (signalOrCode: T extends Omit<ExitEvent, 'exit'> ? T : number) => void
+) {
+  signalHandlers[event] ??= [];
+  if (registeredHandlers.has(event)) {
+    return;
+  }
+  registerHandler(event);
+}
+
+function registerHandler(event: ExitEvent) {
+  registeredHandlers.add(event);
+  process.on(event, async (code?: number) => {
+    for (const cb of signalHandlers[event]) {
+      let next = cb(event === 'exit' ? code : event);
+      if (next instanceof Promise) {
+        await next;
+      }
+    }
+    if (event === 'exit') {
+      // process is already exiting, don't need to exit
+    } else {
+      process.exit(signalToCode(event));
+    }
+  });
+}
+
+for (const event of exitEvents) {
+  registerHandler(event);
+}

--- a/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -127,7 +127,6 @@ async function buildHost(
       }
     });
 
-    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
     process.on('exit', () => staticProcess.kill('SIGTERM'));
   });
 }
@@ -160,9 +159,6 @@ function moveToTmpDirectory(
   const cleanup = () => {
     rmSync(commonOutputDirectory, { force: true, recursive: true });
   };
-  process.on('SIGTERM', () => {
-    cleanup();
-  });
   process.on('exit', () => {
     cleanup();
   });
@@ -210,7 +206,6 @@ export function startProxies(
     const proxyServer = (sslCert ? https : http)
       .createServer({ cert: sslCert, key: sslKey }, expressProxy)
       .listen(staticRemotesConfig.config[app].port);
-    process.on('SIGTERM', () => proxyServer.close());
     process.on('exit', () => proxyServer.close());
   }
   logger.info(`NX Static Producers (remotes) proxies started successfully`);
@@ -236,7 +231,6 @@ export function startProxies(
   const proxyServer = (sslCert ? https : http)
     .createServer({ cert: sslCert, key: sslKey }, expressProxy)
     .listen(hostServeOptions.port);
-  process.on('SIGTERM', () => proxyServer.close());
   process.on('exit', () => proxyServer.close());
   logger.info('NX Static Consumer (host) proxy started successfully');
 }

--- a/packages/remix/src/executors/serve/serve.impl.ts
+++ b/packages/remix/src/executors/serve/serve.impl.ts
@@ -81,9 +81,6 @@ export default async function* serveExecutor(
         }
       };
       process.on('exit', () => killServer());
-      process.on('SIGINT', () => killServer());
-      process.on('SIGTERM', () => killServer());
-      process.on('SIGHUP', () => killServer());
 
       await waitForPortOpen(options.port);
 

--- a/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -127,7 +127,6 @@ async function buildHost(
       }
     });
 
-    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
     process.on('exit', () => staticProcess.kill('SIGTERM'));
   });
 }
@@ -160,9 +159,6 @@ function moveToTmpDirectory(
   const cleanup = () => {
     rmSync(commonOutputDirectory, { force: true, recursive: true });
   };
-  process.on('SIGTERM', () => {
-    cleanup();
-  });
   process.on('exit', () => {
     cleanup();
   });
@@ -214,7 +210,6 @@ export function startProxies(
     const proxyServer = (sslCert ? https : http)
       .createServer({ cert: sslCert, key: sslKey }, expressProxy)
       .listen(staticRemotesConfig.config[app].port);
-    process.on('SIGTERM', () => proxyServer.close());
     process.on('exit', () => proxyServer.close());
   }
   logger.info(`NX Static remotes proxies started successfully`);
@@ -240,7 +235,6 @@ export function startProxies(
   const proxyServer = (sslCert ? https : http)
     .createServer({ cert: sslCert, key: sslKey }, expressProxy)
     .listen(hostServeOptions.port);
-  process.on('SIGTERM', () => proxyServer.close());
   process.on('exit', () => proxyServer.close());
   logger.info('NX Static host proxy started successfully');
 }

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -129,8 +129,6 @@ function registerCleanupCallback(callback: () => void) {
     process.off('exit', wrapped);
   };
 
-  process.on('SIGINT', wrapped);
-  process.on('SIGTERM', wrapped);
   process.on('exit', wrapped);
 }
 

--- a/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
+++ b/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
@@ -70,7 +70,6 @@ export function nxViteBuildCoordinationPlugin(
         if (daemonClient.enabled()) {
           unregisterFileWatcher = await createFileWatcher();
           process.on('exit', () => unregisterFileWatcher());
-          process.on('SIGINT', () => process.exit());
         } else {
           output.warn({
             title:

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -52,8 +52,6 @@ export async function* vitestExecutor(
   };
 
   if (watch) {
-    process.on('SIGINT', processExit);
-    process.on('SIGTERM', processExit);
     process.on('exit', processExit);
   }
 

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -250,7 +250,6 @@ export default async function* fileServerExecutor(
     }
   };
   process.on('exit', processExitListener);
-  process.on('SIGTERM', processExitListener);
 
   serve.stdout.on('data', (chunk) => {
     if (chunk.toString().indexOf('GET') === -1) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
We register a bunch of signal listeners everywhere, and depending on the order they are registered not all are running. Also, we have to make sure to actually shut the process down... 

## Expected Behavior
Signal listeners are registered through a common util, which handles process shutdown.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
