### PR TITLE
docs(misc): fix up /plugin-registry URLs a devkit URLs

### DIFF
--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -1230,7 +1230,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/angular/angular"
+    "path": "/technologies/angular/api"
   },
   "cypress": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1390,7 +1390,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/cypress/cypress"
+    "path": "/technologies/test-tools/cypress/api"
   },
   "detox": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1481,7 +1481,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/detox/detox"
+    "path": "/technologies/test-tools/detox/api"
   },
   "devkit": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1517,7 +1517,7 @@
     "executors": {},
     "generators": {},
     "migrations": {},
-    "path": "/technologies/devkit/devkit"
+    "path": "/reference/core-api/devkit"
   },
   "esbuild": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1559,7 +1559,7 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/esbuild/esbuild"
+    "path": "/technologies/build-tools/esbuild/api"
   },
   "eslint": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1709,7 +1709,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/eslint/eslint"
+    "path": "/technologies/eslint/api"
   },
   "eslint-plugin": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1733,7 +1733,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/eslint-plugin/eslint-plugin"
+    "path": "/technologies/eslint/eslint-plugin/api"
   },
   "expo": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1962,7 +1962,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/expo/expo"
+    "path": "/technologies/react/expo/api"
   },
   "express": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1994,7 +1994,7 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/express/express"
+    "path": "/technologies/node/express/api"
   },
   "gradle": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2097,7 +2097,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/gradle/gradle"
+    "path": "/technologies/java/api"
   },
   "jest": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2199,7 +2199,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/jest/jest"
+    "path": "/technologies/test-tools/jest/api"
   },
   "js": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2412,7 +2412,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/js/js"
+    "path": "/technologies/typescript/api"
   },
   "module-federation": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2446,7 +2446,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/module-federation/module-federation"
+    "path": "/technologies/module-federation/api"
   },
   "nest": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2633,7 +2633,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/nest/nest"
+    "path": "/technologies/node/nest/api"
   },
   "next": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2779,7 +2779,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/next/next"
+    "path": "/technologies/react/next/api"
   },
   "node": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2840,7 +2840,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/node/node"
+    "path": "/technologies/node/api"
   },
   "nuxt": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2892,7 +2892,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/nuxt/nuxt"
+    "path": "/technologies/vue/nuxt/api"
   },
   "nx": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3402,7 +3402,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/nx/nx"
+    "path": "/reference/core-api/nx"
   },
   "playwright": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3474,7 +3474,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/playwright/playwright"
+    "path": "/technologies/test-tools/playwright/api"
   },
   "plugin": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3560,7 +3560,7 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/plugin/plugin"
+    "path": "/reference/core-api/plugin"
   },
   "react": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3917,7 +3917,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/react/react"
+    "path": "/technologies/react/api"
   },
   "react-native": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4172,7 +4172,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/react-native/react-native"
+    "path": "/technologies/react/react-native/api"
   },
   "remix": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4360,7 +4360,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/remix/remix"
+    "path": "/technologies/react/remix/api"
   },
   "rollup": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4422,7 +4422,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/rollup/rollup"
+    "path": "/technologies/build-tools/rollup/api"
   },
   "rsbuild": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4454,7 +4454,7 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/rsbuild/rsbuild"
+    "path": "/technologies/build-tools/rsbuild/api"
   },
   "rspack": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4657,7 +4657,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/rspack/rspack"
+    "path": "/technologies/build-tools/rspack/api"
   },
   "storybook": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4785,7 +4785,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/storybook/storybook"
+    "path": "/technologies/test-tools/storybook/api"
   },
   "vite": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4982,7 +4982,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/vite/vite"
+    "path": "/technologies/build-tools/vite/api"
   },
   "vue": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5080,7 +5080,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/vue/vue"
+    "path": "/technologies/vue/api"
   },
   "web": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5131,7 +5131,7 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/web/web"
