### PR TITLE
fix(webpack): respect user config when applying node target #30937

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,7 @@
     "ts-jest": "29.1.0",
     "ts-loader": "^9.3.1",
     "ts-node": "10.9.1",
+    "ts-checker-rspack-plugin": "^1.1.1",
     "tsconfig-paths": "^4.1.2",
     "tsconfig-paths-webpack-plugin": "4.0.0",
     "typedoc": "0.25.12",

--- a/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
@@ -1,0 +1,156 @@
+import { applyBaseConfig } from './apply-base-config';
+import { NormalizedNxAppRspackPluginOptions } from './models';
+import { Configuration } from '@rspack/core';
+
+describe('apply-base-config libraryTarget handling', () => {
+  let options: NormalizedNxAppRspackPluginOptions;
+  let config: Partial<Configuration>;
+
+  beforeEach(() => {
+    options = {
+      root: '/test',
+      projectRoot: 'apps/test',
+      target: 'node',
+    } as NormalizedNxAppRspackPluginOptions;
+
+    config = {};
+    global.NX_GRAPH_CREATION = false;
+  });
+
+  afterEach(() => {
+    delete global.NX_GRAPH_CREATION;
+  });
+
+  it('should not set libraryTarget when user configures library.type', () => {
+    config.output = {
+      library: { type: 'module' },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+  });
+
+  it('should respect user libraryTarget when set explicitly', () => {
+    config.output = {
+      libraryTarget: 'umd',
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('umd');
+  });
+
+  it('should default to commonjs for node targets when nothing configured', () => {
+    config.output = {};
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs');
+  });
+
+  it('should default to commonjs-module for async-node targets when nothing configured', () => {
+    options.target = 'async-node';
+    config.output = {};
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs-module');
+  });
+
+  it('should not set libraryTarget for web targets when nothing configured', () => {
+    options.target = 'web';
+    config.output = {};
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+  });
+
+  it('should prioritize library.type over libraryTarget when both are present', () => {
+    config.output = {
+      libraryTarget: 'umd',
+      library: { type: 'module' },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+  });
+
+  it('should handle empty output config gracefully', () => {
+    config.output = undefined;
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs');
+  });
+
+  it('should handle undefined library type values', () => {
+    config.output = {
+      library: { type: undefined as any },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs');
+  });
+
+  it('should handle explicit undefined libraryTarget', () => {
+    config.output = {
+      libraryTarget: undefined,
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs');
+  });
+
+  it('should respect empty string libraryTarget', () => {
+    config.output = {
+      libraryTarget: '' as any,
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('');
+  });
+
+  it('should handle complex library configuration', () => {
+    config.output = {
+      library: {
+        type: 'module',
+        name: 'MyLib',
+      },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+    expect((config.output.library as any).type).toBe('module');
+    expect((config.output.library as any).name).toBe('MyLib');
+  });
+
+  it('should respect user configuration for async-node with library.type', () => {
+    options.target = 'async-node';
+    config.output = {
+      library: { type: 'module' },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+    expect((config.output.library as any).type).toBe('module');
+  });
+
+  it('should respect user libraryTarget for async-node target', () => {
+    options.target = 'async-node';
+    config.output = {
+      libraryTarget: 'umd',
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('umd');
+  });
+});

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.spec.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.spec.ts
@@ -1,0 +1,125 @@
+import { applyBaseConfig } from './apply-base-config';
+import { NormalizedNxAppWebpackPluginOptions } from '../nx-app-webpack-plugin-options';
+import { Configuration } from 'webpack';
+
+describe('apply-base-config libraryTarget handling', () => {
+  let options: NormalizedNxAppWebpackPluginOptions;
+  let config: Partial<Configuration>;
+
+  beforeEach(() => {
+    options = {
+      root: '/test',
+      projectRoot: 'apps/test',
+      sourceRoot: 'apps/test/src',
+      target: 'node',
+    } as NormalizedNxAppWebpackPluginOptions;
+
+    config = {};
+    global.NX_GRAPH_CREATION = false;
+  });
+
+  afterEach(() => {
+    delete global.NX_GRAPH_CREATION;
+  });
+
+  it('should not set libraryTarget when user configures library.type', () => {
+    config.output = {
+      library: { type: 'module' },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+  });
+
+  it('should respect user libraryTarget when set explicitly', () => {
+    config.output = {
+      libraryTarget: 'umd',
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('umd');
+  });
+
+  it('should default to commonjs for node targets when nothing configured', () => {
+    config.output = {};
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs');
+  });
+
+  it('should not set libraryTarget for non-node targets when nothing configured', () => {
+    options.target = 'web';
+    config.output = {};
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+  });
+
+  it('should prioritize library.type over libraryTarget when both are present', () => {
+    config.output = {
+      libraryTarget: 'umd',
+      library: { type: 'module' },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+  });
+
+  it('should handle empty output config gracefully', () => {
+    config.output = undefined;
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs');
+  });
+
+  it('should handle undefined library type values', () => {
+    config.output = {
+      library: { type: undefined as any },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs');
+  });
+
+  it('should handle explicit undefined libraryTarget', () => {
+    config.output = {
+      libraryTarget: undefined,
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('commonjs');
+  });
+
+  it('should respect empty string libraryTarget', () => {
+    config.output = {
+      libraryTarget: '' as any,
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBe('');
+  });
+
+  it('should handle complex library configuration', () => {
+    config.output = {
+      library: {
+        type: 'module',
+        name: 'MyLib',
+      },
+    };
+
+    applyBaseConfig(options, config);
+
+    expect(config.output.libraryTarget).toBeUndefined();
+    expect((config.output.library as any).type).toBe('module');
+    expect((config.output.library as any).name).toBe('MyLib');
+  });
+});

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -98,9 +98,30 @@ function applyNxIndependentConfig(
 
   config.output = {
     ...config.output,
-    libraryTarget:
-      (config as Configuration).output?.libraryTarget ??
-      (options.target === 'node' ? 'commonjs' : undefined),
+    libraryTarget: (() => {
+      const existingOutputConfig = config.output as Configuration['output'];
+      const existingLibraryTarget = existingOutputConfig?.libraryTarget;
+      const existingLibraryType =
+        typeof existingOutputConfig?.library === 'object' &&
+        'type' in existingOutputConfig?.library
+          ? existingOutputConfig?.library?.type
+          : undefined;
+
+      // If user is using modern library.type, don't set the deprecated libraryTarget
+      if (existingLibraryType !== undefined) {
+        return undefined;
+      }
+
+      // If user has set libraryTarget explicitly, use it
+      if (existingLibraryTarget !== undefined) {
+        return existingLibraryTarget;
+      }
+
+      // Set defaults based on target when user hasn't configured anything
+      if (options.target === 'node') return 'commonjs';
+      if (options.target === 'async-node') return 'commonjs-module';
+      return undefined;
+    })(),
     path:
       config.output?.path ??
       (options.outputPath

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,6 +1014,9 @@ importers:
       tree-kill:
         specifier: 1.2.2
         version: 1.2.2
+      ts-checker-rspack-plugin:
+        specifier: ^1.1.1
+        version: 1.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.11))(typescript@5.8.3)
       ts-jest:
         specifier: 29.1.0
         version: 29.1.0(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.25.0)(jest@29.7.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3)))(typescript@5.8.3)


### PR DESCRIPTION
## Current Behavior
When a user sets `target: node` in their Webpack or Rspack config, `NxAppRspackPlugin` and `NxAppWebpackPlugin` do not respect additional user config for `library.target`.

## Expected Behavior
The user config should be respected.

## Related Issue(s)

Fixes #30937
