### PR TITLE
fix(angular): respect skipTsConfig option in library generator

### DIFF
--- a/packages/angular/src/generators/library/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/library/lib/normalized-schema.ts
@@ -25,6 +25,7 @@ export interface NormalizedSchema {
     skipModule?: boolean;
     skipPackageJson?: boolean;
     skipPostInstall?: boolean;
+    skipTsConfig?: boolean;
     standalone?: boolean;
     linter: Linter | LinterType;
     unitTestRunner: UnitTestRunner;

--- a/packages/angular/src/generators/library/lib/update-tsconfig-files.ts
+++ b/packages/angular/src/generators/library/lib/update-tsconfig-files.ts
@@ -18,9 +18,13 @@ export function updateTsConfigFiles(
   extractTsConfigBase(tree);
   updateProjectConfig(tree, options);
   updateProjectIvyConfig(tree, options);
-  addTsConfigPath(tree, options.importPath, [
-    joinPathFragments(options.projectRoot, './src', 'index.ts'),
-  ]);
+
+  // Only add tsconfig path mapping if skipTsConfig is not true
+  if (!options.skipTsConfig) {
+    addTsConfigPath(tree, options.importPath, [
+      joinPathFragments(options.projectRoot, './src', 'index.ts'),
+    ]);
+  }
 
   const compilerOptions: Record<string, any> = {
     skipLibCheck: true,

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -2023,4 +2023,49 @@ describe('lib', () => {
       `);
     });
   });
+
+  describe('--skipTsConfig', () => {
+    it('should not update root tsconfig.base.json when skipTsConfig=true', async () => {
+      // ARRANGE
+      const originalTsConfig = readJson(tree, 'tsconfig.base.json');
+
+      // ACT
+      await runLibraryGeneratorWithOpts({
+        skipTsConfig: true,
+      });
+
+      // ASSERT
+      const updatedTsConfig = readJson(tree, 'tsconfig.base.json');
+      expect(updatedTsConfig.compilerOptions.paths).toEqual(
+        originalTsConfig.compilerOptions.paths
+      );
+      expect(
+        updatedTsConfig.compilerOptions.paths['@proj/my-lib']
+      ).toBeUndefined();
+    });
+
+    it('should update root tsconfig.base.json when skipTsConfig=false (default)', async () => {
+      // ACT
+      await runLibraryGeneratorWithOpts({
+        skipTsConfig: false,
+      });
+
+      // ASSERT
+      const tsconfigJson = readJson(tree, 'tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+        'my-lib/src/index.ts',
+      ]);
+    });
+
+    it('should update root tsconfig.base.json when skipTsConfig is not specified (default behavior)', async () => {
+      // ACT
+      await runLibraryGeneratorWithOpts();
+
+      // ASSERT
+      const tsconfigJson = readJson(tree, 'tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+        'my-lib/src/index.ts',
+      ]);
+    });
+  });
 });

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -38,4 +38,5 @@ export interface Schema {
   selector?: string;
   skipSelector?: boolean;
   addPlugin?: boolean;
+  skipTsConfig?: boolean;
 }


### PR DESCRIPTION
## Current Behavior

  The Angular library generator ignores the `skipTsConfig` option and always modifies the `tsconfig.base.json` file, even when users explicitly set `skipTsConfig=true` to avoid TypeScript configuration changes.

  ## Expected Behavior

  When `skipTsConfig=true` is passed to the Angular library generator, the `tsconfig.base.json` file should not be modified. Project-specific tsconfig files should still be created as expected, but the workspace-level TypeScript
   configuration should remain untouched.

  ## Related Issue(s)

  Fixes #31185