### PR TITLE
feat(nx-dev): replace monorepo world link with office hours

### DIFF
--- a/nx-dev/ui-common/src/lib/headers/menu-items.ts
+++ b/nx-dev/ui-common/src/lib/headers/menu-items.ts
@@ -216,10 +216,10 @@ export const learnItems: MenuItem[] = [
 ];
 export const eventItems: MenuItem[] = [
   {
-    name: 'Monorepo World',
+    name: 'Office Hours',
     description: null,
-    href: 'https://monorepo.world',
-    icon: GlobeAltIcon,
+    href: 'https://go.nx.dev/office-hours',
+    icon: DiscordIcon,
     isNew: false,
     isHighlight: false,
   },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The resources menu links Monorepo World

<img width="593" alt="Screenshot 2025-05-12 at 13 20 42" src="https://github.com/user-attachments/assets/9093599a-f326-4cfa-acb8-61115683c111" />


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should rather replace it with the current ongoing Nx Office Hours which is what this PR does.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
