### PR TITLE
fix(core): do not hide task list with run-many if there is only 1 task

### DIFF
--- a/packages/nx/src/native/tui/components/layout_manager.rs
+++ b/packages/nx/src/native/tui/components/layout_manager.rs
@@ -1,5 +1,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
+use crate::native::tui::lifecycle::RunMode;
+
 /// Represents the available layout modes for the TUI application.
 ///
 /// - `Auto`: Layout is determined based on available terminal space
@@ -117,6 +119,18 @@ impl LayoutManager {
             horizontal_padding: 2, // Default horizontal padding of 2 characters
             vertical_padding: 1,   // Default vertical padding of 1 character
         }
+    }
+
+    pub fn new_with_run_mode(task_count: usize, run_mode: RunMode) -> Self {
+        let mut layout_manager = Self::new(task_count);
+        layout_manager.set_task_list_visibility(match run_mode {
+            // nx run task with no dependent tasks
+            RunMode::RunOne if task_count == 1 => TaskListVisibility::Hidden,
+            // nx run task with dependent tasks
+            RunMode::RunOne => TaskListVisibility::Visible,
+            RunMode::RunMany => TaskListVisibility::Visible,
+        });
+        layout_manager
     }
 
     /// Sets the layout mode.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Running `nx run-many -t target` with only a single target causes the TUI to be blank

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running `nx run-many -t target` with only a single target would show the task list with a single target. Pressing spacebar is needed to see the 1 running run-many task. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
