### PR TITLE
fix(core): prevent duplicate nx cloud logs from global and local nx invocations

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -14,6 +14,12 @@ export async function initLocal(workspace: WorkspaceTypeAndRoot) {
   process.env.NX_CLI_SET = 'true';
 
   try {
+    // In case Nx Cloud forcibly exits while the TUI is running, ensure the terminal is restored etc.
+    process.on('exit', (...args) => {
+      if (typeof globalThis.tuiOnProcessExit === 'function') {
+        globalThis.tuiOnProcessExit(...args);
+      }
+    });
     performance.mark('init-local');
 
     if (workspace.type !== 'nx' && shouldDelegateToAngularCLI()) {

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -22,13 +22,6 @@ import { setupWorkspaceContext } from '../src/utils/workspace-context';
 import { daemonClient } from '../src/daemon/client/client';
 import { removeDbConnections } from '../src/utils/db-connection';
 
-// In case Nx Cloud forcibly exits while the TUI is running, ensure the terminal is restored etc.
-process.on('exit', (...args) => {
-  if (typeof globalThis.tuiOnProcessExit === 'function') {
-    globalThis.tuiOnProcessExit(...args);
-  }
-});
-
 async function main() {
   if (
     process.argv[2] !== 'report' &&


### PR DESCRIPTION
## Current Behavior

When Nx is invoked from a global install, both the global and local versions register process exit handlers that flush captured logs. This causes Nx Cloud logs to be displayed twice - once from the global installation and once from the local installation.

## Expected Behavior

Only the local Nx installation should handle log flushing, preventing duplicate log output. The process exit handler is moved from the global entry point (nx.ts) to the local entry point (init-local.ts) so that log flushing only occurs once.

## Related Issue(s)

This change requires users to update their globally installed Nx to fully resolve the duplicate logging issue, as the fix is now in the local version that gets invoked.