### PR TITLE
fix(module-federation): restore support for relative URLs in module federation remotes

### DIFF
--- a/packages/angular/mf/mf.ts
+++ b/packages/angular/mf/mf.ts
@@ -1,4 +1,4 @@
-import { extname } from 'node:path';
+import { processRuntimeRemoteUrl } from './url-helpers';
 
 export type ResolveRemoteUrlFunction = (
   remoteName: string
@@ -133,18 +133,7 @@ async function loadRemoteContainer(remoteName: string) {
     ? remoteUrlDefinitions[remoteName]
     : await resolveRemoteUrl(remoteName);
 
-  const url = new URL(remoteUrl);
-  const ext = extname(url.pathname);
-
-  const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
-
-  if (needsRemoteEntry) {
-    url.pathname = url.pathname.endsWith('/')
-      ? `${url.pathname}remoteEntry.mjs`
-      : `${url.pathname}/remoteEntry.mjs`;
-  }
-
-  const containerUrl = url.href;
+  const containerUrl = processRuntimeRemoteUrl(remoteUrl, 'mjs');
 
   const container = await loadModule(containerUrl);
   await container.init(__webpack_share_scopes__.default);

--- a/packages/angular/mf/url-helpers.ts
+++ b/packages/angular/mf/url-helpers.ts
@@ -1,0 +1,85 @@
+// Helper function to extract file extension from a path
+function extname(path: string): string {
+  const lastDot = path.lastIndexOf('.');
+  const lastSlash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  if (lastDot === -1 || lastDot < lastSlash) {
+    return '';
+  }
+  return path.slice(lastDot);
+}
+
+/**
+ * Checks if a URL string is absolute (has protocol)
+ */
+export function isAbsoluteUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Safely processes remote locations, handling both relative and absolute URLs
+ * while preserving query parameters and hash fragments for absolute URLs
+ */
+export function processRemoteLocation(
+  remoteLocation: string,
+  remoteEntryExt: 'js' | 'mjs'
+): string {
+  // Handle promise-based remotes as-is
+  if (remoteLocation.startsWith('promise new Promise')) {
+    return remoteLocation;
+  }
+
+  if (isAbsoluteUrl(remoteLocation)) {
+    // Use new URL parsing for absolute URLs (supports query params/hash)
+    const url = new URL(remoteLocation);
+    const ext = extname(url.pathname);
+    const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
+
+    if (needsRemoteEntry) {
+      url.pathname = url.pathname.endsWith('/')
+        ? `${url.pathname}remoteEntry.${remoteEntryExt}`
+        : `${url.pathname}/remoteEntry.${remoteEntryExt}`;
+    }
+
+    return url.href;
+  } else {
+    // Use string manipulation for relative URLs (backward compatibility)
+    const ext = extname(remoteLocation);
+    const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
+
+    if (needsRemoteEntry) {
+      const baseRemote = remoteLocation.endsWith('/')
+        ? remoteLocation.slice(0, -1)
+        : remoteLocation;
+      return `${baseRemote}/remoteEntry.${remoteEntryExt}`;
+    }
+
+    return remoteLocation;
+  }
+}
+
+/**
+ * Processes remote URLs for runtime environments, resolving relative URLs against window.location.origin
+ */
+export function processRuntimeRemoteUrl(
+  remoteUrl: string,
+  remoteEntryExt: 'js' | 'mjs'
+): string {
+  if (isAbsoluteUrl(remoteUrl)) {
+    return processRemoteLocation(remoteUrl, remoteEntryExt);
+  } else {
+    // For runtime relative URLs, resolve against current origin
+    const baseUrl =
+      typeof globalThis !== 'undefined' &&
+      typeof (globalThis as any).window !== 'undefined' &&
+      (globalThis as any).window.location
+        ? (globalThis as any).window.location.origin
+        : 'http://localhost';
+    const absoluteUrl = new URL(remoteUrl, baseUrl).href;
+    return processRemoteLocation(absoluteUrl, remoteEntryExt);
+  }
+}

--- a/packages/module-federation/src/utils/remotes.spec.ts
+++ b/packages/module-federation/src/utils/remotes.spec.ts
@@ -1,4 +1,5 @@
 import { mapRemotes } from './remotes';
+import { isAbsoluteUrl, processRemoteLocation } from './url-helpers';
 
 describe('mapRemotes', () => {
   it('should map string remotes', () => {
@@ -53,6 +54,193 @@ describe('mapRemotes', () => {
       remote1: 'remote1@http://localhost:4201/remoteEntry.js',
       remote2: 'remote2@http://localhost:4202/remoteEntry.mjs',
       remote3: 'remote3@http://localhost:4203/mf-manifest.json',
+    });
+  });
+
+  describe('relative URL support', () => {
+    it('should handle relative URLs without remoteEntry', () => {
+      expect(
+        mapRemotes([['remote1', 'remote/path']], 'js', (remote) => remote, true)
+      ).toEqual({
+        remote1: 'remote1@remote/path/remoteEntry.js',
+      });
+    });
+
+    it('should handle relative URLs with remoteEntry', () => {
+      expect(
+        mapRemotes(
+          [['remote1', 'remote/remoteEntry.js']],
+          'js',
+          (remote) => remote,
+          true
+        )
+      ).toEqual({
+        remote1: 'remote1@remote/remoteEntry.js',
+      });
+    });
+
+    it('should handle relative URLs with subdirectories', () => {
+      expect(
+        mapRemotes(
+          [['remote1', 'apps/remote/path']],
+          'js',
+          (remote) => remote,
+          true
+        )
+      ).toEqual({
+        remote1: 'remote1@apps/remote/path/remoteEntry.js',
+      });
+    });
+
+    it('should handle relative URLs with trailing slash', () => {
+      expect(
+        mapRemotes(
+          [['remote1', 'remote/path/']],
+          'js',
+          (remote) => remote,
+          true
+        )
+      ).toEqual({
+        remote1: 'remote1@remote/path/remoteEntry.js',
+      });
+    });
+
+    it('should handle mixed relative and absolute URLs', () => {
+      expect(
+        mapRemotes(
+          [
+            ['remote1', 'remote/path'],
+            ['remote2', 'http://localhost:4201/remoteEntry.js'],
+          ],
+          'js',
+          (remote) => remote,
+          true
+        )
+      ).toEqual({
+        remote1: 'remote1@remote/path/remoteEntry.js',
+        remote2: 'remote2@http://localhost:4201/remoteEntry.js',
+      });
+    });
+
+    it('should preserve absolute URLs with query parameters', () => {
+      expect(
+        mapRemotes(
+          [['remote1', 'http://localhost:4201?version=1.0.0']],
+          'js',
+          (remote) => remote,
+          true
+        )
+      ).toEqual({
+        remote1: 'remote1@http://localhost:4201/remoteEntry.js?version=1.0.0',
+      });
+    });
+
+    it('should preserve absolute URLs with hash fragments', () => {
+      expect(
+        mapRemotes(
+          [['remote1', 'http://localhost:4201#main']],
+          'js',
+          (remote) => remote,
+          true
+        )
+      ).toEqual({
+        remote1: 'remote1@http://localhost:4201/remoteEntry.js#main',
+      });
+    });
+
+    it('should handle promise-based remotes correctly', () => {
+      const promiseCode = `promise new Promise(resolve => {
+        const remoteUrl = 'http://localhost:4201/remoteEntry.js';
+        const script = document.createElement('script');
+        script.src = remoteUrl;
+        script.onload = () => {
+          const proxy = {
+            get: (request) => window.remote1.get(request),
+            init: (arg) => {
+              try {
+                window.remote1.init(arg);
+              } catch (e) {
+                console.log('Remote container already initialized');
+              }
+            }
+          };
+          resolve(proxy);
+        }
+        document.head.appendChild(script);
+      })`;
+
+      expect(
+        mapRemotes([['remote1', promiseCode]], 'js', (remote) => remote, true)
+      ).toEqual({
+        remote1: promiseCode,
+      });
+    });
+  });
+});
+
+describe('URL Helper Functions', () => {
+  describe('isAbsoluteUrl', () => {
+    it('should return true for absolute URLs', () => {
+      expect(isAbsoluteUrl('http://localhost:4201')).toBe(true);
+      expect(isAbsoluteUrl('https://example.com')).toBe(true);
+      expect(isAbsoluteUrl('ftp://example.com')).toBe(true);
+    });
+
+    it('should return false for relative URLs', () => {
+      expect(isAbsoluteUrl('remote/path')).toBe(false);
+      expect(isAbsoluteUrl('./remote/path')).toBe(false);
+      expect(isAbsoluteUrl('../remote/path')).toBe(false);
+      expect(isAbsoluteUrl('/remote/path')).toBe(false);
+    });
+  });
+
+  describe('processRemoteLocation', () => {
+    it('should handle promise-based remotes as-is', () => {
+      const promiseRemote =
+        'promise new Promise((resolve) => { resolve("test"); })';
+      expect(processRemoteLocation(promiseRemote, 'js')).toBe(promiseRemote);
+    });
+
+    it('should add remoteEntry to relative URLs without extension', () => {
+      expect(processRemoteLocation('remote/path', 'js')).toBe(
+        'remote/path/remoteEntry.js'
+      );
+      expect(processRemoteLocation('remote/path', 'mjs')).toBe(
+        'remote/path/remoteEntry.mjs'
+      );
+    });
+
+    it('should preserve relative URLs with valid extensions', () => {
+      expect(processRemoteLocation('remote/remoteEntry.js', 'js')).toBe(
+        'remote/remoteEntry.js'
+      );
+      expect(processRemoteLocation('remote/manifest.json', 'js')).toBe(
+        'remote/manifest.json'
+      );
+    });
+
+    it('should handle relative URLs with trailing slash', () => {
+      expect(processRemoteLocation('remote/path/', 'js')).toBe(
+        'remote/path/remoteEntry.js'
+      );
+    });
+
+    it('should add remoteEntry to absolute URLs without extension', () => {
+      expect(processRemoteLocation('http://localhost:4201', 'js')).toBe(
+        'http://localhost:4201/remoteEntry.js'
+      );
+    });
+
+    it('should preserve absolute URLs with valid extensions', () => {
+      expect(
+        processRemoteLocation('http://localhost:4201/remoteEntry.js', 'js')
+      ).toBe('http://localhost:4201/remoteEntry.js');
+    });
+
+    it('should preserve query parameters and hash fragments for absolute URLs', () => {
+      expect(
+        processRemoteLocation('http://localhost:4201?v=1.0#main', 'js')
+      ).toBe('http://localhost:4201/remoteEntry.js?v=1.0#main');
     });
   });
 });

--- a/packages/module-federation/src/utils/url-helpers.ts
+++ b/packages/module-federation/src/utils/url-helpers.ts
@@ -1,0 +1,77 @@
+import { extname } from 'path';
+
+/**
+ * Checks if a URL string is absolute (has protocol)
+ */
+export function isAbsoluteUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Safely processes remote locations, handling both relative and absolute URLs
+ * while preserving query parameters and hash fragments for absolute URLs
+ */
+export function processRemoteLocation(
+  remoteLocation: string,
+  remoteEntryExt: 'js' | 'mjs'
+): string {
+  // Handle promise-based remotes as-is
+  if (remoteLocation.startsWith('promise new Promise')) {
+    return remoteLocation;
+  }
+
+  if (isAbsoluteUrl(remoteLocation)) {
+    // Use new URL parsing for absolute URLs (supports query params/hash)
+    const url = new URL(remoteLocation);
+    const ext = extname(url.pathname);
+    const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
+
+    if (needsRemoteEntry) {
+      url.pathname = url.pathname.endsWith('/')
+        ? `${url.pathname}remoteEntry.${remoteEntryExt}`
+        : `${url.pathname}/remoteEntry.${remoteEntryExt}`;
+    }
+
+    return url.href;
+  } else {
+    // Use string manipulation for relative URLs (backward compatibility)
+    const ext = extname(remoteLocation);
+    const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
+
+    if (needsRemoteEntry) {
+      const baseRemote = remoteLocation.endsWith('/')
+        ? remoteLocation.slice(0, -1)
+        : remoteLocation;
+      return `${baseRemote}/remoteEntry.${remoteEntryExt}`;
+    }
+
+    return remoteLocation;
+  }
+}
+
+/**
+ * Processes remote URLs for runtime environments, resolving relative URLs against window.location.origin
+ */
+export function processRuntimeRemoteUrl(
+  remoteUrl: string,
+  remoteEntryExt: 'js' | 'mjs'
+): string {
+  if (isAbsoluteUrl(remoteUrl)) {
+    return processRemoteLocation(remoteUrl, remoteEntryExt);
+  } else {
+    // For runtime relative URLs, resolve against current origin
+    const baseUrl =
+      typeof globalThis !== 'undefined' &&
+      typeof (globalThis as any).window !== 'undefined' &&
+      (globalThis as any).window.location
+        ? (globalThis as any).window.location.origin
+        : 'http://localhost';
+    const absoluteUrl = new URL(remoteUrl, baseUrl).href;
+    return processRemoteLocation(absoluteUrl, remoteEntryExt);
+  }
+}

--- a/packages/module-federation/url-helpers.ts
+++ b/packages/module-federation/url-helpers.ts
@@ -1,0 +1,85 @@
+// Browser-safe helper function to extract file extension from a path
+function extname(path: string): string {
+  const lastDot = path.lastIndexOf('.');
+  const lastSlash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  if (lastDot === -1 || lastDot < lastSlash) {
+    return '';
+  }
+  return path.slice(lastDot);
+}
+
+/**
+ * Checks if a URL string is absolute (has protocol)
+ */
+export function isAbsoluteUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Safely processes remote locations, handling both relative and absolute URLs
+ * while preserving query parameters and hash fragments for absolute URLs
+ */
+export function processRemoteLocation(
+  remoteLocation: string,
+  remoteEntryExt: 'js' | 'mjs'
+): string {
+  // Handle promise-based remotes as-is
+  if (remoteLocation.startsWith('promise new Promise')) {
+    return remoteLocation;
+  }
+
+  if (isAbsoluteUrl(remoteLocation)) {
+    // Use new URL parsing for absolute URLs (supports query params/hash)
+    const url = new URL(remoteLocation);
+    const ext = extname(url.pathname);
+    const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
+
+    if (needsRemoteEntry) {
+      url.pathname = url.pathname.endsWith('/')
+        ? `${url.pathname}remoteEntry.${remoteEntryExt}`
+        : `${url.pathname}/remoteEntry.${remoteEntryExt}`;
+    }
+
+    return url.href;
+  } else {
+    // Use string manipulation for relative URLs (backward compatibility)
+    const ext = extname(remoteLocation);
+    const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
+
+    if (needsRemoteEntry) {
+      const baseRemote = remoteLocation.endsWith('/')
+        ? remoteLocation.slice(0, -1)
+        : remoteLocation;
+      return `${baseRemote}/remoteEntry.${remoteEntryExt}`;
+    }
+
+    return remoteLocation;
+  }
+}
+
+/**
+ * Processes remote URLs for runtime environments, resolving relative URLs against window.location.origin
+ */
+export function processRuntimeRemoteUrl(
+  remoteUrl: string,
+  remoteEntryExt: 'js' | 'mjs'
+): string {
+  if (isAbsoluteUrl(remoteUrl)) {
+    return processRemoteLocation(remoteUrl, remoteEntryExt);
+  } else {
+    // For runtime relative URLs, resolve against current origin
+    const baseUrl =
+      typeof globalThis !== 'undefined' &&
+      typeof (globalThis as any).window !== 'undefined' &&
+      (globalThis as any).window.location
+        ? (globalThis as any).window.location.origin
+        : 'http://localhost';
+    const absoluteUrl = new URL(remoteUrl, baseUrl).href;
+    return processRemoteLocation(absoluteUrl, remoteEntryExt);
+  }
+}

--- a/packages/react/mf/dynamic-federation.ts
+++ b/packages/react/mf/dynamic-federation.ts
@@ -1,4 +1,4 @@
-import { extname } from 'node:path';
+import { processRuntimeRemoteUrl } from '@nx/module-federation/url-helpers';
 
 export type ResolveRemoteUrlFunction = (
   remoteName: string
@@ -160,18 +160,7 @@ async function loadRemoteContainer(remoteName: string) {
     ? remoteUrlDefinitions[remoteName]
     : await resolveRemoteUrl(remoteName);
 
-  const url = new URL(remoteUrl);
-  const ext = extname(url.pathname);
-
-  const needsRemoteEntry = !['.js', '.mjs', '.json'].includes(ext);
-
-  if (needsRemoteEntry) {
-    url.pathname = url.pathname.endsWith('/')
-      ? `${url.pathname}remoteEntry.mjs`
-      : `${url.pathname}/remoteEntry.mjs`;
-  }
-
-  const containerUrl = url.href;
+  const containerUrl = processRuntimeRemoteUrl(remoteUrl, 'mjs');
 
   const container = await fetchRemoteModule(containerUrl, remoteName);
   await container.init(__webpack_share_scopes__.default);


### PR DESCRIPTION
  ## Current Behavior

  Module federation configurations with relative URLs are broken due to PR
   #30615, which forced all remote URLs to be parsed as absolute URLs
  using `new URL()`. This breaking change prevents developers from using
  relative URLs in their module federation setups, causing runtime errors
  when the application tries to load remote modules.

  ## Expected Behavior

  Module federation should support both relative and absolute URLs
  seamlessly:
  - Relative URLs should work as they did before, maintaining backward
  compatibility
  - Absolute URLs should continue to work with enhanced query parameter
  support
  - The URL processing should be consistent across all module federation
  helpers (Angular and React)

  ## Related Issue(s)

  Fixes #31538