### PR TITLE
feat(angular): generate pipes with a `-` type separator

### DIFF
--- a/docs/generated/packages/angular/generators/pipe.json
+++ b/docs/generated/packages/angular/generators/pipe.json
@@ -15,11 +15,15 @@
         "command": "nx g @nx/angular:pipe mylib/src/lib/foo.pipe.ts"
       },
       {
-        "description": "Generate a pipe without providing the file extension. It results in the pipe `FooPipe` at `mylib/src/lib/foo.pipe.ts`",
+        "description": "Generate a pipe without providing the file extension. It results in the pipe `FooPipe` at `mylib/src/lib/foo-pipe.ts`",
         "command": "nx g @nx/angular:pipe mylib/src/lib/foo"
       },
       {
-        "description": "Generate a pipe with the exported symbol different from the file name. It results in the pipe `CustomPipe` at `mylib/src/lib/foo.pipe.ts`",
+        "description": "Generate a pipe with a different type separator. It results in the pipe `FooPipe` at `mylib/src/lib/foo.pipe.ts`",
+        "command": "nx g @nx/angular:pipe mylib/src/lib/foo --typeSeparator=."
+      },
+      {
+        "description": "Generate a pipe with the exported symbol different from the file name. It results in the pipe `CustomPipe` at `mylib/src/lib/foo-pipe.ts`",
         "command": "nx g @nx/angular:pipe mylib/src/lib/foo --name=custom"
       }
     ],
@@ -58,6 +62,11 @@
         "type": "boolean",
         "default": false,
         "description": "The declaring NgModule exports this pipe."
+      },
+      "typeSeparator": {
+        "type": "string",
+        "enum": ["-", "."],
+        "description": "The separator character to use before the type within the generated file's name. For example, if you set the option to `.`, the file will be named `example.pipe.ts`. It defaults to '-' for Angular v20+. For versions below v20, it defaults to '.'."
       },
       "skipFormat": {
         "type": "boolean",

--- a/docs/generated/packages/angular/generators/scam-pipe.json
+++ b/docs/generated/packages/angular/generators/scam-pipe.json
@@ -51,6 +51,11 @@
         "default": true,
         "x-priority": "important"
       },
+      "typeSeparator": {
+        "type": "string",
+        "enum": ["-", "."],
+        "description": "The separator character to use before the type within the generated file's name. For example, if you set the option to `.`, the file will be named `example.pipe.ts`. It defaults to '-' for Angular v20+. For versions below v20, it defaults to '.'."
+      },
       "skipFormat": {
         "description": "Skip formatting files.",
         "type": "boolean",

--- a/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
+++ b/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
@@ -18,6 +18,7 @@ exports[`addLinting generator should correctly generate the .eslintrc.json file 
         "*.ts",
       ],
       "rules": {
+        "@angular-eslint/component-class-suffix": "off",
         "@angular-eslint/component-selector": [
           "error",
           {
@@ -26,6 +27,7 @@ exports[`addLinting generator should correctly generate the .eslintrc.json file 
             "type": "element",
           },
         ],
+        "@angular-eslint/directive-class-suffix": "off",
         "@angular-eslint/directive-selector": [
           "error",
           {

--- a/packages/angular/src/generators/add-linting/add-linting.spec.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.spec.ts
@@ -291,7 +291,9 @@ describe('addLinting generator', () => {
                   "prefix": "my-org",
                   "style": "kebab-case"
                 }
-              ]
+              ],
+              "@angular-eslint/component-class-suffix": "off",
+              "@angular-eslint/directive-class-suffix": "off"
             }
           },
           {

--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -125,6 +125,10 @@ export async function addLintingGenerator(
                 style: 'kebab-case',
               },
             ],
