### PR TITLE
fix(core): improve local registry setup and make it more flexible

### DIFF
--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -38,7 +38,7 @@ export default async function (globalConfig: Config.ConfigGlobals) {
       // Keep checking until the configured registry changes from default
       while (currentRegistry === defaultRegistry) {
         console.log(
-          'Waiting for registry configuration to change from default...'
+          `Waiting for registry configuration to change from default (${defaultRegistry})...`
         );
         await new Promise((resolve) => setTimeout(resolve, 250));
         currentRegistry = getCurrentRegistry();

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -38,7 +38,7 @@ export default async function (globalConfig: Config.ConfigGlobals) {
       // Keep checking until the configured registry changes from default
       while (currentRegistry === defaultRegistry) {
         console.log(
-          `Waiting for registry configuration to change from default (${defaultRegistry})...`
+          `Waiting for registry configuration to change from ${defaultRegistry}...`
         );
         await new Promise((resolve) => setTimeout(resolve, 250));
         currentRegistry = getCurrentRegistry();


### PR DESCRIPTION
## Current Behavior

The E2E global setup hardcodes local registry configuration and waits for a specific localhost registry to be available, which can cause issues when the registry setup is managed differently or when using external registries.

## Expected Behavior

The E2E setup should be more flexible and work with different registry configurations:
- Wait for the registry configuration to change from the default instead of assuming local registry
- Properly manage local registry processes with cleanup
- Work with both local and external registries
- Provide better error handling and logging

## Related Issue(s)

This PR improves the E2E local testing setup to be more robust and flexible.

## Changes Made

- Changed from hardcoded local registry waiting to detecting registry configuration changes
- Added proper process management for local registry startup
- Improved error handling and cleanup with process termination  
- Made registry configuration work with both local and external registries
- Refactored code into smaller, focused functions for better maintainability
- Added better logging for debugging setup issues