### PR TITLE
fix(linter): respect the `--quiet` option when running with `--fix`

### DIFF
--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -170,14 +170,14 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     );
   }
 
-  // output fixes to disk, if applicable based on the options
-  await ESLint.outputFixes(lintResults);
-
   // if quiet, only show errors
   if (normalizedOptions.quiet) {
     console.debug('Quiet mode enabled - filtering out warnings\n');
     lintResults = ESLint.getErrorResults(lintResults);
   }
+
+  // output fixes to disk, if applicable based on the options
+  await ESLint.outputFixes(lintResults);
 
   const formatter = await eslint.loadFormatter(normalizedOptions.format);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

`nx run lint --quiet --fix` doesn't respect `--quiet` and fixes all issues, even silenced ones. This is different from how `eslint --quiet --fix` behaves.

## Expected Behavior

`nx run lint --quiet --fix` should only fix issues that aren't silenced by `--quiet`, like `eslint` does

## Related Issue(s)

Fixes #31401
