### PR TITLE
fix(js): stop bumping pinned versions when preserveLocalDependencyPro…

### DIFF
--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -832,10 +832,8 @@ To fix this you will either need to add a package.json file at that location, or
           }
 
           // Apply the new version of the dependency to the dependent (if not preserving locally linked package protocols)
-          const shouldUpdateDependency = !(
-            isLocallyLinkedPackageVersion(currentDependencyVersion) &&
-            options.preserveLocalDependencyProtocols
-          );
+          const shouldUpdateDependency =
+            !options.preserveLocalDependencyProtocols;
           if (shouldUpdateDependency) {
             const newDepVersion = `${versionPrefix}${newDependencyVersion}`;
             json[dependentProject.dependencyCollection][dependencyPackageName] =


### PR DESCRIPTION
…tocols is true

## Current Behavior

In the legacy versioning logic, you could use workspace protocol and pinned versions for the same upstream dependency, and bumping the upstream package would only affect downstream projects that depended on it via workspace protocol:
```
{
  "name": "@company/upstream",
  "version": "8.1.0"
}

{
  "name": "@company/downstream-pinned",
  "version": "0.0.1"
  "dependencies": {
    "@company/upstream": "7.3.4" // <--- pinned
  }
}

{
  "name": "@company/downstream-workspace",
  "version": "0.0.1"
  "dependencies": {
    "@company/upstream": "workspace:^"
  }
}
```
In the new versioning logic, the pinned version would be bumped to the latest version of the upstream package. So bumping `@company/upstream` to `8.2.0` replaces `"@company/upstream": "7.3.4"` with `"@company/upstream": "8.2.0"` in `@company/downstream-pinned`.

## Expected Behavior

Bumping `"@company/upstream"` to `8.2.0` should only affect `"@company/downstream-workspace"` and not `"@company/downstream-pinned"`.

In our Nx monorepo, we generally adhere to a single version policy, but we have a few exceptions where we need to pin versions during migrations. Given that Nx supports both single version policy and independently maintained dependencies, I'd expect that we could continue to use pinned versions in this scenario.

## Related Issue(s)

Fixes # https://github.com/nrwl/nx/issues/31454
