### PR TITLE
fix(angular): generate correct output for buildable libraries on windows

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/entry-point.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/entry-point.ts
@@ -93,7 +93,6 @@ export function createNgEntryPoint(
         ),
         // changed to use esm2022
         declarationsBundled: pathJoinWithDest(
-          'esm2022',
           secondaryDir,
           `${flatModuleFile}.d.ts`
         ),

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -10,7 +10,7 @@
 import type { NgEntryPoint } from 'ng-packagr/src/lib/ng-package/entry-point/entry-point';
 import type { NgPackagrOptions } from 'ng-packagr/src/lib/ng-package/options.di';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname, join, normalize } from 'node:path';
 import { getNgPackagrVersionInfo } from '../../../../utilities/ng-packagr/ng-packagr-version';
 import { importNgPackagrPath } from '../../../../utilities/ng-packagr/package-imports';
 import { createNgEntryPoint, type NgEntryPointType } from './entry-point';
@@ -69,19 +69,28 @@ function normalizeEsm2022Path(
   path: string,
   entryPoint: NgEntryPointType
 ): string {
+  const normalizedPath = normalize(path);
   if (!entryPoint.primaryDestinationPath) {
-    return path;
+    return normalizedPath;
   }
 
-  if (path.startsWith(join(entryPoint.primaryDestinationPath, 'tmp-esm2022'))) {
-    return path.replace('tmp-esm2022', 'esm2022');
+  if (
+    normalizedPath.startsWith(
+      join(entryPoint.primaryDestinationPath, 'tmp-esm2022')
+    )
+  ) {
+    return normalizedPath.replace('tmp-esm2022', 'esm2022');
   }
 
-  if (path.startsWith(join(entryPoint.primaryDestinationPath, 'tmp-typings'))) {
-    return path.replace('tmp-typings', 'esm2022');
+  if (
+    normalizedPath.startsWith(
+      join(entryPoint.primaryDestinationPath, 'tmp-typings')
+    )
+  ) {
+    return normalizedPath.replace('tmp-typings', '');
   }
 
-  return path;
+  return normalizedPath;
 }
 
 function toCustomNgEntryPoint(entryPoint: NgEntryPoint): NgEntryPointType {


### PR DESCRIPTION
## Current Behavior

The `@nx/angular:ng-packagr-lite` executor is generating a wrong output on Windows.

## Expected Behavior

The `@nx/angular:ng-packagr-lite` executor should generate the correct output on Windows.

## Related Issue(s)

Fixes #31436 
