### PR TITLE
fix(storybook): include storybook pkg version migration

### DIFF
--- a/docs/generated/packages/storybook/migrations/20.8.0-package-updates.json
+++ b/docs/generated/packages/storybook/migrations/20.8.0-package-updates.json
@@ -250,7 +250,8 @@
     "@storybook/web-components": {
       "version": "^8.6.11",
       "alwaysAddToPackageJson": false
-    }
+    },
+    "storybook": { "version": "^8.6.11", "alwaysAddToPackageJson": false }
   },
   "aliases": [],
   "description": "",

--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -736,6 +736,10 @@
         "@storybook/web-components": {
           "version": "^8.6.11",
           "alwaysAddToPackageJson": false
+        },
+        "storybook": {
+          "version": "^8.6.11",
+          "alwaysAddToPackageJson": false
         }
       }
     }


### PR DESCRIPTION
Just noticed that storybook package is not being migrated to latest if it's installed explicitly