### PR TITLE
fix(react): routing option to library generator

### DIFF
--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -533,6 +533,23 @@ describe('lib', () => {
     });
   });
 
+  describe('--routing', () => {
+    it('should be able to generate a library with routing', async () => {
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        routing: true,
+      });
+
+      const content = tree.read('my-lib/src/lib/my-lib.tsx', 'utf-8');
+      expect(content).toContain('react-router-dom');
+
+      expect(content).toMatch(/<Link\s*to="\/">my-lib root<\/Link>/);
+      expect(content).toMatch(
+        /<Route\s*path="\/"\s*element={<div>This is the my-lib root route.<\/div>} \/>/
+      );
+    });
+  });
+
   describe('--buildable', () => {
     it('should default to rollup bundler', async () => {
       await libraryGenerator(tree, {

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -248,6 +248,7 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
       export: true,
       routing: options.routing,
       js: options.js,
+      name: options.name,
       inSourceTests: options.inSourceTests,
       skipFormat: true,
       globalCss: options.globalCss,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When we try to generate a library with react it fails because `name` is required.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This should work out of the box.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30721
