### PR TITLE
fix(vite): resolve outDir path correctly for nested monorepos

### DIFF
--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -129,7 +129,11 @@ export async function* viteBuildExecutor(
 
     // Here, we want the outdir relative to the workspace root.
     // So, we calculate the relative path from the workspace root to the outdir.
-    const outDirRelativeToWorkspaceRoot = outDir.replaceAll('../', '');
+    const absoluteOutDir = resolve(resolve(context.root, projectRoot), outDir);
+    const outDirRelativeToWorkspaceRoot = relative(
+      context.root,
+      absoluteOutDir
+    );
     const distPackageJson = resolve(
       outDirRelativeToWorkspaceRoot,
       'package.json'


### PR DESCRIPTION
## Current Behavior

  The Vite build executor uses naive string manipulation to calculate the output directory path, which fails in nested monorepo structures where the workspace root and project root have different relative paths.

## Expected Behavior

  The Vite build executor properly resolves the output directory path using Node.js path utilities, ensuring correct path calculation regardless of monorepo nesting structure.

## Related Issue(s)

  Fixes #31234