### PR TITLE
fix(core): ensure that run-commands processes are cleaned up

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -1,6 +1,5 @@
 import * as yargsParser from 'yargs-parser';
 import { ExecutorContext } from '../../config/misc-interfaces';
-import { isTuiEnabled } from '../../tasks-runner/is-tui-enabled';
 import { PseudoTerminal } from '../../tasks-runner/pseudo-terminal';
 import {
   ParallelRunningTasks,
@@ -129,14 +128,12 @@ export async function runCommands(
     !normalized.commands[0].prefix &&
     normalized.usePty;
 
-  const tuiEnabled = isTuiEnabled();
-
   try {
     const runningTask = isSingleCommandAndCanUsePseudoTerminal
       ? await runSingleCommandWithPseudoTerminal(normalized, context)
       : options.parallel
       ? new ParallelRunningTasks(normalized, context)
-      : new SeriallyRunningTasks(normalized, context, tuiEnabled);
+      : new SeriallyRunningTasks(normalized, context);
     return runningTask;
   } catch (e) {
     if (process.env.NX_VERBOSE_LOGGING === 'true') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx processes do not exit when their child tasks are exit with SIGINT

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx processes do exit when their child tasks are exit with SIGINT

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
