### PR TITLE
docs(js): update tsconfig examples so extend from the root properly to remove confusion

### DIFF
--- a/docs/shared/concepts/typescript-project-linking.md
+++ b/docs/shared/concepts/typescript-project-linking.md
@@ -190,7 +190,7 @@ Each project's `tsconfig.lib.json` file extends the project's `tsconfig.json` fi
 
 ```jsonc {% fileName="packages/cart/tsconfig.lib.json" %}
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     // Any overrides
   },
@@ -212,7 +212,7 @@ The project's `tsconfig.spec.json` does not need to reference project dependenci
 
 ```jsonc {% fileName="packages/cart/tsconfig.spec.json" %}
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     // Any overrides
   },


### PR DESCRIPTION
## Current Behavior

  Documentation examples show `tsconfig.lib.json` and
  `tsconfig.spec.json` extending from `./tsconfig.json`.

  ## Expected Behavior

  Examples should extend directly from `../../tsconfig.base.json` to
  match Nx's recommended TypeScript configuration structure.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31704
