### PR TITLE
feat(js): support publishing with registryConfigKey when pnpm >=9.15.7 <10.0.0 || >=10.5.0

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -1,5 +1,6 @@
 import {
   detectPackageManager,
+  getPackageManagerCommand,
   ExecutorContext,
   readJsonFile,
 } from '@nx/devkit';
@@ -263,14 +264,9 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
    * to running from the package root directly), then special attention should be paid to the fact that npm/pnpm publish will nest its
    * JSON output under the name of the package in that case (and it would need to be handled below).
    */
+  const pmCommand = getPackageManagerCommand(pm);
   const publishCommandSegments = [
-    pm === 'bun'
-      ? // Unlike npm, bun publish does not support a custom registryConfigKey option
-        `bun publish --cwd="${packageRoot}" --json --registry="${registry}" --tag=${tag}`
-      : pm === 'pnpm'
-      ? // Unlike npm, pnpm publish does not support a custom registryConfigKey option, and will error on uncommitted changes by default if --no-git-checks is not set
-        `pnpm publish "${packageRoot}" --json --registry="${registry}" --tag=${tag} --no-git-checks`
-      : `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
+    pmCommand.publish(packageRoot, registry, registryConfigKey, tag),
   ];
 
   if (options.otp) {

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -11,7 +11,7 @@ import {
 } from 'yaml';
 import { rm } from 'node:fs/promises';
 import { dirname, join, relative } from 'path';
-import { gte, lt, parse } from 'semver';
+import { gte, lt, parse, satisfies } from 'semver';
 import { dirSync } from 'tmp';
 import { promisify } from 'util';
 
@@ -44,6 +44,12 @@ export interface PackageManagerCommands {
   run: (script: string, args?: string) => string;
   // Make this required once bun adds programatically support for reading config https://github.com/oven-sh/bun/issues/7140
   getRegistryUrl?: string;
+  publish: (
+    packageRoot: string,
+    registry: string,
+    registryConfigKey: string,
+    tag: string
+  ) => string;
 }
 
 /**
@@ -130,17 +136,28 @@ export function getPackageManagerCommand(
         getRegistryUrl: useBerry
           ? 'yarn config get npmRegistryServer'
           : 'yarn config get registry',
+        publish: (packageRoot, registry, registryConfigKey, tag) =>
+          `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
       };
     },
     pnpm: () => {
-      let modernPnpm: boolean, includeDoubleDashBeforeArgs: boolean;
+      let modernPnpm: boolean,
+        includeDoubleDashBeforeArgs: boolean,
+        allowRegistryConfigKey: boolean;
       try {
         const pnpmVersion = getPackageManagerVersion('pnpm', root);
         modernPnpm = gte(pnpmVersion, '6.13.0');
         includeDoubleDashBeforeArgs = lt(pnpmVersion, '7.0.0');
+        // Support for --@scope:registry was added in pnpm v10.5.0 and backported to v9.15.7.
+        // Versions >=10.0.0 and <10.5.0 do NOT support this CLI option.
+        allowRegistryConfigKey = satisfies(
+          pnpmVersion,
+          '>=9.15.7 <10.0.0 || >=10.5.0'
+        );
       } catch {
         modernPnpm = true;
         includeDoubleDashBeforeArgs = true;
+        allowRegistryConfigKey = false;
       }
 
       const isPnpmWorkspace = existsSync(join(root, 'pnpm-workspace.yaml'));
@@ -163,6 +180,10 @@ export function getPackageManagerCommand(
           }`,
         list: 'pnpm ls --depth 100',
         getRegistryUrl: 'pnpm config get registry',
+        publish: (packageRoot, registry, registryConfigKey, tag) =>
+          `pnpm publish "${packageRoot}" --json --"${
+            allowRegistryConfigKey ? registryConfigKey : 'registry'
+          }=${registry}" --tag=${tag} --no-git-checks`,
       };
     },
     npm: () => {
@@ -182,6 +203,8 @@ export function getPackageManagerCommand(
           `npm run ${script}${args ? ' -- ' + args : ''}`,
         list: 'npm ls',
         getRegistryUrl: 'npm config get registry',
+        publish: (packageRoot, registry, registryConfigKey, tag) =>
+          `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
       };
     },
     bun: () => {
@@ -197,6 +220,9 @@ export function getPackageManagerCommand(
         dlx: 'bunx',
         run: (script: string, args: string) => `bun run ${script} -- ${args}`,
         list: 'bun pm ls',
+        // Unlike npm, bun publish does not support a custom registryConfigKey option
+        publish: (packageRoot, registry, registryConfigKey, tag) =>
+          `bun publish --cwd="${packageRoot}" --json --registry="${registry}" --tag=${tag}`,
       };
     },
   };


### PR DESCRIPTION
### Description

This PR adds support for using a custom scoped registry with `pnpm` during the release process.

### Problem

When using `pnpm < v9.15.7`, and your workspace `.npmrc` includes a scoped registry config like:

```ini
@my-orga:registry=https://npm.pkg.my-orga.io/
//npm.pkg.my-orga.io/:_auth=${MY_NPM_APIKEY}
```

...attempting to override the registry dynamically (e.g., to use a local Verdaccio instance) like this:

```ts
await releasePublish({
  firstRelease: true,
  registry: 'http://localhost:4873',
});
```

...results in the following command:

```bash
pnpm publish "/Users/user/my-orga/packages/library" --json --registry="http://localhost:4873/" --tag=latest --no-git-checks
```

However, due to limitations documented in the [Nx release-publish executor](https://github.com/nrwl/nx/blob/d0d62846a24ffdb4be8506be49c5d4d68503c601/packages/js/src/executors/release-publish/release-publish.impl.ts#L272) and the [pnpm issue #9084](https://github.com/pnpm/pnpm/issues/9084), **`pnpm publish` does not allow overriding scoped registries via `--registry` CLI option**.

### Solution

Starting with `pnpm@10.5` and [patched on `pnpm@9.15.7`](https://github.com/pnpm/pnpm/releases/tag/v9.15.7), it’s possible to override a scoped registry via CLI using:

```bash
--@my-orga:registry=http://localhost:4873/
```

This PR updates the release process to support this by injecting `--@scope:registry` for recent pnpm versions like:
```bash
pnpm publish "/Users/user/org/packages/library" --json --@my-orga:registry="http://localhost:4873/" --tag=latest --no-git-checks
```