### PR TITLE
feat(angular): support the optional `index` option in the application builder

### DIFF
--- a/docs/generated/packages/angular/executors/application.json
+++ b/docs/generated/packages/angular/executors/application.json
@@ -699,7 +699,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["outputPath", "index", "tsConfig"],
+    "required": ["outputPath", "tsConfig"],
     "definitions": {
       "assetPattern": {
         "oneOf": [

--- a/e2e/angular/src/projects.test.ts
+++ b/e2e/angular/src/projects.test.ts
@@ -331,6 +331,7 @@ describe('Angular Projects', () => {
       config.targets.build.options = {
         ...config.targets.build.options,
         outputPath: `dist/${esbuildApp}`,
+        index: `${esbuildApp}/src/index.html`,
         main: config.targets.build.options.browser,
         browser: undefined,
         buildLibsFromSource: false,
@@ -435,6 +436,7 @@ describe('Angular Projects', () => {
         ...config.targets.build.options,
         main: config.targets.build.options.browser,
         browser: undefined,
+        index: `${esbuildApp}/src/index.html`,
       };
       return config;
     });

--- a/packages/angular/src/executors/application/schema.json
+++ b/packages/angular/src/executors/application/schema.json
@@ -641,7 +641,7 @@
     }
   },
   "additionalProperties": false,
-  "required": ["outputPath", "index", "tsConfig"],
+  "required": ["outputPath", "tsConfig"],
   "definitions": {
     "assetPattern": {
       "oneOf": [

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -827,7 +827,6 @@ exports[`app nested should create project configs 1`] = `
           },
         ],
         "browser": "my-dir/my-app/src/main.ts",
-        "index": "my-dir/my-app/src/index.html",
         "outputPath": "dist/my-dir/my-app",
         "polyfills": [
           "zone.js",
@@ -945,7 +944,6 @@ exports[`app not nested should create project configs 1`] = `
           },
         ],
         "browser": "my-app/src/main.ts",
-        "index": "my-app/src/index.html",
         "outputPath": "dist/my-app",
         "polyfills": [
           "zone.js",

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -1329,6 +1329,21 @@ describe('app', () => {
           .useDefineForClassFields
       ).toBe(false);
     });
+
+    it('should set the "index" option of the application builder for versions lower than v20', async () => {
+      updateJson(appTree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~19.0.0',
+        },
+      }));
+
+      await generateApp(appTree, 'my-app', { bundler: 'esbuild' });
+
+      const project = readProjectConfiguration(appTree, 'my-app');
+      expect(project.targets.build.options.index).toBe('my-app/src/index.html');
+    });
   });
 });
 

--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -19,12 +19,14 @@ describe('Init MF', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generateTestApplication(tree, {
       directory: 'app1',
+      bundler: 'webpack',
       routing: true,
       standalone: false,
       skipFormat: true,
     });
     await generateTestApplication(tree, {
       directory: 'remote1',
+      bundler: 'webpack',
       routing: true,
       standalone: false,
       skipFormat: true,

--- a/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
+++ b/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
@@ -34,7 +34,6 @@ exports[`setupSSR with application builder should create the files correctly for
       },
     ],
     "browser": "app1/src/main.ts",
-    "index": "app1/src/index.html",
     "outputPath": "dist/app1",
     "polyfills": [
       "zone.js",
@@ -161,7 +160,6 @@ exports[`setupSSR with application builder should create the files correctly for
       },
     ],
     "browser": "app1/src/main.ts",
-    "index": "app1/src/index.html",
     "outputPath": "dist/app1",
     "polyfills": [
       "zone.js",


### PR DESCRIPTION
Make the `index` option of the application executor optional and generate new applications without it.