### PR TITLE
fix(core): show the correct content in the tui terminal pane for skipped tasks

### DIFF
--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -1005,6 +1005,10 @@ impl App {
                                         in_progress && pty.can_be_interactive();
                                     terminal_pane_data.pty = Some(pty.clone());
                                     has_pty = true;
+                                } else {
+                                    // Clear PTY data when switching to a task that doesn't have a PTY instance
+                                    terminal_pane_data.pty = None;
+                                    terminal_pane_data.can_be_interactive = false;
                                 }
 
                                 let is_focused = match self.focus {

--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -496,6 +496,28 @@ impl<'a> StatefulWidget for TerminalPane<'a> {
             return;
         }
 
+        // If the task was skipped, show skipped message
+        if matches!(state.task_status, TaskStatus::Skipped) {
+            let message_style = if state.is_focused {
+                self.get_base_style(TaskStatus::Skipped)
+            } else {
+                self.get_base_style(TaskStatus::Skipped)
+                    .add_modifier(Modifier::DIM)
+            };
+            let message = vec![Line::from(vec![Span::styled(
+                "Task was skipped",
+                message_style,
+            )])];
+
+            let paragraph = Paragraph::new(message)
+                .block(block)
+                .alignment(Alignment::Center)
+                .style(Style::default());
+
+            Widget::render(paragraph, safe_area, buf);
+            return;
+        }
+
         let inner_area = block.inner(safe_area);
 
         if let Some(pty_data) = &self.pty_data {


### PR DESCRIPTION
## Current Behavior

When a task is skipped (e.g. some dep(s) failed), the terminal pane is completely empty. If you navigate to another task and see its output and navigate back to the skipped task, then you see the correct title and borders but the output is wrong: it shows the output of the previous task.

![image](https://github.com/user-attachments/assets/8d304019-a17e-4a5a-9369-30fb4025aeb3)

![image](https://github.com/user-attachments/assets/c43b9019-2438-46a1-8ebb-cf28c662afa6)

## Expected Behavior

The TUI terminal pane should be correctly rendered for skipped tasks. It should correctly show the title, border and content (`Task was skipped`).

![image](https://github.com/user-attachments/assets/f4f80b39-79c4-41c8-a2e5-cfdcb46030fa)
