### PR TITLE
docs(nx-dev): clarify security mention of caching policies

### DIFF
--- a/nx-dev/ui-enterprise/src/lib/security/cache-poisoning-protection.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/cache-poisoning-protection.tsx
@@ -59,11 +59,11 @@ export function CachePoisoningProtection(): ReactElement {
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
                   />
-                  Writes only from trusted CI{' '}
+                  Writes only from trusted CI branches{' '}
                 </span>
                 – By default, the cache artifacts are reused within each pull
-                request. Only artifacts from verified CI pipelines can enter the
-                shared cache used by everyone. PR environments can’t poison
+                request. Only artifacts from trusted CI pipelines should enter
+                the shared cache used by everyone. PR environments can't poison
                 main.
               </li>
               <li className="relative pl-9">

--- a/nx-dev/ui-enterprise/src/lib/security/personal-access.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/personal-access.tsx
@@ -56,16 +56,6 @@ export function PersonalAccess(): ReactElement {
               </li>
               <li className="relative pl-9">
                 <span className="inline font-semibold text-slate-950 dark:text-white">
-                  <GitHubIcon
-                    aria-hidden="true"
-                    className="absolute left-1 top-1 h-5 w-5"
-                  />
-                  Access is tied to your identity provider{' '}
-                </span>
-                — when SSO or GitHub access is revoked, cache access is too.
-              </li>
-              <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
                   <LinkSlashIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"


### PR DESCRIPTION
Clarified language on cache poisoning protection to emphasize trusted CI branches. Removed redundant content regarding personal access tied to identity providers for simplification.