### PR TITLE
docs(core): improve affected command description to define affected projects

### DIFF
--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -1,11 +1,11 @@
 ---
 title: 'affected - CLI command'
-description: 'Run target for affected projects. See https://nx.dev/ci/features/affected for more details.'
+description: 'Run target for affected projects. Affected projects are projects that have been changed and projects that depend on the changed projects. See https://nx.dev/ci/features/affected for more details.'
 ---
 
 # affected
 
-Run target for affected projects. See [https://nx.dev/ci/features/affected](/ci/features/affected) for more details.
+Run target for affected projects. Affected projects are projects that have been changed and projects that depend on the changed projects. See [https://nx.dev/ci/features/affected](/ci/features/affected) for more details.
 
 ## Usage
 

--- a/docs/generated/packages/nx/documents/affected.md
+++ b/docs/generated/packages/nx/documents/affected.md
@@ -1,11 +1,11 @@
 ---
 title: 'affected - CLI command'
-description: 'Run target for affected projects. See https://nx.dev/ci/features/affected for more details.'
+description: 'Run target for affected projects. Affected projects are projects that have been changed and projects that depend on the changed projects. See https://nx.dev/ci/features/affected for more details.'
 ---
 
 # affected
 
-Run target for affected projects. See [https://nx.dev/ci/features/affected](/ci/features/affected) for more details.
+Run target for affected projects. Affected projects are projects that have been changed and projects that depend on the changed projects. See [https://nx.dev/ci/features/affected](/ci/features/affected) for more details.
 
 ## Usage
 

--- a/packages/nx/src/command-line/affected/command-object.ts
+++ b/packages/nx/src/command-line/affected/command-object.ts
@@ -15,7 +15,7 @@ import {
 export const yargsAffectedCommand: CommandModule = {
   command: 'affected',
   describe:
-    'Run target for affected projects. See https://nx.dev/ci/features/affected for more details.',
+    'Run target for affected projects. Affected projects are projects that have been changed and projects that depend on the changed projects. See https://nx.dev/ci/features/affected for more details.',
   builder: (yargs) =>
     linkToNxDevAndExamples(
       withAffectedOptions(


### PR DESCRIPTION



<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx affected` documentation was unclear and did not state what affected projects actually meant.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Adds a clear definition of "affected projects" to the CLI documentation. Affected projects are projects that have been changed and projects that depend on the changed projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30712
