### PR TITLE
chore(repo): add .cursor/mcp.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ storybook-static
 .claude/settings.local.json
 
 .cursor/rules/nx-rules.mdc
+.cursor/mcp.json
 .github/instructions/nx.instructions.md
 
 # Added by Claude Task Master
@@ -105,3 +106,4 @@ tasks/
 
 # Raw docs local configuration (machine-specific)
 .rawdocs.local.json
+


### PR DESCRIPTION
people use it locally with different ports so we should just add it to gitignore