### PR TITLE
fix(core): ensure nx init implementation for angular correctly resolves `@angular/core`

### DIFF
--- a/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 import { gte, major } from 'semver';
 import { readJsonFile, writeJsonFile } from '../../../../utils/fileutils';
+import { getNxRequirePaths } from '../../../../utils/installation-directory';
 import { sortObjectByKeys } from '../../../../utils/object-sort';
 import { output } from '../../../../utils/output';
 import { readModulePackageJson } from '../../../../utils/package-json';
@@ -11,9 +12,9 @@ import {
   resolvePackageVersionUsingInstallation,
   resolvePackageVersionUsingRegistry,
 } from '../../../../utils/package-manager';
+import { connectExistingRepoToNxCloudPrompt } from '../../../connect/connect-to-nx-cloud';
 import { initCloud } from '../utils';
 import type { Options } from './types';
-import { connectExistingRepoToNxCloudPrompt } from '../../../connect/connect-to-nx-cloud';
 
 // map of Angular major versions to Nx versions to use for legacy `nx init` migrations,
 // key is major Angular version and value is Nx version to use
@@ -35,9 +36,25 @@ export async function getLegacyMigrationFunctionIfApplicable(
   repoRoot: string,
   options: Options
 ): Promise<() => Promise<void> | null> {
-  const angularVersion =
-    readModulePackageJson('@angular/core').packageJson.version;
-  const majorAngularVersion = major(angularVersion);
+  let majorAngularVersion: number;
+  try {
+    const angularVersion = readModulePackageJson('@angular/core', [
+      repoRoot,
+      ...getNxRequirePaths(),
+    ]).packageJson.version;
+    majorAngularVersion = major(angularVersion);
+  } catch {
+    output.error({
+      title: 'Could not determine the existing Angular version',
+      bodyLines: [
+        'Please ensure "@angular/core" is installed in the workspace and you are running this command from the root of the workspace.',
+      ],
+    });
+    // errors are caught in the initHandler and not logged to the user, so we
+    // log it first and then throw to ensure it is logged to the user
+    throw new Error('Could not determine the existing Angular version');
+  }
+
   if (majorAngularVersion >= minMajorAngularVersionSupported) {
     // non-legacy
     return null;


### PR DESCRIPTION
## Current Behavior

When running `nx init` in an Angular CLI repo located in a directory that has an ancestor directory with an Nx installation, it silently exits when trying to determine the compatibility of the Angular version. The migration is not performed, and no feedback is given to the user. This happens because the current implementation will determine that ancestor directory (outside the workspace root) as the workspace root (when starting the migration, there's no `nx` in the repo).

## Expected Behavior

Running `nx init` should work correctly, and proper feedback should be printed to the user if it can't determine the compatibility of the Angular version. It should correctly resolve the `@angular/core` package from the Angular CLI workspace root.

## Related Issue(s)

Fixes #31291 
