### PR TITLE
fix(gradle): exclude private class for atomized test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,8 @@ node_modules/
 *.njsproj
 *.sln
 *.sw?
+.specstory/**
+.cursorindexingignore
 # OS specific
 # Task files
 tasks.json

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "dev.nx.gradle"
 
-version = "0.1.0"
+version = "0.1.1"
 
 repositories { mavenCentral() }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ClassDetectionTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ClassDetectionTest.kt
@@ -1,0 +1,43 @@
+package dev.nx.gradle.utils
+
+import java.io.File
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ClassDetectionTest {
+  @Test
+  fun `detects top-level and annotated nested classes only`() {
+    val kotlinSource =
+        """
+            class ClassA {
+              @Nested
+              class ClassB
+
+              class ClassC
+
+              private class ClassD
+            }
+
+            @Nested
+            class ClassX // not nested — should be ignored
+
+            private class ClassY
+
+            class ClassZ
+        """
+            .trimIndent()
+
+    // Write to temp file
+    val tempFile = File.createTempFile("ClassDetectionTest", ".kt")
+    tempFile.writeText(kotlinSource)
+    tempFile.deleteOnExit()
+
+    // Run the function
+    val result = getAllVisibleClassesWithNestedAnnotation(tempFile)
+
+    // Expected output
+    val expected = setOf("ClassA\$ClassB", "ClassZ")
+
+    assertEquals(expected, result)
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
when there are multiple classes in a test file, it currently get the first class name in a file through regex and ignore the rest

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
should ignore all private class name in a file

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
