### PR TITLE
fix(js): improve typescript plugin build detection

### DIFF
--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -7,9 +7,9 @@ import {
   rmDist,
   runCLI,
   runCommand,
-  tmpProjPath,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e/utils';
 
 describe('Rollup Plugin', () => {
@@ -245,6 +245,21 @@ export default config;
         `export const hello = 'world';\n`
       );
 
+      // Change TypeScript plugin build target to avoid conflict with Rollup
+      updateJson('nx.json', (nxJson) => {
+        nxJson.plugins.forEach((plugin) => {
+          if (
+            plugin.plugin === '@nx/js/typescript' &&
+            plugin.include?.includes(`libs/${myPkg}/*`)
+          ) {
+            if (plugin.options?.build?.targetName === 'build') {
+              plugin.options.build.targetName = 'tsc:build';
+            }
+          }
+        });
+        return nxJson;
+      });
+
       // Update rollup config to use useLegacyTypescriptPlugin: false
       updateFile(
         `libs/${myPkg}/rollup.config.cjs`,
@@ -284,6 +299,21 @@ export default config;
         `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup`
       );
       updateFile(`libs/${myPkg}/src/index.ts`, `export const foo = 'bar';\n`);
+
+      // Change TypeScript plugin build target to avoid conflict with Rollup
+      updateJson('nx.json', (nxJson) => {
+        nxJson.plugins.forEach((plugin) => {
+          if (
+            plugin.plugin === '@nx/js/typescript' &&
+            plugin.include?.includes(`libs/${myPkg}/*`)
+          ) {
+            if (plugin.options?.build?.targetName === 'build') {
+              plugin.options.build.targetName = 'tsc:build';
+            }
+          }
+        });
+        return nxJson;
+      });
 
       // Update rollup config to explicitly use useLegacyTypescriptPlugin: true
       updateFile(

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -95,8 +95,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     "^typecheck",
                   ],
                   "inputs": [
-                  "production",
-                  "^production",
+                    "production",
+                    "^production",
                     {
                       "externalDependencies": [
                         "typescript",

--- a/packages/js/src/plugins/typescript/util.ts
+++ b/packages/js/src/plugins/typescript/util.ts
@@ -142,7 +142,7 @@ export function isValidPackageJsonBuildConfig(
       return true;
     }
 
-    // If outDir is inside project root: set for further checking
+    // If outDir is inside project root, then we should check entry points
     if (!relativePath.startsWith('..')) {
       resolvedOutDir = potentialOutDir;
     }

--- a/packages/js/src/plugins/typescript/util.ts
+++ b/packages/js/src/plugins/typescript/util.ts
@@ -1,6 +1,6 @@
 import { readJsonFile, type TargetConfiguration } from '@nx/devkit';
 import { existsSync } from 'node:fs';
-import { dirname, extname, isAbsolute, relative, resolve } from 'node:path';
+import { extname, isAbsolute, relative, resolve } from 'node:path';
 import { type PackageManagerCommands } from 'nx/src/utils/package-manager';
 import { join } from 'path';
 import { type ParsedCommandLine } from 'typescript';
@@ -94,7 +94,7 @@ export function isValidPackageJsonBuildConfig(
 
     const isPathSourceFile = (path: string): boolean => {
       const normalizedPath = isAbsolute(path)
-        ? resolve(path)
+        ? resolve(workspaceRoot, path.startsWith('/') ? path.slice(1) : path)
         : resolve(workspaceRoot, resolvedProjectPath, path);
 
       // For outFile case, check if path points to the specific outFile
@@ -150,7 +150,7 @@ export function isValidPackageJsonBuildConfig(
 
   const isPathSourceFile = (path: string): boolean => {
     const normalizedPath = isAbsolute(path)
-      ? resolve(workspaceRoot, path.slice(1)) // Remove leading slash and resolve relative to workspace root
+      ? resolve(workspaceRoot, path.startsWith('/') ? path.slice(1) : path)
       : resolve(workspaceRoot, resolvedProjectPath, path);
 
     if (resolvedOutDir) {
@@ -169,6 +169,8 @@ export function isValidPackageJsonBuildConfig(
       if (tsExtensions.includes(ext)) {
         return true;
       }
+      // If include is not defined and it's not a TS file, assume it's not a source file
+      return false;
     }
 
     const projectAbsolutePath = resolve(workspaceRoot, resolvedProjectPath);


### PR DESCRIPTION
This PR enhances the typescript plugin build detection. Notably the changes include:
- Add absolute path handling for package.json entry points.
- Simplify the buildable verification
- Add glob pattern matching for `include` patterns.

MISC: 
- Also fixes `e2e-rollup` test failing due to the typescript plugin having the same build target as rollup so it created an unexpected output.

closes: #29670
