### PR TITLE
fix(core): implement missing --print flag for nx graph command

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -240,6 +240,7 @@ function filterGraph(
 export async function generateGraph(
   args: {
     file?: string;
+    print?: boolean;
     host?: string;
     port?: number;
     groupByFolder?: boolean;
@@ -389,6 +390,23 @@ export async function generateGraph(
     args.focus || null,
     args.exclude || []
   );
+
+  if (args.print) {
+    console.log(
+      JSON.stringify(
+        await createJsonOutput(
+          prunedGraph,
+          rawGraph,
+          args.projects,
+          args.targets
+        ),
+        null,
+        2
+      )
+    );
+    await output.drain();
+    process.exit(0);
+  }
 
   if (args.file) {
     // stdout is a magical constant that doesn't actually write a file

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -391,7 +391,7 @@ export async function generateGraph(
     args.exclude || []
   );
 
-  if (args.print) {
+  if (args.print || args.file === 'stdout') {
     console.log(
       JSON.stringify(
         await createJsonOutput(
@@ -409,24 +409,6 @@ export async function generateGraph(
   }
 
   if (args.file) {
-    // stdout is a magical constant that doesn't actually write a file
-    if (args.file === 'stdout') {
-      console.log(
-        JSON.stringify(
-          await createJsonOutput(
-            prunedGraph,
-            rawGraph,
-            args.projects,
-            args.targets
-          ),
-          null,
-          2
-        )
-      );
-      await output.drain();
-      process.exit(0);
-    }
-
     const workspaceFolder = workspaceRoot;
     const ext = extname(args.file);
     const fullFilePath = isAbsolute(args.file)

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -354,7 +354,7 @@ export async function generateGraph(
         splitArgsIntoNxArgsAndOverrides(
           args,
           'affected',
-          { printWarnings: args.file !== 'stdout' },
+          { printWarnings: !args.print && args.file !== 'stdout' },
           readNxJson()
         ).nxArgs,
         rawGraph


### PR DESCRIPTION
## Current Behavior

The `nx graph --print` flag is documented and shows in CLI help, but when used, it opens the graph UI in a browser instead of printing the dependency graph to the console.

## Expected Behavior

With this PR, `nx graph --print` correctly prints the dependency graph JSON to stdout in the terminal and exits, matching the documented behavior and CLI help description.

## Related Issue(s)

Fixes #30255
Fixes #31406