### PR TITLE
fix(testing): do not re-add vscode recommended extension for jest after initial jest setup

### DIFF
--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -464,6 +464,69 @@ describe('jestProject', () => {
     });
   });
 
+  describe('vscode recommended extensions', () => {
+    it('should add the "firsttris.vscode-jest-runner" extension to the vscode recommended extensions', async () => {
+      tree.write('.vscode/extensions.json', '{}');
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+      });
+
+      expect(tree.read('.vscode/extensions.json', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "recommendations": ["esbenp.prettier-vscode", "firsttris.vscode-jest-runner"]
+        }
+        "
+      `);
+    });
+
+    it('should not duplicate the "firsttris.vscode-jest-runner" extension in the vscode recommended extensions', async () => {
+      writeJson(tree, '.vscode/extensions.json', {
+        recommendations: ['firsttris.vscode-jest-runner'],
+      });
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+      });
+
+      expect(
+        readJson(tree, '.vscode/extensions.json').recommendations.filter(
+          (ext: string) => ext === 'firsttris.vscode-jest-runner'
+        ).length
+      ).toBe(1);
+    });
+
+    it('should not add the "firsttris.vscode-jest-runner" if the jest preset already exists', async () => {
+      tree.write('.vscode/extensions.json', '{}');
+      tree.write('jest.preset.js', 'export default {}');
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+      });
+
+      expect(tree.read('.vscode/extensions.json', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "recommendations": ["esbenp.prettier-vscode"]
+        }
+        "
+      `);
+    });
+
+    it('should not create the .vscode/extensions.json file if it does not exist', async () => {
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+      });
+
+      expect(tree.exists('.vscode/extensions.json')).toBeFalsy();
+    });
+  });
+
   describe('TS solution setup', () => {
     beforeEach(() => {
       tree = createTreeWithEmptyWorkspace();

--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -11,7 +11,10 @@ import {
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { JestPluginOptions } from '../../plugins/plugin';
-import { getPresetExt } from '../../utils/config/config-file';
+import {
+  findRootJestPreset,
+  getPresetExt,
+} from '../../utils/config/config-file';
 import { jestInitGenerator } from '../init/init';
 import { checkForTestTarget } from './lib/check-for-test-target';
 import { createFiles } from './lib/create-files';
@@ -87,6 +90,11 @@ export async function configurationGeneratorInternal(
 ): Promise<GeneratorCallback> {
   const options = normalizeOptions(tree, schema);
 
+  // we'll only add the vscode recommended extension if the jest preset does
+  // not exist, which most likely means this is a first run, in the cases it's
+  // not a first run, we'll skip adding it but it's not a critical thing to do
+  const shouldAddVsCodeRecommendations = findRootJestPreset(tree) === null;
+
   const tasks: GeneratorCallback[] = [];
 
   tasks.push(await jsInitGenerator(tree, { ...schema, skipFormat: true }));
@@ -101,7 +109,10 @@ export async function configurationGeneratorInternal(
   checkForTestTarget(tree, options);
   createFiles(tree, options, presetExt);
   updateTsConfig(tree, options);
-  updateVsCodeRecommendedExtensions(tree);
+
+  if (shouldAddVsCodeRecommendations) {
+    updateVsCodeRecommendedExtensions(tree);
+  }
 
   const nxJson = readNxJson(tree);
   const hasPlugin = nxJson.plugins?.some((p) => {


### PR DESCRIPTION
## Current Behavior

The `@nx/jest:configuration` generator always adds the `firsttris.vscode-jest-runner` to the VSCode recommended extensions if it's missing.

## Expected Behavior

The `@nx/jest:configuration` generator should only add the `firsttris.vscode-jest-runner` to the VSCode recommended extensions when configuring `@nx/jest` for the first time.

## Related Issue(s)

Fixes #29345 
