### PR TITLE
docs(nx-dev): update enterprise page tagline

### DIFF
--- a/nx-dev/nx-dev/pages/enterprise/index.tsx
+++ b/nx-dev/nx-dev/pages/enterprise/index.tsx
@@ -22,11 +22,11 @@ export function Enterprise(): ReactElement {
   return (
     <>
       <NextSeo
-        title="Solving the Performance Paradox, get speed and scale"
+        title="Develop like an enterprise. Deliver like a startup."
         description="Accelerate your organization's journey to tighter collaboration, better developer experience, and speed…lots of speed."
         openGraph={{
           url: 'https://nx.dev' + router.asPath,
-          title: 'Solving the Performance Paradox, get speed and scale',
+          title: 'Develop like an enterprise. Deliver like a startup.',
           description:
             "Accelerate your organization's journey to tighter collaboration, better developer experience, and speed…lots of speed.",
           images: [

--- a/nx-dev/ui-enterprise/src/lib/hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/hero.tsx
@@ -49,9 +49,9 @@ export function Hero(): ReactElement {
               variant="display"
               className="mt-8 text-pretty tracking-tight"
             >
-              Solving the Performance Paradox,{' '}
+              Develop like an enterprise.{' '}
               <span className="rounded-lg bg-gradient-to-r from-pink-500 to-fuchsia-500 bg-clip-text text-transparent">
-                get speed and scale
+                Deliver like a startup.
               </span>
             </SectionHeading>
             <SectionHeading


### PR DESCRIPTION
## Summary
- refresh the hero tagline on the Enterprise page

## Testing
- `npx nx format:check --all` *(fails: Failed to process project graph)*

------
https://chatgpt.com/codex/tasks/task_b_683f2e3ad29483328d432a44fd49583a