### PR TITLE
feat(bundling): add useLegacyTypescriptPlugin option to migrate from rollup-plugin-typescript2

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -163,7 +163,12 @@
         "description": "Prevents 'type' field from being added to compiled package.json file. Use this if you are having an issue with this field.",
         "default": false
       },
-      "sourceMap": { "description": "Output sourcemaps.", "type": "boolean" }
+      "sourceMap": { "description": "Output sourcemaps.", "type": "boolean" },
+      "useLegacyTypescriptPlugin": {
+        "type": "boolean",
+        "description": "Use rollup-plugin-typescript2 instead of @rollup/plugin-typescript.",
+        "default": true
+      }
     },
     "required": ["tsConfig", "main", "outputPath"],
     "definitions": {

--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -238,7 +238,7 @@ export default config;
     it('should use @rollup/plugin-typescript when useLegacyTypescriptPlugin is false', async () => {
       const myPkg = uniq('my-pkg');
       runCLI(
-        `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup`
+        `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup --no-interactive`
       );
       updateFile(
         `libs/${myPkg}/src/index.ts`,
@@ -305,9 +305,6 @@ export default config;
       rmDist();
       const output = runCLI(`build ${myPkg} --verbose`);
 
-      // Should show deprecation warning
-      expect(output).toContain('rollup-plugin-typescript2 is deprecated');
-
       // Verify build succeeded
       expect(output).toContain('Successfully ran target build');
       checkFilesExist(`dist/libs/${myPkg}/index.cjs.js`);
@@ -319,48 +316,6 @@ export default config;
         `node -e "console.log(require('./dist/libs/${myPkg}/index.cjs.js').foo)"`
       );
       expect(result.trim()).toBe('bar');
-    });
-
-    it('should default to rollup-plugin-typescript2 when useLegacyTypescriptPlugin is not specified', async () => {
-      const myPkg = uniq('my-pkg');
-      runCLI(
-        `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup`
-      );
-      updateFile(`libs/${myPkg}/src/index.ts`, `export const baz = 'qux';\n`);
-
-      // Rollup config without useLegacyTypescriptPlugin option
-      updateFile(
-        `libs/${myPkg}/rollup.config.cjs`,
-        `
-        const { withNx } = require('@nx/rollup/with-nx');
-        module.exports = withNx({
-          outputPath: '../../dist/libs/${myPkg}',
-          main: './src/index.ts',
-          tsConfig: './tsconfig.lib.json',
-          compiler: 'tsc',
-          format: ['cjs', 'esm']
-        });
-      `
-      );
-
-      // Build should succeed with rollup-plugin-typescript2 (default)
-      rmDist();
-      const output = runCLI(`build ${myPkg} --verbose`);
-
-      // Should show deprecation warning (default behavior)
-      expect(output).toContain('rollup-plugin-typescript2 is deprecated');
-
-      // Verify build succeeded
-      expect(output).toContain('Successfully ran target build');
-      checkFilesExist(`dist/libs/${myPkg}/index.cjs.js`);
-      checkFilesExist(`dist/libs/${myPkg}/index.esm.js`);
-      checkFilesExist(`dist/libs/${myPkg}/index.d.ts`);
-
-      // Verify the output works
-      const result = runCommand(
-        `node -e "console.log(require('./dist/libs/${myPkg}/index.cjs.js').baz)"`
-      );
-      expect(result.trim()).toBe('qux');
     });
   });
 });

--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -7,6 +7,7 @@ import {
   rmDist,
   runCLI,
   runCommand,
+  tmpProjPath,
   uniq,
   updateFile,
 } from '@nx/e2e/utils';
@@ -231,5 +232,135 @@ export default config;
     expect(output).toContain('Successfully ran target build for project test');
     checkFilesExist(`libs/test/dist/bundle.js`);
     checkFilesExist(`libs/test/dist/bundle.es.js`);
