### PR TITLE
docs(nx-cloud): callout templates use nx-cloud features

### DIFF
--- a/docs/shared/monorepo-ci-azure.md
+++ b/docs/shared/monorepo-ci-azure.md
@@ -67,7 +67,7 @@ jobs:
       # - script: yarn nx-cloud record -- nx format:check
 
       # Without Nx Cloud, run format:check directly
-      - script: yarn nx-cloud record -- nx format:check
+      - script: yarn nx format:check
       - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --targets lint test build
       - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --parallel 1 e2e-ci
 ```

--- a/docs/shared/monorepo-ci-azure.md
+++ b/docs/shared/monorepo-ci-azure.md
@@ -63,7 +63,11 @@ jobs:
         condition: eq(variables['Build.Reason'], 'PullRequest')
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
-      # - script: yarn nx-cloud record -- echo Hello World
+      # This requires connecting your workspace to Nx Cloud. Run "nx connect" to get started w/ Nx Cloud
+      # - script: yarn nx-cloud record -- nx format:check
+
+      # Without Nx Cloud, run format:check directly
+      - script: yarn nx-cloud record -- nx format:check
       - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --targets lint test build
       - script: yarn nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --parallel 1 e2e-ci
 ```

--- a/docs/shared/monorepo-ci-bitbucket-pipelines.md
+++ b/docs/shared/monorepo-ci-bitbucket-pipelines.md
@@ -24,7 +24,12 @@ pipelines:
             - npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
             - npm ci
 
-            - npx nx-cloud record -- nx format:check
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # This requires connecting your workspace to Nx Cloud. Run "nx connect" to get started w/ Nx Cloud
+            # - npx nx-cloud record -- nx format:check
+
+            # Without Nx Cloud, run format:check directly
+            - npx nx format:check
             - npx nx affected -t lint test build e2e-ci --base=origin/main
 
   branches:
@@ -38,7 +43,12 @@ pipelines:
             # - npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
             - npm ci
 
-            - npx nx-cloud record -- nx format:check
+            # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+            # This requires connecting your workspace to Nx Cloud. Run "nx connect" to get started w/ Nx Cloud
+            # - npx nx-cloud record -- nx format:check
+
+            # Without Nx Cloud, run format:check directly
+            - npx nx format:check
             - npx nx affected -t lint test build e2e-ci --base=HEAD~1
 ```
 

--- a/docs/shared/monorepo-ci-circle-ci.md
+++ b/docs/shared/monorepo-ci-circle-ci.md
@@ -26,7 +26,12 @@ jobs:
 
       - nx/set-shas
 
-      - run: npx nx-cloud record -- nx format:check
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # This requires connecting your workspace to Nx Cloud. Run "nx connect" to get started w/ Nx Cloud
+      # - run: npx nx-cloud record -- nx format:check
+
+      # Without Nx Cloud, run format:check directly
+      - run: npx nx format:check
       - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build e2e-ci
 workflows:
   build:

--- a/docs/shared/monorepo-ci-github-actions.md
+++ b/docs/shared/monorepo-ci-github-actions.md
@@ -38,10 +38,14 @@ jobs:
       # The "--stop-agents-after" is optional, but allows idle agents to shut down once the "e2e-ci" targets have been requested
       # - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
       - run: npm ci
-
       - uses: nrwl/nx-set-shas@v4
 
-      - run: npx nx-cloud record -- nx format:check
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # This requires connecting your workspace to Nx Cloud. Run "nx connect" to get started w/ Nx Cloud
+      # - run: npx nx-cloud record -- nx format:check
+
+      # Without Nx Cloud, run format:check directly
+      - run: npx nx format:check
       - run: npx nx affected -t lint test build e2e-ci
 ```
 

--- a/docs/shared/monorepo-ci-gitlab.md
+++ b/docs/shared/monorepo-ci-gitlab.md
@@ -33,6 +33,11 @@ main:
     - NX_HEAD=$CI_COMMIT_SHA
     - NX_BASE=${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
 
-    - npx nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
+    # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+    # This requires connecting your workspace to Nx Cloud. Run "nx connect" to get started w/ Nx Cloud
+    # - npx nx-cloud record -- nx format:check
+
+    # Without Nx Cloud, run format:check directly
+    - npx nx format:check --base=$NX_BASE --head=$NX_HEAD
     - npx nx affected --base=$NX_BASE --head=$NX_HEAD -t lint test build e2e-ci
 ```

--- a/docs/shared/monorepo-ci-jenkins.md
+++ b/docs/shared/monorepo-ci-jenkins.md
@@ -26,7 +26,13 @@ pipeline {
                         // The "--stop-agents-after" is optional, but allows idle agents to shut down once the "e2e-ci" targets have been requested
                         // sh "npx nx-cloud start-ci-run --distribute-on='3 linux-medium-js' --stop-agents-after='e2e-ci'"
                         sh "npm ci"
-                        sh "npx nx-cloud record -- nx format:check"
+
+                        // Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+                        // This requires connecting your workspace to Nx Cloud. Run "nx connect" to get started w/ Nx Cloud
+                        // sh "npx nx-cloud record -- nx format:check"
+
+                        // Without Nx Cloud, run format:check directly
+                        sh "npx nx format:check"
                         sh "npx nx affected --base=HEAD~1 -t lint test build e2e-ci"
                     }
                 }
@@ -40,7 +46,13 @@ pipeline {
                         // The "--stop-agents-after" is optional, but allows idle agents to shut down once the "e2e-ci" targets have been requested
                         // sh "npx nx-cloud start-ci-run --distribute-on='3 linux-medium-js' --stop-agents-after='e2e-ci'"
                         sh "npm ci"
-                        sh "npx nx-cloud record -- nx format:check"
+
+                        // Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+                        // This requires connecting your workspace to Nx Cloud. Run "nx connect" to get started w/ Nx Cloud
+                        // sh "npx nx-cloud record -- nx format:check"
+
+                        // Without Nx Cloud, run format:check directly
+                        sh "npx nx format:check"
                         sh "npx nx affected --base origin/${env.CHANGE_TARGET} -t lint test build e2e-ci"
                     }
                 }


### PR DESCRIPTION
template examples use nx-cloud record feature which will fail if cloud
isn't enable making for bad user experience. We instead commend out the
usage and call attention to how to connect to cloud so the template will
work OOTB
