### PR TITLE
feat(graph): enhance migration state management and introduce migration stopping functionality.

### DIFF
--- a/graph/client/src/app/console-migrate/migrate.app.tsx
+++ b/graph/client/src/app/console-migrate/migrate.app.tsx
@@ -106,6 +106,13 @@ export function MigrateApp({
     });
   };
 
+  const onStopMigration = (migration: MigrationDetailsWithId) => {
+    externalApiService.postEvent({
+      type: 'stop-migration',
+      payload: { migration },
+    });
+  };
+
   return (
     <MigrateUI
       migrations={migrations}
@@ -119,6 +126,7 @@ export function MigrateApp({
       onUndoMigration={onUndoMigration}
       onViewImplementation={onViewImplementation}
       onViewDocumentation={onViewDocumentation}
+      onStopMigration={onStopMigration}
     ></MigrateUI>
   );
 }

--- a/graph/migrate/src/lib/components/automatic-migration.tsx
+++ b/graph/migrate/src/lib/components/automatic-migration.tsx
@@ -8,6 +8,7 @@ import {
   currentMigrationHasChanges,
   currentMigrationHasFailed,
   currentMigrationHasSucceeded,
+  currentMigrationIsStopped,
 } from '../state/automatic/selectors';
 import { MigrationTimeline } from './migration-timeline';
 import { Interpreter } from 'xstate';
@@ -45,15 +46,13 @@ export function AutomaticMigration(props: {
     (migration) => migration.id === currentMigration?.id
   );
 
-  const currentMigrationRunning = useSelector(
-    props.actor,
-    (state) => state.context.currentMigrationRunning
-  );
-
   const currentMigrationFailed = useSelector(props.actor, (state) =>
     currentMigrationHasFailed(state.context)
   );
 
+  const isCurrentMigrationStopped = useSelector(props.actor, (state) =>
+    currentMigrationIsStopped(state.context)
+  );
   const currentMigrationSuccess = useSelector(props.actor, (state) =>
     currentMigrationHasSucceeded(state.context)
   );
@@ -75,15 +74,16 @@ export function AutomaticMigration(props: {
 
   return (
     <MigrationTimeline
+      actor={props.actor}
       migrations={props.migrations}
       nxConsoleMetadata={props.nxConsoleMetadata}
       currentMigrationIndex={
         currentMigrationIndex >= 0 ? currentMigrationIndex : 0
       }
-      currentMigrationRunning={currentMigrationRunning}
       currentMigrationFailed={currentMigrationFailed}
       currentMigrationSuccess={currentMigrationSuccess}
       currentMigrationHasChanges={currentMigrationChanges}
+      currentMigrationStopped={isCurrentMigrationStopped}
       isDone={isDone}
       isInit={isInit}
       onRunMigration={props.onRunMigration}

--- a/graph/migrate/src/lib/components/automatic-migration.tsx
+++ b/graph/migrate/src/lib/components/automatic-migration.tsx
@@ -6,9 +6,7 @@ import type { MigrationsJsonMetadata } from 'nx/src/command-line/migrate/migrate
 import { useSelector } from '@xstate/react';
 import {
   currentMigrationHasChanges,
-  currentMigrationHasFailed,
-  currentMigrationHasSucceeded,
-  currentMigrationIsStopped,
+  getCurrentMigrationType,
 } from '../state/automatic/selectors';
 import { MigrationTimeline } from './migration-timeline';
 import { Interpreter } from 'xstate';
@@ -46,15 +44,18 @@ export function AutomaticMigration(props: {
     (migration) => migration.id === currentMigration?.id
   );
 
-  const currentMigrationFailed = useSelector(props.actor, (state) =>
-    currentMigrationHasFailed(state.context)
+  const currentMigrationFailed = useSelector(
+    props.actor,
+    (state) => getCurrentMigrationType(state.context) === 'failed'
   );
 
-  const isCurrentMigrationStopped = useSelector(props.actor, (state) =>
-    currentMigrationIsStopped(state.context)
+  const isCurrentMigrationStopped = useSelector(
+    props.actor,
+    (state) => getCurrentMigrationType(state.context) === 'stopped'
   );
-  const currentMigrationSuccess = useSelector(props.actor, (state) =>
-    currentMigrationHasSucceeded(state.context)
+  const currentMigrationSuccess = useSelector(
+    props.actor,
+    (state) => getCurrentMigrationType(state.context) === 'successful'
   );
 
   const currentMigrationChanges = useSelector(props.actor, (state) =>

--- a/graph/migrate/src/lib/components/migration-card.tsx
+++ b/graph/migrate/src/lib/components/migration-card.tsx
@@ -28,11 +28,8 @@ import type {
 import { useSelector } from '@xstate/react';
 import {
   currentMigrationHasChanges,
-  isMigrationFailed,
+  getMigrationType,
   isMigrationRunning,
-  isMigrationSkipped,
-  isMigrationStopped,
-  isMigrationSuccessful,
 } from '../state/automatic/selectors';
 
 export interface MigrationCardHandle {
@@ -127,17 +124,21 @@ export const MigrationCard = forwardRef<
   const nextSteps =
     migrationResult?.type === 'successful' ? migrationResult.nextSteps : [];
 
-  const isSucceeded = useSelector(actor, (state) =>
-    isMigrationSuccessful(state.context, migration.id)
+  const isSucceeded = useSelector(
+    actor,
+    (state) => getMigrationType(state.context, migration.id) === 'successful'
   );
-  const isFailed = useSelector(actor, (state) =>
-    isMigrationFailed(state.context, migration.id)
+  const isFailed = useSelector(
+    actor,
+    (state) => getMigrationType(state.context, migration.id) === 'failed'
   );
-  const isSkipped = useSelector(actor, (state) =>
-    isMigrationSkipped(state.context, migration.id)
+  const isSkipped = useSelector(
+    actor,
+    (state) => getMigrationType(state.context, migration.id) === 'skipped'
   );
-  const isStopped = useSelector(actor, (state) =>
-    isMigrationStopped(state.context, migration.id)
+  const isStopped = useSelector(
+    actor,
+    (state) => getMigrationType(state.context, migration.id) === 'stopped'
   );
   const hasChanges = useSelector(actor, (state) =>
     currentMigrationHasChanges(state.context)

--- a/graph/migrate/src/lib/components/migration-card.tsx
+++ b/graph/migrate/src/lib/components/migration-card.tsx
@@ -20,6 +20,20 @@ import {
   type ReactNode,
 } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import type { Interpreter } from 'xstate';
+import type {
+  AutomaticMigrationState,
+  AutomaticMigrationEvents,
+} from '../state/automatic/types';
+import { useSelector } from '@xstate/react';
+import {
+  currentMigrationHasChanges,
+  isMigrationFailed,
+  isMigrationRunning,
+  isMigrationSkipped,
+  isMigrationStopped,
+  isMigrationSuccessful,
+} from '../state/automatic/selectors';
 
 export interface MigrationCardHandle {
   expand: () => void;
@@ -37,6 +51,7 @@ function convertUrlsToLinks(text: string): ReactNode[] {
       result.push(
         <a
           key={i}
+          rel="noopener noreferrer"
           href={urls[i - 1]}
           target="_blank"
           className="text-blue-500 hover:underline"
@@ -54,6 +69,13 @@ function convertUrlsToLinks(text: string): ReactNode[] {
 export const MigrationCard = forwardRef<
   MigrationCardHandle,
   {
+    actor: Interpreter<
+      AutomaticMigrationState,
+      any,
+      AutomaticMigrationEvents,
+      any,
+      any
+    >;
     migration: MigrationDetailsWithId;
     nxConsoleMetadata: MigrationsJsonMetadata;
     isSelected?: boolean;
@@ -62,11 +84,11 @@ export const MigrationCard = forwardRef<
     onFileClick: (file: Omit<FileChange, 'content'>) => void;
     onViewImplementation: () => void;
     onViewDocumentation: () => void;
-    forceIsRunning?: boolean;
     isExpanded?: boolean;
   }
 >(function MigrationCard(
   {
+    actor,
     migration,
     nxConsoleMetadata,
     isSelected,
@@ -75,7 +97,6 @@ export const MigrationCard = forwardRef<
     onFileClick,
     onViewImplementation,
     onViewDocumentation,
-    forceIsRunning,
     isExpanded: isExpandedProp,
   },
   ref
@@ -99,14 +120,31 @@ export const MigrationCard = forwardRef<
   }, [isExpandedProp]);
 
   const migrationResult = nxConsoleMetadata.completedMigrations?.[migration.id];
-  const succeeded = migrationResult?.type === 'successful';
-  const failed = migrationResult?.type === 'failed';
-  const skipped = migrationResult?.type === 'skipped';
-  const inProgress = nxConsoleMetadata.runningMigrations?.includes(
-    migration.id
-  );
 
-  const madeChanges = succeeded && !!migrationResult?.changedFiles.length;
+  const filesChanged =
+    migrationResult?.type === 'successful' ? migrationResult.changedFiles : [];
+
+  const nextSteps =
+    migrationResult?.type === 'successful' ? migrationResult.nextSteps : [];
+
+  const isSucceeded = useSelector(actor, (state) =>
+    isMigrationSuccessful(state.context, migration.id)
+  );
+  const isFailed = useSelector(actor, (state) =>
+    isMigrationFailed(state.context, migration.id)
+  );
+  const isSkipped = useSelector(actor, (state) =>
+    isMigrationSkipped(state.context, migration.id)
+  );
+  const isStopped = useSelector(actor, (state) =>
+    isMigrationStopped(state.context, migration.id)
+  );
+  const hasChanges = useSelector(actor, (state) =>
+    currentMigrationHasChanges(state.context)
+  );
+  const isRunning = useSelector(actor, (state) =>
+    isMigrationRunning(state.context, migration.id)
+  );
 
   const renderSelectBox = onSelect && isSelected !== undefined;
 
@@ -130,9 +168,9 @@ export const MigrationCard = forwardRef<
                 value={migration.id}
                 type="checkbox"
                 className={`h-4 w-4 ${
-                  succeeded
+                  isSucceeded
                     ? 'accent-green-600 dark:accent-green-500'
-                    : failed
+                    : isFailed
                     ? 'accent-red-600 dark:accent-red-500'
                     : 'accent-blue-500 dark:accent-sky-500'
                 }`}
@@ -169,10 +207,10 @@ export const MigrationCard = forwardRef<
 
         <div className="flex items-center gap-2">
           {' '}
-          {succeeded && !madeChanges && (
+          {isSucceeded && !hasChanges && (
             <Pill text="No changes made" color="green" />
           )}
-          {succeeded && madeChanges && (
+          {isSucceeded && hasChanges && (
             <div>
               <div
                 className="cursor-pointer"
@@ -182,38 +220,43 @@ export const MigrationCard = forwardRef<
               >
                 <Pill
                   key="changes"
-                  text={`${migrationResult?.changedFiles.length} changes`}
+                  text={`${filesChanged.length} changes`}
                   color="green"
                 />
               </div>
             </div>
           )}
-          {failed && (
+          {isFailed && (
             <div>
               <Pill text="Failed" color="red" />
             </div>
           )}
-          {skipped && (
+          {isSkipped && (
             <div>
               <Pill text="Skipped" color="grey" />
             </div>
           )}
-          {(onRunMigration || forceIsRunning) && (
+          {isStopped && (
+            <div>
+              <Pill text="Stopped" color="yellow" />
+            </div>
+          )}
+          {onRunMigration && !isStopped && (
             <span
               className={`rounded-md p-1 text-sm ring-1 ring-inset transition-colors ${
-                succeeded
+                isSucceeded
                   ? 'bg-green-50 text-green-700 ring-green-200 hover:bg-green-100 dark:bg-green-900/20 dark:text-green-500 dark:ring-green-900/30 dark:hover:bg-green-900/30'
-                  : failed
+                  : isFailed
                   ? 'bg-red-50 text-red-700 ring-red-200 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-500 dark:ring-red-900/30 dark:hover:bg-red-900/30'
                   : 'bg-inherit text-slate-600 ring-slate-400/40 hover:bg-slate-200 dark:text-slate-300 dark:ring-slate-400/30 dark:hover:bg-slate-700/60'
               }`}
             >
-              {inProgress || forceIsRunning ? (
+              {isRunning ? (
                 <ArrowPathIcon
                   className="h-6 w-6 animate-spin cursor-not-allowed text-blue-500"
                   aria-label="Migration in progress"
                 />
-              ) : !succeeded && !failed ? (
+              ) : !isSucceeded && !isFailed && !isStopped ? (
                 <PlayIcon
                   onClick={onRunMigration}
                   className="h-6 w-6 !cursor-pointer"
@@ -230,14 +273,14 @@ export const MigrationCard = forwardRef<
           )}
         </div>
       </div>
-      {succeeded && migrationResult?.nextSteps?.length ? (
+      {isSucceeded && nextSteps?.length ? (
         <div className="pt-2">
           <div className="my-2 border-t border-slate-200 dark:border-slate-700/60" />
           <span className="pb-2 text-sm font-bold">
             More Information & Next Steps
           </span>
           <ul className="list-inside list-disc pl-2">
-            {migrationResult?.nextSteps.map((step, idx) => (
+            {nextSteps.map((step, idx) => (
               <li key={idx} className="text-sm">
                 {convertUrlsToLinks(step)}
               </li>
@@ -255,7 +298,7 @@ export const MigrationCard = forwardRef<
           <CodeBracketIcon className="h-4 w-4" />
           View Source
         </button>
-        {failed && (
+        {isFailed && (
           <button
             className="flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
             onClick={() => {
@@ -266,7 +309,7 @@ export const MigrationCard = forwardRef<
             {isExpanded ? 'Hide Errors' : 'View Errors'}
           </button>
         )}
-        {succeeded && madeChanges && (
+        {isSucceeded && hasChanges && (
           <button
             className="flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
             onClick={() => {
@@ -279,7 +322,7 @@ export const MigrationCard = forwardRef<
         )}
       </div>
       <AnimatePresence>
-        {failed && isExpanded && (
+        {isFailed && isExpanded && (
           <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: isExpanded ? 'auto' : 0 }}
@@ -287,13 +330,27 @@ export const MigrationCard = forwardRef<
             transition={{ duration: 0.3, ease: 'easeInOut' }}
             className="flex overflow-hidden pt-2"
           >
-            <pre>{migrationResult?.error}</pre>
+            <pre>{(migrationResult as any)?.error}</pre>
           </motion.div>
         )}
       </AnimatePresence>
 
       <AnimatePresence>
-        {succeeded && madeChanges && isExpanded && (
+        {isStopped && isExpanded && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: isExpanded ? 'auto' : 0 }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+            className="flex overflow-hidden pt-2"
+          >
+            <pre>{(migrationResult as any)?.error}</pre>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {isSucceeded && hasChanges && isExpanded && (
           <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: isExpanded ? 'auto' : 0 }}
@@ -304,7 +361,7 @@ export const MigrationCard = forwardRef<
             <div className="my-2 border-t border-slate-200 dark:border-slate-700/60"></div>
             <span className="pb-2 text-sm font-bold">File Changes</span>
             <ul className="flex flex-col gap-2">
-              {migrationResult?.changedFiles.map((file) => {
+              {filesChanged.map((file) => {
                 return (
                   <li
                     className="cursor-pointer text-sm hover:underline"

--- a/graph/migrate/src/lib/components/migration-list.tsx
+++ b/graph/migrate/src/lib/components/migration-list.tsx
@@ -7,8 +7,20 @@ import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
 import { PlayIcon } from '@heroicons/react/24/outline';
 import { useCallback, useMemo, useState } from 'react';
 import { MigrationCard } from './migration-card';
+import type { Interpreter } from 'xstate';
+import type {
+  AutomaticMigrationState,
+  AutomaticMigrationEvents,
+} from '../state/automatic/types';
 
 export function MigrationList(props: {
+  actor: Interpreter<
+    AutomaticMigrationState,
+    any,
+    AutomaticMigrationEvents,
+    any,
+    any
+  >;
   migrations: MigrationDetailsWithId[];
   nxConsoleMetadata: MigrationsJsonMetadata;
   onRunMigration: (migration: MigrationDetailsWithId) => void;
@@ -133,6 +145,7 @@ export function MigrationList(props: {
       <div>
         {props.migrations.map((migration) => (
           <MigrationCard
+            actor={props.actor}
             key={migration.id}
             migration={migration}
             nxConsoleMetadata={props.nxConsoleMetadata}

--- a/graph/migrate/src/lib/components/migration-timeline.tsx
+++ b/graph/migrate/src/lib/components/migration-timeline.tsx
@@ -27,10 +27,7 @@ import type {
 } from '../state/automatic/types';
 import { useSelector } from '@xstate/react';
 import {
-  isMigrationFailed,
-  isMigrationSkipped,
-  isMigrationStopped,
-  isMigrationSuccessful,
+  getMigrationType,
   isMigrationRunning,
 } from '../state/automatic/selectors';
 
@@ -599,21 +596,25 @@ function MigrationStateCircle({
   let textColor = '';
   let Icon = null;
 
-  const isSkipped = useSelector(actor, (state) =>
-    isMigrationSkipped(state.context, migration.id)
+  const isSkipped = useSelector(
+    actor,
+    (state) => getMigrationType(state.context, migration.id) === 'skipped'
   );
 
   const isRunning = useSelector(actor, (state) =>
     isMigrationRunning(state.context, migration.id)
   );
-  const isStopped = useSelector(actor, (state) =>
-    isMigrationStopped(state.context, migration.id)
+  const isStopped = useSelector(
+    actor,
+    (state) => getMigrationType(state.context, migration.id) === 'stopped'
   );
-  const isFailed = useSelector(actor, (state) =>
-    isMigrationFailed(state.context, migration.id)
+  const isFailed = useSelector(
+    actor,
+    (state) => getMigrationType(state.context, migration.id) === 'failed'
   );
-  const isSuccess = useSelector(actor, (state) =>
-    isMigrationSuccessful(state.context, migration.id)
+  const isSuccess = useSelector(
+    actor,
+    (state) => getMigrationType(state.context, migration.id) === 'successful'
   );
   // Check if this migration is in the completed migrations
 

--- a/graph/migrate/src/lib/components/migration-timeline.tsx
+++ b/graph/migrate/src/lib/components/migration-timeline.tsx
@@ -20,15 +20,36 @@ import { useEffect, useState, useRef } from 'react';
 import { MigrationCard, MigrationCardHandle } from './migration-card';
 import { Collapsible } from '@nx/graph/ui-common';
 import { twMerge } from 'tailwind-merge';
+import type { Interpreter } from 'xstate';
+import type {
+  AutomaticMigrationState,
+  AutomaticMigrationEvents,
+} from '../state/automatic/types';
+import { useSelector } from '@xstate/react';
+import {
+  isMigrationFailed,
+  isMigrationSkipped,
+  isMigrationStopped,
+  isMigrationSuccessful,
+  isMigrationRunning,
+} from '../state/automatic/selectors';
 
 export interface MigrationTimelineProps {
+  actor: Interpreter<
+    AutomaticMigrationState,
+    any,
+    AutomaticMigrationEvents,
+    any,
+    any
+  >;
+
   migrations: MigrationDetailsWithId[];
   nxConsoleMetadata: MigrationsJsonMetadata;
   currentMigrationIndex: number;
-  currentMigrationRunning?: boolean;
   currentMigrationFailed?: boolean;
   currentMigrationSuccess?: boolean;
   currentMigrationHasChanges?: boolean;
+  currentMigrationStopped?: boolean;
   isDone?: boolean;
   isInit: boolean;
   onRunMigration: (migration: MigrationDetailsWithId) => void;
@@ -45,13 +66,14 @@ export interface MigrationTimelineProps {
 }
 
 export function MigrationTimeline({
+  actor,
   migrations,
   nxConsoleMetadata,
   currentMigrationIndex,
-  currentMigrationRunning,
   currentMigrationFailed,
   currentMigrationSuccess,
   currentMigrationHasChanges,
+  currentMigrationStopped,
   onRunMigration,
   onSkipMigration,
   onUndoMigration,
@@ -92,10 +114,26 @@ export function MigrationTimeline({
 
   // Auto-expand when entering a failed migration or requires review
   useEffect(() => {
-    if (currentMigrationFailed || currentMigrationHasChanges) {
+    if (
+      currentMigrationFailed ||
+      currentMigrationHasChanges ||
+      currentMigrationStopped
+    ) {
       toggleMigrationExpanded(currentMigration.id, true);
+    } else if (
+      !currentMigrationFailed &&
+      !currentMigrationHasChanges &&
+      !currentMigrationStopped
+    ) {
+      // Collapse the migration when it's no longer failed, stopped, or needing review
+      toggleMigrationExpanded(currentMigration.id, false);
     }
-  }, [currentMigrationHasChanges, currentMigrationFailed, currentMigration]);
+  }, [
+    currentMigrationHasChanges,
+    currentMigrationFailed,
+    currentMigration,
+    currentMigrationStopped,
+  ]);
 
   const toggleMigrationExpanded = (migrationId: string, state?: boolean) => {
     setExpandedMigrations((prev) => ({
@@ -167,8 +205,8 @@ export function MigrationTimeline({
               {visiblePastMigrations.map((migration) => (
                 <div key={migration.id} className="relative mb-6 w-full">
                   <MigrationStateCircle
+                    actor={actor}
                     migration={migration}
-                    nxConsoleMetadata={nxConsoleMetadata}
                     onClick={() => toggleMigrationExpanded(migration.id)}
                   />
 
@@ -227,6 +265,7 @@ export function MigrationTimeline({
                       className="mt-2 w-full rounded-md border border-slate-300 p-3"
                     >
                       <MigrationCard
+                        actor={actor}
                         migration={migration}
                         isExpanded={expandedMigrations[migration.id]}
                         nxConsoleMetadata={nxConsoleMetadata}
@@ -273,13 +312,12 @@ export function MigrationTimeline({
             {/* TODO: Change this to be a clickable element li, button etc... */}
             <div>
               <MigrationStateCircle
+                actor={actor}
                 migration={migrations[currentMigrationIndex]}
-                nxConsoleMetadata={nxConsoleMetadata}
                 needsAttention={
                   currentMigrationHasChanges &&
                   !expandedMigrations[currentMigration.id]
                 }
-                isRunning={currentMigrationRunning}
                 onClick={() => toggleMigrationExpanded(currentMigration.id)}
               />
               <div
@@ -372,12 +410,12 @@ export function MigrationTimeline({
                 >
                   {/* Migration Card */}
                   <MigrationCard
+                    actor={actor}
                     ref={currentMigrationRef}
                     migration={currentMigration}
                     isExpanded={expandedMigrations[currentMigration.id]}
                     nxConsoleMetadata={nxConsoleMetadata}
                     onFileClick={(file) => onFileClick(currentMigration, file)}
-                    forceIsRunning={currentMigrationRunning}
                     onViewImplementation={() =>
                       onViewImplementation(currentMigration)
                     }
@@ -396,8 +434,8 @@ export function MigrationTimeline({
               {visibleFutureMigrations.map((migration) => (
                 <div key={migration.id} className="relative mt-6 w-full">
                   <MigrationStateCircle
+                    actor={actor}
                     migration={migration}
-                    nxConsoleMetadata={nxConsoleMetadata}
                     onClick={() => toggleMigrationExpanded(migration.id)}
                   />
 
@@ -452,6 +490,7 @@ export function MigrationTimeline({
                       className="mt-2 w-full rounded-md border border-slate-300/50 p-3"
                     >
                       <MigrationCard
+                        actor={actor}
                         migration={migration}
                         nxConsoleMetadata={nxConsoleMetadata}
                         isExpanded={expandedMigrations[migration.id]}
@@ -538,17 +577,21 @@ function TimelineButton({ icon: Icon, onClick }: TimelineButtonProps) {
 }
 
 interface MigrationStateCircleProps {
+  actor: Interpreter<
+    AutomaticMigrationState,
+    any,
+    AutomaticMigrationEvents,
+    any,
+    any
+  >;
   migration: MigrationDetailsWithId;
-  nxConsoleMetadata: MigrationsJsonMetadata;
-  isRunning?: boolean;
   needsAttention?: boolean;
   onClick: () => void;
 }
 
 function MigrationStateCircle({
+  actor,
   migration,
-  nxConsoleMetadata,
-  isRunning,
   needsAttention,
   onClick,
 }: MigrationStateCircleProps) {
@@ -556,26 +599,41 @@ function MigrationStateCircle({
   let textColor = '';
   let Icon = null;
 
+  const isSkipped = useSelector(actor, (state) =>
+    isMigrationSkipped(state.context, migration.id)
+  );
+
+  const isRunning = useSelector(actor, (state) =>
+    isMigrationRunning(state.context, migration.id)
+  );
+  const isStopped = useSelector(actor, (state) =>
+    isMigrationStopped(state.context, migration.id)
+  );
+  const isFailed = useSelector(actor, (state) =>
+    isMigrationFailed(state.context, migration.id)
+  );
+  const isSuccess = useSelector(actor, (state) =>
+    isMigrationSuccessful(state.context, migration.id)
+  );
   // Check if this migration is in the completed migrations
-  const completedMigration =
-    nxConsoleMetadata.completedMigrations?.[migration.id];
 
-  const isSkipped = completedMigration?.type === 'skipped';
-  const isError = completedMigration?.type === 'failed';
-  const isSuccess = completedMigration?.type === 'successful';
-
-  if (isSkipped) {
-    bgColor = 'bg-slate-300';
-    textColor = 'text-slate-700';
-    Icon = MinusIcon;
-  } else if (isError) {
-    bgColor = 'bg-red-500';
-    textColor = 'text-white';
-    Icon = ExclamationCircleIcon;
-  } else if (isRunning) {
+  if (isRunning) {
+    // Prioritize running state - show spinner even if metadata still shows stopped
     bgColor = 'bg-blue-500';
     textColor = 'text-white';
     Icon = ClockIcon;
+  } else if (isSkipped) {
+    bgColor = 'bg-slate-300';
+    textColor = 'text-slate-700';
+    Icon = MinusIcon;
+  } else if (isFailed) {
+    bgColor = 'bg-red-500';
+    textColor = 'text-white';
+    Icon = ExclamationCircleIcon;
+  } else if (isStopped) {
+    bgColor = 'bg-yellow-500';
+    textColor = 'text-white';
+    Icon = XMarkIcon;
   } else if (isSuccess) {
     bgColor = 'bg-green-500';
     textColor = 'text-white';

--- a/graph/migrate/src/lib/migrate.stories.tsx
+++ b/graph/migrate/src/lib/migrate.stories.tsx
@@ -315,3 +315,82 @@ export const PendingApproval: Story = {
     },
   },
 };
+
+export const MigrationStopped: Story = {
+  args: {
+    currentMigrationId: 'migration-2',
+    migrations: [
+      {
+        id: 'migration-1',
+        name: 'migration-1',
+        description: 'This is a test migration',
+        version: '1.0.0',
+        package: 'nx',
+        implementation: './src/migrations/migration-1.ts',
+      },
+      {
+        id: 'migration-2',
+        name: 'migration-2',
+        description: 'This is a test migration',
+        version: '1.0.1',
+        package: '@nx/react',
+        implementation: './src/migrations/migration-2.ts',
+      },
+      {
+        id: 'migration-3',
+        name: 'migration-3',
+        description: 'Migrate 3',
+        version: '1.0.1',
+        package: '@nx/react',
+        implementation: './src/migrations/migration-3.ts',
+      },
+    ],
+    nxConsoleMetadata: {
+      completedMigrations: {
+        'migration-1': {
+          name: 'migration-1',
+          type: 'successful',
+          changedFiles: [],
+          ref: '123',
+          nextSteps: [],
+        },
+        'migration-2': {
+          name: 'migration-2',
+          type: 'stopped',
+          error: 'Migration was stopped by the user',
+        },
+      },
+      targetVersion: '20.3.2',
+    },
+    onRunMigration: (migration) => {
+      console.log('run migration', migration);
+    },
+    onRunMany: (migrations, configuration) => {
+      console.log('run many migrations', migrations, configuration);
+    },
+    onSkipMigration: (migration) => {
+      console.log('skip migration', migration);
+    },
+    onUndoMigration: (migration) => {
+      console.log('undo migration', migration);
+    },
+    onFileClick: (migration, file) => {
+      console.log('file click', migration, file);
+    },
+    onViewImplementation: (migration) => {
+      console.log('view implementation', migration);
+    },
+    onViewDocumentation: (migration) => {
+      console.log('view documentation', migration);
+    },
+    onCancel: () => {
+      console.log('cancel');
+    },
+    onFinish: (squash: boolean) => {
+      console.log('finished', squash);
+    },
+    onStopMigration: (migration) => {
+      console.log('stop migration', migration);
+    },
+  },
+};

--- a/graph/migrate/src/lib/migrate.tsx
+++ b/graph/migrate/src/lib/migrate.tsx
@@ -17,10 +17,7 @@ import {
   MigrationSettingsPanel,
   AutomaticMigration,
 } from './components';
-import {
-  currentMigrationIsStopped,
-  currentMigrationHasFailed,
-} from './state/automatic/selectors';
+import { getCurrentMigrationType } from './state/automatic/selectors';
 
 export interface MigrateUIProps {
   migrations: MigrationDetailsWithId[];
@@ -86,11 +83,13 @@ export function MigrateUI(props: MigrateUIProps) {
   const isDone = useSelector(actor, (state) => state.matches('done'));
   const isInit = useSelector(actor, (state) => state.matches('init'));
   const isRunning = useSelector(actor, (state) => state.matches('running'));
-  const isCurrentMigrationStopped = useSelector(actor, (state) =>
-    currentMigrationIsStopped(state.context)
+  const isCurrentMigrationStopped = useSelector(
+    actor,
+    (state) => getCurrentMigrationType(state.context) === 'stopped'
   );
-  const isCurrentMigrationFailed = useSelector(actor, (state) =>
-    currentMigrationHasFailed(state.context)
+  const isCurrentMigrationFailed = useSelector(
+    actor,
+    (state) => getCurrentMigrationType(state.context) === 'failed'
   );
 
   const isNeedReview = useSelector(actor, (state) =>

--- a/graph/migrate/src/lib/migrate.tsx
+++ b/graph/migrate/src/lib/migrate.tsx
@@ -17,6 +17,10 @@ import {
   MigrationSettingsPanel,
   AutomaticMigration,
 } from './components';
+import {
+  currentMigrationIsStopped,
+  currentMigrationHasFailed,
+} from './state/automatic/selectors';
 
 export interface MigrateUIProps {
   migrations: MigrationDetailsWithId[];
@@ -37,6 +41,7 @@ export interface MigrateUIProps {
   ) => void;
   onSkipMigration: (migration: MigrationDetailsWithId) => void;
   onUndoMigration: (migration: MigrationDetailsWithId) => void;
+  onStopMigration: (migration: MigrationDetailsWithId) => void;
   onCancel: () => void;
   onFinish: (squashCommits: boolean) => void;
   onFileClick: (
@@ -49,7 +54,6 @@ export interface MigrateUIProps {
 
 export enum PrimaryAction {
   RunMigrations = 'Run Migrations',
-  PauseMigrations = 'Pause Migrations',
   ApproveChanges = 'Approve Changes to Continue',
   FinishWithoutSquashingCommits = 'Finish without squashing commits',
   FinishSquashingCommits = 'Finish (squash commits)',
@@ -74,9 +78,20 @@ export function MigrateUI(props: MigrateUIProps) {
       },
     },
   });
+  const currentMigration = useSelector(
+    actor,
+    (state) => state.context.currentMigration
+  );
+
   const isDone = useSelector(actor, (state) => state.matches('done'));
   const isInit = useSelector(actor, (state) => state.matches('init'));
   const isRunning = useSelector(actor, (state) => state.matches('running'));
+  const isCurrentMigrationStopped = useSelector(actor, (state) =>
+    currentMigrationIsStopped(state.context)
+  );
+  const isCurrentMigrationFailed = useSelector(actor, (state) =>
+    currentMigrationHasFailed(state.context)
+  );
 
   const isNeedReview = useSelector(actor, (state) =>
     state.matches('needsReview')
@@ -108,40 +123,43 @@ export function MigrateUI(props: MigrateUIProps) {
   useEffect(() => {
     if (
       (primaryAction === PrimaryAction.ApproveChanges ||
-        primaryAction === PrimaryAction.RunMigrations ||
-        primaryAction === PrimaryAction.PauseMigrations) &&
+        primaryAction === PrimaryAction.RunMigrations) &&
       !isInit
     ) {
       setPrimaryAction(
-        isRunning
-          ? PrimaryAction.PauseMigrations
-          : isNeedReview
+        isNeedReview && !isCurrentMigrationFailed
           ? PrimaryAction.ApproveChanges
           : PrimaryAction.RunMigrations
       );
     }
-  }, [isRunning, primaryAction, isInit, isNeedReview]);
+  }, [
+    isRunning,
+    primaryAction,
+    isInit,
+    isNeedReview,
+    isCurrentMigrationFailed,
+  ]);
 
-  const handlePauseResume = () => {
-    if (isRunning) {
-      actor.send({ type: 'pause' });
-    } else {
-      actor.send({ type: 'startRunning' });
-    }
+  const handleStartMigration = () => {
+    actor.send({ type: 'startRunning' });
   };
 
   const handlePrimaryActionSelection = () => {
-    if (
-      primaryAction === PrimaryAction.RunMigrations ||
-      primaryAction === PrimaryAction.PauseMigrations
-    ) {
-      handlePauseResume();
+    if (primaryAction === PrimaryAction.RunMigrations) {
+      handleStartMigration();
     } else if (
       primaryAction === PrimaryAction.FinishWithoutSquashingCommits ||
       primaryAction === PrimaryAction.FinishSquashingCommits
     ) {
       props.onFinish(primaryAction === PrimaryAction.FinishSquashingCommits);
     }
+  };
+
+  const handleStopMigration = () => {
+    if (!currentMigration) {
+      return;
+    }
+    props.onStopMigration(currentMigration);
   };
 
   if (isInit) {
@@ -197,30 +215,43 @@ export function MigrateUI(props: MigrateUIProps) {
         />
       </div>
       <div className="bottom-0 flex shrink-0 justify-end gap-2 bg-transparent py-4">
+        <button
+          onClick={props.onCancel}
+          type="button"
+          className="flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
+        >
+          Cancel
+        </button>
         <div className="flex gap-2">
           <button
-            onClick={props.onCancel}
+            onClick={handleStopMigration}
+            disabled={isCurrentMigrationStopped || isNeedReview}
             type="button"
-            className="flex w-full items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
+            className={`flex items-center rounded-md border px-4 py-2 text-sm font-medium shadow-sm ${
+              isCurrentMigrationStopped || isNeedReview
+                ? 'cursor-not-allowed border-gray-300 bg-gray-300 text-gray-500 dark:border-gray-600 dark:bg-gray-600 dark:text-gray-400'
+                : 'border-red-300 bg-red-500 text-white hover:bg-red-600 dark:border-red-600 dark:bg-red-600 hover:dark:bg-red-700'
+            }`}
           >
-            Cancel
+            Stop Migration
           </button>
+
           <div className="group flex">
             <button
               onClick={handlePrimaryActionSelection}
               type="button"
               title={primaryAction}
               disabled={isNeedReview}
-              className="whitespace-nowrap rounded-l-md border border-blue-700 bg-blue-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-600 disabled:cursor-not-allowed disabled:border-blue-400 disabled:bg-blue-400 disabled:opacity-50 dark:border-blue-700 dark:bg-blue-600 dark:text-white hover:dark:bg-blue-700"
+              className="whitespace-nowrap rounded-l-md border border-blue-700 bg-blue-500 px-4 py-2 text-sm font-medium text-white shadow-sm enabled:hover:bg-blue-600 disabled:cursor-not-allowed disabled:border-blue-400 disabled:bg-blue-400 disabled:opacity-50 dark:border-blue-700 dark:bg-blue-600 dark:text-white enabled:hover:dark:bg-blue-700"
             >
               {primaryAction}
             </button>
             <div className="relative flex">
               <button
                 type="button"
-                onClick={() => setIsOpen((prev) => !prev)}
                 disabled={isNeedReview}
-                className="border-l-1 flex items-center rounded-r-md border border-blue-700 bg-blue-500 px-2 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 disabled:cursor-not-allowed disabled:border-blue-400 disabled:bg-blue-400 disabled:opacity-50 dark:border-blue-700 dark:bg-blue-700 dark:text-white hover:dark:bg-blue-800"
+                onClick={() => setIsOpen((prev) => !prev)}
+                className="border-l-1 flex items-center rounded-r-md border border-blue-700 bg-blue-500 px-2 py-2 text-sm font-medium text-white shadow-sm enabled:hover:bg-blue-700 disabled:cursor-not-allowed disabled:border-blue-400 disabled:bg-blue-400 disabled:opacity-50 dark:border-blue-700 dark:bg-blue-700 dark:text-white enabled:hover:dark:bg-blue-800"
               >
                 <ChevronDownIcon className="h-4 w-4" />
               </button>
@@ -233,52 +264,25 @@ export function MigrateUI(props: MigrateUIProps) {
                 }}
               >
                 <ul className="p-2">
-                  {!isDone && (
-                    <>
-                      {' '}
-                      {!isRunning && (
-                        <li
-                          className="flex cursor-pointer items-center gap-2 p-2 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
-                          onClick={() => {
-                            setPrimaryAction(PrimaryAction.RunMigrations);
-                            setIsOpen(false);
-                          }}
-                        >
-                          <span
-                            className={
-                              primaryAction === PrimaryAction.RunMigrations
-                                ? 'inline-block'
-                                : 'opacity-0'
-                            }
-                          >
-                            <CheckIcon className="h-4 w-4" />
-                          </span>
-                          <span>{'Run Migrations'}</span>
-                        </li>
-                      )}
-                      {isRunning && (
-                        <li
-                          className="flex cursor-pointer items-center gap-2 p-2 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
-                          onClick={() => {
-                            setPrimaryAction(PrimaryAction.PauseMigrations);
-                            setIsOpen(false);
-                          }}
-                        >
-                          <span
-                            className={
-                              primaryAction === PrimaryAction.PauseMigrations
-                                ? 'inline-block'
-                                : 'opacity-0'
-                            }
-                          >
-                            <CheckIcon className="h-4 w-4" />
-                          </span>
-                          <span>{'Pause Migrations'}</span>
-                        </li>
-                      )}
-                      <div className="my-1 h-0.5 w-full bg-slate-300/30" />
-                    </>
-                  )}
+                  <li
+                    className="flex cursor-pointer items-center gap-2 p-2 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
+                    onClick={() => {
+                      setPrimaryAction(PrimaryAction.RunMigrations);
+                      setIsOpen(false);
+                    }}
+                  >
+                    <span
+                      className={
+                        primaryAction === PrimaryAction.RunMigrations
+                          ? 'inline-block'
+                          : 'opacity-0'
+                      }
+                    >
+                      <CheckIcon className="h-4 w-4" />
+                    </span>
+                    <span>{'Run Migrations'}</span>
+                  </li>
+                  <div className="my-1 h-0.5 w-full bg-slate-300/30" />
                   <li
                     className="flex cursor-pointer items-center gap-2 p-2 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700"
                     onClick={() => {

--- a/graph/migrate/src/lib/state/automatic/guards.ts
+++ b/graph/migrate/src/lib/state/automatic/guards.ts
@@ -1,33 +1,32 @@
 import { AutomaticMigrationState } from './types';
 import {
+  getCurrentMigrationType,
   currentMigrationCanLeaveReview,
   currentMigrationHasChanges,
-  currentMigrationHasFailed,
-  currentMigrationHasSucceeded,
-  currentMigrationIsSkipped,
   currentMigrationIsRunning,
 } from './selectors';
 
 export const guards = {
   canStartRunningCurrentMigration: (ctx: AutomaticMigrationState) => {
+    const type = getCurrentMigrationType(ctx);
     return (
       !!ctx.currentMigration &&
       !currentMigrationIsRunning(ctx) &&
-      !currentMigrationIsSkipped(ctx) &&
+      !(type === 'skipped') &&
       // Allow running if migration is not completed
       // stopped migrations can be restarted via the UI, Nx-console will handle the state change
-      !currentMigrationHasFailed(ctx) &&
+      !(type === 'failed') &&
       !currentMigrationHasChanges(ctx)
     );
   },
 
   currentMigrationIsDone: (ctx: AutomaticMigrationState) => {
+    const type = getCurrentMigrationType(ctx);
     return (
       !!ctx.currentMigration &&
       !currentMigrationIsRunning(ctx) &&
-      ((currentMigrationHasSucceeded(ctx) &&
-        currentMigrationCanLeaveReview(ctx)) ||
-        currentMigrationIsSkipped(ctx))
+      ((type === 'successful' && currentMigrationCanLeaveReview(ctx)) ||
+        type === 'skipped')
     );
   },
 

--- a/graph/migrate/src/lib/state/automatic/machine.spec.ts
+++ b/graph/migrate/src/lib/state/automatic/machine.spec.ts
@@ -1,365 +1,363 @@
-/* eslint-disable @nx/enforce-module-boundaries */
-// nx-ignore-next-line
-import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
-// nx-ignore-next-line
-import {
-  addFailedMigration,
-  addSkippedMigration,
-  addSuccessfulMigration,
-  MigrationsJsonMetadata,
-} from 'nx/src/command-line/migrate/migrate-ui-api';
-/* eslint-enable @nx/enforce-module-boundaries */
-
 import { interpret } from 'xstate';
 import { machine } from './machine';
+/* eslint-disable @nx/enforce-module-boundaries */
+import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
+import type { MigrationsJsonMetadata } from 'nx/src/command-line/migrate/migrate-ui-api';
+/* eslint-enable @nx/enforce-module-boundaries */
+const makeMigration = (id: string): MigrationDetailsWithId => ({
+  id,
+  name: `migration-${id}`,
+  version: '1.0.0',
+  package: 'test',
+  description: 'Test migration for ' + id,
+  implementation: './migrations/' + id + '.js',
+});
 
-const dummyMigrations: MigrationDetailsWithId[] = [
-  {
-    id: 'migration-1',
-    name: 'migration-1',
-    description: 'This is a migration that does a thing labeled with one.',
-    version: '1.0.0',
-    package: 'nx',
-    implementation: '/path/to/migration-1',
-  },
-  {
-    id: 'migration-2',
-    name: 'migration-2',
-    description:
-      'Funnily, this is another migration that does a thing labeled with two.',
-    version: '1.0.1',
-    package: '@nx/react',
-    implementation: '/path/to/migration-2',
-  },
-  {
-    id: 'migration-3',
-    name: 'migration-3',
-    description: 'This is a migration that does a thing labeled with three.',
-    version: '1.0.1',
-    package: '@nx/js',
-    implementation: '/path/to/migration-3',
-  },
-  {
-    id: 'migration-4',
-    name: 'migration-4',
-    description: 'This is a migration that does a thing labeled with four.',
-    version: '1.0.2',
-    package: 'nx',
-    implementation: '/path/to/migration-4',
-  },
-  {
-    id: 'migration-3-1',
-    name: 'migration-3',
-    description: 'This is a migration that does a thing labeled with three.',
-    version: '1.0.1',
-    package: '@nx/js',
-    implementation: '/path/to/migration-3',
-  },
-  {
-    id: 'migration-6',
-    name: 'migration-6',
-    description: 'This migration performs updates labeled as number six.',
-    version: '1.0.3',
-    package: '@nx/workspace',
-    implementation: '/path/to/migration-6',
-  },
-  {
-    id: 'migration-7',
-    name: 'migration-7',
-    description: 'Lucky number seven migration that updates configurations.',
-    version: '1.0.3',
-    package: '@nx/devkit',
-    implementation: '/path/to/migration-7',
-  },
-];
+const baseMetadata: MigrationsJsonMetadata = {
+  completedMigrations: {},
+};
 
-describe('Automatic Migration Machine', () => {
-  it('should start in init state', () => {
-    const service = interpret(machine);
-    service.start();
-    expect(service.getSnapshot().value).toBe('init');
-    service.stop();
+describe('automatic migration state machine', () => {
+  it('starts in init', () => {
+    const service = interpret(machine).start();
+    expect(service.state.value).toBe('init');
   });
 
-  it('should keep running migrations until one fails', async () => {
-    let metadata: MigrationsJsonMetadata = {
-      targetVersion: '20.3.2',
-    };
-    const service = interpret(
-      machine.withConfig({
-        actions: {
-          runMigration: (ctx) => {
-            const migration = ctx.currentMigration;
-            if (!migration) {
-              return;
-            }
-            console.log('running migration', migration.id);
-            if (migration.id !== 'migration-3') {
-              metadata = addSuccessfulMigration(
-                migration.id,
-                [],
-                'commit-123'
-              )(metadata);
-            } else {
-              metadata = addFailedMigration(migration.id, 'error')(metadata);
-            }
-            service.send({
-              type: 'updateMetadata',
-              metadata,
-            });
-          },
-        },
-      })
-    );
-    service.start();
+  it('transitions to evaluate from startRunning', () => {
+    const migration = makeMigration('a');
+    const service = interpret(machine).start();
+
     service.send({
       type: 'loadInitialData',
-      migrations: dummyMigrations,
-      metadata: metadata,
+      migrations: [migration],
+      metadata: baseMetadata,
     });
 
-    service.send('startRunning');
-    expect(service.getSnapshot().value).toBe('needsReview');
-    expect(service.getSnapshot().context.currentMigration?.id).toEqual(
-      'migration-3'
-    );
+    service.send({ type: 'startRunning' });
 
-    service.stop();
+    // Should move to evaluate first then end in running
+    expect(service.state.value).toBe('running');
   });
 
-  it('should continue running migrations after failed one is skipped', async () => {
-    let metadata: MigrationsJsonMetadata = {
-      targetVersion: '20.3.2',
-    };
-    const service = interpret(
-      machine.withConfig({
-        actions: {
-          runMigration: (ctx) => {
-            const migration = ctx.currentMigration;
-            if (!migration) {
-              return;
-            }
-            console.log('running migration', migration.id);
-            if (migration.id !== 'migration-3') {
-              metadata = addSuccessfulMigration(
-                migration.id,
-                [],
-                'commit-123'
-              )(metadata);
-            } else {
-              metadata = addFailedMigration(migration.id, 'error')(metadata);
-            }
-            service.send({
-              type: 'updateMetadata',
-              metadata,
-            });
-          },
+  it('enters done if the last migration is reviewed', () => {
+    const migration = makeMigration('a');
+
+    const metadata: MigrationsJsonMetadata = {
+      completedMigrations: {
+        [migration.id]: {
+          type: 'successful',
+          changedFiles: [],
+          name: migration.id,
+          ref: 'migration-ref',
         },
-      })
-    );
-    service.start();
+      },
+    };
+
+    const service = interpret(machine).start();
+
     service.send({
       type: 'loadInitialData',
-      migrations: dummyMigrations,
-      metadata: metadata,
-    });
-
-    service.send('startRunning');
-    expect(service.getSnapshot().value).toBe('needsReview');
-    expect(service.getSnapshot().context.currentMigration?.id).toEqual(
-      'migration-3'
-    );
-
-    metadata = addSkippedMigration('migration-3')(metadata);
-
-    service.send({
-      type: 'updateMetadata',
+      migrations: [migration],
       metadata,
     });
 
-    expect(service.getSnapshot().value).toBe('done');
-    expect(service.getSnapshot().context.currentMigration?.id).toEqual(
-      'migration-7'
-    );
+    service.send({ type: 'startRunning' });
 
-    service.stop();
+    service.send({ type: 'reviewMigration', migrationId: migration.id });
+
+    expect(service.state.value).toBe('done');
   });
 
-  it('should keep running migrations until one has changes', async () => {
-    let metadata: MigrationsJsonMetadata = {
-      targetVersion: '20.3.2',
-    };
-    const service = interpret(
-      machine.withConfig({
-        actions: {
-          runMigration: (ctx) => {
-            const migration = ctx.currentMigration;
-            if (!migration) {
-              return;
-            }
-            console.log('running migration', migration.id);
-            if (migration.id !== 'migration-3') {
-              metadata = addSuccessfulMigration(
-                migration.id,
-                [],
-                'commit-123'
-              )(metadata);
-            } else {
-              metadata = addSuccessfulMigration(
-                migration.id,
-                [
-                  {
-                    type: 'UPDATE',
-                    path: 'apps/app/tsconfig.json',
-                  },
-                ],
-                'commit-123'
-              )(metadata);
-            }
-            service.send({
-              type: 'updateMetadata',
-              metadata,
-            });
-          },
+  it('enters needsReview if there are file changes', () => {
+    const migration = makeMigration('a');
+
+    const metadata: MigrationsJsonMetadata = {
+      completedMigrations: {
+        [migration.id]: {
+          type: 'successful',
+          changedFiles: [{ path: 'file.ts', type: 'CREATE' }],
+          name: migration.id,
+          ref: 'migration-ref',
         },
-      })
-    );
-    service.start();
+      },
+    };
+
+    const service = interpret(machine).start();
+
     service.send({
       type: 'loadInitialData',
-      migrations: dummyMigrations,
-      metadata: metadata,
-    });
-
-    service.send('startRunning');
-    expect(service.getSnapshot().value).toBe('needsReview');
-    expect(service.getSnapshot().context.currentMigration?.id).toEqual(
-      'migration-3'
-    );
-
-    service.stop();
-  });
-
-  it('should keep running migrations after changes are reviewed', async () => {
-    let metadata: MigrationsJsonMetadata = {
-      targetVersion: '20.3.2',
-    };
-    const service = interpret(
-      machine.withConfig({
-        actions: {
-          runMigration: (ctx) => {
-            const migration = ctx.currentMigration;
-            if (!migration) {
-              return;
-            }
-            console.log('running migration', migration.id);
-            if (migration.id !== 'migration-3') {
-              metadata = addSuccessfulMigration(
-                migration.id,
-                [],
-                'commit-123'
-              )(metadata);
-            } else {
-              metadata = addSuccessfulMigration(
-                migration.id,
-                [
-                  {
-                    type: 'UPDATE',
-                    path: 'apps/app/tsconfig.json',
-                  },
-                ],
-                'commit-123'
-              )(metadata);
-            }
-            service.send({
-              type: 'updateMetadata',
-              metadata,
-            });
-          },
-        },
-      })
-    );
-    service.start();
-    service.send({
-      type: 'loadInitialData',
-      migrations: dummyMigrations,
-      metadata: metadata,
-    });
-
-    service.send('startRunning');
-    expect(service.getSnapshot().value).toBe('needsReview');
-    expect(service.getSnapshot().context.currentMigration?.id).toEqual(
-      'migration-3'
-    );
-
-    service.send({
-      type: 'reviewMigration',
-      migrationId: 'migration-3',
-    });
-    expect(service.getSnapshot().value).toBe('done');
-    expect(service.getSnapshot().context.currentMigration?.id).toEqual(
-      'migration-7'
-    );
-    service.stop();
-  });
-
-  it('should not continue running migrations after failed one is skipped if state is paused', async () => {
-    let metadata: MigrationsJsonMetadata = {
-      targetVersion: '20.3.2',
-    };
-    const service = interpret(
-      machine.withConfig({
-        actions: {
-          runMigration: (ctx) => {
-            const migration = ctx.currentMigration;
-            if (!migration) {
-              return;
-            }
-            console.log('running migration', migration.id);
-            if (migration.id !== 'migration-3') {
-              metadata = addSuccessfulMigration(
-                migration.id,
-                [],
-                'commit-123'
-              )(metadata);
-            } else {
-              metadata = addFailedMigration(migration.id, 'error')(metadata);
-            }
-            service.send({
-              type: 'updateMetadata',
-              metadata,
-            });
-          },
-        },
-      })
-    );
-    service.start();
-    service.send({
-      type: 'loadInitialData',
-      migrations: dummyMigrations,
-      metadata: metadata,
-    });
-
-    service.send('startRunning');
-    expect(service.getSnapshot().value).toBe('needsReview');
-    expect(service.getSnapshot().context.currentMigration?.id).toEqual(
-      'migration-3'
-    );
-
-    service.send('pause');
-
-    metadata = addSkippedMigration('migration-3')(metadata);
-
-    service.send({
-      type: 'updateMetadata',
+      migrations: [migration],
       metadata,
     });
 
-    expect(service.getSnapshot().value).toBe('paused');
-    expect(service.getSnapshot().context.currentMigration?.id).toEqual(
-      'migration-3'
-    );
+    service.send({ type: 'startRunning' });
 
-    service.stop();
+    expect(service.state.value).toBe('needsReview');
+  });
+
+  it('goes to next migration after review', () => {
+    const m1 = makeMigration('a');
+    const m2 = makeMigration('b');
+
+    const metadata: MigrationsJsonMetadata = {
+      completedMigrations: {
+        [m1.id]: {
+          type: 'successful',
+          changedFiles: [],
+          name: m1.id,
+          ref: 'migration-a',
+        },
+      },
+    };
+
+    const service = interpret(machine).start();
+
+    service.send({
+      type: 'loadInitialData',
+      migrations: [m1, m2],
+      metadata,
+    });
+
+    service.send({ type: 'startRunning' });
+
+    service.send({ type: 'reviewMigration', migrationId: m1.id });
+
+    expect(service.state.context.currentMigration?.id).toBe(m2.id);
+    expect(service.state.value).toBe('running');
+  });
+
+  it('transitions to running state when startRunning is sent', () => {
+    const service = interpret(machine).start();
+    const migration = makeMigration('a');
+
+    service.send({
+      type: 'loadInitialData',
+      migrations: [migration],
+      metadata: baseMetadata,
+    });
+
+    service.send({ type: 'startRunning' });
+
+    expect(service.state.value).toBe('running');
+  });
+
+  it('transitions to evaluate when stopped via stop event', () => {
+    const migration = makeMigration('a');
+
+    const service = interpret(machine).start();
+
+    service.send({
+      type: 'loadInitialData',
+      migrations: [migration],
+      metadata: baseMetadata,
+    });
+
+    service.send({ type: 'startRunning' });
+
+    // Verify we're in running state first
+    expect(service.state.value).toBe('running');
+
+    service.send({ type: 'stop' });
+
+    // The stop event transitions out of running, but we need to update metadata
+    // to reflect the actual stopped state from the backend
+    service.send({
+      type: 'updateMetadata',
+      metadata: {
+        completedMigrations: {
+          [migration.id]: {
+            type: 'stopped' as const,
+            name: migration.id,
+            error: 'Manually stopped',
+          },
+        },
+      },
+    });
+
+    // After metadata update, should be in stopped state
+    expect(service.state.value).toBe('stopped');
+  });
+
+  it('transitions to stopped when stopped via metadata update', () => {
+    const migration = makeMigration('a');
+
+    const service = interpret(machine).start();
+
+    service.send({
+      type: 'loadInitialData',
+      migrations: [migration],
+      metadata: baseMetadata,
+    });
+
+    service.send({ type: 'startRunning' });
+
+    // Verify we're in running state first
+    expect(service.state.value).toBe('running');
+
+    // Update metadata to mark migration as stopped
+    service.send({
+      type: 'updateMetadata',
+      metadata: {
+        completedMigrations: {
+          [migration.id]: {
+            type: 'stopped' as const,
+            name: migration.id,
+            error: 'Manually stopped',
+          },
+        },
+      },
+    });
+
+    // After updateMetadata, state should be stopped
+    expect(service.state.value).toBe('stopped');
+  });
+
+  it('can restart and continue with multiple migrations after stop', () => {
+    const m1 = makeMigration('migration-1');
+    const m2 = makeMigration('migration-2');
+    const m3 = makeMigration('migration-3');
+
+    const service = interpret(machine).start();
+
+    // Load 3 migrations with first one already completed
+    const initialMetadata = {
+      completedMigrations: {
+        [m1.id]: {
+          type: 'successful' as const,
+          changedFiles: [],
+          name: m1.id,
+          ref: 'ref-1',
+        },
+      },
+    };
+
+    service.send({
+      type: 'loadInitialData',
+      migrations: [m1, m2, m3],
+      metadata: initialMetadata,
+    });
+
+    service.send({ type: 'startRunning' });
+
+    // Should start with migration-2 (since migration-1 is completed)
+    expect(service.state.value).toBe('running');
+    expect(service.state.context.currentMigration?.id).toBe(m2.id);
+
+    // Stop the migration while running migration-2
+    service.send({ type: 'stop' });
+
+    // Update metadata to reflect the migration is stopped (this would come from backend)
+    service.send({
+      type: 'updateMetadata',
+      metadata: {
+        completedMigrations: {
+          [m1.id]: {
+            type: 'successful' as const,
+            changedFiles: [],
+            name: m1.id,
+            ref: 'ref-1',
+          },
+          [m2.id]: {
+            type: 'stopped' as const,
+            name: m2.id,
+            error: 'Manually stopped',
+          },
+        },
+      },
+    });
+
+    // Should be in stopped state
+    expect(service.state.value).toBe('stopped');
+    expect(service.state.context.currentMigration?.id).toBe(m2.id);
+
+    // Clear the stopped status from metadata (simulating user clearing the stop)
+    service.send({
+      type: 'updateMetadata',
+      metadata: initialMetadata, // Back to just having m1 completed
+    });
+
+    // Now restart - should continue with migration-2
+    service.send({ type: 'startRunning' });
+
+    // Should resume running migration-2
+    expect(service.state.value).toBe('running');
+    expect(service.state.context.currentMigration?.id).toBe(m2.id);
+  });
+
+  it('skips migrations marked as skipped and moves to next migration', () => {
+    const m1 = makeMigration('migration-1');
+    const m2 = makeMigration('migration-2');
+    const m3 = makeMigration('migration-3');
+
+    const metadata: MigrationsJsonMetadata = {
+      completedMigrations: {
+        [m2.id]: {
+          type: 'skipped',
+        },
+      },
+    };
+
+    const service = interpret(machine).start();
+
+    service.send({
+      type: 'loadInitialData',
+      migrations: [m1, m2, m3],
+      metadata,
+    });
+
+    service.send({ type: 'startRunning' });
+
+    // Should start with m1 (first incomplete migration)
+    expect(service.state.value).toBe('running');
+    expect(service.state.context.currentMigration?.id).toBe(m1.id);
+
+    // Complete m1 successfully without changes
+    service.send({
+      type: 'updateMetadata',
+      metadata: {
+        completedMigrations: {
+          [m1.id]: {
+            type: 'successful',
+            changedFiles: [],
+            name: m1.id,
+            ref: 'ref-1',
+          },
+          [m2.id]: {
+            type: 'skipped',
+          },
+        },
+      },
+    });
+
+    // After m1 completes, machine should move to m2. Since m2 is skipped,
+    // it should be considered "done" and automatically increment to m3
+    expect(service.state.value).toBe('running');
+    expect(service.state.context.currentMigration?.id).toBe(m3.id);
+  });
+
+  it('does not attempt to run skipped migrations', () => {
+    const migration = makeMigration('skipped-migration');
+
+    const metadata: MigrationsJsonMetadata = {
+      completedMigrations: {
+        [migration.id]: {
+          type: 'skipped',
+        },
+      },
+    };
+
+    const service = interpret(machine).start();
+
+    service.send({
+      type: 'loadInitialData',
+      migrations: [migration],
+      metadata,
+    });
+
+    service.send({ type: 'startRunning' });
+
+    // Should go to done state since the only migration is skipped
+    expect(service.state.value).toBe('done');
+    expect(service.state.context.currentMigration?.id).toBe(migration.id);
   });
 });

--- a/graph/migrate/src/lib/state/automatic/selectors.ts
+++ b/graph/migrate/src/lib/state/automatic/selectors.ts
@@ -16,83 +16,36 @@ export function findFirstIncompleteMigration(
   );
 }
 
-export function currentMigrationHasSucceeded(ctx: AutomaticMigrationState) {
-  if (!ctx.currentMigration) {
-    return false;
-  }
-  return isMigrationSuccessful(ctx, ctx.currentMigration.id);
+export function getMigrationType(
+  ctx: AutomaticMigrationState,
+  migrationId: string
+) {
+  return ctx.nxConsoleMetadata?.completedMigrations?.[migrationId]?.type;
+}
+
+export function getCurrentMigrationType(ctx: AutomaticMigrationState) {
+  if (!ctx.currentMigration) return undefined;
+  return getMigrationType(ctx, ctx.currentMigration.id);
+}
+
+export function getMigrationCompletedData(
+  ctx: AutomaticMigrationState,
+  migrationId: string
+) {
+  return ctx.nxConsoleMetadata?.completedMigrations?.[migrationId];
+}
+
+export function getCurrentMigrationCompletedData(ctx: AutomaticMigrationState) {
+  if (!ctx.currentMigration) return undefined;
+  return getMigrationCompletedData(ctx, ctx.currentMigration.id);
 }
 
 export function currentMigrationHasChanges(ctx: AutomaticMigrationState) {
-  if (!ctx.currentMigration) {
-    return false;
-  }
-  const completed =
-    ctx.nxConsoleMetadata?.completedMigrations?.[ctx.currentMigration?.id];
+  const completed = getCurrentMigrationCompletedData(ctx);
   return (
     completed?.type === 'successful' &&
     (completed.changedFiles?.length ?? 0) > 0
   );
-}
-
-export function isMigrationSuccessful(
-  ctx: AutomaticMigrationState,
-  migrationId: string
-) {
-  return (
-    ctx.nxConsoleMetadata?.completedMigrations?.[migrationId]?.type ===
-    'successful'
-  );
-}
-
-export function isMigrationFailed(
-  ctx: AutomaticMigrationState,
-  migrationId: string
-) {
-  return (
-    ctx.nxConsoleMetadata?.completedMigrations?.[migrationId]?.type === 'failed'
-  );
-}
-
-export function isMigrationSkipped(
-  ctx: AutomaticMigrationState,
-  migrationId: string
-) {
-  return (
-    ctx.nxConsoleMetadata?.completedMigrations?.[migrationId]?.type ===
-    'skipped'
-  );
-}
-
-export function isMigrationStopped(
-  ctx: AutomaticMigrationState,
-  migrationId: string
-) {
-  return (
-    ctx.nxConsoleMetadata?.completedMigrations?.[migrationId]?.type ===
-    'stopped'
-  );
-}
-
-export function currentMigrationIsSkipped(ctx: AutomaticMigrationState) {
-  if (!ctx.currentMigration) {
-    return false;
-  }
-  return isMigrationSkipped(ctx, ctx.currentMigration.id);
-}
-
-export function currentMigrationHasFailed(ctx: AutomaticMigrationState) {
-  if (!ctx.currentMigration) {
-    return false;
-  }
-  return isMigrationFailed(ctx, ctx.currentMigration.id);
-}
-
-export function currentMigrationIsStopped(ctx: AutomaticMigrationState) {
-  if (!ctx.currentMigration) {
-    return false;
-  }
-  return isMigrationStopped(ctx, ctx.currentMigration.id);
 }
 
 export function currentMigrationIsReviewed(ctx: AutomaticMigrationState) {
@@ -103,10 +56,11 @@ export function currentMigrationIsReviewed(ctx: AutomaticMigrationState) {
 }
 
 export function currentMigrationCanLeaveReview(ctx: AutomaticMigrationState) {
+  const type = getCurrentMigrationType(ctx);
   return (
     currentMigrationIsReviewed(ctx) ||
-    currentMigrationIsSkipped(ctx) ||
-    (currentMigrationHasSucceeded(ctx) && !currentMigrationHasChanges(ctx))
+    type === 'skipped' ||
+    (type === 'successful' && !currentMigrationHasChanges(ctx))
   );
 }
 
@@ -120,8 +74,6 @@ export function isMigrationRunning(
 }
 
 export function currentMigrationIsRunning(ctx: AutomaticMigrationState) {
-  if (!ctx.currentMigration) {
-    return false;
-  }
+  if (!ctx.currentMigration) return false;
   return isMigrationRunning(ctx, ctx.currentMigration.id);
 }

--- a/graph/migrate/src/lib/state/automatic/types.ts
+++ b/graph/migrate/src/lib/state/automatic/types.ts
@@ -7,7 +7,6 @@ export type AutomaticMigrationState = {
   migrations?: MigrationDetailsWithId[];
   nxConsoleMetadata?: MigrationsJsonMetadata;
   currentMigration?: MigrationDetailsWithId;
-  currentMigrationRunning?: boolean;
   reviewedMigrations: string[];
 };
 
@@ -23,7 +22,7 @@ export type AutomaticMigrationEvents =
       metadata: MigrationsJsonMetadata;
     }
   | {
-      type: 'pause';
+      type: 'stop';
     }
   | {
       type: 'startRunning';

--- a/packages/nx/src/command-line/migrate/migrate-ui-api.ts
+++ b/packages/nx/src/command-line/migrate/migrate-ui-api.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, spawn, ChildProcess } from 'child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import type { MigrationDetailsWithId } from '../../config/misc-interfaces';
@@ -8,10 +8,14 @@ import {
   readMigrationCollection,
 } from './migrate';
 
+let currentMigrationProcess: ChildProcess | null = null;
+let currentMigrationId: string | null = null;
+let migrationCancelled = false;
+
 export type MigrationsJsonMetadata = {
   completedMigrations?: Record<
     string,
-    SuccessfulMigration | FailedMigration | SkippedMigration
+    SuccessfulMigration | FailedMigration | SkippedMigration | StoppedMigration
   >;
   runningMigrations?: string[];
   initialGitRef?: {
@@ -38,6 +42,12 @@ export type FailedMigration = {
 
 export type SkippedMigration = {
   type: 'skipped';
+};
+
+export type StoppedMigration = {
+  type: 'stopped';
+  name: string;
+  error: string;
 };
 
 export function recordInitialMigrationMetadata(
@@ -121,6 +131,10 @@ export async function runSingleMigration(
   }
 ) {
   try {
+    // Set current migration tracking
+    currentMigrationId = migration.id;
+    migrationCancelled = false;
+
     modifyMigrationsJsonMetadata(
       workspacePath,
       addRunningMigration(migration.id)
@@ -131,32 +145,76 @@ export async function runSingleMigration(
       encoding: 'utf-8',
     }).trim();
 
-    // For Migrate UI, this current module is loaded either from:
-    // 1. The CLI path to the migrated modules. The version of Nx is of the user's choosing. This may or may not have the new migrate API, so Console will check that `runSingleMigration` exists before using it.
-    // 2. Bundled into Console, so the version is fixed to what we build Console with.
-    const updatedMigrateModule = await import('./migrate.js');
+    // Run migration in a separate process so it can be cancelled
+    const runMigrationProcessPath = require.resolve(
+      './run-migration-process.js'
+    );
 
-    const { changes: fileChanges, nextSteps } =
-      await updatedMigrateModule.runNxOrAngularMigration(
+    const migrationProcess = spawn(
+      'node',
+      [
+        runMigrationProcessPath,
         workspacePath,
-        migration,
-        false,
-        configuration.createCommits,
+        migration.id,
+        migration.package,
+        migration.name,
+        migration.version,
+        configuration.createCommits.toString(),
         configuration.commitPrefix || 'chore: [nx migration] ',
-        undefined,
-        true
-      );
+      ],
+      {
+        cwd: workspacePath,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    );
 
-    const gitRefAfter = execSync('git rev-parse HEAD', {
-      cwd: workspacePath,
-      encoding: 'utf-8',
-    }).trim();
+    // Track the process for cancellation
+    currentMigrationProcess = migrationProcess;
+
+    // Handle process output
+    let output = '';
+    migrationProcess.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+
+    migrationProcess.stderr.on('data', (data) => {
+      console.error('Migration stderr:', data.toString());
+    });
+
+    // Wait for the process to complete
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      migrationProcess.on('close', (code) => {
+        resolve(code);
+      });
+
+      migrationProcess.on('error', (error) => {
+        reject(error);
+      });
+    });
+
+    currentMigrationProcess = null;
+
+    if (exitCode !== 0) {
+      throw new Error(`Migration process exited with code ${exitCode}`);
+    }
+
+    // Parse the result from the migration process (extract the JSON output)
+    const jsonStr = output
+      .trim()
+      .split('\n')
+      .find((line) => line.startsWith('{'));
+    const result = JSON.parse(jsonStr);
+    if (result.type === 'error') {
+      throw new Error(result.message);
+    }
+
+    const { fileChanges, gitRefAfter, nextSteps } = result;
 
     modifyMigrationsJsonMetadata(
       workspacePath,
       addSuccessfulMigration(
         migration.id,
-        fileChanges.map((change) => ({
+        fileChanges.map((change: FileChange) => ({
           path: change.path,
           type: change.type,
         })),
@@ -186,11 +244,23 @@ export async function runSingleMigration(
       );
     }
   } catch (e) {
-    modifyMigrationsJsonMetadata(
-      workspacePath,
-      addFailedMigration(migration.id, e.message)
-    );
+    // Check if migration was cancelled/stopped
+    if (migrationCancelled && currentMigrationId === migration.id) {
+      // Migration was stopped by user, don't add as failed since it's already marked as stopped
+      console.log(`Migration ${migration.id} was stopped by user`);
+    } else {
+      // Migration failed normally
+      modifyMigrationsJsonMetadata(
+        workspacePath,
+        addFailedMigration(migration.id, e.message)
+      );
+    }
   } finally {
+    // Clear the tracking variables
+    currentMigrationProcess = null;
+    currentMigrationId = null;
+    migrationCancelled = false;
+
     modifyMigrationsJsonMetadata(
       workspacePath,
       removeRunningMigration(migration.id)
@@ -312,6 +382,24 @@ export function addSkippedMigration(id: string) {
   };
 }
 
+export function addStoppedMigration(id: string, error: string) {
+  return (migrationsJsonMetadata: MigrationsJsonMetadata) => {
+    const copied = { ...migrationsJsonMetadata };
+    if (!copied.completedMigrations) {
+      copied.completedMigrations = {};
+    }
+    copied.completedMigrations = {
+      ...copied.completedMigrations,
+      [id]: {
+        type: 'stopped',
+        name: id,
+        error,
+      },
+    };
+    return copied;
+  };
+}
+
 function addRunningMigration(id: string) {
   return (migrationsJsonMetadata: MigrationsJsonMetadata) => {
     migrationsJsonMetadata.runningMigrations = [
@@ -326,9 +414,6 @@ function removeRunningMigration(id: string) {
   return (migrationsJsonMetadata: MigrationsJsonMetadata) => {
     migrationsJsonMetadata.runningMigrations =
       migrationsJsonMetadata.runningMigrations?.filter((n) => n !== id);
-    if (migrationsJsonMetadata.runningMigrations?.length === 0) {
-      delete migrationsJsonMetadata.runningMigrations;
-    }
     return migrationsJsonMetadata;
   };
 }
@@ -354,5 +439,49 @@ export function undoMigration(workspacePath: string, id: string) {
       type: 'skipped',
     };
     return migrationsJsonMetadata;
+  };
+}
+
+export function killMigrationProcess(
+  migrationId: string,
+  workspacePath?: string
+): boolean {
+  try {
+    if (workspacePath) {
+      modifyMigrationsJsonMetadata(workspacePath, stopMigration(migrationId));
+    }
+
+    // Check if this is the currently running migration and kill the process
+    if (currentMigrationId === migrationId && currentMigrationProcess) {
+      if (process.platform === 'win32') {
+        execSync(`taskkill /f /t /pid ${currentMigrationProcess.pid}`, {
+          stdio: 'ignore',
+        });
+      } else {
+        currentMigrationProcess.kill('SIGTERM');
+        // Some processes may not respond to SIGTERM immediately,
+        // so we give it a short timeout before forcefully killing it
+        setTimeout(() => {
+          if (currentMigrationProcess && !currentMigrationProcess.killed) {
+            currentMigrationProcess.kill('SIGKILL');
+          }
+        }, 2000);
+      }
+    }
+
+    return true;
+  } catch (error) {
+    console.error(`Failed to stop migration ${migrationId}:`, error);
+    return false;
+  }
+}
+
+export function stopMigration(migrationId: string) {
+  return (migrationsJsonMetadata: MigrationsJsonMetadata) => {
+    const updated = addStoppedMigration(
+      migrationId,
+      'Migration was stopped by user'
+    )(migrationsJsonMetadata);
+    return removeRunningMigration(migrationId)(updated);
   };
 }

--- a/packages/nx/src/command-line/migrate/migrate-ui-api.ts
+++ b/packages/nx/src/command-line/migrate/migrate-ui-api.ts
@@ -453,20 +453,14 @@ export function killMigrationProcess(
 
     // Check if this is the currently running migration and kill the process
     if (currentMigrationId === migrationId && currentMigrationProcess) {
-      if (process.platform === 'win32') {
-        execSync(`taskkill /f /t /pid ${currentMigrationProcess.pid}`, {
-          stdio: 'ignore',
-        });
-      } else {
-        currentMigrationProcess.kill('SIGTERM');
-        // Some processes may not respond to SIGTERM immediately,
-        // so we give it a short timeout before forcefully killing it
-        setTimeout(() => {
-          if (currentMigrationProcess && !currentMigrationProcess.killed) {
-            currentMigrationProcess.kill('SIGKILL');
-          }
-        }, 2000);
-      }
+      currentMigrationProcess.kill('SIGTERM');
+      // Some processes may not respond to SIGTERM immediately,
+      // so we give it a short timeout before forcefully killing it
+      setTimeout(() => {
+        if (currentMigrationProcess && !currentMigrationProcess.killed) {
+          currentMigrationProcess.kill('SIGKILL');
+        }
+      }, 2000);
     }
 
     return true;

--- a/packages/nx/src/command-line/migrate/run-migration-process.js
+++ b/packages/nx/src/command-line/migrate/run-migration-process.js
@@ -1,0 +1,85 @@
+const { runNxOrAngularMigration } = require('./migrate');
+const { execSync } = require('child_process');
+
+async function runMigrationProcess() {
+  const [
+    ,
+    ,
+    workspacePath,
+    migrationId,
+    migrationPackage,
+    migrationName,
+    migrationVersion,
+    createCommits,
+    commitPrefix,
+  ] = process.argv;
+
+  const migration = {
+    id: migrationId,
+    package: migrationPackage,
+    name: migrationName,
+    version: migrationVersion,
+  };
+
+  const configuration = {
+    createCommits: createCommits === 'true',
+    commitPrefix: commitPrefix || 'chore: [nx migration] ',
+  };
+
+  try {
+    const gitRefBefore = execSync('git rev-parse HEAD', {
+      cwd: workspacePath,
+      encoding: 'utf-8',
+    }).trim();
+
+    const { changes: fileChanges, nextSteps } = await runNxOrAngularMigration(
+      workspacePath,
+      migration,
+      false,
+      configuration.createCommits,
+      configuration.commitPrefix,
+      undefined,
+      true
+    );
+
+    const gitRefAfter = execSync('git rev-parse HEAD', {
+      cwd: workspacePath,
+      encoding: 'utf-8',
+    }).trim();
+
+    // Report success
+    process.stdout.write(
+      JSON.stringify({
+        type: 'success',
+        fileChanges: fileChanges.map((change) => ({
+          path: change.path,
+          type: change.type,
+        })),
+        gitRefAfter,
+        nextSteps,
+      })
+    );
+
+    process.exit(0);
+  } catch (error) {
+    // Report failure
+    process.stdout.write(
+      JSON.stringify({
+        type: 'error',
+        message: error.message,
+      })
+    );
+
+    process.exit(1);
+  }
+}
+
+runMigrationProcess().catch((error) => {
+  process.stdout.write(
+    JSON.stringify({
+      type: 'error',
+      message: error.message,
+    })
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
## Overview
This PR enhances the Migrate UI by adding a "Stop" button that allows users to halt in-progress migrations at any point during execution.
It works in tandem with https://github.com/nrwl/nx-console/pull/2567

### Currently
When a migration is running and needs to be stopped for any reason:
- User accidentally triggered the migration
- Migration is taking longer than expected
- Changes are needed before completion

Users must wait for the migration to complete before using the available "Undo" or "Skip" options.

### Expected
Users should be able to stop a currently running migration at any time before it completes, providing immediate control over the migration process.

### Key Features:

- Refactor guards to improve migration state checks and add conditions for running and completing migrations.
- Update the state machine to handle new states for running, stopped, and evaluating migrations.
- Implement logic to track running migrations and allow for stopping them gracefully.
- Introduce a new process for running migrations in a separate child process to support cancellation.
- Enhance metadata management to include stopped migrations and update UI accordingly. (The UI is completely driven by the backend now aka Nx Console)
- Add tests to cover new migration states and behaviours.
