### PR TITLE
fix(bundling): respect decision to create babelrc file

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1517,7 +1517,7 @@ describe('lib', () => {
         expect(tree.exists('my-lib/.babelrc')).toBeFalsy();
       });
 
-      it('should not generate a .babelrc when bundler is swc (even if flag is set to true)', async () => {
+      it('should generate a .babelrc when includeBabelRc flag is true (even with swc bundler)', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           directory: 'my-lib',
@@ -1525,7 +1525,8 @@ describe('lib', () => {
           includeBabelRc: true,
         });
 
-        expect(tree.exists('my-lib/.babelrc')).toBeFalsy();
+        expect(tree.exists('my-lib/.babelrc')).toBeTruthy();
+        expect(tree.exists('my-lib/.swcrc')).toBeFalsy();
       });
 
       it('should generate a .babelrc when flag is set to true (even if there is no `@nx/web` plugin installed)', async () => {
@@ -1632,6 +1633,47 @@ describe('lib', () => {
           ],
         },
       });
+    });
+
+    it('should create .babelrc when includeBabelRc is true with rollup bundler', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        bundler: 'rollup',
+        includeBabelRc: true,
+      });
+
+      expect(tree.exists('my-lib/.babelrc')).toBeTruthy();
+      const babelrc = readJson(tree, 'my-lib/.babelrc');
+      expect(babelrc.presets).toEqual([
+        ['@nx/js/babel', { useBuiltIns: 'usage' }],
+      ]);
+
+      // Should NOT create .swcrc when babel is explicitly requested
+      expect(tree.exists('my-lib/.swcrc')).toBeFalsy();
+    });
+
+    it('should create .swcrc when includeBabelRc is false with rollup bundler', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        bundler: 'rollup',
+        includeBabelRc: false,
+      });
+
+      expect(tree.exists('my-lib/.swcrc')).toBeTruthy();
+      expect(tree.exists('my-lib/.babelrc')).toBeFalsy();
+    });
+
+    it('should create .swcrc when includeBabelRc is not set with rollup bundler (default behavior)', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        bundler: 'rollup',
+      });
+
+      expect(tree.exists('my-lib/.swcrc')).toBeTruthy();
+      expect(tree.exists('my-lib/.babelrc')).toBeFalsy();
     });
   });
 

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -584,7 +584,9 @@ function createFiles(tree: Tree, options: NormalizedLibraryGeneratorOptions) {
     );
   }
 
-  if (options.bundler === 'swc' || options.bundler === 'rollup') {
+  if (options.includeBabelRc) {
+    addBabelRc(tree, options);
+  } else if (options.bundler === 'swc' || options.bundler === 'rollup') {
     addSwcConfig(
       tree,
       options.projectRoot,
@@ -592,8 +594,6 @@ function createFiles(tree: Tree, options: NormalizedLibraryGeneratorOptions) {
         ? 'commonjs'
         : 'es6'
     );
-  } else if (options.includeBabelRc) {
-    addBabelRc(tree, options);
   }
 
   if (options.unitTestRunner === 'none') {


### PR DESCRIPTION
## Current Behavior

  When generating a JS library with the rollup bundler, the generator would always create a .swcrc file regardless of the includeBabelRc flag setting. This meant that even when users explicitly requested a Babel configuration by
   setting includeBabelRc: true, the generator would ignore this preference and still use SWC configuration.

## Expected Behavior

  When generating a JS library with any bundler (including rollup), the generator should respect the includeBabelRc flag. If includeBabelRc is set to true, it should create a .babelrc file and skip creating a .swcrc file. Only
  when includeBabelRc is false or not set should it fall back to creating the appropriate transformer configuration file (.swcrc for swc/rollup bundlers).

## Related Issue(s)

  Fixes #31582