### PR TITLE
fix(core): remove log_error function and standardize logging

### DIFF
--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -249,8 +249,6 @@ export const IS_WASM: boolean
 
 export declare export declare function logDebug(message: string): void
 
-export declare export declare function logError(message: string): void
-
 /** Stripped version of the NxJson interface for use in rust */
 export interface NxJson {
   namedInputs?: Record<string, Array<JsInputs>>

--- a/packages/nx/src/native/logger/console.rs
+++ b/packages/nx/src/native/logger/console.rs
@@ -6,9 +6,3 @@ pub fn log_debug(message: String) {
     enable_logger();
     debug!(message);
 }
-
-#[napi]
-pub fn log_error(message: String) {
-    enable_logger();
-    error!(message);
-}

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -392,7 +392,6 @@ module.exports.hashFile = nativeBinding.hashFile
 module.exports.installNxConsole = nativeBinding.installNxConsole
 module.exports.IS_WASM = nativeBinding.IS_WASM
 module.exports.logDebug = nativeBinding.logDebug
-module.exports.logError = nativeBinding.logError
 module.exports.parseTaskStatus = nativeBinding.parseTaskStatus
 module.exports.remove = nativeBinding.remove
 module.exports.restoreTerminal = nativeBinding.restoreTerminal

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -17,7 +17,7 @@ import {
   getTaskDetails,
   hashTasksThatDoNotDependOnOutputsOfOtherTasks,
 } from '../hasher/hash-task';
-import { logError, logDebug, RunMode } from '../native';
+import { logDebug, RunMode } from '../native';
 import {
   runPostTasksExecution,
   runPreTasksExecution,
@@ -216,7 +216,7 @@ async function getTerminalOutputLifeCycle(
         // @ts-ignore
         return (chunk, encoding, callback) => {
           if (isError) {
-            logError(
+            logDebug(
               Buffer.isBuffer(chunk)
                 ? chunk.toString(encoding)
                 : chunk.toString()


### PR DESCRIPTION
## Current Behavior

The codebase has separate `logError` and `logDebug` functions in the native logging infrastructure, with both error and debug logging paths.

## Expected Behavior

Consolidate logging to use a single standardized approach. Error messages are now logged through the debug channel for consistency.

## Related Issue(s)

This change standardizes the logging interface by removing the separate error logging function and routing all log messages through the debug logger.