### PR TITLE
fix(core): ensure destination directories are created before copying files

### DIFF
--- a/scripts/copy-local-native.js
+++ b/scripts/copy-local-native.js
@@ -1,5 +1,6 @@
 //@ts-check
 const fs = require('fs');
+const path = require('path');
 const glob = require('tinyglobby');
 
 const p = process.argv[2];
@@ -9,5 +10,8 @@ const nativeFiles = glob.globSync(`packages/${p}/**/*.{node,wasm,js,mjs,cjs}`);
 console.log({ nativeFiles });
 
 nativeFiles.forEach((file) => {
-  fs.copyFileSync(file, `build/${file}`);
+  const destFile = `build/${file}`;
+  const destDir = path.dirname(destFile);
+  fs.mkdirSync(destDir, { recursive: true });
+  fs.copyFileSync(file, destFile);
 });


### PR DESCRIPTION
This PR updates the `copy-local-native.js` script to ensure destination directories are created before copying files.