### PR TITLE
fix(core): improve pinned tasks annotation on narrow width

### DIFF
--- a/packages/nx/src/native/tui/components/snapshots/nx__native__tui__components__tasks_list__tests__pinned_tasks_with_narrow_width.snap
+++ b/packages/nx/src/native/tui/components/snapshots/nx__native__tui__components__tasks_list__tests__pinned_tasks_with_narrow_width.snap
@@ -1,0 +1,19 @@
+---
+source: packages/nx/src/native/tui/components/tasks_list.rs
+expression: terminal.backend()
+---
+"                                        "
+" NX    Running Test Task        Duration"
+"                                        "
+"                                        "
+"> ·    task1 [1]                     ..."
+"  ·    task2                         ..."
+"  ·    task3                         ..."
+"                                        "
+"                                        "
+"                                        "
+"                                        "
+"                                        "
+"                                        "
+"                                        "
+"  ← 1/1 →               quit: q  help: ?"

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -1001,7 +1001,11 @@ impl TasksList {
                                 .enumerate()
                                 .filter_map(|(idx, task)| {
                                     if task.as_deref() == Some(task_name.as_str()) {
-                                        Some(format!("[Pinned output {}]", idx + 1))
+                                        Some(if has_narrow_area_width {
+                                            format!("[{}]", idx + 1)
+                                        } else {
+                                            format!("[Pinned output {}]", idx + 1)
+                                        })
                                     } else {
                                         None
                                     }
@@ -2777,6 +2781,17 @@ mod tests {
                 "The remote cache will not be read from or written to during this run.".to_string(),
             ))
             .ok();
+
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+        insta::assert_snapshot!(terminal.backend());
+    }
+
+    #[test]
+    fn test_pinned_tasks_with_narrow_width() {
+        let (mut tasks_list, test_tasks) = create_test_tasks_list();
+        let mut terminal = create_test_terminal(40, 15);
+
+        tasks_list.pin_task(test_tasks[0].id.clone(), 0);
 
         render_to_test_backend(&mut terminal, &mut tasks_list);
         insta::assert_snapshot!(terminal.backend());


### PR DESCRIPTION
This is intended to be a super quick improvement until I can work on something a bit more substantial.

## Current Behavior
<!-- This is the behavior we have today -->

We always try and render `[Pinned output {}]`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We only render `[{}]` on narrow widths.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
