### PR TITLE
cleanup(angular): set target version to v22 for the decorate cli script deprecation warning

### DIFF
--- a/packages/nx/src/adapter/decorate-cli.ts
+++ b/packages/nx/src/adapter/decorate-cli.ts
@@ -1,9 +1,11 @@
+// TODO(v22): remove this file
+
 import { readFileSync, writeFileSync } from 'fs';
 import { output } from '../utils/output';
 
 export function decorateCli() {
   output.warn({
-    title: `Decoration of the Angular CLI is deprecated and will be removed in a future version`,
+    title: `Decoration of the Angular CLI is deprecated and will be removed in Nx v22`,
     bodyLines: [
       `Please replace usage of "ng <command>" in any scripts, particularly for CI, with "nx <command>"`,
     ],


### PR DESCRIPTION
## Current Behavior

The deprecation warning for the old script to decorate the Angular CLI doesn't state the version in which it will be removed. This was intentional to allow sufficient time for users to migrate away from it.

## Expected Behavior

The deprecation warning for the old script to decorate the Angular CLI should state that it will be removed in Nx v22. It has been a long time since it was deprecated, and it should have provided more than enough time for users to move away from it.

## Related Issue(s)

Fixes #
