### PR TITLE
feat(repo): add ndcunningham to Claude workflow authorized users

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   claude:
     if: |
-      contains(fromJson('["AgentEnder", "barbados-clemens", "Cammisuli", "Coly010", "FrozenPandaz", "isaacplmann", "JamesHenry", "jaysoo", "leosvelperez", "mandarini", "MaxKless", "meeroslav", "nartc", "philipjfulcher", "vsavkin", "xiongemi"]'), github.actor) &&
+      contains(fromJson('["AgentEnder", "barbados-clemens", "Cammisuli", "Coly010", "FrozenPandaz", "isaacplmann", "JamesHenry", "jaysoo", "leosvelperez", "mandarini", "MaxKless", "meeroslav", "nartc", "ndcunningham", "philipjfulcher", "vsavkin", "xiongemi"]'), github.actor) &&
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
## Current Behavior

Currently, ndcunningham is not included in the list of authorized users who can trigger the Claude AI assistant in GitHub workflows.

## Expected Behavior

With this change, ndcunningham will be able to trigger the Claude AI assistant by mentioning @claude in GitHub issue comments, PR comments, and PR reviews.

## Related Issue(s)

This change adds ndcunningham to the authorized user list for the Claude workflow, enabling them to use the AI assistant for development tasks.