### PR TITLE
fix(react): add missing dependency when generating a react lib that has testing

### DIFF
--- a/packages/react/src/generators/library/lib/install-common-dependencies.ts
+++ b/packages/react/src/generators/library/lib/install-common-dependencies.ts
@@ -11,6 +11,7 @@ import {
   babelPresetReactVersion,
   lessVersion,
   sassVersion,
+  testingLibraryDomVersion,
   testingLibraryReactVersion,
   tsLibVersion,
   typesNodeVersion,
@@ -52,6 +53,7 @@ export async function installCommonDependencies(
 
   if (options.unitTestRunner && options.unitTestRunner !== 'none') {
     devDependencies['@testing-library/react'] = testingLibraryReactVersion;
+    devDependencies['@testing-library/dom'] = testingLibraryDomVersion;
   }
 
   const baseInstallTask = addDependenciesToPackageJson(


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, if we generate a react library with `--unitTestRunner` OOTB it will fail when you run the `test` command because of a missing dependency.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generating a library with `--unitTestRunner` and then running that test should work by default.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