+    "path": "/reference/core-api/web"
   },
   "webpack": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5270,7 +5270,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/webpack/webpack"
+    "path": "/technologies/build-tools/webpack/api"
   },
   "workspace": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5448,7 +5448,7 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/workspace/workspace"
+    "path": "/reference/core-api/workspace"
   },
   "azure-cache": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5473,7 +5473,7 @@
     "executors": {},
     "generators": {},
     "migrations": {},
-    "path": "/technologies/azure-cache/azure-cache"
+    "path": "/reference/core-api/azure-cache"
   },
   "conformance": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5529,7 +5529,7 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/conformance/conformance"
+    "path": "/reference/core-api/conformance"
   },
   "owners": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5573,7 +5573,7 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/owners/owners"
+    "path": "/reference/core-api/owners"
   },
   "gcs-cache": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5598,7 +5598,7 @@
     "executors": {},
     "generators": {},
     "migrations": {},
-    "path": "/technologies/gcs-cache/gcs-cache"
+    "path": "/reference/core-api/gcs-cache"
   },
   "s3-cache": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5623,7 +5623,7 @@
     "executors": {},
     "generators": {},
     "migrations": {},
-    "path": "/technologies/s3-cache/s3-cache"
+    "path": "/reference/core-api/s3-cache"
   },
   "shared-fs-cache": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5658,6 +5658,6 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/shared-fs-cache/shared-fs-cache"
+    "path": "/reference/core-api/shared-fs-cache"
   }
 }

--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -5,7 +5,7 @@ import {
   type RelatedDocument,
 } from '@nx/nx-dev/models-document';
 import { type ProcessedPackageMetadata } from '@nx/nx-dev/models-package';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type TagsApi } from './tags.api';
 
