### PR TITLE
fix(webpack): add support for retrieving all transitive non-buildable dependencies

### DIFF
--- a/packages/rspack/src/plugins/utils/get-non-buildable-libs.ts
+++ b/packages/rspack/src/plugins/utils/get-non-buildable-libs.ts
@@ -1,0 +1,45 @@
+import { type ProjectGraph } from '@nx/devkit';
+import { getAllTransitiveDeps } from './get-transitive-deps';
+import { isBuildableLibrary } from './is-lib-buildable';
+
+/**
+ * Get all non-buildable libraries in the project graph for a given project.
+ * This function retrieves all direct and transitive dependencies of a project,
+ * filtering out only those that are libraries and not buildable.
+ * @param graph Project graph
+ * @param projectName The project name to get dependencies for
+ * @returns A list of all non-buildable libraries that the project depends on, including transitive dependencies.
+ */
+
+export function getNonBuildableLibs(
+  graph: ProjectGraph,
+  projectName: string
+): string[] {
+  const deps = graph?.dependencies?.[projectName] ?? [];
+
+  const allNonBuildable = new Set<string>();
+
+  // First, find all direct non-buildable deps and add them App -> library
+  const directNonBuildable = deps.filter((dep) => {
+    const node = graph.nodes?.[dep.target];
+    if (!node || node.type !== 'lib') return false;
+    const hasBuildTarget = 'build' in (node.data?.targets ?? {});
+    if (hasBuildTarget) return false;
+    return !isBuildableLibrary(node);
+  });
+
+  // Add direct non-buildable dependencies
+  for (const dep of directNonBuildable) {
+    const packageName =
+      graph.nodes?.[dep.target]?.data?.metadata?.js?.packageName;
+    if (packageName) {
+      allNonBuildable.add(packageName);
+    }
+
+    // Get all transitive non-buildable dependencies App -> library1 -> library2
+    const transitiveDeps = getAllTransitiveDeps(graph, dep.target);
+    transitiveDeps.forEach((pkg) => allNonBuildable.add(pkg));
+  }
+
+  return Array.from(allNonBuildable);
+}

