### PR TITLE
fix(angular): update tsconfig files generation to better support angular v20

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -600,9 +600,6 @@ exports[`app --strict should enable strict type checking: app tsconfig.json 1`] 
   "include": [],
   "references": [
     {
-      "path": "./tsconfig.editor.json",
-    },
-    {
       "path": "./tsconfig.app.json",
     },
     {
@@ -1162,9 +1159,6 @@ exports[`app not nested should generate files: tsconfig.json 1`] = `
   "files": [],
   "include": [],
   "references": [
-    {
-      "path": "./tsconfig.editor.json",
-    },
     {
       "path": "./tsconfig.app.json",
     },

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -9,7 +9,6 @@ import {
   Tree,
   updateJson,
   updateNxJson,
-  updateProjectConfiguration,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import * as enquirer from 'enquirer';

--- a/packages/angular/src/generators/application/files/base/tsconfig.json__tpl__
+++ b/packages/angular/src/generators/application/files/base/tsconfig.json__tpl__
@@ -6,10 +6,10 @@
   },
   "files": [],
   "include": [],
-  "references": [
+  "references": [<% if (angularMajorVersion < 20) { %>
     {
       "path": "./tsconfig.editor.json"
-    },
+    },<% } %>
     {
       "path": "./tsconfig.app.json"
     }

--- a/packages/angular/src/generators/library/lib/update-tsconfig-files.ts
+++ b/packages/angular/src/generators/library/lib/update-tsconfig-files.ts
@@ -27,6 +27,7 @@ export function updateTsConfigFiles(
     experimentalDecorators: true,
     importHelpers: true,
     target: 'es2022',
+    moduleResolution: 'bundler',
     ...(options.strict
       ? {
           strict: true,
@@ -46,11 +47,11 @@ export function updateTsConfigFiles(
   if (angularMajorVersion >= 20) {
     compilerOptions.module = 'preserve';
   } else {
-    compilerOptions.moduleResolution = 'bundler';
     compilerOptions.module = 'es2022';
   }
 
-  updateJson(tree, `${options.projectRoot}/tsconfig.json`, (json) => {
+  const tsconfigPath = joinPathFragments(options.projectRoot, 'tsconfig.json');
+  updateJson(tree, tsconfigPath, (json) => {
     json.compilerOptions = {
       ...json.compilerOptions,
       ...compilerOptions,
@@ -73,6 +74,26 @@ export function updateTsConfigFiles(
 
     return json;
   });
+
+  if (options.unitTestRunner === 'jest') {
+    const tsconfigSpecPath = joinPathFragments(
+      options.projectRoot,
+      'tsconfig.spec.json'
+    );
+    updateJson(tree, tsconfigSpecPath, (json) => {
+      json.compilerOptions = {
+        ...json.compilerOptions,
+        module: 'commonjs',
+        moduleResolution: 'node10',
+      };
+      json.compilerOptions = getNeededCompilerOptionOverrides(
+        tree,
+        json.compilerOptions,
+        tsconfigPath
+      );
+      return json;
+    });
+  }
 }
 
 function updateProjectConfig(

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -316,6 +316,7 @@ describe('lib', () => {
           experimentalDecorators: true,
           importHelpers: true,
           module: 'preserve',
+          moduleResolution: 'bundler',
           skipLibCheck: true,
           noFallthroughCasesInSwitch: true,
           noPropertyAccessFromIndexSignature: true,

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -72,8 +72,8 @@ export async function libraryGenerator(
   const project = await addProject(tree, libraryOptions);
 
   createFiles(tree, options, project);
-  updateTsConfigFiles(tree, libraryOptions);
   await addUnitTestRunner(tree, libraryOptions);
+  updateTsConfigFiles(tree, libraryOptions);
   updateNpmScopeIfBuildableOrPublishable(tree, libraryOptions);
   setGeneratorDefaults(tree, options);
 


### PR DESCRIPTION
- Remove TS project reference to non-existent `tsconfig.editor.json` file
- Ensure the `tsconfig.spec.json` file for Jest has the correct `module`/`moduleResolution` compiler options