### PR TITLE
fix(core): Update e2e nightly test to not hang

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,8 +1,8 @@
 name: E2E matrix
 
 on:
-  # schedule:
-  #   - cron: "0 5 * * *"
+  schedule:
+    - cron: "0 5 * * *"
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -19,6 +19,7 @@ jobs:
   preinstall:
     if: ${{ github.repository_owner == 'nrwl' }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       matrix:
         os:
@@ -45,7 +46,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          filter: tree:0
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
@@ -106,6 +108,7 @@ jobs:
   prepare-matrix:
     name: Prepare matrix combinations
     if: ${{ github.repository_owner == 'nrwl' }}
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.process-json.outputs.MATRIX }}
@@ -113,7 +116,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          filter: tree:0
 
       - name: Process matrix data
         id: process-json
@@ -128,6 +132,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 70     # <- cap each job to 70 minutes
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}} # Load matrix from previous job
       fail-fast: false
@@ -137,7 +142,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          filter: tree:0
 
       - name: Prepare dir for output
         run: mkdir -p outputs
@@ -154,12 +160,22 @@ jobs:
           node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
 
-      - name: Cache node_modules
-        id: cache-modules
-        uses: actions/cache@v4
+      - name: Install Rust
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
+          source "$HOME/.cargo/env"
+          rustup toolchain install 1.70.0
+
+      - name: Load Cargo Env
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
+  
+      - name: Install bun
+        if: ${{ matrix.os != 'windows-latest' }}
+        uses: oven-sh/setup-bun@v1
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ hashFiles('pnpm-lock.yaml') }}
+          bun-version: latest
 
       - name: Install packages
         run: pnpm install --frozen-lockfile
@@ -201,12 +217,23 @@ jobs:
         if: steps.cache-cypress.outputs.cache-hit != 'true'
         run: npx cypress install
 
-      - name: Install applesimutils, reset ios simulators
+      - name: Configure Detox Environment, Install applesimutils
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
+          # Check if applesimutils is already installed
+          if ! brew list applesimutils &>/dev/null; then
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
+          else
+            echo "applesimutils is already installed, skipping installation"
+          fi
+        timeout-minutes: 10
+
+      - name: Reset iOS Simulators
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
           xcrun simctl shutdown all && xcrun simctl erase all
+        timeout-minutes: 5
 
       - name: Configure git metadata (needed for lerna smoke tests)
         run: |
@@ -219,8 +246,10 @@ jobs:
         run: |
           echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
-      - name: Run e2e tests
-        id: e2e-run
+
+      - name: Run e2e tests with pnpm (Linux/Windows)
+        id: e2e-run-pnpm
+        if: ${{ matrix.os != 'macos-latest' }}
         run: pnpm nx run ${{ matrix.project }}:e2e-local
         shell: bash
         timeout-minutes: ${{ matrix.os_timeout }}
@@ -237,6 +266,33 @@ jobs:
           SELECTED_PM: ${{ matrix.package_manager }}
           npm_config_registry: http://localhost:4872
           YARN_REGISTRY: http://localhost:4872
+          CI: true
+  
+      - name: Run e2e tests with npm (macOS)
+        id: e2e-run-npm
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          # Run the tests
+          if [[ "${{ matrix.project }}" == "e2e-detox" ]] || [[ "${{ matrix.project }}" == "e2e-react-native" ]] || [[ "${{ matrix.project }}" == "e2e-expo" ]]; then
+            NX_E2E_VERBOSE_DEBUG=1 pnpm nx run ${{ matrix.project }}:e2e-macos-local
+          else
+            NX_E2E_VERBOSE_DEBUG=1 pnpm nx run ${{ matrix.project }}:e2e-local
+          fi
+        
+        env:
+          NX_E2E_CI_CACHE_KEY: e2e-gha-${{ matrix.os }}-${{ matrix.node_version }}-${{ matrix.package_manager }}
+          NX_PERF_LOGGING: 'false'
+          NX_CI_EXECUTION_ENV: 'macos'
+          NX_E2E_VERBOSE_LOGGING: 'true'
+          NX_NATIVE_LOGGING: 'false'
+          NX_E2E_RUN_E2E: 'true'
+          NX_E2E_SKIP_CLEANUP: 'true'
+          NODE_OPTIONS: --max_old_space_size=8192
+          SELECTED_PM: 'npm'
+          npm_config_registry: http://localhost:4872
+          YARN_REGISTRY: http://localhost:4872
+          DEVELOPER_DIR: '/Applications/Xcode.app/Contents/Developer'
+          CI: true
 
       - name: Save matrix config in file
         if: ${{ always() }}
@@ -246,9 +302,13 @@ jobs:
           before=${{ steps.before-e2e.outputs.timestamp }}
           now=$(date +%s)
           delta=$(($now - $before))
+          
+          # Determine the outcome based on which step ran
+          outcome="${{ matrix.os == 'macos-latest' && steps.e2e-run-npm.outcome || steps.e2e-run-pnpm.outcome }}"
+          
           matrix=$((
             echo '${{ toJSON(matrix) }}'
-          ) | jq --argjson delta $delta -c '. + { "status": "${{ steps.e2e-run.outcome}}", "duration": $delta }')
+          ) | jq --argjson delta $delta -c '. + { "status": "'"$outcome"'", "duration": $delta }')
           echo "$matrix" > 'outputs/matrix.json'
 
       - name: Upload matrix config
@@ -271,6 +331,7 @@ jobs:
     if: ${{ always() && github.repository_owner == 'nrwl' }}
     runs-on: ubuntu-latest
     needs: e2e
+    timeout-minutes: 10
     outputs:
       message: ${{ steps.process-json.outputs.SLACK_MESSAGE }}
       proj-duration: ${{ steps.process-json.outputs.SLACK_PROJ_DURATION }}
@@ -430,6 +491,7 @@ jobs:
     needs: process-result
     runs-on: ubuntu-latest
     name: Report failure
+    timeout-minutes: 10
     steps:
       - name: Send notification
         uses: ravsamhq/notify-slack-action@v2
@@ -447,6 +509,7 @@ jobs:
     needs: e2e
     runs-on: ubuntu-latest
     name: Report status
+    timeout-minutes: 10
     steps:
       - name: Send notification
         uses: ravsamhq/notify-slack-action@v2
@@ -462,6 +525,7 @@ jobs:
     if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: process-result
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Report duration per package manager
     steps:
       - name: Send notification
@@ -477,6 +541,7 @@ jobs:
     if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: process-result
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Report duration per package manager
     steps:
       - name: Send notification


### PR DESCRIPTION
Currently, the nightly tests are broken in a few ways this PR addresses some of those issues but ultimately ensures that each step has a timeout to handle the work case scenario i.e. unable to complete. 

- Add bun installation and split e2e runners for macos, linux and windows 
- Add rust installation
- Add timeout for e2e tests 

Here is the result of a previous run: https://github.com/nrwl/nx/actions/runs/14999368644
The most latest run can be found here: https://github.com/nrwl/nx/actions/runs/15027418322

**Note**: The final result will be _failure_ because many tests still need to be addressed, so that is expected.