### PR TITLE
fix(core): scope native logging to nx module by default

### DIFF
--- a/packages/nx/src/native/logger/mod.rs
+++ b/packages/nx/src/native/logger/mod.rs
@@ -108,7 +108,8 @@ pub(crate) fn enable_logger() {
         .with_writer(std::io::stdout)
         .event_format(NxLogFormatter)
         .with_filter(
-            EnvFilter::try_from_env("NX_NATIVE_LOGGING").unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_env("NX_NATIVE_LOGGING")
+                .unwrap_or_else(|_| EnvFilter::new("nx::native=info")),
         );
 
     let registry = tracing_subscriber::registry()


### PR DESCRIPTION
## Current Behavior

The native logging is currently set to a global 'info' level, which can produce verbose output that may not be relevant to users.

## Expected Behavior

Native logging should be scoped to the 'nx::native' module by default with 'info' level, reducing noise while still allowing users to control logging verbosity through the `NX_NATIVE_LOGGING` environment variable.

## Related Issue(s)

This improves the developer experience by providing more focused logging output and reduces unnecessary verbosity in the console.

Fixes https://github.com/nrwl/nx/issues/31518