### PR TITLE
feat(angular): replace `@angular/platform-browser-dynamic` usages with `@angular/platform-browser`

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -673,14 +673,14 @@ exports[`app --unit-test-runner vitest should generate src/test-setup.ts 1`] = `
 "import '@analogjs/vitest-angular/setup-zone';
 
 import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
 import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  BrowserTestingModule,
+  platformBrowserTesting()
 );
 "
 `;

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -68,9 +68,6 @@ describe('app', () => {
     expect(dependencies['@angular/compiler']).toBe(angularVersion);
     expect(dependencies['@angular/core']).toBe(angularVersion);
     expect(dependencies['@angular/platform-browser']).toBe(angularVersion);
-    expect(dependencies['@angular/platform-browser-dynamic']).toBe(
-      angularVersion
-    );
     expect(dependencies['@angular/router']).toBe(angularVersion);
     expect(dependencies['rxjs']).toBeDefined();
     expect(dependencies['tslib']).toBeDefined();
@@ -1022,10 +1019,10 @@ describe('app', () => {
 
     // ASSERT
     expect(appTree.read('myapp/src/main.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+      "import { platformBrowser } from '@angular/platform-browser';
       import { AppModule } from './app/app.module';
 
-      platformBrowserDynamic()
+      platformBrowser()
         .bootstrapModule(AppModule, {
           ngZoneEventCoalescing: true
         })
@@ -1431,6 +1428,30 @@ describe('app', () => {
           "strictInputAccessModifiers": true,
           "strictTemplates": true,
         }
+      `);
+    });
+
+    it('should use platformBrowserDynamic for versions lower than v20', async () => {
+      updateJson(appTree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~19.0.0',
+        },
+      }));
+
+      await generateApp(appTree, 'myapp');
+
+      expect(appTree.read('myapp/src/main.ts', 'utf-8')).toMatchInlineSnapshot(`
+        "import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+        import { AppModule } from './app/app.module';
+
+        platformBrowserDynamic()
+          .bootstrapModule(AppModule, {
+            ngZoneEventCoalescing: true
+          })
+          .catch((err) => console.error(err));
+        "
       `);
     });
   });

--- a/packages/angular/src/generators/application/files/ng-module/src/main.ts__tpl__
+++ b/packages/angular/src/generators/application/files/ng-module/src/main.ts__tpl__
@@ -1,7 +1,15 @@
+<%_ if (usePlatformBrowserDynamic) { _%>
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+<%_ } else { _%>
+import { platformBrowser } from '@angular/platform-browser';
+<%_ } _%>
 import { AppModule } from './app/app.module';
 
+<%_ if (usePlatformBrowserDynamic) { _%>
 platformBrowserDynamic()
+<%_ } else { _%>
+platformBrowser()
+<%_ } _%>
   .bootstrapModule(AppModule, {
     ngZoneEventCoalescing: true
   })

--- a/packages/angular/src/generators/application/lib/create-files.ts
+++ b/packages/angular/src/generators/application/lib/create-files.ts
@@ -56,6 +56,7 @@ export async function createFiles(
     setStandaloneFalse: angularMajorVersion >= 19,
     setStandaloneTrue: angularMajorVersion < 19,
     provideGlobalErrorListener: angularMajorVersion >= 20,
+    usePlatformBrowserDynamic: angularMajorVersion < 20,
     connectCloudUrl,
     tutorialUrl: options.standalone
       ? 'https://nx.dev/getting-started/tutorials/angular-standalone-tutorial?utm_source=nx-project'

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -26,10 +26,10 @@ export class AppModule {}
 `;
 
 exports[`Host App Generator --ssr should generate the correct files 2`] = `
-"import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+"import { platformBrowser } from '@angular/platform-browser';
 import { AppModule } from './app/app.module';
 
-platformBrowserDynamic()
+platformBrowser()
   .bootstrapModule(AppModule, {
     ngZoneEventCoalescing: true,
   })
@@ -700,10 +700,10 @@ export class AppModule {}
 `;
 
 exports[`Host App Generator --ssr should generate the correct files when --typescript=true 2`] = `
-"import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+"import { platformBrowser } from '@angular/platform-browser';
 import { AppModule } from './app/app.module';
 
-platformBrowserDynamic()
+platformBrowser()
   .bootstrapModule(AppModule, {
     ngZoneEventCoalescing: true,
   })

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -79,9 +79,6 @@ describe('lib', () => {
     expect(dependencies['@angular/compiler']).toBe(angularVersion);
     expect(dependencies['@angular/core']).toBe(angularVersion);
     expect(dependencies['@angular/platform-browser']).toBe(angularVersion);
-    expect(dependencies['@angular/platform-browser-dynamic']).toBe(
-      angularVersion
-    );
     expect(dependencies['@angular/router']).toBe(angularVersion);
     expect(dependencies['rxjs']).toBeDefined();
     expect(dependencies['tslib']).toBeDefined();

--- a/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -31,10 +31,10 @@ export class AppModule {}
 `;
 
 exports[`MF Remote App Generator --ssr should generate the correct files 2`] = `
-"import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+"import { platformBrowser } from '@angular/platform-browser';
 import { AppModule } from './app/app.module';
 
-platformBrowserDynamic()
+platformBrowser()
   .bootstrapModule(AppModule, {
     ngZoneEventCoalescing: true,
   })
@@ -264,10 +264,10 @@ export class AppModule {}"
 `;
 
 exports[`MF Remote App Generator --ssr should generate the correct files when --typescriptConfiguration=true 2`] = `
-"import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+"import { platformBrowser } from '@angular/platform-browser';
 import { AppModule } from './app/app.module';
 
-platformBrowserDynamic()
+platformBrowser()
   .bootstrapModule(AppModule, {
     ngZoneEventCoalescing: true,
   })

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -44,10 +44,10 @@ describe('setupSSR', () => {
         "
       `);
       expect(tree.read('app1/src/main.ts', 'utf-8')).toMatchInlineSnapshot(`
-        "import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+        "import { platformBrowser } from '@angular/platform-browser';
         import { AppModule } from './app/app.module';
 
-        platformBrowserDynamic()
+        platformBrowser()
           .bootstrapModule(AppModule, {
             ngZoneEventCoalescing: true,
           })
@@ -318,10 +318,10 @@ describe('setupSSR', () => {
         "
       `);
       expect(tree.read('app1/src/main.ts', 'utf-8')).toMatchInlineSnapshot(`
-        "import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+        "import { platformBrowser } from '@angular/platform-browser';
         import { AppModule } from './app/app.module';
 
-        platformBrowserDynamic()
+        platformBrowser()
           .bootstrapModule(AppModule, {
             ngZoneEventCoalescing: true
           })

--- a/packages/angular/src/generators/utils/add-jest.ts
+++ b/packages/angular/src/generators/utils/add-jest.ts
@@ -4,7 +4,8 @@ import {
   joinPathFragments,
   type Tree,
 } from '@nx/devkit';
-import { jestPresetAngularVersion, nxVersion } from '../../utils/versions';
+import { nxVersion } from '../../utils/versions';
+import { versions } from './version-utils';
 
 export type AddJestOptions = {
   name: string;
@@ -21,10 +22,14 @@ export async function addJest(
   if (!options.skipPackageJson) {
     process.env.npm_config_legacy_peer_deps ??= 'true';
 
+    const pkgVersions = versions(tree);
     addDependenciesToPackageJson(
       tree,
-      {},
-      { 'jest-preset-angular': jestPresetAngularVersion },
+      {
+        // TODO(leo): jest-preset-angular still needs this until https://github.com/thymikee/jest-preset-angular/pull/3079 is merged
+        '@angular/platform-browser-dynamic': pkgVersions.angularVersion,
+      },
+      { 'jest-preset-angular': pkgVersions.jestPresetAngularVersion },
       undefined,
       true
     );

--- a/packages/angular/src/generators/utils/ensure-angular-dependencies.spec.ts
+++ b/packages/angular/src/generators/utils/ensure-angular-dependencies.spec.ts
@@ -22,9 +22,6 @@ describe('ensureAngularDependencies', () => {
     expect(dependencies['@angular/compiler']).toBe(angularVersion);
     expect(dependencies['@angular/core']).toBe(angularVersion);
     expect(dependencies['@angular/platform-browser']).toBe(angularVersion);
-    expect(dependencies['@angular/platform-browser-dynamic']).toBe(
-      angularVersion
-    );
     expect(dependencies['@angular/router']).toBe(angularVersion);
     expect(dependencies['rxjs']).toBeDefined();
     expect(dependencies['tslib']).toBeDefined();

--- a/packages/angular/src/generators/utils/ensure-angular-dependencies.ts
+++ b/packages/angular/src/generators/utils/ensure-angular-dependencies.ts
@@ -39,7 +39,6 @@ export function ensureAngularDependencies(tree: Tree): GeneratorCallback {
     dependencies['@angular/core'] = angularVersion;
     dependencies['@angular/forms'] = angularVersion;
     dependencies['@angular/platform-browser'] = angularVersion;
-    dependencies['@angular/platform-browser-dynamic'] = angularVersion;
     dependencies['@angular/router'] = angularVersion;
     dependencies.rxjs = rxjsVersion;
     dependencies.tslib = tsLibVersion;

--- a/packages/angular/src/utils/nx-devkit/testing.ts
+++ b/packages/angular/src/utils/nx-devkit/testing.ts
@@ -51,11 +51,11 @@ export class AppModule {}
   );
   tree.write(
     `${appName}/src/main.ts`,
-    `import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+    `import { platformBrowser } from '@angular/platform-browser';
 
 import { AppModule } from './app/app.module';
 
-platformBrowserDynamic()
+platformBrowser()
   .bootstrapModule(AppModule)
   .catch(err => console.log(err));
   `

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -4,14 +4,14 @@ exports[`vitest generator angular should generate src/test-setup.ts 1`] = `
 "import '@analogjs/vitest-angular/setup-zone';
 
 import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
 import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  BrowserTestingModule,
+  platformBrowserTesting()
 );
 "
 `;

--- a/packages/vite/src/generators/vitest/vitest.spec.ts
+++ b/packages/vite/src/generators/vitest/vitest.spec.ts
@@ -222,6 +222,34 @@ describe('vitest generator', () => {
       ).toMatchSnapshot();
     });
 
+    it('should generate src/test-setup.ts using @angular/platform-browser-dynamic/testing when Angular version is lower than 20', async () => {
+      const { tree, runGenerator } = setUpAngularWorkspace();
+      tree;
+      updateJson(tree, 'package.json', (json) => {
+        json.dependencies['@angular/core'] = '~19.2.0';
+        return json;
+      });
+
+      await runGenerator();
+
+      expect(tree.read('apps/my-test-angular-app/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import '@analogjs/vitest-angular/setup-zone';
+
+        import {
+          BrowserDynamicTestingModule,
+          platformBrowserDynamicTesting,
+        } from '@angular/platform-browser-dynamic/testing';
+        import { getTestBed } from '@angular/core/testing';
+
+        getTestBed().initTestEnvironment(
+          BrowserDynamicTestingModule,
+          platformBrowserDynamicTesting()
+        );
+        "
+      `);
+    });
+
     it('should exclude src/test-setup.ts in tsconfig.app.json', async () => {
       const tsConfig = readJson(
         appTree,


### PR DESCRIPTION
Update generators to generate code using `@angular/platform-browser` instead of `@angular/platform-browser-dynamic` for v20. With this change, new workspaces/apps won't install `@angular/platform-browser-dynamic` anymore. The only exception is when using Jest as the test runner, as the `jest-preset-angular` package still requires that dependency.