### PR TITLE
fix(vite): enable build watch mode by default for preview (#31604)

### DIFF
--- a/docs/generated/packages/vite/executors/preview-server.json
+++ b/docs/generated/packages/vite/executors/preview-server.json
@@ -27,6 +27,11 @@
         "type": "string",
         "description": "Path where the build artifacts are located. If not provided then it will be infered from the buildTarget executor options as outputPath",
         "x-completion-type": "directory"
+      },
+      "watch": {
+        "type": "boolean",
+        "description": "Enable re-building when files change. If not specified, watch mode will be enabled by default.",
+        "default": true
       }
     },
     "definitions": {},

--- a/packages/vite/src/executors/preview-server/preview-server.impl.ts
+++ b/packages/vite/src/executors/preview-server/preview-server.impl.ts
@@ -53,7 +53,13 @@ export async function* vitePreviewServerExecutor(
   );
 
   const { buildOptions, otherOptions: otherOptionsFromBuild } =
-    await getBuildExtraArgs(buildTargetOptions);
+    await getBuildExtraArgs({
+      ...buildTargetOptions,
+      ...{
+        // Enable watch mode by default for the build target.
+        watch: options.watch ?? true,
+      },
+    });
 
   const { previewOptions, otherOptions } = await getExtraArgs(
     options,

--- a/packages/vite/src/executors/preview-server/schema.d.ts
+++ b/packages/vite/src/executors/preview-server/schema.d.ts
@@ -2,4 +2,5 @@ export interface VitePreviewServerExecutorOptions {
   buildTarget: string;
   proxyConfig?: string;
   staticFilePath?: string;
+  watch?: boolean;
 }

--- a/packages/vite/src/executors/preview-server/schema.json
+++ b/packages/vite/src/executors/preview-server/schema.json
@@ -30,6 +30,11 @@
       "type": "string",
       "description": "Path where the build artifacts are located. If not provided then it will be infered from the buildTarget executor options as outputPath",
       "x-completion-type": "directory"
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Enable re-building when files change. If not specified, watch mode will be enabled by default.",
+      "default": true
     }
   },
   "definitions": {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1579,7 +1579,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.4.1
-        version: 29.7.0(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))
+        version: 29.7.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.9.2))
 
   graph/migrate:
     dependencies:
@@ -1592,7 +1592,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.4.1
-        version: 29.7.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.9.2))
+        version: 29.7.0(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))
 
   graph/project-details:
     dependencies:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx preview <app>` does not enable watch mode on the build.
This used to be the case until (I think) https://github.com/nrwl/nx/pull/20367

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx preview <app>` should also enable watch mode and rebuild on files change.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

FYI: I also had to apply [this config change](https://github.com/vitejs/vite/issues/19410#issuecomment-2655507784) for Vite 6 to unstuck from "Rebuilding project...". Maybe it's just my project, not sure but in any case those are 2 separate issues. 

Fixes #31604
