### PR TITLE
feat(js): deprecate simpleName option in library generator

### DIFF
--- a/docs/generated/packages/angular/generators/library.json
+++ b/docs/generated/packages/angular/generators/library.json
@@ -48,7 +48,7 @@
         "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
         "type": "boolean",
         "default": false,
-        "x-deprecated": "Provide the exact name instead. This option will be removed in Nx 22."
+        "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
       },
       "addModuleSpec": {
         "description": "Add a module spec file.",

--- a/docs/generated/packages/angular/generators/library.json
+++ b/docs/generated/packages/angular/generators/library.json
@@ -47,7 +47,8 @@
       "simpleName": {
         "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
         "type": "boolean",
-        "default": false
+        "default": false,
+        "x-deprecated": "Provide the exact name instead. This option will be removed in Nx 22."
       },
       "addModuleSpec": {
         "description": "Add a module spec file.",

--- a/docs/generated/packages/js/generators/library.json
+++ b/docs/generated/packages/js/generators/library.json
@@ -130,7 +130,8 @@
       "simpleName": {
         "description": "Don't include the directory in the generated file name.",
         "type": "boolean",
-        "default": false
+        "default": false,
+        "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
       },
       "useProjectJson": {
         "type": "boolean",

--- a/docs/generated/packages/nest/generators/library.json
+++ b/docs/generated/packages/nest/generators/library.json
@@ -132,7 +132,8 @@
       "simpleName": {
         "description": "Don't include the directory in the name of the module of the library.",
         "type": "boolean",
-        "default": false
+        "default": false,
+        "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
       },
       "useProjectJson": {
         "type": "boolean",

--- a/docs/generated/packages/react/generators/library.json
+++ b/docs/generated/packages/react/generators/library.json
@@ -183,7 +183,8 @@
       "simpleName": {
         "description": "Don't include the directory in the name of the module of the library.",
         "type": "boolean",
-        "default": false
+        "default": false,
+        "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
       },
       "useProjectJson": {
         "type": "boolean",

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -51,7 +51,7 @@ export async function libraryGenerator(
   if (schema.simpleName !== undefined && schema.simpleName !== false) {
     // TODO(v22): Remove simpleName as user should be using name.
     logger.warn(
-      `The "simpleName" option is deprecated and will be removed in Nx 22. Please provide the exact name you want to use for the library instead.`
+      `The "--simpleName" option is deprecated and will be removed in Nx 22. Please use the "--name" option to provide the exact name you want for the library.`
     );
   }
 

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -3,6 +3,7 @@ import {
   formatFiles,
   GeneratorCallback,
   installPackagesTask,
+  logger,
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
@@ -44,6 +45,13 @@ export async function libraryGenerator(
   if (schema.publishable === true && !schema.importPath) {
     throw new Error(
       `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
+    );
+  }
+
+  if (schema.simpleName !== undefined && schema.simpleName !== false) {
+    // TODO(v22): Remove simpleName as user should be using name.
+    logger.warn(
+      `The "simpleName" option is deprecated and will be removed in Nx 22. Please provide the exact name you want to use for the library instead.`
     );
   }
 

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -47,7 +47,8 @@
     "simpleName": {
       "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-deprecated": "Provide the exact name instead. This option will be removed in Nx 22."
     },
     "addModuleSpec": {
       "description": "Add a module spec file.",

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -48,7 +48,7 @@
       "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
       "type": "boolean",
       "default": false,
-      "x-deprecated": "Provide the exact name instead. This option will be removed in Nx 22."
+      "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
     },
     "addModuleSpec": {
       "description": "Add a module spec file.",

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -7,6 +7,7 @@ import {
   GeneratorCallback,
   installPackagesTask,
   joinPathFragments,
+  logger,
   names,
   offsetFromRoot,
   ProjectConfiguration,
@@ -101,6 +102,13 @@ export async function libraryGeneratorInternal(
     })
   );
   const options = await normalizeOptions(tree, schema);
+
+  if (schema.simpleName !== undefined && schema.simpleName !== false) {
+    // TODO(v22): Remove simpleName as user should be using name.
+    logger.warn(
+      `The "--simpleName" option is deprecated and will be removed in Nx 22. Please use the "--name" option to provide the exact name you want for the library.`
+    );
+  }
 
   createFiles(tree, options);
 

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -130,7 +130,8 @@
     "simpleName": {
       "description": "Don't include the directory in the generated file name.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
     },
     "useProjectJson": {
       "type": "boolean",

--- a/packages/nest/src/generators/library/library.ts
+++ b/packages/nest/src/generators/library/library.ts
@@ -2,6 +2,7 @@ import type { GeneratorCallback, Tree } from '@nx/devkit';
 import {
   formatFiles,
   joinPathFragments,
+  logger,
   readJson,
   runTasksInSerial,
   writeJson,
@@ -37,6 +38,14 @@ export async function libraryGeneratorInternal(
   rawOptions: LibraryGeneratorOptions
 ): Promise<GeneratorCallback> {
   const options = await normalizeOptions(tree, rawOptions);
+
+  if (rawOptions.simpleName !== undefined && rawOptions.simpleName !== false) {
+    // TODO(v22): Remove simpleName as user should be using name.
+    logger.warn(
+      `The "--simpleName" option is deprecated and will be removed in Nx 22. Please use the "--name" option to provide the exact name you want for the library.`
+    );
+  }
+
   const jsLibraryTask = await jsLibraryGenerator(
     tree,
     toJsLibraryGeneratorOptions(options)

--- a/packages/nest/src/generators/library/schema.json
+++ b/packages/nest/src/generators/library/schema.json
@@ -132,7 +132,8 @@
     "simpleName": {
       "description": "Don't include the directory in the name of the module of the library.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
     },
     "useProjectJson": {
       "type": "boolean",

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -5,6 +5,7 @@ import {
   GeneratorCallback,
   installPackagesTask,
   joinPathFragments,
+  logger,
   readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
@@ -73,6 +74,14 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
       `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
     );
   }
+
+  if (schema.simpleName !== undefined && schema.simpleName !== false) {
+    // TODO(v22): Remove simpleName as user should be using name.
+    logger.warn(
+      `The "--simpleName" option is deprecated and will be removed in Nx 22. Please use the "--name" option to provide the exact name you want for the library.`
+    );
+  }
+
   if (!options.component) {
     options.style = 'none';
   }

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -189,7 +189,8 @@
     "simpleName": {
       "description": "Don't include the directory in the name of the module of the library.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
     },
     "useProjectJson": {
       "type": "boolean",


### PR DESCRIPTION
The simpleName option is no longer useful as we've moved to using options "as provided" without transformation. Users should provide the exact name, directory, and import path they want to use.

## Changes
- Add x-deprecated to schema.json marking for removal in Nx 22
- Add runtime warning when simpleName is used


🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Users are confused with `--simpleName` with using `--name` AND `--directory`

## Expected Behavior
We should tell users that only `--name` should be used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29508
