### PR TITLE
feat(nx-cloud): update description on nx login and logout

### DIFF
--- a/docs/generated/cli/login.md
+++ b/docs/generated/cli/login.md
@@ -1,11 +1,11 @@
 ---
 title: 'login - CLI command'
-description: 'Login to Nx Cloud. This command is an alias for [`nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).'
+description: 'Login to Nx Cloud. This command is an alias for `nx-cloud login`.'
 ---
 
 # login
 
-Login to Nx Cloud. This command is an alias for [`nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
+Login to Nx Cloud. This command is an alias for `nx-cloud login`.
 
 ## Usage
 
@@ -20,6 +20,6 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 | Option         | Type    | Description                                                                                                                                                                      |
 | -------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--help`       | boolean | Show help.                                                                                                                                                                       |
-| `--nxCloudUrl` | string  | The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to [https://cloud.nx.app](https://cloud.nx.app). |
+| `--nxCloudUrl` | string  | The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to your configured Nx Cloud instance by default. |
 | `--verbose`    | boolean | Prints additional information about the commands (e.g., stack traces).                                                                                                           |
 | `--version`    | boolean | Show version number.                                                                                                                                                             |

--- a/docs/generated/cli/logout.md
+++ b/docs/generated/cli/logout.md
@@ -1,11 +1,11 @@
 ---
 title: 'logout - CLI command'
-description: 'Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).'
+description: 'Logout from Nx Cloud. This command is an alias for `nx-cloud logout`.'
 ---
 
 # logout
 
-Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).
+Logout from Nx Cloud. This command is an alias for `nx-cloud logout`.
 
 ## Usage
 

--- a/docs/generated/packages/nx/documents/login.md
+++ b/docs/generated/packages/nx/documents/login.md
@@ -1,11 +1,11 @@
 ---
 title: 'login - CLI command'
-description: 'Login to Nx Cloud. This command is an alias for [`nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).'
+description: 'Login to Nx Cloud. This command is an alias for `nx-cloud login`.'
 ---
 
 # login
 
-Login to Nx Cloud. This command is an alias for [`nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).
+Login to Nx Cloud. This command is an alias for `nx-cloud login`.
 
 ## Usage
 
@@ -20,6 +20,6 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 | Option         | Type    | Description                                                                                                                                                                      |
 | -------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--help`       | boolean | Show help.                                                                                                                                                                       |
-| `--nxCloudUrl` | string  | The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to [https://cloud.nx.app](https://cloud.nx.app). |
+| `--nxCloudUrl` | string  | The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to your configured Nx Cloud instance by default. |
 | `--verbose`    | boolean | Prints additional information about the commands (e.g., stack traces).                                                                                                           |
 | `--version`    | boolean | Show version number.                                                                                                                                                             |

--- a/docs/generated/packages/nx/documents/logout.md
+++ b/docs/generated/packages/nx/documents/logout.md
@@ -1,11 +1,11 @@
 ---
 title: 'logout - CLI command'
-description: 'Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).'
+description: 'Logout from Nx Cloud. This command is an alias for `nx-cloud logout`.'
 ---
 
 # logout
 
-Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).
+Logout from Nx Cloud. This command is an alias for `nx-cloud logout`.
 
 ## Usage
 

--- a/packages/nx/src/command-line/nx-cloud/login/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/login/command-object.ts
@@ -3,13 +3,12 @@ import { withVerbose } from '../../yargs-utils/shared-options';
 
 export const yargsLoginCommand: CommandModule = {
   command: 'login [nxCloudUrl]',
-  describe:
-    'Login to Nx Cloud. This command is an alias for [`nx-cloud login`](/ci/reference/nx-cloud-cli#npx-nxcloud-login).',
+  describe: 'Login to Nx Cloud. This command is an alias for `nx-cloud login`.',
   builder: (yargs) =>
     withVerbose(
       yargs.positional('nxCloudUrl', {
         describe:
-          'The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to https://cloud.nx.app.',
+          'The Nx Cloud URL of the instance you are trying to connect to. If no positional argument is provided, this command will connect to your configured Nx Cloud instance by default.',
         type: 'string',
         required: false,
       })

--- a/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
@@ -4,7 +4,7 @@ import { withVerbose } from '../../yargs-utils/shared-options';
 export const yargsLogoutCommand: CommandModule = {
   command: 'logout',
   describe:
-    'Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).',
+    'Logout from Nx Cloud. This command is an alias for `nx-cloud logout`.',
   builder: (yargs) =>
     withVerbose(yargs)
       .help(false)


### PR DESCRIPTION
## Expected Behavior
Fixed the description of the commands to not have raw markdown when running `npx nx login help`. Also updated the description such that we don't specifically mention `cloud.nx.app` as not all users will be using this environment by default