### PR TITLE
fix(core): show all native logs for debug mode

### DIFF
--- a/packages/nx/src/native/logger/mod.rs
+++ b/packages/nx/src/native/logger/mod.rs
@@ -109,6 +109,7 @@ pub(crate) fn enable_logger() {
     let registry = tracing_subscriber::registry()
         .with(stdout_layer)
         .with(TuiTracingSubscriberLayer);
+    tui_logger::init_logger(tui_logger::LevelFilter::Trace).ok();
 
     if env::var("NX_NATIVE_FILE_LOGGING").is_err() {
         // File logging is not enabled

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -3,7 +3,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEventKind};
 use hashbrown::HashSet;
 use napi::bindgen_prelude::External;
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
-use ratatui::layout::{Alignment, Position, Rect, Size};
+use ratatui::layout::{Alignment, Rect, Size};
 use ratatui::style::Modifier;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, trace};
-use tui_logger::{TuiLoggerSmartWidget, TuiLoggerWidget, TuiWidgetEvent, TuiWidgetState};
+use tui_logger::{LevelFilter, TuiLoggerSmartWidget, TuiWidgetEvent, TuiWidgetState};
 use vt100_ctt::Parser;
 
 use crate::native::tui::tui::Tui;
@@ -135,7 +135,7 @@ impl App {
             selection_manager,
             tasks,
             debug_mode: false,
-            debug_state: TuiWidgetState::default(),
+            debug_state: TuiWidgetState::default().set_default_display_level(LevelFilter::Debug),
         })
     }
 

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -162,7 +162,6 @@ impl AppLifeCycle {
         done_callback: ThreadsafeFunction<(), ErrorStrategy::Fatal>,
     ) -> napi::Result<()> {
         enable_logger();
-        tui_logger::init_logger(tui_logger::LevelFilter::Debug).unwrap();
         debug!("Initializing Terminal UI");
 
         let app_mutex = self.app.clone();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

TUI debug mode only shows native logs since the TUI launched.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

TUI debug mode shows logs even before the TUI launched such as task hashing logs and more.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
