### PR TITLE
fix(misc): nx should error if atomization brings in invalid file paths

### DIFF
--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -358,6 +358,25 @@ async function buildCypressTargets(
 
       for (const file of specFiles) {
         const relativeSpecFilePath = normalizePath(relative(projectRoot, file));
+
+        if (relativeSpecFilePath.includes('../')) {
+          throw new Error(
+            '@nx/cypress/plugin attempted to run tests outside of the project root. This is not supported and should not happen. Please open an issue at https://github.com/nrwl/nx/issues/new/choose with the following information:\n\n' +
+              `\n\n${JSON.stringify(
+                {
+                  projectRoot,
+                  relativeSpecFilePath,
+                  specFiles,
+                  context,
+                  excludeSpecPatterns,
+                  specPatterns,
+                },
+                null,
+                2
+              )}`
+          );
+        }
+
         const targetName = options.ciTargetName + '--' + relativeSpecFilePath;
         const outputSubfolder = relativeSpecFilePath
           .replace(/[\/\\]/g, '-')

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -329,7 +329,7 @@ async function buildJestTargets(
     ));
 
     if (options?.ciTargetName) {
-      const testPaths = await getTestPaths(
+      const { specs, testMatch } = await getTestPaths(
         projectRoot,
         rawConfig,
         absConfigFilePath,
@@ -349,10 +349,27 @@ async function buildJestTargets(
           (p: string) => new RegExp(replaceRootDirInPath(projectRoot, p))
         );
 
-      for (const testPath of testPaths) {
+      for (const testPath of specs) {
         const relativePath = normalizePath(
           relative(join(context.workspaceRoot, projectRoot), testPath)
         );
+
+        if (relativePath.includes('../')) {
+          throw new Error(
+            '@nx/jest/plugin attempted to run tests outside of the project root. This is not supported and should not happen. Please open an issue at https://github.com/nrwl/nx/issues/new/choose with the following information:\n\n' +
+              `\n\n${JSON.stringify(
+                {
+                  projectRoot,
+                  relativePath,
+                  specs,
+                  context,
+                  testMatch,
+                },
+                null,
+                2
+              )}`
+          );
+        }
 
         if (specIgnoreRegexes?.some((regex) => regex.test(relativePath))) {
           continue;
@@ -496,6 +513,23 @@ async function buildJestTargets(
           const relativePath = normalizePath(
             relative(join(context.workspaceRoot, projectRoot), testPath)
           );
+
+          if (relativePath.includes('../')) {
+            throw new Error(
+              '@nx/jest/plugin attempted to run tests outside of the project root. This is not supported and should not happen. Please open an issue at https://github.com/nrwl/nx/issues/new/choose with the following information:\n\n' +
+                `\n\n${JSON.stringify(
+                  {
+                    projectRoot,
+                    relativePath,
+                    testPaths,
+                    context,
+                  },
+                  null,
+                  2
+                )}`
+            );
+          }
+
           const targetName = `${options.ciTargetName}--${relativePath}`;
           dependsOn.push(targetName);
           targets[targetName] = {
@@ -711,7 +745,7 @@ async function getTestPaths(
   absConfigFilePath: string,
   context: CreateNodesContext,
   presetCache: Record<string, unknown>
-): Promise<string[]> {
+): Promise<{ specs: string[]; testMatch: string[] }> {
   const testMatch = await getJestOption<string[]>(
     rawConfig,
     absConfigFilePath,
@@ -746,7 +780,7 @@ async function getTestPaths(
     );
   }
 
-  return paths;
+  return { specs: paths, testMatch };
 }
 
 async function getJestOption<T = any>(

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -349,8 +349,10 @@ async function getAllTestFiles(opts: {
   path: string;
   config: PlaywrightTestConfig;
 }) {
-  const files: string[] = [];
-  await getFilesInDirectoryUsingContext(opts.context.workspaceRoot, opts.path);
+  const files = await getFilesInDirectoryUsingContext(
+    opts.context.workspaceRoot,
+    opts.path
+  );
   const matcher = createMatcher(opts.config.testMatch);
   const ignoredMatcher = opts.config.testIgnore
     ? createMatcher(opts.config.testIgnore)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
In some rare occurences we've observed our atomization plugins returning an invalid list of test files. We've only seen this in the jest plugin in our internal monorepo under a very specific yet hard to repro area.

## Expected Behavior
If this occurs, the plugin errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
