### PR TITLE
fix(expo): update heading text assertion to use regex for flexibility

### DIFF
--- a/packages/expo/src/generators/application/files/base/src/app/App.spec.tsx.template
+++ b/packages/expo/src/generators/application/files/base/src/app/App.spec.tsx.template
@@ -5,5 +5,5 @@ import App from './App';
 
 test('renders correctly', () => {
   const { getByTestId } = render(<App />);
-  expect(getByTestId('heading')).toHaveTextContent('Welcome');
+  expect(getByTestId('heading')).toHaveTextContent(/Welcome/);
 });

--- a/packages/react-native/src/generators/application/files/app/src/app/App.spec.tsx.template
+++ b/packages/react-native/src/generators/application/files/app/src/app/App.spec.tsx.template
@@ -5,5 +5,5 @@ import App from './App';
 
 test('renders correctly', () => {
   const { getByTestId } = render(<App />);
-  expect(getByTestId('heading')).toHaveTextContent('Welcome');
+  expect(getByTestId('heading')).toHaveTextContent(/Welcome/);
 });


### PR DESCRIPTION
## Current Behavior
The heading unit test for the @nx/expo:application generator uses toHaveTextContent with a strict string comparison. This causes the test to fail when the heading output includes minor formatting differences or additional content.

![image](https://github.com/user-attachments/assets/0cfe6c22-25b7-4520-b929-b7854971eecd)


## Expected Behavior
The test should use a regular expression with toHaveTextContent to allow partial matches.