### PR TITLE
fix(core): remove tabs from local workspace plugins section in nx report

### DIFF
--- a/packages/nx/src/command-line/report/report.ts
+++ b/packages/nx/src/command-line/report/report.ts
@@ -196,7 +196,7 @@ export async function reportHandler() {
     bodyLines.push('Local workspace plugins:');
 
     for (const plugin of localPlugins) {
-      bodyLines.push(`\t ${chalk.green(plugin)}`);
+      bodyLines.push(`${chalk.green(plugin)}`);
     }
   }
 


### PR DESCRIPTION
## Current Behavior

The `nx report` command uses tab characters for indenting local workspace plugins in its output, which creates inconsistent formatting compared to other sections like 'Registered Plugins' and 'Community plugins'.

## Expected Behavior

Local workspace plugins should be formatted consistently with other plugin sections in the report output, without tab indentation.

## Related Issue(s)

This is a minor formatting improvement for better consistency in the nx report output. No specific issue was filed for this change.