### PR TITLE
chore(repo): disable failing remix tests due to yarn errors

### DIFF
--- a/e2e/remix/src/nx-remix.test.ts
+++ b/e2e/remix/src/nx-remix.test.ts
@@ -103,7 +103,8 @@ describe('Remix E2E Tests', () => {
         expect(result).toContain(`Successfully ran target test`);
       }, 120_000);
 
-      it('should generate a library with jest and test correctly', async () => {
+      // TODO(nicholas): This test is failing. It doesn't look like the yarn usage is correct.
+      xit('should generate a library with jest and test correctly', async () => {
         const reactapp = uniq('react');
         runCLI(
           `generate @nx/react:application ${reactapp} --unitTestRunner=jest --linter=eslint`
@@ -121,7 +122,8 @@ describe('Remix E2E Tests', () => {
       }, 120_000);
     });
 
-    describe('error checking', () => {
+    // TODO(nicholas): These test are failing. It doesn't look like the yarn usage is correct.
+    xdescribe('error checking', () => {
       const plugin = uniq('remix');
 
       beforeAll(async () => {
@@ -148,7 +150,7 @@ describe('Remix E2E Tests', () => {
 
       // This is expecting yarn v1, or else there will be complaints of lockfile errors.
       // TODO(nicholas): The workspace is created with npm, but we're running `yarn nx` which causes lockfile errors in yarn 2/3/4. I think we need to create with yarn instead?
-      xit('should pass un-escaped dollar signs in routes with skipChecks flag', async () => {
+      it('should pass un-escaped dollar signs in routes with skipChecks flag', async () => {
         await runCommandAsync(
           `someWeirdUseCase=route-segment && yarn nx generate @nx/remix:route --path="apps/${plugin}/app/routes/my.route.$someWeirdUseCase.tsx" --force`
         );
@@ -176,7 +178,7 @@ describe('Remix E2E Tests', () => {
         ).not.toThrow();
       }, 120000);
 
-      xit('should pass un-escaped dollar signs in resource routes with skipChecks flag', async () => {
+      it('should pass un-escaped dollar signs in resource routes with skipChecks flag', async () => {
         await runCommandAsync(
           `someWeirdUseCase=route-segment && yarn nx generate @nx/remix:resource-route --path="apps/${plugin}/app/routes/my.route.$someWeirdUseCase.ts" --force`
         );


### PR DESCRIPTION
This PR disables Remix+Yarn tests. It looks like the tests aren't set up correctly, and we're using `yarn` even thought he workspace is set up with pnpm.