### PR TITLE
fix(vite): fix the build command for the deps in the vite tsconfig paths plugin

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -104,16 +104,18 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
           exitOnError: false,
           resetDaemonClient: true,
         });
+        // When using incremental building and the serve target is called
+        // we need to get the deps for the 'build' target instead.
+        const depsBuildTarget =
+          process.env.NX_TASK_TARGET_TARGET === 'serve'
+            ? 'build'
+            : process.env.NX_TASK_TARGET_TARGET;
         const { dependencies } = calculateProjectBuildableDependencies(
           undefined,
           projectGraph,
           workspaceRoot,
           process.env.NX_TASK_TARGET_PROJECT,
-          // When using incremental building and the serve target is called
-          // we need to get the deps for the 'build' target instead.
-          process.env.NX_TASK_TARGET_TARGET === 'serve'
-            ? 'build'
-            : process.env.NX_TASK_TARGET_TARGET,
+          depsBuildTarget,
           process.env.NX_TASK_TARGET_CONFIGURATION
         );
         // This tsconfig is used via the Vite ts paths plugin.
@@ -131,7 +133,7 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
             .filter((dep) => dep.node.type === 'lib')
             .map((dep) => dep.node.name)
             .join(',');
-          const buildCommand = `npx nx run-many --target=${process.env.NX_TASK_TARGET_TARGET} --projects=${buildableLibraryDependencies}`;
+          const buildCommand = `npx nx run-many --target=${depsBuildTarget} --projects=${buildableLibraryDependencies}`;
           config.plugins.push(nxViteBuildCoordinationPlugin({ buildCommand }));
         }
       }


### PR DESCRIPTION
## Current Behavior

The `nxViteTsPaths` plugin determines the buildable libraries by checking the existence of the following target:

```ts
process.env.NX_TASK_TARGET_TARGET === 'serve'
  ? 'build'
  : process.env.NX_TASK_TARGET_TARGET
```

But it later creates the command to build the dependencies to always run the `process.env.NX_TASK_TARGET_TARGET` target. This is wrong and results in trying to run the `serve` task for the dependencies when the root task is `serve`.

## Expected Behavior

The `nxViteTsPaths` plugin should use the same task name to determine the buildable libraries and run the command to build the dependencies.

## Related Issue(s)

Fixes #31333 
