### PR TITLE
docs(misc): add titles to intro/overview pages

### DIFF
--- a/docs/blog/2025-01-06-nx-update-20-3.md
+++ b/docs/blog/2025-01-06-nx-update-20-3.md
@@ -195,7 +195,7 @@ We've also introduced spinners into the terminal ui for instances where a task i
 
 > Update: Self-hosted cache was previously part of Powerpack. But no more, it is no free for everyone to use.
 
-We just improved support for our [self-hosted caching packages](/recipes/running-tasks/self-hosted-caching) by adding adapters for [Azure](/reference/core-api/azure-cache) and [Google Cloud Storage](/reference/core-api/gcs-cache) as supported storage providers (in addition to [S3](/reference/core-api/s3-cache) or [simply using a shared file system](/reference/core-api/shared-fs-cache)).
+We just improved support for our [self-hosted caching packages](/recipes/running-tasks/self-hosted-caching) by adding adapters for [Azure](/reference/core-api/azure-cache/overview) and [Google Cloud Storage](/reference/core-api/gcs-cache/overview) as supported storage providers (in addition to [S3](/reference/core-api/s3-cache/overview) or [simply using a shared file system](/reference/core-api/shared-fs-cache/overview)).
 
 We've also [added support for S3 compatible providers](/reference/core-api/s3-cache#s3-compatible-providers) such as:
 

--- a/docs/generated/packages/angular/documents/overview.md
+++ b/docs/generated/packages/angular/documents/overview.md
@@ -4,6 +4,8 @@ description: The Nx Plugin for Angular contains executors, generators, and utili
 keywords: [angular]
 ---
 
+# @nx/angular
+
 The Nx Plugin for Angular contains executors, generators, and utilities for managing Angular applications and libraries
 within an Nx workspace. It also enables using Angular Devkit builders and schematics in Nx workspaces.
 

--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Cypress Plugin
 description: The Nx Plugin for Cypress contains executors and generators that support e2e testing with Cypress. This page also explains how to configure Cypress on your Nx workspace.
 ---
 
+# @nx/cypress
+
 Cypress is a test runner built for the modern web. It has a lot of great features:
 
 - Time travel

--- a/docs/generated/packages/detox/documents/overview.md
+++ b/docs/generated/packages/detox/documents/overview.md
@@ -3,6 +3,8 @@ title: Detox Plugin for Nx
 description: Learn how to set up and use Detox for end-to-end testing of mobile applications in your Nx workspace, including environment setup and configuration options.
 ---
 
+# @nx/detox
+
 Detox is gray box end-to-end testing and automation library for mobile apps. It has a lot of great features:
 
 - Cross Platform

--- a/docs/generated/packages/esbuild/documents/overview.md
+++ b/docs/generated/packages/esbuild/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx esbuild Plugin
 description: The Nx Plugin for esbuild contains executors and generators that support building applications using esbuild. This page also explains how to configure esbuild on your Nx workspace.
 ---
 
