### PR TITLE
fix(core): do not auto-exit tui when there are multiple failed tasks

### DIFF
--- a/packages/nx/src/native/tui/action.rs
+++ b/packages/nx/src/native/tui/action.rs
@@ -37,4 +37,5 @@ pub enum Action {
     ToggleDebugMode,
     SendConsoleMessage(String),
     ConsoleMessengerAvailable(bool),
+    EndCommand,
 }


### PR DESCRIPTION
## Current Behavior

When the user hasn't interacted with the TUI and has not disabled the auto-exit functionality, it will always auto-exit regardless of the number of failed tasks.

## Expected Behavior

When the user hasn't interacted with the TUI and has not disabled the auto-exit functionality, it should not auto-exit if there are multiple failed tasks. Additionally, as long as no terminal output panes are open (e.g., the run one command will always display the initiating task terminal pane), it should focus and open the first failed task.

If all tasks succeed or there's only one failure, it should continue to auto-exit.