### PR TITLE
fix(vite): add ajv dependency for non-pnpm package managers

### DIFF
--- a/packages/vite/src/utils/ensure-dependencies.ts
+++ b/packages/vite/src/utils/ensure-dependencies.ts
@@ -1,10 +1,12 @@
 import {
   addDependenciesToPackageJson,
+  detectPackageManager,
   logger,
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
 import {
+  ajvVersion,
   analogVitestAngular,
   edgeRuntimeVmVersion,
   happyDomVersion,
@@ -54,6 +56,9 @@ export function ensureDependencies(
 
   if (schema.includeLib) {
     devDependencies['vite-plugin-dts'] = vitePluginDtsVersion;
+    if (detectPackageManager() !== 'pnpm') {
+      devDependencies['ajv'] = ajvVersion;
+    }
   }
 
   return addDependenciesToPackageJson(host, {}, devDependencies);

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -8,6 +8,7 @@ export const vitePluginReactVersion = '^4.2.0';
 export const vitePluginReactSwcVersion = '^3.5.0';
 export const jsdomVersion = '~22.1.0';
 export const vitePluginDtsVersion = '~4.5.0';
+export const ajvVersion = '^8.0.0';
 export const happyDomVersion = '~9.20.3';
 export const edgeRuntimeVmVersion = '~3.0.2';
 export const jitiVersion = '2.4.2';


### PR DESCRIPTION
This PR updates your `package.json` to add `ajv` as a devDependency to ensure the correct version is hoisted during module resolution.

For non-pnpm package managers notably (yarn and npm) the hosited version is outdated and it spawns errors when vite is generating types via `vite-plugin-dts`.
```shell
 - packages/vite-parent-lib9113241/vite.config.ts: Error: Cannot find module 'ajv/dist/core'
  Require stack:
  - /private/var/folders/tp/bfmjfn9s0hd59bm9z80j3mgm0000gn/T/nx-e2e--29165-pQZxOyX4J3ot/nx/proj2191858/node_modules/ajv-draft-04/dist/index.js
  - /private/var/folders/tp/bfmjfn9s0hd59bm9z80j3mgm0000gn/T/nx-e2e--29165-pQZxOyX4J3ot/nx/proj2191858/node_modules/@rushstack/node-core-library/lib/JsonSchema.js
  - /private/var/folders/tp/bfmjfn9s0hd59bm9z80j3mgm0000gn/T/nx-e2e--29165-pQZxOyX4J3ot/nx/proj2191858/node_modules/@rushstack/node-core-library/lib/index.js
  - /private/var/folders/tp/bfmjfn9s0hd59bm9z80j3mgm0000gn/T/nx-e2e--29165-pQZxOyX4J3ot/nx/proj2191858/node_modules/@microsoft/api-extractor/lib/api/CompilerState.js
```
Here is an example of the failures: 
- ❌ [NPM + MacOS] https://staging.nx.app/runs/uaJ1pbWHtK/task/e2e-js%3Ae2e-local
- ✅ [PNPM + Linux] https://staging.nx.app/runs/WRgY8Z6Jlw/task/e2e-js%3Ae2e-local 
- ❌ [NPM + Linux] https://staging.nx.app/runs/Ght82l5Upa/task/e2e-js%3Ae2e-local