### PR TITLE
fix(vite): ensure path aliases are not replaced when building vite projects and using ts path mappings

### DIFF
--- a/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -104,6 +104,7 @@ export default defineConfig(() => ({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
   ],
   // Uncomment this if you are using workers.

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -17,6 +17,7 @@ export default defineConfig(() => ({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
   ],
   // Uncomment this if you are using workers.
@@ -188,6 +189,7 @@ export default defineConfig(() => ({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
   ],
   // Uncomment this if you are using workers.
@@ -240,6 +242,7 @@ export default defineConfig(() => ({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
   ],
   // Uncomment this if you are using workers.
@@ -324,6 +327,7 @@ export default defineConfig({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
   ],
 

--- a/packages/vite/src/utils/generator-utils.spec.ts
+++ b/packages/vite/src/utils/generator-utils.spec.ts
@@ -2,7 +2,9 @@ import {
   addProjectConfiguration,
   readProjectConfiguration,
   Tree,
+  updateJson,
   updateProjectConfiguration,
+  writeJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
@@ -147,7 +149,7 @@ describe('generator utils', () => {
         export default defineConfig(() => ({
           root: __dirname,
           cacheDir: '../node_modules/.vite/myproj',
-          plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md']), dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') })],
+          plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md']), dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'), pathsToAliases: false })],
           // Uncomment this if you are using workers.
           // worker: {
           //  plugins: [ nxViteTsPaths() ],
@@ -241,6 +243,97 @@ describe('generator utils', () => {
             commonjsOptions: {
               transformMixedEsModules: true,
             },
+          },
+        }));
+        "
+      `);
+    });
+
+    it('should generate correct config when using ts solution setup', () => {
+      updateJson(tree, '/package.json', (json) => {
+        json.workspaces = ['apps/*'];
+        return json;
+      });
+      writeJson(tree, 'tsconfig.base.json', {
+        compilerOptions: {
+          composite: true,
+          declaration: true,
+          customConditions: ['development'],
+        },
+      });
+      writeJson(tree, 'tsconfig.json', {
+        extends: './tsconfig.base.json',
+        files: [],
+        references: [],
+      });
+      addProjectConfiguration(tree, 'myproj', {
+        name: 'myproj',
+        root: 'apps/myproj',
+      });
+
+      createOrEditViteConfig(
+        tree,
+        {
+          project: 'myproj',
+          inSourceTests: true,
+          includeVitest: true,
+          includeLib: true,
+        },
+        false
+      );
+
+      expect(tree.read('apps/myproj/vite.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "/// <reference types='vitest' />
+        import { defineConfig } from 'vite';
+        import dts from 'vite-plugin-dts';
+        import * as path from 'path';
+
+        export default defineConfig(() => ({
+          root: __dirname,
+          cacheDir: '../../node_modules/.vite/apps/myproj',
+          plugins: [dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') })],
+          // Uncomment this if you are using workers.
+          // worker: {
+          //  plugins: [ nxViteTsPaths() ],
+          // },
+          // Configuration for building your library.
+          // See: https://vitejs.dev/guide/build.html#library-mode
+          build: {
+            outDir: './dist',
+            emptyOutDir: true,
+            reportCompressedSize: true,
+            commonjsOptions: {
+              transformMixedEsModules: true,
+            },
+            lib: {
+              // Could also be a dictionary or array of multiple entry points.
+              entry: 'src/index.ts',
+              name: 'myproj',
+              fileName: 'index',
+              // Change this to the formats you want to support.
+              // Don't forget to update your package.json as well.
+              formats: ['es' as const]
+            },
+            rollupOptions: {
+              // External packages that should not be bundled into your library.
+              external: []
+            },
+          },
+          define: {
+            'import.meta.vitest': undefined
+          },
+          test: {
+            watch: false,
+            globals: true,
+            environment: 'jsdom',
+            include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+            includeSource: ['src/**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+            reporters: ['default'],
+            coverage: {
+              reportsDirectory: './test-output/vitest/coverage',
+              provider: 'v8' as const,
+            }
           },
         }));
         "

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -396,8 +396,8 @@ export function createOrEditViteConfig(
     ? `${projectRoot}/vitest.config.${extension}`
     : `${projectRoot}/vite.config.${extension}`;
 
-  const isUsingTsPlugin = isUsingTsSolutionSetup(tree);
-  const buildOutDir = isUsingTsPlugin
+  const isTsSolutionSetup = isUsingTsSolutionSetup(tree);
+  const buildOutDir = isTsSolutionSetup
     ? './dist'
     : projectRoot === '.'
     ? `./dist/${options.project}`
@@ -448,7 +448,7 @@ export function createOrEditViteConfig(
     );
   }
 
-  if (!isUsingTsPlugin) {
+  if (!isTsSolutionSetup) {
     imports.push(
       `import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'`,
       `import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'`
@@ -458,11 +458,13 @@ export function createOrEditViteConfig(
 
   if (!onlyVitest && options.includeLib) {
     plugins.push(
-      `dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') })`
+      `dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json')${
+        !isTsSolutionSetup ? ', pathsToAliases: false' : ''
+      } })`
     );
   }
 
-  const reportsDirectory = isUsingTsPlugin
+  const reportsDirectory = isTsSolutionSetup
     ? './test-output/vitest/coverage'
     : projectRoot === '.'
     ? `./coverage/${options.project}`

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -19,6 +19,7 @@ export default defineConfig(() => ({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
   ],
   // Uncomment this if you are using workers.
@@ -110,6 +111,7 @@ export default defineConfig(() => ({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
   ],
   // Uncomment this if you are using workers.


### PR DESCRIPTION
## Current Behavior

Projects generated with Vite that import from another project will produce incorrect declaration files when built in an integrated workspace (using TS path mappings).

## Expected Behavior

Projects generated with Vite that import from another project should produce the correct declaration files when built in an integrated workspace (using TS path mappings).

## Related Issue(s)

Fixes #30814 
