### PR TITLE
Import ng-packagr colors from lib and not src

### DIFF
--- a/packages/angular/src/executors/utilities/ng-packagr/pre-v19/stylesheet-processor.ts
+++ b/packages/angular/src/executors/utilities/ng-packagr/pre-v19/stylesheet-processor.ts
@@ -9,7 +9,7 @@
 import { workspaceRoot } from '@nx/devkit';
 import browserslist from 'browserslist';
 import { existsSync } from 'fs';
-import { colors } from 'ng-packagr/src/lib/utils/color';
+import { colors } from 'ng-packagr/lib/utils/color';
 import { dirname, join } from 'path';
 
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

importing ng-packagr colors from src fails in cases where node_modules do not contain the src folder (not published in npm)
thus creating a missing import
```
 NX   Cannot find module 'ng-packagr/src/lib/utils/color'

Require stack:
- /node_modules/@nx/angular/src/executors/utilities/ng-packagr/pre-v19/stylesheet-processor.js
- /node_modules/@nx/angular/src/executors/utilities/ng-packagr/stylesheet-processor.di.js: Error during instantiation of InjectionToken ng.v5.stylesheetProcessor! (InjectionToken ng.v5.packageTransform -> InjectionToken ng.v5.entryPointTransform -> InjectionToken ng.v5.compileNgcTransform -> InjectionToken ng.v5.stylesheetProcessor).
Pass --verbose to see the stacktrace.

```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

should import colors from public lib and not from src
ideally colors should be exported as public api. but it doesnt seem to be.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31597

https://github.com/nrwl/nx/issues/31597