### PR TITLE
fix(module-federation): ensure manifest path not prepended with workspace root

### DIFF
--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-dev-server-plugin.ts
@@ -96,10 +96,15 @@ export class NxModuleFederationDevServerPlugin implements RspackPluginInstance {
       this._options.devServerConfig.pathToManifestFile =
         getDynamicMfManifestFile(project, workspaceRoot);
     } else {
-      const userPathToManifestFile = join(
-        workspaceRoot,
-        this._options.devServerConfig.pathToManifestFile
-      );
+      const userPathToManifestFile =
+        this._options.devServerConfig.pathToManifestFile.startsWith(
+          workspaceRoot
+        )
+          ? this._options.devServerConfig.pathToManifestFile
+          : join(
+              workspaceRoot,
+              this._options.devServerConfig.pathToManifestFile
+            );
       if (!existsSync(userPathToManifestFile)) {
         throw new Error(
           `The provided Module Federation manifest file path does not exist. Please check the file exists at "${userPathToManifestFile}".`

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-dev-server-plugin.ts
@@ -96,10 +96,15 @@ export class NxModuleFederationDevServerPlugin implements RspackPluginInstance {
       this._options.devServerConfig.pathToManifestFile =
         getDynamicMfManifestFile(project, workspaceRoot);
     } else {
-      const userPathToManifestFile = join(
-        workspaceRoot,
-        this._options.devServerConfig.pathToManifestFile
-      );
+      const userPathToManifestFile =
+        this._options.devServerConfig.pathToManifestFile.startsWith(
+          workspaceRoot
+        )
+          ? this._options.devServerConfig.pathToManifestFile
+          : join(
+              workspaceRoot,
+              this._options.devServerConfig.pathToManifestFile
+            );
       if (!existsSync(userPathToManifestFile)) {
         throw new Error(
           `The provided Module Federation manifest file path does not exist. Please check the file exists at "${userPathToManifestFile}".`


### PR DESCRIPTION
## Current Behavior

  When users provide an absolute path for the Module Federation manifest file
  that already includes the workspace root, the plugin incorrectly prepends the
  workspace root again, resulting in an invalid path like
  `/workspace/root/workspace/root/path/to/manifest.json`.

  ## Expected Behavior

  The plugin should detect if the provided manifest file path already starts with
   the workspace root and avoid prepending it again. This allows users to provide
   either relative or absolute paths for the manifest file, and both will work
  correctly.

  ## Related Issue(s)

  Fixes #31524