### PR TITLE
docs(ci): add Bun to supported package managers list

### DIFF
--- a/docs/shared/recipes/ci-deployment.md
+++ b/docs/shared/recipes/ci-deployment.md
@@ -92,7 +92,7 @@ const { writeFileSync } = require('fs');
 
 async function main() {
   const outputDir = 'dist'; // You can replace this with the output directory you want to use
-  // Detect the package manager you are using (npm, yarn, pnpm)
+  // Detect the package manager you are using (npm, yarn, pnpm, bun)
   const pm = detectPackageManager();
   let projectGraph = readCachedProjectGraph();
   if (!projectGraph) {
@@ -137,7 +137,7 @@ Then to run the script, update your `package.json` to include the following:
 
 Now, you can run `npm run custom-build` to build your application and generate the `package.json` and lock file.
 
-You can replace _npm_ with _yarn_ or _pnpm_ if you are using those package managers.
+You can replace _npm_ with _yarn_, _pnpm_, or _bun_ if you are using those package managers.
 
 {% /tab %}
 


### PR DESCRIPTION
This PR adds bun to list of package managers that can be used on the CI deployment page.

Fixes #31431

##  Current Behavior

The CI deployment documentation at https://nx.dev/ci/recipes/other/ci-deployment only mentions npm, yarn, and pnpm as supported package managers. However, Bun is actually supported by Nx as shown in the PackageManager type
   definition which includes 'bun' as a valid option.

##  Expected Behavior

The documentation should accurately reflect all supported package managers, including Bun. Users should be aware that they can use Bun as their package manager when following the CI deployment recipes.

## Related Issue(s)

Fixes #31431