+# @nx/esbuild
+
 The Nx Plugin for [esbuild](https://esbuild.github.io/api/), an extremely fast JavaScript bundler.
 
 Why should you use this plugin?

--- a/docs/generated/packages/eslint/documents/overview.md
+++ b/docs/generated/packages/eslint/documents/overview.md
@@ -3,6 +3,8 @@ title: ESLint Plugin for Nx
 description: Learn how to set up and use the @nx/eslint plugin to integrate ESLint with Nx, enabling caching and providing code generators for ESLint configuration.
 ---
 
+# @nx/eslint
+
 The ESLint plugin integrates [ESLint](https://eslint.org/) with Nx. It allows you to run ESLint through Nx with caching enabled. It also includes code generators to help you set up ESLint in your workspace.
 
 ## Setting Up @nx/eslint

--- a/docs/generated/packages/expo/documents/overview.md
+++ b/docs/generated/packages/expo/documents/overview.md
@@ -3,6 +3,8 @@ title: Expo Plugin for Nx
 description: Learn how to use the @nx/expo plugin to manage Expo applications and libraries within an Nx workspace, including setup, configuration, and task inference.
 ---
 
+# @nx/expo
+
 Expo is an open-source framework for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
 
 Expo is a set of tools built on top of React Native. The Nx Plugin for Expo contains generators for managing Expo applications and libraries within an Nx workspace.

--- a/docs/generated/packages/express/documents/overview.md
+++ b/docs/generated/packages/express/documents/overview.md
@@ -3,6 +3,8 @@ title: Express Plugin for Nx
 description: Learn how to use the @nx/express plugin to create and manage Express applications in your Nx workspace, including setup and common recipes.
 ---
 
+# @nx/express
+
 [Express](https://expressjs.com/) is a mature, minimal, and an open source web framework for making web applications and
 apis.
 

--- a/docs/generated/packages/gradle/documents/overview.md
+++ b/docs/generated/packages/gradle/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Gradle Plugin
 description: The Nx Plugin for Gradle allows Gradle tasks to be run through Nx.
 ---
 
+# @nx/gradle
+
 [Gradle](https://gradle.org/) is a fast, dependable, and adaptable open-source build automation tool with an elegant and extensible declarative build language. Gradle supports Android, Java, Kotlin Multiplatform, Groovy, Scala, Javascript, and C/C++.
 
 The Nx Gradle plugin registers Gradle projects in your Nx workspace. It allows Gradle tasks to be run through Nx. Nx effortlessly makes your [CI faster](/ci/intro/ci-with-nx).

--- a/docs/generated/packages/jest/documents/overview.md
+++ b/docs/generated/packages/jest/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Jest Plugin
 description: The Nx Plugin for Jest contains executors and generators that support testing projects using Jest. This page also explains how to configure Jest on your Nx workspace.
 ---
 
+# @nx/jest
+
 [Jest](https://jestjs.io/) is an open source test runner created by Facebook. It has a lot of great features:
 
 - Immersive watch mode for providing near instant feedback when developing tests.

--- a/docs/generated/packages/js/documents/overview.md
+++ b/docs/generated/packages/js/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx JS Plugin
 description: The Nx JS plugin contains executors and generators that are useful for JavaScript/TypeScript projects in an Nx workspace.
 ---
 
+# @nx/js
+
 The JS plugin contains executors and generators that are useful for JavaScript/TypeScript projects in an Nx workspace.
 
 ## Setting Up @nx/js

--- a/docs/generated/packages/nest/documents/overview.md
+++ b/docs/generated/packages/nest/documents/overview.md
@@ -4,6 +4,8 @@ description: Learn how to use the @nx/nest plugin to create and manage Nest.js a
 keywords: [nest, nestjs]
 ---
 
+# @nx/nest
+
 Nest.js is a framework designed for building scalable server-side applications. In many ways, Nest is familiar to Angular developers:
 
 - It has excellent TypeScript support.

--- a/docs/generated/packages/next/documents/overview.md
+++ b/docs/generated/packages/next/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Next.js Plugin
 description: The Nx Next.js plugin contains executors and generators for managing Next.js applications and libraries within an Nx workspace. This page also explains how to configure Next.js on your Nx workspace.
 ---
 
+# @nx/next
+
 When using Next.js in Nx, you get the out-of-the-box support for TypeScript, Cypress, and Jest. No need to configure anything: watch mode, source maps, and typings just work.
 
 The Next.js plugin contains executors and generators for managing Next.js applications and libraries within an Nx workspace. It provides:

--- a/docs/generated/packages/node/documents/overview.md
+++ b/docs/generated/packages/node/documents/overview.md
@@ -3,6 +3,8 @@ title: Node.js Plugin for Nx
 description: Learn how to use the @nx/node plugin to create and manage Node.js applications and libraries in your Nx workspace, including setup, building, and testing.
 ---
 
+# @nx/node
+
 The Node Plugin contains generators and executors to manage Node applications within an Nx workspace. It provides:
 
 ## Setting Up @nx/node

--- a/docs/generated/packages/nuxt/documents/overview.md
+++ b/docs/generated/packages/nuxt/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Nuxt Plugin
 description: The Nx Plugin for Nuxt contains generators for managing Nuxt applications within a Nx workspace. This page also explains how to configure Nuxt on your Nx workspace.
 ---
 
+# @nx/nuxt
+
 The Nx plugin for [Nuxt](https://nuxt.com/).
 
 ## Setting up a new Nx workspace with @nx/nuxt

--- a/docs/generated/packages/playwright/documents/overview.md
+++ b/docs/generated/packages/playwright/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Playwright Plugin
 description: The Nx Plugin for Playwright contains executors and generators that support e2e testing with Playwright. This page also explains how to configure Playwright on your Nx workspace.
 ---
 
+# @nx/playwright
+
 Playwright is a modern web test runner. With included features such as:
 
 - Cross browser support, including mobile browsers

--- a/docs/generated/packages/react-native/documents/overview.md
+++ b/docs/generated/packages/react-native/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx React Native Plugin
 description: The Nx Plugin for React Native contains generators for managing React Native applications and libraries within an Nx workspace. This page also explains how to configure React Native on your Nx workspace.
 ---
 
+# @nx/react-native
+
 React Native brings React's declarative UI framework to iOS and Android. With React Native, you use native UI controls and have full access to the native platform.
 
 The Nx Plugin for React Native contains generators for managing React Native applications and libraries within an Nx workspace. It provides:

--- a/docs/generated/packages/react/documents/overview.md
+++ b/docs/generated/packages/react/documents/overview.md
@@ -4,6 +4,8 @@ description: Learn how to use the @nx/react plugin to create and manage React ap
 keywords: [react]
 ---
 
+# @nx/react
+
 The React plugin contains executors and generators for managing React applications and libraries within an Nx workspace.
 It provides:
 

--- a/docs/generated/packages/remix/documents/overview.md
+++ b/docs/generated/packages/remix/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Remix Plugin
 description: The Nx Plugin for Remix contains executors, generators, and utilities for managing Remix applications and libraries within an Nx workspace.
 ---
 
+# @nx/remix
+
 The Nx Plugin for Remix contains executors, generators, and utilities for managing Remix applications and libraries
 within an Nx workspace. It provides:
 

--- a/docs/generated/packages/rspack/documents/overview.md
+++ b/docs/generated/packages/rspack/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Rspack Plugin
 description: The Nx Plugin for Rspack contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
 ---
 
+# @nx/rspack
+
 The Nx Plugin for Rspack contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
 
 ## Setting Up @nx/rspack

--- a/docs/generated/packages/storybook/documents/overview.md
+++ b/docs/generated/packages/storybook/documents/overview.md
@@ -3,6 +3,8 @@ title: Nx Storybook Plugin Overview
 description: This is an overview page for the Storybook plugin in Nx. It explains what Storybook is and how to set it up in your Nx workspace.
 ---
 
+# @nx/storybook
+
 [Storybook](https://storybook.js.org) is a development environment for UI components. It allows you to browse a component library, view the different states of each component, and interactively develop and test components.
 
 This guide will briefly walk you through using Storybook within an Nx workspace.

--- a/docs/generated/packages/vite/documents/overview.md
+++ b/docs/generated/packages/vite/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Vite Plugin
 description: The Nx Plugin for Vite contains executors and generators that support building applications using Vite. This page also explains how to configure Vite on your Nx workspace.
 ---
 
+# @nx/vite
+
 The Nx plugin for [Vite](https://vitejs.dev/) and [Vitest](https://vitest.dev/).
 
 [Vite.js](https://vitejs.dev/) is a build tool that aims to provide a faster and leaner development experience for modern web projects.

--- a/docs/generated/packages/vue/documents/overview.md
+++ b/docs/generated/packages/vue/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Vue Plugin
 description: The Nx Plugin for Vue contains generators for managing Vue applications and libraries within an Nx workspace. This page also explains how to configure Vue on your Nx workspace.
 ---
 
+# @nx/vue
+
 The Nx plugin for [Vue](https://vuejs.org/).
 
 ## Setting Up @nx/vue

--- a/docs/generated/packages/webpack/documents/overview.md
+++ b/docs/generated/packages/webpack/documents/overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Webpack Plugin
 description: The Nx Plugin for Webpack contains executors and generators that support building applications using Webpack.
 ---
 
+# @nx/webpack
+
 The Nx plugin for [webpack](https://webpack.js.org/).
 
 [Webpack](https://webpack.js.org/) is a static module bundler for modern JavaScript applications. The `@nx/webpack` plugin provides executors that allow you to build and serve your projects using webpack, plus an executor for SSR.

--- a/docs/shared/deprecated/custom-tasks-runner.md
+++ b/docs/shared/deprecated/custom-tasks-runner.md
@@ -20,7 +20,7 @@ Read more in our [documentation](/recipes/running-tasks/self-hosted-caching).
 
 ### Migrating from `@nx-aws-plugin`
 
-If you've been using the `@nx-aws-plugin/nx-aws-cache` community plugin, you should be easily able to migrate to the free [Nx S3 cache plugin](/reference/core-api/s3-cache). The specific modification depends on your repository's configuration.
+If you've been using the `@nx-aws-plugin/nx-aws-cache` community plugin, you should be easily able to migrate to the free [Nx S3 cache plugin](/reference/core-api/s3-cache/overview). The specific modification depends on your repository's configuration.
 
 The following is one example, where a custom tasks runner configuration in `nx.json` will be removed:
 

--- a/docs/shared/packages/angular/angular-plugin.md
+++ b/docs/shared/packages/angular/angular-plugin.md
@@ -4,6 +4,8 @@ description: The Nx Plugin for Angular contains executors, generators, and utili
 keywords: [angular]
 ---
 
+# @nx/angular
+
 The Nx Plugin for Angular contains executors, generators, and utilities for managing Angular applications and libraries
 within an Nx workspace. It also enables using Angular Devkit builders and schematics in Nx workspaces.
 

--- a/docs/shared/packages/azure-cache/azure-cache-plugin.md
+++ b/docs/shared/packages/azure-cache/azure-cache-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Azure Cache Plugin
 description: The @nx/azure-cache plugin enables you to use Azure Storage to host your remote cache for efficient build caching across your team.
 ---
 
+# @nx/azure-cache
+
 The `@nx/azure-cache` plugin enables you to self-host your remote cache on [Azure Storage](https://azure.microsoft.com/en-us/products/storage/blobs).
 
 {% callout type="deepdive" title="Free managed remote cache with Nx Cloud" %}

--- a/docs/shared/packages/conformance/conformance-plugin.md
+++ b/docs/shared/packages/conformance/conformance-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx powerpack-conformance Plugin
 description: The Nx Powerpack Conformance plugin provides the ability to write and apply rules for your workspace
 ---
 
+# @nx/conformance
+
 The `@nx/conformance` plugin allows [Nx Powerpack](/powerpack) users to write and apply rules for your entire workspace that help with **consistency**, **maintainability**, **reliability** and **security**.
 
 The conformance plugin allows you to encode your own organization's standards so that they can be enforced automatically. Conformance rules can also complement linting tools by enforcing that those tools are configured in the recommended way. The rules are written in TypeScript but can be applied to any language in the codebase or focus entirely on configuration files.

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Cypress Plugin
 description: The Nx Plugin for Cypress contains executors and generators that support e2e testing with Cypress. This page also explains how to configure Cypress on your Nx workspace.
 ---
 
+# @nx/cypress
+
 Cypress is a test runner built for the modern web. It has a lot of great features:
 
 - Time travel

--- a/docs/shared/packages/detox/detox-plugin.md
+++ b/docs/shared/packages/detox/detox-plugin.md
@@ -3,6 +3,8 @@ title: Detox Plugin for Nx
 description: Learn how to set up and use Detox for end-to-end testing of mobile applications in your Nx workspace, including environment setup and configuration options.
 ---
 
+# @nx/detox
+
 Detox is gray box end-to-end testing and automation library for mobile apps. It has a lot of great features:
 
 - Cross Platform

--- a/docs/shared/packages/esbuild/esbuild-plugin.md
+++ b/docs/shared/packages/esbuild/esbuild-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx esbuild Plugin
 description: The Nx Plugin for esbuild contains executors and generators that support building applications using esbuild. This page also explains how to configure esbuild on your Nx workspace.
 ---
 
+# @nx/esbuild
+
 The Nx Plugin for [esbuild](https://esbuild.github.io/api/), an extremely fast JavaScript bundler.
 
 Why should you use this plugin?

--- a/docs/shared/packages/eslint/eslint.md
+++ b/docs/shared/packages/eslint/eslint.md
@@ -3,6 +3,8 @@ title: ESLint Plugin for Nx
 description: Learn how to set up and use the @nx/eslint plugin to integrate ESLint with Nx, enabling caching and providing code generators for ESLint configuration.
 ---
 
+# @nx/eslint
+
 The ESLint plugin integrates [ESLint](https://eslint.org/) with Nx. It allows you to run ESLint through Nx with caching enabled. It also includes code generators to help you set up ESLint in your workspace.
 
 ## Setting Up @nx/eslint

--- a/docs/shared/packages/expo/expo-plugin.md
+++ b/docs/shared/packages/expo/expo-plugin.md
@@ -3,6 +3,8 @@ title: Expo Plugin for Nx
 description: Learn how to use the @nx/expo plugin to manage Expo applications and libraries within an Nx workspace, including setup, configuration, and task inference.
 ---
 
+# @nx/expo
+
 Expo is an open-source framework for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
 
 Expo is a set of tools built on top of React Native. The Nx Plugin for Expo contains generators for managing Expo applications and libraries within an Nx workspace.

--- a/docs/shared/packages/express/express-plugin.md
+++ b/docs/shared/packages/express/express-plugin.md
@@ -3,6 +3,8 @@ title: Express Plugin for Nx
 description: Learn how to use the @nx/express plugin to create and manage Express applications in your Nx workspace, including setup and common recipes.
 ---
 
+# @nx/express
+
 [Express](https://expressjs.com/) is a mature, minimal, and an open source web framework for making web applications and
 apis.
 

--- a/docs/shared/packages/gcs-cache/gcs-cache-plugin.md
+++ b/docs/shared/packages/gcs-cache/gcs-cache-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx GCS Cache Plugin
 description: The @nx/gcs-cache plugin enables you to use Google Cloud Storage to host your remote cache for efficient build caching across your team.
 ---
 
+# @nx/gcs-cache
+
 The `@nx/gcs-cache` plugin enables you to self-host your remote cache on [Google Cloud Storage](https://cloud.google.com/storage).
 
 {% callout type="deepdive" title="Free managed remote cache with Nx Cloud" %}

--- a/docs/shared/packages/gradle/gradle-plugin.md
+++ b/docs/shared/packages/gradle/gradle-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Gradle Plugin
 description: The Nx Plugin for Gradle allows Gradle tasks to be run through Nx.
 ---
 
+# @nx/gradle
+
 [Gradle](https://gradle.org/) is a fast, dependable, and adaptable open-source build automation tool with an elegant and extensible declarative build language. Gradle supports Android, Java, Kotlin Multiplatform, Groovy, Scala, Javascript, and C/C++.
 
 The Nx Gradle plugin registers Gradle projects in your Nx workspace. It allows Gradle tasks to be run through Nx. Nx effortlessly makes your [CI faster](/ci/intro/ci-with-nx).

--- a/docs/shared/packages/jest/jest-plugin.md
+++ b/docs/shared/packages/jest/jest-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Jest Plugin
 description: The Nx Plugin for Jest contains executors and generators that support testing projects using Jest. This page also explains how to configure Jest on your Nx workspace.
 ---
 
+# @nx/jest
+
 [Jest](https://jestjs.io/) is an open source test runner created by Facebook. It has a lot of great features:
 
 - Immersive watch mode for providing near instant feedback when developing tests.

--- a/docs/shared/packages/js/js-plugin.md
+++ b/docs/shared/packages/js/js-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx JS Plugin
 description: The Nx JS plugin contains executors and generators that are useful for JavaScript/TypeScript projects in an Nx workspace.
 ---
 
+# @nx/js
+
 The JS plugin contains executors and generators that are useful for JavaScript/TypeScript projects in an Nx workspace.
 
 ## Setting Up @nx/js

--- a/docs/shared/packages/nest/nest-plugin.md
+++ b/docs/shared/packages/nest/nest-plugin.md
@@ -4,6 +4,8 @@ description: Learn how to use the @nx/nest plugin to create and manage Nest.js a
 keywords: [nest, nestjs]
 ---
 
+# @nx/nest
+
 Nest.js is a framework designed for building scalable server-side applications. In many ways, Nest is familiar to Angular developers:
 
 - It has excellent TypeScript support.

--- a/docs/shared/packages/next/plugin-overview.md
+++ b/docs/shared/packages/next/plugin-overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Next.js Plugin
 description: The Nx Next.js plugin contains executors and generators for managing Next.js applications and libraries within an Nx workspace. This page also explains how to configure Next.js on your Nx workspace.
 ---
 
+# @nx/next
+
 When using Next.js in Nx, you get the out-of-the-box support for TypeScript, Cypress, and Jest. No need to configure anything: watch mode, source maps, and typings just work.
 
 The Next.js plugin contains executors and generators for managing Next.js applications and libraries within an Nx workspace. It provides:

--- a/docs/shared/packages/node/node-plugin.md
+++ b/docs/shared/packages/node/node-plugin.md
@@ -3,6 +3,8 @@ title: Node.js Plugin for Nx
 description: Learn how to use the @nx/node plugin to create and manage Node.js applications and libraries in your Nx workspace, including setup, building, and testing.
 ---
 
+# @nx/node
+
 The Node Plugin contains generators and executors to manage Node applications within an Nx workspace. It provides:
 
 ## Setting Up @nx/node

--- a/docs/shared/packages/nuxt/nuxt-plugin.md
+++ b/docs/shared/packages/nuxt/nuxt-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Nuxt Plugin
 description: The Nx Plugin for Nuxt contains generators for managing Nuxt applications within a Nx workspace. This page also explains how to configure Nuxt on your Nx workspace.
 ---
 
+# @nx/nuxt
+
 The Nx plugin for [Nuxt](https://nuxt.com/).
 
 ## Setting up a new Nx workspace with @nx/nuxt

--- a/docs/shared/packages/owners/owners-plugin.md
+++ b/docs/shared/packages/owners/owners-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx powerpack-owners Plugin
 description: The Nx Powerpack Owners plugin provides the ability to define code ownership based on projects in addition to files
 ---
 
+# @nx/owners
+
 The `@nx/owners` plugin extends the CODEOWNERS functionality to allow you to define code ownership based on projects in addition to the standard file-based definitions. It leverages the [`nx sync`](/concepts/sync-generators) command to compile `owners` configuration settings from `nx.json` and project configuration files into valid CODEOWNERS files for [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-use-code-owners/) or [GitLab](https://docs.gitlab.com/ee/user/project/codeowners/).
 
 With this plugin, you can specify code ownership using the same project matcher syntax as [`nx run-many`](/reference/core-api/nx/documents/run-many#examples). This allows you to easily define rules for multiple projects that may not be located in the same directory. Also, the CODEOWNERS rules will not need to be revisited if a project location is changed or a new project is added.

--- a/docs/shared/packages/playwright/playwright-plugin.md
+++ b/docs/shared/packages/playwright/playwright-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Playwright Plugin
 description: The Nx Plugin for Playwright contains executors and generators that support e2e testing with Playwright. This page also explains how to configure Playwright on your Nx workspace.
 ---
 
+# @nx/playwright
+
 Playwright is a modern web test runner. With included features such as:
 
 - Cross browser support, including mobile browsers

--- a/docs/shared/packages/react-native/react-native-plugin.md
+++ b/docs/shared/packages/react-native/react-native-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx React Native Plugin
 description: The Nx Plugin for React Native contains generators for managing React Native applications and libraries within an Nx workspace. This page also explains how to configure React Native on your Nx workspace.
 ---
 
+# @nx/react-native
+
 React Native brings React's declarative UI framework to iOS and Android. With React Native, you use native UI controls and have full access to the native platform.
 
 The Nx Plugin for React Native contains generators for managing React Native applications and libraries within an Nx workspace. It provides:

--- a/docs/shared/packages/react/react-plugin.md
+++ b/docs/shared/packages/react/react-plugin.md
@@ -4,6 +4,8 @@ description: Learn how to use the @nx/react plugin to create and manage React ap
 keywords: [react]
 ---
 
+# @nx/react
+
 The React plugin contains executors and generators for managing React applications and libraries within an Nx workspace.
 It provides:
 

--- a/docs/shared/packages/remix/remix-plugin.md
+++ b/docs/shared/packages/remix/remix-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Remix Plugin
 description: The Nx Plugin for Remix contains executors, generators, and utilities for managing Remix applications and libraries within an Nx workspace.
 ---
 
+# @nx/remix
+
 The Nx Plugin for Remix contains executors, generators, and utilities for managing Remix applications and libraries
 within an Nx workspace. It provides:
 

--- a/docs/shared/packages/rspack/rspack-plugin.md
+++ b/docs/shared/packages/rspack/rspack-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Rspack Plugin
 description: The Nx Plugin for Rspack contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
 ---
 
+# @nx/rspack
+
 The Nx Plugin for Rspack contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
 
 ## Setting Up @nx/rspack

--- a/docs/shared/packages/s3-cache/s3-cache-plugin.md
+++ b/docs/shared/packages/s3-cache/s3-cache-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx S3 Cache Plugin
 description: The @nx/s3-cache plugin enables you to use an Amazon S3 bucket to host your remote cache for efficient build caching across your team.
 ---
 
+# @nx/s3-cache
+
 The `@nx/s3-cache` plugin enables you to self-host your remote cache on an [Amazon S3](https://aws.amazon.com/s3) bucket.
 
 {% callout type="deepdive" title="Free managed remote cache with Nx Cloud" %}

--- a/docs/shared/packages/shared-fs-cache/shared-fs-cache-plugin.md
+++ b/docs/shared/packages/shared-fs-cache/shared-fs-cache-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Shared File System Cache Plugin
 description: The @nx/shared-fs-cache plugin enables you to use a shared file system directory to host your remote cache for efficient build caching across your team.
 ---
 
+# @nx/shared-fs-cache
+
 The `@nx/shared-fs-cache` plugin enables you to host your remote cache on a shared file system directory. While you're responsible for implementing the actual directory sharing mechanism, the plugin configures Nx to read from both your local cache and the shared directory.
 
 {% callout type="warning" title="Potential Cache Poisoning" %}

--- a/docs/shared/packages/storybook/plugin-overview.md
+++ b/docs/shared/packages/storybook/plugin-overview.md
@@ -3,6 +3,8 @@ title: Nx Storybook Plugin Overview
 description: This is an overview page for the Storybook plugin in Nx. It explains what Storybook is and how to set it up in your Nx workspace.
 ---
 
+# @nx/storybook
+
 [Storybook](https://storybook.js.org) is a development environment for UI components. It allows you to browse a component library, view the different states of each component, and interactively develop and test components.
 
 This guide will briefly walk you through using Storybook within an Nx workspace.

--- a/docs/shared/packages/vite/vite-plugin.md
+++ b/docs/shared/packages/vite/vite-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Vite Plugin
 description: The Nx Plugin for Vite contains executors and generators that support building applications using Vite. This page also explains how to configure Vite on your Nx workspace.
 ---
 
+# @nx/vite
+
 The Nx plugin for [Vite](https://vitejs.dev/) and [Vitest](https://vitest.dev/).
 
 [Vite.js](https://vitejs.dev/) is a build tool that aims to provide a faster and leaner development experience for modern web projects.

--- a/docs/shared/packages/vue/vue-plugin.md
+++ b/docs/shared/packages/vue/vue-plugin.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Vue Plugin
 description: The Nx Plugin for Vue contains generators for managing Vue applications and libraries within an Nx workspace. This page also explains how to configure Vue on your Nx workspace.
 ---
 
+# @nx/vue
+
 The Nx plugin for [Vue](https://vuejs.org/).
 
 ## Setting Up @nx/vue

--- a/docs/shared/packages/webpack/plugin-overview.md
+++ b/docs/shared/packages/webpack/plugin-overview.md
@@ -3,6 +3,8 @@ title: Overview of the Nx Webpack Plugin
 description: The Nx Plugin for Webpack contains executors and generators that support building applications using Webpack.
 ---
 
+# @nx/webpack
+
 The Nx plugin for [webpack](https://webpack.js.org/).
 
 [Webpack](https://webpack.js.org/) is a static module bundler for modern JavaScript applications. The `@nx/webpack` plugin provides executors that allow you to build and serve your projects using webpack, plus an executor for SSR.

--- a/docs/shared/recipes/running-tasks/self-hosted-caching.md
+++ b/docs/shared/recipes/running-tasks/self-hosted-caching.md
@@ -26,10 +26,10 @@ The official self-hosted cache packages are the easiest migration path if you've
 
 The following remote cache adapters are available:
 
-- [@nx/s3-cache](/reference/core-api/s3-cache): Cache is self-hosted on an Amazon S3 bucket
-- [@nx/gcs-cache](/reference/core-api/gcs-cache): Cache is self-hosted on Google Cloud storage
-- [@nx/azure-cache](/reference/core-api/azure-cache): Cache is self-hosted on Azure
-- [@nx/shared-fs-cache](/reference/core-api/shared-fs-cache): Cache is self-hosted on a shared file system location
+- [@nx/s3-cache](/reference/core-api/s3-cache/overview): Cache is self-hosted on an Amazon S3 bucket
+- [@nx/gcs-cache](/reference/core-api/gcs-cache/overview): Cache is self-hosted on Google Cloud storage
+- [@nx/azure-cache](/reference/core-api/azure-cache/overview): Cache is self-hosted on Azure
+- [@nx/shared-fs-cache](/reference/core-api/shared-fs-cache/overview): Cache is self-hosted on a shared file system location
 
 > Why require an activation key? It simply helps us know and support our users. If you prefer not to provide this information, you can also [build your own cache server](#build-your-own-caching-server).
 


### PR DESCRIPTION
## Current Behavior

- Documentation pages under "technologies" and "core-api" sections with "introduction"/"overview" IDs lack H1 titles after front matter
- Some remote caching package links point to parent sections instead of overview pages

## Expected Behavior

- All affected documentation pages should have H1 titles for consistency
- Links should point directly to overview pages

## Related Issue(s)

Fixes #

## Changes Made

### 1. Updated Remote Caching Links (commit fae9055f8c)

Updated links in 3 files to point directly to overview pages:
- `docs/blog/2025-01-06-nx-update-20-3.md`
- `docs/shared/deprecated/custom-tasks-runner.md`
- `docs/shared/recipes/running-tasks/self-hosted-caching.md`

Changed links from:
- `/reference/core-api/azure-cache` → `/reference/core-api/azure-cache/overview`
- `/reference/core-api/gcs-cache` → `/reference/core-api/gcs-cache/overview`
- `/reference/core-api/s3-cache` → `/reference/core-api/s3-cache/overview`
- `/reference/core-api/shared-fs-cache` → `/reference/core-api/shared-fs-cache/overview`

### 2. Added H1 Titles to Documentation Pages

Added H1 titles to 29 documentation files that were missing them:

#### Core API Overview Pages (6 files)
- `docs/shared/packages/azure-cache/azure-cache-plugin.md` → `# @nx/azure-cache`
- `docs/shared/packages/conformance/conformance-plugin.md` → `# @nx/conformance`
- `docs/shared/packages/gcs-cache/gcs-cache-plugin.md` → `# @nx/gcs-cache`
- `docs/shared/packages/owners/owners-plugin.md` → `# @nx/owners`
- `docs/shared/packages/s3-cache/s3-cache-plugin.md` → `# @nx/s3-cache`
- `docs/shared/packages/shared-fs-cache/shared-fs-cache-plugin.md` → `# @nx/shared-fs-cache`

#### Technology Introduction Pages (23 files)
- `docs/shared/packages/angular/angular-plugin.md` → `# @nx/angular`
- `docs/shared/packages/esbuild/esbuild-plugin.md` → `# @nx/esbuild`
- `docs/shared/packages/rspack/rspack-plugin.md` → `# @nx/rspack`
- `docs/shared/packages/vite/vite-plugin.md` → `# @nx/vite`
- `docs/shared/packages/webpack/plugin-overview.md` → `# @nx/webpack`
- `docs/shared/packages/eslint/eslint.md` → `# @nx/eslint`
- `docs/shared/packages/gradle/gradle-plugin.md` → `# @nx/gradle`
- `docs/shared/packages/express/express-plugin.md` → `# @nx/express`
- `docs/shared/packages/node/node-plugin.md` → `# @nx/node`
- `docs/shared/packages/nest/nest-plugin.md` → `# @nx/nest`
- `docs/shared/packages/expo/expo-plugin.md` → `# @nx/expo`
- `docs/shared/packages/react/react-plugin.md` → `# @nx/react`
- `docs/shared/packages/next/plugin-overview.md` → `# @nx/next`
- `docs/shared/packages/react-native/react-native-plugin.md` → `# @nx/react-native`
- `docs/shared/packages/remix/remix-plugin.md` → `# @nx/remix`
- `docs/shared/packages/cypress/cypress-plugin.md` → `# @nx/cypress`
- `docs/shared/packages/detox/detox-plugin.md` → `# @nx/detox`
- `docs/shared/packages/jest/jest-plugin.md` → `# @nx/jest`
- `docs/shared/packages/playwright/playwright-plugin.md` → `# @nx/playwright`
- `docs/shared/packages/storybook/plugin-overview.md` → `# @nx/storybook`
- `docs/shared/packages/js/js-plugin.md` → `# @nx/js`
- `docs/shared/packages/vue/vue-plugin.md` → `# @nx/vue`
- `docs/shared/packages/nuxt/nuxt-plugin.md` → `# @nx/nuxt`

Note: The Angular Rspack introduction page (`docs/shared/guides/angular-rspack/introduction.md`) already had an appropriate H1
title "# Introduction" and was left unchanged.

All changes improve documentation consistency and navigation by ensuring proper titles and direct links to overview pages.