### PR TITLE
fix(testing): update jest ci target to forward top level args

### DIFF
--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -188,7 +188,11 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                   "test-ci": {
                     "cache": true,
                     "dependsOn": [
-                      "test-ci--src/unit.spec.ts",
+                      {
+                        "params": "forward",
+                        "projects": "self",
+                        "target": "test-ci--src/unit.spec.ts",
+                      },
                     ],
                     "executor": "nx:noop",
                     "inputs": [
@@ -491,7 +495,11 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "test-ci": {
                       "cache": true,
                       "dependsOn": [
-                        "test-ci--src/unit.spec.ts",
+                        {
+                          "params": "forward",
+                          "projects": "self",
+                          "target": "test-ci--src/unit.spec.ts",
+                        },
                       ],
                       "executor": "nx:noop",
                       "inputs": [
@@ -641,7 +649,11 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "test-ci": {
                       "cache": true,
                       "dependsOn": [
-                        "test-ci--src/unit.spec.ts",
+                        {
+                          "params": "forward",
+                          "projects": "self",
+                          "target": "test-ci--src/unit.spec.ts",
+                        },
                       ],
                       "executor": "nx:noop",
                       "inputs": [
@@ -791,7 +803,11 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "testci": {
                       "cache": true,
                       "dependsOn": [
-                        "testci--src/unit.spec.ts",
+                        {
+                          "params": "forward",
+                          "projects": "self",
+                          "target": "testci--src/unit.spec.ts",
+                        },
                       ],
                       "executor": "nx:noop",
                       "inputs": [

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -189,6 +189,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                     "cache": true,
                     "dependsOn": [
                       {
+                        "options": "forward",
                         "params": "forward",
                         "projects": "self",
                         "target": "test-ci--src/unit.spec.ts",
@@ -496,6 +497,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "cache": true,
                       "dependsOn": [
                         {
+                          "options": "forward",
                           "params": "forward",
                           "projects": "self",
                           "target": "test-ci--src/unit.spec.ts",
@@ -650,6 +652,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "cache": true,
                       "dependsOn": [
                         {
+                          "options": "forward",
                           "params": "forward",
                           "projects": "self",
                           "target": "test-ci--src/unit.spec.ts",
@@ -804,6 +807,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       "cache": true,
                       "dependsOn": [
                         {
+                          "options": "forward",
                           "params": "forward",
                           "projects": "self",
                           "target": "testci--src/unit.spec.ts",

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -301,7 +301,7 @@ async function buildJestTargets(
         presetCache
       );
       const targetGroup = [];
-      const dependsOn: string[] = [];
+      const dependsOn: TargetConfiguration['dependsOn'] = [];
       metadata = {
         targetGroups: {
           [groupName]: targetGroup,
@@ -340,7 +340,12 @@ async function buildJestTargets(
         }
 
         const targetName = `${options.ciTargetName}--${relativePath}`;
-        dependsOn.push(targetName);
+        dependsOn.push({
+          target: targetName,
+          projects: 'self',
+          params: 'forward',
+        });
+
         targets[targetName] = {
           command: `jest ${relativePath}`,
           cache,
@@ -452,29 +457,7 @@ async function buildJestTargets(
             [groupName]: targetGroup,
           },
         };
-        const dependsOn: string[] = [];
-
-        targets[options.ciTargetName] = {
-          executor: 'nx:noop',
-          cache: true,
-          inputs,
-          outputs,
-          dependsOn,
-          metadata: {
-            technologies: ['jest'],
-            description: 'Run Jest Tests in CI',
-            nonAtomizedTarget: options.targetName,
-            help: {
-              command: `${pmc.exec} jest --help`,
-              example: {
-                options: {
-                  coverage: true,
-                },
-              },
-            },
-          },
-        };
-        targetGroup.push(options.ciTargetName);
+        const dependsOn: TargetConfiguration['dependsOn'] = [];
 
         for (const testPath of testPaths) {
           const relativePath = normalizePath(
@@ -498,7 +481,11 @@ async function buildJestTargets(
           }
 
           const targetName = `${options.ciTargetName}--${relativePath}`;
-          dependsOn.push(targetName);
+          dependsOn.push({
+            target: targetName,
+            projects: 'self',
+            params: 'forward',
+          });
           targets[targetName] = {
             command: `jest ${relativePath}`,
             cache,
@@ -523,6 +510,27 @@ async function buildJestTargets(
           };
           targetGroup.push(targetName);
         }
+        targets[options.ciTargetName] = {
+          executor: 'nx:noop',
+          cache: true,
+          inputs,
+          outputs,
+          dependsOn,
+          metadata: {
+            technologies: ['jest'],
+            description: 'Run Jest Tests in CI',
+            nonAtomizedTarget: options.targetName,
+            help: {
+              command: `${pmc.exec} jest --help`,
+              example: {
+                options: {
+                  coverage: true,
+                },
+              },
+            },
+          },
+        };
+        targetGroup.unshift(options.ciTargetName);
       }
     }
   }

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -344,6 +344,7 @@ async function buildJestTargets(
           target: targetName,
           projects: 'self',
           params: 'forward',
+          options: 'forward',
         });
 
         targets[targetName] = {
@@ -485,6 +486,7 @@ async function buildJestTargets(
             target: targetName,
             projects: 'self',
             params: 'forward',
+            options: 'forward',
           });
           targets[targetName] = {
             command: `jest ${relativePath}`,


### PR DESCRIPTION
This pull request refactors the `dependsOn` configuration for Jest targets in the Nx plugin to improve flexibility and maintainability. The changes replace string-based dependencies with structured objects, ensuring better alignment with Nx's target configuration standards.

This PR updates the `dependsOn` configuration for Jest `ciTarget` to ensure that top-level args are passed on if the parent target has a dependsOn for other targets.

For example if i pass `nx run-many e2e-ci -- --json --outputFile=my-test-results.json` the options:
- `--json`
- `--outputFile`

Should be forwarded to the dependent targets.

