### PR TITLE
fix(rspack): Add missing return for rspack composoable plugin

### DIFF
--- a/packages/rspack/src/utils/read-rspack-options.ts
+++ b/packages/rspack/src/utils/read-rspack-options.ts
@@ -20,9 +20,8 @@ export async function readRspackOptions(
   const resolveConfig = async (
     config: unknown
   ): Promise<Configuration | Configuration[]> => {
-    let resolvedConfig: Configuration;
     if (isNxRspackComposablePlugin(config)) {
-      resolvedConfig = await config(
+      return await config(
         {},
         {
           // These values are only used during build-time, so passing stubs here just to read out


### PR DESCRIPTION
This was broken in https://github.com/nrwl/nx/pull/29691

it's missing this return.