### PR TITLE
feat(angular): add error global listeners to new apps

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -213,7 +213,7 @@ exports[`app --minimal should generate a correct setup when --bundler=rspack inc
 `;
 
 exports[`app --minimal should skip "nx-welcome.component.ts" file and references for non-standalone apps with routing 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -225,7 +225,7 @@ import { appRoutes } from './app.routes';
     BrowserModule,
     RouterModule.forRoot(appRoutes),
   ],
-  providers: [],
+  providers: [provideBrowserGlobalErrorListeners()],
   bootstrap: [AppComponent],
 })
 export class AppModule {}
@@ -277,7 +277,7 @@ exports[`app --minimal should skip "nx-welcome.component.ts" file and references
 `;
 
 exports[`app --minimal should skip "nx-welcome.component.ts" file and references for non-standalone apps without routing 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 
@@ -286,7 +286,7 @@ import { AppComponent } from './app.component';
   imports: [
     BrowserModule,
   ],
-  providers: [],
+  providers: [provideBrowserGlobalErrorListeners()],
   bootstrap: [AppComponent],
 })
 export class AppModule {}
@@ -432,12 +432,16 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 `;
 
 exports[`app --standalone should generate a standalone app correctly with routing 2`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };
 "
 `;
@@ -509,10 +513,13 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 `;
 
 exports[`app --standalone should generate a standalone app correctly without routing 2`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true })]
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true })
+  ]
 };
 "
 `;
