### PR TITLE
fix(core): do not follow symlinks when creating remote cache tarball

### DIFF
--- a/packages/nx/src/native/cache/http_remote_cache.rs
+++ b/packages/nx/src/native/cache/http_remote_cache.rs
@@ -109,6 +109,7 @@ impl HttpRemoteCache {
         let tar_gz: Vec<u8> = Vec::new();
         let enc = flate2::write::GzEncoder::new(tar_gz, Compression::default());
         let mut archive = Builder::new(enc);
+        archive.follow_symlinks(false);
         trace!("Created tar file for writing");
 
         let cache_path = Path::new(&cache_directory);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

Symlinks in the remote cache tarball are "followed". That modifies the output of Next.js projects using pnpm, causing a restored cache not to work in production.

## Expected Behavior

Symlinks are added to the tarball, instead of being followed. I.e. the cache output is not modified.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Should fix #31085.
