### PR TITLE
fix(testing): do not update component configuration in cypress `set-inject-document-domain` migration

### DIFF
--- a/packages/cypress/src/migrations/update-20-8-0/set-inject-document-domain.spec.ts
+++ b/packages/cypress/src/migrations/update-20-8-0/set-inject-document-domain.spec.ts
@@ -500,7 +500,7 @@ export default defineConfig({
     `);
   });
 
-  it('should set the injectDocumentDomain property to true in the component config when defined and experimentalSkipDomainInjection is not set', async () => {
+  it('should not set the injectDocumentDomain property in the component config', async () => {
     addProjectConfiguration(tree, 'app1-e2e', {
       root: 'apps/app1-e2e',
       projectType: 'application',
@@ -514,120 +514,6 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
   component: {
     ...nxComponentTestingPreset(__filename, { bundler: 'vite' }),
-  },
-});
-`
-    );
-
-    await migration(tree);
-
-    expect(tree.read('apps/app1-e2e/cypress.config.ts', 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
-      import { defineConfig } from 'cypress';
-
-      export default defineConfig({
-        component: {
-          ...nxComponentTestingPreset(__filename, { bundler: 'vite' }),
-          // Please ensure you use \`cy.origin()\` when navigating between domains and remove this option.
-          // See https://docs.cypress.io/app/references/migration-guide#Changes-to-cyorigin
-          injectDocumentDomain: true,
-        },
-      });
-      "
-    `);
-  });
-
-  it('should set the injectDocumentDomain property to true in the component config when it is not an object literal', async () => {
-    addProjectConfiguration(tree, 'app1-e2e', {
-      root: 'apps/app1-e2e',
-      projectType: 'application',
-      targets: {},
-    });
-    tree.write(
-      'apps/app1-e2e/cypress.config.ts',
-      `import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
-import { defineConfig } from 'cypress';
-
-export default defineConfig({
-  component: nxComponentTestingPreset(__filename, { bundler: 'vite' }),
-});
-`
-    );
-
-    await migration(tree);
-
-    expect(tree.read('apps/app1-e2e/cypress.config.ts', 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
-      import { defineConfig } from 'cypress';
-
-      export default defineConfig({
-        component: {
-          ...nxComponentTestingPreset(__filename, { bundler: 'vite' }),
-          // Please ensure you use \`cy.origin()\` when navigating between domains and remove this option.
-          // See https://docs.cypress.io/app/references/migration-guide#Changes-to-cyorigin
-          injectDocumentDomain: true,
-        },
-      });
-      "
-    `);
-  });
-
-  it('should replace the experimentalSkipDomainInjection property in the component config with injectDocumentDomain when it is set to an empty array', async () => {
-    addProjectConfiguration(tree, 'app1-e2e', {
-      root: 'apps/app1-e2e',
-      projectType: 'application',
-      targets: {},
-    });
-    tree.write(
-      'apps/app1-e2e/cypress.config.ts',
-      `import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
-import { defineConfig } from 'cypress';
-
-export default defineConfig({
-  component: {
-    ...nxComponentTestingPreset(__filename, { bundler: 'vite' }),
-    experimentalSkipDomainInjection: [],
-  },
-});
-`
-    );
-
-    await migration(tree);
-
-    expect(tree.read('apps/app1-e2e/cypress.config.ts', 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
-      import { defineConfig } from 'cypress';
-
-      export default defineConfig({
-        component: {
-          ...nxComponentTestingPreset(__filename, { bundler: 'vite' }),
-          // Please ensure you use \`cy.origin()\` when navigating between domains and remove this option.
-          // See https://docs.cypress.io/app/references/migration-guide#Changes-to-cyorigin
-          injectDocumentDomain: true,
-        },
-      });
-      "
-    `);
-  });
-
-  it('should remove the experimentalSkipDomainInjection property in the component config when it is set to a non-empty array', async () => {
-    addProjectConfiguration(tree, 'app1-e2e', {
-      root: 'apps/app1-e2e',
-      projectType: 'application',
-      targets: {},
-    });
-    tree.write(
-      'apps/app1-e2e/cypress.config.ts',
-      `import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
-import { defineConfig } from 'cypress';
-
-export default defineConfig({
-  component: {
-    ...nxComponentTestingPreset(__filename, { bundler: 'vite' }),
-    experimentalSkipDomainInjection: ['https://example.com'],
   },
 });
 `


### PR DESCRIPTION
## Current Behavior

The `set-inject-document-domain` migration updates the component configuration. This is incorrect since the `inject-document-domain` is not a property supported by the component configuration.

## Expected Behavior

The `set-inject-document-domain` migration should not update the component configuration.

## Related Issue(s)

Fixes #31610 
