### PR TITLE
fix(core): do not set tasks which cannot be interactive to interactive

### DIFF
--- a/packages/nx/src/native/pseudo_terminal/child_process.rs
+++ b/packages/nx/src/native/pseudo_terminal/child_process.rs
@@ -9,8 +9,9 @@ use napi::{
         ErrorStrategy::Fatal, ThreadsafeFunction, ThreadsafeFunctionCallMode::NonBlocking,
     },
 };
+use parking_lot::Mutex;
 use std::io::Write;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use tracing::warn;
 use vt100_ctt::Parser;
 

--- a/packages/nx/src/native/pseudo_terminal/command/unix.rs
+++ b/packages/nx/src/native/pseudo_terminal/command/unix.rs
@@ -46,10 +46,9 @@ pub fn write_to_pty(stdin: &mut Stdin, writer: WriterArc) -> anyhow::Result<()> 
                 mio::Token(0) => {
                     // Read data from stdin
                     loop {
-                        let mut writer = writer.lock().expect("Failed to lock writer");
-
                         match stdin.read(&mut buffer) {
                             Ok(n) => {
+                                let mut writer = writer.lock();
                                 writer.write_all(&buffer[..n])?;
                                 writer.flush()?;
                             }

--- a/packages/nx/src/native/pseudo_terminal/command/windows.rs
+++ b/packages/nx/src/native/pseudo_terminal/command/windows.rs
@@ -26,7 +26,7 @@ pub fn handle_path_space(path: String) -> String {
 }
 
 pub fn write_to_pty(stdin: &mut Stdin, writer: WriterArc) -> anyhow::Result<()> {
-    let mut writer = writer.lock().expect("Failed to lock writer");
+    let mut writer = writer.lock();
     std::io::copy(stdin, writer.as_mut())
         .map_err(|e| anyhow::anyhow!(e))
         .map(|_| ())

--- a/packages/nx/src/native/pseudo_terminal/process_killer/unix.rs
+++ b/packages/nx/src/native/pseudo_terminal/process_killer/unix.rs
@@ -2,6 +2,7 @@ use nix::{
     sys::signal::{Signal as NixSignal, kill},
     unistd::Pid,
 };
+use tracing::debug;
 
 pub struct ProcessKiller {
     pid: i32,
@@ -13,12 +14,12 @@ impl ProcessKiller {
     }
 
     pub fn kill(&self, signal: Option<&str>) -> anyhow::Result<()> {
+        let signal = signal.unwrap_or("SIGINT");
+        debug!("Killing process {} with {}", &self.pid, signal);
         let pid = Pid::from_raw(self.pid);
         match kill(
             pid,
-            NixSignal::from(
-                Signal::try_from(signal.unwrap_or("SIGINT")).map_err(|e| anyhow::anyhow!(e))?,
-            ),
+            NixSignal::from(Signal::try_from(signal).map_err(|e| anyhow::anyhow!(e))?),
         ) {
             Ok(_) => Ok(()),
             Err(e) => Err(anyhow::anyhow!("Failed to kill process: {}", e)),

--- a/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
+++ b/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
@@ -6,9 +6,10 @@ use crossterm::{
     tty::IsTty,
 };
 use napi::bindgen_prelude::*;
+use parking_lot::Mutex;
 use portable_pty::{CommandBuilder, NativePtySystem, PtyPair, PtySize, PtySystem};
 use std::io::stdout;
-use std::sync::{Mutex, RwLock};
+use std::sync::RwLock;
 use std::{
     collections::HashMap,
     io::{Read, Write},

--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -11,6 +11,7 @@ use ratatui::{
     },
 };
 use std::{io, sync::Arc};
+use tracing::debug;
 use tui_term::widget::PseudoTerminal;
 
 use crate::native::tui::components::tasks_list::TaskStatus;
@@ -100,6 +101,7 @@ impl TerminalPaneData {
                 _ if self.is_interactive => match key.code {
                     KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         let ascii_code = (c as u8) - 0x60;
+                        debug!("Sending ASCII code: {}", &[ascii_code].escape_ascii());
                         pty_mut.write_input(&[ascii_code])?;
                     }
                     KeyCode::Char(c) => {

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -256,14 +256,14 @@ impl AppLifeCycle {
     ) {
         self.app
             .lock()
-            .register_running_task(task_id, parser_and_writer)
+            .register_running_interactive_task(task_id, parser_and_writer)
     }
 
     #[napi]
     pub fn register_running_task_with_empty_parser(&mut self, task_id: String) {
         self.app
             .lock()
-            .register_running_task_with_empty_parser(task_id)
+            .register_running_non_interactive_task(task_id)
     }
 
     #[napi]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Some tasks cannot be interactive because of the way they are implemented. At the moment, those tasks can be set to interactive mode.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Tasks which cannot be interactive are not set as interactive

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
