### PR TITLE
chore(angular): ensure e2es with rspack builds are minimized

### DIFF
--- a/e2e/angular/src/misc.test.ts
+++ b/e2e/angular/src/misc.test.ts
@@ -162,13 +162,9 @@ describe('Convert Angular Webpack Project to Rspack', () => {
 
   it('should convert an Angular Webpack project to Rspack', async () => {
     runCLI(`generate @nx/angular:convert-to-rspack --project=${app1}`);
-    const rspackConfigFileContents = readFile(join(app1, 'rspack.config.ts'));
-    const updatedConfigFileContents = rspackConfigFileContents.replace(
-      `maximumError: '1mb'`,
-      `maximumError: '3mb'`
-    );
-    updateFile(join(app1, 'rspack.config.ts'), updatedConfigFileContents);
-    const buildOutput = runCLI(`build ${app1}`);
+    const buildOutput = runCLI(`build ${app1}`, {
+      env: { NODE_ENV: 'production' },
+    });
     expect(buildOutput).toContain('rspack build');
     expect(buildOutput).toContain('Successfully ran target build for project');
   });

--- a/e2e/angular/src/module-federation.rspack.test.ts
+++ b/e2e/angular/src/module-federation.rspack.test.ts
@@ -46,7 +46,7 @@ describe('Angular Module Federation', () => {
     let rspackConfigFileContents = readFile(join(hostApp, 'rspack.config.ts'));
     let updatedConfigFileContents = rspackConfigFileContents.replace(
       `maximumError: '1mb'`,
-      `maximumError: '11mb'`
+      `maximumError: '3mb'`
     );
     updateFile(join(hostApp, 'rspack.config.ts'), updatedConfigFileContents);
 
@@ -57,7 +57,7 @@ describe('Angular Module Federation', () => {
     rspackConfigFileContents = readFile(join(remoteApp1, 'rspack.config.ts'));
     updatedConfigFileContents = rspackConfigFileContents.replace(
       `maximumError: '1mb'`,
-      `maximumError: '11mb'`
+      `maximumError: '3mb'`
     );
     updateFile(join(remoteApp1, 'rspack.config.ts'), updatedConfigFileContents);
 
@@ -68,7 +68,9 @@ describe('Angular Module Federation', () => {
     );
 
     // check default generated host is built successfully
-    const buildOutput = runCLI(`build ${hostApp}`);
+    const buildOutput = runCLI(`build ${hostApp}`, {
+      env: { NODE_ENV: 'production' },
+    });
     expect(buildOutput).toContain('Successfully ran target build');
 
     // generate a shared lib with a seconary entry point

--- a/e2e/angular/src/projects.test.ts
+++ b/e2e/angular/src/projects.test.ts
@@ -154,18 +154,9 @@ describe('Angular Projects', () => {
     runCLI(
       `generate @nx/angular:app my-dir/${app} --bundler=rspack --no-interactive`
     );
-    const rspackConfigFileContents = readFile(
-      join('my-dir', app, 'rspack.config.ts')
-    );
-    const updatedConfigFileContents = rspackConfigFileContents.replace(
-      `maximumError: '1mb'`,
-      `maximumError: '3mb'`
-    );
-    updateFile(
-      join('my-dir', app, 'rspack.config.ts'),
-      updatedConfigFileContents
-    );
-    runCLI(`build ${app}`);
+    runCLI(`build ${app}`, {
+      env: { NODE_ENV: 'production' },
+    });
 
     if (runE2ETests()) {
       expect(() => runCLI(`e2e ${app}-e2e`)).not.toThrow();


### PR DESCRIPTION
## Current Behavior
The e2e tests running Angular Rspack are not having their builds minimized currently.

## Expected Behavior
Ensure `NODE_ENV=production` is set when calling the build commands

