### PR TITLE
fix(core): only cleanup db connection on exit

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -283,26 +283,8 @@ const getLatestVersionOfNx = ((fn: () => string) => {
   return () => cache || (cache = fn());
 })(_getLatestVersionOfNx);
 
-function nxCleanup(signal?: NodeJS.Signals) {
-  removeDbConnections();
-  if (signal) {
-    process.exit(signalToCode(signal));
-  } else {
-    process.exit();
-  }
-}
-
 process.on('exit', () => {
-  nxCleanup();
-});
-process.on('SIGINT', () => {
-  nxCleanup('SIGINT');
-});
-process.on('SIGTERM', () => {
-  nxCleanup('SIGTERM');
-});
-process.on('SIGHUP', () => {
-  nxCleanup('SIGHUP');
+  removeDbConnections();
 });
 
 main();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

db connections are cleaned up on SIGTERM, SIGHUP, SIGINT, AND exit. On SIGTERM, SIGHUP, and SIGINT, the process exits there.. which short circuits other SIGTERM, SIGHUP, and SIGINT handlers.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

db connections are only cleaned up when the process actually exits. It does not exit the process here in response to any signals.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
