### PR TITLE
docs(misc): update getSchemaViewModel to return new API path rather than /nx-api/:plugin

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/get-schema-view-model.ts
+++ b/nx-dev/feature-package-schema-viewer/src/lib/get-schema-view-model.ts
@@ -11,6 +11,7 @@ import {
 } from '@nx/nx-dev/models-package';
 import { ParsedUrlQuery } from 'querystring';
 import { Errors, Example, generateJsonExampleFor } from './examples';
+import { pkgToGeneratedApiDocs } from '@nx/nx-dev/models-document';
 
 function getReferenceFromQuery(query: string): string {
   return query.replace('root/', '#/');
@@ -28,7 +29,7 @@ export interface SchemaViewModel {
   schemaGithubUrl: string;
   schemaMetadata: SchemaMetadata;
   subReference: string;
-  type: 'executor' | 'generator';
+  type: 'executor' | 'generator' | 'migration';
 }
 
 export function getSchemaViewModel(
@@ -37,11 +38,12 @@ export function getSchemaViewModel(
   schema: SchemaMetadata
 ): SchemaViewModel | null {
   if (!schema.schema) return null;
+  const packageUrl = pkgToGeneratedApiDocs[pkg.name].pagePath;
 
   return {
     schemaMetadata: schema,
     packageName: pkg.packageName,
-    packageUrl: `/nx-api/${pkg.name}`,
+    packageUrl,
     schemaGithubUrl: pkg.githubRoot + schema.path,
     rootReference: '#',
     subReference:


### PR DESCRIPTION
This PR updates pages like `/technologies/typescript/api/executors/verdaccio`, such that the backlink to the API index is correct. Even though we redirect `/nx-api` pages, the Next.js pages router does not respect them and users see 404 instead.
 