### PR TITLE
feat(angular): add migrations for server rendering changes

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -454,6 +454,26 @@
         "path": "/nx-api/angular/migrations/update-angular-cli-version-20-0-0-rc-0",
         "type": "migration"
       },
+      "/nx-api/angular/migrations/migrate-provide-server-rendering-import": {
+        "description": "Migrate imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`.",
+        "file": "generated/packages/angular/migrations/migrate-provide-server-rendering-import.json",
+        "hidden": false,
+        "name": "migrate-provide-server-rendering-import",
+        "version": "21.2.0-beta.0",
+        "originalFilePath": "/packages/angular",
+        "path": "/nx-api/angular/migrations/migrate-provide-server-rendering-import",
+        "type": "migration"
+      },
+      "/nx-api/angular/migrations/replace-provide-server-routing": {
+        "description": "Replace `provideServerRouting` with `provideServerRendering` using `withRoutes`.",
+        "file": "generated/packages/angular/migrations/replace-provide-server-routing.json",
+        "hidden": false,
+        "name": "replace-provide-server-routing",
+        "version": "21.2.0-beta.0",
+        "originalFilePath": "/packages/angular",
+        "path": "/nx-api/angular/migrations/replace-provide-server-routing",
+        "type": "migration"
+      },
       "/nx-api/angular/migrations/21.2.0-package-updates": {
         "description": "",
         "file": "generated/packages/angular/migrations/21.2.0-package-updates.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -450,6 +450,26 @@
         "type": "migration"
       },
       {
+        "description": "Migrate imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`.",
+        "file": "generated/packages/angular/migrations/migrate-provide-server-rendering-import.json",
+        "hidden": false,
+        "name": "migrate-provide-server-rendering-import",
+        "version": "21.2.0-beta.0",
+        "originalFilePath": "/packages/angular",
+        "path": "angular/migrations/migrate-provide-server-rendering-import",
+        "type": "migration"
+      },
+      {
+        "description": "Replace `provideServerRouting` with `provideServerRendering` using `withRoutes`.",
+        "file": "generated/packages/angular/migrations/replace-provide-server-routing.json",
+        "hidden": false,
+        "name": "replace-provide-server-routing",
+        "version": "21.2.0-beta.0",
+        "originalFilePath": "/packages/angular",
+        "path": "angular/migrations/replace-provide-server-routing",
+        "type": "migration"
+      },
+      {
         "description": "",
         "file": "generated/packages/angular/migrations/21.2.0-package-updates.json",
         "hidden": false,

--- a/docs/generated/packages/angular/migrations/migrate-provide-server-rendering-import.json
+++ b/docs/generated/packages/angular/migrations/migrate-provide-server-rendering-import.json
@@ -1,0 +1,14 @@
+{
+  "name": "migrate-provide-server-rendering-import",
+  "version": "21.2.0-beta.0",
+  "requires": { "@angular/core": ">=20.0.0-rc.0" },
+  "description": "Migrate imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`.",
+  "factory": "./src/migrations/update-21-2-0/migrate-provide-server-rendering-import",
+  "implementation": "/packages/angular/src/migrations/update-21-2-0/migrate-provide-server-rendering-import.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/angular",
+  "schema": null,
+  "type": "migration",
+  "examplesFile": "#### Migrate Imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`\n\nMigrate the imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`. This migration will also add the `@angular/ssr` package to your dependencies if needed.\n\n#### Examples\n\nChange the import of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`:\n\n{% tabs %}\n{% tab label=\"Before\" %}\n\n```ts {% fileName=\"app/app.config.server.ts\" highlightLines=[2] %}\nimport { ApplicationConfig } from '@angular/core';\nimport { provideServerRendering } from '@angular/platform-server';\n\nconst serverConfig: ApplicationConfig = {\n  providers: [provideServerRendering()],\n};\n```\n\n{% /tab %}\n\n{% tab label=\"After\" %}\n\n```ts {% fileName=\"app/app.config.server.ts\" highlightLines=[2] %}\nimport { ApplicationConfig } from '@angular/core';\nimport { provideServerRendering } from '@angular/ssr';\n\nconst serverConfig: ApplicationConfig = {\n  providers: [provideServerRendering()],\n};\n```\n\n{% /tab %}\n{% /tabs %}\n\nIf you already have imports from `@angular/ssr`, the migration will add `provideServerRendering` to the existing import:\n\n{% tabs %}\n{% tab label=\"Before\" %}\n\n```ts {% fileName=\"app/app.config.server.ts\" highlightLines=[2,3] %}\nimport { ApplicationConfig } from '@angular/core';\nimport { provideServerRendering } from '@angular/platform-server';\nimport { provideServerRouting } from '@angular/ssr';\nimport { serverRoutes } from './app.routes.server';\n\nconst serverConfig: ApplicationConfig = {\n  providers: [provideServerRendering(), provideServerRouting(serverRoutes)],\n};\n```\n\n{% /tab %}\n\n{% tab label=\"After\" %}\n\n```ts {% fileName=\"app/app.config.server.ts\" highlightLines=[2] %}\nimport { ApplicationConfig } from '@angular/core';\nimport { provideServerRouting, provideServerRendering } from '@angular/ssr';\nimport { serverRoutes } from './app.routes.server';\n\nconst serverConfig: ApplicationConfig = {\n  providers: [provideServerRendering(), provideServerRouting(serverRoutes)],\n};\n```\n\n{% /tab %}\n{% /tabs %}\n"
+}

--- a/docs/generated/packages/angular/migrations/replace-provide-server-routing.json
+++ b/docs/generated/packages/angular/migrations/replace-provide-server-routing.json
@@ -1,0 +1,14 @@
+{
+  "name": "replace-provide-server-routing",
+  "version": "21.2.0-beta.0",
+  "requires": { "@angular/core": ">=20.0.0-rc.0" },
+  "description": "Replace `provideServerRouting` with `provideServerRendering` using `withRoutes`.",
+  "factory": "./src/migrations/update-21-2-0/replace-provide-server-routing",
+  "implementation": "/packages/angular/src/migrations/update-21-2-0/replace-provide-server-routing.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/angular",
+  "schema": null,
+  "type": "migration",
+  "examplesFile": "#### Replace `provideServerRouting` with `provideServerRendering`\n\nReplace `provideServerRouting` calls with `provideServerRendering` using `withRoutes`.\n\n#### Examples\n\nRemove `provideServerRouting` from your providers array and update the `provideServerRendering` call to use `withRoutes`:\n\n{% tabs %}\n{% tab label=\"Before\" %}\n\n```ts {% fileName=\"app/app.config.server.ts\" highlightLines=[2,6] %}\nimport { ApplicationConfig } from '@angular/core';\nimport { provideServerRendering, provideServerRouting } from '@angular/ssr';\nimport { serverRoutes } from './app.routes.server';\n\nconst serverConfig: ApplicationConfig = {\n  providers: [provideServerRendering(), provideServerRouting(serverRoutes)],\n};\n```\n\n{% /tab %}\n\n{% tab label=\"After\" %}\n\n```ts {% fileName=\"app/app.config.server.ts\" highlightLines=[2,6] %}\nimport { ApplicationConfig } from '@angular/core';\nimport { provideServerRendering, withRoutes } from '@angular/ssr';\nimport { serverRoutes } from './app.routes.server';\n\nconst serverConfig: ApplicationConfig = {\n  providers: [provideServerRendering(withRoutes(serverRoutes))],\n};\n```\n\n{% /tab %}\n{% /tabs %}\n\nIf you have `provideServerRouting` with additional arguments, the migration will preserve them:\n\n{% tabs %}\n{% tab label=\"Before\" %}\n\n```ts {% fileName=\"app/app.config.server.ts\" highlightLines=[4,11,12] %}\nimport { ApplicationConfig } from '@angular/core';\nimport {\n  provideServerRendering,\n  provideServerRouting,\n  withAppShell,\n} from '@angular/ssr';\nimport { serverRoutes } from './app.routes.server';\n\nconst serverConfig: ApplicationConfig = {\n  providers: [\n    provideServerRendering(),\n    provideServerRouting(serverRoutes, withAppShell(AppShellComponent)),\n  ],\n};\n```\n\n{% /tab %}\n\n{% tab label=\"After\" %}\n\n```ts {% fileName=\"app/app.config.server.ts\" highlightLines=[2,\"7-10\"] %}\nimport { ApplicationConfig } from '@angular/core';\nimport { provideServerRendering, withAppShell, withRoutes } from '@angular/ssr';\nimport { serverRoutes } from './app.routes.server';\n\nconst serverConfig: ApplicationConfig = {\n  providers: [\n    provideServerRendering(\n      withRoutes(serverRoutes),\n      withAppShell(AppShellComponent)\n    ),\n  ],\n};\n```\n\n{% /tab %}\n{% /tabs %}\n"
+}

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -311,6 +311,22 @@
       },
       "description": "Update the @angular/cli package version to 20.0.0-rc.0.",
       "factory": "./src/migrations/update-21-2-0/update-angular-cli"
