### PR TITLE
fix(gradle): make ci inputs same as test inputs

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -88,8 +88,10 @@ private fun buildTestCiTarget(
     testFile: File,
     testTask: Task,
     projectRoot: String,
-    workspaceRoot: String
+    workspaceRoot: String,
 ): MutableMap<String, Any?> {
+  val taskInputs = getInputsForTask(testTask, projectRoot, workspaceRoot, null)
+
   val target =
       mutableMapOf<String, Any?>(
           "executor" to "@nx/gradle:gradle",
@@ -100,7 +102,7 @@ private fun buildTestCiTarget(
           "metadata" to
               getMetadata("Runs Gradle test $testClassName in CI", projectBuildPath, "test"),
           "cache" to true,
-          "inputs" to arrayOf(replaceRootInPath(testFile.path, projectRoot, workspaceRoot)))
+          "inputs" to taskInputs)
 
   getDependsOnForTask(testTask, null)
       ?.takeIf { it.isNotEmpty() }
@@ -115,7 +117,6 @@ private fun buildTestCiTarget(
         testTask.logger.info("${testTask.path}: found ${it.size} outputs entries")
         target["outputs"] = it
       }
-
   return target
 }
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -93,7 +93,7 @@ fun getInputsForTask(
     val mappedInputsIncludeExternal: MutableList<Any> = mutableListOf()
     val inputs = task.inputs
     val externalDependencies = mutableListOf<String>()
-    inputs.sourceFiles.forEach { file ->
+    inputs.files.forEach { file ->
       val path: String = file.path
       // replace the absolute path to contain {projectRoot} or {workspaceRoot}
       val pathWithReplacedRoot = replaceRootInPath(path, projectRoot, workspaceRoot)
@@ -101,8 +101,7 @@ fun getInputsForTask(
         mappedInputsIncludeExternal.add((pathWithReplacedRoot))
       }
       // if the path is outside of workspace
-      if (pathWithReplacedRoot == null &&
-          externalNodes != null) { // add it to external dependencies
+      if (pathWithReplacedRoot == null) { // add it to external dependencies
         try {
           val externalDep = getExternalDepFromInputFile(path, externalNodes, task.logger)
           externalDep?.let { externalDependencies.add(it) }
@@ -251,7 +250,7 @@ fun getMetadata(
  */
 fun getExternalDepFromInputFile(
     inputFile: String,
-    externalNodes: MutableMap<String, ExternalNode>,
+    externalNodes: MutableMap<String, ExternalNode>?,
     logger: org.gradle.api.logging.Logger
 ): String? {
   try {
@@ -279,7 +278,9 @@ fun getExternalDepFromInputFile(
     val externalKey = "gradle:$nameKey"
     val node = ExternalNode("gradle", externalKey, data)
 
-    externalNodes[externalKey] = node
+    if (externalNodes != null) {
+      externalNodes[externalKey] = node
+    }
 
     return externalKey
   } catch (e: Exception) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

current ci test target does not contain inputs of test, it just contains the test source file

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
change the ci targets to contain inputs of test
<img width="903" alt="Screenshot 2025-05-13 at 1 31 22 PM" src="https://github.com/user-attachments/assets/d73de232-440a-439b-adb8-e22fc3fe3d8a" />


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
