### PR TITLE
feat(angular): add type checking of host bindings to strict config

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -577,6 +577,7 @@ exports[`app --strict should enable strict type checking: app tsconfig.json 1`] 
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true,
+    "typeCheckHostBindings": true,
   },
   "compilerOptions": {
     "esModuleInterop": true,
@@ -1079,6 +1080,7 @@ exports[`app not nested should generate files: tsconfig.json 1`] = `
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true,
+    "typeCheckHostBindings": true,
   },
   "compilerOptions": {
     "esModuleInterop": true,

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -1411,6 +1411,28 @@ describe('app', () => {
         appTree.read('my-app/src/app/app.config.ts', 'utf-8')
       ).not.toContain('provideBrowserGlobalErrorListeners');
     });
+
+    it('should not set "typeCheckHostBindings" when strict is true if Angular version is lower than v20', async () => {
+      updateJson(appTree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~19.0.0',
+        },
+      }));
+
+      await generateApp(appTree, 'my-app', { strict: true });
+
+      const appTsConfig = readJson(appTree, 'my-app/tsconfig.json');
+      expect(appTsConfig.angularCompilerOptions).toMatchInlineSnapshot(`
+        {
+          "enableI18nLegacyMessageIdFormat": false,
+          "strictInjectionParameters": true,
+          "strictInputAccessModifiers": true,
+          "strictTemplates": true,
+        }
+      `);
+    });
   });
 });
 

--- a/packages/angular/src/generators/application/lib/enable-strict-type-checking.ts
+++ b/packages/angular/src/generators/application/lib/enable-strict-type-checking.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { updateJson } from '@nx/devkit';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema } from './normalized-schema';
 
 export function enableStrictTypeChecking(
@@ -18,12 +19,15 @@ export function enableStrictTypeChecking(
 
   const appTsConfigPath = `${options.appProjectRoot}/tsconfig.json`;
   if (host.exists(appTsConfigPath)) {
+    const { major: angularMajorVersion } = getInstalledAngularVersionInfo(host);
+
     updateJson(host, appTsConfigPath, (json) => {
       json.compilerOptions = { ...json.compilerOptions, ...compilerOptions };
       json.angularCompilerOptions = {
         enableI18nLegacyMessageIdFormat: false,
         strictInjectionParameters: true,
         strictInputAccessModifiers: true,
+        typeCheckHostBindings: angularMajorVersion >= 20 ? true : undefined,
         strictTemplates: true,
       };
       return json;

--- a/packages/angular/src/generators/library/lib/enable-strict-type-checking.ts
+++ b/packages/angular/src/generators/library/lib/enable-strict-type-checking.ts
@@ -1,6 +1,7 @@
 import type { Tree } from '@nx/devkit';
 import { readNxJson, updateJson, updateNxJson } from '@nx/devkit';
-import { NormalizedSchema } from './normalized-schema';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
+import type { NormalizedSchema } from './normalized-schema';
 
 /**
  * Enable Strict Mode in the library and spec TS Config
@@ -31,6 +32,8 @@ function updateTsConfig(
   host: Tree,
   options: NormalizedSchema['libraryOptions']
 ) {
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(host);
+
   // Update the settings in the tsconfig.app.json to enable strict type checking.
   // This matches the settings defined by the Angular CL https://angular.io/guide/strict-mode
   updateJson(host, `${options.projectRoot}/tsconfig.json`, (json) => {
@@ -51,6 +54,7 @@ function updateTsConfig(
       enableI18nLegacyMessageIdFormat: false,
       strictInjectionParameters: true,
       strictInputAccessModifiers: true,
+      typeCheckHostBindings: angularMajorVersion >= 20 ? true : undefined,
       strictTemplates: true,
     };
 

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -311,6 +311,7 @@ describe('lib', () => {
           strictInjectionParameters: true,
           strictInputAccessModifiers: true,
           strictTemplates: true,
+          typeCheckHostBindings: true,
         },
         compilerOptions: {
           forceConsistentCasingInFileNames: true,
@@ -1831,6 +1832,28 @@ describe('lib', () => {
         readJson(tree, 'my-lib/tsconfig.json').compilerOptions
           .useDefineForClassFields
       ).toBe(false);
+    });
+
+    it('should not set "typeCheckHostBindings" when strict is true if Angular version is lower than v20', async () => {
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~19.0.0',
+        },
+      }));
+
+      await runLibraryGeneratorWithOpts();
+
+      expect(readJson(tree, 'my-lib/tsconfig.json').angularCompilerOptions)
+        .toMatchInlineSnapshot(`
+        {
+          "enableI18nLegacyMessageIdFormat": false,
+          "strictInjectionParameters": true,
+          "strictInputAccessModifiers": true,
+          "strictTemplates": true,
+        }
+      `);
     });
   });
 });


### PR DESCRIPTION
Add `typeCheckHostBindings` to the `angularCompilerOption` when generating projects with strict type checking.