@@ -147,6 +147,29 @@ export class DocumentsApi {
           Object.keys(pkg.documents).forEach((path) => {
             paths.push(path);
           });
+
+          // Legacy devkit API documents
+          if (pkg.name === 'devkit') {
+            readdirSync('../../docs/generated/devkit').forEach((fileName) => {
+              // Private files
+              if (fileName.startsWith('.')) return;
+              if (fileName.endsWith('.md')) {
+                const apiDocPath = `${
+                  pkgToGeneratedApiDocs['devkit'].pagePath
+                }/documents/${fileName.replace('.md', '')}`;
+                paths.push(apiDocPath);
+              } else {
+                readdirSync('../../docs/generated/devkit/' + fileName).forEach(
+                  (subFileName) => {
+                    const apiDocPath = `${
+                      pkgToGeneratedApiDocs['devkit'].pagePath
+                    }/documents/${fileName}/${subFileName.replace('.md', '')}`;
+                    paths.push(apiDocPath);
+                  }
+                );
+              }
+            });
+          }
         }
 
         paths.push(`${apiPagePath}/executors`);

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -1294,8 +1294,8 @@ const nxApiRedirects = {
     '/technologies/build-tools/rsbuild/recipes/:slug*',
   '/nx-api/rsbuild/:slug*': '/technologies/build-tools/rsbuild/api/:slug*',
   '/nx-api/cypress/documents/:slug*':
-    '/technologies/build-tools/cypress/recipes/:slug*',
-  '/nx-api/cypress/:slug*': '/technologies/build-tools/cypress/api/:slug*',
+    '/technologies/test-tools/cypress/recipes/:slug*',
+  '/nx-api/cypress/:slug*': '/technologies/test-tools/cypress/api/:slug*',
   '/nx-api/jest/documents/:slug*':
     '/technologies/test-tools/jest/recipes/:slug*',
   '/nx-api/jest/:slug*': '/technologies/test-tools/jest/api/:slug*',

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -1237,7 +1237,9 @@ const nxApiRedirects = {
   '/nx-api/devkit/:slug*': '/reference/core-api/devkit/:slug*',
   '/nx-api/nx/:slug*': '/reference/core-api/nx/:slug*',
   '/nx-api/workspace/:slug*': '/reference/core-api/workspace/:slug*',
+  '/nx-api/plugin/documents/:slug*': '/reference/core-api/plugin',
   '/nx-api/plugin/:slug*': '/reference/core-api/plugin/:slug*',
+  '/nx-api/web/documents/:slug*': '/reference/core-api/web',
   '/nx-api/web/:slug*': '/reference/core-api/web/:slug*',
   '/nx-api/azure-cache/:slug*': '/reference/core-api/azure-cache/:slug*',
   '/nx-api/conformance/:slug*': '/reference/core-api/conformance/:slug*',
@@ -1246,11 +1248,62 @@ const nxApiRedirects = {
   '/nx-api/s3-cache/:slug*': '/reference/core-api/s3-cache/:slug*',
   '/nx-api/shared-fs-cache/:slug*':
     '/reference/core-api/shared-fs-cache/:slug*',
-  '/nx-api/create-nx-plugin/:slug*':
-    '/reference/core-api/create-nx-plugin/:slug*',
+  // These don't exist and never provided any actual content so let's just redirect to core api
+  '/nx-api/create-nx-plugin/:slug*': '/reference/core-api',
+  '/nx-api/create-nx-workspace/migrations/:slug*': '/reference/core-api',
+  '/nx-api/create-nx-workspace/generators/:slug*': '/reference/core-api',
+  '/nx-api/create-nx-workspace/executors/:slug*': '/reference/core-api',
+  '/nx-api/create-nx-workspace/documents': '/reference/core-api',
   '/nx-api/create-nx-workspace/:slug*':
     '/reference/core-api/create-nx-workspace/:slug*',
   // Technologies
+  '/nx-api/angular/documents/overview': '/technologies/angular/introduction',
+  '/nx-api/react/documents/overview': '/technologies/react/introduction',
+  '/nx-api/react-native/documents/overview':
+    '/technologies/react/react-native/introduction',
+  '/nx-api/vue/documents': '/technologies/vue/introduction',
+  '/nx-api/vue/documents/overview': '/technologies/vue/introduction',
+  '/nx-api/next/documents/overview': '/technologies/react/next/introduction',
+  '/nx-api/remix/documents/overview': '/technologies/react/remix/introduction',
+  '/nx-api/nuxt/documents/overview': '/technologies/vue/nuxt/introduction',
+  '/nx-api/expo/documents/overview': '/technologies/react/expo/introduction',
+  '/nx-api/nest/documents': '/technologies/node/nest/introduction',
+  '/nx-api/nest/documents/overview': '/technologies/node/nest/introduction',
+  '/nx-api/express/documents': '/technologies/node/express/introduction',
+  '/nx-api/express/documents/overview':
+    '/technologies/node/express/introduction',
+  '/nx-api/node/documents/overview': '/technologies/node/introduction',
+  '/nx-api/webpack/documents/overview':
+    '/technologies/build-tools/webpack/introduction',
+  '/nx-api/vite/documents/overview':
+    '/technologies/build-tools/vite/introduction',
+  '/nx-api/rollup/documents/overview':
+    '/technologies/build-tools/rollup/introduction',
+  '/nx-api/esbuild/documents/overview':
+    '/technologies/build-tools/esbuild/introduction',
+  '/nx-api/rspack/documents/overview':
+    '/technologies/build-tools/rspack/introduction',
+  '/nx-api/rsbuild/documents/overview':
+    '/technologies/build-tools/rsbuild/introduction',
+  '/nx-api/cypress/documents/overview':
+    '/technologies/test-tools/cypress/introduction',
+  '/nx-api/jest/documents/overview':
+    '/technologies/test-tools/jest/introduction',
+  '/nx-api/playwright/documents/overview':
+    '/technologies/test-tools/playwright/introduction',
+  '/nx-api/storybook/documents/overview':
+    '/technologies/test-tools/storybook/introduction',
+  '/nx-api/detox/documents/overview':
+    '/technologies/test-tools/detox/introduction',
+  '/nx-api/js/documents/overview': '/technologies/typescript/introduction',
+  '/nx-api/gradle/documents': '/technologies/java/introduction',
+  '/nx-api/gradle/documents/overview': '/technologies/java/introduction',
+  '/nx-api/eslint/documents/overview': '/technologies/eslint/introduction',
+  '/nx-api/eslint-plugin/documents/overview':
+    '/technologies/eslint/eslint-plugin/api',
+  '/nx-api/module-federation/documents/overview':
+    '/technologies/module-federation/introduction',
+  // Wildcard rules (must come after specific rules)
   '/nx-api/angular/documents/:slug*': '/technologies/angular/recipes/:slug*',
   '/nx-api/angular/:slug*': '/technologies/angular/api/:slug*',
   '/nx-api/react/documents/:slug*': '/technologies/react/recipes/:slug*',
@@ -1269,7 +1322,7 @@ const nxApiRedirects = {
   '/nx-api/expo/documents/:slug*': '/technologies/react/expo/recipes/:slug*',
   '/nx-api/expo/:slug*': '/technologies/react/expo/api/:slug*',
   '/nx-api/nest/documents/:slug*': '/technologies/nest/recipes/:slug*',
-  '/nx-api/nest/:slug*': '/technologies/nest/api/:slug*',
+  '/nx-api/nest/:slug*': '/technologies/node/nest/api/:slug*',
   '/nx-api/express/documents/:slug*':
     '/technologies/node/express/recipes/:slug*',
   '/nx-api/express/:slug*': '/technologies/node/express/api/:slug*',
@@ -1364,7 +1417,21 @@ const nxRecipesRedirects = {
   '/recipes/tips-n-tricks/eslint': '/technologies/eslint',
   '/recipes/tips-n-tricks/flat-config':
     '/technologies/eslint/recipes/flat-config',
-  '/recipes/tips-n-tricks/:slug*': '/technologies/typescript/recipes/:slug*',
+  '/recipes/tips-n-tricks/switch-to-workspaces-project-references':
+    '/technologies/typescript/recipes/switch-to-workspaces-project-references',
+  '/recipes/tips-n-tricks/enable-tsc-batch-mode':
+    '/technologies/typescript/recipes/enable-tsc-batch-mode',
+  '/recipes/tips-n-tricks/define-secondary-entrypoints':
+    '/technologies/typescript/recipes/define-secondary-entrypoints',
+  '/recipes/tips-n-tricks/compile-multiple-formats':
+    '/technologies/typescript/recipes/compile-multiple-formats',
+  '/recipes/tips-n-tricks/js-and-ts':
+    '/technologies/typescript/recipes/js-and-ts',
+};
+
+const nxModuleFederationConceptsRedirects = {
+  '/concepts/module-federation/:slug*':
+    '/technologies/module-federation/concepts/:slug*',
 };
 
 /**
@@ -1406,4 +1473,5 @@ module.exports = {
   tmpTerminalUiRedirects,
   nxApiRedirects,
   nxRecipesRedirects,
+  nxModuleFederationConceptsRedirects,
 };

--- a/scripts/documentation/generators/generate-manifests.ts
+++ b/scripts/documentation/generators/generate-manifests.ts
@@ -416,7 +416,7 @@ function createNewPackagesManifest(packages: PackageMetadata[]): {
         })),
         'path'
       ),
-      path: generatePath({ id: p.name, path: '' }, `technologies/${p.name}`),
+      path: data.pagePath,
     };
   });
 


### PR DESCRIPTION
This PR fixes two issues with the docs restructure:

1. `/plugin-registry` was reading from `new-nx-api.json`, which had the wrong base path for API docs -- it was not using `mapping.ts`
2. `/reference/core-api/devkit/documents` did not statically generate all URLs -- this required a change specifically to handle legacy devkit documents