### PR TITLE
feat(angular): generate directives without a `.directive`/`Directive` suffix/type

### DIFF
--- a/docs/generated/packages/angular/generators/directive.json
+++ b/docs/generated/packages/angular/generators/directive.json
@@ -15,11 +15,15 @@
         "command": "nx g @nx/angular:directive mylib/src/lib/foo.directive.ts"
       },
       {
-        "description": "Generate a directive without providing the file extension. It results in the directive `FooDirective` at `mylib/src/lib/foo.directive.ts`",
+        "description": "Generate a directive without providing the file extension. It results in the directive `Foo` at `mylib/src/lib/foo.ts`",
         "command": "nx g @nx/angular:directive mylib/src/lib/foo"
       },
       {
-        "description": "Generate a directive with the exported symbol different from the file name. It results in the directive `CustomDirective` at `mylib/src/lib/foo.directive.ts`",
+        "description": "Generate a directive with a given type/suffix. It results in the directive `FooDirective` at `mylib/src/lib/foo.directive.ts`",
+        "command": "nx g @nx/angular:directive mylib/src/lib/foo --type=directive"
+      },
+      {
+        "description": "Generate a directive with the exported symbol different from the file name. It results in the directive `Custom` at `mylib/src/lib/foo.ts`",
         "command": "nx g @nx/angular:directive mylib/src/lib/foo --name=custom"
       }
     ],
@@ -72,6 +76,10 @@
         "type": "boolean",
         "default": false,
         "description": "The declaring NgModule exports this directive."
+      },
+      "type": {
+        "type": "string",
+        "description": "Append a custom type to the directive's filename. It defaults to 'directive' for Angular versions below v20. For Angular v20 and above, no type is appended unless specified."
       },
       "skipFormat": {
         "type": "boolean",

--- a/docs/generated/packages/angular/generators/scam-directive.json
+++ b/docs/generated/packages/angular/generators/scam-directive.json
@@ -13,11 +13,15 @@
         "command": "nx g @nx/angular:scam-directive mylib/src/lib/foo.directive.ts"
       },
       {
-        "description": "Generate a directive without providing the file extension. It results in the directive `FooDirective` at `mylib/src/lib/foo.directive.ts`",
+        "description": "Generate a directive without providing the file extension. It results in the directive `Foo` at `mylib/src/lib/foo.ts`",
         "command": "nx g @nx/angular:scam-directive mylib/src/lib/foo"
       },
       {
-        "description": "Generate a directive with the exported symbol different from the file name. It results in the directive `CustomDirective` at `mylib/src/lib/foo.directive.ts`",
+        "description": "Generate a directive with a given type/suffix. It results in the directive `FooDirective` at `mylib/src/lib/foo.directive.ts`",
+        "command": "nx g @nx/angular:scam-directive mylib/src/lib/foo --type=directive"
+      },
+      {
+        "description": "Generate a directive with the exported symbol different from the file name. It results in the directive `Custom` at `mylib/src/lib/foo.ts`",
         "command": "nx g @nx/angular:scam-directive mylib/src/lib/foo --name=custom"
       }
     ],
@@ -64,6 +68,10 @@
         "description": "Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.",
         "default": true,
         "x-priority": "important"
+      },
+      "type": {
+        "type": "string",
+        "description": "Append a custom type to the directive's filename. It defaults to 'directive' for Angular versions below v20. For Angular v20 and above, no type is appended unless specified."
       },
       "skipFormat": {
         "description": "Skip formatting files.",

--- a/packages/angular/src/generators/directive/__snapshots__/directive.spec.ts.snap
+++ b/packages/angular/src/generators/directive/__snapshots__/directive.spec.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`directive generator --no-standalone should export the directive correctly when directory is nested deeper 1`] = `
 "import { NgModule } from '@angular/core';
-import { TestDirective } from './my-directives/test/test.directive';
+import { Test } from './my-directives/test/test';
 @NgModule({
   imports: [],
-  declarations: [TestDirective],
-  exports: [TestDirective],
+  declarations: [Test],
+  exports: [Test],
 })
 export class TestModule {}
 "
@@ -19,18 +19,18 @@ exports[`directive generator --no-standalone should generate a directive with te
   selector: '[test]',
   standalone: false,
 })