--- a/packages/rspack/src/plugins/utils/get-transitive-deps.ts
+++ b/packages/rspack/src/plugins/utils/get-transitive-deps.ts
@@ -1,0 +1,56 @@
+import { type ProjectGraph } from '@nx/devkit';
+import { isBuildableLibrary } from './is-lib-buildable';
+
+/**
+ * Get all transitive dependencies of a target that are non-buildable libraries.
+ * This function traverses the project graph to find all dependencies of a given target,
+ * @param graph Graph of the project
+ * @param targetName The project name to get dependencies for
+ * @param visited Set to keep track of visited nodes to prevent infinite loops in circular dependencies
+ * @returns string[] - List of all transitive dependencies that are non-buildable libraries
+ */
+export function getAllTransitiveDeps(
+  graph: ProjectGraph,
+  targetName: string,
+  visited = new Set<string>()
+): string[] {
+  if (visited.has(targetName)) {
+    return [];
+  }
+
+  visited.add(targetName);
+
+  const node = graph.nodes?.[targetName];
+  if (!node) {
+    return [];
+  }
+
+  // Get direct dependencies of this target
+  const directDeps = graph.dependencies?.[targetName] || [];
+  const transitiveDeps: string[] = [];
+
+  for (const dep of directDeps) {
+    const depNode = graph.nodes?.[dep.target];
+
+    // Only consider library dependencies
+    if (!depNode || depNode.type !== 'lib') {
+      continue;
+    }
+
+    // Check if this dependency is non-buildable
+    const hasBuildTarget = 'build' in (depNode.data?.targets ?? {});
+    const isBuildable = hasBuildTarget || isBuildableLibrary(depNode);
+
+    if (!isBuildable) {
+      const packageName = depNode.data?.metadata?.js?.packageName;
+      if (packageName) {
+        transitiveDeps.push(packageName);
+      }
+
+      const nestedDeps = getAllTransitiveDeps(graph, dep.target, visited);
+      transitiveDeps.push(...nestedDeps);
+    }
+  }
+
+  return transitiveDeps;
+}

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -20,7 +20,7 @@ import { NormalizedNxAppWebpackPluginOptions } from '../nx-app-webpack-plugin-op
 import TerserPlugin = require('terser-webpack-plugin');
 import nodeExternals = require('webpack-node-externals');
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
-import { isBuildableLibrary } from './utils';
+import { getNonBuildableLibs } from './utils';
 
 const IGNORED_WEBPACK_WARNINGS = [
   /The comment file/i,
@@ -355,32 +355,12 @@ function applyNxDependentConfig(
     const graph = options.projectGraph;
     const projectName = options.projectName;
 
-    const deps = graph?.dependencies?.[projectName] ?? [];
-
     // Collect non-buildable TS project references so that they are bundled
     // in the final output. This is needed for projects that are not buildable
-    // but are referenced by buildable projects. This is needed for the new TS
-    // solution setup.
+    // but are referenced by buildable projects.
+
     const nonBuildableWorkspaceLibs = isUsingTsSolution
-      ? deps
-          .filter((dep) => {
-            const node = graph.nodes?.[dep.target];
-            if (!node || node.type !== 'lib') return false;
-
-            const hasBuildTarget = 'build' in (node.data?.targets ?? {});
-
-            if (hasBuildTarget) {
-              return false;
-            }
-
-            // If there is no build target we check the package exports to see if they reference
-            // source files
-            return !isBuildableLibrary(node);
-          })
-          .map(
-            (dep) => graph.nodes?.[dep.target]?.data?.metadata?.js?.packageName
-          )
-          .filter((name): name is string => !!name)
+      ? getNonBuildableLibs(graph, projectName)
       : [];
 
     externals.push(

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/utils.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type ProjectGraphProjectNode } from '@nx/devkit';
+import type { ProjectGraph, ProjectGraphProjectNode } from '@nx/devkit';
 
 function isSourceFile(path: string): boolean {
   return ['.ts', '.tsx', '.mts', '.cts'].some((ext) => path.endsWith(ext));
@@ -55,4 +55,99 @@ export function isBuildableLibrary(node: ProjectGraphProjectNode): boolean {
     packageMain !== '' &&
     !isSourceFile(packageMain)
   );
+}
+/**
+ * Get all transitive dependencies of a target that are non-buildable libraries.
+ * This function traverses the project graph to find all dependencies of a given target,
+ * @param graph Graph of the project
+ * @param targetName The project name to get dependencies for
+ * @param visited Set to keep track of visited nodes to prevent infinite loops in circular dependencies
+ * @returns string[] - List of all transitive dependencies that are non-buildable libraries
+ */
+export function getAllTransitiveDeps(
+  graph: ProjectGraph,
+  targetName: string,
+  visited = new Set<string>()
+): string[] {
+  if (visited.has(targetName)) {
+    return [];
+  }
+
+  visited.add(targetName);
+
+  const node = graph.nodes?.[targetName];
+  if (!node) {
+    return [];
+  }
+
+  // Get direct dependencies of this target
+  const directDeps = graph.dependencies?.[targetName] || [];
+  const transitiveDeps: string[] = [];
+
+  for (const dep of directDeps) {
+    const depNode = graph.nodes?.[dep.target];
+
+    // Only consider library dependencies
+    if (!depNode || depNode.type !== 'lib') {
+      continue;
+    }
+
+    // Check if this dependency is non-buildable
+    const hasBuildTarget = 'build' in (depNode.data?.targets ?? {});
+    const isBuildable = hasBuildTarget || isBuildableLibrary(depNode);
+
+    if (!isBuildable) {
+      const packageName = depNode.data?.metadata?.js?.packageName;
+      if (packageName) {
+        transitiveDeps.push(packageName);
+      }
+
+      const nestedDeps = getAllTransitiveDeps(graph, dep.target, visited);
+      transitiveDeps.push(...nestedDeps);
+    }
+  }
+
+  return transitiveDeps;
+}
+
+/**
+ * Get all non-buildable libraries in the project graph for a given project.
+ * This function retrieves all direct and transitive dependencies of a project,
+ * filtering out only those that are libraries and not buildable.
+ * @param graph Project graph
+ * @param projectName The project name to get dependencies for
+ * @returns A list of all non-buildable libraries that the project depends on, including transitive dependencies.
+ */
+
+export function getNonBuildableLibs(
+  graph: ProjectGraph,
+  projectName: string
+): string[] {
+  const deps = graph?.dependencies?.[projectName] ?? [];
+
+  const allNonBuildable = new Set<string>();
+
+  // First, find all direct non-buildable deps and add them App -> library
+  const directNonBuildable = deps.filter((dep) => {
+    const node = graph.nodes?.[dep.target];
+    if (!node || node.type !== 'lib') return false;
+    const hasBuildTarget = 'build' in (node.data?.targets ?? {});
+    if (hasBuildTarget) return false;
+    return !isBuildableLibrary(node);
+  });
+
+  // Add direct non-buildable dependencies
+  for (const dep of directNonBuildable) {
+    const packageName =
+      graph.nodes?.[dep.target]?.data?.metadata?.js?.packageName;
+    if (packageName) {
+      allNonBuildable.add(packageName);
+    }
+
+    // Get all transitive non-buildable dependencies App -> library1 -> library2
+    const transitiveDeps = getAllTransitiveDeps(graph, dep.target);
+    transitiveDeps.forEach((pkg) => allNonBuildable.add(pkg));
+  }
+
+  return Array.from(allNonBuildable);
 }


### PR DESCRIPTION
This PR improves dependency resolution for Node.js apps using Webpack or Rspack.

While we already handle direct dependencies for non-buildable libraries, this update ensures that **transitive dependencies** are also properly included. This guarantees that all necessary dependencies are bundled when the main app/library is built.

closes: https://github.com/nrwl/nx/issues/31334