### PR TITLE
docs(misc): update broken URL

### DIFF
--- a/docs/shared/concepts/module-federation/nx-module-federation-technical-overview.md
+++ b/docs/shared/concepts/module-federation/nx-module-federation-technical-overview.md
@@ -6,7 +6,7 @@ description: Understand the technical details of how Nx implements Module Federa
 # Nx Module Federation Technical Overview
 
 Nx's Module Federation support is provided through a mixture of `executors` and the `withModuleFederation()` util that is used in your `webpack.config` or `rspack.config` file. Understanding what is happening under the hood can help when developing applications that use Module Federation as well as debugging any potential issues you run into.
-With Rspack, Module Federation support can also be provided through the [`NxModuleFederationPlugin`](nx-api/module-federation/documents/nx-module-federation-plugin) and [`NxModuleFederationDevServerPlugin`](nx-api/module-federation/documents/nx-module-federation-dev-server-plugin) plugins that can be used in the `rspack.config` file when utilizing [Inferred Tasks]().
+With Rspack, Module Federation support can also be provided through the [`NxModuleFederationPlugin`](nx-api/module-federation/documents/nx-module-federation-plugin) and [`NxModuleFederationDevServerPlugin`](nx-api/module-federation/documents/nx-module-federation-dev-server-plugin) plugins that can be used in the `rspack.config` file when utilizing [Inferred Tasks](/concepts/inferred-tasks).
 
 ## What happens when you serve your host?
 


### PR DESCRIPTION
This PR updates fixes a broken URL on https://nx.dev/concepts/module-federation/nx-module-federation-technical-overview.