### PR TITLE
fix(nextjs): Update glob for cache output

### DIFF
--- a/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
                 "tty": false,
               },
               "outputs": [
-                "{workspaceRoot}/my-app/.next",
+                "{workspaceRoot}/my-app/.next/!(cache)/**/*",
                 "{workspaceRoot}/my-app/.next/!(cache)",
               ],
             },
@@ -109,7 +109,7 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
                 "tty": false,
               },
               "outputs": [
-                "{projectRoot}/.next",
+                "{projectRoot}/.next/!(cache)/**/*",
                 "{projectRoot}/.next/!(cache)",
               ],
             },

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -207,7 +207,7 @@ async function getBuildTargetConfig(
     dependsOn: ['^build'],
     cache: true,
     inputs: getInputs(namedInputs),
-    outputs: [nextOutputPath, `${nextOutputPath}/!(cache)`],
+    outputs: [`${nextOutputPath}/!(cache)/**/*`, `${nextOutputPath}/!(cache)`],
   };
 
   // TODO(ndcunningham): Update this to be consider different versions of next.js which is running


### PR DESCRIPTION
This PR refines the Next.js package plugin’s output glob to exclude the .next/cache directory. Caching that path via AWS S3 leads to checksum mismatches when restoring from the remote cache, so it’s now omitted.

related: https://github.com/nrwl/nx/issues/30338