### PR TITLE
fix(js): recognize NodeNext as ESM

### DIFF
--- a/packages/js/src/executors/tsc/tsc.impl.spec.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.spec.ts
@@ -1,7 +1,19 @@
 import { ExecutorContext } from '@nx/devkit';
+import { TempFs } from '@nx/devkit/internal-testing-utils';
+import * as ts from 'typescript';
 import { ExecutorOptions } from '../../utils/schema';
+import { readTsConfig } from '../../utils/typescript/ts-config';
 import { normalizeOptions } from './lib';
-import { createTypeScriptCompilationOptions } from './tsc.impl';
+import {
+  createTypeScriptCompilationOptions,
+  determineModuleFormatFromTsConfig,
+} from './tsc.impl';
+
+jest.mock('../../utils/typescript/ts-config');
+
+const mockReadTsConfig = readTsConfig as jest.MockedFunction<
+  typeof readTsConfig
+>;
 
 describe('tscExecutor', () => {
   let context: ExecutorContext;
@@ -67,6 +79,200 @@ describe('tscExecutor', () => {
       expect(result).toMatchObject({
         rootDir: '/root/libs/ui/src',
       });
+    });
+  });
+});
+
+describe('determineModuleFormatFromTsConfig', () => {
+  let tempFs: TempFs;
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    tempFs = new TempFs('tsc-module-format');
+    workspaceRoot = tempFs.tempDir;
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+  });
+
+  describe('ESM module kinds', () => {
+    it('should return esm for ES2015 module', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.ES2015 },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`
+      );
+
+      expect(result).toBe('esm');
+    });
+
+    it('should return esm for ES2020 module', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.ES2020 },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`
+      );
+
+      expect(result).toBe('esm');
+    });
+
+    it('should return esm for ES2022 module', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.ES2022 },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`
+      );
+
+      expect(result).toBe('esm');
+    });
+
+    it('should return esm for ESNext module', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.ESNext },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`
+      );
+
+      expect(result).toBe('esm');
+    });
+  });
+
+  describe('CJS module kinds', () => {
+    it('should return cjs for CommonJS module', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.CommonJS },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`
+      );
+
+      expect(result).toBe('cjs');
+    });
+  });
+
+  describe('NodeNext module kind', () => {
+    it('should return esm for NodeNext when package.json has type: module', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+        'libs/ui/package.json': JSON.stringify({ type: 'module' }),
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.NodeNext },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`,
+        'libs/ui',
+        workspaceRoot
+      );
+
+      expect(result).toBe('esm');
+    });
+
+    it('should return cjs for NodeNext when package.json has type: commonjs', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+        'libs/ui/package.json': JSON.stringify({ type: 'commonjs' }),
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.NodeNext },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`,
+        'libs/ui',
+        workspaceRoot
+      );
+
+      expect(result).toBe('cjs');
+    });
+
+    it('should return cjs for NodeNext when package.json has no type field', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+        'libs/ui/package.json': JSON.stringify({ name: 'test' }),
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.NodeNext },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`,
+        'libs/ui',
+        workspaceRoot
+      );
+
+      expect(result).toBe('cjs');
+    });
+
+    it('should return cjs for NodeNext when package.json does not exist', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.NodeNext },
+      } as any);
+
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`,
+        'libs/ui',
+        workspaceRoot
+      );
+
+      expect(result).toBe('cjs');
+    });
+
+    it('should return cjs for NodeNext when projectRoot/workspaceRoot not provided (backward compatible)', () => {
+      tempFs.createFilesSync({
+        'libs/ui/tsconfig.json': '{}',
+        'libs/ui/package.json': JSON.stringify({ type: 'module' }),
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.NodeNext },
+      } as any);
+
+      // Without projectRoot and workspaceRoot, should default to cjs
+      const result = determineModuleFormatFromTsConfig(
+        `${workspaceRoot}/libs/ui/tsconfig.json`
+      );
+
+      expect(result).toBe('cjs');
     });
   });
 });

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -4,7 +4,10 @@ import {
   isDaemonEnabled,
   joinPathFragments,
   output,
+  readJsonFile,
 } from '@nx/devkit';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import type { TypeScriptCompilationOptions } from '@nx/workspace/src/utilities/typescript/compilation';
 import { CopyAssetsHandler } from '../../utils/assets/copy-assets-handler';
 import { checkDependencies } from '../../utils/check-dependencies';
@@ -21,15 +24,38 @@ import { readTsConfig } from '../../utils/typescript/ts-config';
 import { createEntryPoints } from '../../utils/package-json/create-entry-points';
 
 export function determineModuleFormatFromTsConfig(
-  absolutePathToTsConfig: string
+  absolutePathToTsConfig: string,
+  projectRoot?: string,
+  workspaceRoot?: string
 ): 'cjs' | 'esm' {
   const tsConfig = readTsConfig(absolutePathToTsConfig);
+
+  // NodeNext is context-dependent - check package.json type field
+  // NodeNext outputs ESM only when package.json has "type": "module"
+  // Otherwise it outputs CJS (when "type": "commonjs" or no type field)
+  if (tsConfig.options.module === ts.ModuleKind.NodeNext) {
+    if (projectRoot && workspaceRoot) {
+      const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json');
+      if (existsSync(packageJsonPath)) {
+        try {
+          const packageJson = readJsonFile(packageJsonPath);
+          if (packageJson.type === 'module') {
+            return 'esm';
+          }
+        } catch {
+          // Fall through to default CJS
+        }
+      }
+    }
+    // NodeNext defaults to CJS when no type field or when we can't check
+    return 'cjs';
+  }
+
   if (
     tsConfig.options.module === ts.ModuleKind.ES2015 ||
     tsConfig.options.module === ts.ModuleKind.ES2020 ||
     tsConfig.options.module === ts.ModuleKind.ES2022 ||
-    tsConfig.options.module === ts.ModuleKind.ESNext ||
-    tsConfig.options.module === ts.ModuleKind.NodeNext
+    tsConfig.options.module === ts.ModuleKind.ESNext
   ) {
     return 'esm';
   } else {
@@ -109,7 +135,13 @@ export async function* tscExecutor(
               options.additionalEntryPoints,
               context.root
             ),
-            format: [determineModuleFormatFromTsConfig(options.tsConfig)],
+            format: [
+              determineModuleFormatFromTsConfig(
+                options.tsConfig,
+                options.projectRoot,
+                context.root
+              ),
+            ],
           },
           context,
           target,
@@ -143,7 +175,13 @@ export async function* tscExecutor(
                 options.additionalEntryPoints,
                 context.root
               ),
-              format: [determineModuleFormatFromTsConfig(options.tsConfig)],
+              format: [
+                determineModuleFormatFromTsConfig(
+                  options.tsConfig,
+                  options.projectRoot,
+                  context.root
+                ),
+              ],
             },
             context,
             target,

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -28,7 +28,8 @@ export function determineModuleFormatFromTsConfig(
     tsConfig.options.module === ts.ModuleKind.ES2015 ||
     tsConfig.options.module === ts.ModuleKind.ES2020 ||
     tsConfig.options.module === ts.ModuleKind.ES2022 ||
-    tsConfig.options.module === ts.ModuleKind.ESNext
+    tsConfig.options.module === ts.ModuleKind.ESNext ||
+    tsConfig.options.module === ts.ModuleKind.NodeNext
   ) {
     return 'esm';
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
NodeNext is not recognized as ESM. This causes this warning message to be logged, even when you have `"type": "module",` in the `package.json` file and are compile TypeScript to `"module": "NodeNext"`.

```
Package type is set to "module" but "cjs" format is included. Going to use "esm" format instead. You can change the package type to "commonjs" or remove type in the package.json file.
```

## Expected Behavior
Don't log this message. It is incorrect.

