### PR TITLE
fix(module-federation): use runtimeChunk false when not in dev mode

### DIFF
--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
@@ -11,6 +11,7 @@ export async function withModuleFederationForSSR(
   if (global.NX_GRAPH_CREATION) {
     return (config) => config;
   }
+  const isDevServer = process.env['WEBPACK_SERVE'];
 
   const { sharedLibraries, sharedDependencies, mappedRemotes } =
     await getModuleFederationConfig(options, {
@@ -27,6 +28,9 @@ export async function withModuleFederationForSSR(
       },
       optimization: {
         ...(config.optimization ?? {}),
+        runtimeChunk: isDevServer
+          ? config.optimization?.runtimeChunk ?? undefined
+          : false,
       },
       resolve: {
         ...(config.resolve ?? {}),

--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
@@ -12,6 +12,7 @@ export async function withModuleFederation(
   if (global.NX_GRAPH_CREATION) {
     return (config) => config;
   }
+  const isDevServer = process.env['WEBPACK_SERVE'];
 
   const { sharedLibraries, sharedDependencies, mappedRemotes } =
     await getModuleFederationConfig(options);
@@ -26,6 +27,9 @@ export async function withModuleFederation(
       },
       optimization: {
         ...(config.optimization ?? {}),
+        runtimeChunk: isDevServer
+          ? config.optimization?.runtimeChunk ?? undefined
+          : false,
       },
       resolve: {
         ...(config.resolve ?? {}),

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
@@ -12,6 +12,7 @@ export async function withModuleFederationForSSR(
   if (global.NX_GRAPH_CREATION) {
     return (config) => config;
   }
+  const isDevServer = process.env['WEBPACK_SERVE'];
 
   const { sharedLibraries, sharedDependencies, mappedRemotes } =
     getModuleFederationConfig(options, {
@@ -26,6 +27,9 @@ export async function withModuleFederationForSSR(
     };
     config.optimization = {
       ...(config.optimization ?? {}),
+      runtimeChunk: isDevServer
+        ? config.optimization?.runtimeChunk ?? undefined
+        : false,
     };
 
     config.plugins.push(

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
@@ -24,6 +24,7 @@ export async function withModuleFederation(
       return config;
     };
   }
+  const isDevServer = process.env['WEBPACK_SERVE'];
 
   const { sharedDependencies, sharedLibraries, mappedRemotes } =
     getModuleFederationConfig(options);
@@ -42,6 +43,9 @@ export async function withModuleFederation(
 
     config.optimization = {
       ...(config.optimization ?? {}),
+      runtimeChunk: isDevServer
+        ? config.optimization?.runtimeChunk ?? undefined
+        : false,
     };
 
     if (

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
@@ -12,6 +12,7 @@ export async function withModuleFederationForSSR(
   if (global.NX_GRAPH_CREATION) {
     return (config) => config;
   }
+  const isDevServer = process.env['WEBPACK_SERVE'];
 
   const { sharedLibraries, sharedDependencies, mappedRemotes } =
     await getModuleFederationConfig(options, {
@@ -23,6 +24,9 @@ export async function withModuleFederationForSSR(
     config.output.uniqueName = options.name;
     config.optimization = {
       ...(config.optimization ?? {}),
+      runtimeChunk: isDevServer
+        ? config.optimization?.runtimeChunk ?? undefined
+        : false,
     };
 
     config.plugins.push(

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
@@ -16,6 +16,7 @@ export async function withModuleFederation(
   if (global.NX_GRAPH_CREATION) {
     return (config) => config;
   }
+  const isDevServer = process.env['WEBPACK_SERVE'];
 
   const { sharedDependencies, sharedLibraries, mappedRemotes } =
     await getModuleFederationConfig(options);
@@ -27,6 +28,9 @@ export async function withModuleFederation(
     config.output.scriptType = 'text/javascript';
     config.optimization = {
       ...(config.optimization ?? {}),
+      runtimeChunk: isDevServer
+        ? config.optimization?.runtimeChunk ?? undefined
+        : false,
     };
 
     if (

--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -64,6 +64,7 @@ function applyNxIndependentConfig(
 ): void {
   const isProd =
     process.env.NODE_ENV === 'production' || options.mode === 'production';
+  const isDevServer = process.env['WEBPACK_SERVE'];
   const hashFormat = getOutputHashFormat(options.outputHashing as string);
   config.context = path.join(options.root, options.projectRoot);
   config.target ??= options.target as 'async-node' | 'node' | 'web';
@@ -178,6 +179,9 @@ function applyNxIndependentConfig(
           }),
         ],
         concatenateModules: true,
+        runtimeChunk: isDevServer
+          ? config.optimization?.runtimeChunk ?? undefined
+          : false,
       };
 
   config.stats = {


### PR DESCRIPTION
## Current Behavior
In #30637 `runtimeChunk: false` was removed to allow HMR for styles.

## Expected Behavior
We need to set runtimeChunk to false or multiple when working with MF.
https://github.com/nrwl/nx/issues/31114#issuecomment-2881996043

## Related Issue(s)

Fixes #31114
