### PR TITLE
docs(nx-dev): update headers to reference "Nx Enterprise"

### DIFF
--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -307,6 +307,14 @@ export function DocumentationHeader({
             </Popover>
             <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
             <Link
+              href="/ai"
+              title="AI"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              prefetch={false}
+            >
+              AI
+            </Link>
+            <Link
               href="/remote-cache"
               title="Nx Remote Cache"
               className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
@@ -337,7 +345,7 @@ export function DocumentationHeader({
               className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
               prefetch={false}
             >
-              Enterprise
+              Nx Enterprise
             </Link>
           </nav>
         </div>

--- a/nx-dev/ui-common/src/lib/headers/header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/header.tsx
@@ -252,7 +252,7 @@ export function Header({ ctaButtons }: HeaderProps): ReactElement {
               className="hidden gap-2 px-3 py-2 font-semibold leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
               prefetch={false}
             >
-              Enterprise
+              Nx Enterprise
             </Link>
             <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
             <div className="px-3 opacity-50 hover:opacity-100">
@@ -531,7 +531,7 @@ export function Header({ ctaButtons }: HeaderProps): ReactElement {
                                     'flex w-full items-center justify-between py-4 text-left text-base font-medium focus:outline-none'
                                   )}
                                 >
-                                  <span>Enterprise</span>
+                                  <span>Nx Enterprise</span>
                                   <ChevronDownIcon
                                     aria-hidden="true"
                                     className={cx(


### PR DESCRIPTION
Revised "Enterprise" references to "Nx Enterprise" across headers for consistency. Added a new link to "AI" in the documentation header.