### PR TITLE
fix(angular): install `@angular/build` when using vitest test runner

### DIFF
--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -1,5 +1,10 @@
-import { ensurePackage, type Tree } from '@nx/devkit';
+import {
+  addDependenciesToPackageJson,
+  ensurePackage,
+  type Tree,
+} from '@nx/devkit';
 import { nxVersion } from '../../utils/versions';
+import { getInstalledAngularDevkitVersion, versions } from './version-utils';
 
 export type AddVitestOptions = {
   name: string;
@@ -25,4 +30,18 @@ export async function addVitest(
     coverageProvider: 'v8',
     addPlugin: options.addPlugin ?? false,
   });
+
+  if (!options.skipPackageJson) {
+    const angularDevkitVersion =
+      getInstalledAngularDevkitVersion(tree) ??
+      versions(tree).angularDevkitVersion;
+
+    addDependenciesToPackageJson(
+      tree,
+      {},
+      { '@angular/build': angularDevkitVersion },
+      undefined,
+      true
+    );
+  }
 }

--- a/packages/angular/src/generators/utils/version-utils.ts
+++ b/packages/angular/src/generators/utils/version-utils.ts
@@ -8,6 +8,13 @@ import {
 import * as latestVersions from '../../utils/versions';
 import { angularVersion } from '../../utils/versions';
 
+export function getInstalledAngularDevkitVersion(tree: Tree): string | null {
+  return (
+    getInstalledPackageVersion(tree, '@angular-devkit/build-angular') ??
+    getInstalledPackageVersion(tree, '@angular/build')
+  );
+}
+
 export function getInstalledAngularVersion(tree: Tree): string {
   const pkgJson = readJson(tree, 'package.json');
   const installedAngularVersion =


### PR DESCRIPTION
## Current Behavior

The application and library generators do not install the `@angular/build` package when using the `vitest` test runner. This can cause resolution issues depending on the package manager because the package is a peer dependency of the `@analogjs/vite-plugin-angular` package.

## Expected Behavior

The application and library generators should install the `@angular/build` package when using the `vitest` test runner.

## Related Issue(s)

Fixes #30646 
