### PR TITLE
fix(core): nx.json should not be required to run tasks

### DIFF
--- a/packages/nx/src/utils/workspace-root.spec.ts
+++ b/packages/nx/src/utils/workspace-root.spec.ts
@@ -102,4 +102,113 @@ describe('workspaceRootInner', () => {
       '/home/workspace'
     );
   });
+
+  it('should find workspace root from package.json with nx dependency', () => {
+    jest
+      .spyOn(fileUtils, 'fileExists')
+      .mockImplementation((p) =>
+        ['/home/workspace/package.json'].includes(p.toString())
+      );
+    jest.spyOn(fileUtils, 'readJsonFile').mockImplementation((path) => {
+      if (path === '/home/workspace/package.json') {
+        return {
+          name: 'my-workspace',
+          dependencies: {
+            nx: '^17.0.0',
+          },
+        };
+      }
+      throw new Error('File not found');
+    });
+
+    expect(workspaceRootInner('/home/workspace', null)).toEqual(
+      '/home/workspace'
+    );
+  });
+
+  it('should find workspace root from package.json with nx devDependency', () => {
+    jest
+      .spyOn(fileUtils, 'fileExists')
+      .mockImplementation((p) =>
+        ['/home/workspace/package.json'].includes(p.toString())
+      );
+    jest.spyOn(fileUtils, 'readJsonFile').mockImplementation((path) => {
+      if (path === '/home/workspace/package.json') {
+        return {
+          name: 'my-workspace',
+          devDependencies: {
+            nx: '^17.0.0',
+          },
+        };
+      }
+      throw new Error('File not found');
+    });
+
+    expect(workspaceRootInner('/home/workspace', null)).toEqual(
+      '/home/workspace'
+    );
+  });
+
+  it('should find workspace root from package.json with nx peerDependency', () => {
+    jest
+      .spyOn(fileUtils, 'fileExists')
+      .mockImplementation((p) =>
+        ['/home/workspace/package.json'].includes(p.toString())
+      );
+    jest.spyOn(fileUtils, 'readJsonFile').mockImplementation((path) => {
+      if (path === '/home/workspace/package.json') {
+        return {
+          name: 'my-workspace',
+          peerDependencies: {
+            nx: '^17.0.0',
+          },
+        };
+      }
+      throw new Error('File not found');
+    });
+
+    expect(workspaceRootInner('/home/workspace', null)).toEqual(
+      '/home/workspace'
+    );
+  });
+
+  it('should continue search if package.json exists but has no nx dependency', () => {
+    jest
+      .spyOn(fileUtils, 'fileExists')
+      .mockImplementation((p) =>
+        [
+          '/home/workspace/package.json',
+          '/home/node_modules/nx/package.json',
+        ].includes(p.toString())
+      );
+    jest.spyOn(fileUtils, 'readJsonFile').mockImplementation((path) => {
+      if (path === '/home/workspace/package.json') {
+        return {
+          name: 'my-workspace',
+          dependencies: {
+            react: '^18.0.0',
+          },
+        };
+      }
+      throw new Error('File not found');
+    });
+
+    expect(workspaceRootInner('/home/workspace', null)).toEqual('/home');
+  });
+
+  it('should continue search if package.json cannot be read', () => {
+    jest
+      .spyOn(fileUtils, 'fileExists')
+      .mockImplementation((p) =>
+        [
+          '/home/workspace/package.json',
+          '/home/node_modules/nx/package.json',
+        ].includes(p.toString())
+      );
+    jest.spyOn(fileUtils, 'readJsonFile').mockImplementation(() => {
+      throw new Error('Cannot read file');
+    });
+
+    expect(workspaceRootInner('/home/workspace', null)).toEqual('/home');
+  });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

You get a " NX   Could not find Nx modules in this workspace." error when there's no "nx.json"

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should just work. Nx should still be able to run tasks.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
