### PR TITLE
fix(linter): update lint executor to always log errors and stack traces

### DIFF
--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -1,4 +1,4 @@
-import { joinPathFragments, type ExecutorContext } from '@nx/devkit';
+import { joinPathFragments, output, type ExecutorContext } from '@nx/devkit';
 import type { ESLint } from 'eslint';
 import { mkdirSync, writeFileSync } from 'fs';
 import { interpolate } from 'nx/src/tasks-runner/utils';
@@ -141,8 +141,21 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
         success: false,
       };
     }
-    // If some unexpected error, rethrow
-    throw err;
+
+    // log unexpected errors
+    const lines = (err.message ? err.message : err.toString()).split('\n');
+    const bodyLines: string[] = lines.slice(1);
+    if (err.stack) {
+      bodyLines.push(...err.stack.split('\n'));
+    }
+    output.error({
+      title: lines[0],
+      bodyLines,
+    });
+
+    return {
+      success: false,
+    };
   }
 
   if (lintResults.length === 0 && errorOnUnmatchedPattern) {


### PR DESCRIPTION
## Current Behavior

When the `@nx/eslint:lint` executor runs and an unexpected error occurs, only the error message is displayed and not the stack trace. This requires users to re-run with `--verbose` to see the stack trace.

## Expected Behavior

When the `@nx/eslint:lint` executor runs and an unexpected error occurs, the error message and the stack trace should be logged.

## Related Issue(s)

Fixes #21630 
