### PR TITLE
feat(angular): update the application executor schema

### DIFF
--- a/docs/generated/packages/angular/executors/application.json
+++ b/docs/generated/packages/angular/executors/application.json
@@ -54,7 +54,6 @@
         "description": "The full path for the browser entry point to the application, relative to the current workspace."
       },
       "server": {
-        "type": "string",
         "description": "The full path for the server entry point to the application, relative to the current workspace.",
         "oneOf": [
           {
@@ -304,6 +303,11 @@
         "type": "object",
         "additionalProperties": { "type": "string" }
       },
+      "conditions": {
+        "description": "Custom package resolution conditions used to resolve conditional exports/imports. Defaults to ['module', 'development'/'production']. The following special conditions are always present if the requirements are satisfied: 'default', 'import', 'require', 'browser', 'node'. _Note: this is only supported in Angular versions >= 20.0.0_.",
+        "type": "array",
+        "items": { "type": "string" }
+      },
       "fileReplacements": {
         "description": "Replace compilation source files with other compilation source files in the build.",
         "type": "array",
@@ -387,6 +391,11 @@
                 "type": "boolean",
                 "description": "Resolve vendor packages source maps.",
                 "default": false
+              },
+              "sourcesContent": {
+                "type": "boolean",
+                "description": "Output original source content for files within the source map. _Note: this is only supported in Angular versions >= 20.0.0_.",
+                "default": true
               }
             },
             "additionalProperties": false

--- a/packages/angular/src/executors/application/schema.json
+++ b/packages/angular/src/executors/application/schema.json
@@ -19,7 +19,6 @@
       "description": "The full path for the browser entry point to the application, relative to the current workspace."
     },
     "server": {
-      "type": "string",
       "description": "The full path for the server entry point to the application, relative to the current workspace.",
       "oneOf": [
         {
@@ -292,6 +291,13 @@
         "type": "string"
       }
     },
+    "conditions": {
+      "description": "Custom package resolution conditions used to resolve conditional exports/imports. Defaults to ['module', 'development'/'production']. The following special conditions are always present if the requirements are satisfied: 'default', 'import', 'require', 'browser', 'node'. _Note: this is only supported in Angular versions >= 20.0.0_.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "fileReplacements": {
       "description": "Replace compilation source files with other compilation source files in the build.",
       "type": "array",
@@ -368,6 +374,11 @@
               "type": "boolean",
               "description": "Resolve vendor packages source maps.",
               "default": false
+            },
+            "sourcesContent": {
+              "type": "boolean",
+              "description": "Output original source content for files within the source map. _Note: this is only supported in Angular versions >= 20.0.0_.",
+              "default": true
             }
           },
           "additionalProperties": false

--- a/packages/angular/src/executors/application/utils/normalize-options.ts
+++ b/packages/angular/src/executors/application/utils/normalize-options.ts
@@ -35,5 +35,15 @@ export function normalizeOptions(
     prerender ??= false;
   }
 
-  return { ...options, appShell, prerender, security };
+  let sourceMap = options.sourceMap;
+  if (
+    sourceMap &&
+    typeof sourceMap === 'object' &&
+    sourceMap.sourcesContent !== undefined &&
+    angularMajorVersion < 20
+  ) {
+    delete sourceMap.sourcesContent;
+  }
+
+  return { ...options, appShell, prerender, security, sourceMap };
 }

--- a/packages/angular/src/executors/application/utils/validate-options.ts
+++ b/packages/angular/src/executors/application/utils/validate-options.ts
@@ -36,4 +36,22 @@ export function validateOptions(options: ApplicationExecutorOptions): void {
       );
     }
   }
+
+  if (lt(angularVersion, '20.0.0')) {
+    if (
+      options.sourceMap &&
+      typeof options.sourceMap === 'object' &&
+      options.sourceMap.sourcesContent === false
+    ) {
+      throw new Error(
+        `The "sourceMap.sourcesContent" option requires Angular version 20.0.0 or greater. You are currently using version ${angularVersion}.`
+      );
+    }
+
+    if (options.conditions) {
+      throw new Error(
+        `The "conditions" option requires Angular version 20.0.0 or greater. You are currently using version ${angularVersion}.`
+      );
+    }
+  }
 }


### PR DESCRIPTION
- Allow control of source map sources content for application builds by adding the `sourcesContent` property to the `sourceMap` option
- Support custom resolution conditions with applications by adding the `conditions` option
- Fix `server` option type