### PR TITLE
fix(testing): prefer using tsconfig.spec.json when loading jest config in plugin

### DIFF
--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -249,7 +249,16 @@ async function buildJestTargets(
   const absConfigFilePath = resolve(context.workspaceRoot, configFilePath);
 
   if (require.cache[absConfigFilePath]) clearRequireCache();
-  const rawConfig = await loadConfigFile(absConfigFilePath);
+  const rawConfig = await loadConfigFile(
+    absConfigFilePath,
+    // lookup for the same files we look for in the resolver and fall back to tsconfig.json
+    [
+      'tsconfig.spec.json',
+      'tsconfig.test.json',
+      'tsconfig.jest.json',
+      'tsconfig.json',
+    ]
+  );
 
   const targets: Record<string, TargetConfiguration> = {};
   const namedInputs = getNamedInputs(projectRoot, context);


### PR DESCRIPTION
## Current Behavior

The `@nx/jest/plugin` loads the Jest config file using the project's `tsconfig.json` file.

## Expected Behavior

The `@nx/jest/plugin` should try to load the Jest config file using the `tsconfig.spec.json` file (or other common filenames also handled by the nx jest resolver). If those files don't exist, it should fall back to the project's `tsconfig.json` file.

## Related Issue(s)

Fixes #31351 
