### PR TITLE
feat(nx-plugin): refactor plugin options normalization to common method with defaultOptions (normalizeOptions)

### DIFF
--- a/packages/nx/src/utils/normalize-extensions.spec.ts
+++ b/packages/nx/src/utils/normalize-extensions.spec.ts
@@ -1,0 +1,34 @@
+import { normalizeExtensions } from './normalize-extensions';
+
+describe('normalizeExtensions', () => {
+  it('returns undefined for non-arrays', () => {
+    expect(normalizeExtensions(undefined)).toBeUndefined();
+    expect(normalizeExtensions(null as any)).toBeUndefined();
+    expect(normalizeExtensions('foo' as any)).toBeUndefined();
+  });
+
+  it('returns empty array as is', () => {
+    expect(normalizeExtensions([])).toEqual([]);
+  });
+
+  it('normalizes, trims, strips dots, lowercases, and dedupes', () => {
+    expect(
+      normalizeExtensions([
+        '  .JS ',
+        'js',
+        'TS',
+        '.ts',
+        'Ts',
+        'tsx',
+        ' TSX ',
+        '',
+        '.',
+        '  ',
+      ])
+    ).toEqual(['js', 'ts', 'tsx']);
+  });
+
+  it('filters out empty/invalid after normalization', () => {
+    expect(normalizeExtensions(['', '   ', '.', '...'])).toEqual([]);
+  });
+});

--- a/packages/nx/src/utils/normalize-extensions.ts
+++ b/packages/nx/src/utils/normalize-extensions.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalize user input for extensions
+ * - trim
+ * - strip leading . characters
+ * - convert to lower case
+ * - unique
+ *
+ * Returns undefined for non-arrays, returns empty array as is.
+ */
+
+export function normalizeExtensions(
+  extensions: string[] | undefined
+): string[] | undefined {
+  if (!Array.isArray(extensions)) return undefined;
+  if (extensions.length === 0) return extensions;
+  const normalized = extensions
+    .map((f: string) =>
+      f.trim().replace(/^"+/, '').replace(/^[.]+/, '').toLowerCase()
+    )
+    .filter((f) => f.length > 0);
+  return Array.from(new Set(normalized));
+}

--- a/packages/nx/src/utils/normalize-options.spec.ts
+++ b/packages/nx/src/utils/normalize-options.spec.ts
@@ -1,0 +1,47 @@
+import { normalizeOptions } from './normalize-options';
+
+describe('normalizeOptions', () => {
+  it('should apply defaults and override undefined user options', () => {
+    const defaults = { a: 1, b: 2, c: 3 };
+    const user = { a: 10 };
+    const result = normalizeOptions<typeof defaults>(user, defaults);
+    expect(result).toEqual({ a: 10, b: 2, c: 3 });
+  });
+
+  it('should handle empty user options', () => {
+    const defaults = { a: 1, b: 2 };
+    expect(normalizeOptions(undefined, defaults)).toEqual(defaults);
+    expect(normalizeOptions({}, defaults)).toEqual(defaults);
+  });
+
+  it('should work with partial defaults (Partial<T>)', () => {
+    const defaults = { a: 1 } as Partial<{ a: number; b: number }>;
+    const user = { b: 2 };
+    const result = normalizeOptions(user, defaults);
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it('should return an empty object if both options and defaults are empty', () => {
+    expect(normalizeOptions({}, {})).toEqual({});
+    expect(normalizeOptions(undefined, {})).toEqual({});
+  });
+
+  it('should not modify the original options or defaults objects', () => {
+    const defaults = { a: 1, b: 2 };
+    const user = { a: 10 };
+    const originalDefaults = { ...defaults };
+    const originalUser = { ...user };
+
+    normalizeOptions(user, defaults);
+
+    expect(defaults).toEqual(originalDefaults);
+    expect(user).toEqual(originalUser);
+  });
+
+  it('should not deep merge nested objects, that should be done per option if needed or handled by the consuming code', () => {
+    const defaults = { a: { x: 1, y: 2 }, b: 2 };
+    const user = { a: { x: 10 } };
+    const result = normalizeOptions(user, defaults);
+    expect(result).toEqual({ a: { x: 10 }, b: 2 });
+  });
+});

--- a/packages/nx/src/utils/normalize-options.ts
+++ b/packages/nx/src/utils/normalize-options.ts
@@ -1,0 +1,23 @@
+/**
+ * normalizes options with defaults (e.g. for plugins)
+ * populates undefined options with defaults.
+ */
+
+// Overload: defaults is Required<T> standard case
+export function normalizeOptions<T extends object>(
+  options: Partial<T> | undefined,
+  defaults: Required<T>
+): Required<T>;
+// Overload: defaults is Partial<T> eg in cypress plugin
+export function normalizeOptions<T extends object>(
+  options: Partial<T> | undefined,
+  defaults: Partial<T>
+): Partial<T>;
+// Implementation
+export function normalizeOptions<T extends object>(
+  options: Partial<T> | undefined = {},
+  defaults: Required<T> | Partial<T>
+): Required<T> | Partial<T> {
+  const normalized = { ...defaults, ...options };
+  return normalized;
+}

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -22,6 +22,7 @@ import {
   calculateHashForCreateNodes,
 } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
+import { normalizeOptions } from 'nx/src/utils/normalize-options';
 import { getLockFileName } from '@nx/js';
 import { loadViteDynamicImport } from '../utils/executor-utils';
 import { hashObject } from 'nx/src/hasher/file-hasher';
@@ -45,6 +46,15 @@ export interface VitePluginOptions {
   watchDepsTargetName?: string;
   buildDepsTargetName?: string;
 }
+
+const defaultOptions: VitePluginOptions = {
+  buildTargetName: 'build',
+  testTargetName: 'test',
+  devTargetName: 'dev',
+  previewTargetName: 'preview',
+  serveStaticTargetName: 'serve-static',
+  typecheckTargetName: 'typecheck',
+};
 
 type ViteTargets = Pick<
   ProjectConfiguration,
@@ -74,7 +84,7 @@ export const createNodesV2: CreateNodesV2<VitePluginOptions> = [
   viteVitestConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
-    const normalizedOptions = normalizeOptions(options);
+    const normalizedOptions = normalizeOptions(options, defaultOptions);
     const cachePath = join(workspaceDataDirectory, `vite-${optionsHash}.hash`);
     const targetsCache = readTargetsCache(cachePath);
     const isUsingTsSolutionSetup = _isUsingTsSolutionSetup();
@@ -202,7 +212,7 @@ export const createNodes: CreateNodes<VitePluginOptions> = [
       );
     });
 
-    const normalizedOptions = normalizeOptions(options);
+    const normalizedOptions = normalizeOptions(options, defaultOptions);
 
     const isUsingTsSolutionSetup = _isUsingTsSolutionSetup();
 
@@ -615,18 +625,6 @@ function normalizeOutputPath(
       }
     }
   }
