### PR TITLE
docs: clarify that gitignored files are excluded from inputs

### DIFF
--- a/docs/shared/reference/inputs.md
+++ b/docs/shared/reference/inputs.md
@@ -49,7 +49,7 @@ For example, in a structure like `packages/parent/nested-child/`, using `{projec
 {% /callout %}
 
 {% callout type="info" title="Gitignored Files Are Excluded" %}
-Files that are listed in `.gitignore` are automatically excluded from inputs. Nx will not consider gitignored files when computing the hash for tasks, so changes to ignored files will not invalidate the cache.
+Files listed in `.gitignore` are automatically excluded from inputs. Nx will not consider gitignored files when computing the hash for tasks; therefore, changes to ignored files will not invalidate the cache.
 {% /callout %}
 
 Prefixing a source file input with `!` will exclude the files matching the pattern from the set of files used to calculate the hash.

--- a/docs/shared/reference/inputs.md
+++ b/docs/shared/reference/inputs.md
@@ -48,6 +48,10 @@ These tokens behave differently when dealing with nested projects:
 For example, in a structure like `packages/parent/nested-child/`, using `{projectRoot}/**/*` for the `parent` project will exclude files from `nested-child`, while `{workspaceRoot}/packages/parent/**/*` will include them.
 {% /callout %}
 
+{% callout type="info" title="Gitignored Files Are Excluded" %}
+Files that are listed in `.gitignore` are automatically excluded from inputs. Nx will not consider gitignored files when computing the hash for tasks, so changes to ignored files will not invalidate the cache.
+{% /callout %}
+
 Prefixing a source file input with `!` will exclude the files matching the pattern from the set of files used to calculate the hash.
 Prefixing a source file input with `^` means this entry applies to the project dependencies of the project, not the project itself.
 


### PR DESCRIPTION
Add callout box to the inputs documentation explaining that .gitignored files are automatically excluded from inputs and won't affect task hash computation.

Fixes #31574

Generated with [Claude Code](https://claude.ai/code)