### PR TITLE
fix(gradle): add dependsOn outputs to inputs dependentTasksOutputFiles

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -162,7 +162,8 @@ private fun buildTestCiTarget(
     projectRoot: String,
     workspaceRoot: String,
 ): MutableMap<String, Any?> {
-  val taskInputs = getInputsForTask(testTask, projectRoot, workspaceRoot, null)
+  val dependsOnTasks = getDependsOnTask(testTask)
+  val taskInputs = getInputsForTask(dependsOnTasks, testTask, projectRoot, workspaceRoot)
 
   val target =
       mutableMapOf<String, Any?>(
@@ -176,7 +177,7 @@ private fun buildTestCiTarget(
           "cache" to true,
           "inputs" to taskInputs)
 
-  getDependsOnForTask(testTask, null)
+  getDependsOnForTask(dependsOnTasks, testTask)
       ?.takeIf { it.isNotEmpty() }
       ?.let {
         testTask.logger.info("${testTask.path}: found ${it.size} dependsOn entries")

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -3,6 +3,7 @@ package dev.nx.gradle.utils
 import dev.nx.gradle.data.Dependency
 import dev.nx.gradle.data.ExternalDepData
 import dev.nx.gradle.data.ExternalNode
+import java.io.File
 import org.gradle.api.Task
 
 /**
@@ -25,19 +26,15 @@ fun processTask(
   val logger = task.logger
   logger.info("NxProjectReportTask: process $task for $projectRoot")
   val target = mutableMapOf<String, Any?>()
-  target["cache"] = isCacheable(task) // set cache based on whether the task is cacheable
+  target["cache"] = isCacheable(task)
 
   val continuous = isContinuous(task)
   if (continuous) {
     target["continuous"] = true
   }
 
-  // process inputs
-  val inputs = getInputsForTask(task, projectRoot, workspaceRoot, externalNodes)
-  if (!inputs.isNullOrEmpty()) {
-    logger.info("${task}: processed ${inputs.size} inputs")
-    target["inputs"] = inputs
-  }
+  // Get combined depends on tasks once and reuse
+  val dependsOnTasks = getDependsOnTask(task)
 
   // process outputs
   val outputs = getOutputsForTask(task, projectRoot, workspaceRoot)
@@ -47,10 +44,17 @@ fun processTask(
   }
 
   // process dependsOn
-  val dependsOn = getDependsOnForTask(task, dependencies, targetNameOverrides)
+  val dependsOn = getDependsOnForTask(dependsOnTasks, task, dependencies, targetNameOverrides)
   if (!dependsOn.isNullOrEmpty()) {
     logger.info("${task}: processed ${dependsOn.size} dependsOn")
     target["dependsOn"] = dependsOn
+  }
+
+  // process inputs
+  val inputs = getInputsForTask(dependsOnTasks, task, projectRoot, workspaceRoot, externalNodes)
+  if (!inputs.isNullOrEmpty()) {
+    logger.info("${task}: processed ${inputs.size} inputs")
+    target["inputs"] = inputs
   }
 
   target["executor"] = "@nx/gradle:gradle"
@@ -66,42 +70,83 @@ fun processTask(
 }
 
 fun getGradlewCommand(): String {
-  val gradlewCommand: String
   val operatingSystem = System.getProperty("os.name").lowercase()
-  gradlewCommand =
-      if (operatingSystem.contains("win")) {
-        ".\\gradlew.bat"
-      } else {
-        "./gradlew"
-      }
-  return gradlewCommand
+  return if (operatingSystem.contains("win")) {
+    ".\\gradlew.bat"
+  } else {
+    "./gradlew"
+  }
 }
 
 /**
  * Parse task and get inputs for this task
  *
  * @param task task to process
+ * @param projectRoot the project root path
+ * @param workspaceRoot the workspace root path
+ * @param externalNodes map of external nodes
  * @return a list of inputs including external dependencies, null if empty or an error occurred
  */
 fun getInputsForTask(
+    dependsOnTasks: Set<Task>?,
     task: Task,
     projectRoot: String,
     workspaceRoot: String,
-    externalNodes: MutableMap<String, ExternalNode>?
-): MutableList<Any>? {
+    externalNodes: MutableMap<String, ExternalNode>? = null
+): List<Any>? {
+  fun getDependentTasksOutputFile(file: File): String {
+    val relativePathToWorkspaceRoot =
+        file.path.substring(workspaceRoot.length + 1) // also remove the file separator
+    val dependentTasksOutputFiles =
+        if (file.name.contains('.') ||
+            (file.exists() &&
+                file.isFile)) { // if file does not exists, file.isFile would always be false
+          relativePathToWorkspaceRoot
+        } else {
+          "$relativePathToWorkspaceRoot${File.separator}**${File.separator}*"
+        }
+    return dependentTasksOutputFiles
+  }
+
   return try {
     val mappedInputsIncludeExternal: MutableList<Any> = mutableListOf()
-    val inputs = task.inputs
-    val externalDependencies = mutableListOf<String>()
-    inputs.files.forEach { file ->
-      val path: String = file.path
-      // replace the absolute path to contain {projectRoot} or {workspaceRoot}
-      val pathWithReplacedRoot = replaceRootInPath(path, projectRoot, workspaceRoot)
-      if (pathWithReplacedRoot != null) { // if the path is inside workspace
-        mappedInputsIncludeExternal.add((pathWithReplacedRoot))
+
+    val dependsOnOutputs: MutableSet<File> = mutableSetOf()
+    val combinedDependsOn: Set<Task> = dependsOnTasks ?: getDependsOnTask(task)
+    combinedDependsOn.forEach { dependsOnTask ->
+      dependsOnTask.outputs.files.files.forEach { file ->
+        if (file.path.startsWith(workspaceRoot + File.separator)) {
+          dependsOnOutputs.add(file)
+          val dependentTasksOutputFiles = getDependentTasksOutputFile(file)
+          mappedInputsIncludeExternal.add(
+              mapOf("dependentTasksOutputFiles" to dependentTasksOutputFiles))
+        }
       }
-      // if the path is outside of workspace
-      if (pathWithReplacedRoot == null) { // add it to external dependencies
+    }
+
+    val externalDependencies = mutableListOf<String>()
+    val buildDir = task.project.layout.buildDirectory.get().asFile
+
+    task.inputs.files.forEach { file ->
+      val path: String = file.path
+      val pathWithReplacedRoot = replaceRootInPath(path, projectRoot, workspaceRoot)
+
+      if (pathWithReplacedRoot != null) {
+        val isInTaskOutputBuildDir = file.path.startsWith(buildDir.path + File.separator)
+        if (!isInTaskOutputBuildDir) {
+          mappedInputsIncludeExternal.add(pathWithReplacedRoot)
+        } else {
+          val isInDependsOnOutputs =
+              dependsOnOutputs.any { outputFile ->
+                file == outputFile || file.path.startsWith(outputFile.path + File.separator)
+              }
+          if (!isInDependsOnOutputs) {
+            val dependentTasksOutputFile = getDependentTasksOutputFile(file)
+            mappedInputsIncludeExternal.add(
+                mapOf("dependentTasksOutputFiles" to dependentTasksOutputFile))
+          }
+        }
+      } else {
         try {
           val externalDep = getExternalDepFromInputFile(path, externalNodes, task.logger)
           externalDep?.let { externalDependencies.add(it) }
@@ -110,16 +155,17 @@ fun getInputsForTask(
         }
       }
     }
+
     if (externalDependencies.isNotEmpty()) {
-      mappedInputsIncludeExternal.add(mutableMapOf("externalDependencies" to externalDependencies))
+      mappedInputsIncludeExternal.add(mapOf("externalDependencies" to externalDependencies))
     }
+
     if (mappedInputsIncludeExternal.isNotEmpty()) {
       return mappedInputsIncludeExternal
     }
     return null
   } catch (e: Exception) {
-    // Log the error but don't fail the build
-    task.logger.info("Error getting outputs for ${task.path}: ${e.message}")
+    task.logger.info("Error getting inputs for ${task.path}: ${e.message}")
     task.logger.debug("Stack trace:", e)
     null
   }
@@ -129,7 +175,9 @@ fun getInputsForTask(
  * Get outputs for task
  *
  * @param task task to process
- * @return list of outputs file, will not include if output file is outside workspace, null if empty
+ * @param projectRoot the project root path
+ * @param workspaceRoot the workspace root path
+ * @return list of output files, will not include if output file is outside workspace, null if empty
  *   or an error occurred
  */
 fun getOutputsForTask(task: Task, projectRoot: String, workspaceRoot: String): List<String>? {
@@ -143,11 +191,33 @@ fun getOutputsForTask(task: Task, projectRoot: String, workspaceRoot: String): L
     }
     null
   } catch (e: Exception) {
-    // Log the error but don't fail the build
     task.logger.info("Error getting outputs for ${task.path}: ${e.message}")
     task.logger.debug("Stack trace:", e)
     null
   }
+}
+
+fun getDependsOnTask(task: Task): Set<Task> {
+  val dependsOnFromTaskDependencies: Set<Task> =
+      try {
+        task.taskDependencies.getDependencies(task)
+      } catch (e: Exception) {
+        task.logger.info("Error calling getDependencies for ${task.path}: ${e.message}")
+        task.logger.debug("Stack trace:", e)
+        emptySet()
+      }
+
+  val dependsOnFromDependsOnProperty: Set<Task> = task.dependsOn.filterIsInstance<Task>().toSet()
+
+  val combinedDependsOn = dependsOnFromTaskDependencies.union(dependsOnFromDependsOnProperty)
+
+  task.logger.info(
+      "Dependencies from taskDependencies.getDependencies for $task: $dependsOnFromTaskDependencies")
+  task.logger.info(
+      "Dependencies from task.dependsOn property for $task: $dependsOnFromDependsOnProperty")
+  task.logger.info("Combined dependencies for $task: $combinedDependsOn")
+
+  return combinedDependsOn
 }
 
 /**
@@ -160,8 +230,9 @@ fun getOutputsForTask(task: Task, projectRoot: String, workspaceRoot: String): L
  * @return list of dependsOn task names (possibly replaced), or null if none found or error occurred
  */
 fun getDependsOnForTask(
+    dependsOnTasks: Set<Task>?,
     task: Task,
-    dependencies: MutableSet<Dependency>?, // Assuming Dependency class is defined elsewhere
+    dependencies: MutableSet<Dependency>? = null,
     targetNameOverrides: Map<String, String> = emptyMap()
 ): List<String>? {
 
@@ -178,41 +249,16 @@ fun getDependsOnForTask(
                 taskProject.buildFile.path))
       }
 
-      // Check if this task name needs to be overridden
       val taskName = targetNameOverrides.getOrDefault(depTask.name + "TargetName", depTask.name)
-      val overriddenTaskName = "${depProject.name}:${taskName}"
-
-      overriddenTaskName
+      "${depProject.name}:${taskName}"
     }
   }
 
   return try {
-    // 1. Get dependencies from task.taskDependencies.getDependencies(task)
-    val dependsOnFromTaskDependencies: Set<Task> =
-        try {
-          task.taskDependencies.getDependencies(task)
-        } catch (e: Exception) {
-          task.logger.info("Error calling getDependencies for ${task.path}: ${e.message}")
-          task.logger.debug("Stack trace:", e)
-          emptySet<Task>() // If it fails, return an empty set to be combined later
-        }
-
-    // 2. Get dependencies from task.dependsOn and filter for Task instances
-    val dependsOnFromDependsOnProperty: Set<Task> = task.dependsOn.filterIsInstance<Task>().toSet()
-
-    // 3. Combine the two sets of dependencies
-    val combinedDependsOn = dependsOnFromTaskDependencies.union(dependsOnFromDependsOnProperty)
-
-    task.logger.info(
-        "Dependencies from taskDependencies.getDependencies for $task: $dependsOnFromTaskDependencies")
-    task.logger.info(
-        "Dependencies from task.dependsOn property for $task: $dependsOnFromDependsOnProperty")
-    task.logger.info("Combined dependencies for $task: $combinedDependsOn")
-
+    val combinedDependsOn = dependsOnTasks ?: getDependsOnTask(task)
     if (combinedDependsOn.isNotEmpty()) {
       return mapTasksToNames(combinedDependsOn)
     }
-
     null
   } catch (e: Exception) {
     task.logger.info("Unexpected error getting dependencies for ${task.path}: ${e.message}")
@@ -224,7 +270,10 @@ fun getDependsOnForTask(
 /**
  * Get metadata for task
  *
- * @param description
+ * @param description task description
+ * @param projectBuildPath project build path
+ * @param helpTaskName help task name
+ * @param nonAtomizedTarget non-atomized target name
  */
 fun getMetadata(
     description: String?,
@@ -251,6 +300,7 @@ fun getMetadata(
  *
  * @param inputFile Path to the dependency jar.
  * @param externalNodes Map to populate with the resulting ExternalNode.
+ * @param logger Gradle logger for warnings and debug info
  * @return The external dependency key (e.g., gradle:commons-lang3-3.13.0), or null if parsing
  *   fails.
  */
@@ -262,24 +312,19 @@ fun getExternalDepFromInputFile(
   try {
     val segments = inputFile.split("/")
 
-    // Expecting at least 5 segments to safely extract group, package, version, hash, filename
     if (segments.size < 5) {
       logger.warn("Invalid input path: '$inputFile'. Expected at least 5 segments.")
       return null
     }
 
     val fileName = segments.last()
-
-    // Remove any file extension (after the last dot), if present
     val nameKey = fileName.substringBeforeLast(".", fileName)
-
     val hash = segments[segments.size - 2]
     val version = segments[segments.size - 3]
     val packageName = segments[segments.size - 4]
     val packageGroup = segments[segments.size - 5]
 
     val fullPackageName = "$packageGroup.$packageName"
-
     val data = ExternalDepData(version, fullPackageName, hash)
     val externalKey = "gradle:$nameKey"
     val node = ExternalNode("gradle", externalKey, data)
@@ -297,29 +342,28 @@ fun getExternalDepFromInputFile(
 }
 
 /**
- * Going to replace the projectRoot with {projectRoot} and workspaceRoot with {workspaceRoot}
+ * Replace the projectRoot with {projectRoot} and workspaceRoot with {workspaceRoot}
  *
+ * @param path the path to process
+ * @param projectRoot the project root path
+ * @param workspaceRoot the workspace root path
  * @return mapped path if inside workspace, null if outside workspace
  */
-fun replaceRootInPath(p: String, projectRoot: String, workspaceRoot: String): String? {
-  var path = p
-  if (path.startsWith(projectRoot)) {
-    path = path.replace(projectRoot, "{projectRoot}")
-    return path
-  } else if (path.startsWith(workspaceRoot)) {
-    path = path.replace(workspaceRoot, "{workspaceRoot}")
-    return path
+fun replaceRootInPath(path: String, projectRoot: String, workspaceRoot: String): String? {
+  return when {
+    path.startsWith(projectRoot) -> path.replace(projectRoot, "{projectRoot}")
+    path.startsWith(workspaceRoot) -> path.replace(workspaceRoot, "{workspaceRoot}")
+    else -> null
   }
-  return null
 }
 
-val continuousTasks = setOf("bootRun")
+private val continuousTasks = setOf("bootRun")
 
 fun isContinuous(task: Task): Boolean {
   return continuousTasks.contains(task.name)
 }
 
-val nonCacheableTasks = setOf("bootRun", "run")
+private val nonCacheableTasks = setOf("bootRun", "run")
 
 fun isCacheable(task: Task): Boolean {
   return !nonCacheableTasks.contains(task.name)

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -64,7 +64,7 @@ class ProcessTaskUtilsTest {
     taskA.dependsOn(taskB)
 
     val dependencies = mutableSetOf<Dependency>()
-    val dependsOn = getDependsOnForTask(taskA, dependencies)
+    val dependsOn = getDependsOnForTask(null, taskA, dependencies)
 
     assertNotNull(dependsOn)
     assertTrue(dependsOn!!.contains("myApp:taskB"))
@@ -91,5 +91,339 @@ class ProcessTaskUtilsTest {
     assertEquals(result["executor"], "@nx/gradle:gradle")
     assertNotNull(result["metadata"])
     assertNotNull(result["options"])
+  }
+
+  @Test
+  fun `test getInputsForTask with dependsOn outputs exclusion`() {
+    val project = ProjectBuilder.builder().build()
+    val workspaceRoot = project.rootDir.path
+    val projectRoot = project.projectDir.path
+
+    // Create dependent task with outputs
+    val dependentTask = project.tasks.register("dependentTask").get()
+    val outputFile = java.io.File("$workspaceRoot/dist/output.jar")
+    dependentTask.outputs.file(outputFile)
+
+    // Create main task with inputs and dependsOn
+    val mainTask = project.tasks.register("mainTask").get()
+    mainTask.dependsOn(dependentTask)
+
+    // Add inputs - one that matches dependent output, one that doesn't
+    val inputFile1 = java.io.File("$workspaceRoot/dist/output.jar") // Should be excluded
+    val inputFile2 = java.io.File("$workspaceRoot/src/main.kt") // Should be included
+    mainTask.inputs.files(inputFile1, inputFile2)
+
+    val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+
+    assertNotNull(result)
+
+    // Should contain dependentTasksOutputFiles for the output
+    assertTrue(
+        result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar" })
+
+    // Should contain the non-conflicting input file
+    assertTrue(result.any { it == "{projectRoot}/src/main.kt" })
+
+    // Should NOT contain the input file that matches dependent output
+    assertFalse(result.any { it == "{workspaceRoot}/dist/output.jar" })
+  }
+
+  @Test
+  fun `test getInputsForTask directory vs file patterns`() {
+    val project = ProjectBuilder.builder().build()
+    val workspaceRoot = project.rootDir.path
+    val projectRoot = project.projectDir.path
+
+    val dependentTask = project.tasks.register("dependentTask").get()
+
+    // Add file output (should get exact path)
+    val outputFile = java.io.File("$workspaceRoot/dist/app.jar")
+    dependentTask.outputs.file(outputFile)
+
+    // Add directory output (should get /**/* pattern)
+    val outputDir = java.io.File("$workspaceRoot/build/classes")
+    dependentTask.outputs.dir(outputDir)
+
+    val mainTask = project.tasks.register("mainTask").get()
+    mainTask.dependsOn(dependentTask)
+
+    val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+
+    assertNotNull(result)
+
+    // File should get exact path
+    assertTrue(
+        result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/app.jar" })
+
+    // Directory should get glob pattern
+    assertTrue(
+        result.any {
+          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).endsWith("/**/*")
+        })
+  }
+
+  @Test
+  fun `test getInputsForTask excludes build directory files`() {
+    val project = ProjectBuilder.builder().build()
+    val workspaceRoot = project.rootDir.path
+    val projectRoot = project.projectDir.path
+    val buildDir = project.layout.buildDirectory.get().asFile
+
+    val mainTask = project.tasks.register("mainTask").get()
+
+    // Add inputs - one in build dir, one outside
+    val buildDirFile = java.io.File("${buildDir.path}/classes/Main.class")
+    val sourceFile = java.io.File("$workspaceRoot/src/main.kt")
+    mainTask.inputs.files(buildDirFile, sourceFile)
+
+    val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+
+    assertNotNull(result)
+
+    // Should contain the source file
+    assertTrue(result!!.any { it == "{projectRoot}/src/main.kt" })
+
+    // Should NOT contain the build directory file
+    assertFalse(result.any { it.toString().contains("build") && it !is Map<*, *> })
+  }
+
+  @Test
+  fun `test getInputsForTask with build dir input as dependentTasksOutputFiles`() {
+    val project = ProjectBuilder.builder().build()
+    val workspaceRoot = project.rootDir.path
+    val projectRoot = project.projectDir.path
+    val buildDir = project.layout.buildDirectory.get().asFile
+
+    // Create dependent task with build dir output
+    val dependentTask = project.tasks.register("dependentTask").get()
+    val buildDirOutput = java.io.File("${buildDir.path}/libs/app.jar")
+    dependentTask.outputs.file(buildDirOutput)
+
+    val mainTask = project.tasks.register("mainTask").get()
+    mainTask.dependsOn(dependentTask)
+
+    // Add build dir file as input that matches dependent output
+    mainTask.inputs.files(buildDirOutput)
+
+    val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+
+    assertNotNull(result)
+
+    // Should contain dependentTasksOutputFiles for the build dir output
+    assertTrue(
+        result!!.any {
+          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("libs/app.jar")
+        })
+
+    // Should NOT contain it as a regular input
+    assertFalse(result.any { it.toString().contains("build") && it !is Map<*, *> })
+  }
+
+  @Test
+  fun `test getInputsForTask with pre-computed dependsOnTasks`() {
+    val project = ProjectBuilder.builder().build()
+    val workspaceRoot = project.rootDir.path
+    val projectRoot = project.projectDir.path
+
+    // Create dependent task with output
+    val dependentTask = project.tasks.register("dependentTask").get()
+    val outputFile = java.io.File("$workspaceRoot/dist/output.jar")
+    dependentTask.outputs.file(outputFile)
+
+    // Create main task with dependsOn
+    val mainTask = project.tasks.register("mainTask").get()
+    mainTask.dependsOn(dependentTask)
+
+    // Add input file
+    val inputFile = java.io.File("$workspaceRoot/src/main.kt")
+    mainTask.inputs.files(inputFile)
+
+    // Pre-compute dependsOnTasks using getDependsOnTask
+    val preComputedDependsOn = getDependsOnTask(mainTask)
+
+    // Test with pre-computed dependsOnTasks
+    val resultWithPreComputed =
+        getInputsForTask(preComputedDependsOn, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+
+    // Test without pre-computed (should compute internally)
+    val resultWithoutPreComputed =
+        getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+
+    // Both results should be identical
+    assertNotNull(resultWithPreComputed)
+    assertNotNull(resultWithoutPreComputed)
+    assertEquals(resultWithPreComputed!!.size, resultWithoutPreComputed!!.size)
+
+    // Should contain dependentTasksOutputFiles for the dependent task output
+    assertTrue(
+        resultWithPreComputed.any {
+          it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar"
+        })
+    assertTrue(
+        resultWithoutPreComputed.any {
+          it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar"
+        })
+
+    // Should contain the input file
+    assertTrue(resultWithPreComputed.any { it == "{projectRoot}/src/main.kt" })
+    assertTrue(resultWithoutPreComputed.any { it == "{projectRoot}/src/main.kt" })
+  }
+
+  @Test
+  fun `test getDependsOnForTask with pre-computed dependsOnTasks`() {
+    val project = ProjectBuilder.builder().withName("testProject").build()
+    val taskA = project.tasks.register("taskA").get()
+    val taskB = project.tasks.register("taskB").get()
+    val taskC = project.tasks.register("taskC").get()
+
+    taskA.dependsOn(taskB, taskC)
+
+    val dependencies = mutableSetOf<Dependency>()
+
+    // Pre-compute dependsOnTasks using getDependsOnTask
+    val preComputedDependsOn = getDependsOnTask(taskA)
+
+    // Test with pre-computed dependsOnTasks
+    val resultWithPreComputed = getDependsOnForTask(preComputedDependsOn, taskA, dependencies)
+
+    // Test without pre-computed (should compute internally)
+    val dependencies2 = mutableSetOf<Dependency>()
+    val resultWithoutPreComputed = getDependsOnForTask(null, taskA, dependencies2)
+
+    // Both results should be identical
+    assertNotNull(resultWithPreComputed)
+    assertNotNull(resultWithoutPreComputed)
+    assertEquals(resultWithPreComputed!!.size, resultWithoutPreComputed!!.size)
+    assertEquals(2, resultWithPreComputed.size)
+
+    // Should contain both dependencies
+    assertTrue(resultWithPreComputed.contains("testProject:taskB"))
+    assertTrue(resultWithPreComputed.contains("testProject:taskC"))
+    assertTrue(resultWithoutPreComputed!!.contains("testProject:taskB"))
+    assertTrue(resultWithoutPreComputed.contains("testProject:taskC"))
+  }
+
+  @Test
+  fun `test dependentTasksOutputFiles generation with reused dependsOnTasks`() {
+    val project = ProjectBuilder.builder().build()
+    val workspaceRoot = project.rootDir.path
+    val projectRoot = project.projectDir.path
+
+    // Create multiple dependent tasks with different output types
+    val dependentTask1 = project.tasks.register("dependentTask1").get()
+    val fileOutput = java.io.File("$workspaceRoot/dist/app.jar")
+    dependentTask1.outputs.file(fileOutput)
+
+    val dependentTask2 = project.tasks.register("dependentTask2").get()
+    val dirOutput = java.io.File("$workspaceRoot/build/classes")
+    dependentTask2.outputs.dir(dirOutput)
+
+    val dependentTask3 = project.tasks.register("dependentTask3").get()
+    val multipleOutputs =
+        listOf(
+            java.io.File("$workspaceRoot/reports/test.xml"),
+            java.io.File("$workspaceRoot/reports/coverage"))
+    dependentTask3.outputs.files(multipleOutputs)
+
+    // Create main task that depends on all three
+    val mainTask = project.tasks.register("mainTask").get()
+    mainTask.dependsOn(dependentTask1, dependentTask2, dependentTask3)
+
+    // Add some input files
+    val inputFiles =
+        listOf(
+            java.io.File("$workspaceRoot/src/main.kt"),
+            java.io.File("$workspaceRoot/config/app.properties"))
+    mainTask.inputs.files(inputFiles)
+
+    // Get dependsOnTasks once and reuse
+    val dependsOnTasks = getDependsOnTask(mainTask)
+    val result =
+        getInputsForTask(dependsOnTasks, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+
+    assertNotNull(result)
+
+    // Should contain dependentTasksOutputFiles for file output (exact path)
+    assertTrue(
+        result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/app.jar" })
+
+    // Should contain dependentTasksOutputFiles for directory output (with /**/* pattern)
+    assertTrue(
+        result.any {
+          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String) == "build/classes/**/*"
+        })
+
+    // Should contain dependentTasksOutputFiles for test report file
+    assertTrue(
+        result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "reports/test.xml" })
+
+    // Should contain dependentTasksOutputFiles for coverage directory (with /**/* pattern)
+    assertTrue(
+        result.any {
+          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String) == "reports/coverage/**/*"
+        })
+
+    // Should contain regular input files
+    assertTrue(result.any { it == "{projectRoot}/src/main.kt" })
+    assertTrue(result.any { it == "{projectRoot}/config/app.properties" })
+
+    // Verify we have the expected number of dependentTasksOutputFiles entries (4 outputs from 3
+    // tasks)
+    val dependentTasksOutputFilesCount =
+        result.count { it is Map<*, *> && it.containsKey("dependentTasksOutputFiles") }
+    assertEquals(4, dependentTasksOutputFilesCount)
+
+    // Verify we have the expected number of regular input files (2)
+    val regularInputsCount = result.count { it is String && it.startsWith("{projectRoot}") }
+    assertEquals(2, regularInputsCount)
+  }
+
+  @Test
+  fun `test processTask uses getDependsOnTask efficiently`() {
+    val project = ProjectBuilder.builder().withName("testProject").build()
+    val dependentTask = project.tasks.register("compile").get()
+    val outputFile = java.io.File("${project.rootDir.path}/build/classes")
+    dependentTask.outputs.dir(outputFile)
+
+    val mainTask = project.tasks.register("test").get()
+    mainTask.dependsOn(dependentTask)
+    mainTask.description = "Run tests"
+
+    // Add inputs
+    val inputFile = java.io.File("${project.rootDir.path}/src/test.kt")
+    mainTask.inputs.files(inputFile)
+
+    val result =
+        processTask(
+            mainTask,
+            projectBuildPath = ":testProject",
+            projectRoot = project.projectDir.path,
+            workspaceRoot = project.rootDir.path,
+            externalNodes = mutableMapOf(),
+            dependencies = mutableSetOf(),
+            targetNameOverrides = emptyMap())
+
+    assertNotNull(result)
+
+    // Verify basic target properties
+    assertEquals("@nx/gradle:gradle", result["executor"])
+    assertEquals(true, result["cache"])
+    assertNotNull(result["metadata"])
+    assertNotNull(result["options"])
+
+    // Verify dependsOn is populated
+    val dependsOn = result["dependsOn"] as? List<*>
+    assertNotNull(dependsOn)
+    assertEquals(1, dependsOn!!.size)
+    assertEquals("testProject:compile", dependsOn[0])
+
+    // Verify inputs contain both regular inputs and dependentTasksOutputFiles
+    val inputs = result["inputs"] as? List<*>
+    assertNotNull(inputs)
+    assertTrue(inputs!!.any { it == "{projectRoot}/src/test.kt" })
+    assertTrue(
+        inputs.any {
+          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String) == "build/classes/**/*"
+        })
   }
 }

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -64,7 +64,9 @@ export async function newGenerator(tree: Tree, opts: Schema) {
 
   return async () => {
     if (!options.skipInstall) {
-      const pmc = getPackageManagerCommand(options.packageManager as PackageManager);
+      const pmc = getPackageManagerCommand(
+        options.packageManager as PackageManager
+      );
       if (pmc.preInstall) {
         execSync(pmc.preInstall, {
           cwd: joinPathFragments(tree.root, options.directory),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
for gradle, its inputs depends on outputs of its dependsOn task. (e.g. jar task)
however, if the output file does not exist, (for example, running for 1st time in ci), it will not add to inputs.
when getting inputs, it would give a warning like
```
file or directory '/Users/emily/code/ocean/dist/libs/shared/db-schema-kotlin/classes/java/main', not found
file or directory '/Users/emily/code/ocean/dist/libs/shared/db-schema-kotlin/classes/kotlin/main', not found
file or directory '/Users/emily/code/ocean/dist/libs/shared/db-schema-kotlin/resources/main', not found
```
it is a warning, not an error, so can't be caught.

```
In Gradle's file resolution internals:

When you call task.inputs.files → Gradle resolves each file/directory.

If a declared file or dir does not exist AND it's allowed to be missing, Gradle does not throw an error — instead it logs:
file or directory '...' not found
This log is just an INFO or DEBUG message.
Gradle's normal file resolution is designed to be tolerant —
so missing files do NOT stop the build by default
```

## Expected Behavior
this solution basically take AL
<img width="1106" alt="Screenshot 2025-06-22 at 1 02 33 PM" src="https://github.com/user-attachments/assets/7a6e8a50-44ec-4c83-bf3d-dc52346b331d" />
L of outputs of dependsOn tasks and add to inputs.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