@@ -711,7 +718,7 @@ export default defineConfig(() => ({
 exports[`app at the root should accept numbers in the path 1`] = `"src/9-websites/my-app"`;
 
 exports[`app format files should format files 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -721,7 +728,7 @@ import { NxWelcomeComponent } from './nx-welcome.component';
 @NgModule({
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
-  providers: [],
+  providers: [provideBrowserGlobalErrorListeners()],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -1376,6 +1376,41 @@ describe('app', () => {
         ]
       ).toBeDefined();
     });
+
+    it('should not set provideBrowserGlobalErrorListeners in app.module.ts for versions lower than v20', async () => {
+      updateJson(appTree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~19.0.0',
+        },
+      }));
+
+      await generateApp(appTree, 'my-app', { bundler: 'esbuild' });
+
+      expect(
+        appTree.read('my-app/src/app/app.module.ts', 'utf-8')
+      ).not.toContain('provideBrowserGlobalErrorListeners');
+    });
+
+    it('should not set provideBrowserGlobalErrorListeners in standalone app.config.ts for versions lower than v20', async () => {
+      updateJson(appTree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~19.0.0',
+        },
+      }));
+
+      await generateApp(appTree, 'my-app', {
+        bundler: 'esbuild',
+        standalone: true,
+      });
+
+      expect(
+        appTree.read('my-app/src/app/app.config.ts', 'utf-8')
+      ).not.toContain('provideBrowserGlobalErrorListeners');
+    });
   });
 });
 

--- a/packages/angular/src/generators/application/files/ng-module/src/app/app.module.ts__tpl__
+++ b/packages/angular/src/generators/application/files/ng-module/src/app/app.module.ts__tpl__
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule<% if (provideGlobalErrorListener) { %>, provideBrowserGlobalErrorListeners<% } %> } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';<% if(routing) { %>
 import { RouterModule } from '@angular/router';<% } %>
 import { AppComponent } from './app.component';<% if(routing) { %>
@@ -11,7 +11,7 @@ import { NxWelcomeComponent } from './nx-welcome.component';<% } %>
     BrowserModule,<% if(routing) { %>
     RouterModule.forRoot(appRoutes),<% } %>
   ],
-  providers: [],
+  providers: [<% if (provideGlobalErrorListener) { %>provideBrowserGlobalErrorListeners()<% } %>],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/packages/angular/src/generators/application/files/standalone-components/src/app/app.config.ts__tpl__
+++ b/packages/angular/src/generators/application/files/standalone-components/src/app/app.config.ts__tpl__
@@ -1,7 +1,11 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';<% if (routing) { %>
+import { ApplicationConfig<% if (provideGlobalErrorListener) { %>, provideBrowserGlobalErrorListeners<% } %>, provideZoneChangeDetection } from '@angular/core';<% if (routing) { %>
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';<% } %>
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true })<% if (routing) { %>, provideRouter(appRoutes)<% } %>]
+  providers: [<% if (provideGlobalErrorListener) { %>
+    provideBrowserGlobalErrorListeners(),<% } %>
+    provideZoneChangeDetection({ eventCoalescing: true })<% if (routing) { %>,
+    provideRouter(appRoutes)<% } %>
+  ]
 };

--- a/packages/angular/src/generators/application/lib/create-files.ts
+++ b/packages/angular/src/generators/application/lib/create-files.ts
@@ -55,6 +55,7 @@ export async function createFiles(
     // Angular v19 or higher defaults to true, while lower versions default to false
     setStandaloneFalse: angularMajorVersion >= 19,
     setStandaloneTrue: angularMajorVersion < 19,
+    provideGlobalErrorListener: angularMajorVersion >= 20,
     connectCloudUrl,
     tutorialUrl: options.standalone
       ? 'https://nx.dev/getting-started/tutorials/angular-standalone-tutorial?utm_source=nx-project'

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Host App Generator --ssr should generate the correct files 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import {
   BrowserModule,
   provideClientHydration,
@@ -15,7 +15,10 @@ import { NxWelcomeComponent } from './nx-welcome.component';
 @NgModule({
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
-  providers: [provideClientHydration(withEventReplay())],
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideClientHydration(withEventReplay()),
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}
@@ -357,7 +360,11 @@ export const appRoutes: Route[] = [
 `;
 
 exports[`Host App Generator --ssr should generate the correct files for standalone 8`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import {
+  ApplicationConfig,
+  provideBrowserGlobalErrorListeners,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import {
@@ -368,6 +375,7 @@ import {
 export const appConfig: ApplicationConfig = {
   providers: [
     provideClientHydration(withEventReplay()),
+    provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
   ],
@@ -583,7 +591,11 @@ export const appRoutes: Route[] = [
 `;
 
 exports[`Host App Generator --ssr should generate the correct files for standalone when --typescript=true 8`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import {
+  ApplicationConfig,
+  provideBrowserGlobalErrorListeners,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import {
@@ -594,6 +606,7 @@ import {
 export const appConfig: ApplicationConfig = {
   providers: [
     provideClientHydration(withEventReplay()),
+    provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
   ],
@@ -662,7 +675,7 @@ exports[`Host App Generator --ssr should generate the correct files for standalo
 `;
 
 exports[`Host App Generator --ssr should generate the correct files when --typescript=true 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import {
   BrowserModule,
   provideClientHydration,
@@ -676,7 +689,10 @@ import { NxWelcomeComponent } from './nx-welcome.component';
 @NgModule({
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
-  providers: [provideClientHydration(withEventReplay())],
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideClientHydration(withEventReplay()),
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/packages/angular/src/generators/ngrx-root-store/__snapshots__/ngrx-root-store.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx-root-store/__snapshots__/ngrx-root-store.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NgRxRootStoreGenerator NgModule should add a facade when --facade=true 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -34,7 +34,7 @@ import { UsersFacade } from './+state/users.facade';
     StoreModule.forFeature(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),
     EffectsModule.forFeature([UsersEffects]),
   ],
-  providers: [UsersFacade],
+  providers: [provideBrowserGlobalErrorListeners(), UsersFacade],
   bootstrap: [AppComponent],
 })
 export class AppModule {}
@@ -73,7 +73,7 @@ export class UsersFacade {
 `;
 
 exports[`NgRxRootStoreGenerator NgModule should add a root module and root state when --minimal=false 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -105,7 +105,7 @@ import { UsersEffects } from './+state/users.effects';
     StoreModule.forFeature(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),
     EffectsModule.forFeature([UsersEffects]),
   ],
-  providers: [],
+  providers: [provideBrowserGlobalErrorListeners()],
   bootstrap: [AppComponent],
 })
 export class AppModule {}
@@ -358,7 +358,7 @@ describe('Users Selectors', () => {
 `;
 
 exports[`NgRxRootStoreGenerator NgModule should add an empty root module when --minimal=true 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -383,7 +383,7 @@ import { StoreRouterConnectingModule } from '@ngrx/router-store';
     }),
     StoreRouterConnectingModule.forRoot(),
   ],
-  providers: [],
+  providers: [provideBrowserGlobalErrorListeners()],
   bootstrap: [AppComponent],
 })
 export class AppModule {}
@@ -391,7 +391,7 @@ export class AppModule {}
 `;
 
 exports[`NgRxRootStoreGenerator NgModule should instrument the store devtools when "addDevTools: true" 1`] = `
-"import { NgModule, isDevMode } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners, isDevMode } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -418,7 +418,7 @@ import { StoreRouterConnectingModule } from '@ngrx/router-store';
     }),
     StoreRouterConnectingModule.forRoot(),
   ],
-  providers: [],
+  providers: [provideBrowserGlobalErrorListeners()],
   bootstrap: [AppComponent],
 })
 export class AppModule {}
