### PR TITLE
docs(core): update package names

### DIFF
--- a/docs/shared/features/run-tasks.md
+++ b/docs/shared/features/run-tasks.md
@@ -218,7 +218,7 @@ However, you need to specify for which targets this ordering is important. In th
 }
 ```
 
-This means that if we run `nx build myreactapp`, Nx will first execute `build` on `modules-shared-ui` and `modules-products` before running `build` on `myreactapp`.
+This means that if we run `nx build myreactapp`, Nx will first execute `build` on `shared-ui` and `feat-products` before running `build` on `myreactapp`.
 
 You can define these task dependencies globally for your workspace in `nx.json` or individually in each project's `project.json` file.
 


### PR DESCRIPTION
## Summary

This pull request updates the documentation to reflect changes in project names for task dependencies. The documentation was referring to the `modules-shared-ui` and `modules-products` packages on the chart, but these packages are called differently.

![image](https://github.com/user-attachments/assets/c924ad1f-f13f-4b6c-9f0e-a95317e73987)
