### PR TITLE
fix(testing): unset `customConditions` when running the `open-cypress` inferred task

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -160,6 +160,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                   },
                 },
@@ -259,6 +262,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                   },
                 },
@@ -455,6 +461,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                   },
                 },
@@ -662,6 +671,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                   },
                 },
@@ -859,6 +871,9 @@ describe('@nx/cypress/plugin', () => {
                     },
                     "options": {
                       "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
                     },
                   },
                 },

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -459,7 +459,10 @@ async function buildCypressTargets(
 
   targets[options.openTargetName] = {
     command: `cypress open`,
-    options: { cwd: projectRoot },
+    options: {
+      cwd: projectRoot,
+      env: { TS_NODE_COMPILER_OPTIONS: tsNodeCompilerOptions },
+    },
     metadata: {
       technologies: ['cypress'],
       description: 'Opens Cypress',


### PR DESCRIPTION
## Current Behavior

Cypress `open-cypress` inferred task in a workspace with the `customConditions` TypeScript compiler option set, fail with the error:

```bash
TSError: ⨯ Unable to compile TypeScript:
error TS5098: Option 'customConditions' can only be used when 'moduleResolution' is set to 'node16', 'nodenext', or 'bundler'.
```

This happens because Cypress forces `ts-node` to use `module: commonjs` and `moduleResolution: node10`, which is incompatible with the `customConditions` TypeScript compiler option.

## Expected Behavior

Cypress `open-cypress` inferred task in a workspace with the `customConditions` TypeScript compiler option set should work as expected.

## Related Issue(s)

Fixes #31616
