### PR TITLE
fix(core): update getTouchedProjectsFromLockFile to handle deleted/moved projects correctly

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.spec.ts
@@ -62,7 +62,7 @@ describe('getTouchedProjectsFromLockFile', () => {
           ],
           graph.nodes
         );
-        expect(result).toEqual([]);
+        expect(result).toStrictEqual([]);
       });
 
       it(`should return all nodes when "${lockFile}" is touched`, () => {
@@ -76,7 +76,7 @@ describe('getTouchedProjectsFromLockFile', () => {
           ],
           graph.nodes
         );
-        expect(result).toEqual(allNodes);
+        expect(result).toStrictEqual(allNodes);
       });
     });
   });
@@ -111,7 +111,7 @@ describe('getTouchedProjectsFromLockFile', () => {
           ],
           graph.nodes
         );
-        expect(result).toEqual([]);
+        expect(result).toStrictEqual([]);
       });
 
       it(`should not return changes when whole lock file "${lockFile}" is changed`, () => {
@@ -125,7 +125,7 @@ describe('getTouchedProjectsFromLockFile', () => {
           ],
           graph.nodes
         );
-        expect(result).toEqual([]);
+        expect(result).toStrictEqual([]);
       });
 
       it(`should return only changed projects when "${lockFile}" is touched`, () => {
@@ -163,12 +163,26 @@ describe('getTouchedProjectsFromLockFile', () => {
                     rhs: '4.0.1',
                   },
                 },
+                {
+                  type: JsonDiffType.Deleted,
+                  path: [
+                    'importers',
+                    'apps/app-that-was-deleted',
+                    'devDependencies',
+                    'some-other-external-package',
+                    'version',
+                  ],
+                  value: {
+                    lhs: '4.0.1',
+                    rhs: undefined,
+                  },
+                },
               ],
             },
           ],
           graph.nodes
         );
-        expect(result).toEqual(['proj1', 'app1']);
+        expect(result).toStrictEqual(['proj1', 'app1']);
       });
     });
   });

--- a/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/lock-file-changes.ts
@@ -78,10 +78,13 @@ const getProjectsNamesFromPaths = (
   projectGraphNodes: Record<string, ProjectGraphProjectNode>,
   projectPaths: string[]
 ): string[] => {
+  if (!projectPaths.length) {
+    return [];
+  }
   const lookup = new RootPathLookup(projectGraphNodes);
-  return projectPaths.map((path) => {
-    return lookup.findNodeNameByRoot(path);
-  });
+  return projectPaths
+    .map((path) => lookup.findNodeNameByRoot(path))
+    .filter(Boolean);
 };
 
 class RootPathLookup {


### PR DESCRIPTION
## Current Behavior

This fixes a case that was not handled in https://github.com/nrwl/nx/pull/31091.

Currently, for pnpm projects with `'projectsAffectedByDependencyUpdates': 'auto'`, when a project is deleted from the workspace or moved to a different directory, it is added to the `getTouchedProjectsFromLockFile` list as `undefined`. This results in the following error when you run commands that calculate affected projects:
```
Error: Invalid project name is detected: "undefined"
    at addAffectedNodes ...
```

## Expected Behavior

`getTouchedProjectsFromLockFile` should only return project names for existing projects.
Because the `changedProjectPaths` entry for deleted/moved projects will not map to a project in the `projectGraphNodes` object, we should filter them out of the `getProjectsNamesFromPaths` result.

## Related Issue(s)

None that I'm aware of.

---

~~I spent some time trying to debug the failing `nx release version plans › should pick new versions based on version plans using programmatic api` e2e test and am not seeing how my changes could have caused the `TypeError: yargs.version is not a function` failure. 😕 I'd appreciate some help debugging that one! 🙏~~
Update: it eventually passed after rebase with no changes on my end. 🤷 