### PR TITLE
fix(node): ensure args are set in target correctly

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -41,14 +41,14 @@ describe('application generator', () => {
             "configurations": {
               "development": {
                 "args": [
-                  "node-env=development",
+                  "--node-env=development",
                 ],
               },
             },
             "executor": "nx:run-commands",
             "options": {
               "args": [
-                "node-env=production",
+                "--node-env=production",
               ],
               "command": "webpack-cli build",
             },
@@ -232,14 +232,14 @@ describe('application generator', () => {
                 "configurations": {
                   "development": {
                     "args": [
-                      "node-env=development",
+                      "--node-env=development",
                     ],
                   },
                 },
                 "executor": "nx:run-commands",
                 "options": {
                   "args": [
-                    "node-env=production",
+                    "--node-env=production",
                   ],
                   "command": "webpack-cli build",
                 },
@@ -398,14 +398,14 @@ describe('application generator', () => {
               "configurations": {
                 "development": {
                   "args": [
-                    "node-env=development",
+                    "--node-env=development",
                   ],
                 },
               },
               "executor": "nx:run-commands",
               "options": {
                 "args": [
-                  "node-env=production",
+                  "--node-env=production",
                 ],
                 "command": "webpack-cli build",
               },

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -951,4 +951,25 @@ describe('app', () => {
       expect(readJson(tree, 'myapp-e2e/package.json').nx).toBeUndefined();
     });
   });
+
+  describe('Nest.js with webpack bundler', () => {
+    it('should generate correct build target configuration with webpack-cli args', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-nest-app',
+        bundler: 'webpack',
+        framework: 'nest',
+        addPlugin: true,
+      });
+
+      const project = readProjectConfiguration(tree, 'my-nest-app');
+      const buildTarget = project.targets.build;
+
+      expect(buildTarget.executor).toBe('nx:run-commands');
+      expect(buildTarget.options.command).toBe('webpack-cli build');
+      expect(buildTarget.options.args).toEqual(['--node-env=production']);
+      expect(buildTarget.configurations.development.args).toEqual([
+        '--node-env=development',
+      ]);
+    });
+  });
 });

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -111,11 +111,11 @@ export function getNestWebpackBuildConfig(): TargetConfiguration {
     executor: 'nx:run-commands',
     options: {
       command: 'webpack-cli build',
-      args: ['node-env=production'],
+      args: ['--node-env=production'],
     },
     configurations: {
       development: {
-        args: ['node-env=development'],
+        args: ['--node-env=development'],
       },
     },
   };


### PR DESCRIPTION
  ## Current Behavior

  The Nest.js webpack build target configuration was generating webpack-cli arguments without the required -- prefix, resulting in node-env=production and node-env=development instead of proper CLI arguments.

  ## Expected Behavior

  The Nest.js webpack build target should generate proper webpack-cli arguments with the -- prefix: --node-env=production and --node-env=development for correct command line execution.

  ## Related Issue(s)

  Fixes #31578