-}
-
-function normalizeOptions(options: VitePluginOptions): VitePluginOptions {
-  options ??= {};
-  options.buildTargetName ??= 'build';
-  options.serveTargetName ??= 'serve';
-  options.devTargetName ??= 'dev';
-  options.previewTargetName ??= 'preview';
-  options.testTargetName ??= 'test';
-  options.serveStaticTargetName ??= 'serve-static';
-  options.typecheckTargetName ??= 'typecheck';
-  return options;
 }
 
 function checkIfConfigFileShouldBeProject(


### PR DESCRIPTION
- Move all plugin option normalization to a shared utility
- Add formatter and fallback logic, with tests for normalizeOptions/normalizeExtensions
- Webpack plugin now is no longer overriding user supplied build/watch deps strings, it fills them from defaults if unset
- Note: consider whether internal options like buildDepsTargetName and watchDepsTargetName should be exposed to users at all

This is a refactor for plugin option handling. Further plugin-specific improvements.

found some likely inconsistencies in the process.

## Current Behavior

in nx.json

ommiting options
```
{
  "plugin": "@nx/storybook/plugin",
}
```

causes failure in processin project graph

```
npx nx run-many -t=build --verbose

 NX   Failed to process project graph.

     - TypeError: Cannot read properties of undefined (reading 'buildStorybookTargetName')
      at normalizeOptions (workspaceRoot/node_modules/@nx/storybook/src/plugins/plugin.js:240:43)
      at exports.createNodesV2 (workspaceRoot/node_modules/@nx/storybook/src/plugins/plugin.js:31:35)

```

this works:
```
{
  "plugin": "@nx/storybook/plugin",
  "options": {}
}
```
## Expected Behavior
```
{
  "plugin": "@nx/storybook/plugin",
}
```
should just run with all default Options

## Related Issue(s)
could not find any open issues in that context

Fixes #