+            // Temporary disable these rules until Angular ESLint recommended
+            // rules are updated with the new Style Guide
+            '@angular-eslint/component-class-suffix': 'off',
+            '@angular-eslint/directive-class-suffix': 'off',
           },
         },
         {

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -672,6 +672,7 @@ describe('app', () => {
                   "*.ts",
                 ],
                 "rules": {
+                  "@angular-eslint/component-class-suffix": "off",
                   "@angular-eslint/component-selector": [
                     "error",
                     {
@@ -680,6 +681,7 @@ describe('app', () => {
                       "type": "element",
                     },
                   ],
+                  "@angular-eslint/directive-class-suffix": "off",
                   "@angular-eslint/directive-selector": [
                     "error",
                     {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -681,7 +681,9 @@ describe('lib', () => {
                     "prefix": "lib",
                     "style": "kebab-case"
                   }
-                ]
+                ],
+                "@angular-eslint/component-class-suffix": "off",
+                "@angular-eslint/directive-class-suffix": "off"
               }
             },
             {
@@ -1272,6 +1274,7 @@ describe('lib', () => {
                   "*.ts",
                 ],
                 "rules": {
+                  "@angular-eslint/component-class-suffix": "off",
                   "@angular-eslint/component-selector": [
                     "error",
                     {
@@ -1280,6 +1283,7 @@ describe('lib', () => {
                       "type": "element",
                     },
                   ],
+                  "@angular-eslint/directive-class-suffix": "off",
                   "@angular-eslint/directive-selector": [
                     "error",
                     {
@@ -1332,6 +1336,7 @@ describe('lib', () => {
                   "*.ts",
                 ],
                 "rules": {
+                  "@angular-eslint/component-class-suffix": "off",
                   "@angular-eslint/component-selector": [
                     "error",
                     {
@@ -1340,6 +1345,7 @@ describe('lib', () => {
                       "type": "element",
                     },
                   ],
+                  "@angular-eslint/directive-class-suffix": "off",
                   "@angular-eslint/directive-selector": [
                     "error",
                     {

--- a/packages/angular/src/generators/pipe/__snapshots__/pipe.spec.ts.snap
+++ b/packages/angular/src/generators/pipe/__snapshots__/pipe.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pipe generator --no-standalone should export the pipe correctly when directory is nested deeper 1`] = `
 "import { NgModule } from '@angular/core';
-import { TestPipe } from './my-pipes/test/test.pipe';
+import { TestPipe } from './my-pipes/test/test-pipe';
 @NgModule({
   imports: [],
   declarations: [TestPipe],
@@ -28,7 +28,7 @@ export class TestPipe implements PipeTransform {
 `;
 
 exports[`pipe generator --no-standalone should generate a pipe with test files and attach to the NgModule automatically 2`] = `
-"import { TestPipe } from './test.pipe';
+"import { TestPipe } from './test-pipe';
 
 describe('TestPipe', () => {
   it('create an instance', () => {
@@ -41,7 +41,7 @@ describe('TestPipe', () => {
 
 exports[`pipe generator --no-standalone should generate a pipe with test files and attach to the NgModule automatically 3`] = `
 "import { NgModule } from '@angular/core';
-import { TestPipe } from './test.pipe';
+import { TestPipe } from './test-pipe';
 @NgModule({
   imports: [],
   declarations: [TestPipe],
@@ -67,7 +67,7 @@ export class TestPipe implements PipeTransform {
 `;
 
 exports[`pipe generator --no-standalone should import the pipe correctly when files are flat 2`] = `
-"import { TestPipe } from './test.pipe';
+"import { TestPipe } from './test-pipe';
 
 describe('TestPipe', () => {
   it('create an instance', () => {
@@ -80,7 +80,7 @@ describe('TestPipe', () => {
 
 exports[`pipe generator --no-standalone should import the pipe correctly when files are flat 3`] = `
 "import { NgModule } from '@angular/core';
-import { TestPipe } from './test/test.pipe';
+import { TestPipe } from './test/test-pipe';
 @NgModule({
   imports: [],
   declarations: [TestPipe],
@@ -106,7 +106,7 @@ export class TestPipe implements PipeTransform {
 `;
 
 exports[`pipe generator --no-standalone should import the pipe correctly when files are flat but deeply nested 2`] = `
-"import { TestPipe } from './test.pipe';
+"import { TestPipe } from './test-pipe';
 
 describe('TestPipe', () => {
   it('create an instance', () => {
@@ -119,7 +119,7 @@ describe('TestPipe', () => {
 
 exports[`pipe generator --no-standalone should import the pipe correctly when files are flat but deeply nested 3`] = `
 "import { NgModule } from '@angular/core';
-import { TestPipe } from './my-pipes/test/test.pipe';
+import { TestPipe } from './my-pipes/test/test-pipe';
 @NgModule({
   imports: [],
   declarations: [TestPipe],
@@ -144,7 +144,7 @@ export class TestPipe implements PipeTransform {
 `;
 
 exports[`pipe generator should generate correctly 2`] = `
-"import { TestPipe } from './test.pipe';
+"import { TestPipe } from './test-pipe';
 
 describe('TestPipe', () => {
   it('create an instance', () => {

--- a/packages/angular/src/generators/pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/pipe/lib/normalize-options.ts
@@ -2,12 +2,16 @@ import type { Tree } from '@nx/devkit';
 import { names } from '@nx/devkit';
 import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { validateClassName } from '../../utils/validations';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export async function normalizeOptions(
   tree: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+  options.typeSeparator ??= angularMajorVersion < 20 ? '.' : '-';
+
   const {
     artifactName: name,
     directory,
@@ -18,6 +22,7 @@ export async function normalizeOptions(
     name: options.name,
     path: options.path,
     suffix: 'pipe',
+    suffixSeparator: options.typeSeparator,
     allowedFileExtensions: ['ts'],
     fileExtension: 'ts',
   });

--- a/packages/angular/src/generators/pipe/schema.d.ts
+++ b/packages/angular/src/generators/pipe/schema.d.ts
@@ -6,6 +6,7 @@ export interface Schema {
   standalone?: boolean;
   module?: string;
   export?: boolean;
+  typeSeparator?: string;
   skipFormat?: boolean;
 }
 

--- a/packages/angular/src/generators/pipe/schema.json
+++ b/packages/angular/src/generators/pipe/schema.json
@@ -12,11 +12,15 @@
       "command": "nx g @nx/angular:pipe mylib/src/lib/foo.pipe.ts"
     },
     {
-      "description": "Generate a pipe without providing the file extension. It results in the pipe `FooPipe` at `mylib/src/lib/foo.pipe.ts`",
+      "description": "Generate a pipe without providing the file extension. It results in the pipe `FooPipe` at `mylib/src/lib/foo-pipe.ts`",
       "command": "nx g @nx/angular:pipe mylib/src/lib/foo"
     },
     {
-      "description": "Generate a pipe with the exported symbol different from the file name. It results in the pipe `CustomPipe` at `mylib/src/lib/foo.pipe.ts`",
+      "description": "Generate a pipe with a different type separator. It results in the pipe `FooPipe` at `mylib/src/lib/foo.pipe.ts`",
+      "command": "nx g @nx/angular:pipe mylib/src/lib/foo --typeSeparator=."
+    },
+    {
+      "description": "Generate a pipe with the exported symbol different from the file name. It results in the pipe `CustomPipe` at `mylib/src/lib/foo-pipe.ts`",
       "command": "nx g @nx/angular:pipe mylib/src/lib/foo --name=custom"
     }
   ],
@@ -58,6 +62,11 @@
       "type": "boolean",
       "default": false,
       "description": "The declaring NgModule exports this pipe."
+    },
+    "typeSeparator": {
+      "type": "string",
+      "enum": ["-", "."],
+      "description": "The separator character to use before the type within the generated file's name. For example, if you set the option to `.`, the file will be named `example.pipe.ts`. It defaults to '-' for Angular v20+. For versions below v20, it defaults to '.'."
     },
     "skipFormat": {
       "type": "boolean",

--- a/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
@@ -6,7 +6,7 @@ import { convertPipeToScam } from './convert-pipe-to-scam';
 describe('convertPipeToScam', () => {
   it('should create the scam pipe inline correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -26,8 +26,8 @@ describe('convertPipeToScam', () => {
     convertPipeToScam(tree, {
       path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
-      fileName: 'example.pipe',
-      filePath: 'apps/app1/src/app/example/example.pipe.ts',
+      fileName: 'example-pipe',
+      filePath: 'apps/app1/src/app/example/example-pipe.ts',
       name: 'example',
       projectName: 'app1',
       export: false,
@@ -37,7 +37,7 @@ describe('convertPipeToScam', () => {
 
     // ASSERT
     const pipeSource = tree.read(
-      'apps/app1/src/app/example/example.pipe.ts',
+      'apps/app1/src/app/example/example-pipe.ts',
       'utf-8'
     );
     expect(pipeSource).toMatchInlineSnapshot(`
@@ -66,7 +66,7 @@ describe('convertPipeToScam', () => {
 
   it('should create the scam pipe separately correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -85,8 +85,8 @@ describe('convertPipeToScam', () => {
     convertPipeToScam(tree, {
       path: 'apps/app1/src/app/example/example',
       directory: 'apps/app1/src/app/example',
-      fileName: 'example.pipe',
-      filePath: 'apps/app1/src/app/example/example.pipe.ts',
+      fileName: 'example-pipe',
+      filePath: 'apps/app1/src/app/example/example-pipe.ts',
       name: 'example',
       projectName: 'app1',
       export: false,
@@ -102,7 +102,7 @@ describe('convertPipeToScam', () => {
     expect(pipeModuleSource).toMatchInlineSnapshot(`
       "import { NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
-      import { ExamplePipe } from './example.pipe';
+      import { ExamplePipe } from './example-pipe';
 
       @NgModule({
         imports: [CommonModule],

--- a/packages/angular/src/generators/scam-pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/normalize-options.ts
@@ -3,11 +3,15 @@ import { names } from '@nx/devkit';
 import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { validateClassName } from '../../utils/validations';
 import type { NormalizedSchema, Schema } from '../schema';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 
 export async function normalizeOptions(
   tree: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+  options.typeSeparator ??= angularMajorVersion < 20 ? '.' : '-';
+
   const {
     artifactName: name,
     directory,
@@ -18,6 +22,7 @@ export async function normalizeOptions(
     name: options.name,
     path: options.path,
     suffix: 'pipe',
+    suffixSeparator: options.typeSeparator,
     allowedFileExtensions: ['ts'],
     fileExtension: 'ts',
   });

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.spec.ts
@@ -1,11 +1,11 @@
-import { addProjectConfiguration, writeJson } from '@nx/devkit';
+import { addProjectConfiguration, updateJson, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { scamPipeGenerator } from './scam-pipe';
 
 describe('SCAM Pipe Generator', () => {
   it('should create the inline scam pipe correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -21,6 +21,50 @@ describe('SCAM Pipe Generator', () => {
     });
 
     // ASSERT
+    const pipeSource = tree.read(
+      'apps/app1/src/app/example/example-pipe.ts',
+      'utf-8'
+    );
+    expect(pipeSource).toMatchInlineSnapshot(`
+      "import { Pipe, PipeTransform, NgModule } from '@angular/core';
+      import { CommonModule } from '@angular/common';
+
+      @Pipe({
+        name: 'example',
+        standalone: false
+      })
+      export class ExamplePipe implements PipeTransform {
+        transform(value: unknown, ...args: unknown[]): unknown {
+          return null;
+        }
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        declarations: [ExamplePipe],
+        exports: [ExamplePipe],
+      })
+      export class ExamplePipeModule {}
+      "
+    `);
+  });
+
+  it('should create the inline scam pipe file with the provided type separator', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app1', {
+      projectType: 'application',
+      sourceRoot: 'apps/app1/src',
+      root: 'apps/app1',
+    });
+
+    await scamPipeGenerator(tree, {
+      name: 'example',
+      path: 'apps/app1/src/app/example/example',
+      inlineScam: true,
+      typeSeparator: '.',
+      skipFormat: true,
+    });
+
     const pipeSource = tree.read(
       'apps/app1/src/app/example/example.pipe.ts',
       'utf-8'
@@ -51,7 +95,7 @@ describe('SCAM Pipe Generator', () => {
 
   it('should create the separate scam pipe correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -74,7 +118,7 @@ describe('SCAM Pipe Generator', () => {
     expect(pipeModuleSource).toMatchInlineSnapshot(`
       "import { NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
-      import { ExamplePipe } from './example.pipe';
+      import { ExamplePipe } from './example-pipe';
 
       @NgModule({
         imports: [CommonModule],
@@ -87,7 +131,7 @@ describe('SCAM Pipe Generator', () => {
   });
 
   it('should handle path with file extension', async () => {
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -131,7 +175,7 @@ describe('SCAM Pipe Generator', () => {
 
   it('should create the scam pipe correctly and export it for a secondary entrypoint', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -159,7 +203,7 @@ describe('SCAM Pipe Generator', () => {
     expect(pipeModuleSource).toMatchInlineSnapshot(`
       "import { NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
-      import { ExamplePipe } from './example.pipe';
+      import { ExamplePipe } from './example-pipe';
 
       @NgModule({
         imports: [CommonModule],
@@ -174,7 +218,7 @@ describe('SCAM Pipe Generator', () => {
       'utf-8'
     );
     expect(secondaryEntryPointSource).toMatchInlineSnapshot(`
-      "export * from './lib/example/example.pipe';
+      "export * from './lib/example/example-pipe';
       export * from './lib/example/example.module';"
     `);
   });
@@ -196,9 +240,9 @@ describe('SCAM Pipe Generator', () => {
   });
 
   describe('--path', () => {
-    it('should not throw when the path does not exist under project', async () => {
+    it('should not throw when the path exists under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -215,7 +259,7 @@ describe('SCAM Pipe Generator', () => {
 
       // ASSERT
       const pipeSource = tree.read(
-        'apps/app1/src/app/random/example/example.pipe.ts',
+        'apps/app1/src/app/random/example/example-pipe.ts',
         'utf-8'
       );
       expect(pipeSource).toMatchInlineSnapshot(`
@@ -244,7 +288,7 @@ describe('SCAM Pipe Generator', () => {
 
     it('should not matter if the path starts with a slash', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -261,7 +305,7 @@ describe('SCAM Pipe Generator', () => {
 
       // ASSERT
       const pipeSource = tree.read(
-        'apps/app1/src/app/random/example/example.pipe.ts',
+        'apps/app1/src/app/random/example/example-pipe.ts',
         'utf-8'
       );
       expect(pipeSource).toMatchInlineSnapshot(`
@@ -290,7 +334,7 @@ describe('SCAM Pipe Generator', () => {
 
     it('should throw when the path does not exist under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -308,6 +352,55 @@ describe('SCAM Pipe Generator', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"The provided directory resolved relative to the current working directory "libs/proj/src/lib/random/example" does not exist under any project root. Please make sure to navigate to a location or provide a directory that exists under a project root."`
       );
+    });
+  });
+
+  describe('compat', () => {
+    it('should generate scam pipe file with the "." type separator for versions lower than v20', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => {
+        json.dependencies = {
+          ...json.dependencies,
+          '@angular/core': '~19.2.0',
+        };
+        return json;
+      });
+      addProjectConfiguration(tree, 'app1', {
+        projectType: 'application',
+        sourceRoot: 'apps/app1/src',
+        root: 'apps/app1',
+      });
+
+      await scamPipeGenerator(tree, {
+        name: 'example',
+        path: 'apps/app1/src/app/example/example',
+        inlineScam: true,
+        skipFormat: true,
+      });
+
+      expect(tree.read('apps/app1/src/app/example/example.pipe.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { Pipe, PipeTransform, NgModule } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+
+        @Pipe({
+          name: 'example',
+          standalone: false
+        })
+        export class ExamplePipe implements PipeTransform {
+          transform(value: unknown, ...args: unknown[]): unknown {
+            return null;
+          }
+        }
+
+        @NgModule({
+          imports: [CommonModule],
+          declarations: [ExamplePipe],
+          exports: [ExamplePipe],
+        })
+        export class ExamplePipeModule {}
+        "
+      `);
     });
   });
 });

--- a/packages/angular/src/generators/scam-pipe/schema.d.ts
+++ b/packages/angular/src/generators/scam-pipe/schema.d.ts
@@ -4,6 +4,7 @@ export interface Schema {
   skipTests?: boolean;
   inlineScam?: boolean;
   export?: boolean;
+  typeSeparator?: string;
   skipFormat?: boolean;
 }
 

--- a/packages/angular/src/generators/scam-pipe/schema.json
+++ b/packages/angular/src/generators/scam-pipe/schema.json
@@ -51,6 +51,11 @@
       "default": true,
       "x-priority": "important"
     },
+    "typeSeparator": {
+      "type": "string",
+      "enum": ["-", "."],
+      "description": "The separator character to use before the type within the generated file's name. For example, if you set the option to `.`, the file will be named `example.pipe.ts`. It defaults to '-' for Angular v20+. For versions below v20, it defaults to '.'."
+    },
     "skipFormat": {
       "description": "Skip formatting files.",
       "type": "boolean",

--- a/packages/devkit/src/generators/artifact-name-and-directory-utils.spec.ts
+++ b/packages/devkit/src/generators/artifact-name-and-directory-utils.spec.ts
@@ -135,6 +135,29 @@ describe('determineArtifactNameAndDirectoryOptions', () => {
     });
   });
 
+  it('should support receiving a suffix separator', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+    });
+
+    const result = await determineArtifactNameAndDirectoryOptions(tree, {
+      suffix: 'component',
+      suffixSeparator: '-',
+      path: 'apps/app1/myComponent',
+    });
+
+    expect(result).toStrictEqual({
+      artifactName: 'myComponent',
+      directory: 'apps/app1',
+      fileName: 'myComponent-component',
+      filePath: 'apps/app1/myComponent-component.ts',
+      fileExtension: 'ts',
+      fileExtensionType: 'ts',
+      project: 'app1',
+    });
+  });
+
   it('should support receiving the full file path including the file extension', async () => {
     addProjectConfiguration(tree, 'app1', {
       root: 'apps/app1',

--- a/packages/devkit/src/generators/artifact-name-and-directory-utils.ts
+++ b/packages/devkit/src/generators/artifact-name-and-directory-utils.ts
@@ -25,8 +25,8 @@ export type ArtifactGenerationOptions = {
   name?: string;
   fileExtension?: string;
   suffix?: string;
+  suffixSeparator?: string;
   allowedFileExtensions?: string[];
-
   /**
    * @deprecated Provide the full file path including the file extension in the `path` option. This option will be removed in Nx v21.
    */
@@ -116,7 +116,7 @@ function getNameAndDirectoryOptions(
     fileName = fileName.replace(fileExtensionRegex, '');
     extractedName = fileName;
   } else if (options.suffix) {
-    fileName = `${fileName}.${options.suffix}`;
+    fileName = `${fileName}${options.suffixSeparator ?? '.'}${options.suffix}`;
   }
 
   const filePath = joinPathFragments(directory, `${fileName}.${fileExtension}`);

--- a/packages/workspace/src/generators/preset/preset.spec.ts
+++ b/packages/workspace/src/generators/preset/preset.spec.ts
@@ -44,12 +44,12 @@ describe('preset', () => {
     `);
     expect(tree.children(`apps/${name}/src/app`).sort()).toMatchInlineSnapshot(`
       [
-        "app.component.css",
-        "app.component.html",
-        "app.component.spec.ts",
-        "app.component.ts",
+        "app.css",
+        "app.html",
         "app.module.ts",
-        "nx-welcome.component.ts",
+        "app.spec.ts",
+        "app.ts",
+        "nx-welcome.ts",
       ]
     `);
   }, 60_000);


### PR DESCRIPTION
- Update pipe and scam pipe generators to use a `-` type separator by default for Angular v20
- Generate pipes with a `.` type separator for Angular versions below v20
- Add the `typeSeparator` option to allow choosing between both

Note: a migration will be provided in a separate PR so existing workspaces continue generating pipes with the `.` type separator.