### PR TITLE
fix(js): enable end-to-end tests for Vue application in dev mode

### DIFF
--- a/e2e/vue/src/vue.test.ts
+++ b/e2e/vue/src/vue.test.ts
@@ -5,6 +5,7 @@ import {
   runCLI,
   runE2ETests,
   uniq,
+  updateFile,
 } from '@nx/e2e/utils';
 
 describe('Vue Plugin', () => {
@@ -18,7 +19,7 @@ describe('Vue Plugin', () => {
 
   afterAll(() => cleanupProject());
 
-  it('should serve application in dev mode', async () => {
+  it('should serve application in dev mode vite config', async () => {
     const app = uniq('app');
 
     runCLI(
@@ -32,12 +33,36 @@ describe('Vue Plugin', () => {
       `Successfully ran target build for project ${app}`
     );
 
-    // TODO: enable this when tests are passing again.
-    // if (runE2ETests()) {
-    //   const e2eResults = runCLI(`e2e ${app}-e2e --no-watch`);
-    //   expect(e2eResults).toContain('Successfully ran target e2e');
-    //   expect(await killPorts()).toBeTruthy();
-    // }
+    if (runE2ETests('playwright')) {
+      const availablePort = await getAvailablePort();
+
+      updateFile(`${app}-e2e/playwright.config.ts`, (content) => {
+        return content
+          .replace(
+            /const baseURL = process\.env\['BASE_URL'\] \|\| '[^']*';/,
+            `const baseURL = process.env['BASE_URL'] || 'http://localhost:${availablePort}';`
+          )
+          .replace(
+            /command: 'npx nx run [^:]*:preview'/,
+            `command: 'npx nx run ${app}:preview'`
+          )
+          .replace(/url: '[^']*'/, `url: 'http://localhost:${availablePort}'`);
+      });
+
+      updateFile(`${app}/vite.config.ts`, (content) => {
+        return content.replace(
+          /preview:\s*{[^}]*}/,
+          `preview: {
+    port: ${availablePort},
+    host: 'localhost',
+  }`
+        );
+      });
+
+      const e2eResults = runCLI(`e2e ${app}-e2e`);
+      expect(e2eResults).toContain('Successfully ran target e2e');
+      expect(await killPorts(availablePort)).toBeTruthy();
+    }
   }, 200_000);
 
   it('should serve application in dev mode with rsbuild', async () => {
@@ -54,13 +79,34 @@ describe('Vue Plugin', () => {
       `Successfully ran target build for project ${app}`
     );
 
-    // TODO: enable this when tests are passing again.
-    // Colum confirmed locally that the generated config and the playwright tests are working.
-    // if (runE2ETests()) {
-    //   const e2eResults = runCLI(`e2e ${app}-e2e --no-watch`);
-    //   expect(e2eResults).toContain('Successfully ran target e2e');
-    //   expect(await killPorts()).toBeTruthy();
-    // }
+    const availablePort = await getAvailablePort();
+
+    updateFile(`${app}-e2e/playwright.config.ts`, (content) => {
+      return content
+        .replace(
+          /const baseURL = process\.env\['BASE_URL'\] \|\| '[^']*';/,
+          `const baseURL = process.env['BASE_URL'] || 'http://localhost:${availablePort}';`
+        )
+        .replace(
+          /command: 'npx nx run [^:]*:preview'/,
+          `command: 'npx nx run ${app}:preview'`
+        )
+        .replace(/url: '[^']*'/, `url: 'http://localhost:${availablePort}'`);
+    });
+
+    updateFile(`${app}/vite.config.ts`, (content) => {
+      return content.replace(
+        /preview:\s*{[^}]*}/,
+        `preview: {
+    port: ${availablePort},
+    host: 'localhost',
+  }`
+      );
+    });
+
+    const e2eResults = runCLI(`e2e ${app}-e2e`);
+    expect(e2eResults).toContain('Successfully ran target e2e');
+    expect(await killPorts(availablePort)).toBeTruthy();
   }, 200_000);
 
   it('should build library', async () => {
@@ -76,3 +122,20 @@ describe('Vue Plugin', () => {
     );
   });
 });
+
+async function getAvailablePort(startPort = 4300): Promise<number> {
+  const net = require('net');
+
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+
+    server.listen(0, () => {
+      const port = server.address()?.port;
+      server.close(() => {
+        resolve(port || startPort);
+      });
+    });
+  });
+}


### PR DESCRIPTION
This PR updates Vite's E2E testing setup for the Vue plugin. 

Instead of commenting out the serve for vite and rsbuild when using playwright we update the test to ensure the ports are available before attempting to run their preview target. 