+    },
+    "migrate-provide-server-rendering-import": {
+      "version": "21.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=20.0.0-rc.0"
+      },
+      "description": "Migrate imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`.",
+      "factory": "./src/migrations/update-21-2-0/migrate-provide-server-rendering-import"
+    },
+    "replace-provide-server-routing": {
+      "version": "21.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=20.0.0-rc.0"
+      },
+      "description": "Replace `provideServerRouting` with `provideServerRendering` using `withRoutes`.",
+      "factory": "./src/migrations/update-21-2-0/replace-provide-server-routing"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-21-2-0/migrate-provide-server-rendering-import.md
+++ b/packages/angular/src/migrations/update-21-2-0/migrate-provide-server-rendering-import.md
@@ -1,0 +1,68 @@
+#### Migrate Imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`
+
+Migrate the imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`. This migration will also add the `@angular/ssr` package to your dependencies if needed.
+
+#### Examples
+
+Change the import of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`:
+
+{% tabs %}
+{% tab label="Before" %}
+
+```ts {% fileName="app/app.config.server.ts" highlightLines=[2] %}
+import { ApplicationConfig } from '@angular/core';
+import { provideServerRendering } from '@angular/platform-server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering()],
+};
+```
+
+{% /tab %}
+
+{% tab label="After" %}
+
+```ts {% fileName="app/app.config.server.ts" highlightLines=[2] %}
+import { ApplicationConfig } from '@angular/core';
+import { provideServerRendering } from '@angular/ssr';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering()],
+};
+```
+
+{% /tab %}
+{% /tabs %}
+
+If you already have imports from `@angular/ssr`, the migration will add `provideServerRendering` to the existing import:
+
+{% tabs %}
+{% tab label="Before" %}
+
+```ts {% fileName="app/app.config.server.ts" highlightLines=[2,3] %}
+import { ApplicationConfig } from '@angular/core';
+import { provideServerRendering } from '@angular/platform-server';
+import { provideServerRouting } from '@angular/ssr';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering(), provideServerRouting(serverRoutes)],
+};
+```
+
+{% /tab %}
+
+{% tab label="After" %}
+
+```ts {% fileName="app/app.config.server.ts" highlightLines=[2] %}
+import { ApplicationConfig } from '@angular/core';
+import { provideServerRouting, provideServerRendering } from '@angular/ssr';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering(), provideServerRouting(serverRoutes)],
+};
+```
+
+{% /tab %}
+{% /tabs %}

