### PR TITLE
fix(vite): NxReporter compatible with Vitest ≥0.29

### DIFF
--- a/packages/vite/src/executors/test/lib/nx-reporter.ts
+++ b/packages/vite/src/executors/test/lib/nx-reporter.ts
@@ -28,7 +28,17 @@ export class NxReporter implements Reporter {
     };
   }
 
+  /** Vitest ≥ 0.29 */
+  onTestRunEnd(files: any[], errors?: any) {
+    this._handleFinished(files, errors);
+  }
+  /** Vitest ≤ 0.28 */
   onFinished(files: File[], errors?: unknown[]) {
+    this._handleFinished(files, errors);
+  }
+
+  // --- private ----------------------------------------------------------
+  private _handleFinished(files: any[], errors?: any) {
     const hasErrors =
       files.some((f) => f.result?.state === 'fail') || errors?.length > 0;
     this.deferred.resolve(hasErrors);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(vite): must begin with lowercase` -->

## Current Behavior
Running `nx test … --reporter=verbose` (or any additional Vitest reporter) on  
projects that use **Vitest ≥ 0.29** hangs indefinitely at the end of the run.
`vitest` itself finishes, but the Nx task-runner never receives the *done*
signal because **`NxReporter` only implements the legacy
`onFinished()` hook**.  
When multiple reporters are configured, Vitest now emits
`onTestRunEnd()` instead of `onFinished()`, so the promise in `NxReporter`
remains unresolved and the worker process stays alive forever.

## Expected Behavior
`nx test` (and affected `nx run-many --target=test`) exits cleanly on **all**
Vitest versions, regardless of how many reporters are passed.

* `NxReporter` resolves its internal promise via **either**
  `onTestRunEnd` (Vitest ≥ 0.29) **or** `onFinished` (Vitest ≤ 0.28).
* No functional change in watch-mode.
* No extra timers or fallbacks – just one shared helper.

## Implementation Notes
* Added `onTestRunEnd` method that delegates to a private `_handleFinished`.
* Re-implemented `onFinished` as a thin delegate to the same helper.
* Original error-detection logic is untouched.

## Related Issue(s)
Closes nrwl/nx#<insert-issue-number-if/when-one-exists>