### PR TITLE
feat(angular): expand browser support in ng-packagr executors

### DIFF
--- a/packages/angular/src/executors/utilities/ng-packagr/v19+/stylesheet-processor.ts
+++ b/packages/angular/src/executors/utilities/ng-packagr/v19+/stylesheet-processor.ts
@@ -53,15 +53,21 @@ export function getStylesheetProcessor(): new (
       // By default, browserslist defaults are too inclusive
       // https://github.com/browserslist/browserslist/blob/83764ea81ffaa39111c204b02c371afa44a4ff07/index.js#L516-L522
       // We change the default query to browsers that Angular support.
-      // https://angular.io/guide/browser-support
-      (browserslist.defaults as string[]) = [
-        'last 2 Chrome versions',
-        'last 1 Firefox version',
-        'last 2 Edge major versions',
-        'last 2 Safari major versions',
-        'last 2 iOS major versions',
-        'Firefox ESR',
-      ];
+      // https://angular.dev/reference/versions#browser-support
+      if (ngPackagrMajorVersion >= 20) {
+        (browserslist.defaults as string[]) = browserslist(undefined, {
+          path: require.resolve('ng-packagr/.browserslistrc'),
+        });
+      } else {
+        (browserslist.defaults as string[]) = [
+          'last 2 Chrome versions',
+          'last 1 Firefox version',
+          'last 2 Edge major versions',
+          'last 2 Safari major versions',
+          'last 2 iOS major versions',
+          'Firefox ESR',
+        ];
+      }
 
       const browserslistData = browserslist(undefined, { path: basePath });
       let searchDirs = generateSearchDirectories([projectBasePath]);


### PR DESCRIPTION
Expand the browser support to the widely available Baseline in ng-packagr executors.