### PR TITLE
fix(core): simplify Nx Console installation prompt

### DIFF
--- a/packages/nx/src/utils/nx-console-prompt.ts
+++ b/packages/nx/src/utils/nx-console-prompt.ts
@@ -35,13 +35,11 @@ export async function ensureNxConsoleInstalled() {
 async function promptForNxConsoleInstallation(): Promise<boolean> {
   try {
     output.log({
-      title:
-        "Enhance your developer experience with Nx Console, Nx's official editor extension",
+      title: "Install Nx's official editor extension to:",
       bodyLines: [
         '- Enable your AI assistant to do more by understanding your workspace',
         '- Add IntelliSense for Nx configuration files',
         '- Explore your workspace visually',
-        '- Generate code and execute tasks interactively',
       ],
     });
 


### PR DESCRIPTION
## Current Behavior

The Nx Console installation prompt has verbose and redundant wording that makes the message unclear.

## Expected Behavior

The prompt is simplified and more concise, focusing on the key benefits of installing Nx Console while being more direct about what users will gain.

## Related Issue(s)

This change improves the user experience when prompted to install Nx Console.