### PR TITLE
feat(angular): handle prerender and appshell in covert to rspack

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -32,7 +32,13 @@ exports[`app --minimal should generate a correct setup when --bundler=rspack and
   "ssr": {
     "entry": "./src/server.ts"
   },
-  "server": "./src/main.server.ts"
+  "server": "./src/main.server.ts",
+  "prerender": {
+    "discoverRoutes": true,
+    "routes": [
+      "/"
+    ]
+  }
 
     }
   }, {
@@ -52,7 +58,11 @@ exports[`app --minimal should generate a correct setup when --bundler=rspack and
     }
   ],
   "outputHashing": "all",
-  "devServer": {}
+  "devServer": {},
+  "prerender": {
+    "discoverRoutes": true,
+    "routes": []
+  }
 
         }
       },
@@ -65,7 +75,11 @@ exports[`app --minimal should generate a correct setup when --bundler=rspack and
   "extractLicenses": false,
   "sourceMap": true,
   "namedChunks": true,
-  "devServer": {}
+  "devServer": {},
+  "prerender": {
+    "discoverRoutes": true,
+    "routes": []
+  }
 
         }
       }});"

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -1257,6 +1257,7 @@ describe('app', () => {
       });
 
       const project = readProjectConfiguration(appTree, 'app2');
+
       expect(appTree.exists('app2/rspack.config.ts')).toBeTruthy();
       expect(appTree.read('app2/rspack.config.ts', 'utf-8')).toMatchSnapshot();
       expect(appTree.read('app2/src/server.ts', 'utf-8')).toMatchSnapshot();

--- a/packages/rspack/src/generators/init/init.ts
+++ b/packages/rspack/src/generators/init/init.ts
@@ -87,8 +87,12 @@ export async function rspackInitGenerator(
   const devDependencies = {
     '@rspack/core': rspackCoreVersion,
     '@rspack/cli': rspackCoreVersion,
-    '@rspack/plugin-react-refresh': rspackPluginReactRefreshVersion,
-    'react-refresh': reactRefreshVersion,
+    ...(!schema.framework || schema.framework === 'react'
+      ? {
+          '@rspack/plugin-react-refresh': rspackPluginReactRefreshVersion,
+          'react-refresh': reactRefreshVersion,
+        }
+      : {}),
   };
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/rspack/src/generators/init/schema.d.ts
+++ b/packages/rspack/src/generators/init/schema.d.ts
@@ -1,4 +1,4 @@
-export type Framework = 'none' | 'react' | 'web' | 'nest';
+export type Framework = 'none' | 'react' | 'web' | 'nest' | 'angular';
 
 export interface InitGeneratorSchema {
   addPlugin?: boolean;

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -6,6 +6,7 @@ import {
 import { Preset } from '../utils/presets';
 import {
   angularCliVersion,
+  angularRspackVersion,
   nxVersion,
   typescriptVersion,
 } from '../../utils/versions';
@@ -128,6 +129,9 @@ function getPresetDependencies({
         dev: {
           '@angular-devkit/core': angularCliVersion,
           '@nx/angular': nxVersion,
+          '@nx/rspack': bundler === 'rspack' ? nxVersion : undefined,
+          '@nx/angular-rspack':
+            bundler === 'rspack' ? angularRspackVersion : undefined,
           typescript: typescriptVersion,
         },
       };

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -28,7 +28,7 @@ interface Schema {
   nextAppDir?: boolean;
   nextSrcDir?: boolean;
   linter?: Linter | LinterType;
-  bundler?: 'vite' | 'webpack';
+  bundler?: 'vite' | 'webpack' | 'rspack';
   standaloneApi?: boolean;
   routing?: boolean;
   useReactRouter?: boolean;

--- a/packages/workspace/src/utils/versions.ts
+++ b/packages/workspace/src/utils/versions.ts
@@ -5,3 +5,4 @@ export const typescriptVersion = '~5.7.2';
 // TODO: remove when preset generation is reworked and
 // deps are not installed from workspace
 export const angularCliVersion = '~19.2.0';
+export const angularRspackVersion = '^20.9.0';


### PR DESCRIPTION
## Current Behavior
The `convert-to-rspack` generator does not handle projects that use Prerendering or App Shell

## Expected Behavior
The generator sets up Prerendering and App Shell

Fixes https://github.com/nrwl/angular-rspack/issues/88
