### PR TITLE
fix(release): adjust publish error message and version schema

### DIFF
--- a/e2e/release/src/private-js-packages.test.ts
+++ b/e2e/release/src/private-js-packages.test.ts
@@ -206,8 +206,10 @@ describe('nx release - private JS packages', () => {
 
       - {private-project-name}
 
-      This is usually caused by not having an appropriate plugin, such as "@nx/js" installed, which will add the appropriate "nx-release-publish" target for you automatically.
-
+      This is usually caused by either
+      - not having an appropriate plugin, such as "@nx/js" installed, which will add the appropriate "nx-release-publish" target for you automatically
+      - having "private": true set in your package.json, which prevents the target from being created
+      
       Pass --verbose to see the stacktrace.
 
 

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -745,7 +745,28 @@
           "manifestRootsToUpdate": {
             "type": "array",
             "items": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Path to the directory containing a manifest file to update. Supports placeholders like {projectRoot} and {projectName}."
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "description": "Path to the directory containing a manifest file to update. Supports placeholders like {projectRoot} and {projectName}."
+                    },
+                    "preserveLocalDependencyProtocols": {
+                      "type": "boolean",
+                      "description": "Whether to preserve local dependency references using protocols like 'workspace:' or 'file:'. Set this to false for dist files that need to be published if not using a package manager that swaps references at publish time like pnpm or bun.",
+                      "default": true
+                    }
+                  },
+                  "required": ["path"],
+                  "additionalProperties": false
+                }
+              ]
             },
             "description": "A list of directories containing manifest files (such as package.json) to apply updates to when versioning. By default, only the project root will be used, but you could customize this to only version a manifest in a dist directory, or even version multiple manifests in different directories, such as both source and dist."
           },

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -257,7 +257,9 @@ async function runPublishOnProjects(
       `Based on your config, the following projects were matched for publishing but do not have the "${requiredTargetName}" target specified:\n${[
         ...projectsToRun.map((p) => `- ${p.name}`),
         '',
-        `This is usually caused by not having an appropriate plugin, such as "@nx/js" installed, which will add the appropriate "${requiredTargetName}" target for you automatically.`,
+        `This is usually caused by either`,
+        `- not having an appropriate plugin, such as "@nx/js" installed, which will add the appropriate "${requiredTargetName}" target for you automatically`,
+        `- having "private": true set in your package.json, which prevents the target from being created`,
       ].join('\n')}\n`
     );
   }


### PR DESCRIPTION
this fixes a small mismatch in the nx release schema and improves the messaging around it