@@ -426,7 +426,7 @@ export class AppModule {}
 `;
 
 exports[`NgRxRootStoreGenerator Standalone APIs should add a facade when --facade=true 1`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
@@ -436,7 +436,11 @@ import { UsersEffects } from './+state/users.effects';
 import { UsersFacade } from './+state/users.facade';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideEffects(UsersEffects),provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),UsersFacade,provideStore(),provideEffects(),provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+  providers: [provideEffects(UsersEffects),provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),UsersFacade,provideStore(),provideEffects(),
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };
 "
 `;
@@ -473,7 +477,7 @@ export class UsersFacade {
 `;
 
 exports[`NgRxRootStoreGenerator Standalone APIs should add a root module and root state when --minimal=false 1`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
@@ -482,7 +486,11 @@ import * as fromUsers from './+state/users.reducer';
 import { UsersEffects } from './+state/users.effects';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideEffects(UsersEffects),provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),provideStore(),provideEffects(),provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+  providers: [provideEffects(UsersEffects),provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),provideStore(),provideEffects(),
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };
 "
 `;
@@ -722,20 +730,24 @@ describe('Users Selectors', () => {
 `;
 
 exports[`NgRxRootStoreGenerator Standalone APIs should add an empty root module when --minimal=true 1`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideStore(),provideEffects(),provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+  providers: [provideStore(),provideEffects(),
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };
 "
 `;
 
 exports[`NgRxRootStoreGenerator Standalone APIs should instrument the store devtools when "addDevTools: true" 1`] = `
-"import { ApplicationConfig, provideZoneChangeDetection, isDevMode } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection, isDevMode } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore } from '@ngrx/store';
@@ -743,7 +755,11 @@ import { provideEffects } from '@ngrx/effects';
 import { provideStoreDevtools } from '@ngrx/store-devtools';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideStore(),provideStoreDevtools({ logOnly: !isDevMode() }),provideEffects(),provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+  providers: [provideStore(),provideStoreDevtools({ logOnly: !isDevMode() }),provideEffects(),
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };
 "
 `;

--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
@@ -756,7 +756,7 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 `;
 
 exports[`ngrx Standalone APIs should add a root module with feature module when minimal is set to false 2`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
@@ -765,7 +765,11 @@ import * as fromUsers from './+state/users.reducer';
 import { UsersEffects } from './+state/users.effects';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideEffects(UsersEffects),provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),provideEffects(),provideStore(),provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+  providers: [provideEffects(UsersEffects),provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),provideEffects(),provideStore(),
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };
 "
 `;
@@ -782,14 +786,18 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 `;
 
 exports[`ngrx Standalone APIs should add an empty provideStore when minimal and root are set to true 2`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideEffects(),provideStore(),provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+  providers: [provideEffects(),provideStore(),
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };
 "
 `;
@@ -806,7 +814,7 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 `;
 
 exports[`ngrx Standalone APIs should add facade provider when facade is true 2`] = `
-"import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+"import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
@@ -816,7 +824,11 @@ import { UsersEffects } from './+state/users.effects';
 import { UsersFacade } from './+state/users.facade';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideEffects(UsersEffects),provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),provideEffects(),provideStore(),UsersFacade,provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+  providers: [provideEffects(UsersEffects),provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),provideEffects(),provideStore(),UsersFacade,
+    provideBrowserGlobalErrorListeners(),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };
 "
 `;

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -90,7 +90,7 @@ describe('setupSSR', () => {
       `);
       expect(tree.read('app1/src/app/app.module.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "import { NgModule } from '@angular/core';
+        "import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
         import {
           BrowserModule,
           provideClientHydration,
@@ -104,7 +104,10 @@ describe('setupSSR', () => {
         @NgModule({
           declarations: [AppComponent, NxWelcomeComponent],
           imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
-          providers: [provideClientHydration(withEventReplay())],
+          providers: [
+            provideBrowserGlobalErrorListeners(),
+            provideClientHydration(withEventReplay()),
+          ],
           bootstrap: [AppComponent],
         })
         export class AppModule {}
@@ -364,7 +367,7 @@ describe('setupSSR', () => {
       `);
       expect(tree.read('app1/src/app/app.module.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "import { NgModule } from '@angular/core';
+        "import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
         import { BrowserModule, provideClientHydration, withEventReplay } from '@angular/platform-browser';
         import { RouterModule } from '@angular/router';
         import { AppComponent } from './app.component';
@@ -377,7 +380,7 @@ describe('setupSSR', () => {
             BrowserModule,
             RouterModule.forRoot(appRoutes),
           ],
-          providers: [provideClientHydration(withEventReplay())],
+          providers: [provideBrowserGlobalErrorListeners(), provideClientHydration(withEventReplay())],
           bootstrap: [AppComponent],
         })
         export class AppModule {}
@@ -540,7 +543,7 @@ describe('setupSSR', () => {
     // ASSERT
     expect(tree.read('app1/src/app/app.module.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { NgModule } from '@angular/core';
+      "import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
       import { BrowserModule, provideClientHydration, withEventReplay } from '@angular/platform-browser';
       import { RouterModule } from '@angular/router';
       import { AppComponent } from './app.component';
@@ -553,7 +556,7 @@ describe('setupSSR', () => {
           BrowserModule,
           RouterModule.forRoot(appRoutes),
         ],
-        providers: [provideClientHydration(withEventReplay())],
+        providers: [provideBrowserGlobalErrorListeners(), provideClientHydration(withEventReplay())],
         bootstrap: [AppComponent],
       })
       export class AppModule {}
@@ -580,13 +583,17 @@ describe('setupSSR', () => {
     // ASSERT
     expect(tree.read('app1/src/app/app.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+      "import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
       import { provideRouter } from '@angular/router';
       import { appRoutes } from './app.routes';
       import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
       export const appConfig: ApplicationConfig = {
-        providers: [provideClientHydration(withEventReplay()),provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+        providers: [provideClientHydration(withEventReplay()),
+          provideBrowserGlobalErrorListeners(),
+          provideZoneChangeDetection({ eventCoalescing: true }),
+          provideRouter(appRoutes)
+        ]
       };
       "
     `);
@@ -626,7 +633,7 @@ describe('setupSSR', () => {
 
     expect(tree.read('app1/src/app/app.module.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { NgModule } from '@angular/core';
+      "import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
       import { BrowserModule } from '@angular/platform-browser';
       import { RouterModule } from '@angular/router';
       import { AppComponent } from './app.component';
@@ -639,7 +646,7 @@ describe('setupSSR', () => {
           BrowserModule,
           RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledBlocking' }),
         ],
-        providers: [],
+        providers: [provideBrowserGlobalErrorListeners()],
         bootstrap: [AppComponent],
       })
       export class AppModule {}
@@ -662,12 +669,16 @@ describe('setupSSR', () => {
 
     expect(tree.read('app1/src/app/app.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+      "import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
       import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
       import { appRoutes } from './app.routes';
 
       export const appConfig: ApplicationConfig = {
-        providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes, withEnabledBlockingInitialNavigation())]
+        providers: [
+          provideBrowserGlobalErrorListeners(),
+          provideZoneChangeDetection({ eventCoalescing: true }),
+          provideRouter(appRoutes, withEnabledBlockingInitialNavigation())
+        ]
       };
       "
     `);
@@ -781,7 +792,10 @@ describe('setupSSR', () => {
         import { provideClientHydration } from '@angular/platform-browser';
 
         export const appConfig: ApplicationConfig = {
-          providers: [provideClientHydration(),provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(appRoutes)]
+          providers: [provideClientHydration(),
+            provideZoneChangeDetection({ eventCoalescing: true }),
+            provideRouter(appRoutes)
+          ]
         };
         "
       `);


### PR DESCRIPTION
Update the application generator to generate apps using the `provideBrowserGlobalErrorListeners` provider.