### PR TITLE
docs(misc): update installation via Homebrew

### DIFF
--- a/docs/generated/packages/gradle/documents/overview.md
+++ b/docs/generated/packages/gradle/documents/overview.md
@@ -28,7 +28,6 @@ You can install Nx globally. Depending on your package manager, use one of the f
 {% tab label="Homebrew" %}
 
 ```shell
-brew tap nrwl/nx
 brew install nx
 ```
 

--- a/docs/shared/getting-started/installation.md
+++ b/docs/shared/getting-started/installation.md
@@ -80,7 +80,6 @@ You can install Nx globally. Depending on your package manager, use one of the f
 {% tab label="Homebrew" %}
 
 ```shell
-brew tap nrwl/nx
 brew install nx
 ```
 

--- a/docs/shared/packages/gradle/gradle-plugin.md
+++ b/docs/shared/packages/gradle/gradle-plugin.md
@@ -28,7 +28,6 @@ You can install Nx globally. Depending on your package manager, use one of the f
 {% tab label="Homebrew" %}
 
 ```shell
-brew tap nrwl/nx
 brew install nx
 ```
 

--- a/docs/shared/recipes/installation/install-non-javascript.md
+++ b/docs/shared/recipes/installation/install-non-javascript.md
@@ -9,7 +9,7 @@ Nx can manage its own installation without requiring a `package.json` file or a 
 
 ## Globally Install Nx
 
-First globally install Nx using Homebrew (Mac only) or with a manually installed version of Node (any OS).
+First globally install Nx using Homebrew (Mac and Linux) or with a manually installed version of Node (any OS).
 
 {% tabs %}
 {% tab label="Homebrew" %}
@@ -17,7 +17,6 @@ First globally install Nx using Homebrew (Mac only) or with a manually installed
 If you have [Homebrew installed](https://brew.sh/), you can install Nx globally with these commands:
 
 ```shell
-brew tap nrwl/nx
 brew install nx
 ```
 

--- a/docs/shared/tutorials/gradle.md
+++ b/docs/shared/tutorials/gradle.md
@@ -27,7 +27,7 @@ To verify that Gradle was installed correctly, run this command:
 gradle --version
 ```
 
-To streamline this tutorial, we'll install Nx globally on your system. You can use Homebrew (Mac only) or a manually installed Node version (any OS).
+To streamline this tutorial, we'll install Nx globally on your system. You can use Homebrew (Mac and Linux) or a manually installed Node version (any OS).
 
 {% tabs %}
 {% tab label="Homebrew" %}
@@ -35,7 +35,6 @@ To streamline this tutorial, we'll install Nx globally on your system. You can u
 Make sure [Homebrew is installed](https://brew.sh/), then install Nx globally with these commands:
 
 ```shell
-brew tap nrwl/nx
 brew install nx
 ```
 

--- a/nx-dev/ui-gradle/src/lib/hero.tsx
+++ b/nx-dev/ui-gradle/src/lib/hero.tsx
@@ -76,7 +76,7 @@ export function GettingStarted(): ReactElement {
         <div className="mt-12 grid grid-cols-1 gap-6 sm:gap-8 md:grid-cols-2 ">
           <GetStartedCard
             title="Install Nx"
-            command="brew tap nrwl/nx && brew install nx"
+            command="brew install nx"
             description="Get the <code>nx</code> executable from homebrew"
           />
           <GetStartedCard


### PR DESCRIPTION
Now that Nx is merged into [`homebrew-core`](https://github.com/Homebrew/homebrew-core/pull/225452) we no longer need to tap to access a non-official formula.

This PR updates our brew install to remove `brew tap nrwl/nx`. It also mentions Linux for Homebrew since it is supported across different Linux distros.