### PR TITLE
fix(docs): add missing --project parameter to Angular service generation command

### DIFF
--- a/docs/shared/recipes/module-federation/dynamic-mfe-angular.md
+++ b/docs/shared/recipes/module-federation/dynamic-mfe-angular.md
@@ -216,7 +216,7 @@ This will scaffold a new library for us to use.
 We need an Angular Service that we will use to hold state:
 
 ```shell
-nx g @nx/angular:service libs/shared/data-access-user/src/lib/user
+nx g @nx/angular:service user --project=data-access-user
 ```
 
 This will create the `libs/shared/data-access-user/src/lib/user.service.ts` file. Change its contents to match:


### PR DESCRIPTION
The command `nx g @nx/angular:service libs/shared/data-access-user/src/lib/user` was missing the required `--project` parameter. Added `--project=data-access-user` to fix the error "Required property 'project' is missing".

Fixes #31410

Generated with [Claude Code](https://claude.ai/code)