### PR TITLE
feat(angular): update `nx init` legacy integrated migration for angular to handle angular v17

### DIFF
--- a/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
@@ -21,9 +21,11 @@ const nxAngularLegacyVersionMap: Record<number, string> = {
   14: '~17.0.0',
   15: '~19.0.0',
   16: '~20.1.0',
+  17: '~21.1.0',
 };
 // min major angular version supported in latest Nx
-const minMajorAngularVersionSupported = 17;
+const minMajorAngularVersionSupported =
+  Math.max(...Object.keys(nxAngularLegacyVersionMap).map(Number)) + 1;
 // version when the Nx CLI changed from @nrwl/tao & @nrwl/cli to nx
 const versionWithConsolidatedPackages = '13.9.0';
 // version when packages were rescoped from @nrwl/* to @nx/*


### PR DESCRIPTION
## Current Behavior

The `nx init` legacy integrated migration for Angular doesn't handle Angular v17 because it was part of the LTS versions. With the upcoming Angular v20, that version is no longer part of the LTS, so it needs to be handled by the legacy migration.

## Expected Behavior

The `nx init` legacy integrated migration for Angular should handle Angular v17 because it's no longer part of the LTS versions.
