### PR TITLE
docs(misc): fix issue with GA events during local development

### DIFF
--- a/nx-dev/feature-analytics/src/lib/google-analytics.ts
+++ b/nx-dev/feature-analytics/src/lib/google-analytics.ts
@@ -12,6 +12,7 @@ export function sendPageViewEvent(data: {
   path?: string;
   title?: string;
 }): void {
+  if (process.env.NODE_ENV !== 'production') return;
   try {
     gtag('config', data.gaId, {
       ...(!!data.path && { page_path: data.path }),
@@ -29,6 +30,7 @@ export function sendCustomEvent(
   value?: number,
   customObject?: Record<string, unknown>
 ): void {
+  if (process.env.NODE_ENV !== 'production') return;
   try {
     gtag('event', action, {
       event_category: category,


### PR DESCRIPTION
This PR fixes an issue when you serve nx-dev locally and navigate between pages in the browser. You'll get an error that `gtag` is not defined since we never loaded it. We now check that we're in production environment before sending events.