### PR TITLE
fix(core): MacOS failures in our E2E Tests

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -256,8 +256,6 @@ jobs:
           # Verify Xcode installation
           xcodebuild -version
           
-          # List available simulators
-          xcrun simctl list devices available
         timeout-minutes: 10
         continue-on-error: false
 
@@ -302,9 +300,6 @@ jobs:
         run: |
           # Verify CoreSimulator service restarted
           pgrep -fl "CoreSimulator" || (echo "CoreSimulator service not running" && exit 1)
-          
-          # Check simulator list is clean
-          xcrun simctl list devices
           
           # Verify simulator runtime paths exist and are writable
           test -d ~/Library/Developer/CoreSimulator/Devices || (echo "Simulator devices directory missing" && exit 1)

--- a/project.json
+++ b/project.json
@@ -18,7 +18,8 @@
           "input": "production",
           "projects": ["tag:npm:public"]
         },
-        "{workspaceRoot}/scripts/local-registry"
+        "{workspaceRoot}/scripts/local-registry",
+        "native"
       ],
       "dependsOn": [
         "local-registry",


### PR DESCRIPTION
This PR modifies the populate-local-registry-storage inputs to invalidate the cache when the native task is updated (which includes OS/architecture information).

This change addresses MacOS failures we've been encountering in our nightly GitHub Actions runs. The issue stems from incorrect cache restoration when running multiple OS and Node.js version combinations, which explains why native modules were consistently missing in most MacOS tests.

Here is the result: https://github.com/nrwl/nx/actions/runs/15562011534