### PR TITLE
fix(nx-dev): update sorting of pinned posts

### DIFF
--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -87,7 +87,7 @@ export default function CustomApp({
       </Link>
       <Component {...pageProps} />
       {/* <LiveStreamNotifier /> */}
-      <WebinarNotifier />
+      {/* <WebinarNotifier /> */}
 
       {/* All tracking scripts consolidated in GlobalScripts component */}
       <GlobalScripts

--- a/nx-dev/ui-blog/src/lib/blog-container.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-container.tsx
@@ -7,6 +7,7 @@ import { Filters } from './filters';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { ALL_TOPICS } from './topics';
+import { sortFirstFivePosts } from './sort-featured-posts';
 import {
   ComputerDesktopIcon,
   BookOpenIcon,
@@ -23,24 +24,6 @@ import {
 export interface BlogContainerProps {
   blogPosts: BlogPostDataEntry[];
   tags: string[];
-}
-
-// first five blog posts should prioritize pinned posts, then show recent posts
-// excluding any posts that have specific slugs we want to deprioritize
-export function sortFirstFivePosts(
-  posts: BlogPostDataEntry[]
-): BlogPostDataEntry[] {
-  // Sort posts: pinned posts first, then by date
-  const sortedPosts = posts.sort((a, b) => {
-    // If one is pinned and the other isn't, prioritize the pinned one
-    if (a.pinned === true && b.pinned !== true) return -1;
-    if (b.pinned === true && a.pinned !== true) return 1;
-
-    // Otherwise, sort by date (newest first)
-    return new Date(b.date).valueOf() - new Date(a.date).valueOf();
-  });
-
-  return sortedPosts.slice(0, 5);
 }
 
 export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {

--- a/nx-dev/ui-blog/src/lib/sort-featured-posts.ts
+++ b/nx-dev/ui-blog/src/lib/sort-featured-posts.ts
@@ -1,0 +1,32 @@
+import { BlogPostDataEntry } from '@nx/nx-dev/data-access-documents/node-only';
+
+// first five blog posts should prioritize pinned posts, then show recent posts
+// if there are fewer than 5 pinned posts, fill remaining spots with newest posts by date
+// then sort the final 5 posts by date so newer posts can appear before older pinned posts
+export function sortFirstFivePosts(
+  posts: BlogPostDataEntry[]
+): BlogPostDataEntry[] {
+  // Separate pinned and non-pinned posts
+  const pinnedPosts = posts.filter((post) => post.pinned === true);
+  const nonPinnedPosts = posts.filter((post) => post.pinned !== true);
+
+  // Sort both groups by date (newest first)
+  pinnedPosts.sort(
+    (a, b) => new Date(b.date).valueOf() - new Date(a.date).valueOf()
+  );
+  nonPinnedPosts.sort(
+    (a, b) => new Date(b.date).valueOf() - new Date(a.date).valueOf()
+  );
+
+  // Take up to 5 pinned posts, then fill remaining spots with newest non-pinned posts
+  const selectedPosts = [
+    ...pinnedPosts.slice(0, 5),
+    ...nonPinnedPosts.slice(0, Math.max(0, 5 - pinnedPosts.length)),
+  ];
+
+  // Sort the final selection by date (newest first)
+  // This allows newer non-pinned posts to appear before older pinned posts
+  return selectedPosts
+    .sort((a, b) => new Date(b.date).valueOf() - new Date(a.date).valueOf())
+    .slice(0, 5);
+}


### PR DESCRIPTION
Fixes the current logic of the /blog page where pinned posts would not be properly sorted and mixed with non-pinned ones in the header section of the blog page