### PR TITLE
feat(angular): support the optional `outputPath` in application builder

### DIFF
--- a/e2e/angular/src/ng-add.test.ts
+++ b/e2e/angular/src/ng-add.test.ts
@@ -179,7 +179,9 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
     expect(projectConfig.sourceRoot).toEqual(`apps/${project}/src`);
     expect(projectConfig.targets.build).toStrictEqual({
       executor: '@angular/build:application',
+      outputs: ['{options.outputPath}'],
       options: {
+        outputPath: `dist/${project}`,
         browser: `apps/${project}/src/main.ts`,
         polyfills: [`zone.js`],
         tsConfig: `apps/${project}/tsconfig.app.json`,

--- a/packages/angular/src/generators/ng-add/migrators/projects/app.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/app.migrator.spec.ts
@@ -710,6 +710,7 @@ describe('app migrator', () => {
       const { targets } = readProjectConfiguration(tree, 'app1');
       expect(targets.build).toStrictEqual({
         executor: '@angular-devkit/build-angular:browser',
+        outputs: ['{options.outputPath}'],
         options: {
           outputPath: 'dist/apps/app1',
           index: 'apps/app1/src/index.html',
@@ -785,6 +786,7 @@ describe('app migrator', () => {
       const { targets } = readProjectConfiguration(tree, 'app1');
       expect(targets.build).toStrictEqual({
         executor: '@angular-devkit/build-angular:application',
+        outputs: ['{options.outputPath}'],
         options: {
           outputPath: 'dist/apps/app1',
           index: 'apps/app1/src/index.html',
@@ -853,6 +855,7 @@ describe('app migrator', () => {
       const { targets } = readProjectConfiguration(tree, 'app1');
       expect(targets.build).toStrictEqual({
         executor: '@angular-devkit/build-angular:browser',
+        outputs: ['{options.outputPath}'],
         options: {
           outputPath: 'dist/apps/app1',
           index: 'apps/app1/src/index.html',
@@ -910,6 +913,7 @@ describe('app migrator', () => {
       const { targets } = readProjectConfiguration(tree, 'app1');
       expect(targets.myCustomBuildTarget).toStrictEqual({
         executor: '@angular-devkit/build-angular:browser',
+        outputs: ['{options.outputPath}'],
         options: {
           outputPath: 'dist/apps/app1',
           index: 'apps/app1/src/index.html',
@@ -954,6 +958,7 @@ describe('app migrator', () => {
       const { targets } = readProjectConfiguration(tree, 'app1');
       expect(targets.build).toStrictEqual({
         executor: '@angular-devkit/build-angular:browser',
+        outputs: ['{options.outputPath}'],
         options: { outputPath: 'dist/apps/app1/browser' },
       });
     });

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -48,6 +48,13 @@ export function updateProjectConfigForApplicationBuilder(
       delete outputPath.browser;
     } else {
       outputPath = outputPath.base;
+      if (buildTarget.outputs && buildTarget.outputs.length > 0) {
+        buildTarget.outputs = buildTarget.outputs.map((output) =>
+          output === '{options.outputPath.base}'
+            ? '{options.outputPath}'
+            : output
+        );
+      }
     }
   }
 


### PR DESCRIPTION
- Update Angular CLI to Nx migration to handle the optional `outputPath` option of the `application` builder
- Update a couple of places to properly handle `outputs`