### PR TITLE
fix(expo): respect `--unit-test-runner=none` properly when generating expo apps and libs

### DIFF
--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -90,6 +90,68 @@ describe('app', () => {
     expect(appTree.exists('my-app/.eslintrc.json')).toBe(true);
   });
 
+  it('should generate test files and install test dependencies if unitTestRunner is jest', async () => {
+    await expoApplicationGenerator(appTree, {
+      directory: 'my-app',
+      linter: 'eslint',
+      e2eTestRunner: 'none',
+      skipFormat: false,
+      js: false,
+      unitTestRunner: 'jest',
+    });
+
+    expect(appTree.exists('my-app/jest.config.ts')).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/App.spec.tsx')).toBeTruthy();
+    expect(appTree.exists('my-app/tsconfig.spec.json')).toBeTruthy();
+    expect(readJson(appTree, 'my-app/tsconfig.json').references).toEqual(
+      expect.arrayContaining([
+        {
+          path: './tsconfig.spec.json',
+        },
+      ])
+    );
+    const packageJson = readJson(appTree, 'package.json');
+    expect(packageJson.devDependencies['react-test-renderer']).toBeDefined();
+    expect(
+      packageJson.devDependencies['@testing-library/react-native']
+    ).toBeDefined();
+    expect(
+      packageJson.devDependencies['@testing-library/jest-native']
+    ).toBeDefined();
+    expect(packageJson.devDependencies['jest-expo']).toBeDefined();
+  });
+
+  it('should not generate test files or install test dependencies if unitTestRunner is none', async () => {
+    await expoApplicationGenerator(appTree, {
+      directory: 'my-app',
+      linter: 'eslint',
+      e2eTestRunner: 'none',
+      skipFormat: false,
+      js: false,
+      unitTestRunner: 'none',
+    });
+
+    expect(appTree.exists('my-app/jest.config.ts')).toBe(false);
+    expect(appTree.exists('my-app/src/app/App.spec.tsx')).toBe(false);
+    expect(appTree.exists('my-app/tsconfig.spec.json')).toBe(false);
+    expect(readJson(appTree, 'my-app/tsconfig.json').references).not.toEqual(
+      expect.arrayContaining([
+        {
+          path: './tsconfig.spec.json',
+        },
+      ])
+    );
+    const packageJson = readJson(appTree, 'package.json');
+    expect(packageJson.devDependencies['react-test-renderer']).toBeUndefined();
+    expect(
+      packageJson.devDependencies['@testing-library/react-native']
+    ).toBeUndefined();
+    expect(
+      packageJson.devDependencies['@testing-library/jest-native']
+    ).toBeUndefined();
+    expect(packageJson.devDependencies['jest-expo']).toBeUndefined();
+  });
+
   describe('detox', () => {
     it('should create e2e app with directory', async () => {
       await expoApplicationGenerator(appTree, {

--- a/packages/expo/src/generators/application/application.ts
+++ b/packages/expo/src/generators/application/application.ts
@@ -56,7 +56,7 @@ export async function expoApplicationGeneratorInternal(
   const initTask = await initGenerator(host, { ...options, skipFormat: true });
   tasks.push(initTask);
   if (!options.skipPackageJson) {
-    tasks.push(ensureDependencies(host));
+    tasks.push(ensureDependencies(host, options.unitTestRunner));
   }
   initRootBabelConfig(host);
 

--- a/packages/expo/src/generators/application/lib/create-application-files.ts
+++ b/packages/expo/src/generators/application/lib/create-application-files.ts
@@ -51,7 +51,7 @@ export async function createApplicationFiles(
   );
 
   if (options.unitTestRunner === 'none') {
-    host.delete(join(options.appProjectRoot, `App.spec.tsx`));
+    host.delete(join(options.appProjectRoot, 'src/app/App.spec.tsx'));
   }
   if (options.js) {
     toJS(host);

--- a/packages/expo/src/generators/library/lib/normalize-options.ts
+++ b/packages/expo/src/generators/library/lib/normalize-options.ts
@@ -56,6 +56,7 @@ export async function normalizeOptions(
     importPath,
     isUsingTsSolutionConfig,
     useProjectJson,
+    unitTestRunner: options.unitTestRunner ?? 'none',
   };
 
   return normalized;

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -247,7 +247,7 @@ describe('lib', () => {
   });
 
   describe('--unit-test-runner', () => {
-    it('should not generate test configuration', async () => {
+    it('should not generate test configuration or install test dependencies when unitTestRunner is none', async () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
         unitTestRunner: 'none',
@@ -267,9 +267,20 @@ describe('lib', () => {
           "targets": {},
         }
       `);
+      const packageJson = readJson(appTree, 'package.json');
+      expect(
+        packageJson.devDependencies['react-test-renderer']
+      ).toBeUndefined();
+      expect(
+        packageJson.devDependencies['@testing-library/react-native']
+      ).toBeUndefined();
+      expect(
+        packageJson.devDependencies['@testing-library/jest-native']
+      ).toBeUndefined();
+      expect(packageJson.devDependencies['jest-expo']).toBeUndefined();
     });
 
-    it('should generate test configuration', async () => {
+    it('should generate test configuration and install test dependencies when unitTestRunner is jest', async () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
         unitTestRunner: 'jest',
@@ -327,6 +338,15 @@ describe('lib', () => {
         };
         "
       `);
+      const packageJson = readJson(appTree, 'package.json');
+      expect(packageJson.devDependencies['react-test-renderer']).toBeDefined();
+      expect(
+        packageJson.devDependencies['@testing-library/react-native']
+      ).toBeDefined();
+      expect(
+        packageJson.devDependencies['@testing-library/jest-native']
+      ).toBeDefined();
+      expect(packageJson.devDependencies['jest-expo']).toBeDefined();
     });
   });
 

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -76,7 +76,7 @@ export async function expoLibraryGeneratorInternal(
   const initTask = await init(host, { ...options, skipFormat: true });
   tasks.push(initTask);
   if (!options.skipPackageJson) {
-    tasks.push(ensureDependencies(host));
+    tasks.push(ensureDependencies(host, options.unitTestRunner));
   }
   initRootBabelConfig(host);
 

--- a/packages/expo/src/utils/ensure-dependencies.ts
+++ b/packages/expo/src/utils/ensure-dependencies.ts
@@ -21,8 +21,29 @@ import {
   typesReactVersion,
 } from './versions';
 
-export function ensureDependencies(host: Tree): GeneratorCallback {
+export function ensureDependencies(
+  host: Tree,
+  unitTestRunner: 'jest' | 'none'
+): GeneratorCallback {
+  const devDependencies: Record<string, string> = {
+    '@types/react': typesReactVersion,
+    'babel-preset-expo': babelPresetExpoVersion,
+  };
+
   const isPnpm = detectPackageManager(host.root) === 'pnpm';
+  if (isPnpm) {
+    devDependencies['@babel/runtime'] = babelRuntimeVersion; // @babel/runtime is used by react-native-svg
+  }
+
+  if (unitTestRunner === 'jest') {
+    devDependencies['react-test-renderer'] = reactTestRendererVersion;
+    devDependencies['@testing-library/react-native'] =
+      testingLibraryReactNativeVersion;
+    devDependencies['@testing-library/jest-native'] =
+      testingLibraryJestNativeVersion;
+    devDependencies['jest-expo'] = jestExpoVersion;
+  }
+
   return addDependenciesToPackageJson(
     host,
     {
@@ -34,18 +55,6 @@ export function ensureDependencies(host: Tree): GeneratorCallback {
       'react-native-svg-transformer': reactNativeSvgTransformerVersion,
       'react-native-svg': reactNativeSvgVersion,
     },
-    {
-      '@types/react': typesReactVersion,
-      'react-test-renderer': reactTestRendererVersion,
-      '@testing-library/react-native': testingLibraryReactNativeVersion,
-      '@testing-library/jest-native': testingLibraryJestNativeVersion,
-      'jest-expo': jestExpoVersion,
-      'babel-preset-expo': babelPresetExpoVersion,
-      ...(isPnpm
-        ? {
-            '@babel/runtime': babelRuntimeVersion, // @babel/runtime is used by react-native-svg
-          }
-        : {}),
-    }
+    devDependencies
   );
 }


### PR DESCRIPTION
## Current Behavior

When generating Expo apps and libs with `--unit-test-runner=none` some test-specific files and dependencies are generated.

## Expected Behavior

When generating Expo apps and libs with `--unit-test-runner=none` no test-specific files and dependencies should be generated.

## Related Issue(s)

Fixes #30366 
