### PR TITLE
Add AI nav link

### DIFF
--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -307,6 +307,14 @@ export function DocumentationHeader({
             </Popover>
             <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
             <Link
+              href="/ai"
+              title="Nx AI"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              prefetch={false}
+            >
+              AI
+            </Link>
+            <Link
               href="/remote-cache"
               title="Nx Remote Cache"
               className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"

--- a/nx-dev/ui-common/src/lib/headers/header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/header.tsx
@@ -211,6 +211,14 @@ export function Header({ ctaButtons }: HeaderProps): ReactElement {
             </Popover>
             <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
             <Link
+              href="/ai"
+              title="Nx AI"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              prefetch={false}
+            >
+              AI
+            </Link>
+            <Link
               href="/remote-cache"
               title="Nx Remote Cache"
               className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
@@ -488,6 +496,14 @@ export function Header({ ctaButtons }: HeaderProps): ReactElement {
                             prefetch={false}
                           >
                             Pricing
+                          </Link>
+                          <Link
+                            href="/ai"
+                            title="Nx AI"
+                            className="flex w-full gap-2 py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
+                            prefetch={false}
+                          >
+                            AI
                           </Link>
                           <Link
                             href="/remote-cache"


### PR DESCRIPTION
## Summary
- show an Nx AI entry in the main header before the Remote Cache item
- sync docs header navigation with the new Nx AI link

## Testing
- `npx prettier --check nx-dev/ui-common/src/lib/headers/header.tsx nx-dev/ui-common/src/lib/headers/documentation-header.tsx`

------
https://chatgpt.com/codex/tasks/task_b_68503d722d348332a840560ef49c2ff8