### PR TITLE
fix(angular): expand nx tokens in project configurations when running schematic migrations

### DIFF
--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -501,6 +501,15 @@ describe('migrate', () => {
                       }},
                     }
                   });
+                } else if (packageName === 'nx-token-migration-package') {
+                  return Promise.resolve({
+                    version: '2.0.0',
+                    generators: {
+                      'some-migration': {
+                        version: '2.0.0'
+                      }
+                    }
+                  });
                 } else {
                   return Promise.resolve({version: '9.0.0'});
                 }
@@ -699,6 +708,154 @@ describe('migrate', () => {
     });
 
     expect(output).toContain(`Migrations file 'migrations.json' doesn't exist`);
+  });
+
+  it('should handle Nx tokens correctly in Angular CLI migration schematics', () => {
+    const app1 = uniq('app1');
+
+    updateFile(
+      `apps/${app1}/project.json`,
+      JSON.stringify(
+        {
+          name: app1,
+          projectType: 'application',
+          sourceRoot: `apps/${app1}/src`,
+          prefix: 'app',
+          targets: {
+            build: {
+              outputs: ['{options.outputPath}'],
+              executor: '@angular/build:application',
+              options: {
+                outputPath: '{workspaceRoot}/dist/{projectName}',
+                browser: '{projectRoot}/src/main.ts',
+                polyfills: ['zone.js'],
+                tsConfig: '{projectRoot}/tsconfig.app.json',
+                assets: [
+                  {
+                    glob: '**/*',
+                    input: '{projectRoot}/public',
+                  },
+                ],
+                styles: [
+                  '{projectRoot}/src/styles.css',
+                  '{workspaceRoot}/shared/styles.css',
+                ],
+              },
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    // Create an Angular CLI migration schematic that reads and modifies the angular.json (Nx project.json)
+    updateFile(
+      `./node_modules/nx-token-migration-package/package.json`,
+      JSON.stringify({
+        name: 'nx-token-migration-package',
+        version: '1.0.0',
+        'ng-update': {
+          migrations: './migrations.json',
+        },
+      })
+    );
+    updateFile(
+      `./node_modules/nx-token-migration-package/migrations.json`,
+      JSON.stringify({
+        schematics: {
+          'some-migration': {
+            version: '2.0.0',
+            factory: './some-migration',
+            description: 'A description of the migration',
+          },
+        },
+      })
+    );
+    // Create a migration schematic that validates Nx tokens are properly resolved
+    updateFile(
+      `./node_modules/nx-token-migration-package/some-migration.js`,
+      `
+        const { readWorkspace, writeWorkspace } = require('@schematics/angular/utility');
+
+        exports.default = function migration() {
+          return async function (host) {
+            const workspace = await readWorkspace(host);
+            const project = workspace.projects.get('${app1}');
+            const buildTarget = project.targets.get('build');
+
+            // write the build target data to a file to verify it outside of the migration
+            host.create('project-data.json', JSON.stringify(buildTarget, null, 2));
+
+            // make some changes to verify to the build target to verify how it's written
+            // back to the project.json file
+            buildTarget.options.outputPath = 'dist/apps/${app1}';
+            buildTarget.options.styles = ['apps/${app1}/src/base_styles.css', 'shared/styles.css'];
+
+            writeWorkspace(host, workspace);
+          };
+        };
+      `
+    );
+
+    // Run the migration
+    const output = runCLI(
+      'migrate nx-token-migration-package@2.0.0 --from="nx-token-migration-package@1.0.0"',
+      {
+        env: {
+          NX_MIGRATE_SKIP_INSTALL: 'true',
+          NX_MIGRATE_USE_LOCAL: 'true',
+        },
+      }
+    );
+    runCLI('migrate --run-migrations=migrations.json', {
+      env: {
+        NX_MIGRATE_SKIP_INSTALL: 'true',
+        NX_MIGRATE_USE_LOCAL: 'true',
+      },
+      verbose: true,
+    });
+
+    // Verify that the Angular CLI migration schematic read the build target
+    // with the Nx tokens resolved to actual values
+    const angularJsonBuildTarget = readJson('project-data.json');
+    expect(angularJsonBuildTarget.options).toStrictEqual({
+      outputPath: `dist/${app1}`,
+      browser: `apps/${app1}/src/main.ts`,
+      polyfills: ['zone.js'],
+      tsConfig: `apps/${app1}/tsconfig.app.json`,
+      assets: [
+        {
+          glob: '**/*',
+          input: `apps/${app1}/public`,
+        },
+      ],
+      styles: [`apps/${app1}/src/styles.css`, 'shared/styles.css'],
+    });
+    // Verify that the project.json file has been updated with the new values
+    // and the Nx tokens have been restored where appropriate
+    const projectJson = readJson(`apps/${app1}/project.json`);
+    expect(projectJson.targets.build.options).toStrictEqual({
+      // this was changed, so only the {workspaceRoot} token is restored
+      outputPath: `{workspaceRoot}/dist/apps/${app1}`,
+      // these were all unchanged, so the Nx tokens are restored
+      browser: '{projectRoot}/src/main.ts',
+      polyfills: ['zone.js'],
+      tsConfig: '{projectRoot}/tsconfig.app.json',
+      assets: [
+        {
+          glob: '**/*',
+          input: '{projectRoot}/public',
+        },
+      ],
+      styles: [
+        // this was changed, but it still starts with {projectRoot}, so the
+        // {projectRoot} token is restored
+        '{projectRoot}/src/base_styles.css',
+        // this was unchanged, so the {workspaceRoot} token is restored
+        '{workspaceRoot}/shared/styles.css',
+      ],
+    });
   });
 });
 

--- a/packages/nx/src/adapter/ngcli-adapter.spec.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.spec.ts
@@ -1,9 +1,11 @@
-import {
-  arrayBufferToString,
-  wrapAngularDevkitSchematic,
-} from './ngcli-adapter';
+import type { ProjectConfiguration } from '../config/workspace-json-project-json';
 import { createTreeWithEmptyWorkspace } from '../generators/testing-utils/create-tree-with-empty-workspace';
 import { addProjectConfiguration } from '../generators/utils/project-configuration';
+import {
+  arrayBufferToString,
+  restoreNxTokensInOptions,
+  wrapAngularDevkitSchematic,
+} from './ngcli-adapter';
 
 jest.mock('../project-graph/project-graph', () => ({
   ...jest.requireActual('../project-graph/project-graph'),
@@ -38,5 +40,96 @@ describe('ngcli-adapter', () => {
 
     // ASSERT
     expect(tree.exists('src/lib/test.ts')).toBeTruthy();
+  });
+
+  describe('restoreNxTokensInOptions', () => {
+    const project: ProjectConfiguration = {
+      name: 'lib1',
+      root: 'libs/lib1',
+      targets: {},
+    };
+
+    it('should restore {projectRoot} if the new value matches the resolved previous value', () => {
+      const previousValue = { outputPath: '{projectRoot}/dist' }; // libs/lib1/dist
+      const newValue = { outputPath: 'libs/lib1/dist' };
+
+      expect(
+        restoreNxTokensInOptions(newValue, previousValue, project)
+      ).toEqual(previousValue);
+    });
+
+    it('should restore {projectRoot} if the new value is different but starts with the project root', () => {
+      const previousValue = { outputPath: '{projectRoot}/dist' }; // libs/lib1/dist
+      const newValue = { outputPath: 'libs/lib1/dist/app' };
+
+      expect(
+        restoreNxTokensInOptions(newValue, previousValue, project)
+      ).toEqual({ outputPath: '{projectRoot}/dist/app' });
+    });
+
+    it('should not restore {projectRoot} if the new value is different and does not start with the project root', () => {
+      const previousValue = { outputPath: '{projectRoot}/dist' }; // libs/lib1/dist
+      const newValue = { outputPath: 'dist/libs/lib1' };
+
+      expect(
+        restoreNxTokensInOptions(newValue, previousValue, project)
+      ).toEqual(newValue);
+    });
+
+    it('should restore {workspaceRoot} if the new value matches the resolved previous value', () => {
+      const previousValue = { config: '{workspaceRoot}/global.json' }; // global.json
+      const newValue = { config: 'global.json' };
+
+      expect(
+        restoreNxTokensInOptions(newValue, previousValue, project)
+      ).toEqual(previousValue);
+    });
+
+    it('should restore {projectName} if the new value matches the resolved previous value', () => {
+      const previousValue = { folder: '{projectName}/src' }; // lib1/src
+      const newValue = { folder: 'lib1/src' };
+
+      expect(
+        restoreNxTokensInOptions(newValue, previousValue, project)
+      ).toEqual(previousValue);
+    });
+
+    it('should handle nested objects', () => {
+      const previousValue = { a: { b: '{projectRoot}/foo' } }; // libs/lib1/foo
+      const newValue = { a: { b: 'libs/lib1/foo' } };
+
+      expect(
+        restoreNxTokensInOptions(newValue, previousValue, project)
+      ).toEqual(previousValue);
+    });
+
+    it('should handle arrays of objects', () => {
+      const previousValue = {
+        arr: [{ path: '{projectRoot}/foo' }, { path: '{projectRoot}/bar' }], // libs/lib1/foo, libs/lib1/bar
+      };
+      const newValue = {
+        arr: [{ path: 'libs/lib1/foo' }, { path: 'libs/lib1/bar' }],
+      };
+
+      expect(
+        restoreNxTokensInOptions(newValue, previousValue, project)
+      ).toEqual(previousValue);
+    });
+
+    it('should prefix new value with {workspaceRoot}/ if previous started with {workspaceRoot}/ and value changed', () => {
+      const prev = { config: '{workspaceRoot}/global.json' };
+      const next = { config: 'changed.json' };
+      expect(restoreNxTokensInOptions(next, prev, project)).toEqual({
+        config: '{workspaceRoot}/changed.json',
+      });
+    });
+
+    it('should not double slash when new value starts with a slash and previous started with {workspaceRoot}/', () => {
+      const prev = { config: '{workspaceRoot}/global.json' };
+      const next = { config: '/changed.json' };
+      expect(restoreNxTokensInOptions(next, prev, project)).toEqual({
+        config: '{workspaceRoot}/changed.json',
+      });
+    });
   });
 });

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -74,6 +74,7 @@ import {
   resolveImplementation,
   resolveSchema,
 } from '../config/schema-utils';
+import { resolveNxTokensInOptions } from '../project-graph/utils/project-configuration-utils';
 
 export async function createBuilderContext(
   builderInfo: {
@@ -505,9 +506,50 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
           const projects = configV2.projects;
           const allObservables = [];
           Object.keys(projects).forEach((projectName) => {
-            if (projectsInAngularJson.includes(projectName)) {
-              // ignore updates to angular.json
-            } else {
+            if (!projectsInAngularJson.includes(projectName)) {
+              // Restore tokens in options if they were present before
+              const previousProject = existingConfig.projects[projectName];
+              const newProject = projects[projectName];
+              if (
+                previousProject &&
+                newProject.targets &&
+                previousProject.targets
+              ) {
+                for (const [targetName, target] of Object.entries(
+                  newProject.targets
+                )) {
+                  const previousTarget = previousProject.targets[targetName];
+                  if (
+                    target.options &&
+                    previousTarget &&
+                    previousTarget.options
+                  ) {
+                    target.options = restoreNxTokensInOptions(
+                      target.options,
+                      previousTarget.options,
+                      newProject
+                    );
+                  }
+                  if (
+                    target.configurations &&
+                    previousTarget &&
+                    previousTarget.configurations
+                  ) {
+                    for (const [configName, config] of Object.entries(
+                      target.configurations
+                    )) {
+                      if (previousTarget.configurations[configName]) {
+                        target.configurations[configName] =
+                          restoreNxTokensInOptions(
+                            config,
+                            previousTarget.configurations[configName],
+                            newProject
+                          );
+                      }
+                    }
+                  }
+                }
+              }
               updateProjectConfiguration(
                 {
                   root,
@@ -684,9 +726,33 @@ export class NxScopeHostUsedForWrappedSchematics extends NxScopedHost {
       (path === 'angular.json' || path === '/angular.json') &&
       isAngularPluginInstalled()
     ) {
-      const projectJsonConfig = toOldFormat({
-        projects: Object.fromEntries(getProjects(this.host)),
-      });
+      // Replace the Nx-specific tokens in all target options
+      const projects = Object.fromEntries(getProjects(this.host));
+      for (const [projectName, project] of Object.entries(projects)) {
+        if (project.targets) {
+          for (const [targetName, target] of Object.entries(project.targets)) {
+            if (target.options) {
+              target.options = resolveNxTokensInOptions(
+                target.options,
+                { ...project, name: projectName },
+                `${projectName}:${targetName}`
+              );
+            }
+            if (target.configurations) {
+              for (const [configName, config] of Object.entries(
+                target.configurations
+              )) {
+                target.configurations[configName] = resolveNxTokensInOptions(
+                  config,
+                  { ...project, name: projectName },
+                  `${projectName}:${targetName}:${configName}`
+                );
+              }
+            }
+          }
+        }
+      }
+      const projectJsonConfig = toOldFormat({ projects });
       return super.readExistingAngularJson().pipe(
         map((angularJson) => {
           if (angularJson) {
@@ -1305,4 +1371,70 @@ async function getWrappedWorkspaceNodeModulesArchitectHost(
     root,
     projects
   );
+}
+
+/**
+ * Restores Nx tokens in options when possible by comparing new and previous
+ * options.
+ * The function preserves tokens in the following cases:
+ * 1. When the resolved previous value matches the new value exactly
+ * 2. When the previous value used {workspaceRoot}
+ * 3. When the previous value used {projectRoot} and the new value starts with
+ *    the project root path
+ * Those are the only safe cases, for all other cases, the new value is used as-is.
+ */
+export function restoreNxTokensInOptions<T extends Object | Array<unknown>>(
+  newOptions: T,
+  previousOptions: T,
+  project: ProjectConfiguration
+): T {
+  if (!newOptions || !previousOptions) {
+    return newOptions;
+  }
+
+  const result: T = Array.isArray(newOptions)
+    ? ([...newOptions] as T)
+    : { ...newOptions };
+
+  const resolvedPreviousOptions = resolveNxTokensInOptions(
+    previousOptions,
+    project,
+    ''
+  );
+  for (const key of Object.keys(newOptions)) {
+    const newValue = newOptions[key];
+    const previousValue = previousOptions[key];
+    if (typeof newValue === 'string' && typeof previousValue === 'string') {
+      if (resolvedPreviousOptions[key] === newValue) {
+        // If the resolved previous value matches the new value, use the previous
+        // value (potentially with tokens)
+        result[key] = previousValue;
+      } else if (previousValue.startsWith('{workspaceRoot}/')) {
+        // If the previous value started with {workspaceRoot}, prefix the new
+        // value with {workspaceRoot}
+        result[key] = `{workspaceRoot}/${newValue.replace(/^\//, '')}`;
+      } else if (
+        previousValue.startsWith('{projectRoot}/') &&
+        newValue.startsWith(`${project.root}/`)
+      ) {
+        // If the previous value started with {projectRoot} and the new value
+        // starts with the project root, replace the project root with the
+        // {projectRoot} token
+        result[key] = newValue.replace(`${project.root}/`, '{projectRoot}/');
+      } else {
+        // Otherwise, use the new value as-is
+        result[key] = newValue;
+      }
+    } else if (
+      typeof newValue === 'object' &&
+      typeof previousValue === 'object' &&
+      newValue &&
+      previousValue
+    ) {
+      result[key] = restoreNxTokensInOptions(newValue, previousValue, project);
+    } else {
+      result[key] = newValue;
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
## Current Behavior

Running Angular CLI schematic migrations that update project configurations that contain Nx tokens (e.g. `{workspaceRoot}`, `{projectRoot}`, `{projectName}`) does not work correctly. The schematic migrations receive the project configuration option values with the non-expanded tokens, which is not something handled.

## Expected Behavior

The Nx adapter for Angular should expand Nx tokens in project configurations so schematic migrations can correctly process them. When writing the project configuration back, the tokens should be restored on a best-effort basis.

## Related Issue(s)

Fixes #29052 