### PR TITLE
fix(core): ensure that global nx works with dot-nx workspace after init

### DIFF
--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -63,6 +63,9 @@ export function generateDotNxSetup(version?: string) {
   const changes = host.listChanges();
   printChanges(changes);
   flushChanges(host.root, changes);
+  // Ensure that the dot-nx installation is available.
+  // This is needed when using a global nx with dot-nx, otherwise running any nx command using global command will fail due to missing modules.
+  execSync('./nx --version', { stdio: 'ignore' });
 }
 
 export function normalizeVersionForNxJson(pkg: string, version: string) {


### PR DESCRIPTION
This PR fixes an issue with the global `nx` command, where running `nx init` in a non-JS folder (i.e. using dot-nx setup) results in a workspace that doesn't work with the global command.

e.g.

```
brew install nx
cd some-java-project
nx init
nx report
```

https://www.loom.com/share/e8dbb2fb7a084300a4dd1e5dff2c0db1

## Current Behavior
`nx report` or any other command fails

## Expected Behavior
`nx` commands should work

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
