### PR TITLE
fix(core): record task runs via the queue

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -423,7 +423,7 @@ export class DaemonClient {
       type: RECORD_TASK_RUNS,
       taskRuns,
     };
-    return this.sendMessageToDaemon(message);
+    return this.sendToDaemonViaQueue(message);
   }
 
   getSyncGeneratorChanges(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Recording task runs does not send via the queue so the daemon could hang without handling the response properly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Recording task runs sends via the queue and does not hang

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
