### PR TITLE
fix(core): handle run-commands targets with no commands

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -22,6 +22,18 @@ describe('Run Commands', () => {
     jest.clearAllMocks();
   });
 
+  it('should handle empty commands array', async () => {
+    const result = await runCommands(
+      {
+        commands: [],
+        __unparsed__: [],
+      },
+      context
+    );
+    expect(result.success).toEqual(true);
+    expect(result.terminalOutput).toEqual('');
+  });
+
   it('should interpolate provided --args', async () => {
     const f = fileSync().name;
     const result = await runCommands(

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -2,6 +2,7 @@ import * as yargsParser from 'yargs-parser';
 import { ExecutorContext } from '../../config/misc-interfaces';
 import { isTuiEnabled } from '../../tasks-runner/is-tui-enabled';
 import { PseudoTerminal } from '../../tasks-runner/pseudo-terminal';
+import { NoopChildProcess } from '../../tasks-runner/running-tasks/noop-child-process';
 import {
   ParallelRunningTasks,
   runSingleCommandWithPseudoTerminal,
@@ -115,6 +116,11 @@ export async function runCommands(
     throw new Error(
       'ERROR: Bad executor config for run-commands - "prefix", "prefixColor", "color" and "bgColor" can only be set when "parallel=true".'
     );
+  }
+
+  // Handle empty commands array - return immediately with success
+  if (normalized.commands.length === 0) {
+    return new NoopChildProcess({ code: 0, terminalOutput: '' });
   }
 
   const isSingleCommand = normalized.commands.length === 1;

--- a/packages/nx/src/tasks-runner/running-tasks/noop-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/noop-child-process.ts
@@ -1,4 +1,3 @@
-import { Serializable } from 'child_process';
 import { RunningTask } from './running-task';
 
 export class NoopChildProcess implements RunningTask {
@@ -14,7 +13,11 @@ export class NoopChildProcess implements RunningTask {
     return;
   }
 
-  onExit(cb: (code: number) => void): void {
-    cb(this.results.code);
+  onExit(cb: (code: number, terminalOutput: string) => void): void {
+    cb(this.results.code, this.results.terminalOutput);
+  }
+
+  onOutput(cb: (terminalOutput: string) => void): void {
+    cb(this.results.terminalOutput);
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx hangs when here is a `run-commands` target with no commands.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx does not hang when there is a `run-commands` target with no commands.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31345 
