### PR TITLE
docs(nx-dev): fix issue with related docs not loading

### DIFF
--- a/nx-dev/models-document/src/lib/related-documents.utils.ts
+++ b/nx-dev/models-document/src/lib/related-documents.utils.ts
@@ -26,14 +26,15 @@ export function categorizeRelatedDocuments(
     },
     {
       id: 'recipes',
-      name: 'Recipes',
-      matchers: ['/recipes/'],
+      name: 'Guides',
+      matchers: ['/recipes/', '/guides/'],
       relatedDocuments: [],
     },
     {
       id: 'reference',
       name: 'Reference',
-      matchers: ['/workspace/', '/nx-api/'],
+      // TODO(caleb): including /technologies/ in the route will duplicate the display of `recipes/guides` so leaving off for now
+      matchers: ['/workspace/', '/nx-api/', '/core-api/'],
       relatedDocuments: [],
     },
     {

--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -288,6 +288,9 @@ export const getStaticProps: GetStaticProps = async ({
           githubStarsCount: await fetchGithubStarCount(),
         },
         menu,
+        relatedDocuments: tagsApi
+          .getAssociatedItemsFromTags(document.tags)
+          .filter((item) => item.path !== '/' + params.segments.join('/')), // Remove currently displayed item
       },
     };
   } catch (e) {


### PR DESCRIPTION
make sure new paths work for related docs resolution
include related docs for 'legacy' fallback page logic


## before: 
on the `/features/manage-releases` route
![WKMac 2025-06-16T15-37-13](https://github.com/user-attachments/assets/570493bb-571c-47fb-9dd8-dae6b138f951)

on the `/ci/features/affected` route
![WKMac 2025-06-16T15-37-53](https://github.com/user-attachments/assets/f269c6fe-01ec-43a4-a98a-37448d486a54)


## after:
on the `/features/manage-releases` route
![WKMac 2025-06-16T15-38-43](https://github.com/user-attachments/assets/98ed4e98-ea99-485b-b09e-82079bd88fdd)

on the `/ci/features/affected` route
![WKMac 2025-06-16T15-36-17](https://github.com/user-attachments/assets/31bf3be2-3104-4c3c-bdbf-c8701e99ce10)

rename recipes to guides for the related docs card
![WKMac 2025-06-16T16-01-05](https://github.com/user-attachments/assets/4fd6dcf9-dd02-4042-9102-b1d9e72e3866)


