### PR TITLE
fix(core): shutdown running tasks properly when recieving sigterm

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -434,6 +434,25 @@ class RunningNodeProcess implements RunningTask {
         }
       }
     });
+    // Terminate any task processes on exit
+    process.on('exit', () => {
+      this.childProcess.kill();
+    });
+    process.on('SIGINT', () => {
+      this.childProcess.kill('SIGTERM');
+      // we exit here because we don't need to write anything to cache.
+      process.exit(signalToCode('SIGINT'));
+    });
+    process.on('SIGTERM', () => {
+      this.childProcess.kill('SIGTERM');
+      // no exit here because we expect child processes to terminate which
+      // will store results to the cache and will terminate this process
+    });
+    process.on('SIGHUP', () => {
+      this.childProcess.kill('SIGTERM');
+      // no exit here because we expect child processes to terminate which
+      // will store results to the cache and will terminate this process
+    });
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When running Nx tasks without the daemon, tui, and using run-commands w/ serially running tasks, its possible that Nx will not properly terminate on receiving SIGTERM.

## Expected Behavior
Nx properly shuts down child tasks on receiving SIGTERM

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
