### PR TITLE
fix(nx-dev): Add docs for disableChecksum option for s3-cache

### DIFF
--- a/docs/external-generated/packages/s3-cache/documents/overview.md
+++ b/docs/external-generated/packages/s3-cache/documents/overview.md
@@ -155,10 +155,15 @@ Below is an example on how to connect to MinIO:
     "endpoint": "https://play.min.io",
     "forcePathStyle": true,
     "accessKeyId": "abc1234",
-    "secretAccessKey": "4321cba"
+    "secretAccessKey": "4321cba",
+    "disableChecksum": true
   }
 }
 ```
+
+{% callout type="note" title="Minio and checksum validation" %}
+If you are using MinIO earlier than `2024-07-04T14-25-45Z` it is recommended to enabled `disabledChecksum` else you may trigger aws-sdk checksum errors such as `x-amz-checksum-crc32`.
+{% /callout %}
 
 | **Property**        | **Description**                                                                                           |
 | ------------------- | --------------------------------------------------------------------------------------------------------- |
@@ -168,6 +173,7 @@ Below is an example on how to connect to MinIO:
 | **endpoint**        | The custom endpoint to upload artifacts to. If endpoint is not defined, the default AWS endpoint is used  |
 | **accessKeyId**     | AWS Access Key ID (optional if `AWS_ACCESS_KEY_ID` is set in the environment)                             |
 | **secretAccessKey** | AWS secret access key (optional if `AWS_SECRET_ACCESS_KEY` is set in the environment)                     |
+| **disableChecksum** | This disables AWS' checksum validation for cache entries                                                  |
 
 # Cache Modes
 

--- a/docs/shared/packages/s3-cache/s3-cache-plugin.md
+++ b/docs/shared/packages/s3-cache/s3-cache-plugin.md
@@ -155,10 +155,15 @@ Below is an example on how to connect to MinIO:
     "endpoint": "https://play.min.io",
     "forcePathStyle": true,
     "accessKeyId": "abc1234",
-    "secretAccessKey": "4321cba"
+    "secretAccessKey": "4321cba",
+    "disableChecksum: true
   }
 }
 ```
+
+{% callout type="note" title="Minio and checksum validation" %}
+If you are using MinIO earlier than `2024-07-04T14-25-45Z` it is recommended to enabled `disabledChecksum` else you may trigger aws-sdk checksum errors such as `x-amz-checksum-crc32`.
+{% /callout %}
 
 | **Property**        | **Description**                                                                                           |
 | ------------------- | --------------------------------------------------------------------------------------------------------- |
@@ -168,6 +173,7 @@ Below is an example on how to connect to MinIO:
 | **endpoint**        | The custom endpoint to upload artifacts to. If endpoint is not defined, the default AWS endpoint is used  |
 | **accessKeyId**     | AWS Access Key ID (optional if `AWS_ACCESS_KEY_ID` is set in the environment)                             |
 | **secretAccessKey** | AWS secret access key (optional if `AWS_SECRET_ACCESS_KEY` is set in the environment)                     |
+| **disableChecksum** | This disables AWS' checksum validation for cache entries                                                  |
 
 # Cache Modes
 


### PR DESCRIPTION
Add documentation for `disableChecksum` flag for AWS S3 storage options so users can opt out of validating checksum while retrieving remote cache.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
