### PR TITLE
feat(angular): use `@angular/build` for new projects using the esbuild bundler

### DIFF
--- a/e2e/angular/src/config.test.ts
+++ b/e2e/angular/src/config.test.ts
@@ -13,7 +13,9 @@ describe('angular.json v1 config', () => {
 
   beforeAll(() => {
     newProject({ packages: ['@nx/angular'] });
-    runCLI(`generate @nx/angular:app ${app1} --no-interactive`);
+    runCLI(
+      `generate @nx/angular:app ${app1} --bundler=webpack --no-interactive`
+    );
     // reset workspace to use v1 config
     updateFile(`angular.json`, angularV1Json(app1));
     removeFile(`${app1}/project.json`);

--- a/e2e/angular/src/module-federation.test.ts
+++ b/e2e/angular/src/module-federation.test.ts
@@ -86,7 +86,7 @@ describe('Angular Module Federation', () => {
       import { ${
         names(wildcardLib).className
       }Module } from '@${proj}/${wildcardLib}/${
-        names(secondaryEntry).fileName
+        names(wildcardLib).fileName
       }.module';
       import { ${
         names(sharedLib).className

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@angular-eslint/eslint-plugin": "19.2.0",
     "@angular-eslint/eslint-plugin-template": "19.2.0",
     "@angular-eslint/template-parser": "19.2.0",
+    "@angular/build": "20.0.0-rc.0",
     "@angular/cli": "20.0.0-rc.0",
     "@angular/common": "20.0.0-rc.0",
     "@angular/compiler": "20.0.0-rc.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -67,11 +67,20 @@
     "webpack-merge": "^5.8.0"
   },
   "peerDependencies": {
+    "@angular/build": ">= 18.0.0 < 21.0.0",
     "@angular-devkit/build-angular": ">= 18.0.0 < 21.0.0",
     "@angular-devkit/core": ">= 18.0.0 < 21.0.0",
     "@angular-devkit/schematics": ">= 18.0.0 < 21.0.0",
     "@schematics/angular": ">= 18.0.0 < 21.0.0",
     "rxjs": "^6.5.3 || ^7.5.0"
+  },
+  "peerDependenciesMeta": {
+    "@angular/build": {
+      "optional": true
+    },
+    "@angular-devkit/build-angular": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/angular/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/angular/src/builders/dev-server/dev-server.impl.ts
@@ -12,11 +12,13 @@ import { getRootTsConfigPath } from '@nx/js';
 import type { DependentBuildableProjectNode } from '@nx/js/src/utils/buildable-libs-utils';
 import { WebpackNxBuildCoordinationPlugin } from '@nx/webpack/src/plugins/webpack-nx-build-coordination-plugin';
 import { existsSync } from 'fs';
+import { readNxJson } from 'nx/src/config/configuration';
 import { isNpmProject } from 'nx/src/project-graph/operators';
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
 import { relative } from 'path';
 import { combineLatest, from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { assertBuilderPackageIsInstalled } from '../../executors/utilities/builder-package';
 import {
   loadIndexHtmlTransformer,
   loadMiddleware,
@@ -31,8 +33,6 @@ import {
 } from '../utilities/webpack';
 import { normalizeOptions, validateOptions } from './lib';
 import type { NormalizedSchema, Schema } from './schema';
-import { readNxJson } from 'nx/src/config/configuration';
-
 type BuildTargetOptions = {
   tsConfig: string;
   buildLibsFromSource?: boolean;
@@ -167,6 +167,7 @@ export function executeDevServerBuilder(
    * handle `@nx/angular:*` executors.
    */
   patchBuilderContext(context, !isUsingWebpackBuilder, parsedBuildTarget);
+  assertBuilderPackageIsInstalled('@angular-devkit/build-angular');
 
   return combineLatest([
     from(import('@angular-devkit/build-angular')),

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -13,6 +13,7 @@ import { getDependencyConfigs } from 'nx/src/tasks-runner/utils';
 import { relative } from 'path';
 import { from, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { assertBuilderPackageIsInstalled } from '../../executors/utilities/builder-package';
 import { createTmpTsConfigForBuildableLibs } from '../utilities/buildable-libs';
 import {
   mergeCustomWebpackConfig,
@@ -98,6 +99,7 @@ export function executeWebpackBrowserBuilder(
     );
   }
 
+  assertBuilderPackageIsInstalled('@angular-devkit/build-angular');
   return from(import('@angular-devkit/build-angular')).pipe(
     switchMap(({ executeBrowserBuilder }) =>
       executeBrowserBuilder(delegateBuilderOptions, context as any, {

--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -1,3 +1,5 @@
+import type { BuilderContext } from '@angular-devkit/architect';
+import type { ServerBuilderOutput } from '@angular-devkit/build-angular';
 import {
   joinPathFragments,
   normalizePath,
@@ -7,14 +9,17 @@ import { existsSync } from 'fs';
 import { relative } from 'path';
 import { Observable, from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { assertBuilderPackageIsInstalled } from '../../executors/utilities/builder-package';
 import { createTmpTsConfigForBuildableLibs } from '../utilities/buildable-libs';
 import { mergeCustomWebpackConfig } from '../utilities/webpack';
 import { Schema } from './schema';
 
 function buildServerApp(
   options: Schema,
-  context: import('@angular-devkit/architect').BuilderContext
-): Observable<import('@angular-devkit/build-angular').ServerBuilderOutput> {
+  context: BuilderContext
+): Observable<ServerBuilderOutput> {
+  assertBuilderPackageIsInstalled('@angular-devkit/build-angular');
+
   const { buildLibsFromSource, customWebpackConfig, ...delegateOptions } =
     options;
   // If there is a path to custom webpack config
@@ -47,7 +52,7 @@ function buildServerApp(
 
 function buildServerAppWithCustomWebpackConfiguration(
   options: Schema,
-  context: import('@angular-devkit/architect').BuilderContext,
+  context: BuilderContext,
   pathToWebpackConfig: string
 ) {
   return from(import('@angular-devkit/build-angular')).pipe(
@@ -89,8 +94,8 @@ function buildServerAppWithCustomWebpackConfiguration(
 
 export function executeWebpackServerBuilder(
   options: Schema,
-  context: import('@angular-devkit/architect').BuilderContext
-): Observable<import('@angular-devkit/build-angular').ServerBuilderOutput> {
+  context: BuilderContext
+): Observable<ServerBuilderOutput> {
   options.buildLibsFromSource ??= true;
 
   process.env.NX_BUILD_LIBS_FROM_SOURCE = `${options.buildLibsFromSource}`;

--- a/packages/angular/src/executors/application/schema.d.ts
+++ b/packages/angular/src/executors/application/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ApplicationBuilderOptions } from '@angular-devkit/build-angular';
+import type { ApplicationBuilderOptions } from '@angular/build';
 import type { PluginSpec } from '../utilities/esbuild-extensions';
 
 export interface ApplicationExecutorOptions extends ApplicationBuilderOptions {

--- a/packages/angular/src/executors/extract-i18n/extract-i18n.impl.ts
+++ b/packages/angular/src/executors/extract-i18n/extract-i18n.impl.ts
@@ -1,6 +1,7 @@
 import { parseTargetString, type ExecutorContext } from '@nx/devkit';
 import { createBuilderContext } from 'nx/src/adapter/ngcli-adapter';
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
+import { assertBuilderPackageIsInstalled } from '../utilities/builder-package';
 import { patchBuilderContext } from '../utilities/patch-builder-context';
 import type { ExtractI18nExecutorOptions } from './schema';
 
@@ -41,6 +42,7 @@ export default async function* extractI18nExecutor(
    */
   patchBuilderContext(builderContext, isUsingEsbuildBuilder, parsedBuildTarget);
 
+  assertBuilderPackageIsInstalled('@angular-devkit/build-angular');
   const { executeExtractI18nBuilder } = await import(
     '@angular-devkit/build-angular'
   );

--- a/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -1,30 +1,35 @@
-import { executeSSRDevServerBuilder } from '@angular-devkit/build-angular';
 import { type ExecutorContext, logger } from '@nx/devkit';
-import { existsSync } from 'fs';
-import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
-import { extname, join } from 'path';
-import {
-  getDynamicMfManifestFile,
-  validateDevRemotes,
-} from '../../builders/utilities/module-federation';
-import type { Schema } from './schema';
-import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
-import { startRemotes } from './lib/start-dev-remotes';
 import {
   combineAsyncIterables,
   createAsyncIterable,
   mapAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
 import { eachValueFrom } from '@nx/devkit/src/utils/rxjs-for-await';
-import { createBuilderContext } from 'nx/src/adapter/ngcli-adapter';
-import { normalizeOptions } from './lib/normalize-options';
+import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import { existsSync } from 'fs';
+import { createBuilderContext } from 'nx/src/adapter/ngcli-adapter';
+import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
+import { extname, join } from 'path';
+import {
+  getDynamicMfManifestFile,
+  validateDevRemotes,
+} from '../../builders/utilities/module-federation';
+import { assertBuilderPackageIsInstalled } from '../utilities/builder-package';
+import { normalizeOptions } from './lib/normalize-options';
+import { startRemotes } from './lib/start-dev-remotes';
+import type { Schema } from './schema';
 
 export async function* moduleFederationSsrDevServerExecutor(
   schema: Schema,
   context: ExecutorContext
 ) {
   const options = normalizeOptions(schema);
+
+  assertBuilderPackageIsInstalled('@angular-devkit/build-angular');
+  const { executeSSRDevServerBuilder } = await import(
+    '@angular-devkit/build-angular'
+  );
 
   const currIter = eachValueFrom(
     executeSSRDevServerBuilder(

--- a/packages/angular/src/executors/utilities/builder-package.ts
+++ b/packages/angular/src/executors/utilities/builder-package.ts
@@ -1,0 +1,9 @@
+export function assertBuilderPackageIsInstalled(packageName: string): void {
+  try {
+    require(packageName);
+  } catch {
+    throw new Error(
+      `The required package ${packageName} is not installed. Please make sure it is installed and try again.`
+    );
+  }
+}

--- a/packages/angular/src/executors/utilities/esbuild-extensions.ts
+++ b/packages/angular/src/executors/utilities/esbuild-extensions.ts
@@ -1,12 +1,11 @@
+import type { buildApplication } from '@angular/build';
 import { registerTsProject } from '@nx/js/src/internal';
 import { loadModule } from './module-loader';
 
 // This is a workaround to make sure we use the same esbuild version as the
 // Angular DevKit uses. This is only used internally to load the plugins and
 // forward them to the Angular DevKit builders.
-type Plugin = Parameters<
-  typeof import('@angular-devkit/build-angular').buildApplication
->[2]['codePlugins'][number];
+type Plugin = Parameters<typeof buildApplication>[2]['codePlugins'][number];
 
 export type PluginSpec = {
   path: string;

--- a/packages/angular/src/executors/utilities/patch-builder-context.ts
+++ b/packages/angular/src/executors/utilities/patch-builder-context.ts
@@ -1,9 +1,7 @@
 import type { BuilderContext } from '@angular-devkit/architect';
-import type {
-  ApplicationBuilderOptions,
-  BrowserBuilderOptions,
-} from '@angular-devkit/build-angular';
+import type { BrowserBuilderOptions } from '@angular-devkit/build-angular';
 import type { Schema as BrowserEsbuildBuilderOptions } from '@angular-devkit/build-angular/src/builders/browser-esbuild/schema';
+import type { ApplicationBuilderOptions } from '@angular/build';
 import type { Target } from '@nx/devkit';
 
 const executorToBuilderMap = new Map<string, string>([

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -27,7 +27,6 @@ exports[`app --minimal should generate a correct setup when --bundler=rspack and
   "styles": [
     "./src/styles.css"
   ],
-  "scripts": [],
   "devServer": {},
   "ssr": {
     "entry": "./src/server.ts"
@@ -174,7 +173,6 @@ exports[`app --minimal should generate a correct setup when --bundler=rspack inc
   "styles": [
     "./src/styles.css"
   ],
-  "scripts": [],
   "devServer": {}
 
     }
@@ -818,7 +816,7 @@ exports[`app nested should create project configs 1`] = `
         },
       },
       "defaultConfiguration": "production",
-      "executor": "@angular-devkit/build-angular:application",
+      "executor": "@angular/build:application",
       "options": {
         "assets": [
           {
@@ -831,7 +829,6 @@ exports[`app nested should create project configs 1`] = `
         "polyfills": [
           "zone.js",
         ],
-        "scripts": [],
         "styles": [
           "my-dir/my-app/src/styles.css",
         ],
@@ -842,7 +839,7 @@ exports[`app nested should create project configs 1`] = `
       ],
     },
     "extract-i18n": {
-      "executor": "@angular-devkit/build-angular:extract-i18n",
+      "executor": "@angular/build:extract-i18n",
       "options": {
         "buildTarget": "my-app:build",
       },
@@ -861,7 +858,7 @@ exports[`app nested should create project configs 1`] = `
       },
       "continuous": true,
       "defaultConfiguration": "development",
-      "executor": "@angular-devkit/build-angular:dev-server",
+      "executor": "@angular/build:dev-server",
     },
     "serve-static": {
       "continuous": true,
@@ -935,7 +932,7 @@ exports[`app not nested should create project configs 1`] = `
         },
       },
       "defaultConfiguration": "production",
-      "executor": "@angular-devkit/build-angular:application",
+      "executor": "@angular/build:application",
       "options": {
         "assets": [
           {
@@ -948,7 +945,6 @@ exports[`app not nested should create project configs 1`] = `
         "polyfills": [
           "zone.js",
         ],
-        "scripts": [],
         "styles": [
           "my-app/src/styles.css",
         ],
@@ -959,7 +955,7 @@ exports[`app not nested should create project configs 1`] = `
       ],
     },
     "extract-i18n": {
-      "executor": "@angular-devkit/build-angular:extract-i18n",
+      "executor": "@angular/build:extract-i18n",
       "options": {
         "buildTarget": "my-app:build",
       },
@@ -978,7 +974,7 @@ exports[`app not nested should create project configs 1`] = `
       },
       "continuous": true,
       "defaultConfiguration": "development",
-      "executor": "@angular-devkit/build-angular:dev-server",
+      "executor": "@angular/build:dev-server",
     },
     "serve-static": {
       "continuous": true,

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -78,12 +78,20 @@ describe('app', () => {
     expect(devDependencies['@angular/cli']).toBe(angularDevkitVersion);
     expect(devDependencies['@angular/compiler-cli']).toBe(angularVersion);
     expect(devDependencies['@angular/language-service']).toBe(angularVersion);
-    expect(devDependencies['@angular-devkit/build-angular']).toBe(
-      angularDevkitVersion
-    );
+    expect(devDependencies['@angular/build']).toBe(angularDevkitVersion);
 
     // codelyzer should no longer be there by default
     expect(devDependencies['codelyzer']).toBeUndefined();
+  });
+
+  it('should add both packages for builders when using rspack bundler', async () => {
+    await generateApp(appTree, 'my-app', { bundler: 'rspack' });
+
+    const { devDependencies } = readJson(appTree, 'package.json');
+    expect(devDependencies['@angular/build']).toBe(angularDevkitVersion);
+    expect(devDependencies['@angular-devkit/build-angular']).toBe(
+      angularDevkitVersion
+    );
   });
 
   it('should generate correct tsconfig.editor.json', async () => {
@@ -787,9 +795,7 @@ describe('app', () => {
           unitTestRunner: UnitTestRunner.Vitest,
         });
         const { targets } = readProjectConfiguration(appTree, 'my-app');
-        expect(targets.build.executor).toBe(
-          '@angular-devkit/build-angular:application'
-        );
+        expect(targets.build.executor).toBe('@angular/build:application');
       });
 
       it('should not override serve configuration when using vitest as a test runner', async () => {
@@ -797,9 +803,7 @@ describe('app', () => {
           unitTestRunner: UnitTestRunner.Vitest,
         });
         const { targets } = readProjectConfiguration(appTree, 'my-app');
-        expect(targets.serve.executor).toBe(
-          '@angular-devkit/build-angular:dev-server'
-        );
+        expect(targets.serve.executor).toBe('@angular/build:dev-server');
       });
     });
 
@@ -1144,7 +1148,7 @@ describe('app', () => {
 
       const project = readProjectConfiguration(appTree, 'ngesbuild');
       expect(project.targets.build.executor).toEqual(
-        '@angular-devkit/build-angular:application'
+        '@angular/build:application'
       );
       expect(
         project.targets.build.configurations.development.buildOptimizer
@@ -1343,6 +1347,34 @@ describe('app', () => {
 
       const project = readProjectConfiguration(appTree, 'my-app');
       expect(project.targets.build.options.index).toBe('my-app/src/index.html');
+    });
+
+    it('should use builders from "@angular-devkit/build-angular" for versions lower than v20', async () => {
+      updateJson(appTree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~19.0.0',
+        },
+      }));
+
+      await generateApp(appTree, 'my-app', { bundler: 'esbuild' });
+
+      const project = readProjectConfiguration(appTree, 'my-app');
+      expect(project.targets.build.executor).toBe(
+        '@angular-devkit/build-angular:application'
+      );
+      expect(project.targets.serve.executor).toBe(
+        '@angular-devkit/build-angular:dev-server'
+      );
+      expect(project.targets['extract-i18n'].executor).toBe(
+        '@angular-devkit/build-angular:extract-i18n'
+      );
+      expect(
+        readJson(appTree, 'package.json').devDependencies[
+          '@angular-devkit/build-angular'
+        ]
+      ).toBeDefined();
     });
   });
 });

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -1,4 +1,5 @@
 import {
+  addDependenciesToPackageJson,
   formatFiles,
   generateFiles,
   GeneratorCallback,
@@ -12,11 +13,16 @@ import {
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
-import { angularInitGenerator } from '../init/init';
 import { convertToRspack } from '../convert-to-rspack/convert-to-rspack';
+import { angularInitGenerator } from '../init/init';
 import { setupSsr } from '../setup-ssr/setup-ssr';
 import { setupTailwindGenerator } from '../setup-tailwind/setup-tailwind';
 import { ensureAngularDependencies } from '../utils/ensure-angular-dependencies';
+import {
+  getInstalledAngularDevkitVersion,
+  getInstalledAngularVersionInfo,
+  versions,
+} from '../utils/version-utils';
 import {
   addE2e,
   addLinting,
@@ -131,6 +137,27 @@ export async function applicationGenerator(
           tmpl: '',
         }
       );
+    }
+  }
+
+  if (!options.skipPackageJson) {
+    const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+    if (angularMajorVersion >= 20) {
+      const angularDevkitVersion =
+        getInstalledAngularDevkitVersion(tree) ??
+        versions(tree).angularDevkitVersion;
+
+      const devDependencies: Record<string, string> = {};
+      if (options.bundler === 'esbuild') {
+        devDependencies['@angular/build'] = angularDevkitVersion;
+      } else if (isRspack) {
+        devDependencies['@angular/build'] = angularDevkitVersion;
+        devDependencies['@angular-devkit/build-angular'] = angularDevkitVersion;
+      } else {
+        devDependencies['@angular-devkit/build-angular'] = angularDevkitVersion;
+      }
+
+      addDependenciesToPackageJson(tree, {}, devDependencies, undefined, true);
     }
   }
 

--- a/packages/angular/src/generators/application/lib/create-project.ts
+++ b/packages/angular/src/generators/application/lib/create-project.ts
@@ -1,6 +1,7 @@
 import {
   addProjectConfiguration,
   joinPathFragments,
+  type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
 import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
@@ -9,19 +10,24 @@ import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema } from './normalized-schema';
 
 export function createProject(tree: Tree, options: NormalizedSchema) {
-  const buildExecutor =
-    options.bundler === 'webpack'
-      ? '@angular-devkit/build-angular:browser'
-      : '@angular-devkit/build-angular:application';
-  const buildMainOptionName =
-    options.bundler === 'esbuild' ? 'browser' : 'main';
+  let project: ProjectConfiguration;
 
+  if (options.bundler === 'esbuild') {
+    project = createProjectForEsbuild(tree, options);
+  } else {
+    project = createProjectForWebpack(tree, options);
+  }
+
+  addProjectConfiguration(tree, options.name, project);
+}
+
+function createProjectForEsbuild(tree: Tree, options: NormalizedSchema) {
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
-  const index =
-    buildExecutor === '@angular-devkit/build-angular:application' &&
+
+  const buildExecutor =
     angularMajorVersion >= 20
-      ? undefined
-      : `${options.appProjectSourceRoot}/index.html`;
+      ? '@angular/build:application'
+      : '@angular-devkit/build-angular:application';
 
   addBuildTargetDefaults(tree, buildExecutor);
 
@@ -62,8 +68,11 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
         outputs: ['{options.outputPath}'],
         options: {
           outputPath: options.outputPath,
-          index,
-          [buildMainOptionName]: `${options.appProjectSourceRoot}/main.ts`,
+          index:
+            angularMajorVersion >= 20
+              ? undefined
+              : `${options.appProjectSourceRoot}/index.html`,
+          browser: `${options.appProjectSourceRoot}/main.ts`,
           polyfills: ['zone.js'],
           tsConfig: joinPathFragments(
             options.appProjectRoot,
@@ -77,7 +86,6 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
             },
           ],
           styles: [`${options.appProjectSourceRoot}/styles.${options.style}`],
-          scripts: [],
         },
         configurations: {
           production: {
@@ -85,12 +93,115 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
             outputHashing: 'all',
           },
           development: {
-            buildOptimizer: options.bundler === 'webpack' ? false : undefined,
             optimization: false,
-            vendorChunk: options.bundler === 'webpack' ? true : undefined,
             extractLicenses: false,
             sourceMap: true,
-            namedChunks: options.bundler === 'webpack' ? true : undefined,
+          },
+        },
+        defaultConfiguration: 'production',
+      },
+      serve: {
+        continuous: true,
+        executor:
+          angularMajorVersion >= 20
+            ? '@angular/build:dev-server'
+            : '@angular-devkit/build-angular:dev-server',
+        options: options.port ? { port: options.port } : undefined,
+        configurations: {
+          production: {
+            buildTarget: `${options.name}:build:production`,
+          },
+          development: {
+            buildTarget: `${options.name}:build:development`,
+          },
+        },
+        defaultConfiguration: 'development',
+      },
+      'extract-i18n': {
+        executor:
+          angularMajorVersion >= 20
+            ? '@angular/build:extract-i18n'
+            : '@angular-devkit/build-angular:extract-i18n',
+        options: {
+          buildTarget: `${options.name}:build`,
+        },
+      },
+    },
+  };
+
+  return project;
+}
+
+function createProjectForWebpack(tree: Tree, options: NormalizedSchema) {
+  const buildExecutor = '@angular-devkit/build-angular:browser';
+
+  addBuildTargetDefaults(tree, buildExecutor);
+
+  let budgets = undefined;
+  if (options.strict) {
+    budgets = [
+      { type: 'initial', maximumWarning: '500kb', maximumError: '1mb' },
+      {
+        type: 'anyComponentStyle',
+        maximumWarning: '4kb',
+        maximumError: '8kb',
+      },
+    ];
+  } else {
+    budgets = [
+      { type: 'initial', maximumWarning: '2mb', maximumError: '5mb' },
+      {
+        type: 'anyComponentStyle',
+        maximumWarning: '6kb',
+        maximumError: '10kb',
+      },
+    ];
+  }
+
+  const inlineStyleLanguage =
+    options?.style !== 'css' ? options.style : undefined;
+
+  const project: AngularProjectConfiguration = {
+    name: options.name,
+    projectType: 'application',
+    prefix: options.prefix,
+    root: options.appProjectRoot,
+    sourceRoot: options.appProjectSourceRoot,
+    tags: options.parsedTags,
+    targets: {
+      build: {
+        executor: buildExecutor,
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath: options.outputPath,
+          index: `${options.appProjectSourceRoot}/index.html`,
+          main: `${options.appProjectSourceRoot}/main.ts`,
+          polyfills: ['zone.js'],
+          tsConfig: joinPathFragments(
+            options.appProjectRoot,
+            'tsconfig.app.json'
+          ),
+          inlineStyleLanguage,
+          assets: [
+            {
+              glob: '**/*',
+              input: joinPathFragments(options.appProjectRoot, 'public'),
+            },
+          ],
+          styles: [`${options.appProjectSourceRoot}/styles.${options.style}`],
+        },
+        configurations: {
+          production: {
+            budgets,
+            outputHashing: 'all',
+          },
+          development: {
+            buildOptimizer: false,
+            optimization: false,
+            vendorChunk: true,
+            extractLicenses: false,
+            sourceMap: true,
+            namedChunks: true,
           },
         },
         defaultConfiguration: 'production',
@@ -98,11 +209,7 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
       serve: {
         continuous: true,
         executor: '@angular-devkit/build-angular:dev-server',
-        options: options.port
-          ? {
-              port: options.port,
-            }
-          : undefined,
+        options: options.port ? { port: options.port } : undefined,
         configurations: {
           production: {
             buildTarget: `${options.name}:build:production`,
@@ -122,5 +229,5 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
     },
   };
 
-  addProjectConfiguration(tree, options.name, project);
+  return project;
 }

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -11,7 +11,11 @@ import {
 import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodesV2 } from '../../plugins/plugin';
-import { getInstalledPackageVersion, versions } from '../utils/version-utils';
+import {
+  getInstalledAngularDevkitVersion,
+  getInstalledPackageVersion,
+  versions,
+} from '../utils/version-utils';
 import { Schema } from './schema';
 
 export async function angularInitGenerator(
@@ -61,8 +65,7 @@ function installAngularDevkitCoreIfMissing(
   if (!packageVersion) {
     const pkgVersions = versions(tree);
     const devkitVersion =
-      getInstalledPackageVersion(tree, '@angular-devkit/build-angular') ??
-      getInstalledPackageVersion(tree, '@angular/build') ??
+      getInstalledAngularDevkitVersion(tree) ??
       pkgVersions.angularDevkitVersion;
 
     try {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -89,12 +89,21 @@ describe('lib', () => {
     expect(devDependencies['@angular/cli']).toBe(angularDevkitVersion);
     expect(devDependencies['@angular/compiler-cli']).toBe(angularVersion);
     expect(devDependencies['@angular/language-service']).toBe(angularVersion);
-    expect(devDependencies['@angular-devkit/build-angular']).toBe(
-      angularDevkitVersion
-    );
 
+    // @angular/build should no be installed unless using vitest, as no other
+    // task requires it
+    expect(devDependencies['@angular/build']).toBeUndefined();
     // codelyzer should no longer be there by default
     expect(devDependencies['codelyzer']).toBeUndefined();
+  });
+
+  it('should add @angular/build when using vitest', async () => {
+    await runLibraryGeneratorWithOpts({
+      unitTestRunner: UnitTestRunner.Vitest,
+    });
+
+    const { devDependencies } = readJson(tree, 'package.json');
+    expect(devDependencies['@angular/build']).toBe(angularDevkitVersion);
   });
 
   it('should not touch the package.json when run with `--skipPackageJson`', async () => {

--- a/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
+++ b/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`setupSSR with application builder should create the files correctly for
     },
   },
   "defaultConfiguration": "production",
-  "executor": "@angular-devkit/build-angular:application",
+  "executor": "@angular/build:application",
   "options": {
     "assets": [
       {
@@ -39,7 +39,6 @@ exports[`setupSSR with application builder should create the files correctly for
       "zone.js",
     ],
     "prerender": true,
-    "scripts": [],
     "server": "app1/src/main.server.ts",
     "ssr": {
       "entry": "app1/src/server.ts",
@@ -151,7 +150,7 @@ exports[`setupSSR with application builder should create the files correctly for
     },
   },
   "defaultConfiguration": "production",
-  "executor": "@angular-devkit/build-angular:application",
+  "executor": "@angular/build:application",
   "options": {
     "assets": [
       {
@@ -165,7 +164,6 @@ exports[`setupSSR with application builder should create the files correctly for
       "zone.js",
     ],
     "prerender": true,
-    "scripts": [],
     "server": "app1/src/main.server.ts",
     "ssr": {
       "entry": "app1/src/server.ts",

--- a/packages/angular/src/generators/setup-ssr/lib/add-dependencies.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/add-dependencies.ts
@@ -1,5 +1,6 @@
 import { addDependenciesToPackageJson, type Tree } from '@nx/devkit';
 import {
+  getInstalledAngularDevkitVersion,
   getInstalledPackageVersion,
   versions,
 } from '../../utils/version-utils';
@@ -21,9 +22,7 @@ export function addDependencies(
   };
 
   dependencies['@angular/ssr'] =
-    getInstalledPackageVersion(tree, '@angular-devkit/build-angular') ??
-    getInstalledPackageVersion(tree, '@angular/build') ??
-    pkgVersions.angularDevkitVersion;
+    getInstalledAngularDevkitVersion(tree) ?? pkgVersions.angularDevkitVersion;
   if (!isUsingApplicationBuilder) {
     devDependencies['browser-sync'] = pkgVersions.browserSyncVersion;
   }

--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -1,5 +1,10 @@
-import { ensurePackage, type Tree } from '@nx/devkit';
+import {
+  addDependenciesToPackageJson,
+  ensurePackage,
+  type Tree,
+} from '@nx/devkit';
 import { nxVersion } from '../../utils/versions';
+import { getInstalledAngularDevkitVersion, versions } from './version-utils';
 
 export type AddVitestOptions = {
   name: string;
@@ -25,4 +30,18 @@ export async function addVitest(
     coverageProvider: 'v8',
     addPlugin: options.addPlugin ?? false,
   });
+
+  if (!options.skipPackageJson) {
+    const angularDevkitVersion =
+      getInstalledAngularDevkitVersion(tree) ??
+      versions(tree).angularDevkitVersion;
+
+    addDependenciesToPackageJson(
+      tree,
+      {},
+      { '@angular/build': angularDevkitVersion },
+      undefined,
+      true
+    );
+  }
 }

--- a/packages/angular/src/generators/utils/ensure-angular-dependencies.spec.ts
+++ b/packages/angular/src/generators/utils/ensure-angular-dependencies.spec.ts
@@ -2,6 +2,7 @@ import { readJson, updateJson, type Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { angularDevkitVersion, angularVersion } from '../../utils/versions';
 import { ensureAngularDependencies } from './ensure-angular-dependencies';
+import { backwardCompatibleVersions } from '../../utils/backward-compatible-versions';
 
 describe('ensureAngularDependencies', () => {
   let tree: Tree;
@@ -31,13 +32,28 @@ describe('ensureAngularDependencies', () => {
     expect(devDependencies['@angular/cli']).toBe(angularDevkitVersion);
     expect(devDependencies['@angular/compiler-cli']).toBe(angularVersion);
     expect(devDependencies['@angular/language-service']).toBe(angularVersion);
-    expect(devDependencies['@angular-devkit/build-angular']).toBe(
-      angularDevkitVersion
-    );
     expect(devDependencies['@angular-devkit/schematics']).toBe(
       angularDevkitVersion
     );
     expect(devDependencies['@schematics/angular']).toBe(angularDevkitVersion);
+  });
+
+  it('should add both packages for builders when angular version is less than 20', () => {
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { ...json.dependencies, '@angular/core': '~18.0.0' },
+    }));
+
+    ensureAngularDependencies(tree);
+
+    const { devDependencies } = readJson(tree, 'package.json');
+
+    expect(devDependencies['@angular/build']).toBe(
+      backwardCompatibleVersions.angularV18.angularDevkitVersion
+    );
+    expect(devDependencies['@angular-devkit/build-angular']).toBe(
+      backwardCompatibleVersions.angularV18.angularDevkitVersion
+    );
   });
 
   it('should add peer dependencies respecting the @angular/devkit installed version', () => {

--- a/packages/angular/src/generators/utils/ensure-angular-dependencies.ts
+++ b/packages/angular/src/generators/utils/ensure-angular-dependencies.ts
@@ -3,7 +3,12 @@ import {
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
-import { getInstalledPackageVersion, versions } from './version-utils';
+import {
+  getInstalledAngularDevkitVersion,
+  getInstalledAngularVersionInfo,
+  getInstalledPackageVersion,
+  versions,
+} from './version-utils';
 
 export function ensureAngularDependencies(tree: Tree): GeneratorCallback {
   const dependencies: Record<string, string> = {};
@@ -41,9 +46,7 @@ export function ensureAngularDependencies(tree: Tree): GeneratorCallback {
     dependencies['zone.js'] = zoneJsVersion;
   }
 
-  const installedAngularDevkitVersion =
-    getInstalledPackageVersion(tree, '@angular-devkit/build-angular') ??
-    getInstalledPackageVersion(tree, '@angular/build');
+  const installedAngularDevkitVersion = getInstalledAngularDevkitVersion(tree);
   if (!installedAngularDevkitVersion) {
     /**
      * If `@angular-devkit/build-angular` is already installed, we assume the workspace
@@ -58,9 +61,14 @@ export function ensureAngularDependencies(tree: Tree): GeneratorCallback {
   // Ensure the `@nx/angular` peer dependencies are always installed.
   const angularDevkitVersion =
     installedAngularDevkitVersion ?? pkgVersions.angularDevkitVersion;
-  devDependencies['@angular-devkit/build-angular'] = angularDevkitVersion;
   devDependencies['@angular-devkit/schematics'] = angularDevkitVersion;
   devDependencies['@schematics/angular'] = angularDevkitVersion;
+
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+  if (angularMajorVersion < 20) {
+    devDependencies['@angular/build'] = angularDevkitVersion;
+    devDependencies['@angular-devkit/build-angular'] = angularDevkitVersion;
+  }
 
   return addDependenciesToPackageJson(
     tree,

--- a/packages/angular/src/generators/utils/version-utils.ts
+++ b/packages/angular/src/generators/utils/version-utils.ts
@@ -8,6 +8,13 @@ import {
 import * as latestVersions from '../../utils/versions';
 import { angularVersion } from '../../utils/versions';
 
+export function getInstalledAngularDevkitVersion(tree: Tree): string | null {
+  return (
+    getInstalledPackageVersion(tree, '@angular-devkit/build-angular') ??
+    getInstalledPackageVersion(tree, '@angular/build')
+  );
+}
+
 export function getInstalledAngularVersion(tree: Tree): string {
   const pkgJson = readJson(tree, 'package.json');
   const installedAngularVersion =

--- a/packages/nx/.eslintrc.json
+++ b/packages/nx/.eslintrc.json
@@ -105,6 +105,7 @@
               "typescript",
               "@nrwl/angular",
               "@angular-devkit/build-angular",
+              "@angular/build",
               "@angular-devkit/core",
               "@angular-devkit/architect",
               "@swc/core", //Optional, used in JS analysis if available

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -112,6 +112,10 @@ if (!patched) {
       () => {};
   } catch (e) {}
 
+  try {
+    require('@angular/build/private').assertCompatibleAngularVersion = () => {};
+  } catch (e) {}
+
   patched = true;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@angular-eslint/template-parser':
         specifier: 19.2.0
         version: 19.2.0(eslint@8.57.0)(typescript@5.8.3)
+      '@angular/build':
+        specifier: 20.0.0-rc.0
+        version: 20.0.0-rc.0(3nsqfp5k4b2noomgoyq4jeuxr4)
       '@angular/cli':
         specifier: 20.0.0-rc.0
         version: 20.0.0-rc.0(@types/node@20.16.10)(chokidar@3.6.0)
@@ -11856,9 +11859,6 @@ packages:
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
 
-  domutils@3.1.0:
-    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
-
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -12596,14 +12596,6 @@ packages:
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
-  fdir@6.4.2:
-    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
 
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
@@ -21355,6 +21347,60 @@ snapshots:
       eslint: 8.57.0
       typescript: 5.8.3
 
+  '@angular/build@20.0.0-rc.0(3nsqfp5k4b2noomgoyq4jeuxr4)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.2000.0-rc.0(chokidar@3.6.0)
+      '@angular/compiler': 20.0.0-rc.0
+      '@angular/compiler-cli': 20.0.0-rc.0(@angular/compiler@20.0.0-rc.0)(typescript@5.8.3)
+      '@babel/core': 7.27.1
+      '@babel/helper-annotate-as-pure': 7.27.1
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@inquirer/confirm': 5.1.9(@types/node@20.16.10)
+      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.87.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1))
+      beasties: 0.3.3
+      browserslist: 4.24.4
+      esbuild: 0.25.4
+      https-proxy-agent: 7.0.6
+      istanbul-lib-instrument: 6.0.3
+      jsonc-parser: 3.3.1
+      listr2: 8.3.3
+      magic-string: 0.30.17
+      mrmime: 2.0.1
+      parse5-html-rewriting-stream: 7.1.0
+      picomatch: 4.0.2
+      piscina: 5.0.0
+      rollup: 4.40.2
+      sass: 1.87.0
+      semver: 7.7.1
+      source-map-support: 0.5.21
+      tinyglobby: 0.2.13
+      tslib: 2.7.0
+      typescript: 5.8.3
+      vite: 6.3.5(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.87.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1)
+      watchpack: 2.4.2
+    optionalDependencies:
+      '@angular/core': 20.0.0-rc.0(@angular/compiler@20.0.0-rc.0)(rxjs@7.8.2)(zone.js@0.14.10)
+      '@angular/platform-browser': 20.0.0-rc.0(@angular/common@20.0.0-rc.0(@angular/core@20.0.0-rc.0(@angular/compiler@20.0.0-rc.0)(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@20.0.0-rc.0(@angular/compiler@20.0.0-rc.0)(rxjs@7.8.2)(zone.js@0.14.10))
+      less: 4.1.3
+      lmdb: 3.3.0
+      ng-packagr: 20.0.0-rc.0(@angular/compiler-cli@20.0.0-rc.0(@angular/compiler@20.0.0-rc.0)(typescript@5.8.3))(tailwindcss@3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3)))(tslib@2.7.0)(typescript@5.8.3)
+      postcss: 8.4.38
+      tailwindcss: 3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3))
+      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@1.21.6)(jsdom@20.0.3(bufferutil@4.0.7))(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - chokidar
+      - jiti
+      - lightningcss
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@angular/build@20.0.0-rc.0(elndpnciu56uip3p6aocftk6cu)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -22037,6 +22083,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.27.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/traverse': 7.25.9
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-class-features-plugin@7.27.1(@babel/core@7.27.1)':
     dependencies:
       '@babel/core': 7.27.1
@@ -22199,6 +22258,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.27.1(@babel/core@7.27.1)':
     dependencies:
       '@babel/core': 7.27.1
@@ -22227,7 +22295,7 @@ snapshots:
   '@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-wrap-function': 7.25.9
       '@babel/traverse': 7.26.9
     transitivePeerDependencies:
@@ -22236,7 +22304,7 @@ snapshots:
   '@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-wrap-function': 7.25.9
       '@babel/traverse': 7.26.9
     transitivePeerDependencies:
@@ -22272,6 +22340,15 @@ snapshots:
   '@babel/helper-replace-supers@7.25.9(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.26.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.25.9(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
       '@babel/traverse': 7.26.9
@@ -22503,6 +22580,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-decorators@7.24.7(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.27.1)
+      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/plugin-syntax-decorators': 7.24.7(@babel/core@7.27.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -22590,6 +22676,11 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.26.5
+
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -22635,6 +22726,11 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.26.5
+
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.27.1)':
     dependencies:
       '@babel/core': 7.27.1
@@ -22653,6 +22749,11 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
+      '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.2)':
@@ -22683,6 +22784,11 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.2)':
@@ -22818,6 +22924,11 @@ snapshots:
   '@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
+      '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.25.2)':
@@ -22990,7 +23101,7 @@ snapshots:
   '@babel/plugin-transform-classes@7.25.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.25.2)
@@ -23002,7 +23113,7 @@ snapshots:
   '@babel/plugin-transform-classes@7.25.9(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.26.9)
@@ -23321,6 +23432,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-commonjs@7.24.8(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.27.1)
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-simple-access': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-commonjs@7.26.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
@@ -23599,7 +23719,7 @@ snapshots:
   '@babel/plugin-transform-private-property-in-object@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.2)
@@ -23609,7 +23729,7 @@ snapshots:
   '@babel/plugin-transform-private-property-in-object@7.25.9(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.9)
       '@babel/helper-plugin-utils': 7.26.5
     transitivePeerDependencies:
@@ -23669,7 +23789,7 @@ snapshots:
   '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
@@ -23680,7 +23800,7 @@ snapshots:
   '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.26.9)
@@ -23691,7 +23811,7 @@ snapshots:
   '@babel/plugin-transform-react-pure-annotations@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.25.2)':
@@ -23888,6 +24008,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
       '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.26.9)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.25.2(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.27.1)
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.27.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24262,6 +24393,17 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.26.9)
       '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.26.9)
       '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.26.9)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.24.7(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.27.1)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.27.1)
+      '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.27.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26057,7 +26199,7 @@ snapshots:
 
   '@mdx-js/mdx@3.1.0(acorn@8.14.0)':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
@@ -27057,7 +27199,7 @@ snapshots:
       semver: 7.7.1
       simple-git: 3.27.0
       sirv: 2.0.4
-      tinyglobby: 0.2.12
+      tinyglobby: 0.2.13
       unimport: 3.12.0(rollup@4.22.0)(webpack-sources@3.2.3)
       vite: 6.2.0(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1)
       vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.0)(webpack-sources@3.2.3))(rollup@4.22.0)(vite@6.2.0(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1))
@@ -29340,11 +29482,11 @@ snapshots:
       '@lezer/javascript': 1.4.21
       '@lezer/lr': 1.4.2
 
-  '@rollup/plugin-alias@5.1.0(rollup@4.34.8)':
+  '@rollup/plugin-alias@5.1.0(rollup@4.40.2)':
     dependencies:
       slash: 4.0.0
     optionalDependencies:
-      rollup: 4.34.8
+      rollup: 4.40.2
 
   '@rollup/plugin-babel@6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.22.0)':
     dependencies:
@@ -29368,16 +29510,16 @@ snapshots:
     optionalDependencies:
       rollup: 4.22.0
 
-  '@rollup/plugin-commonjs@25.0.8(rollup@4.34.8)':
+  '@rollup/plugin-commonjs@25.0.8(rollup@4.40.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
+      '@rollup/pluginutils': 5.1.0(rollup@4.40.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.11
     optionalDependencies:
-      rollup: 4.34.8
+      rollup: 4.40.2
 
   '@rollup/plugin-image@3.0.3(rollup@4.22.0)':
     dependencies:
@@ -29386,13 +29528,13 @@ snapshots:
     optionalDependencies:
       rollup: 4.22.0
 
-  '@rollup/plugin-inject@5.0.5(rollup@4.34.8)':
+  '@rollup/plugin-inject@5.0.5(rollup@4.40.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
+      '@rollup/pluginutils': 5.1.0(rollup@4.40.2)
       estree-walker: 2.0.2
       magic-string: 0.30.17
     optionalDependencies:
-      rollup: 4.34.8
+      rollup: 4.40.2
 
   '@rollup/plugin-json@6.1.0(rollup@4.22.0)':
     dependencies:
@@ -29400,17 +29542,17 @@ snapshots:
     optionalDependencies:
       rollup: 4.22.0
 
-  '@rollup/plugin-json@6.1.0(rollup@4.34.8)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
-    optionalDependencies:
-      rollup: 4.34.8
-
   '@rollup/plugin-json@6.1.0(rollup@4.39.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.39.0)
     optionalDependencies:
       rollup: 4.39.0
+
+  '@rollup/plugin-json@6.1.0(rollup@4.40.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.40.2)
+    optionalDependencies:
+      rollup: 4.40.2
 
   '@rollup/plugin-node-resolve@15.2.3(rollup@4.22.0)':
     dependencies:
@@ -29423,16 +29565,16 @@ snapshots:
     optionalDependencies:
       rollup: 4.22.0
 
-  '@rollup/plugin-node-resolve@15.2.3(rollup@4.34.8)':
+  '@rollup/plugin-node-resolve@15.2.3(rollup@4.40.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
+      '@rollup/pluginutils': 5.1.0(rollup@4.40.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
     optionalDependencies:
-      rollup: 4.34.8
+      rollup: 4.40.2
 
   '@rollup/plugin-replace@5.0.7(rollup@4.22.0)':
     dependencies:
@@ -29441,20 +29583,20 @@ snapshots:
     optionalDependencies:
       rollup: 4.22.0
 
-  '@rollup/plugin-replace@5.0.7(rollup@4.34.8)':
+  '@rollup/plugin-replace@5.0.7(rollup@4.40.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
+      '@rollup/pluginutils': 5.1.0(rollup@4.40.2)
       magic-string: 0.30.17
     optionalDependencies:
-      rollup: 4.34.8
+      rollup: 4.40.2
 
-  '@rollup/plugin-terser@0.4.4(rollup@4.34.8)':
+  '@rollup/plugin-terser@0.4.4(rollup@4.40.2)':
     dependencies:
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.39.0
     optionalDependencies:
-      rollup: 4.34.8
+      rollup: 4.40.2
 
   '@rollup/plugin-url@8.0.2(rollup@4.22.0)':
     dependencies:
@@ -29471,27 +29613,27 @@ snapshots:
 
   '@rollup/pluginutils@5.1.0(rollup@4.22.0)':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 4.22.0
 
-  '@rollup/pluginutils@5.1.0(rollup@4.34.8)':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.34.8
-
   '@rollup/pluginutils@5.1.0(rollup@4.39.0)':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 4.39.0
+
+  '@rollup/pluginutils@5.1.0(rollup@4.40.2)':
+    dependencies:
+      '@types/estree': 1.0.7
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.40.2
 
   '@rollup/rollup-android-arm-eabi@4.22.0':
     optional: true
@@ -30379,54 +30521,54 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.25.2)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.25.2)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.25.2)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.25.2)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.25.2)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.25.2)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.25.2)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.25.2)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.25.2)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.25.2
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.25.2)
+      '@babel/core': 7.27.1
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.27.1)
 
   '@svgr/core@8.1.0(typescript@5.8.3)':
     dependencies:
-      '@babel/core': 7.25.2
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.25.2)
+      '@babel/core': 7.27.1
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.27.1)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.8.3)
       snake-case: 3.0.4
@@ -30441,8 +30583,8 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))':
     dependencies:
-      '@babel/core': 7.25.2
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.25.2)
+      '@babel/core': 7.27.1
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.27.1)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -30864,7 +31006,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/aria-query@5.0.4': {}
 
@@ -30945,7 +31087,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/estree@1.0.5': {}
 
@@ -31582,9 +31724,9 @@ snapshots:
 
   '@unocss/transformer-attributify-jsx-babel@0.59.4':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.26.9)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.26.9)
+      '@babel/core': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.27.1)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.27.1)
       '@unocss/core': 0.59.4
     transitivePeerDependencies:
       - supports-color
@@ -31632,7 +31774,7 @@ snapshots:
 
   '@vanilla-extract/babel-plugin-debug-ids@1.0.6':
     dependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -31655,8 +31797,8 @@ snapshots:
 
   '@vanilla-extract/integration@6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.39.0)':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.26.9)
+      '@babel/core': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.27.1)
       '@vanilla-extract/babel-plugin-debug-ids': 1.0.6
       '@vanilla-extract/css': 1.15.5(babel-plugin-macros@3.1.0)
       esbuild: 0.19.5
@@ -31866,6 +32008,10 @@ snapshots:
     dependencies:
       vite: 6.2.0(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1)
 
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.87.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1))':
+    dependencies:
+      vite: 6.3.5(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.87.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1)
+
   '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@20.16.10)(jiti@1.21.6)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.87.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1))':
     dependencies:
       vite: 6.3.5(@types/node@20.16.10)(jiti@1.21.6)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.87.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1)
@@ -31894,9 +32040,9 @@ snapshots:
 
   '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.11(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.39.0))(vue@3.5.6(typescript@5.8.3))':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.26.9)
-      '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.9)
+      '@babel/core': 7.27.1
+      '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.27.1)
+      '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.27.1)
       vite: 5.4.11(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.39.0)
       vue: 3.5.6(typescript@5.8.3)
     transitivePeerDependencies:
@@ -32044,27 +32190,27 @@ snapshots:
 
   '@vue/babel-helper-vue-transform-on@1.2.5': {}
 
-  '@vue/babel-plugin-jsx@1.2.5(@babel/core@7.26.9)':
+  '@vue/babel-plugin-jsx@1.2.5(@babel/core@7.27.1)':
     dependencies:
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.26.9)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.27.1)
       '@babel/template': 7.26.9
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
       '@vue/babel-helper-vue-transform-on': 1.2.5
-      '@vue/babel-plugin-resolve-type': 1.2.5(@babel/core@7.26.9)
+      '@vue/babel-plugin-resolve-type': 1.2.5(@babel/core@7.27.1)
       html-tags: 3.3.1
       svg-tags: 1.0.0
     optionalDependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/babel-plugin-resolve-type@1.2.5(@babel/core@7.26.9)':
+  '@vue/babel-plugin-resolve-type@1.2.5(@babel/core@7.27.1)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/parser': 7.26.9
@@ -34327,7 +34473,7 @@ snapshots:
       boolbase: 1.0.0
       css-what: 6.1.0
       domhandler: 5.0.3
-      domutils: 3.1.0
+      domutils: 3.2.2
       nth-check: 2.1.1
 
   css-selector-parser@3.1.2: {}
@@ -34869,12 +35015,6 @@ snapshots:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
-
-  domutils@3.1.0:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
 
   domutils@3.2.2:
     dependencies:
@@ -35847,11 +35987,11 @@ snapshots:
 
   estree-util-attach-comments@2.1.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   estree-util-build-jsx@2.2.2:
     dependencies:
@@ -35874,7 +36014,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
 
   estree-util-to-js@1.2.0:
@@ -35909,7 +36049,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   esutils@2.0.3: {}
 
@@ -36199,10 +36339,6 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
-
-  fdir@6.4.2(picomatch@4.0.2):
-    optionalDependencies:
-      picomatch: 4.0.2
 
   fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
@@ -37038,7 +37174,7 @@ snapshots:
 
   hast-util-to-estree@2.3.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.5
       '@types/hast': 2.3.10
       '@types/unist': 2.0.11
@@ -37058,7 +37194,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -37093,7 +37229,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -37844,11 +37980,11 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   is-reference@3.0.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   is-regex@1.1.4:
     dependencies:
@@ -37986,7 +38122,7 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
       '@babel/parser': 7.26.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -39519,7 +39655,7 @@ snapshots:
 
   metro-babel-transformer@0.80.12:
     dependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.23.1
       nullthrows: 1.1.1
@@ -39617,7 +39753,7 @@ snapshots:
 
   metro-transform-plugins@0.80.12:
     dependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
       '@babel/generator': 7.26.9
       '@babel/template': 7.26.9
       '@babel/traverse': 7.26.9
@@ -39628,7 +39764,7 @@ snapshots:
 
   metro-transform-worker@0.80.12(bufferutil@4.0.7):
     dependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
       '@babel/generator': 7.26.9
       '@babel/parser': 7.26.9
       '@babel/types': 7.26.9
@@ -39810,7 +39946,7 @@ snapshots:
 
   micromark-extension-mdx-expression@1.0.8:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
@@ -39821,7 +39957,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -39833,7 +39969,7 @@ snapshots:
   micromark-extension-mdx-jsx@1.0.5:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-util-is-identifier-name: 2.1.0
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
@@ -39845,7 +39981,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -39866,7 +40002,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@1.0.5:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       micromark-core-commonmark: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
@@ -39878,7 +40014,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -39938,7 +40074,7 @@ snapshots:
 
   micromark-factory-mdx-expression@1.0.9:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
       micromark-util-symbol: 1.1.0
@@ -39949,7 +40085,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -40066,7 +40202,7 @@ snapshots:
   micromark-util-events-to-acorn@1.2.3:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/unist': 2.0.11
       estree-util-visit: 1.2.1
       micromark-util-symbol: 1.1.0
@@ -40076,7 +40212,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -40522,14 +40658,14 @@ snapshots:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@netlify/functions': 2.8.1
-      '@rollup/plugin-alias': 5.1.0(rollup@4.34.8)
-      '@rollup/plugin-commonjs': 25.0.8(rollup@4.34.8)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.34.8)
-      '@rollup/plugin-json': 6.1.0(rollup@4.34.8)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.34.8)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.34.8)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.34.8)
-      '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
+      '@rollup/plugin-alias': 5.1.0(rollup@4.40.2)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@4.40.2)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.40.2)
+      '@rollup/plugin-json': 6.1.0(rollup@4.40.2)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.40.2)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.40.2)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.40.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.40.2)
       '@types/http-proxy': 1.17.15
       '@vercel/nft': 0.26.5(encoding@0.1.13)
       archiver: 7.0.1
@@ -40572,8 +40708,8 @@ snapshots:
       pkg-types: 1.2.0
       pretty-bytes: 6.1.1
       radix3: 1.1.2
-      rollup: 4.34.8
-      rollup-plugin-visualizer: 5.12.0(rollup@4.34.8)
+      rollup: 4.40.2
+      rollup-plugin-visualizer: 5.12.0(rollup@4.40.2)
       scule: 1.3.0
       semver: 7.7.1
       serve-placeholder: 2.0.2
@@ -40583,7 +40719,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1(webpack-sources@3.2.3)
       unenv: 1.10.0
-      unimport: 3.12.0(rollup@4.34.8)(webpack-sources@3.2.3)
+      unimport: 3.12.0(rollup@4.40.2)(webpack-sources@3.2.3)
       unstorage: 1.12.0(@azure/identity@4.5.0)(@azure/storage-blob@12.25.0)(ioredis@5.4.1)
       unwasm: 0.3.9(webpack-sources@3.2.3)
     transitivePeerDependencies:
@@ -41507,7 +41643,7 @@ snapshots:
 
   periscopic@3.1.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
@@ -42664,7 +42800,7 @@ snapshots:
 
   react-docgen@7.0.3:
     dependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       '@types/babel__core': 7.20.5
@@ -42936,7 +43072,7 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -42952,14 +43088,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -43101,7 +43237,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -43414,14 +43550,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.22.0
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.34.8):
+  rollup-plugin-visualizer@5.12.0(rollup@4.40.2):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.6.2
     optionalDependencies:
-      rollup: 4.34.8
+      rollup: 4.40.2
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -44990,7 +45126,7 @@ snapshots:
 
   tinyglobby@0.2.6:
     dependencies:
-      fdir: 6.4.2(picomatch@4.0.2)
+      fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
   tinypool@1.0.2: {}
@@ -45503,9 +45639,9 @@ snapshots:
       - rollup
       - webpack-sources
 
-  unimport@3.12.0(rollup@4.34.8)(webpack-sources@3.2.3):
+  unimport@3.12.0(rollup@4.40.2)(webpack-sources@3.2.3):
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
+      '@rollup/pluginutils': 5.1.0(rollup@4.40.2)
       acorn: 8.14.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -45733,7 +45869,7 @@ snapshots:
 
   untyped@1.4.2:
     dependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
       '@babel/standalone': 7.25.6
       '@babel/types': 7.26.9
       defu: 6.1.4
@@ -46100,12 +46236,12 @@ snapshots:
 
   vite-plugin-vue-inspector@5.2.0(vite@6.2.0(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1)):
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.26.9)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.9)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.9)
-      '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.26.9)
-      '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.9)
+      '@babel/core': 7.27.1
+      '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.27.1)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.27.1)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.27.1)
+      '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.27.1)
+      '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.27.1)
       '@vue/compiler-dom': 3.5.6
       kolorist: 1.8.0
       magic-string: 0.30.17
@@ -46117,7 +46253,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.3
-      rollup: 4.34.8
+      rollup: 4.40.2
     optionalDependencies:
       '@types/node': 20.16.10
       fsevents: 2.3.3
@@ -46138,6 +46274,25 @@ snapshots:
       jiti: 1.21.6
       less: 4.1.3
       sass: 1.55.0
+      sass-embedded: 1.85.1
+      stylus: 0.64.0
+      terser: 5.39.0
+      yaml: 2.6.1
+
+  vite@6.3.5(@types/node@20.16.10)(jiti@1.21.6)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.87.0)(stylus@0.64.0)(terser@5.39.0)(yaml@2.6.1):
+    dependencies:
+      esbuild: 0.25.0
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.3
+      rollup: 4.40.2
+      tinyglobby: 0.2.13
+    optionalDependencies:
+      '@types/node': 20.16.10
+      fsevents: 2.3.3
+      jiti: 1.21.6
+      less: 4.1.3
+      sass: 1.87.0
       sass-embedded: 1.85.1
       stylus: 0.64.0
       terser: 5.39.0
@@ -46665,7 +46820,7 @@ snapshots:
 
   webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.1)(webpack@5.99.8)):
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1


### PR DESCRIPTION
- Generate new projects with Angular CLI builders from `@angular/build` when using the esbuild bundler
- Use `@angular/build` directly in executors for Angular v20
- Only install the packages `@angular-devkit/build-angular` and `@angular/build` when needed
- Have both packages as optional peer dependencies (they'll be needed depending on what the workspace uses)
- Assert those packages are installed before using them at runtime to alert users in case they might be missing them (useful when manually adding/changing executors without installing the packages)