### PR TITLE
feat(core): pass in progress task outputs to tui for non-direct child processes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,8 @@ Fixes #ISSUE_NUMBER
 ### Guidelines
 
 - Ensure your commit message follows the conventional commit format (use `pnpm commit`)
+  - Use `fix:`, `feat:`, `chore:`, etc. as appropriate types.
+  - Scope is **required** for all commits. Possible scopes are listed in `scripts/commitizen.js`.
 - Read the submission guidelines in CONTRIBUTING.md before posting
 - For complex changes, you can request a dedicated Nx release by mentioning the Nx team
 - Always link the related issue using "Fixes #ISSUE_NUMBER" to automatically close it when merged

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -153,6 +153,7 @@ export class ForkedProcessTaskRunner {
       !disablePseudoTerminal &&
       (this.tuiEnabled || (streamOutput && !shouldPrefix))
     ) {
+      // Use pseudo-terminal for interactive tasks that can support user input
       return this.forkProcessWithPseudoTerminal(task, {
         temporaryOutputPath,
         streamOutput,
@@ -160,6 +161,9 @@ export class ForkedProcessTaskRunner {
         env,
       });
     } else {
+      // Use non-interactive process with piped output
+      // Tradeoff: These tasks cannot support interactivity but can still provide
+      // progressive output to the TUI if it's enabled
       return this.forkProcessWithPrefixAndNotTTY(task, {
         temporaryOutputPath,
         streamOutput,

--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
@@ -103,14 +103,6 @@ export class NodeChildProcessWithNonDirectOutput implements RunningTask {
       this.childProcess.kill(signal);
     }
   }
-
-  /**
-   * Returns true if this task can provide progressive output for TUI display.
-   * NodeChildProcessWithNonDirectOutput can stream output but doesn't support interactivity.
-   */
-  public canProvideProgressiveOutput(): boolean {
-    return true;
-  }
 }
 
 function addPrefixTransformer(prefix?: string) {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -635,7 +635,6 @@ export class TaskOrchestrator {
         temporaryOutputPath,
         streamOutput
       );
-
       if (this.tuiEnabled) {
         if (runningTask instanceof PseudoTtyProcess) {
           // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
@@ -646,11 +645,18 @@ export class TaskOrchestrator {
           runningTask.onOutput((output) => {
             this.options.lifeCycle.appendTaskOutput(task.id, output, true);
           });
-        } else if ('onOutput' in runningTask) {
+        } else if (
+          'onOutput' in runningTask &&
+          typeof runningTask.onOutput === 'function'
+        ) {
+          // Register task that can provide progressive output but isn't interactive (e.g., NodeChildProcessWithNonDirectOutput)
           this.options.lifeCycle.registerRunningTaskWithEmptyParser(task.id);
           runningTask.onOutput((output) => {
             this.options.lifeCycle.appendTaskOutput(task.id, output, false);
           });
+        } else {
+          // Fallback for tasks that don't support progressive output
+          this.options.lifeCycle.registerRunningTaskWithEmptyParser(task.id);
         }
       }
 


### PR DESCRIPTION
## Current Behavior
Currently the TUI is disabled on windows due to poor support for the pseudoterminal and some lingering issues. 

## Expected Behavior
This PR starts tackling this by making the TUI more usable without the pty. The first step here is enabling processes created without the pty to display live outputs in the TUI, which was currently not possible.

## Copilot Summary
This pull request introduces enhancements to task execution and output handling in the Nx task runner. The changes focus on improving the handling of progressive output for the TUI (Text User Interface), adding support for pseudo-terminal processes, and refining the orchestration of tasks. Below are the most important changes grouped by theme:

### Enhancements to Task Execution and Output Handling:
* [`packages/nx/src/tasks-runner/running-tasks/node-child-process.ts`](diffhunk://#diff-8c0c3712ab796458d8f6fc6cb685f68a45c01fb94f2210d9b60eaabb07610a7cR12): Added a new `onOutput` method to allow streaming output to the TUI via callbacks. Updated `stdout` and `stderr` handlers to invoke these callbacks for progressive output. Introduced a `canProvideProgressiveOutput` method to indicate whether a task can stream output. [[1]](diffhunk://#diff-8c0c3712ab796458d8f6fc6cb685f68a45c01fb94f2210d9b60eaabb07610a7cR12) [[2]](diffhunk://#diff-8c0c3712ab796458d8f6fc6cb685f68a45c01fb94f2210d9b60eaabb07610a7cL55-R80) [[3]](diffhunk://#diff-8c0c3712ab796458d8f6fc6cb685f68a45c01fb94f2210d9b60eaabb07610a7cL88-R112)

### Support for Pseudo-Terminal Processes:
* [`packages/nx/src/tasks-runner/forked-process-task-runner.ts`](diffhunk://#diff-9e7468f39e004b5e6087ab9a309150efa755b4f9f8047514b63fc71f8034c930L143-R143): Added comments to clarify when pseudo-terminal processes are used for interactive tasks and when non-interactive processes with piped output are used. These changes improve readability and understanding of the trade-offs involved. [[1]](diffhunk://#diff-9e7468f39e004b5e6087ab9a309150efa755b4f9f8047514b63fc71f8034c930L143-R143) [[2]](diffhunk://#diff-9e7468f39e004b5e6087ab9a309150efa755b4f9f8047514b63fc71f8034c930R155-R165)

### Improvements to Task Orchestration:
* [`packages/nx/src/tasks-runner/task-orchestrator.ts`](diffhunk://#diff-e9bae83332b3d6e57c023959ab2e5f191c97e0a154a8c1d36dd81f8f869e1bdfL637-R637): Enhanced the registration of tasks in the TUI lifecycle. Added checks to ensure tasks that support progressive output but are not interactive (e.g., `NodeChildProcessWithNonDirectOutput`) are registered correctly. Introduced a fallback for tasks that don't support progressive output. [[1]](diffhunk://#diff-e9bae83332b3d6e57c023959ab2e5f191c97e0a154a8c1d36dd81f8f869e1bdfL637-R637) [[2]](diffhunk://#diff-e9bae83332b3d6e57c023959ab2e5f191c97e0a154a8c1d36dd81f8f869e1bdfL649-R655)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
