### PR TITLE
fix(core): improve error handling in daemon server

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -330,8 +330,13 @@ export async function handleResult(
   type: string,
   hrFn: () => Promise<HandlerResult>
 ) {
+  let hr: HandlerResult;
   const startMark = new Date();
-  const hr = await hrFn();
+  try {
+    hr = await hrFn();
+  } catch (error) {
+    hr = { description: `[${type}]`, error };
+  }
   const doneHandlingMark = new Date();
   if (hr.error) {
     await respondWithErrorAndExit(socket, hr.description, hr.error);


### PR DESCRIPTION
## Current Behavior

When a message handler in the Daemon server throws an error, the process exits, and nothing is printed to the terminal.

## Expected Behavior

Errors thrown by message handlers in the Daemon server should be handled appropriately and printed to the output.

## Related Issue(s)

Fixes #31407 
Fixes #31567 
