### PR TITLE
docs(nx-dev): add CVE reference on security

### DIFF
--- a/nx-dev/ui-enterprise/src/lib/security/cache-poisoning-protection.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/cache-poisoning-protection.tsx
@@ -28,7 +28,7 @@ export function CachePoisoningProtection(): ReactElement {
               Cache Poisoning Protection, By Design
             </SectionHeading>
             <SectionHeading as="p" variant="subtitle" className="mt-6">
-              Protect your main branch – and your customers – from compromised
+              Protect your main branch — and your customers — from compromised
               builds.
             </SectionHeading>
 
@@ -61,7 +61,7 @@ export function CachePoisoningProtection(): ReactElement {
                   />
                   Writes only from trusted CI branches{' '}
                 </span>
-                – By default, the cache artifacts are reused within each pull
+                — By default, the cache artifacts are reused within each pull
                 request. Only artifacts from trusted CI pipelines should enter
                 the shared cache used by everyone. PR environments can't poison
                 main.
@@ -74,7 +74,7 @@ export function CachePoisoningProtection(): ReactElement {
                   />
                   Artifact traceability{' '}
                 </span>
-                – Artifacts are tied to the identity and permissions of the user
+                — Artifacts are tied to the identity and permissions of the user
                 or process that created them.
               </li>
               <li className="relative pl-9">
@@ -85,7 +85,7 @@ export function CachePoisoningProtection(): ReactElement {
                   />
                   Automatic invalidation{' '}
                 </span>
-                – Revoke a token and every artifact it produced becomes
+                — Revoke a token and every artifact it produced becomes
                 unusable.
               </li>
             </ul>

--- a/nx-dev/ui-enterprise/src/lib/security/failing-compliance.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/failing-compliance.tsx
@@ -1,12 +1,7 @@
 'use client';
 import {
-  BugAntIcon,
-  DocumentCheckIcon,
   ExclamationTriangleIcon,
-  EyeSlashIcon,
-  FingerPrintIcon,
-  LinkSlashIcon,
-  ServerIcon,
+  ShieldExclamationIcon,
 } from '@heroicons/react/24/outline';
 import {
   ButtonLink,
@@ -27,26 +22,79 @@ export function FailingCompliance(): ReactElement {
               Rolling Your Own Cache Fails in Regulated Sectors
             </SectionHeading>
             <SectionHeading as="p" variant="subtitle" className="mt-6">
-              Unmanaged caching may be convenient now—but it’s a liability down
-              the road.
+              Unmanaged caching may be convenient now — but it’s a liability
+              down the road.
             </SectionHeading>
 
             <SectionDescription as="p" className="mt-6">
-              If you operate in a regulated sector—
+              If you operate in a regulated sector —{' '}
               <Strong>
                 finance, healthcare, government, defense, aerospace, or
                 pharmaceuticals
+              </Strong>{' '}
+              — self-hosting your remote cache may expose you to{' '}
+              <Strong>
+                serious risks like the{' '}
+                <abbr
+                  title="Cache Race-condition Exploit Enables Poisoning"
+                  className="cursor-help"
+                >
+                  CREEP
+                </abbr>{' '}
+                cache poisoning vulnerability
               </Strong>
-              —self-hosting your remote cache may expose you to{' '}
-              <Strong>serious risks like cache poisoning</Strong>.
+              .
             </SectionDescription>
 
-            <SectionDescription as="p" className="mt-6">
+            <div className="mt-6 flex justify-center">
+              <div className="max-w-sm rounded-lg border border-slate-200 bg-white p-4 shadow-lg dark:border-slate-800 dark:bg-slate-800/60">
+                <div className="flex items-start">
+                  <ShieldExclamationIcon
+                    aria-hidden="true"
+                    className="size-5 flex-shrink-0 text-red-500 dark:text-white"
+                  />
+                  <div className="ml-4 flex-1">
+                    <p className="text-sm font-medium text-slate-900 dark:text-white">
+                      <abbr
+                        title="Cache Race-condition Exploit Enables Poisoning"
+                        className="cursor-help"
+                      >
+                        CREEP
+                      </abbr>{' '}
+                      (CVE-2025-36852)
+                    </p>
+                    <p className="mt-1 text-xs text-slate-600 dark:text-slate-400">
+                      Critical Cache Poisoning Vulnerability Affects Multiple
+                      Build Systems.
+                    </p>
+                    <div className="mt-2 flex justify-end">
+                      <Link
+                        href="/blog/cve-2025-36852-critical-cache-poisoning-vulnerability-creep"
+                        target="_blank"
+                        title="CVE - CREEP"
+                        prefetch={false}
+                        className="text-xs/7 font-semibold"
+                      >
+                        Learn more <span aria-hidden="true">→</span>
+                      </Link>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <SectionDescription as="p" className="mt-8">
               Community-built cache solutions reading and writing directly from
-              the file storage are vulnerable to the Cache Poisoning by
-              Construction attack resulting in any contributor with pull request
-              privileges being able to potentially inject compromised artifacts
-              into production environments without detection.{' '}
+              the file storage are vulnerable to the{' '}
+              <abbr
+                title="Cache Race-condition Exploit Enables Poisoning"
+                className="cursor-help"
+              >
+                CREEP
+              </abbr>{' '}
+              attack resulting in any contributor with pull request privileges
+              being able to potentially inject compromised artifacts into
+              production environments without detection.{' '}
               <Strong>
                 This vulnerability completely circumvents conventional security
                 protections like encryption, access control and key management
@@ -129,11 +177,23 @@ export function FailingCompliance(): ReactElement {
             </ul>
 
             <div className="mt-10 text-center">
+              <SectionDescription as="p">
+                Questions about{' '}
+                <abbr
+                  title="Cache Race-condition Exploit Enables Poisoning"
+                  className="cursor-help"
+                >
+                  CREEP
+                </abbr>{' '}
+                or your security posture? <br />
+                Contact our team for a personalized assessment.
+              </SectionDescription>
               <ButtonLink
                 href="/contact/sales"
                 variant="primary"
                 size="default"
                 title="Talk to an expert"
+                className="mt-4"
               >
                 Talk to an expert
               </ButtonLink>

--- a/nx-dev/ui-enterprise/src/lib/security/personal-access.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/personal-access.tsx
@@ -69,6 +69,7 @@ export function PersonalAccess(): ReactElement {
             <div className="mt-4">
               <Link
                 href="/ci/recipes/security/personal-access-tokens"
+                prefetch={false}
                 title="Learn more about Personal Access Tokens"
                 className="text-sm/6 font-semibold"
               >

--- a/nx-dev/ui-enterprise/src/lib/security/why-ci-security-matters.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/why-ci-security-matters.tsx
@@ -29,7 +29,7 @@ export function WhyCiSecurityMatters(): ReactElement {
               Why CI Security Matters
             </SectionHeading>
             <SectionHeading as="p" variant="subtitle" className="mt-6">
-              CI pipelines are often an overlooked threat – and your cache is a
+              CI pipelines are often an overlooked threat — and your cache is a
               critical entry point.
             </SectionHeading>
 
@@ -60,7 +60,7 @@ export function WhyCiSecurityMatters(): ReactElement {
                   />
                   Build artifacts can be compromised and deployed{' '}
                 </span>
-                – if left unprotected
+                — if left unprotected
               </li>
               <li className="relative pl-9">
                 <span className="inline font-semibold text-slate-950 dark:text-white">

--- a/nx-dev/ui-enterprise/src/lib/solutions/platform/cost-efficient-compute.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/platform/cost-efficient-compute.tsx
@@ -74,7 +74,7 @@ export function CostEfficientCompute(): ReactElement {
           variant="title"
           id="cost-efficient-compute-without-sacrificing-speed-title"
         >
-          Cost-Efficient Compute – Without Sacrificing Speed
+          Cost-Efficient Compute — Without Sacrificing Speed
         </SectionHeading>
         <SectionHeading as="p" variant="subtitle" className="mt-6">
           Reduce infrastructure costs without compromising performance.

--- a/nx-dev/ui-enterprise/src/lib/solutions/solutions-faq.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/solutions-faq.tsx
@@ -32,12 +32,12 @@ export function SolutionsFaq(): ReactElement {
     {
       question: 'Do I need to migrate to Nx all at once?',
       answerJson:
-        'Not at all. Nx can be incrementally adopted. You can start with just your team – and expand at your own pace.',
+        'Not at all. Nx can be incrementally adopted. You can start with just your team — and expand at your own pace.',
       answerUi: (
         <>
           <p>
             Not at all. Nx can be incrementally adopted. You can start with just
-            your team – and expand at your own pace.
+            your team — and expand at your own pace.
           </p>
         </>
       ),


### PR DESCRIPTION
Improved the clarity of caching risks, added detailed explanations on CREEP vulnerability, and linked to the CVE-2025-36852 publication.