### PR TITLE
docs(nx-dev): fix typo

### DIFF
--- a/docs/blog/2025-06-12-cve-2025-36852-critical-cache-poisoning-vulnerability-creep.md
+++ b/docs/blog/2025-06-12-cve-2025-36852-critical-cache-poisoning-vulnerability-creep.md
@@ -18,7 +18,7 @@ The CREEP vulnerability allows any contributor with pull request privileges to i
 - Nx Cloud is **NOT** affected due to its security architecture
 - Review this post to determine if your self-hosted cache solution is vulnerable
 
-{% callout type="warn" title="DIY implementations are vulnerable" %}
+{% callout type="warning" title="DIY implementations are vulnerable" %}
 DIY remote caches are likely vulnerable. Scanners won't catch all affected implementations, so understanding the vulnerability is crucial.
 {% /callout %}
 


### PR DESCRIPTION
Update callout type from 'warn' to 'warning' in CVE blog post.
