### PR TITLE
chore(core): increase verdaccio max_body_size to 20mb

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -5,7 +5,7 @@ auth:
   htpasswd:
     file: ./htpasswd
 
-max_body_size: 15mb
+max_body_size: 20mb
 
 # a list of other known repositories we can talk to
 uplinks:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Got error: "413 Payload Too Large - PUT http://localhost:4873/nx - request entity too large"
<img width="873" alt="Screenshot 2025-05-16 at 4 23 17 PM" src="https://github.com/user-attachments/assets/fd151405-6f4a-4987-b9cd-63b5dc9cef2f" />


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
increase body size to avoid this error

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