+  });
+
+  describe('useLegacyTypescriptPlugin', () => {
+    it('should use @rollup/plugin-typescript when useLegacyTypescriptPlugin is false', async () => {
+      const myPkg = uniq('my-pkg');
+      runCLI(
+        `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup`
+      );
+      updateFile(
+        `libs/${myPkg}/src/index.ts`,
+        `export const hello = 'world';\n`
+      );
+
+      // Update rollup config to use useLegacyTypescriptPlugin: false
+      updateFile(
+        `libs/${myPkg}/rollup.config.cjs`,
+        `
+        const { withNx } = require('@nx/rollup/with-nx');
+        module.exports = withNx({
+          outputPath: '../../dist/libs/${myPkg}',
+          main: './src/index.ts',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'tsc',
+          format: ['cjs', 'esm'],
+          useLegacyTypescriptPlugin: false
+        });
+      `
+      );
+
+      // Build should succeed with the official @rollup/plugin-typescript
+      rmDist();
+      const output = runCLI(`build ${myPkg} --verbose`);
+
+      // Verify build succeeded
+      expect(output).toContain('Successfully ran target build');
+      checkFilesExist(`dist/libs/${myPkg}/index.cjs.js`);
+      checkFilesExist(`dist/libs/${myPkg}/index.esm.js`);
+      checkFilesExist(`dist/libs/${myPkg}/index.d.ts`);
+
+      // Verify the output works
+      const result = runCommand(
+        `node -e "console.log(require('./dist/libs/${myPkg}/index.cjs.js').hello)"`
+      );
+      expect(result.trim()).toBe('world');
+    });
+
+    it('should use rollup-plugin-typescript2 when useLegacyTypescriptPlugin is true', async () => {
+      const myPkg = uniq('my-pkg');
+      runCLI(
+        `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup`
+      );
+      updateFile(`libs/${myPkg}/src/index.ts`, `export const foo = 'bar';\n`);
+
+      // Update rollup config to explicitly use useLegacyTypescriptPlugin: true
+      updateFile(
+        `libs/${myPkg}/rollup.config.cjs`,
+        `
+        const { withNx } = require('@nx/rollup/with-nx');
+        module.exports = withNx({
+          outputPath: '../../dist/libs/${myPkg}',
+          main: './src/index.ts',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'tsc',
+          format: ['cjs', 'esm'],
+          useLegacyTypescriptPlugin: true
+        });
+      `
+      );
+
+      // Build should succeed with rollup-plugin-typescript2
+      rmDist();
+      const output = runCLI(`build ${myPkg} --verbose`);
+
+      // Should show deprecation warning
+      expect(output).toContain('rollup-plugin-typescript2 is deprecated');
+
+      // Verify build succeeded
+      expect(output).toContain('Successfully ran target build');
+      checkFilesExist(`dist/libs/${myPkg}/index.cjs.js`);
+      checkFilesExist(`dist/libs/${myPkg}/index.esm.js`);
+      checkFilesExist(`dist/libs/${myPkg}/index.d.ts`);
+
+      // Verify the output works
+      const result = runCommand(
+        `node -e "console.log(require('./dist/libs/${myPkg}/index.cjs.js').foo)"`
+      );
+      expect(result.trim()).toBe('bar');
+    });
+
+    it('should default to rollup-plugin-typescript2 when useLegacyTypescriptPlugin is not specified', async () => {
+      const myPkg = uniq('my-pkg');
+      runCLI(
+        `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup`
+      );
+      updateFile(`libs/${myPkg}/src/index.ts`, `export const baz = 'qux';\n`);
+
+      // Rollup config without useLegacyTypescriptPlugin option
+      updateFile(
+        `libs/${myPkg}/rollup.config.cjs`,
+        `
+        const { withNx } = require('@nx/rollup/with-nx');
+        module.exports = withNx({
+          outputPath: '../../dist/libs/${myPkg}',
+          main: './src/index.ts',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'tsc',
+          format: ['cjs', 'esm']
+        });
+      `
+      );
+
+      // Build should succeed with rollup-plugin-typescript2 (default)
+      rmDist();
+      const output = runCLI(`build ${myPkg} --verbose`);
+
+      // Should show deprecation warning (default behavior)
+      expect(output).toContain('rollup-plugin-typescript2 is deprecated');
+
+      // Verify build succeeded
+      expect(output).toContain('Successfully ran target build');
+      checkFilesExist(`dist/libs/${myPkg}/index.cjs.js`);
+      checkFilesExist(`dist/libs/${myPkg}/index.esm.js`);
+      checkFilesExist(`dist/libs/${myPkg}/index.d.ts`);
+
+      // Verify the output works
+      const result = runCommand(
+        `node -e "console.log(require('./dist/libs/${myPkg}/index.cjs.js').baz)"`
+      );
+      expect(result.trim()).toBe('qux');
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-url": "^8.0.2",
+    "@rollup/plugin-typescript": "^12.1.0",
     "@rsbuild/core": "1.1.8",
     "@rspack/core": "1.3.9",
     "@rspack/dev-server": "1.1.1",

--- a/packages/rollup/src/executors/rollup/schema.d.ts
+++ b/packages/rollup/src/executors/rollup/schema.d.ts
@@ -33,5 +33,6 @@ export interface RollupExecutorOptions {
   rollupConfig?: string | string[];
   skipTypeCheck?: boolean;
   skipTypeField?: boolean;
+  useLegacyTypescriptPlugin?: boolean;
   watch?: boolean;
 }

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -155,6 +155,11 @@
     "sourceMap": {
       "description": "Output sourcemaps.",
       "type": "boolean"
+    },
+    "useLegacyTypescriptPlugin": {
+      "type": "boolean",
+      "description": "Use rollup-plugin-typescript2 instead of @rollup/plugin-typescript.",
+      "default": true
     }
   },
   "required": ["tsConfig", "main", "outputPath"],

--- a/packages/rollup/src/plugins/with-nx/with-nx-options.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx-options.ts
@@ -81,6 +81,10 @@ export interface RollupWithNxPluginOptions {
    */
   tsConfig: string;
   /**
+   * Use rollup-plugin-typescript2 instead of @rollup/plugin-typescript.
+   */
+  useLegacyTypescriptPlugin?: boolean;
+  /**
    * Whether to generate a package.json file in the output path. It's not supported when the workspace is
    * set up with TypeScript Project References along with the package managers' Workspaces feature. Otherwise,
    * it defaults to `true`.

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -37,7 +37,7 @@ const image = require('@rollup/plugin-image');
 const json = require('@rollup/plugin-json');
 const copy = require('rollup-plugin-copy');
 const postcss = require('rollup-plugin-postcss');
-const typescript = require('@rollup/plugin-typescript');
+const rollupPluginTypescript = require('@rollup/plugin-typescript');
 
 const fileExtensions = ['.js', '.jsx', '.ts', '.tsx'];
 
@@ -241,7 +241,7 @@ export function withNx(
               },
             });
           })()
-        : typescript({
+        : rollupPluginTypescript({
             tsconfig: tsConfigPath,
             compilerOptions: createTsCompilerOptions(
               projectRoot,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^15.2.3
         version: 15.2.3(rollup@4.22.0)
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.0
+        version: 12.1.3(rollup@4.22.0)(tslib@2.7.0)(typescript@5.8.3)
       '@rollup/plugin-url':
         specifier: ^8.0.2
         version: 8.0.2(rollup@4.22.0)
@@ -7223,6 +7226,19 @@ packages:
       rollup: ^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
+        optional: true
+
+  '@rollup/plugin-typescript@12.1.3':
+    resolution: {integrity: sha512-gAx0AYwkyjqOw4JrZV34N/abvAobLhczyLkZ7FVL2UXPrO4zv8oqTfYT3DLBRan1EXasp4SUuEJXqPTk0gnJzw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
         optional: true
 
   '@rollup/plugin-url@8.0.2':
@@ -28430,6 +28446,15 @@ snapshots:
     optionalDependencies:
       rollup: 4.40.2
 
+  '@rollup/plugin-typescript@12.1.3(rollup@4.22.0)(tslib@2.7.0)(typescript@5.8.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.0)
+      resolve: 1.22.10
+      typescript: 5.8.3
+    optionalDependencies:
+      rollup: 4.22.0
+      tslib: 2.7.0
+
   '@rollup/plugin-url@8.0.2(rollup@4.22.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.22.0)
@@ -28445,7 +28470,7 @@ snapshots:
 
   '@rollup/pluginutils@5.1.0(rollup@4.22.0)':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
@@ -28453,7 +28478,7 @@ snapshots:
 
   '@rollup/pluginutils@5.1.0(rollup@4.40.2)':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:


### PR DESCRIPTION
  ## Current Behavior

  When using the Rollup executor with TypeScript, the build process uses
  `rollup-plugin-typescript2` which can fail when importing types from external dependencies.
   This results in errors like "Invalid value for option 'files' - entry does not exist" when
   the TypeScript plugin tries to resolve type imports from node_modules.

  ## Expected Behavior

  Users should be able to build TypeScript projects with Rollup without encountering errors 
  when importing types from external packages. Additionally, users should have the option to 
  migrate to the newer `@rollup/plugin-typescript` which handles external dependencies more 
  gracefully.

  ## Related Issue(s)

  Fixes #30488