### PR TITLE
docs(core): add docs for tui options in nx.json

### DIFF
--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -65,7 +65,11 @@ The following is an expanded example showing all options. Your `nx.json` will li
       "buildable": true
     }
   },
-  "extends": "nx/presets/npm.json"
+  "extends": "nx/presets/npm.json",
+  "tui": {
+    "enabled": true,
+    "autoExit": true
+  }
 }
 ```
 
@@ -425,7 +429,8 @@ Some important changes in Nx 21:
 - The `release.version.generatorOptions` object has been removed, with its properties moved to the top level of `release.version`
 - `packageRoot` has been replaced by the more flexible `manifestRootsToUpdate` array
 - Ecosystem-specific options like `skipLockFileUpdate` are now under `versionActionsOptions`
-- `preserveLocalDependencyProtocols` (also now at the top level)now defaults to `true` (previously `false` when it was a generatorOption)
+- `preserveLocalDependencyProtocols` (also now at the top level) now defaults to `true` (previously `false` when it was a generatorOption)
+- `tui` object has been added to control the new [Terminal UI](/recipes/running-tasks/terminal-ui)
 
 ### Changelog
 
@@ -606,3 +611,19 @@ Valid values for `maxCacheSize` can be specified in bytes, kilobytes (KB), megab
 ```
 
 Regardless of the `maxCacheSize` setting, Nx will remove cache entries that have not been accessed in the last 7 days.
+
+## TUI
+
+The `tui` property in `nx.json` configures the [Terminal UI](/recipes/running-tasks/terminal-ui). It allows you to enable or disable the TUI and configure its behavior.
+
+```json {% fileName="nx.json" %}
+{
+  "tui": {
+    // Enable the Nx TUI
+    "enabled": true,
+    // Automatically exit the TUI when completed
+    // Use a number to specify the seconds to keep the TUI open for after completion
+    "autoExit": true
+  }
+}
+```


### PR DESCRIPTION
This PR adds the missing `tui` property in `nx.json` on this page: https://nx.dev/reference/nx-json

<img width="884" alt="Screenshot 2025-06-04 at 1 10 04 PM" src="https://github.com/user-attachments/assets/d7edb8dd-7b1a-4e3e-a738-4eb0dbb1feba" />

Preview: https://nx-dev-git-docs-add-tui-option-nrwl.vercel.app/reference/nx-json