### PR TITLE
docs(nx-dev): add CVE reference on remote cache

### DIFF
--- a/docs/shared/packages/azure-cache/azure-cache-plugin.md
+++ b/docs/shared/packages/azure-cache/azure-cache-plugin.md
@@ -15,9 +15,9 @@ If you are an enterprise and **data privacy and security is a concern**, [reach 
 
 {% /callout %}
 
-{% callout type="info" title="Self-hosted caching is now free" %}
+{% callout type="warning" title="Bucket-based caches are vulnerable to poisoning and often prohibited in organizations" %}
 
-Self-hosted caching is **now free for everyone** to use.
+CREEP (CVE-2025-36852) is a critical vulnerability in bucket-based self-hosted remote caches. It lets attackers with PR access poison production builds via a race condition during artifact creation—before security checks can catch it. [Learn more](/blog/cve-2025-36852-critical-cache-poisoning-vulnerability-creep)
 
 {% /callout %}
 

--- a/docs/shared/packages/gcs-cache/gcs-cache-plugin.md
+++ b/docs/shared/packages/gcs-cache/gcs-cache-plugin.md
@@ -15,9 +15,9 @@ If you are an enterprise and **data privacy and security is a concern**, [reach 
 
 {% /callout %}
 
-{% callout type="info" title="Self-hosted caching is now free" %}
+{% callout type="warning" title="Bucket-based caches are vulnerable to poisoning and often prohibited in organizations" %}
 
-Self-hosted caching is **now free for everyone** to use.
+CREEP (CVE-2025-36852) is a critical vulnerability in bucket-based self-hosted remote caches. It lets attackers with PR access poison production builds via a race condition during artifact creation—before security checks can catch it. [Learn more](/blog/cve-2025-36852-critical-cache-poisoning-vulnerability-creep)
 
 {% /callout %}
 

--- a/docs/shared/packages/s3-cache/s3-cache-plugin.md
+++ b/docs/shared/packages/s3-cache/s3-cache-plugin.md
@@ -14,9 +14,9 @@ If you are an enterprise and **data privacy and security is a concern**, [reach 
 **Are you an OSS project?** Nx Cloud is free for OSS. [Reach out here](/pricing#oss).
 {% /callout %}
 
-{% callout type="info" title="Self-hosted caching is now free" %}
+{% callout type="warning" title="Bucket-based caches are vulnerable to poisoning and often prohibited in organizations" %}
 
-Self-hosted caching is **now free for everyone** to use.
+CREEP (CVE-2025-36852) is a critical vulnerability in bucket-based self-hosted remote caches. It lets attackers with PR access poison production builds via a race condition during artifact creation—before security checks can catch it. [Learn more](/blog/cve-2025-36852-critical-cache-poisoning-vulnerability-creep)
 
 {% /callout %}
 

--- a/docs/shared/packages/shared-fs-cache/shared-fs-cache-plugin.md
+++ b/docs/shared/packages/shared-fs-cache/shared-fs-cache-plugin.md
@@ -5,10 +5,6 @@ description: The @nx/shared-fs-cache plugin enables you to use a shared file sys
 
 The `@nx/shared-fs-cache` plugin enables you to host your remote cache on a shared file system directory. While you're responsible for implementing the actual directory sharing mechanism, the plugin configures Nx to read from both your local cache and the shared directory.
 
-{% callout type="warning" title="Potential Cache Poisoning" %}
-Using a shared file system folder for remote caching introduces the risk of [cache poisoning](/troubleshooting/unknown-local-cache). To mitigate this risk, consider using [Nx Replay](/ci/features/remote-cache) instead.
-{% /callout %}
-
 {% callout type="deepdive" title="Free managed remote cache with Nx Cloud" %}
 
 Note, you can get started for free with a **fully managed remote caching powered by Nx Cloud**. It comes with a generous Hobby plan that is enough for most small teams. [Learn more here](/nx-cloud).
@@ -19,9 +15,9 @@ If you are an enterprise and **data privacy and security is a concern**, [reach 
 
 {% /callout %}
 
-{% callout type="info" title="Self-hosted caching is now free" %}
+{% callout type="warning" title="Bucket-based caches are vulnerable to poisoning and often prohibited in organizations" %}
 
-Self-hosted caching is **now free for everyone** to use.
+CREEP (CVE-2025-36852) is a critical vulnerability in bucket-based self-hosted remote caches. It lets attackers with PR access poison production builds via a race condition during artifact creation—before security checks can catch it. [Learn more](/blog/cve-2025-36852-critical-cache-poisoning-vulnerability-creep)
 
 {% /callout %}
 

--- a/docs/shared/recipes/running-tasks/self-hosted-caching.md
+++ b/docs/shared/recipes/running-tasks/self-hosted-caching.md
@@ -10,7 +10,13 @@ Nx offers different ways to enable self-hosted remote caching for your workspace
 - **Using the official Nx packages** that come with ready-to-use adapters for AWS S3, GCP, Azure, and more.
 - **Build your own cache server** by following the Nx Remote Caching OpenAPI spec.
 
-{% callout type="note" title="Free managed remote cache with Nx Cloud" %}
+{% callout type="warning" title="Bucket-based caches are vulnerable to poisoning and often prohibited in organizations" %}
+
+CREEP (CVE-2025-36852) is a critical vulnerability in bucket-based self-hosted remote caches. It lets attackers with PR access poison production builds via a race condition during artifact creation—before security checks can catch it. [Learn more](/blog/cve-2025-36852-critical-cache-poisoning-vulnerability-creep)
+
+{% /callout %}
+
+{% callout type="note" title="Free & secure managed remote cache with Nx Cloud" %}
 
 Note, you can get started for free with a **fully managed remote caching powered by Nx Cloud**. It comes with a generous Hobby plan that is enough for most small teams. [Learn more here](/nx-cloud).
 

--- a/nx-dev/ui-remote-cache/src/lib/faq.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/faq.tsx
@@ -41,6 +41,7 @@ export function Faq(): ReactElement {
             <Link
               href="/deprecated/custom-tasks-runner#deprecating-custom-tasks-runner"
               title="See documentation"
+              prefetch={false}
               className="font-semibold"
             >
               documented here.
@@ -68,6 +69,32 @@ export function Faq(): ReactElement {
           <Link
             href="/recipes/running-tasks/self-hosted-caching#build-your-own-caching-server"
             title="Learn more"
+            prefetch={false}
+            className="font-semibold"
+          >
+            Learn more here.
+          </Link>
+        </p>
+      ),
+    },
+    {
+      question:
+        'What cache poisoning vulnerabilities affect self-hosted solutions?',
+      answerJson:
+        'CREEP (Cache Race-condition Exploit Enables Poisoning) is a critical vulnerability (CVE-2025-36852) that affects self-hosted remote cache solutions. <br /> It allows any developer with pull request access to inject malicious code into your production builds through a race condition in the caching system. The attack is undetectable because it happens during artifact creation, before any security measures take effect.',
+      answerUi: (
+        <p>
+          CREEP (Cache Race-condition Exploit Enables Poisoning) is a critical
+          vulnerability (CVE-2025-36852) that affects self-hosted remote cache
+          solutions. <br /> It allows any developer with pull request access to
+          inject malicious code into your production builds through a race
+          condition in the caching system. The attack is undetectable because it
+          happens during artifact creation, before any security measures take
+          effect.{' '}
+          <Link
+            href="/blog/cve-2025-36852-critical-cache-poisoning-vulnerability-creep"
+            title="Learn more"
+            prefetch={false}
             className="font-semibold"
           >
             Learn more here.
@@ -91,6 +118,7 @@ export function Faq(): ReactElement {
           <Link
             href="/enterprise/security"
             title="Learn more"
+            prefetch={false}
             className="font-semibold"
           >
             Learn more here.
@@ -111,37 +139,34 @@ export function Faq(): ReactElement {
       answerUi: (
         <>
           <p>
-            Nx Cloud includes{' '}
-            <Strong>enterprise-grade security features</Strong> designed to give
-            organizations more control over access and data protection.
+            Nx Cloud includes enterprise-grade security features designed to
+            give organizations more control over access and data protection.
           </p>
           <ul className="mt-4 list-disc space-y-2 px-4">
             <li>
-              <Strong>Access Management</Strong>: Nx Cloud supports{' '}
-              <Strong>individual user authentication</Strong> tied to personal
-              accounts, enabling precise control over who can access cached
-              data. If a user leaves the company or changes roles, their access
-              can be revoked immediately — without impacting others.
+              Access Management: Nx Cloud supports individual user
+              authentication tied to personal accounts, enabling precise control
+              over who can access cached data. If a user leaves the company or
+              changes roles, their access can be revoked immediately — without
+              impacting others.
             </li>
             <li>
-              <Strong>Personal Access Tokens</Strong>: Teams can issue and
-              revoke multiple access tokens, allowing fine-grained control over
-              automation and integrations.
+              Personal Access Tokens: Teams can issue and revoke multiple access
+              tokens, allowing fine-grained control over automation and
+              integrations.
             </li>
             <li>
-              <Strong>No Cache Overrides</Strong>: Nx Cloud prevents
-              unauthorized cache modifications.
+              No Cache Overrides: Nx Cloud prevents unauthorized cache
+              modifications.
             </li>
             <li>
-              <Strong>SOC 2 Compliance</Strong>: Nx Cloud is SOC 2 certified,
-              demonstrating a high standard for security, availability, and
-              confidentiality.
+              SOC 2 Compliance Nx Cloud is SOC 2 certified, demonstrating a high
+              standard for security, availability, and confidentiality.
             </li>
             <li>
-              <Strong>Secure Deployment Options</Strong>: Nx Cloud though{' '}
-              <Strong>Nx Enterprise</Strong>, includes{' '}
-              <Strong>single-tenant or on-prem options</Strong> for teams
-              needing full control over their data storage and access policies.
+              Secure Deployment Options Nx Cloud though Nx Enterprise includes{' '}
+              single-tenant or on-prem options for teams needing full control
+              over their data storage and access policies.
             </li>
           </ul>
         </>

--- a/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
@@ -4,7 +4,7 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon,
 } from '@heroicons/react/24/solid';
-import { ButtonLink, SectionHeading } from '@nx/nx-dev/ui-common';
+import { ButtonLink, SectionHeading, Strong } from '@nx/nx-dev/ui-common';
 import { sendCustomEvent } from '@nx/nx-dev/feature-analytics';
 import Link from 'next/link';
 
@@ -20,6 +20,7 @@ export function RemoteCacheSolutions(): ReactElement {
             Free remote caching solutions for any team.
           </SectionHeading>
         </header>
+
         <div className="mt-24 flow-root">
           <div className="-mt-16 grid max-w-full grid-cols-1 gap-12 sm:mx-auto lg:mt-0 lg:grid-cols-3 xl:-mx-4">
             {/* NX CLOUD */}
@@ -186,22 +187,19 @@ export function RemoteCacheSolutions(): ReactElement {
                 </div>
                 <ul className="mt-4 divide-y divide-slate-200 border-t border-slate-200 text-sm dark:divide-slate-800 dark:border-slate-800">
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
-                    <CheckCircleIcon
-                      aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
-                    />
-                    <span>Free for all users</span>
-                  </li>
-                  <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <ExclamationCircleIcon
                       aria-hidden="true"
                       className="h-6 w-5 flex-none text-yellow-600 dark:text-yellow-500"
                     />
-                    <span>
-                      Not recommended for organizations requiring HIPAA or SOC 2
-                      compliance (
+                    <div>
+                      <Strong>
+                        Bucket-based solutions are vulnerable to cache poisoning
+                        attacks. Most regulated organizations prohibit their
+                        use.
+                      </Strong>{' '}
+                      Consult your security team before using. (
                       <Link
-                        href="/enterprise/security"
+                        href="/enterprise/security#compliance-section"
                         prefetch={false}
                         title="Remote caching security"
                         className="font-semibold underline"
@@ -209,7 +207,14 @@ export function RemoteCacheSolutions(): ReactElement {
                         learn more
                       </Link>
                       )
-                    </span>
+                    </div>
+                  </li>
+                  <li className="flex items-start justify-start gap-x-2 py-2.5">
+                    <CheckCircleIcon
+                      aria-hidden="true"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    />
+                    <span>Free for all users</span>
                   </li>
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon


### PR DESCRIPTION
Improved the clarity of caching risks, added detailed explanations on CREEP vulnerability, and linked to the CVE-2025-36852 publication.