--- a/packages/angular/src/migrations/update-21-2-0/migrate-provide-server-rendering-import.spec.ts
+++ b/packages/angular/src/migrations/update-21-2-0/migrate-provide-server-rendering-import.spec.ts
@@ -1,0 +1,105 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './migrate-provide-server-rendering-import';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(projectGraph)),
+}));
+
+describe('migrate-provide-server-rendering-import migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app1', { root: 'apps/app1' });
+    projectGraph = {
+      dependencies: {
+        app1: [
+          {
+            source: 'app1',
+            target: 'npm:@angular/platform-server',
+            type: 'static',
+          },
+        ],
+      },
+      nodes: {
+        app1: {
+          data: { root: 'apps/app1' },
+          name: 'app1',
+          type: 'app',
+        },
+      },
+    };
+  });
+
+  it('should replace provideServerRouting with provideServerRendering', async () => {
+    tree.write(
+      'apps/app1/src/app/app.config.server.ts',
+      `import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerRendering } from '@angular/platform-server';
+import { provideServerRouting } from '@angular/ssr';
+import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(),
+    provideServerRouting(serverRoutes)
+  ]
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);
+`
+    );
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/src/app/app.config.server.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+      import { provideServerRouting, provideServerRendering } from '@angular/ssr';
+      import { appConfig } from './app.config';
+      import { serverRoutes } from './app.routes.server';
+
+      const serverConfig: ApplicationConfig = {
+        providers: [provideServerRendering(), provideServerRouting(serverRoutes)],
+      };
+
+      export const config = mergeApplicationConfig(appConfig, serverConfig);
+      "
+    `);
+  });
+
+  it('should add "@angular/ssr" when the import is changed', async () => {
+    tree.write(
+      'apps/app1/src/app/app.config.server.ts',
+      `import { provideServerRendering } from '@angular/platform-server';`
+    );
+
+    await migration(tree);
+
+    const { dependencies } = readJson(tree, 'package.json');
+    expect(dependencies['@angular/ssr']).toBeDefined();
+  });
+
+  it('should not add "@angular/ssr" dependency when no imports have been updated', async () => {
+    tree.write(
+      'apps/app1/src/app/app.config.server.ts',
+      `import { provideClientHydration } from '@angular/platform-browser';`
+    );
+
+    await migration(tree);
+
+    const { dependencies } = readJson(tree, 'package.json');
+    expect(dependencies['@angular/ssr']).toBeUndefined();
+  });
+});

--- a/packages/angular/src/migrations/update-21-2-0/migrate-provide-server-rendering-import.ts
+++ b/packages/angular/src/migrations/update-21-2-0/migrate-provide-server-rendering-import.ts
@@ -1,0 +1,175 @@
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  visitNotIgnoredFiles,
+  type Tree,
+} from '@nx/devkit';
+import * as ts from 'typescript';
+import { FileChangeRecorder } from '../../utils/file-change-recorder';
+import { angularDevkitVersion } from '../../utils/versions';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+
+export default async function (tree: Tree) {
+  const projects = await getProjectsFilteredByDependencies(tree, [
+    'npm:@angular/platform-server',
+  ]);
+
+  if (!projects.length) {
+    return;
+  }
+
+  let isSsrInstalled = false;
+  for (const { project } of projects) {
+    visitNotIgnoredFiles(tree, project.root, (file) => {
+      if (!file.endsWith('.ts') || file.endsWith('.d.ts')) {
+        return;
+      }
+
+      const shouldInstallSsr = processFile(tree, file);
+
+      if (shouldInstallSsr && !isSsrInstalled) {
+        isSsrInstalled = true;
+        addDependenciesToPackageJson(
+          tree,
+          { '@angular/ssr': angularDevkitVersion },
+          {},
+          undefined,
+          true
+        );
+      }
+    });
+  }
+
+  await formatFiles(tree);
+}
+
+function processFile(tree: Tree, filePath: string): boolean {
+  const content = tree.read(filePath, 'utf-8');
+
+  if (
+    !content.includes('provideServerRendering') ||
+    !content.includes('@angular/platform-server')
+  ) {
+    return false;
+  }
+
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  let platformServerHasProvideServerRendering = false;
+  let platformServerImportNode: ts.ImportDeclaration | undefined;
+  let ssrImportNode: ts.ImportDeclaration | undefined;
+  const platformServerImports = new Set<string>();
+
+  sourceFile.forEachChild((node) => {
+    if (!ts.isImportDeclaration(node)) {
+      return;
+    }
+
+    const moduleSpecifier = node.moduleSpecifier.getText(sourceFile);
+    if (moduleSpecifier.includes('@angular/platform-server')) {
+      platformServerImportNode = node;
+      const importClause = node.importClause;
+      if (
+        importClause &&
+        importClause.namedBindings &&
+        ts.isNamedImports(importClause.namedBindings)
+      ) {
+        const namedImports = importClause.namedBindings.elements.map((e) =>
+          e.getText(sourceFile)
+        );
+        namedImports.forEach((importName) => {
+          if (importName === 'provideServerRendering') {
+            platformServerHasProvideServerRendering = true;
+          } else {
+            platformServerImports.add(importName);
+          }
+        });
+      }
+    } else if (moduleSpecifier.includes('@angular/ssr')) {
+      ssrImportNode = node;
+    }
+  });
+
+  if (!platformServerHasProvideServerRendering) {
+    return;
+  }
+
+  const recorder = new FileChangeRecorder(tree, filePath);
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+  });
+  if (
+    ssrImportNode?.importClause?.namedBindings &&
+    ts.isNamedImports(ssrImportNode.importClause.namedBindings)
+  ) {
+    const namedBindingsNode = ssrImportNode.importClause!
+      .namedBindings as ts.NamedImports;
+    const updatedNamedBindingsNode = ts.factory.updateNamedImports(
+      namedBindingsNode,
+      [
+        ...namedBindingsNode.elements,
+        ts.factory.createImportSpecifier(
+          false,
+          undefined,
+          ts.factory.createIdentifier('provideServerRendering')
+        ),
+      ]
+    );
+    recorder.replace(
+      namedBindingsNode,
+      printer.printNode(
+        ts.EmitHint.Unspecified,
+        updatedNamedBindingsNode,
+        sourceFile
+      )
+    );
+  } else {
+    /**
+     * Add a new import statement with the needed named import in case it
+     * doesn't exist yet or it doesn't have named imports.
+     *
+     * It would be quite uncommon to have an import from @angular/ssr without
+     * named imports, but if that's the case, we'll just add an extra import
+     * statement with the needed named import.
+     */
+    recorder.insertLeft(
+      0,
+      `import { provideServerRendering } from '@angular/ssr';\n`
+    );
+  }
+
+  if (platformServerImports.size > 0) {
+    // we only collected platform server imports because there were named
+    // imports, so we can safely use the type
+    const namedBindingsNode = platformServerImportNode.importClause!
+      .namedBindings as ts.NamedImports;
+    const updatedNamedBindingsNode = ts.factory.updateNamedImports(
+      namedBindingsNode,
+      namedBindingsNode.elements.filter((e) =>
+        platformServerImports.has(e.getText(sourceFile))
+      )
+    );
+    recorder.replace(
+      namedBindingsNode,
+      printer.printNode(
+        ts.EmitHint.Unspecified,
+        updatedNamedBindingsNode,
+        sourceFile
+      )
+    );
+  } else {
+    recorder.remove(
+      platformServerImportNode.getFullStart(),
+      platformServerImportNode.getEnd()
+    );
+  }
+
+  recorder.applyChanges();
+
+  return true;
+}

--- a/packages/angular/src/migrations/update-21-2-0/replace-provide-server-routing.md
+++ b/packages/angular/src/migrations/update-21-2-0/replace-provide-server-routing.md
@@ -1,0 +1,81 @@
+#### Replace `provideServerRouting` with `provideServerRendering`
+
+Replace `provideServerRouting` calls with `provideServerRendering` using `withRoutes`.
+
+#### Examples
+
+Remove `provideServerRouting` from your providers array and update the `provideServerRendering` call to use `withRoutes`:
+
+{% tabs %}
+{% tab label="Before" %}
+
+```ts {% fileName="app/app.config.server.ts" highlightLines=[2,6] %}
+import { ApplicationConfig } from '@angular/core';
+import { provideServerRendering, provideServerRouting } from '@angular/ssr';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering(), provideServerRouting(serverRoutes)],
+};
+```
+
+{% /tab %}
+
+{% tab label="After" %}
+
+```ts {% fileName="app/app.config.server.ts" highlightLines=[2,6] %}
+import { ApplicationConfig } from '@angular/core';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering(withRoutes(serverRoutes))],
+};
+```
+
+{% /tab %}
+{% /tabs %}
+
+If you have `provideServerRouting` with additional arguments, the migration will preserve them:
+
+{% tabs %}
+{% tab label="Before" %}
+
+```ts {% fileName="app/app.config.server.ts" highlightLines=[4,11,12] %}
+import { ApplicationConfig } from '@angular/core';
+import {
+  provideServerRendering,
+  provideServerRouting,
+  withAppShell,
+} from '@angular/ssr';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(),
+    provideServerRouting(serverRoutes, withAppShell(AppShellComponent)),
+  ],
+};
+```
+
+{% /tab %}
+
+{% tab label="After" %}
+
+```ts {% fileName="app/app.config.server.ts" highlightLines=[2,"7-10"] %}
+import { ApplicationConfig } from '@angular/core';
+import { provideServerRendering, withAppShell, withRoutes } from '@angular/ssr';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(
+      withRoutes(serverRoutes),
+      withAppShell(AppShellComponent)
+    ),
+  ],
+};
+```
+
+{% /tab %}
+{% /tabs %}

--- a/packages/angular/src/migrations/update-21-2-0/replace-provide-server-routing.spec.ts
+++ b/packages/angular/src/migrations/update-21-2-0/replace-provide-server-routing.spec.ts
@@ -1,0 +1,118 @@
+import {
+  addProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './replace-provide-server-routing';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(projectGraph)),
+}));
+
+describe('replace-provide-server-routing migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app1', { root: 'apps/app1' });
+    projectGraph = {
+      dependencies: {
+        app1: [
+          {
+            source: 'app1',
+            target: 'npm:@angular/ssr',
+            type: 'static',
+          },
+        ],
+      },
+      nodes: {
+        app1: {
+          data: { root: 'apps/app1' },
+          name: 'app1',
+          type: 'app',
+        },
+      },
+    };
+  });
+
+  it('should remove "provideServerRouting", add an import for "withRoutes" and update "provideServerRendering" to use "withRoutes"', async () => {
+    tree.write(
+      'apps/app1/src/app/app.config.server.ts',
+      `import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerRendering, provideServerRouting } from '@angular/ssr';
+import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering(), provideServerRouting(serverRoutes)],
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);
+`
+    );
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/src/app/app.config.server.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+      import { provideServerRendering, withRoutes } from '@angular/ssr';
+      import { appConfig } from './app.config';
+      import { serverRoutes } from './app.routes.server';
+
+      const serverConfig: ApplicationConfig = {
+        providers: [provideServerRendering(withRoutes(serverRoutes))],
+      };
+
+      export const config = mergeApplicationConfig(appConfig, serverConfig);
+      "
+    `);
+  });
+
+  it('should include extra arguments provided to "provideServerRouting"', async () => {
+    tree.write(
+      'apps/app1/src/app/app.config.server.ts',
+      `import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerRendering, provideServerRouting, withAppShell } from '@angular/ssr';
+import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(),
+    provideServerRouting(serverRoutes, withAppShell(AppShellComponent)),
+  ],
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);
+`
+    );
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/src/app/app.config.server.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+      import { provideServerRendering, withAppShell, withRoutes } from '@angular/ssr';
+      import { appConfig } from './app.config';
+      import { serverRoutes } from './app.routes.server';
+      
+      const serverConfig: ApplicationConfig = {
+        providers: [
+          provideServerRendering(
+            withRoutes(serverRoutes),
+            withAppShell(AppShellComponent)
+          ),
+        ],
+      };
+
+      export const config = mergeApplicationConfig(appConfig, serverConfig);
+      "
+    `);
+  });
+});

--- a/packages/angular/src/migrations/update-21-2-0/replace-provide-server-routing.ts
+++ b/packages/angular/src/migrations/update-21-2-0/replace-provide-server-routing.ts
@@ -1,0 +1,181 @@
+import { formatFiles, visitNotIgnoredFiles, type Tree } from '@nx/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import * as ts from 'typescript';
+import { FileChangeRecorder } from '../../utils/file-change-recorder';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+
+export default async function (tree: Tree) {
+  const projects = await getProjectsFilteredByDependencies(tree, [
+    'npm:@angular/ssr',
+  ]);
+
+  if (!projects.length) {
+    return;
+  }
+
+  for (const { project } of projects) {
+    visitNotIgnoredFiles(tree, project.root, (file) => {
+      if (!file.endsWith('.ts') || file.endsWith('.d.ts')) {
+        return;
+      }
+
+      processFile(tree, file);
+    });
+  }
+
+  await formatFiles(tree);
+}
+
+function processFile(tree: Tree, filePath: string): void {
+  const content = tree.read(filePath, 'utf-8');
+
+  if (
+    !content.includes('provideServerRouting') ||
+    !content.includes('@angular/ssr')
+  ) {
+    return;
+  }
+
+  const sourceFile = tsquery.ast(content);
+
+  const providersArray = tsquery.query<ts.ArrayLiteralExpression>(
+    sourceFile,
+    'PropertyAssignment:has(Identifier[name=providers]) > ArrayLiteralExpression:has(CallExpression > Identifier[name=provideServerRouting])',
+    { visitAllChildren: true }
+  )[0];
+  if (!providersArray) {
+    return;
+  }
+
+  const recorder = new FileChangeRecorder(tree, filePath);
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+  });
+
+  let provideServerRenderingCall: ts.CallExpression | undefined;
+  let provideServerRoutingCall: ts.CallExpression;
+
+  const providerCallNodes = providersArray.elements.filter((el) =>
+    ts.isCallExpression(el)
+  );
+  for (const node of providerCallNodes) {
+    if (node.expression.getText() === 'provideServerRendering') {
+      provideServerRenderingCall = node;
+    } else if (node.expression.getText() === 'provideServerRouting') {
+      provideServerRoutingCall = node;
+    }
+  }
+
+  const withRoutesCall = ts.factory.createCallExpression(
+    ts.factory.createIdentifier('withRoutes'),
+    undefined,
+    [provideServerRoutingCall.arguments.at(0)]
+  );
+
+  let updatedProvidersArray: ts.ArrayLiteralExpression;
+  if (provideServerRenderingCall) {
+    // remove the "provideServerRouting" call and update the existing "provideServerRendering" call
+    updatedProvidersArray = ts.factory.updateArrayLiteralExpression(
+      providersArray,
+      providersArray.elements
+        .filter(
+          (el) =>
+            !(
+              ts.isCallExpression(el) &&
+              ts.isIdentifier(el.expression) &&
+              el.expression.text === 'provideServerRouting'
+            )
+        )
+        .map((el) => {
+          if (
+            ts.isCallExpression(el) &&
+            ts.isIdentifier(el.expression) &&
+            el.expression.text === 'provideServerRendering'
+          ) {
+            return ts.factory.updateCallExpression(
+              el,
+              el.expression,
+              el.typeArguments,
+              [withRoutesCall, ...provideServerRoutingCall.arguments.slice(1)]
+            );
+          }
+
+          return el;
+        })
+    );
+  } else {
+    // replace the "provideServerRouting" call with the new "provideServerRendering" call
+    updatedProvidersArray = ts.factory.updateArrayLiteralExpression(
+      providersArray,
+      providersArray.elements.map((el) => {
+        if (
+          ts.isCallExpression(el) &&
+          ts.isIdentifier(el.expression) &&
+          el.expression.text === 'provideServerRouting'
+        ) {
+          return ts.factory.createCallExpression(
+            ts.factory.createIdentifier('provideServerRendering'),
+            undefined,
+            [withRoutesCall, ...provideServerRoutingCall.arguments.slice(1)]
+          );
+        }
+
+        return el;
+      })
+    );
+  }
+
+  recorder.replace(
+    providersArray,
+    printer.printNode(
+      ts.EmitHint.Unspecified,
+      updatedProvidersArray,
+      sourceFile
+    )
+  );
+
+  const importDecl = sourceFile.statements.find(
+    (stmt) =>
+      ts.isImportDeclaration(stmt) &&
+      ts.isStringLiteral(stmt.moduleSpecifier) &&
+      stmt.moduleSpecifier.text === '@angular/ssr'
+  ) as ts.ImportDeclaration | undefined;
+
+  if (importDecl?.importClause?.namedBindings) {
+    const namedBindings = importDecl?.importClause.namedBindings;
+
+    if (ts.isNamedImports(namedBindings)) {
+      // remove the "provideServerRouting" import and ensure we have the "withRoutes" import
+      const updatedElementNames = new Set([
+        ...namedBindings.elements
+          .map((el) => el.getText())
+          .filter((x) => x !== 'provideServerRouting'),
+        'withRoutes',
+      ]);
+      const updatedNamedBindings = ts.factory.updateNamedImports(
+        namedBindings,
+        Array.from(updatedElementNames).map((name) =>
+          ts.factory.createImportSpecifier(
+            false,
+            undefined,
+            ts.factory.createIdentifier(name)
+          )
+        )
+      );
+
+      const printer = ts.createPrinter({
+        newLine: ts.NewLineKind.LineFeed,
+      });
+      recorder.replace(
+        namedBindings,
+        printer.printNode(
+          ts.EmitHint.Unspecified,
+          updatedNamedBindings,
+          sourceFile
+        )
+      );
+    }
+  }
+
+  recorder.applyChanges();
+}


### PR DESCRIPTION
Add migrations for the server rendering changes:

- Move imports of `provideServerRendering` from `@angular/platform-server` to `@angular/ssr`
- Replace `provideServerRouting` (no longer exists from v20 onwards) with `provideServerRendering` + `withRoutes`