### PR TITLE
fix(js): failing e2e test due to dependency

### DIFF
--- a/e2e/js/src/js-ts-solution.test.ts
+++ b/e2e/js/src/js-ts-solution.test.ts
@@ -90,28 +90,34 @@ ${content}`
     addImports(viteParentLib);
 
     const pm = getSelectedPackageManager();
+    // Add local packages as dependencies to each consumer package.json
+    // This is required for all package managers to satisfy dependency checks
+    const addDeps = (parentLib: string, includeRollupChildLib = false) => {
+      updateJson(`packages/${parentLib}/package.json`, (json) => {
+        json.dependencies ??= {};
+        json.dependencies[`@proj/${esbuildChildLib}`] =
+          pm === 'pnpm' ? 'workspace:*' : '*';
+        if (includeRollupChildLib) {
+          json.dependencies[`@proj/${rollupChildLib}`] =
+            pm === 'pnpm' ? 'workspace:*' : '*';
+        }
+        json.dependencies[`@proj/${swcChildLib}`] =
+          pm === 'pnpm' ? 'workspace:*' : '*';
+        json.dependencies[`@proj/${tscChildLib}`] =
+          pm === 'pnpm' ? 'workspace:*' : '*';
+        json.dependencies[`@proj/${viteChildLib}`] =
+          pm === 'pnpm' ? 'workspace:*' : '*';
+        return json;
+      });
+    };
+
+    addDeps(esbuildParentLib);
+    addDeps(rollupParentLib, true);
+    addDeps(swcParentLib);
+    addDeps(tscParentLib);
+    addDeps(viteParentLib);
+
     if (pm === 'pnpm') {
-      // for pnpm we need to add the local packages as dependencies to each consumer package.json
-      const addDeps = (parentLib: string, includeRollupChildLib = false) => {
-        updateJson(`packages/${parentLib}/package.json`, (json) => {
-          json.dependencies ??= {};
-          json.dependencies[`@proj/${esbuildChildLib}`] = 'workspace:*';
-          if (includeRollupChildLib) {
-            json.dependencies[`@proj/${rollupChildLib}`] = 'workspace:*';
-          }
-          json.dependencies[`@proj/${swcChildLib}`] = 'workspace:*';
-          json.dependencies[`@proj/${tscChildLib}`] = 'workspace:*';
-          json.dependencies[`@proj/${viteChildLib}`] = 'workspace:*';
-          return json;
-        });
-      };
-
-      addDeps(esbuildParentLib);
-      addDeps(rollupParentLib, true);
-      addDeps(swcParentLib);
-      addDeps(tscParentLib);
-      addDeps(viteParentLib);
-
       const pmc = getPackageManagerCommand({ packageManager: pm });
       runCommand(pmc.install);
     }


### PR DESCRIPTION
This PR updates our `e2e-js` test to include dependencies for all package managers and not just pnpm.

E2E Matrix for `e2e-js` is now passing: https://github.com/nrwl/nx/actions/runs/15786673606/job/44504580439