### PR TITLE
fix(react): add .js extensions to subpath imports in module federation templates

### DIFF
--- a/packages/react/src/generators/host/__snapshots__/host.rspack.spec.ts.snap
+++ b/packages/react/src/generators/host/__snapshots__/host.rspack.spec.ts.snap
@@ -116,9 +116,9 @@ module.exports = {
 `;
 
 exports[`hostGenerator bundler=rspack should generate host files and configs when --typescriptConfiguration=true 1`] = `
-"import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
-import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
-import { NxModuleFederationPlugin, NxModuleFederationDevServerPlugin } from '@nx/module-federation/rspack';
+"import { NxAppRspackPlugin } from '@nx/rspack/app-plugin.js';
+import { NxReactRspackPlugin } from '@nx/rspack/react-plugin.js';
+import { NxModuleFederationPlugin, NxModuleFederationDevServerPlugin } from '@nx/module-federation/rspack.js';
 import { join } from 'path';
 
 import config from './module-federation.config';

--- a/packages/react/src/generators/host/__snapshots__/host.webpack.spec.ts.snap
+++ b/packages/react/src/generators/host/__snapshots__/host.webpack.spec.ts.snap
@@ -46,7 +46,7 @@ module.exports = moduleFederationConfig;
 exports[`hostGenerator bundler=webpack should generate host files and configs for SSR when --typescriptConfiguration=true 1`] = `
 "import { composePlugins, withNx } from '@nx/webpack';
 import { withReact } from '@nx/react';
-import { withModuleFederationForSSR } from '@nx/module-federation/webpack';
+import { withModuleFederationForSSR } from '@nx/module-federation/webpack.js';
 
 import baseConfig from './module-federation.config';
 
@@ -134,7 +134,7 @@ module.exports = {
 exports[`hostGenerator bundler=webpack should generate host files and configs when --typescriptConfiguration=true 1`] = `
 "import {composePlugins, withNx} from '@nx/webpack';
 import {withReact} from '@nx/react';
-import {withModuleFederation} from '@nx/module-federation/webpack';
+import {withModuleFederation} from '@nx/module-federation/webpack.js';
 import { ModuleFederationConfig } from '@nx/module-federation';
 
 import baseConfig from './module-federation.config';

--- a/packages/react/src/generators/host/files/rspack-module-federation-ssr-ts/rspack.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation-ssr-ts/rspack.config.ts__tmpl__
@@ -1,6 +1,6 @@
-import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
-import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
-import { NxModuleFederationPlugin, NxModuleFederationSSRDevServerPlugin } from '@nx/module-federation/rspack';
+import { NxAppRspackPlugin } from '@nx/rspack/app-plugin.js';
+import { NxReactRspackPlugin } from '@nx/rspack/react-plugin.js';
+import { NxModuleFederationPlugin, NxModuleFederationSSRDevServerPlugin } from '@nx/module-federation/rspack.js';
 import { join } from 'path';
 
 import browserMfConfig from './module-federation.config';

--- a/packages/react/src/generators/host/files/rspack-module-federation-ts/rspack.config.prod.ts__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation-ts/rspack.config.prod.ts__tmpl__
@@ -1,6 +1,6 @@
-import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
-import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
-import { NxModuleFederationPlugin, NxModuleFederationDevServerPlugin } from '@nx/module-federation/rspack';
+import { NxAppRspackPlugin } from '@nx/rspack/app-plugin.js';
+import { NxReactRspackPlugin } from '@nx/rspack/react-plugin.js';
+import { NxModuleFederationPlugin, NxModuleFederationDevServerPlugin } from '@nx/module-federation/rspack.js';
 import { ModuleFederationConfig } from '@nx/module-federation';
 import { join } from 'path';
 

--- a/packages/react/src/generators/host/files/rspack-module-federation-ts/rspack.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-module-federation-ts/rspack.config.ts__tmpl__
@@ -1,6 +1,6 @@
-import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
-import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
-import { NxModuleFederationPlugin, NxModuleFederationDevServerPlugin } from '@nx/module-federation/rspack';
+import { NxAppRspackPlugin } from '@nx/rspack/app-plugin.js';
+import { NxReactRspackPlugin } from '@nx/rspack/react-plugin.js';
+import { NxModuleFederationPlugin, NxModuleFederationDevServerPlugin } from '@nx/module-federation/rspack.js';
 import { join } from 'path';
 
 import config from './module-federation.config';

--- a/packages/react/src/generators/host/files/webpack-module-federation-ssr-ts/webpack.server.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/webpack-module-federation-ssr-ts/webpack.server.config.ts__tmpl__
@@ -1,6 +1,6 @@
 import {composePlugins, withNx} from '@nx/webpack';
 import {withReact} from '@nx/react';
-import {withModuleFederationForSSR} from '@nx/module-federation/webpack';
+import {withModuleFederationForSSR} from '@nx/module-federation/webpack.js';
 
 import baseConfig from './module-federation.config';
 

--- a/packages/react/src/generators/host/files/webpack-module-federation-ts/webpack.config.prod.ts__tmpl__
+++ b/packages/react/src/generators/host/files/webpack-module-federation-ts/webpack.config.prod.ts__tmpl__
@@ -1,6 +1,6 @@
 import { composePlugins, withNx } from '@nx/webpack';
 import { withReact } from '@nx/react';
-import { withModuleFederation } from '@nx/module-federation/webpack';
+import { withModuleFederation } from '@nx/module-federation/webpack.js';
 import { ModuleFederationConfig } from '@nx/module-federation';
 
 import baseConfig from './module-federation.config';

--- a/packages/react/src/generators/host/files/webpack-module-federation-ts/webpack.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/webpack-module-federation-ts/webpack.config.ts__tmpl__
@@ -1,6 +1,6 @@
 import {composePlugins, withNx} from '@nx/webpack';
 import {withReact} from '@nx/react';
-import {withModuleFederation} from '@nx/module-federation/webpack';
+import {withModuleFederation} from '@nx/module-federation/webpack.js';
 import { ModuleFederationConfig } from '@nx/module-federation';
 
 import baseConfig from './module-federation.config';

--- a/packages/react/src/generators/remote/__snapshots__/remote.rspack.spec.ts.snap
+++ b/packages/react/src/generators/remote/__snapshots__/remote.rspack.spec.ts.snap
@@ -125,12 +125,12 @@ module.exports = {
 `;
 
 exports[`remote generator bundler=rspack should create the remote with the correct config files when --typescriptConfiguration=true 1`] = `
-"import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
-import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
+"import { NxAppRspackPlugin } from '@nx/rspack/app-plugin.js';
+import { NxReactRspackPlugin } from '@nx/rspack/react-plugin.js';
 import {
   NxModuleFederationPlugin,
   NxModuleFederationDevServerPlugin,
-} from '@nx/module-federation/rspack';
+} from '@nx/module-federation/rspack.js';
 import { join } from 'path';
 
 import config from './module-federation.config';

--- a/packages/react/src/generators/remote/__snapshots__/remote.webpack.spec.ts.snap
+++ b/packages/react/src/generators/remote/__snapshots__/remote.webpack.spec.ts.snap
@@ -75,7 +75,7 @@ module.exports = {
 exports[`remote generator bundler=webpack should create the remote with the correct config files when --typescriptConfiguration=true 1`] = `
 "import { composePlugins, withNx } from '@nx/webpack';
 import { withReact } from '@nx/react';
-import { withModuleFederation } from '@nx/module-federation/webpack';
+import { withModuleFederation } from '@nx/module-federation/webpack.js';
 
 import baseConfig from './module-federation.config';
 
@@ -156,7 +156,7 @@ module.exports = {
 exports[`remote generator bundler=webpack should generate correct remote with config files when using --ssr and --typescriptConfiguration=true 1`] = `
 "import { composePlugins, withNx } from '@nx/webpack';
 import { withReact } from '@nx/react';
-import { withModuleFederationForSSR } from '@nx/module-federation/webpack';
+import { withModuleFederationForSSR } from '@nx/module-federation/webpack.js';
 
 import baseConfig from './module-federation.server.config';
 

--- a/packages/react/src/generators/remote/files/rspack-module-federation-ssr-ts/rspack.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/rspack-module-federation-ssr-ts/rspack.config.ts__tmpl__
@@ -1,6 +1,6 @@
-import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
-import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
-import { NxModuleFederationPlugin, NxModuleFederationSSRDevServerPlugin } from '@nx/module-federation/rspack';
+import { NxAppRspackPlugin } from '@nx/rspack/app-plugin.js';
+import { NxReactRspackPlugin } from '@nx/rspack/react-plugin.js';
+import { NxModuleFederationPlugin, NxModuleFederationSSRDevServerPlugin } from '@nx/module-federation/rspack.js';
 import { join } from 'path';
 
 import browserMfConfig from './module-federation.config';

--- a/packages/react/src/generators/remote/files/rspack-module-federation-ts/rspack.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/rspack-module-federation-ts/rspack.config.ts__tmpl__
@@ -1,6 +1,6 @@
-import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
-import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
-import { NxModuleFederationPlugin, NxModuleFederationDevServerPlugin } from '@nx/module-federation/rspack';
+import { NxAppRspackPlugin } from '@nx/rspack/app-plugin.js';
+import { NxReactRspackPlugin } from '@nx/rspack/react-plugin.js';
+import { NxModuleFederationPlugin, NxModuleFederationDevServerPlugin } from '@nx/module-federation/rspack.js';
 import { join } from 'path';
 
 import config from './module-federation.config';

--- a/packages/react/src/generators/remote/files/webpack-module-federation-ssr-ts/webpack.server.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/webpack-module-federation-ssr-ts/webpack.server.config.ts__tmpl__
@@ -1,6 +1,6 @@
 import {composePlugins, withNx} from '@nx/webpack';
 import {withReact} from '@nx/react';
-import {withModuleFederationForSSR} from '@nx/module-federation/webpack';
+import {withModuleFederationForSSR} from '@nx/module-federation/webpack.js';
 
 import baseConfig from "./module-federation.server.config";
 

--- a/packages/react/src/generators/remote/files/webpack-module-federation-ts/webpack.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/webpack-module-federation-ts/webpack.config.ts__tmpl__
@@ -1,6 +1,6 @@
 import {composePlugins, withNx} from '@nx/webpack';
 import {withReact} from '@nx/react';
-import {withModuleFederation} from '@nx/module-federation/webpack';
+import {withModuleFederation} from '@nx/module-federation/webpack.js';
 
 import baseConfig from './module-federation.config';
 

--- a/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
+++ b/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
@@ -142,11 +142,11 @@ describe('Convert webpack', () => {
 
     expect(tree.exists('demo/rspack.config.ts')).toBeTruthy();
     expect(tree.read('demo/rspack.config.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/module-federation/rspack';
-      import { withReact } from '@nx/rspack';
+      "import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';
 
+      import { withModuleFederation } from '@nx/module-federation/webpack.js';
       import { ModuleFederationConfig } from '@nx/module-federation';
 
       import baseConfig from './module-federation.config';
@@ -244,10 +244,11 @@ describe('Convert webpack', () => {
     expect(tree.exists('remote1/rspack.config.ts')).toBeTruthy();
     expect(tree.read('remote1/rspack.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/module-federation/rspack';
-      import { withReact } from '@nx/rspack';
+      "import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';
+
+      import { withModuleFederation } from '@nx/module-federation/webpack.js';
 
       import baseConfig from './module-federation.config';
 
@@ -350,10 +351,11 @@ describe('Convert webpack', () => {
     expect(tree.exists('remote2/rspack.config.ts')).toBeTruthy();
     expect(tree.read('remote2/rspack.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/module-federation/rspack';
-      import { withReact } from '@nx/rspack';
+      "import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';
+
+      import { withModuleFederation } from '@nx/module-federation/webpack.js';
 
       import baseConfig from './module-federation.config';
 

--- a/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
+++ b/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
@@ -142,11 +142,11 @@ describe('Convert webpack', () => {
 
     expect(tree.exists('demo/rspack.config.ts')).toBeTruthy();
     expect(tree.read('demo/rspack.config.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "import { withReact } from '@nx/rspack';
+      "import { withModuleFederation } from '@nx/module-federation/rspack.js';
+      import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';
 
-      import { withModuleFederation } from '@nx/module-federation/webpack.js';
       import { ModuleFederationConfig } from '@nx/module-federation';
 
       import baseConfig from './module-federation.config';
@@ -244,11 +244,10 @@ describe('Convert webpack', () => {
     expect(tree.exists('remote1/rspack.config.ts')).toBeTruthy();
     expect(tree.read('remote1/rspack.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { withReact } from '@nx/rspack';
+      "import { withModuleFederation } from '@nx/module-federation/rspack.js';
+      import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';
-
-      import { withModuleFederation } from '@nx/module-federation/webpack.js';
 
       import baseConfig from './module-federation.config';
 
@@ -351,11 +350,10 @@ describe('Convert webpack', () => {
     expect(tree.exists('remote2/rspack.config.ts')).toBeTruthy();
     expect(tree.read('remote2/rspack.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "import { withReact } from '@nx/rspack';
+      "import { withModuleFederation } from '@nx/module-federation/rspack.js';
+      import { withReact } from '@nx/rspack';
       import { withNx } from '@nx/rspack';
       import { composePlugins } from '@nx/rspack';
-
-      import { withModuleFederation } from '@nx/module-federation/webpack.js';
 
       import baseConfig from './module-federation.config';
 

--- a/packages/rspack/src/generators/convert-webpack/lib/transform-cjs.ts
+++ b/packages/rspack/src/generators/convert-webpack/lib/transform-cjs.ts
@@ -302,7 +302,9 @@ function transformWithModuleFederation(
   const configContents = tree.read(configPath, 'utf-8');
   const ast = tsquery.ast(configContents);
 
-  const HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT = `VariableDeclaration:has(Identifier[name=withModuleFederation]) > CallExpression:has(Identifier[name=require]) StringLiteral[value=${scope}/module-federation/webpack]`;
+  const HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT = `VariableDeclaration:has(Identifier[name=withModuleFederation]) > CallExpression:has(Identifier[name=require]) StringLiteral[value="${scope}/module-federation/webpack${
+    usesJsExtensions ? '.js' : ''
+  }"]`;
   const nodes = tsquery(ast, HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT);
   if (nodes.length === 0) {
     return;
@@ -339,7 +341,9 @@ function transformWithModuleFederationSSR(
   const configContents = tree.read(configPath, 'utf-8');
   const ast = tsquery.ast(configContents);
 
-  const HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT = `VariableDeclaration:has(Identifier[name=withModuleFederationForSSR]) > CallExpression:has(Identifier[name=require]) StringLiteral[value=${scope}/module-federation/webpack]`;
+  const HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT = `VariableDeclaration:has(Identifier[name=withModuleFederationForSSR]) > CallExpression:has(Identifier[name=require]) StringLiteral[value="${scope}/module-federation/webpack${
+    usesJsExtensions ? '.js' : ''
+  }"]`;
   const nodes = tsquery(ast, HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT);
   if (nodes.length === 0) {
     return;

--- a/packages/rspack/src/generators/convert-webpack/lib/transform-esm.ts
+++ b/packages/rspack/src/generators/convert-webpack/lib/transform-esm.ts
@@ -268,7 +268,9 @@ function transformWithModuleFederation(
   const configContents = tree.read(configPath, 'utf-8');
   const ast = tsquery.ast(configContents);
 
-  const HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT = `ImportDeclaration:has(Identifier[name=withModuleFederation]) > StringLiteral[value=${scope}/module-federation/webpack]`;
+  const HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT = `ImportDeclaration:has(Identifier[name=withModuleFederation]) > StringLiteral[value="${scope}/module-federation/webpack${
+    usesJsExtension ? '.js' : ''
+  }"]`;
   const nodes = tsquery(ast, HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT);
   if (nodes.length === 0) {
     return;
@@ -338,7 +340,9 @@ function transformWithModuleFederationSSR(
   const configContents = tree.read(configPath, 'utf-8');
   const ast = tsquery.ast(configContents);
 
-  const HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT = `ImportDeclaration:has(Identifier[name=withModuleFederationForSSR]) > StringLiteral[value=${scope}/module-federation/webpack]`;
+  const HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT = `ImportDeclaration:has(Identifier[name=withModuleFederationForSSR]) > StringLiteral[value="${scope}/module-federation/webpack${
+    usesJsExtensions ? '.js' : ''
+  }"]`;
   const nodes = tsquery(ast, HAS_WITH_MODULE_FEDERATION_FROM_NX_REACT);
   if (nodes.length === 0) {
     return;

--- a/packages/rspack/src/generators/convert-webpack/lib/transform-esm.ts
+++ b/packages/rspack/src/generators/convert-webpack/lib/transform-esm.ts
@@ -2,18 +2,27 @@ import type { Tree } from '@nx/devkit';
 import { tsquery } from '@phenomnomnominal/tsquery';
 
 export function transformEsmConfigFile(tree: Tree, configPath: string) {
+  const configContents = tree.read(configPath, 'utf-8');
+  const usesJsExtensions = detectJsExtensions(configContents);
+
   ['@nx', '@nrwl'].forEach((scope: '@nx' | '@nrwl') => {
     transformComposePlugins(tree, configPath, scope);
     transformWithNx(tree, configPath, scope);
     transformWithWeb(tree, configPath, scope);
     transformWithReact(tree, configPath, scope);
     transformModuleFederationConfig(tree, configPath, scope);
-    transformWithModuleFederation(tree, configPath, scope);
-    transformWithModuleFederationSSR(tree, configPath, scope);
+    transformWithModuleFederation(tree, configPath, scope, usesJsExtensions);
+    transformWithModuleFederationSSR(tree, configPath, scope, usesJsExtensions);
   });
 
   // Add useLegacyHtmlPlugin: true to withWeb() calls
   transformWithWebCalls(tree, configPath);
+}
+
+function detectJsExtensions(configContents: string): boolean {
+  // Check if any imports use .js extensions
+  const importWithJsExtensionRegex = /from\s+['"]@nx\/[^'"]*\.js['"]/;
+  return importWithJsExtensionRegex.test(configContents);
 }
 
 function transformWithWebCalls(tree: Tree, configPath: string) {
@@ -253,7 +262,8 @@ function transformWithReact(
 function transformWithModuleFederation(
   tree: Tree,
   configPath: string,
-  scope: '@nx' | '@nrwl'
+  scope: '@nx' | '@nrwl',
+  usesJsExtension: boolean
 ) {
   const configContents = tree.read(configPath, 'utf-8');
   const ast = tsquery.ast(configContents);
@@ -277,7 +287,10 @@ function transformWithModuleFederation(
     endIndex++;
   }
 
-  const newContents = `import { withModuleFederation } from '@nx/module-federation/rspack';
+  const moduleFederationImport = usesJsExtension
+    ? '@nx/module-federation/rspack.js'
+    : '@nx/module-federation/rspack';
+  const newContents = `import { withModuleFederation } from '${moduleFederationImport}';
   ${configContents.slice(0, startIndex)}${configContents.slice(endIndex)}`;
 
   tree.write(configPath, newContents);
@@ -319,7 +332,8 @@ function transformModuleFederationConfig(
 function transformWithModuleFederationSSR(
   tree: Tree,
   configPath: string,
-  scope: '@nx' | '@nrwl'
+  scope: '@nx' | '@nrwl',
+  usesJsExtensions: boolean
 ) {
   const configContents = tree.read(configPath, 'utf-8');
   const ast = tsquery.ast(configContents);
@@ -343,7 +357,10 @@ function transformWithModuleFederationSSR(
     endIndex++;
   }
 
-  const newContents = `import { withModuleFederationForSSR } from '@nx/module-federation/rspack';
+  const rspackImport = usesJsExtensions
+    ? '@nx/module-federation/rspack.js'
+    : '@nx/module-federation/rspack';
+  const newContents = `import { withModuleFederationForSSR } from '${rspackImport}';
   ${configContents.slice(0, startIndex)}${configContents.slice(endIndex)}`;
 
   tree.write(configPath, newContents);


### PR DESCRIPTION
  ## Current Behavior

  Module federation templates in React generators use subpath imports
  without explicit file extensions (e.g., @nx/rspack/app-plugin,
  @nx/module-federation/webpack). This causes compatibility issues with
  Node.js 24's native TypeScript support, which requires explicit file
  extensions for ESM package subpath imports.

  ## Expected Behavior

  Module federation templates should include .js extensions on all subpath
   imports to ensure compatibility with Node.js 24 while maintaining
  backwards compatibility with earlier Node.js versions. The imports
  should be in the format @nx/rspack/app-plugin.js,
  @nx/module-federation/webpack.js, etc.

  ## Related Issue(s)

  Fixes #31448