### PR TITLE
chore(nx-dev): remove references to live webinar banners

### DIFF
--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -87,7 +87,7 @@ export default function CustomApp({
       </Link>
       <Component {...pageProps} />
       {/* <LiveStreamNotifier /> */}
-      <WebinarNotifier />
+      {/*<WebinarNotifier />*/}
 
       {/* All tracking scripts consolidated in GlobalScripts component */}
       <GlobalScripts

--- a/nx-dev/ui-enterprise/src/lib/hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/hero.tsx
@@ -25,24 +25,24 @@ export function Hero(): ReactElement {
       <div className="absolute inset-0">
         <div className="mx-auto max-w-7xl lg:flex">
           <div className="mx-auto max-w-3xl px-6 pb-24 pt-36 lg:mx-0 lg:shrink-0 lg:px-8">
-            <p>
-              <a
-                href="https://bit.ly/4jQLCqp"
-                title="See live event in details"
-                className="group/event-link inline-flex space-x-6"
-              >
-                <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">
-                  Live event
-                </span>
-                <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">
-                  <span>Webinar + live Q&A on May 28th</span>
-                  <ChevronRightIcon
-                    aria-hidden="true"
-                    className="size-5 transform transition-all group-hover/event-link:translate-x-1"
-                  />
-                </span>
-              </a>
-            </p>
+            {/*<p>*/}
+            {/*  <a*/}
+            {/*    href="https://bit.ly/4jQLCqp"*/}
+            {/*    title="See live event in details"*/}
+            {/*    className="group/event-link inline-flex space-x-6"*/}
+            {/*  >*/}
+            {/*    <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">*/}
+            {/*      Live event*/}
+            {/*    </span>*/}
+            {/*    <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">*/}
+            {/*      <span>Webinar + live Q&A on May 28th</span>*/}
+            {/*      <ChevronRightIcon*/}
+            {/*        aria-hidden="true"*/}
+            {/*        className="size-5 transform transition-all group-hover/event-link:translate-x-1"*/}
+            {/*      />*/}
+            {/*    </span>*/}
+            {/*  </a>*/}
+            {/*</p>*/}
             <SectionHeading
               id="get-speed-and-scale"
               as="h1"

--- a/nx-dev/ui-enterprise/src/lib/solutions/engineering/solutions-engineering-hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/engineering/solutions-engineering-hero.tsx
@@ -84,24 +84,24 @@ export function SolutionsEngineeringHero(): ReactElement {
     <section className="relative overflow-hidden">
       <div className="mx-auto max-w-7xl lg:flex">
         <div className="mx-auto max-w-3xl px-6 py-24 lg:mx-0 lg:shrink-0 lg:px-8">
-          <p>
-            <a
-              href="https://bit.ly/4jQLCqp"
-              title="See live event in details"
-              className="group/event-link inline-flex space-x-6"
-            >
-              <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">
-                Live event
-              </span>
-              <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">
-                <span>Webinar + live Q&A on May 28th</span>
-                <ChevronRightIcon
-                  aria-hidden="true"
-                  className="size-5 transform transition-all group-hover/event-link:translate-x-1"
-                />
-              </span>
-            </a>
-          </p>
+          {/*<p>*/}
+          {/*  <a*/}
+          {/*    href="https://bit.ly/4jQLCqp"*/}
+          {/*    title="See live event in details"*/}
+          {/*    className="group/event-link inline-flex space-x-6"*/}
+          {/*  >*/}
+          {/*    <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">*/}
+          {/*      Live event*/}
+          {/*    </span>*/}
+          {/*    <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">*/}
+          {/*      <span>Webinar + live Q&A on May 28th</span>*/}
+          {/*      <ChevronRightIcon*/}
+          {/*        aria-hidden="true"*/}
+          {/*        className="size-5 transform transition-all group-hover/event-link:translate-x-1"*/}
+          {/*      />*/}
+          {/*    </span>*/}
+          {/*  </a>*/}
+          {/*</p>*/}
           <SectionHeading
             id="get-speed-and-scale"
             as="h1"

--- a/nx-dev/ui-enterprise/src/lib/solutions/leadership/solutions-leadership-hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/leadership/solutions-leadership-hero.tsx
@@ -84,24 +84,24 @@ export function SolutionsLeadershipHero(): ReactElement {
     <section className="relative overflow-hidden">
       <div className="mx-auto max-w-7xl lg:flex">
         <div className="mx-auto max-w-3xl px-6 py-24 lg:mx-0 lg:shrink-0 lg:px-8">
-          <p>
-            <a
-              href="https://bit.ly/4jQLCqp"
-              title="See live event in details"
-              className="group/event-link inline-flex space-x-6"
-            >
-              <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">
-                Live event
-              </span>
-              <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">
-                <span>Webinar + live Q&A on May 28th</span>
-                <ChevronRightIcon
-                  aria-hidden="true"
-                  className="size-5 transform transition-all group-hover/event-link:translate-x-1"
-                />
-              </span>
-            </a>
-          </p>
+          {/*<p>*/}
+          {/*  <a*/}
+          {/*    href="https://bit.ly/4jQLCqp"*/}
+          {/*    title="See live event in details"*/}
+          {/*    className="group/event-link inline-flex space-x-6"*/}
+          {/*  >*/}
+          {/*    <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">*/}
+          {/*      Live event*/}
+          {/*    </span>*/}
+          {/*    <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">*/}
+          {/*      <span>Webinar + live Q&A on May 28th</span>*/}
+          {/*      <ChevronRightIcon*/}
+          {/*        aria-hidden="true"*/}
+          {/*        className="size-5 transform transition-all group-hover/event-link:translate-x-1"*/}
+          {/*      />*/}
+          {/*    </span>*/}
+          {/*  </a>*/}
+          {/*</p>*/}
           <SectionHeading
             id="get-speed-and-scale"
             as="h1"

--- a/nx-dev/ui-enterprise/src/lib/solutions/management/solutions-management-hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/management/solutions-management-hero.tsx
@@ -84,24 +84,24 @@ export function SolutionsManagementHero(): ReactElement {
     <section className="relative overflow-hidden">
       <div className="mx-auto max-w-7xl lg:flex">
         <div className="mx-auto max-w-3xl px-6 py-24 lg:mx-0 lg:shrink-0 lg:px-8">
-          <p>
-            <a
-              href="https://bit.ly/4jQLCqp"
-              title="See live event in details"
-              className="group/event-link inline-flex space-x-6"
-            >
-              <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">
-                Live event
-              </span>
-              <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">
-                <span>Webinar + live Q&A on May 28th</span>
-                <ChevronRightIcon
-                  aria-hidden="true"
-                  className="size-5 transform transition-all group-hover/event-link:translate-x-1"
-                />
-              </span>
-            </a>
-          </p>
+          {/*<p>*/}
+          {/*  <a*/}
+          {/*    href="https://bit.ly/4jQLCqp"*/}
+          {/*    title="See live event in details"*/}
+          {/*    className="group/event-link inline-flex space-x-6"*/}
+          {/*  >*/}
+          {/*    <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">*/}
+          {/*      Live event*/}
+          {/*    </span>*/}
+          {/*    <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">*/}
+          {/*      <span>Webinar + live Q&A on May 28th</span>*/}
+          {/*      <ChevronRightIcon*/}
+          {/*        aria-hidden="true"*/}
+          {/*        className="size-5 transform transition-all group-hover/event-link:translate-x-1"*/}
+          {/*      />*/}
+          {/*    </span>*/}
+          {/*  </a>*/}
+          {/*</p>*/}
           <SectionHeading
             id="get-speed-and-scale"
             as="h1"

--- a/nx-dev/ui-enterprise/src/lib/solutions/platform/solutions-platform-hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/platform/solutions-platform-hero.tsx
@@ -84,24 +84,24 @@ export function SolutionsPlatformHero(): ReactElement {
     <section className="relative overflow-hidden">
       <div className="mx-auto max-w-7xl lg:flex">
         <div className="mx-auto max-w-3xl px-6 py-24 lg:mx-0 lg:shrink-0 lg:px-8">
-          <p>
-            <a
-              href="https://bit.ly/4jQLCqp"
-              title="See live event in details"
-              className="group/event-link inline-flex space-x-6"
-            >
-              <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">
-                Live event
-              </span>
-              <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">
-                <span>Webinar + live Q&A on May 28th</span>
-                <ChevronRightIcon
-                  aria-hidden="true"
-                  className="size-5 transform transition-all group-hover/event-link:translate-x-1"
-                />
-              </span>
-            </a>
-          </p>
+          {/*<p>*/}
+          {/*  <a*/}
+          {/*    href="https://bit.ly/4jQLCqp"*/}
+          {/*    title="See live event in details"*/}
+          {/*    className="group/event-link inline-flex space-x-6"*/}
+          {/*  >*/}
+          {/*    <span className="rounded-full bg-blue-600/10 px-3 py-1 text-sm/6 font-semibold text-blue-600 ring-1 ring-inset ring-blue-600/10 dark:bg-cyan-600/10 dark:text-cyan-600 dark:ring-cyan-600/10">*/}
+          {/*      Live event*/}
+          {/*    </span>*/}
+          {/*    <span className="inline-flex items-center space-x-2 text-sm/6 font-medium">*/}
+          {/*      <span>Webinar + live Q&A on May 28th</span>*/}
+          {/*      <ChevronRightIcon*/}
+          {/*        aria-hidden="true"*/}
+          {/*        className="size-5 transform transition-all group-hover/event-link:translate-x-1"*/}
+          {/*      />*/}
+          {/*    </span>*/}
+          {/*  </a>*/}
+          {/*</p>*/}
           <SectionHeading
             id="get-speed-and-scale"
             as="h1"


### PR DESCRIPTION
Commented out `WebinarNotifier` and all instances of the live event banner in hero components across the project.