### PR TITLE
fix(release): sort groups topologically bottom-up and fix typo to allow multi-level group dependencies

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -344,6 +344,12 @@ describe('nx release - independent projects', () => {
 
 
         "name": "@proj/{project-name}",
+        -   "version": "999.9.9-version-git-operations-test.2",
+        +   "version": "999.9.9-version-git-operations-test.3",
+        "scripts": {
+
+
+        "name": "@proj/{project-name}",
         -   "version": "999.9.9",
         +   "version": "999.9.9-version-git-operations-test.3",
         "scripts": {
@@ -352,12 +358,6 @@ describe('nx release - independent projects', () => {
         -     "@proj/{project-name}": "999.9.9-package.3"
         +     "@proj/{project-name}": "999.9.9-version-git-operations-test.3"
         }
-
-
-        "name": "@proj/{project-name}",
-        -   "version": "999.9.9-version-git-operations-test.2",
-        +   "version": "999.9.9-version-git-operations-test.3",
-        "scripts": {
 
 
         Skipped lock file update because {package-manager} workspaces are not enabled.
@@ -906,7 +906,7 @@ describe('nx release - independent projects', () => {
       expect(
         releaseOutput.match(new RegExp(`New version 1\.4\.1 written`, 'g'))
           .length
-      ).toEqual(1);
+      ).toEqual(2);
 
       expect(
         releaseOutput.match(new RegExp(`New version 1\.6\.1 written`, 'g'))

--- a/e2e/release/src/multiple-release-branches.test.ts
+++ b/e2e/release/src/multiple-release-branches.test.ts
@@ -191,20 +191,20 @@ describe('nx release multiple release branches', () => {
       +   "version": "0.1.0",
       "scripts": {
 
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.7",
-      +   "version": "0.1.0",
-      "scripts": {
-
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.7",
-      +   "version": "0.1.0",
-      "scripts": {
-
       }
       +
+
+
+      "name": "@proj/{project-name}",
+      -   "version": "0.0.7",
+      +   "version": "0.1.0",
+      "scripts": {
+
+
+      "name": "@proj/{project-name}",
+      -   "version": "0.0.7",
+      +   "version": "0.1.0",
+      "scripts": {
 
 
       NX   Committing changes with git
@@ -330,20 +330,20 @@ describe('nx release multiple release branches', () => {
       +   "version": "0.1.0",
       "scripts": {
 
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.0",
-      +   "version": "0.1.0",
-      "scripts": {
-
-
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.0",
-      +   "version": "0.1.0",
-      "scripts": {
-
       }
       +
+
+
+      "name": "@proj/{project-name}",
+      -   "version": "0.0.0",
+      +   "version": "0.1.0",
+      "scripts": {
+
+
+      "name": "@proj/{project-name}",
+      -   "version": "0.0.0",
+      +   "version": "0.1.0",
+      "scripts": {
 
 
       NX   Committing changes with git

--- a/e2e/release/src/preserve-local-dependency-protocols.test.ts
+++ b/e2e/release/src/preserve-local-dependency-protocols.test.ts
@@ -149,16 +149,16 @@ describe('nx release preserve local dependency protocols', () => {
       -   "version": "0.0.0",
       +   "version": "0.1.0",
       "scripts": {
+      "name": "@proj/{project-name}",
+      -   "version": "0.0.0",
+      +   "version": "0.1.0",
+      "scripts": {
       "dependencies": {
       -     "@proj/{project-name}": "workspace:*"
       +     "@proj/{project-name}": "0.1.0"
       }
       }
       +
-      "name": "@proj/{project-name}",
-      -   "version": "0.0.0",
-      +   "version": "0.1.0",
-      "scripts": {
       NX   Updating PM lock file
       Would update pnpm-lock.yaml with the following command, but --dry-run was set:
       pnpm install --lockfile-only
@@ -194,12 +194,12 @@ describe('nx release preserve local dependency protocols', () => {
       -   "version": "0.0.0",
       +   "version": "0.1.0",
       "scripts": {
-      }
-      +
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.1.0",
       "scripts": {
+      }
+      +
       NX   Updating PM lock file
       Would update pnpm-lock.yaml with the following command, but --dry-run was set:
       pnpm install --lockfile-only

--- a/e2e/release/src/version-plans.test.ts
+++ b/e2e/release/src/version-plans.test.ts
@@ -950,7 +950,7 @@ Update packages in both groups with a mix #2
     );
 
     expect(versionResult).toContain(
-      `git add ${pkg5}/package.json ${pkg4}/package.json ${pkg3}/package.json ${pkg2}/package.json ${pkg1}/package.json`
+      `git add ${pkg1}/package.json ${pkg2}/package.json ${pkg3}/package.json ${pkg4}/package.json ${pkg5}/package.json`
     );
 
     expect(readdirSync(versionPlansDir).length).toEqual(2);

--- a/packages/nx/src/command-line/release/version/multiple-release-groups.spec.ts
+++ b/packages/nx/src/command-line/release/version/multiple-release-groups.spec.ts
@@ -434,6 +434,118 @@ describe('Multiple Release Groups', () => {
     });
   });
 
+  describe('Three related groups, all fixed relationship, just JS', () => {
+    it('should correctly version projects across transitive group boundaries', async () => {
+      const {
+        nxReleaseConfig,
+        projectGraph,
+        releaseGroups,
+        releaseGroupToFilteredProjects,
+        filters,
+      } = await createNxReleaseConfigAndPopulateWorkspace(
+        tree,
+        `
+            group1 ({ "projectsRelationship": "fixed" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "fixed" }):
+              - pkg-c@2.0.0 [js]
+                -> depends on pkg-e
+              - pkg-d@2.0.0 [js]
+            group3 ({ "projectsRelationship": "fixed" }):
+              - pkg-e@3.0.0 [js]
+              - pkg-f@3.0.0 [js]
+          `,
+        {
+          version: {
+            conventionalCommits: true,
+          },
+        },
+        mockResolveCurrentVersion
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          // pkg-e has a bump, which should cause pkg-f to bump because they are in a fixed group
+          // pkg-c depends on pkg-e so should also bump, and pkg-d is in a fixed group with pkg-c so should also bump
+          // pkg-a depends on pkg-c so should also bump, and pkg-b is in a fixed group with pkg-a so should also bump
+          if (projectName === 'pkg-e') return 'patch';
+          return 'none';
+        }
+      );
+
+      const processor = new ReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        releaseGroups,
+        releaseGroupToFilteredProjects,
+        {
+          dryRun: false,
+          verbose: false,
+          firstRelease: false,
+          preid: undefined,
+          filters,
+        }
+      );
+
+      await processor.init();
+      await processor.processGroups();
+
+      expect(mockResolveVersionActionsForProject).toHaveBeenCalledTimes(6);
+
+      expect(tree.read('pkg-a/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "pkg-a",
+          "version": "1.0.1",
+          "dependencies": {
+            "pkg-c": "2.0.1"
+          }
+        }
+        "
+      `);
+      expect(tree.read('pkg-b/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "pkg-b",
+          "version": "1.0.1"
+        }
+        "
+      `);
+      expect(tree.read('pkg-c/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "pkg-c",
+          "version": "2.0.1",
+          "dependencies": {
+            "pkg-e": "3.0.1"
+          }
+        }
+        "
+      `);
+      expect(tree.read('pkg-d/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "pkg-d",
+          "version": "2.0.1"
+        }
+        "
+      `);
+      expect(tree.read('pkg-e/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "pkg-e",
+          "version": "3.0.1"
+        }
+        "
+      `);
+      expect(tree.read('pkg-f/package.json', 'utf-8')).toMatchInlineSnapshot(`
+        "{
+          "name": "pkg-f",
+          "version": "3.0.1"
+        }
+        "
+      `);
+    });
+  });
+
   describe('Two related groups, both independent relationship, just JS', () => {
     const graphDefinition = `
       group1 ({ "projectsRelationship": "independent" }):

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -1504,7 +1504,7 @@ Valid values are: ${validReleaseVersionPrefixes
 
     if (releaseGroup.projectsRelationship === 'fixed') {
       // For fixed groups, we only need to check one project
-      const project = releaseGroupFilteredProjects[0];
+      const project = releaseGroupFilteredProjects.values().next().value;
       const dependencies = this.projectGraph.dependencies[project] || [];
       const hasDependencyInChangedGroup = dependencies.some(
         (dep) =>

--- a/packages/nx/src/command-line/release/version/topological-sort.spec.ts
+++ b/packages/nx/src/command-line/release/version/topological-sort.spec.ts
@@ -25,10 +25,10 @@ describe('topologicalSort', () => {
     const indexC = result.indexOf('C');
     const indexD = result.indexOf('D');
 
-    expect(indexA).toBeLessThan(indexB); // A before B
-    expect(indexA).toBeLessThan(indexD); // A before D
-    expect(indexB).toBeLessThan(indexC); // B before C
-    expect(indexD).toBeLessThan(indexC); // D before C
+    expect(indexB).toBeLessThan(indexA); // B before A
+    expect(indexD).toBeLessThan(indexA); // D before A
+    expect(indexC).toBeLessThan(indexB); // C before B
+    expect(indexC).toBeLessThan(indexD); // C before D
   });
 
   it('should handle cycles by breaking them', () => {
@@ -149,8 +149,8 @@ describe('topologicalSort', () => {
     const indexC = result.indexOf('C');
     const indexD = result.indexOf('D');
 
-    expect(indexA).toBeLessThan(indexB); // A before B
-    expect(indexC).toBeLessThan(indexD); // C before D
+    expect(indexB).toBeLessThan(indexA); // B before A
+    expect(indexD).toBeLessThan(indexC); // D before C
   });
 
   it('should handle circular dependencies between two nodes', () => {

--- a/packages/nx/src/command-line/release/version/topological-sort.ts
+++ b/packages/nx/src/command-line/release/version/topological-sort.ts
@@ -44,5 +44,5 @@ export function topologicalSort<T>(
     }
   }
 
-  return result.reverse();
+  return result;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

* topological sorting returns array top-bottom (i.e.: if A -> B -> C, it returns [A, B, C])
* multi-level dependencies are not bumped (i.e.: if A -> B -> C and C is bumped, B is bumped but A is not)
* a `set: Set<string>` is accessed with `set[0]`, which always returns `undefined`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

* topological sorting returns array bottom-up ([C, B, A]), because we typically want to deal with leaves first, and then "touch" the intermediate nodes as we travel up the tree
* multi-level dependencies are bumped (C bumps B, which bumps A)
* set is accessed with `set.values().next().value`, assuming we want to get any one element from it

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31375