-export class TestDirective {
+export class Test {
   constructor() {}
 }
 "
 `;
 
 exports[`directive generator --no-standalone should generate a directive with test files and attach to the NgModule automatically 2`] = `
-"import { TestDirective } from './test.directive';
+"import { Test } from './test';
 
-describe('TestDirective', () => {
+describe('Test', () => {
   it('should create an instance', () => {
-    const directive = new TestDirective();
+    const directive = new Test();
     expect(directive).toBeTruthy();
   });
 });
@@ -39,10 +39,10 @@ describe('TestDirective', () => {
 
 exports[`directive generator --no-standalone should generate a directive with test files and attach to the NgModule automatically 3`] = `
 "import { NgModule } from '@angular/core';
-import { TestDirective } from './test.directive';
+import { Test } from './test';
 @NgModule({
   imports: [],
-  declarations: [TestDirective],
+  declarations: [Test],
   exports: [],
 })
 export class TestModule {}
@@ -55,10 +55,10 @@ exports[`directive generator --no-standalone should import the directive correct
 
 exports[`directive generator --no-standalone should import the directive correctly 3`] = `
 "import { NgModule } from '@angular/core';
-import { TestDirective } from './test.directive';
+import { Test } from './test';
 @NgModule({
   imports: [],
-  declarations: [TestDirective],
+  declarations: [Test],
   exports: [],
 })
 export class TestModule {}
@@ -72,18 +72,18 @@ exports[`directive generator --no-standalone should import the directive correct
   selector: '[test]',
   standalone: false
 })
-export class TestDirective {
+export class Test {
   constructor() {}
 }
 "
 `;
 
 exports[`directive generator --no-standalone should import the directive correctly when directory is nested deeper 2`] = `
-"import { TestDirective } from './test.directive';
+"import { Test } from './test';
 
-describe('TestDirective', () => {
+describe('Test', () => {
   it('should create an instance', () => {
-    const directive = new TestDirective();
+    const directive = new Test();
     expect(directive).toBeTruthy();
   });
 });
@@ -92,10 +92,10 @@ describe('TestDirective', () => {
 
 exports[`directive generator --no-standalone should import the directive correctly when directory is nested deeper 3`] = `
 "import { NgModule } from '@angular/core';
-import { TestDirective } from './my-directives/test/test.directive';
+import { Test } from './my-directives/test/test';
 @NgModule({
   imports: [],
-  declarations: [TestDirective],
+  declarations: [Test],
   exports: [],
 })
 export class TestModule {}
@@ -108,18 +108,18 @@ exports[`directive generator should generate correctly 1`] = `
 @Directive({
   selector: '[test]',
 })
-export class TestDirective {
+export class Test {
   constructor() {}
 }
 "
 `;
 
 exports[`directive generator should generate correctly 2`] = `
-"import { TestDirective } from './test.directive';
+"import { Test } from './test';
 
-describe('TestDirective', () => {
+describe('Test', () => {
   it('should create an instance', () => {
-    const directive = new TestDirective();
+    const directive = new Test();
     expect(directive).toBeTruthy();
   });
 });
@@ -132,18 +132,18 @@ exports[`directive generator should handle path with file extension 1`] = `
 @Directive({
   selector: '[test]',
 })
-export class TestDirective {
+export class Test {
   constructor() {}
 }
 "
 `;
 
 exports[`directive generator should handle path with file extension 2`] = `
-"import { TestDirective } from './test.directive';
+"import { Test } from './test.directive';
 
-describe('TestDirective', () => {
+describe('Test', () => {
   it('should create an instance', () => {
-    const directive = new TestDirective();
+    const directive = new Test();
     expect(directive).toBeTruthy();
   });
 });

--- a/packages/angular/src/generators/directive/lib/normalize-options.ts
+++ b/packages/angular/src/generators/directive/lib/normalize-options.ts
@@ -4,12 +4,18 @@ import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generat
 import type { AngularProjectConfiguration } from '../../../utils/types';
 import { buildSelector, validateHtmlSelector } from '../../utils/selector';
 import { validateClassName } from '../../utils/validations';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export async function normalizeOptions(
   tree: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+  if (angularMajorVersion < 20) {
+    options.type ??= 'directive';
+  }
+
   const {
     artifactName: name,
     directory,
@@ -19,13 +25,13 @@ export async function normalizeOptions(
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
     path: options.path,
-    suffix: 'directive',
+    suffix: options.type,
     allowedFileExtensions: ['ts'],
     fileExtension: 'ts',
   });
 
   const { className } = names(name);
-  const { className: suffixClassName } = names('directive');
+  const suffixClassName = options.type ? names(options.type).className : '';
   const symbolName = `${className}${suffixClassName}`;
   validateClassName(symbolName);
 

--- a/packages/angular/src/generators/directive/schema.d.ts
+++ b/packages/angular/src/generators/directive/schema.d.ts
@@ -8,6 +8,7 @@ export interface Schema {
   standalone?: boolean;
   module?: string;
   export?: boolean;
+  type?: string;
   skipFormat?: boolean;
 }
 

--- a/packages/angular/src/generators/directive/schema.json
+++ b/packages/angular/src/generators/directive/schema.json
@@ -12,11 +12,15 @@
       "command": "nx g @nx/angular:directive mylib/src/lib/foo.directive.ts"
     },
     {
-      "description": "Generate a directive without providing the file extension. It results in the directive `FooDirective` at `mylib/src/lib/foo.directive.ts`",
+      "description": "Generate a directive without providing the file extension. It results in the directive `Foo` at `mylib/src/lib/foo.ts`",
       "command": "nx g @nx/angular:directive mylib/src/lib/foo"
     },
     {
-      "description": "Generate a directive with the exported symbol different from the file name. It results in the directive `CustomDirective` at `mylib/src/lib/foo.directive.ts`",
+      "description": "Generate a directive with a given type/suffix. It results in the directive `FooDirective` at `mylib/src/lib/foo.directive.ts`",
+      "command": "nx g @nx/angular:directive mylib/src/lib/foo --type=directive"
+    },
+    {
+      "description": "Generate a directive with the exported symbol different from the file name. It results in the directive `Custom` at `mylib/src/lib/foo.ts`",
       "command": "nx g @nx/angular:directive mylib/src/lib/foo --name=custom"
     }
   ],
@@ -77,6 +81,10 @@
       "type": "boolean",
       "default": false,
       "description": "The declaring NgModule exports this directive."
+    },
+    "type": {
+      "type": "string",
+      "description": "Append a custom type to the directive's filename. It defaults to 'directive' for Angular versions below v20. For Angular v20 and above, no type is appended unless specified."
     },
     "skipFormat": {
       "type": "boolean",

--- a/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
@@ -6,7 +6,7 @@ import { convertDirectiveToScam } from './convert-directive-to-scam';
 describe('convertDirectiveToScam', () => {
   it('should create the scam directive inline correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -26,18 +26,18 @@ describe('convertDirectiveToScam', () => {
     convertDirectiveToScam(tree, {
       path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
-      fileName: 'example.directive',
-      filePath: 'apps/app1/src/app/example/example.directive.ts',
+      fileName: 'example',
+      filePath: 'apps/app1/src/app/example/example.ts',
       name: 'example',
       projectName: 'app1',
       export: false,
       inlineScam: true,
-      symbolName: 'ExampleDirective',
+      symbolName: 'Example',
     });
 
     // ASSERT
     const directiveSource = tree.read(
-      'apps/app1/src/app/example/example.directive.ts',
+      'apps/app1/src/app/example/example.ts',
       'utf-8'
     );
     expect(directiveSource).toMatchInlineSnapshot(`
@@ -48,23 +48,23 @@ describe('convertDirectiveToScam', () => {
         selector: '[example]',
         standalone: false
       })
-      export class ExampleDirective {
+      export class Example {
         constructor() {}
       }
 
       @NgModule({
         imports: [CommonModule],
-        declarations: [ExampleDirective],
-        exports: [ExampleDirective],
+        declarations: [Example],
+        exports: [Example],
       })
-      export class ExampleDirectiveModule {}
+      export class ExampleModule {}
       "
     `);
   });
 
   it('should create the scam directive separately correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -84,13 +84,13 @@ describe('convertDirectiveToScam', () => {
     convertDirectiveToScam(tree, {
       path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
-      fileName: 'example.directive',
-      filePath: 'apps/app1/src/app/example/example.directive.ts',
+      fileName: 'example',
+      filePath: 'apps/app1/src/app/example/example.ts',
       name: 'example',
       projectName: 'app1',
       export: false,
       inlineScam: false,
-      symbolName: 'ExampleDirective',
+      symbolName: 'Example',
     });
 
     // ASSERT
@@ -101,14 +101,14 @@ describe('convertDirectiveToScam', () => {
     expect(directiveModuleSource).toMatchInlineSnapshot(`
       "import { NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
-      import { ExampleDirective } from './example.directive';
+      import { Example } from './example';
 
       @NgModule({
         imports: [CommonModule],
-        declarations: [ExampleDirective],
-        exports: [ExampleDirective],
+        declarations: [Example],
+        exports: [Example],
       })
-      export class ExampleDirectiveModule {}
+      export class ExampleModule {}
       "
     `);
   });

--- a/packages/angular/src/generators/scam-directive/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam-directive/lib/normalize-options.ts
@@ -2,12 +2,18 @@ import type { Tree } from '@nx/devkit';
 import { names } from '@nx/devkit';
 import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { validateClassName } from '../../utils/validations';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export async function normalizeOptions(
   tree: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+  if (angularMajorVersion < 20) {
+    options.type ??= 'directive';
+  }
+
   const {
     artifactName: name,
     directory,
@@ -17,13 +23,13 @@ export async function normalizeOptions(
   } = await determineArtifactNameAndDirectoryOptions(tree, {
     name: options.name,
     path: options.path,
-    suffix: 'directive',
+    suffix: options.type,
     allowedFileExtensions: ['ts'],
     fileExtension: 'ts',
   });
 
   const { className } = names(name);
-  const { className: suffixClassName } = names('directive');
+  const suffixClassName = options.type ? names(options.type).className : '';
   const symbolName = `${className}${suffixClassName}`;
   validateClassName(symbolName);
 

--- a/packages/angular/src/generators/scam-directive/scam-directive.spec.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.spec.ts
@@ -1,11 +1,11 @@
-import { addProjectConfiguration, writeJson } from '@nx/devkit';
+import { addProjectConfiguration, updateJson, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { scamDirectiveGenerator } from './scam-directive';
 
 describe('SCAM Directive Generator', () => {
   it('should create the inline scam directive correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -21,11 +21,47 @@ describe('SCAM Directive Generator', () => {
     });
 
     // ASSERT
-    const directiveSource = tree.read(
-      'apps/app1/src/app/example.directive.ts',
-      'utf-8'
-    );
+    const directiveSource = tree.read('apps/app1/src/app/example.ts', 'utf-8');
     expect(directiveSource).toMatchInlineSnapshot(`
+      "import { Directive, NgModule } from '@angular/core';
+      import { CommonModule } from '@angular/common';
+
+      @Directive({
+        selector: '[example]',
+        standalone: false
+      })
+      export class Example {
+        constructor() {}
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        declarations: [Example],
+        exports: [Example],
+      })
+      export class ExampleModule {}
+      "
+    `);
+  });
+
+  it('should create the inline scam directive with the provided "directive" type', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app1', {
+      projectType: 'application',
+      sourceRoot: 'apps/app1/src',
+      root: 'apps/app1',
+    });
+
+    await scamDirectiveGenerator(tree, {
+      name: 'example',
+      path: 'apps/app1/src/app/example',
+      inlineScam: true,
+      type: 'directive',
+      skipFormat: true,
+    });
+
+    expect(tree.read('apps/app1/src/app/example.directive.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
       "import { Directive, NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
 
@@ -49,7 +85,7 @@ describe('SCAM Directive Generator', () => {
 
   it('should create the separate scam directive correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -72,20 +108,20 @@ describe('SCAM Directive Generator', () => {
     expect(directiveModuleSource).toMatchInlineSnapshot(`
       "import { NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
-      import { ExampleDirective } from './example.directive';
+      import { Example } from './example';
 
       @NgModule({
         imports: [CommonModule],
-        declarations: [ExampleDirective],
-        exports: [ExampleDirective],
+        declarations: [Example],
+        exports: [Example],
       })
-      export class ExampleDirectiveModule {}
+      export class ExampleModule {}
       "
     `);
   });
 
   it('should handle path with file extension', async () => {
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -111,23 +147,23 @@ describe('SCAM Directive Generator', () => {
         selector: '[example]',
         standalone: false
       })
-      export class ExampleDirective {
+      export class Example {
         constructor() {}
       }
 
       @NgModule({
         imports: [CommonModule],
-        declarations: [ExampleDirective],
-        exports: [ExampleDirective],
+        declarations: [Example],
+        exports: [Example],
       })
-      export class ExampleDirectiveModule {}
+      export class ExampleModule {}
       "
     `);
   });
 
   it('should create the scam directive correctly and export it for a secondary entrypoint', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -155,14 +191,14 @@ describe('SCAM Directive Generator', () => {
     expect(directiveModuleSource).toMatchInlineSnapshot(`
       "import { NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
-      import { ExampleDirective } from './example.directive';
+      import { Example } from './example';
 
       @NgModule({
         imports: [CommonModule],
-        declarations: [ExampleDirective],
-        exports: [ExampleDirective],
+        declarations: [Example],
+        exports: [Example],
       })
-      export class ExampleDirectiveModule {}
+      export class ExampleModule {}
       "
     `);
     const secondaryEntryPointSource = tree.read(
@@ -170,7 +206,7 @@ describe('SCAM Directive Generator', () => {
       'utf-8'
     );
     expect(secondaryEntryPointSource).toMatchInlineSnapshot(`
-      "export * from './lib/example/example.directive';
+      "export * from './lib/example/example';
       export * from './lib/example/example.module';"
     `);
   });
@@ -188,13 +224,13 @@ describe('SCAM Directive Generator', () => {
         name: '404',
         path: 'apps/app1/src/app/example',
       })
-    ).rejects.toThrow('Class name "404Directive" is invalid.');
+    ).rejects.toThrow('Class name "404" is invalid.');
   });
 
   describe('--path', () => {
-    it('should not throw when the path does not exist under project', async () => {
+    it('should not throw when the path exists under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -211,7 +247,7 @@ describe('SCAM Directive Generator', () => {
 
       // ASSERT
       const directiveSource = tree.read(
-        'apps/app1/src/app/random/example/example.directive.ts',
+        'apps/app1/src/app/random/example/example.ts',
         'utf-8'
       );
       expect(directiveSource).toMatchInlineSnapshot(`
@@ -222,23 +258,23 @@ describe('SCAM Directive Generator', () => {
           selector: '[example]',
           standalone: false
         })
-        export class ExampleDirective {
+        export class Example {
           constructor() {}
         }
 
         @NgModule({
           imports: [CommonModule],
-          declarations: [ExampleDirective],
-          exports: [ExampleDirective],
+          declarations: [Example],
+          exports: [Example],
         })
-        export class ExampleDirectiveModule {}
+        export class ExampleModule {}
         "
       `);
     });
 
     it('should not matter if the path starts with a slash', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -255,7 +291,7 @@ describe('SCAM Directive Generator', () => {
 
       // ASSERT
       const directiveSource = tree.read(
-        'apps/app1/src/app/random/example/example.directive.ts',
+        'apps/app1/src/app/random/example/example.ts',
         'utf-8'
       );
       expect(directiveSource).toMatchInlineSnapshot(`
@@ -266,23 +302,23 @@ describe('SCAM Directive Generator', () => {
           selector: '[example]',
           standalone: false
         })
-        export class ExampleDirective {
+        export class Example {
           constructor() {}
         }
 
         @NgModule({
           imports: [CommonModule],
-          declarations: [ExampleDirective],
-          exports: [ExampleDirective],
+          declarations: [Example],
+          exports: [Example],
         })
-        export class ExampleDirectiveModule {}
+        export class ExampleModule {}
         "
       `);
     });
 
     it('should throw when the path does not exist under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -300,6 +336,53 @@ describe('SCAM Directive Generator', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"The provided directory resolved relative to the current working directory "libs/proj/src/lib/random/example" does not exist under any project root. Please make sure to navigate to a location or provide a directory that exists under a project root."`
       );
+    });
+  });
+
+  describe('compat', () => {
+    it('should generate the scam directive with the "directive" type for versions lower than v20', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => {
+        json.dependencies = {
+          ...json.dependencies,
+          '@angular/core': '~19.2.0',
+        };
+        return json;
+      });
+      addProjectConfiguration(tree, 'app1', {
+        projectType: 'application',
+        sourceRoot: 'apps/app1/src',
+        root: 'apps/app1',
+      });
+
+      await scamDirectiveGenerator(tree, {
+        name: 'example',
+        path: 'apps/app1/src/app/example',
+        inlineScam: true,
+        skipFormat: true,
+      });
+
+      expect(tree.read('apps/app1/src/app/example.directive.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { Directive, NgModule } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+
+        @Directive({
+          selector: '[example]',
+          standalone: false
+        })
+        export class ExampleDirective {
+          constructor() {}
+        }
+
+        @NgModule({
+          imports: [CommonModule],
+          declarations: [ExampleDirective],
+          exports: [ExampleDirective],
+        })
+        export class ExampleDirectiveModule {}
+        "
+      `);
     });
   });
 });

--- a/packages/angular/src/generators/scam-directive/schema.d.ts
+++ b/packages/angular/src/generators/scam-directive/schema.d.ts
@@ -6,6 +6,7 @@ export interface Schema {
   prefix?: string;
   selector?: string;
   export?: boolean;
+  type?: string;
   skipFormat?: boolean;
 }
 

--- a/packages/angular/src/generators/scam-directive/schema.json
+++ b/packages/angular/src/generators/scam-directive/schema.json
@@ -10,11 +10,15 @@
       "command": "nx g @nx/angular:scam-directive mylib/src/lib/foo.directive.ts"
     },
     {
-      "description": "Generate a directive without providing the file extension. It results in the directive `FooDirective` at `mylib/src/lib/foo.directive.ts`",
+      "description": "Generate a directive without providing the file extension. It results in the directive `Foo` at `mylib/src/lib/foo.ts`",
       "command": "nx g @nx/angular:scam-directive mylib/src/lib/foo"
     },
     {
-      "description": "Generate a directive with the exported symbol different from the file name. It results in the directive `CustomDirective` at `mylib/src/lib/foo.directive.ts`",
+      "description": "Generate a directive with a given type/suffix. It results in the directive `FooDirective` at `mylib/src/lib/foo.directive.ts`",
+      "command": "nx g @nx/angular:scam-directive mylib/src/lib/foo --type=directive"
+    },
+    {
+      "description": "Generate a directive with the exported symbol different from the file name. It results in the directive `Custom` at `mylib/src/lib/foo.ts`",
       "command": "nx g @nx/angular:scam-directive mylib/src/lib/foo --name=custom"
     }
   ],
@@ -69,6 +73,10 @@
       "description": "Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.",
       "default": true,
       "x-priority": "important"
+    },
+    "type": {
+      "type": "string",
+      "description": "Append a custom type to the directive's filename. It defaults to 'directive' for Angular versions below v20. For Angular v20 and above, no type is appended unless specified."
     },
     "skipFormat": {
       "description": "Skip formatting files.",


### PR DESCRIPTION
- Update generators to generate directives without the `.directive`/`Directive` suffix/type by default for Angular v20
- Keep the ability to generate directives with the `.directive`/`Directive` suffix/type by providing the `type` option for the `@nx/angular:directive` and `@nx/angular:scam-directive` generators
- When the workspace uses a version lower than v20, the generators will still generate directives with the `.directive`/`Directive` suffix/type by default

Note: a migration will be provided in a separate PR so existing workspaces continue generating directives with the `.directive`/`Directive` suffix/type.