### PR TITLE
fix(nuxt): fix TypeScript configuration chain for Nuxt components and composables

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -115,7 +115,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -152,7 +152,7 @@ exports[`app generated files content - as-provided - my-app general application 
       "path": "./tsconfig.spec.json"
     }
   ],
-  "extends": "../tsconfig.base.json"
+  "extends": "./.nuxt/tsconfig.json"
 }
 "
 `;
@@ -233,7 +233,7 @@ exports[`app generated files content - as-provided - my-app general application 
       "path": "./tsconfig.spec.json"
     }
   ],
-  "extends": "../tsconfig.base.json"
+  "extends": "./.nuxt/tsconfig.json"
 }
 "
 `;
@@ -290,7 +290,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -320,7 +320,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -350,7 +350,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -380,7 +380,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -508,7 +508,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -545,7 +545,7 @@ exports[`app generated files content - as-provided - myApp general application s
       "path": "./tsconfig.spec.json"
     }
   ],
-  "extends": "../tsconfig.base.json"
+  "extends": "./.nuxt/tsconfig.json"
 }
 "
 `;
@@ -626,7 +626,7 @@ exports[`app generated files content - as-provided - myApp general application s
       "path": "./tsconfig.spec.json"
     }
   ],
-  "extends": "../tsconfig.base.json"
+  "extends": "./.nuxt/tsconfig.json"
 }
 "
 `;
@@ -683,7 +683,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -713,7 +713,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -743,7 +743,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {
@@ -773,7 +773,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
+      extends: '../../tsconfig.base.json', // Nuxt copies this string as-is to the \`./.nuxt/tsconfig.json\`, therefore it needs to be relative to that directory
     },
   },
   imports: {

--- a/packages/nuxt/src/generators/application/application.spec.ts
+++ b/packages/nuxt/src/generators/application/application.spec.ts
@@ -268,7 +268,7 @@ describe('app', () => {
       `);
       expect(readJson(tree, 'myapp/tsconfig.json')).toMatchInlineSnapshot(`
         {
-          "extends": "../tsconfig.base.json",
+          "extends": "./.nuxt/tsconfig.json",
           "files": [],
           "references": [
             {

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -111,6 +111,10 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
     {
       ...options,
       offsetFromRoot: projectOffsetFromRoot,
+      relativePathToRootTsConfig: getRelativePathToRootTsConfig(
+        tree,
+        options.appProjectRoot
+      ),
       title: options.projectName,
       dot: '.',
       tmpl: '',

--- a/packages/nuxt/src/generators/application/files/base/nuxt.config.ts__tmpl__
+++ b/packages/nuxt/src/generators/application/files/base/nuxt.config.ts__tmpl__
@@ -13,7 +13,7 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: true,
     tsConfig: {
-      extends: '../tsconfig.app.json', // Nuxt copies this string as-is to the `./.nuxt/tsconfig.json`, therefore it needs to be relative to that directory
+      extends: '../<%= relativePathToRootTsConfig %>', // Nuxt copies this string as-is to the `./.nuxt/tsconfig.json`, therefore it needs to be relative to that directory
     },
   },
   imports: {

--- a/packages/nuxt/src/utils/create-ts-config.ts
+++ b/packages/nuxt/src/utils/create-ts-config.ts
@@ -37,7 +37,7 @@ export function createTsConfig(
     };
     json.exclude = ['node_modules', 'tmp'];
   } else {
-    json.extends = relativePathToRootTsConfig;
+    json.extends = './.nuxt/tsconfig.json';
   }
 
   writeJson(host, `${options.projectRoot}/tsconfig.json`, json);


### PR DESCRIPTION
- Modified create-ts-config.ts to make tsconfig.json extend ./.nuxt/tsconfig.json instead of root tsconfig
- Updated nuxt.config.ts template to make .nuxt/tsconfig.json extend the root tsconfig with correct relative path
- Added relativePathToRootTsConfig parameter to template generation
- Updated test snapshots to reflect the new configuration chain

This ensures IDEs can properly recognize Nuxt components, composables, and auto-imports by establishing the correct TypeScript configuration inheritance chain: tsconfig.app.json → tsconfig.json → .nuxt/tsconfig.json → tsconfig.base.json

## Related Issues
#30742 