### PR TITLE
fix(misc): add fallback for missing source root

### DIFF
--- a/packages/angular/src/builders/utilities/module-federation.ts
+++ b/packages/angular/src/builders/utilities/module-federation.ts
@@ -1,7 +1,8 @@
-import { join } from 'path';
-import { existsSync, readFileSync } from 'fs';
 import { logger, ProjectConfiguration } from '@nx/devkit';
 import { registerTsProject } from '@nx/js/src/internal';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 
 export type DevRemoteDefinition =
   | string
@@ -196,7 +197,7 @@ export function getDynamicMfManifestFile(
     join(workspaceRoot, project.root, 'public/module-federation.manifest.json'),
     join(
       workspaceRoot,
-      project.sourceRoot,
+      getProjectSourceRoot(project),
       'assets/module-federation.manifest.json'
     ),
   ].find((path) => existsSync(path));

--- a/packages/angular/src/generators/host/lib/update-ssr-setup.ts
+++ b/packages/angular/src/generators/host/lib/update-ssr-setup.ts
@@ -6,6 +6,7 @@ import {
   readProjectConfiguration,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { join } from 'path';
 import {
   corsVersion,
@@ -23,15 +24,14 @@ export async function updateSsrSetup(
 ) {
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
   let project = readProjectConfiguration(tree, appName);
+  const sourceRoot = getProjectSourceRoot(project, tree);
 
   tree.rename(
-    joinPathFragments(project.sourceRoot, 'main.server.ts'),
-    joinPathFragments(project.sourceRoot, 'bootstrap.server.ts')
+    joinPathFragments(sourceRoot, 'main.server.ts'),
+    joinPathFragments(sourceRoot, 'bootstrap.server.ts')
   );
   const pathToServerEntry = joinPathFragments(
-    angularMajorVersion >= 19
-      ? project.sourceRoot ?? joinPathFragments(project.root, 'src')
-      : project.root,
+    angularMajorVersion >= 19 ? sourceRoot : project.root,
     'server.ts'
   );
   tree.write(

--- a/packages/angular/src/generators/library/lib/create-files.ts
+++ b/packages/angular/src/generators/library/lib/create-files.ts
@@ -6,6 +6,7 @@ import {
   offsetFromRoot,
 } from '@nx/devkit';
 import { getRootTsConfigFileName } from '@nx/js';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { parse } from 'semver';
 import { UnitTestRunner } from '../../../utils/test-runners';
 import type { AngularProjectConfiguration } from '../../../utils/types';
@@ -84,7 +85,12 @@ export function createFiles(
   }
 
   if (!options.libraryOptions.routing) {
-    tree.delete(joinPathFragments(project.sourceRoot, `lib/lib.routes.ts`));
+    tree.delete(
+      joinPathFragments(
+        getProjectSourceRoot(project, tree),
+        `lib/lib.routes.ts`
+      )
+    );
   }
 
   if (

--- a/packages/angular/src/generators/move/lib/update-module-name.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.ts
@@ -8,6 +8,7 @@ import {
   visitNotIgnoredFiles,
 } from '@nx/devkit';
 import type { MoveImplOptions } from './types';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 /**
  * Updates the Angular module name (including the spec file and index.ts)
@@ -57,15 +58,16 @@ export function updateModuleName(
     },
   ];
 
+  const sourceRoot = getProjectSourceRoot(project, tree);
   const filesToRename = moduleFiles.flatMap((moduleFile) =>
     [
       {
-        from: `${project.sourceRoot}/lib/${moduleFile.from}.ts`,
-        to: `${project.sourceRoot}/lib/${moduleFile.to}.ts`,
+        from: `${sourceRoot}/lib/${moduleFile.from}.ts`,
+        to: `${sourceRoot}/lib/${moduleFile.to}.ts`,
       },
       {
-        from: `${project.sourceRoot}/lib/${moduleFile.from}.spec.ts`,
-        to: `${project.sourceRoot}/lib/${moduleFile.to}.spec.ts`,
+        from: `${sourceRoot}/lib/${moduleFile.from}.spec.ts`,
+        to: `${sourceRoot}/lib/${moduleFile.to}.spec.ts`,
       },
     ].filter((rename) => rename.from !== rename.to)
   );
@@ -95,7 +97,7 @@ export function updateModuleName(
   });
 
   // update index file
-  const indexFile = joinPathFragments(project.sourceRoot, 'index.ts');
+  const indexFile = joinPathFragments(sourceRoot, 'index.ts');
   if (tree.exists(indexFile)) {
     updateFileContent(tree, replacements, indexFile);
   }

--- a/packages/angular/src/generators/ngrx-root-store/lib/normalize-options.ts
+++ b/packages/angular/src/generators/ngrx-root-store/lib/normalize-options.ts
@@ -9,6 +9,7 @@ import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
 import { rxjsVersion as defaultRxjsVersion } from '../../../utils/versions';
 import type { Schema } from '../schema';
 import { isNgStandaloneApp } from '../../../utils/nx-devkit/ast-utils';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export type NormalizedNgRxRootStoreGeneratorOptions = Schema & {
   parent: string;
@@ -31,15 +32,11 @@ export function normalizeOptions(
 
   const project = readProjectConfiguration(tree, options.project);
   const isStandalone = isNgStandaloneApp(tree, options.project);
-  const appConfigPath = joinPathFragments(
-    project.sourceRoot,
-    'app/app.config.ts'
-  );
+  const sourceRoot = getProjectSourceRoot(project, tree);
+  const appConfigPath = joinPathFragments(sourceRoot, 'app/app.config.ts');
   let appMainPath =
     project.targets.build.options.main ?? project.targets.build.options.browser;
   if (!appMainPath) {
-    const sourceRoot =
-      project.sourceRoot ?? joinPathFragments(project.root, 'src');
     appMainPath = joinPathFragments(sourceRoot, 'main.ts');
   }
 
@@ -50,9 +47,9 @@ export function normalizeOptions(
    * --> If so, use that
    * --> If not, use main.ts
    */
-  let ngModulePath = joinPathFragments(project.sourceRoot, 'app/app.module.ts');
+  let ngModulePath = joinPathFragments(sourceRoot, 'app/app.module.ts');
   if (!tree.exists(ngModulePath)) {
-    ngModulePath = joinPathFragments(project.sourceRoot, 'app/app-module.ts');
+    ngModulePath = joinPathFragments(sourceRoot, 'app/app-module.ts');
   }
   const parent =
     !isStandalone && tree.exists(ngModulePath)

--- a/packages/angular/src/generators/remote/lib/update-ssr-setup.ts
+++ b/packages/angular/src/generators/remote/lib/update-ssr-setup.ts
@@ -7,6 +7,7 @@ import {
   readProjectConfiguration,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { join } from 'path';
 import {
   corsVersion,
@@ -34,16 +35,15 @@ export async function updateSsrSetup(
 ) {
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
   let project = readProjectConfiguration(tree, appName);
+  const sourceRoot = getProjectSourceRoot(project, tree);
 
   tree.rename(
-    joinPathFragments(project.sourceRoot, 'main.server.ts'),
-    joinPathFragments(project.sourceRoot, 'bootstrap.server.ts')
+    joinPathFragments(sourceRoot, 'main.server.ts'),
+    joinPathFragments(sourceRoot, 'bootstrap.server.ts')
   );
 
   const pathToServerEntry = joinPathFragments(
-    angularMajorVersion >= 19
-      ? project.sourceRoot ?? joinPathFragments(project.root, 'src')
-      : project.root,
+    angularMajorVersion >= 19 ? sourceRoot : project.root,
     'server.ts'
   );
   tree.write(

--- a/packages/angular/src/generators/setup-mf/lib/add-cypress-workaround.ts
+++ b/packages/angular/src/generators/setup-mf/lib/add-cypress-workaround.ts
@@ -10,6 +10,7 @@ import {
   readProjectConfiguration,
   stripIndents,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { Schema } from '../schema';
 
 export function addCypressOnErrorWorkaround(tree: Tree, schema: Schema) {
@@ -58,7 +59,7 @@ export function addCypressOnErrorWorkaround(tree: Tree, schema: Schema) {
   });`;
 
   const pathToCommandsFile = joinPathFragments(
-    e2eProject.sourceRoot,
+    getProjectSourceRoot(e2eProject, tree),
     'support/e2e.ts'
   );
 

--- a/packages/angular/src/generators/setup-mf/lib/remove-dead-code-from-remote.ts
+++ b/packages/angular/src/generators/setup-mf/lib/remove-dead-code-from-remote.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { joinPathFragments, readProjectConfiguration } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { NormalizedOptions } from '../schema';
 
 export function removeDeadCodeFromRemote(
@@ -8,13 +9,14 @@ export function removeDeadCodeFromRemote(
 ) {
   const projectName = options.appName;
   const project = readProjectConfiguration(tree, projectName);
+  const sourceRoot = getProjectSourceRoot(project, tree);
 
   const { appComponentInfo, nxWelcomeComponentInfo, entryModuleFileName } =
     options;
 
   ['css', 'less', 'scss', 'sass'].forEach((style) => {
     const pathToComponentStyle = joinPathFragments(
-      project.sourceRoot,
+      sourceRoot,
       `app/${appComponentInfo.extensionlessFileName}.${style}`
     );
     if (tree.exists(pathToComponentStyle)) {
@@ -25,19 +27,19 @@ export function removeDeadCodeFromRemote(
   tree.rename(
     nxWelcomeComponentInfo.path,
     joinPathFragments(
-      project.sourceRoot,
+      sourceRoot,
       `app/remote-entry/${nxWelcomeComponentInfo.fileName}`
     )
   );
   tree.delete(
     joinPathFragments(
-      project.sourceRoot,
+      sourceRoot,
       `app/${appComponentInfo.extensionlessFileName}.spec.ts`
     )
   );
   tree.delete(
     joinPathFragments(
-      project.sourceRoot,
+      sourceRoot,
       `app/${appComponentInfo.extensionlessFileName}.html`
     )
   );
@@ -56,9 +58,9 @@ export class ${appComponentInfo.symbolName} {}`;
 
     tree.write(appComponentInfo.path, component);
 
-    let modulePath = joinPathFragments(project.sourceRoot, 'app/app.module.ts');
+    let modulePath = joinPathFragments(sourceRoot, 'app/app.module.ts');
     if (!tree.exists(modulePath)) {
-      modulePath = joinPathFragments(project.sourceRoot, 'app/app-module.ts');
+      modulePath = joinPathFragments(sourceRoot, 'app/app-module.ts');
     }
     tree.write(
       modulePath,

--- a/packages/angular/src/generators/setup-ssr/lib/add-hydration.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/add-hydration.ts
@@ -5,6 +5,7 @@ import {
 } from '@nx/devkit';
 import { insertImport } from '@nx/js';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { CallExpression, SourceFile } from 'typescript';
 import {
   addProviderToAppConfig,
@@ -18,6 +19,7 @@ let tsquery: typeof import('@phenomnomnominal/tsquery').tsquery;
 
 export function addHydration(tree: Tree, options: NormalizedGeneratorOptions) {
   const projectConfig = readProjectConfiguration(tree, options.project);
+  const sourceRoot = getProjectSourceRoot(projectConfig, tree);
 
   if (!tsModule) {
     tsModule = ensureTypescript();
@@ -26,18 +28,12 @@ export function addHydration(tree: Tree, options: NormalizedGeneratorOptions) {
 
   let pathToClientConfigFile: string;
   if (options.standalone) {
-    pathToClientConfigFile = joinPathFragments(
-      projectConfig.sourceRoot,
-      'app/app.config.ts'
-    );
+    pathToClientConfigFile = joinPathFragments(sourceRoot, 'app/app.config.ts');
   } else {
-    pathToClientConfigFile = joinPathFragments(
-      projectConfig.sourceRoot,
-      'app/app.module.ts'
-    );
+    pathToClientConfigFile = joinPathFragments(sourceRoot, 'app/app.module.ts');
     if (!tree.exists(pathToClientConfigFile)) {
       pathToClientConfigFile = joinPathFragments(
-        projectConfig.sourceRoot,
+        sourceRoot,
         'app/app-module.ts'
       );
     }

--- a/packages/angular/src/generators/setup-ssr/lib/add-server-file.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/add-server-file.ts
@@ -1,9 +1,6 @@
 import type { Tree } from '@nx/devkit';
-import {
-  generateFiles,
-  joinPathFragments,
-  readProjectConfiguration,
-} from '@nx/devkit';
+import { generateFiles, readProjectConfiguration } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { join } from 'path';
 import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedGeneratorOptions } from '../schema';
@@ -49,8 +46,7 @@ export function addServerFile(tree: Tree, options: NormalizedGeneratorOptions) {
     );
   }
 
-  const sourceRoot =
-    project.sourceRoot ?? joinPathFragments(project.root, 'src');
+  const sourceRoot = getProjectSourceRoot(project, tree);
 
   generateFiles(
     tree,

--- a/packages/angular/src/generators/setup-ssr/lib/generate-files.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/generate-files.ts
@@ -4,6 +4,7 @@ import {
   joinPathFragments,
   readProjectConfiguration,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { join } from 'path';
 import { clean, coerce, gte } from 'semver';
 import { getAppComponentInfo } from '../../utils/app-components-info';
@@ -61,8 +62,7 @@ export function generateSSRFiles(
     );
   }
 
-  const sourceRoot =
-    project.sourceRoot ?? joinPathFragments(project.root, 'src');
+  const sourceRoot = getProjectSourceRoot(project, tree);
 
   const ssrVersion = getInstalledPackageVersion(tree, '@angular/ssr');
   const cleanedSsrVersion = ssrVersion

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -11,6 +11,7 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedGeneratorOptions } from '../schema';
 import {
@@ -59,8 +60,7 @@ export function updateProjectConfigForApplicationBuilder(
   }
 
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
-  const sourceRoot =
-    project.sourceRoot ?? joinPathFragments(project.root, 'src');
+  const sourceRoot = getProjectSourceRoot(project, tree);
 
   buildTarget.options ??= {};
   buildTarget.options.outputPath = outputPath;
@@ -103,8 +103,7 @@ export function updateProjectConfigForBrowserBuilder(
   }
 
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
-  const sourceRoot =
-    projectConfig.sourceRoot ?? joinPathFragments(projectConfig.root, 'src');
+  const sourceRoot = getProjectSourceRoot(projectConfig, tree);
 
   projectConfig.targets.server = {
     dependsOn: ['build'],

--- a/packages/angular/src/generators/setup-tailwind/lib/add-tailwind-config.ts
+++ b/packages/angular/src/generators/setup-tailwind/lib/add-tailwind-config.ts
@@ -5,6 +5,7 @@ import {
   stripIndents,
   Tree,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { relative } from 'path';
 import { GeneratorOptions } from '../schema';
 
@@ -28,7 +29,10 @@ export function addTailwindConfig(
     joinPathFragments(__dirname, '..', filesDir),
     project.root,
     {
-      relativeSourceRoot: relative(project.root, project.sourceRoot),
+      relativeSourceRoot: relative(
+        project.root,
+        getProjectSourceRoot(project, tree)
+      ),
       tmpl: '',
     }
   );

--- a/packages/angular/src/generators/setup-tailwind/lib/update-application-styles.ts
+++ b/packages/angular/src/generators/setup-tailwind/lib/update-application-styles.ts
@@ -4,6 +4,7 @@ import {
   stripIndents,
   Tree,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { NormalizedGeneratorOptions } from '../schema';
 
 export function updateApplicationStyles(
@@ -46,12 +47,13 @@ function findStylesEntryPoint(
   options: NormalizedGeneratorOptions,
   project: ProjectConfiguration
 ): string | undefined {
+  const sourceRoot = getProjectSourceRoot(project, tree);
   // first check for common names
   const possibleStylesEntryPoints = [
-    joinPathFragments(project.sourceRoot ?? project.root, 'styles.css'),
-    joinPathFragments(project.sourceRoot ?? project.root, 'styles.scss'),
-    joinPathFragments(project.sourceRoot ?? project.root, 'styles.sass'),
-    joinPathFragments(project.sourceRoot ?? project.root, 'styles.less'),
+    joinPathFragments(sourceRoot, 'styles.css'),
+    joinPathFragments(sourceRoot, 'styles.scss'),
+    joinPathFragments(sourceRoot, 'styles.sass'),
+    joinPathFragments(sourceRoot, 'styles.less'),
   ];
 
   let stylesEntryPoint = possibleStylesEntryPoints.find((s) => tree.exists(s));

--- a/packages/angular/src/generators/utils/app-components-info.ts
+++ b/packages/angular/src/generators/utils/app-components-info.ts
@@ -4,6 +4,7 @@ import {
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { basename } from 'node:path';
 import { getInstalledAngularVersionInfo } from './version-utils';
 
@@ -37,22 +38,20 @@ function getComponentInfo(
   componentFileSuffix: string,
   project: ProjectConfiguration
 ): ComponentMetadata {
+  const sourceRoot = getProjectSourceRoot(project, tree);
   let componentPath = joinPathFragments(
-    project.sourceRoot,
+    sourceRoot,
     `app/${component}.component.ts`
   );
 
   if (!tree.exists(componentPath)) {
-    componentPath = joinPathFragments(
-      project.sourceRoot,
-      `app/${component}.ts`
-    );
+    componentPath = joinPathFragments(sourceRoot, `app/${component}.ts`);
   }
 
   if (!tree.exists(componentPath)) {
     if (componentFileSuffix) {
       componentPath = joinPathFragments(
-        project.sourceRoot,
+        sourceRoot,
         `app/${component}${componentFileSuffix}.ts`
       );
     }
@@ -61,7 +60,7 @@ function getComponentInfo(
   if (!tree.exists(componentPath)) {
     const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
     componentPath = joinPathFragments(
-      project.sourceRoot,
+      sourceRoot,
       angularMajorVersion >= 20
         ? `app/${component}.ts`
         : `app/${component}.component.ts`

--- a/packages/angular/src/generators/utils/testing.ts
+++ b/packages/angular/src/generators/utils/testing.ts
@@ -1,6 +1,7 @@
 import type { Tree } from '@nx/devkit';
 import { names, readProjectConfiguration } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { UnitTestRunner } from '../../utils/test-runners';
 import { applicationGenerator } from '../application/application';
 import type { Schema as ApplicationOptions } from '../application/schema';
@@ -298,7 +299,7 @@ function generateModule(
   const project = readProjectConfiguration(tree, options.project);
 
   if (options.path === undefined) {
-    const sourceRoot = project.sourceRoot ?? `${project.root}/src`;
+    const sourceRoot = getProjectSourceRoot(project, tree);
     const projectDirName =
       project.projectType === 'application' ? 'app' : 'lib';
     options.path = `${sourceRoot}/${projectDirName}`;

--- a/packages/angular/src/migrations/update-17-1-0/replace-nguniversal-engines.ts
+++ b/packages/angular/src/migrations/update-17-1-0/replace-nguniversal-engines.ts
@@ -14,6 +14,7 @@ import {
 } from '../../generators/utils/version-utils';
 import { allTargetOptions } from '../../utils/targets';
 import { getProjectsFilteredByDependencies } from '../utils/projects';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 const UNIVERSAL_PACKAGES = [
   '@nguniversal/common',
@@ -75,7 +76,7 @@ export default async function (tree: Tree) {
 
     // Replace all import specifiers in all files.
     let hasExpressTokens = false;
-    const root = project.sourceRoot ?? `${project.root}/src`;
+    const root = getProjectSourceRoot(project, tree);
     const tokensFilePath = `${root}/express.tokens.ts`;
 
     visitNotIgnoredFiles(tree, root, (path) => {

--- a/packages/angular/src/utils/nx-devkit/ast-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/ast-utils.ts
@@ -13,6 +13,7 @@ import {
   replaceChange,
 } from '@nx/js';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { dirname, join } from 'path';
 import type * as ts from 'typescript';
 import { getInstalledAngularVersionInfo } from '../../executors/utilities/angular-version-utils';
@@ -714,8 +715,7 @@ export function isNgStandaloneApp(tree: Tree, projectName: string) {
   if (mainFile) {
     hasMainFile = true;
   } else {
-    const sourceRoot =
-      project.sourceRoot ?? joinPathFragments(project.root, 'src');
+    const sourceRoot = getProjectSourceRoot(project, tree);
     mainFile = joinPathFragments(sourceRoot, 'main.ts');
     hasMainFile = tree.exists(mainFile);
   }
@@ -940,8 +940,7 @@ export function readBootstrapInfo(
       config.targets.build.options?.main ??
       config.targets.build.options?.browser;
     if (!mainPath) {
-      const sourceRoot =
-        config.sourceRoot ?? joinPathFragments(config.root, 'src');
+      const sourceRoot = getProjectSourceRoot(config, host);
       mainPath = joinPathFragments(sourceRoot, 'main.ts');
     }
   } catch (e) {

--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -81,11 +81,7 @@ function addBuildTarget(
   };
 
   if (isTsSolutionSetup) {
-    buildOptions.declarationRootDir = getProjectSourceRoot(
-      tree,
-      project.sourceRoot,
-      project.root
-    );
+    buildOptions.declarationRootDir = getProjectSourceRoot(project, tree);
   } else {
     buildOptions.assets = [];
 

--- a/packages/eslint-plugin/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin/src/utils/ast-utils.ts
@@ -5,6 +5,7 @@ import {
   workspaceRoot,
 } from '@nx/devkit';
 import { findNodes } from '@nx/js';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { getModifiers } from '@typescript-eslint/type-utils';
 import { existsSync, lstatSync, readdirSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
@@ -70,9 +71,10 @@ export function getBarrelEntryPointProjectNode(
       .filter((entry) => {
         const sourceFolderPaths = tsConfigBase.compilerOptions.paths[entry];
         return sourceFolderPaths.some((sourceFolderPath) => {
+          const sourceRoot = getProjectSourceRoot(projectNode.data);
           return (
-            sourceFolderPath === projectNode.data.sourceRoot ||
-            sourceFolderPath.indexOf(`${projectNode.data.sourceRoot}/`) === 0
+            sourceFolderPath === sourceRoot ||
+            sourceFolderPath.indexOf(`${sourceRoot}/`) === 0
           );
         });
       })

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -17,7 +17,6 @@ import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-default
 import { basename, dirname, join } from 'node:path/posix';
 import { mergeTargetConfigurations } from 'nx/src/devkit-internals';
 import type { PackageJson } from 'nx/src/utils/package-json';
-import { ensureProjectIsIncludedInPluginRegistrations } from '../../utils/typescript/plugin';
 import { getImportPath } from '../../utils/get-import-path';
 import {
   getUpdatedPackageJsonContent,
@@ -26,8 +25,12 @@ import {
 import { addSwcConfig } from '../../utils/swc/add-swc-config';
 import { addSwcDependencies } from '../../utils/swc/add-swc-dependencies';
 import { ensureTypescript } from '../../utils/typescript/ensure-typescript';
+import { ensureProjectIsIncludedInPluginRegistrations } from '../../utils/typescript/plugin';
 import { readTsConfig } from '../../utils/typescript/ts-config';
-import { isUsingTsSolutionSetup } from '../../utils/typescript/ts-solution-setup';
+import {
+  getProjectSourceRoot,
+  isUsingTsSolutionSetup,
+} from '../../utils/typescript/ts-solution-setup';
 import { nxVersion } from '../../utils/versions';
 import { SetupBuildGeneratorSchema } from './schema';
 
@@ -50,7 +53,7 @@ export async function setupBuildGenerator(
   } else if (options.main) {
     mainFile = options.main;
   } else {
-    const root = project.sourceRoot ?? project.root;
+    const root = getProjectSourceRoot(project, tree);
     for (const f of [
       joinPathFragments(root, 'main.ts'),
       joinPathFragments(root, 'main.js'),

--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -10,6 +10,7 @@ import {
 } from 'node:fs';
 import { join, relative } from 'path';
 import type { NormalizedExecutorOptions } from './schema';
+import { getProjectSourceRoot } from './typescript/ts-solution-setup';
 
 interface InlineProjectNode {
   name: string;
@@ -134,7 +135,7 @@ function projectNodeToInlineProjectNode(
   return {
     name: projectNode.name,
     root: projectNode.data.root,
-    sourceRoot: projectNode.data.sourceRoot,
+    sourceRoot: getProjectSourceRoot(projectNode.data),
     pathAlias,
     buildOutputPath,
   };

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -3,6 +3,7 @@ import {
   joinPathFragments,
   offsetFromRoot,
   output,
+  type ProjectConfiguration,
   readJson,
   readNxJson,
   type Tree,
@@ -290,14 +291,15 @@ export function getProjectType(
 }
 
 export function getProjectSourceRoot(
-  tree: Tree,
-  projectSourceRoot: string | undefined,
-  projectRoot: string
-): string | undefined {
+  project: ProjectConfiguration,
+  tree?: Tree
+): string {
+  tree ??= new FsTree(workspaceRoot, false);
+
   return (
-    projectSourceRoot ??
-    (tree.exists(joinPathFragments(projectRoot, 'src'))
-      ? joinPathFragments(projectRoot, 'src')
-      : projectRoot)
+    project.sourceRoot ??
+    (tree.exists(joinPathFragments(project.root, 'src'))
+      ? joinPathFragments(project.root, 'src')
+      : project.root)
   );
 }

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -10,6 +10,7 @@ import {
   updateJson,
   workspaceRoot,
 } from '@nx/devkit';
+import { existsSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path/posix';
 import { FsTree } from 'nx/src/generators/tree';
 import {
@@ -294,11 +295,18 @@ export function getProjectSourceRoot(
   project: ProjectConfiguration,
   tree?: Tree
 ): string {
-  tree ??= new FsTree(workspaceRoot, false);
+  if (tree) {
+    return (
+      project.sourceRoot ??
+      (tree.exists(joinPathFragments(project.root, 'src'))
+        ? joinPathFragments(project.root, 'src')
+        : project.root)
+    );
+  }
 
   return (
     project.sourceRoot ??
-    (tree.exists(joinPathFragments(project.root, 'src'))
+    (existsSync(join(workspaceRoot, project.root, 'src'))
       ? joinPathFragments(project.root, 'src')
       : project.root)
   );

--- a/packages/module-federation/src/plugins/utils/get-dynamic-manifest-file.ts
+++ b/packages/module-federation/src/plugins/utils/get-dynamic-manifest-file.ts
@@ -1,6 +1,7 @@
-import { join } from 'path';
-import { existsSync } from 'fs';
 import { type ProjectConfiguration } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { existsSync } from 'fs';
+import { join } from 'path';
 
 export function getDynamicMfManifestFile(
   project: ProjectConfiguration,
@@ -16,7 +17,7 @@ export function getDynamicMfManifestFile(
     join(workspaceRoot, project.root, 'public/module-federation.manifest.json'),
     join(
       workspaceRoot,
-      project.sourceRoot!,
+      getProjectSourceRoot(project),
       'assets/module-federation.manifest.json'
     ),
   ].find((path) => existsSync(path));

--- a/packages/module-federation/src/utils/dependencies.ts
+++ b/packages/module-federation/src/utils/dependencies.ts
@@ -1,10 +1,11 @@
 import type { ProjectGraph } from '@nx/devkit';
-import type { WorkspaceLibrary } from './models';
-import { readTsPathMappings } from './typescript';
 import {
   getOutputsForTargetAndConfiguration,
   parseTargetString,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import type { WorkspaceLibrary } from './models';
+import { readTsPathMappings } from './typescript';
 
 export function getDependentPackagesForProject(
   projectGraph: ProjectGraph,
@@ -66,7 +67,7 @@ function getLibraryImportPath(
     buildLibsFromSource = process.env.NX_BUILD_LIBS_FROM_SOURCE === 'true';
   }
   const libraryNode = projectGraph.nodes[library];
-  let sourceRoots = [libraryNode.data.sourceRoot];
+  let sourceRoots = [getProjectSourceRoot(libraryNode.data)];
 
   if (!buildLibsFromSource && process.env.NX_BUILD_TARGET) {
     const buildTarget = parseTargetString(

--- a/packages/next/plugins/component-testing.ts
+++ b/packages/next/plugins/component-testing.ts
@@ -1,11 +1,12 @@
 import {
-  createExecutorContext,
-  getProjectConfigByPath,
-} from '@nx/cypress/src/utils/ct-helpers';
-import {
   nxBaseCypressPreset,
   NxComponentTestingOptions,
 } from '@nx/cypress/plugins/cypress-preset';
+import { CypressExecutorOptions } from '@nx/cypress/src/executors/cypress/cypress.impl';
+import {
+  createExecutorContext,
+  getProjectConfigByPath,
+} from '@nx/cypress/src/utils/ct-helpers';
 import {
   ExecutorContext,
   parseTargetString,
@@ -15,6 +16,7 @@ import {
   stripIndents,
   workspaceRoot,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { withReact } from '@nx/react';
 import {
   AssetGlobPattern,
@@ -22,10 +24,9 @@ import {
   NormalizedWebpackExecutorOptions,
   withNx,
 } from '@nx/webpack';
+import { readNxJson } from 'nx/src/config/configuration';
 import { join } from 'path';
 import { NextBuildBuilderOptions } from '../src/utils/types';
-import { CypressExecutorOptions } from '@nx/cypress/src/executors/cypress/cypress.impl';
-import { readNxJson } from 'nx/src/config/configuration';
 
 export function nxComponentTestingPreset(
   pathToConfig: string,
@@ -125,7 +126,7 @@ Able to find CT project, ${!!ctProjectConfig}.`);
   const webpackOptions: NormalizedWebpackExecutorOptions = {
     root: ctExecutorContext.root,
     projectRoot: ctProjectConfig.root,
-    sourceRoot: ctProjectConfig.sourceRoot,
+    sourceRoot: getProjectSourceRoot(ctProjectConfig),
     main: '',
     useTsconfigPaths: undefined,
     fileReplacements: buildFileReplacements,

--- a/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -10,11 +10,12 @@ import {
   updateProjectConfiguration,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { isComponent } from '@nx/react/src/utils/ct-utils';
-import { CypressComponentConfigurationGeneratorSchema } from './schema';
-import { nxVersion } from '../../utils/versions';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { componentTestGenerator } from '@nx/react';
+import { isComponent } from '@nx/react/src/utils/ct-utils';
 import { relative } from 'path';
+import { nxVersion } from '../../utils/versions';
+import { CypressComponentConfigurationGeneratorSchema } from './schema';
 
 export function cypressComponentConfiguration(
   tree: Tree,
@@ -144,7 +145,8 @@ ${
 
   if (opts.generateTests) {
     const filePaths = [];
-    visitNotIgnoredFiles(tree, projectConfig.sourceRoot, (filePath) => {
+    const sourceRoot = getProjectSourceRoot(projectConfig, tree);
+    visitNotIgnoredFiles(tree, sourceRoot, (filePath) => {
       const fromProjectRootPath = relative(projectConfig.root, filePath);
       // we don't generate tests for pages/server-side/appDir components
       if (

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -27,11 +27,11 @@ export function addProject(tree: Tree, options: NormalizedSchema) {
 
   if (options.bundler === 'esbuild') {
     addBuildTargetDefaults(tree, '@nx/esbuild:esbuild');
-    project.targets.build = getEsBuildConfig(project, options);
+    project.targets.build = getEsBuildConfig(tree, project, options);
   } else if (options.bundler === 'webpack') {
     if (!hasWebpackPlugin(tree) && options.addPlugin === false) {
       addBuildTargetDefaults(tree, `@nx/webpack:webpack`);
-      project.targets.build = getWebpackBuildConfig(project, options);
+      project.targets.build = getWebpackBuildConfig(tree, project, options);
     } else if (options.isNest) {
       // If we are using Nest that has the webpack plugin we need to override the
       // build target so that node-env can be set to production or development so the serve target can be run in development mode

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -1,14 +1,18 @@
 import {
   joinPathFragments,
   ProjectConfiguration,
+  Tree,
   TargetConfiguration,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { NormalizedSchema } from './normalized-schema';
 
 export function getWebpackBuildConfig(
+  tree: Tree,
   project: ProjectConfiguration,
   options: NormalizedSchema
 ): TargetConfiguration {
+  const sourceRoot = getProjectSourceRoot(project, tree);
   return {
     executor: `@nx/webpack:webpack`,
     outputs: ['{options.outputPath}'],
@@ -18,11 +22,11 @@ export function getWebpackBuildConfig(
       compiler: 'tsc',
       outputPath: options.outputPath,
       main: joinPathFragments(
-        project.sourceRoot,
+        sourceRoot,
         'main' + (options.js ? '.js' : '.ts')
       ),
       tsConfig: joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
-      assets: [joinPathFragments(project.sourceRoot, 'assets')],
+      assets: [joinPathFragments(sourceRoot, 'assets')],
       webpackConfig: joinPathFragments(
         options.appProjectRoot,
         'webpack.config.js'
@@ -41,9 +45,11 @@ export function getWebpackBuildConfig(
 }
 
 export function getEsBuildConfig(
+  tree: Tree,
   project: ProjectConfiguration,
   options: NormalizedSchema
 ): TargetConfiguration {
+  const sourceRoot = getProjectSourceRoot(project, tree);
   return {
     executor: '@nx/esbuild:esbuild',
     outputs: ['{options.outputPath}'],
@@ -55,11 +61,11 @@ export function getEsBuildConfig(
       format: ['cjs'],
       bundle: false,
       main: joinPathFragments(
-        project.sourceRoot,
+        sourceRoot,
         'main' + (options.js ? '.js' : '.ts')
       ),
       tsConfig: joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
-      assets: [joinPathFragments(project.sourceRoot, 'assets')],
+      assets: [joinPathFragments(sourceRoot, 'assets')],
       generatePackageJson: options.isUsingTsSolutionConfig ? undefined : true,
       esbuildOptions: {
         sourcemap: true,

--- a/packages/plugin/src/generators/create-package/create-package.ts
+++ b/packages/plugin/src/generators/create-package/create-package.ts
@@ -14,7 +14,10 @@ import {
 } from '@nx/devkit';
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
 import { addTsLibDependencies } from '@nx/js/src/utils/typescript/add-tslib-dependencies';
-import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import {
+  getProjectSourceRoot,
+  isUsingTsSolutionSetup,
+} from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { tsLibVersion } from '@nx/js/src/utils/versions';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { nxVersion } from 'nx/src/utils/versions';
@@ -214,7 +217,7 @@ function addE2eProject(host: Tree, options: NormalizedSchema) {
   generateFiles(
     host,
     joinPathFragments(__dirname, './files/e2e'),
-    e2eProjectConfiguration.sourceRoot,
+    getProjectSourceRoot(e2eProjectConfiguration, host),
     {
       pluginName: options.project,
       cliName: options.name,

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -17,6 +17,7 @@ import {
   addSwcRegisterDependencies,
 } from '@nx/js/src/utils/swc/add-swc-dependencies';
 import { addTsLibDependencies } from '@nx/js/src/utils/typescript/add-tslib-dependencies';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import * as path from 'path';
 import { e2eProjectGenerator } from '../e2e-project/e2e';
 import pluginLintCheckGenerator from '../lint-checks/generator';
@@ -44,8 +45,10 @@ function updatePluginConfig(host: Tree, options: NormalizedSchema) {
 
   if (project.targets.build) {
     if (options.isTsSolutionSetup && options.bundler === 'tsc') {
-      project.targets.build.options.rootDir =
-        project.sourceRoot ?? joinPathFragments(project.root, 'src');
+      project.targets.build.options.rootDir = getProjectSourceRoot(
+        project,
+        host
+      );
       project.targets.build.options.generatePackageJson = false;
     }
 

--- a/packages/plugin/src/utils/paths.ts
+++ b/packages/plugin/src/utils/paths.ts
@@ -1,4 +1,5 @@
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { dirname, join, relative } from 'node:path/posix';
 
 export function getArtifactMetadataDirectory(
@@ -39,11 +40,7 @@ export function getArtifactMetadataDirectory(
   // unless the user manually changed the build process. In that case, we can't
   // reliably determine the output directory because it depends on the build
   // tool, so we'll just assume some defaults.
-  const baseDir =
-    project.sourceRoot ??
-    (tree.exists(join(project.root, 'src'))
-      ? join(project.root, 'src')
-      : project.root);
+  const baseDir = getProjectSourceRoot(project, tree);
 
   return `./${join('dist', relative(baseDir, sourceDirectory))}`;
 }

--- a/packages/react/plugins/component-testing/index.ts
+++ b/packages/react/plugins/component-testing/index.ts
@@ -4,6 +4,10 @@ import {
 } from '@nx/cypress/plugins/cypress-preset';
 import type { CypressExecutorOptions } from '@nx/cypress/src/executors/cypress/cypress.impl';
 import {
+  createExecutorContext,
+  getProjectConfigByPath,
+} from '@nx/cypress/src/utils/ct-helpers';
+import {
   ExecutorContext,
   joinPathFragments,
   logger,
@@ -14,11 +18,8 @@ import {
   Target,
   workspaceRoot,
 } from '@nx/devkit';
-import {
-  createExecutorContext,
-  getProjectConfigByPath,
-} from '@nx/cypress/src/utils/ct-helpers';
 
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 
@@ -269,7 +270,7 @@ function buildTargetWebpack(
     withSchemaDefaults(parsed, context),
     workspaceRoot,
     buildableProjectConfig.root!,
-    buildableProjectConfig.sourceRoot!
+    getProjectSourceRoot(buildableProjectConfig)
   );
 
   let customWebpack: any;
@@ -301,7 +302,7 @@ function buildTargetWebpack(
           extractLicenses: false,
           root: workspaceRoot,
           projectRoot: ctProjectConfig.root,
-          sourceRoot: ctProjectConfig.sourceRoot,
+          sourceRoot: getProjectSourceRoot(ctProjectConfig),
         },
         context,
       }

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -5,8 +5,10 @@ import {
   ProjectGraphProjectNode,
   workspaceRoot,
 } from '@nx/devkit';
-import { composePluginsSync } from '@nx/webpack/src/utils/config';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { NormalizedWebpackExecutorOptions } from '@nx/webpack/src/executors/webpack/schema';
+import { composePluginsSync } from '@nx/webpack/src/utils/config';
+import { existsSync } from 'fs';
 import { join } from 'path';
 import {
   Configuration,
@@ -14,9 +16,8 @@ import {
   ResolvePluginInstance,
   WebpackPluginInstance,
 } from 'webpack';
-import { mergePlugins } from './merge-plugins';
 import { withReact } from '../with-react';
-import { existsSync } from 'fs';
+import { mergePlugins } from './merge-plugins';
 
 // This is shamelessly taken from CRA and modified for NX use
 // https://github.com/facebook/create-react-app/blob/4784997f0682e75eb32a897b4ffe34d735912e6c/packages/react-scripts/config/env.js#L71
@@ -90,7 +91,7 @@ const getProjectData = async (
     ? {
         workspaceRoot: process.env.NX_WORKSPACE_ROOT,
         projectRoot: projectNode.data.root,
-        sourceRoot: projectNode.data.sourceRoot,
+        sourceRoot: getProjectSourceRoot(projectNode.data),
         projectNode,
       }
     : // Edge-case: missing project node
@@ -182,7 +183,7 @@ export const webpack = async (
     ...options,
     root: projectData.workspaceRoot,
     projectRoot: projectData.projectRoot,
-    sourceRoot: projectData.sourceRoot,
+    sourceRoot: getProjectSourceRoot(projectData.projectNode.data),
     fileReplacements: [],
     sourceMap: true,
     styles: options.styles ?? [],

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -1,16 +1,17 @@
 import { ExecutorContext, logger } from '@nx/devkit';
-import devServerExecutor from '@nx/webpack/src/executors/dev-server/dev-server.impl';
-import fileServerExecutor from '@nx/web/src/executors/file-server/file-server.impl';
-import { ModuleFederationDevServerOptions } from './schema';
-import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
 import {
   combineAsyncIterables,
   createAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
+import fileServerExecutor from '@nx/web/src/executors/file-server/file-server.impl';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import devServerExecutor from '@nx/webpack/src/executors/dev-server/dev-server.impl';
 import { existsSync } from 'fs';
 import { extname, join } from 'path';
-import { getBuildOptions, normalizeOptions, startRemotes } from './lib';
+import { normalizeOptions, startRemotes } from './lib';
+import { ModuleFederationDevServerOptions } from './schema';
 
 export default async function* moduleFederationDevServer(
   schema: ModuleFederationDevServerOptions,
@@ -32,11 +33,10 @@ export default async function* moduleFederationDevServer(
     : devServerExecutor(options, context);
 
   const p = context.projectsConfigurations.projects[context.projectName];
-  const buildOptions = getBuildOptions(options.buildTarget, context);
 
   let pathToManifestFile = join(
     context.root,
-    p.sourceRoot,
+    getProjectSourceRoot(p),
     'assets/module-federation.manifest.json'
   );
   if (options.pathToManifestFile) {

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -1,15 +1,16 @@
 import { ExecutorContext, logger } from '@nx/devkit';
-import ssrDevServerExecutor from '@nx/webpack/src/executors/ssr-dev-server/ssr-dev-server.impl';
-import { extname, join } from 'path';
-import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
 import {
   combineAsyncIterables,
   createAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
-import { existsSync } from 'fs';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import ssrDevServerExecutor from '@nx/webpack/src/executors/ssr-dev-server/ssr-dev-server.impl';
+import { existsSync } from 'fs';
+import { extname, join } from 'path';
+import { normalizeOptions, startRemotes } from './lib';
 import { ModuleFederationSsrDevServerOptions } from './schema';
-import { getBuildOptions, normalizeOptions, startRemotes } from './lib';
 
 export default async function* moduleFederationSsrDevServer(
   ssrDevServerOptions: ModuleFederationSsrDevServerOptions,
@@ -19,11 +20,10 @@ export default async function* moduleFederationSsrDevServer(
   let iter: any = ssrDevServerExecutor(options, context);
   const projectConfig =
     context.projectsConfigurations.projects[context.projectName];
-  const buildOptions = getBuildOptions(options.browserTarget, context);
 
   let pathToManifestFile = join(
     context.root,
-    projectConfig.sourceRoot,
+    getProjectSourceRoot(projectConfig),
     'assets/module-federation.manifest.json'
   );
 

--- a/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -1,7 +1,3 @@
-import { ModuleFederationStaticServerSchema } from './schema';
-import { ModuleFederationDevServerOptions } from '../module-federation-dev-server/schema';
-import { ExecutorContext } from 'nx/src/config/misc-interfaces';
-import { basename, extname, join } from 'path';
 import {
   logger,
   parseTargetString,
@@ -9,24 +5,29 @@ import {
   Target,
   workspaceRoot,
 } from '@nx/devkit';
-import { cpSync, existsSync, readFileSync, rmSync } from 'fs';
+import {
+  combineAsyncIterables,
+  createAsyncIterable,
+} from '@nx/devkit/src/utils/async-iterable';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { buildStaticRemotes } from '@nx/module-federation/src/executors/utils';
 import {
   getModuleFederationConfig,
   getRemotes,
   parseStaticRemotesConfig,
   StaticRemotesConfig,
 } from '@nx/module-federation/src/utils';
-import { buildStaticRemotes } from '@nx/module-federation/src/executors/utils';
-import { fork } from 'child_process';
-import type { WebpackExecutorOptions } from '@nx/webpack';
-import * as process from 'node:process';
 import fileServerExecutor from '@nx/web/src/executors/file-server/file-server.impl';
-import type { Express } from 'express';
-import {
-  combineAsyncIterables,
-  createAsyncIterable,
-} from '@nx/devkit/src/utils/async-iterable';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import type { WebpackExecutorOptions } from '@nx/webpack';
+import { fork } from 'child_process';
+import type { Express } from 'express';
+import { cpSync, existsSync, readFileSync, rmSync } from 'fs';
+import * as process from 'node:process';
+import { ExecutorContext } from 'nx/src/config/misc-interfaces';
+import { basename, extname, join } from 'path';
+import { ModuleFederationDevServerOptions } from '../module-federation-dev-server/schema';
+import { ModuleFederationStaticServerSchema } from './schema';
 
 function getBuildAndServeOptionsFromServeTarget(
   serveTarget: string,
@@ -47,7 +48,7 @@ function getBuildAndServeOptionsFromServeTarget(
 
   let pathToManifestFile = join(
     context.root,
-    context.projectGraph.nodes[context.projectName].data.sourceRoot,
+    getProjectSourceRoot(context.projectGraph.nodes[context.projectName].data),
     'assets/module-federation.manifest.json'
   );
   if (serveOptions.pathToManifestFile) {

--- a/packages/react/src/generators/component-story/component-story.ts
+++ b/packages/react/src/generators/component-story/component-story.ts
@@ -6,13 +6,14 @@ import {
   normalizePath,
   Tree,
 } from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type * as ts from 'typescript';
 import {
   findExportDeclarationsForJsx,
   getComponentNode,
 } from '../../utils/ast-utils';
 import { getComponentPropDefaults } from '../../utils/component-props';
-import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
 
 let tsModule: typeof import('typescript');
 
@@ -33,7 +34,7 @@ export function createComponentStoriesFile(
   const proj = getProjects(host).get(project);
 
   const componentFilePath = joinPathFragments(
-    proj.sourceRoot ?? proj.root,
+    getProjectSourceRoot(proj, host),
     componentPath
   );
 

--- a/packages/react/src/generators/component-test/component-test.ts
+++ b/packages/react/src/generators/component-test/component-test.ts
@@ -5,6 +5,8 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { basename, dirname, extname, join, relative } from 'path';
 import {
   findExportDeclarationsForJsx,
@@ -13,7 +15,6 @@ import {
 import { getComponentPropDefaults } from '../../utils/component-props';
 import { nxVersion } from '../../utils/versions';
 import { ComponentTestSchema } from './schema';
-import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
 
 let tsModule: typeof import('typescript');
 
@@ -30,17 +31,13 @@ export async function componentTestGenerator(
   options.componentPath = options.componentPath.replace(/\\/g, '/');
 
   const projectConfig = readProjectConfiguration(tree, options.project);
+  const sourceRoot = getProjectSourceRoot(projectConfig, tree);
 
-  const normalizedPath = options.componentPath.startsWith(
-    projectConfig.sourceRoot
-  )
-    ? relative(projectConfig.sourceRoot, options.componentPath)
+  const normalizedPath = options.componentPath.startsWith(sourceRoot)
+    ? relative(sourceRoot, options.componentPath)
     : options.componentPath;
 
-  const componentPath = joinPathFragments(
-    projectConfig.sourceRoot,
-    normalizedPath
-  );
+  const componentPath = joinPathFragments(sourceRoot, normalizedPath);
 
   if (tree.exists(componentPath)) {
     generateSpecsForComponents(tree, componentPath);

--- a/packages/react/src/generators/cypress-component-configuration/lib/add-files.ts
+++ b/packages/react/src/generators/cypress-component-configuration/lib/add-files.ts
@@ -7,6 +7,7 @@ import {
   Tree,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nxVersion } from 'nx/src/utils/versions';
 import { getActualBundler, isComponent } from '../../../utils/ct-utils';
 import { componentTestGenerator } from '../../component-test/component-test';
@@ -71,7 +72,8 @@ export async function addFiles(
 
   if (options.generateTests) {
     const filePaths = [];
-    visitNotIgnoredFiles(tree, projectConfig.sourceRoot, (filePath) => {
+    const sourceRoot = getProjectSourceRoot(projectConfig, tree);
+    visitNotIgnoredFiles(tree, sourceRoot, (filePath) => {
       if (isComponent(tree, filePath)) {
         filePaths.push(filePath);
       }

--- a/packages/react/src/generators/host/lib/add-module-federation-files.ts
+++ b/packages/react/src/generators/host/lib/add-module-federation-files.ts
@@ -3,15 +3,16 @@ import {
   generateFiles,
   joinPathFragments,
   names,
-  readProjectConfiguration,
   offsetFromRoot,
+  readProjectConfiguration,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { maybeJs } from '../../../utils/maybe-js';
-import { NormalizedSchema } from '../schema';
 import {
   createNxRspackPluginOptions,
   getDefaultTemplateVariables,
 } from '../../application/lib/create-application-files';
+import { NormalizedSchema } from '../schema';
 
 export function addModuleFederationFiles(
   host: Tree,
@@ -53,7 +54,7 @@ export function addModuleFederationFiles(
 
   const projectConfig = readProjectConfiguration(host, options.projectName);
   const pathToMFManifest = joinPathFragments(
-    projectConfig.sourceRoot,
+    getProjectSourceRoot(projectConfig, host),
     'assets/module-federation.manifest.json'
   );
 

--- a/packages/react/src/generators/library/lib/normalize-options.ts
+++ b/packages/react/src/generators/library/lib/normalize-options.ts
@@ -102,11 +102,7 @@ export async function normalizeOptions(
       );
     }
 
-    const appSourceRoot = getProjectSourceRoot(
-      host,
-      appProjectConfig.sourceRoot,
-      appProjectConfig.root
-    );
+    const appSourceRoot = getProjectSourceRoot(appProjectConfig, host);
 
     normalized.appMain =
       appProjectConfig.targets.build?.options?.main ??

--- a/packages/react/src/generators/redux/redux.ts
+++ b/packages/react/src/generators/redux/redux.ts
@@ -1,11 +1,3 @@
-import * as path from 'path';
-import {
-  addImport,
-  addReduxStoreToMain,
-  updateReduxStore,
-} from '../../utils/ast-utils';
-import { reactReduxVersion, reduxjsToolkitVersion } from '../../utils/versions';
-import { NormalizedSchema, Schema } from './schema';
 import {
   addDependenciesToPackageJson,
   applyChangesToString,
@@ -17,10 +9,21 @@ import {
   readJson,
   Tree,
 } from '@nx/devkit';
+import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { getRootTsConfigPathInTree } from '@nx/js';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
-import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
-import { getProjectType } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import {
+  getProjectSourceRoot,
+  getProjectType,
+} from '@nx/js/src/utils/typescript/ts-solution-setup';
+import * as path from 'path';
+import {
+  addImport,
+  addReduxStoreToMain,
+  updateReduxStore,
+} from '../../utils/ast-utils';
+import { reactReduxVersion, reduxjsToolkitVersion } from '../../utils/versions';
+import { NormalizedSchema, Schema } from './schema';
 
 let tsModule: typeof import('typescript');
 
@@ -193,7 +196,7 @@ async function normalizeOptions(
         `Expected ${options.appProject} to be an application but got ${appConfig.projectType}`
       );
     }
-    appProjectSourcePath = appConfig.sourceRoot;
+    appProjectSourcePath = getProjectSourceRoot(appConfig, host);
     appMainFilePath = path.join(
       appProjectSourcePath,
       options.js ? 'main.js' : 'main.tsx'

--- a/packages/react/src/generators/remote/lib/update-host-with-remote.ts
+++ b/packages/react/src/generators/remote/lib/update-host-with-remote.ts
@@ -6,11 +6,12 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import {
   addRemoteRoute,
   addRemoteToConfig,
 } from '../../../module-federation/ast-utils';
-import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
 
 let tsModule: typeof import('typescript');
 
@@ -37,7 +38,10 @@ export function updateHostWithRemote(
     );
   }
 
-  const appComponentPath = findAppComponentPath(host, hostConfig.sourceRoot);
+  const appComponentPath = findAppComponentPath(
+    host,
+    getProjectSourceRoot(hostConfig, host)
+  );
 
   if (host.exists(moduleFederationConfigPath)) {
     // find the host project path

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -13,29 +12,31 @@ import {
   Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { join } from 'path';
 
-import { normalizeOptions } from '../application/lib/normalize-options';
-import applicationGenerator from '../application/application';
-import { NormalizedSchema } from '../application/schema';
-import { updateHostWithRemote } from './lib/update-host-with-remote';
+import { ensureRootProjectName } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import { isValidVariable } from '@nx/js';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { updateModuleFederationProject } from '../../rules/update-module-federation-project';
-import { Schema } from './schema';
-import setupSsrGenerator from '../setup-ssr/setup-ssr';
-import { setupSsrForRemote } from './lib/setup-ssr-for-remote';
-import { setupTspathForRemote } from './lib/setup-tspath-for-remote';
-import { addRemoteToDynamicHost } from './lib/add-remote-to-dynamic-host';
 import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs';
 import { maybeJs } from '../../utils/maybe-js';
-import { isValidVariable } from '@nx/js';
 import {
   moduleFederationEnhancedVersion,
   nxVersion,
 } from '../../utils/versions';
-import { ensureRootProjectName } from '@nx/devkit/src/generators/project-name-and-root-utils';
+import applicationGenerator from '../application/application';
 import {
   createNxRspackPluginOptions,
   getDefaultTemplateVariables,
 } from '../application/lib/create-application-files';
+import { normalizeOptions } from '../application/lib/normalize-options';
+import { NormalizedSchema } from '../application/schema';
+import setupSsrGenerator from '../setup-ssr/setup-ssr';
+import { addRemoteToDynamicHost } from './lib/add-remote-to-dynamic-host';
+import { setupSsrForRemote } from './lib/setup-ssr-for-remote';
+import { setupTspathForRemote } from './lib/setup-tspath-for-remote';
+import { updateHostWithRemote } from './lib/update-host-with-remote';
+import { Schema } from './schema';
 
 export function addModuleFederationFiles(
   host: Tree,
@@ -231,7 +232,7 @@ export async function remoteGenerator(host: Tree, schema: Schema) {
   if (options.host && options.dynamic) {
     const hostConfig = readProjectConfiguration(host, schema.host);
     const pathToMFManifest = joinPathFragments(
-      hostConfig.sourceRoot,
+      getProjectSourceRoot(hostConfig, host),
       'assets/module-federation.manifest.json'
     );
     addRemoteToDynamicHost(

--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -1,4 +1,3 @@
-import type * as ts from 'typescript';
 import {
   addDependenciesToPackageJson,
   applyChangesToString,
@@ -6,7 +5,6 @@ import {
   formatFiles,
   generateFiles,
   joinPathFragments,
-  type ProjectGraph,
   readCachedProjectGraph,
   readNxJson,
   readProjectConfiguration,
@@ -14,8 +12,12 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import type * as ts from 'typescript';
 
-import type { Schema } from './schema';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { join } from 'path';
+import { addStaticRouter } from '../../utils/ast-utils';
 import {
   corsVersion,
   expressVersion,
@@ -23,9 +25,7 @@ import {
   typesCorsVersion,
   typesExpressVersion,
 } from '../../utils/versions';
-import { addStaticRouter } from '../../utils/ast-utils';
-import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
-import { join } from 'path';
+import type { Schema } from './schema';
 
 let tsModule: typeof import('typescript');
 
@@ -81,7 +81,7 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
     return {
       importPath,
       filePath: joinPathFragments(
-        projectConfig.sourceRoot || projectConfig.root,
+        getProjectSourceRoot(projectConfig, tree),
         `${importPath}.tsx`
       ),
     };

--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -1,25 +1,23 @@
-import componentStoryGenerator from '../component-story/component-story';
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  ProjectConfiguration,
+  Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import {
+  getProjectSourceRoot,
+  getProjectType,
+} from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { minimatch } from 'minimatch';
+import { basename, join } from 'path';
 import {
   findExportDeclarationsForJsx,
   getComponentNode,
 } from '../../utils/ast-utils';
-import {
-  addDependenciesToPackageJson,
-  ensurePackage,
-  formatFiles,
-  GeneratorCallback,
-  getProjects,
-  joinPathFragments,
-  ProjectConfiguration,
-  runTasksInSerial,
-  Tree,
-  visitNotIgnoredFiles,
-} from '@nx/devkit';
-import { basename, join } from 'path';
-import { minimatch } from 'minimatch';
-import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
-import { nxVersion } from '../../utils/versions';
-import { getProjectType } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import componentStoryGenerator from '../component-story/component-story';
 
 let tsModule: typeof import('typescript');
 
@@ -51,7 +49,7 @@ export async function projectRootPath(
   } else {
     projectDir = '.';
   }
-  return joinPathFragments(config.sourceRoot ?? config.root, projectDir);
+  return joinPathFragments(getProjectSourceRoot(config, tree), projectDir);
 }
 
 export function containsComponentDeclaration(

--- a/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
+++ b/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
@@ -12,11 +12,8 @@ export function addTsconfigEntryPoints(
   tree: Tree,
   options: RemixLibraryOptions
 ) {
-  const { root: projectRoot, sourceRoot } = readProjectConfiguration(
-    tree,
-    options.projectName
-  );
-  const projectSourceRoot = getProjectSourceRoot(tree, sourceRoot, projectRoot);
+  const project = readProjectConfiguration(tree, options.projectName);
+  const projectSourceRoot = getProjectSourceRoot(project, tree);
   const serverFilePath = joinPathFragments(projectSourceRoot, 'server.ts');
 
   tree.write(

--- a/packages/rspack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/rspack/src/executors/dev-server/dev-server.impl.ts
@@ -5,13 +5,14 @@ import {
   readTargetOptions,
 } from '@nx/devkit';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { Configuration } from '@rspack/core';
 import { RspackDevServer } from '@rspack/dev-server';
 import { createCompiler, isMultiCompiler } from '../../utils/create-compiler';
 import { isMode } from '../../utils/mode-utils';
+import { normalizeOptions } from '../rspack/lib/normalize-options';
 import { getDevServerOptions } from './lib/get-dev-server-config';
 import { DevServerExecutorSchema } from './schema';
-import { normalizeOptions } from '../rspack/lib/normalize-options';
 
 type DevServer = Configuration['devServer'];
 export default async function* runExecutor(
@@ -35,7 +36,7 @@ export default async function* runExecutor(
   process.env.NX_BUILD_TARGET = options.buildTarget;
 
   const metadata = context.projectsConfigurations.projects[context.projectName];
-  const sourceRoot = metadata.sourceRoot;
+  const sourceRoot = getProjectSourceRoot(metadata);
   const normalizedBuildOptions = normalizeOptions(
     buildOptions,
     context.root,

--- a/packages/rspack/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -3,14 +3,15 @@ import {
   combineAsyncIterables,
   createAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
 import fileServerExecutor from '@nx/web/src/executors/file-server/file-server.impl';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
 import { existsSync } from 'fs';
 import { extname, join } from 'path';
-import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
 import devServerExecutor from '../dev-server/dev-server.impl';
+import { normalizeOptions, startRemotes } from './lib';
 import { ModuleFederationDevServerOptions } from './schema';
-import { getBuildOptions, normalizeOptions, startRemotes } from './lib';
 
 export default async function* moduleFederationDevServer(
   schema: ModuleFederationDevServerOptions,
@@ -32,11 +33,10 @@ export default async function* moduleFederationDevServer(
     : devServerExecutor(options, context);
 
   const p = context.projectsConfigurations.projects[context.projectName];
-  const buildOptions = getBuildOptions(options.buildTarget, context);
 
   let pathToManifestFile = join(
     context.root,
-    p.sourceRoot,
+    getProjectSourceRoot(p),
     'assets/module-federation.manifest.json'
   );
   if (options.pathToManifestFile) {

--- a/packages/rspack/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -1,15 +1,16 @@
 import { ExecutorContext, logger } from '@nx/devkit';
-import { extname, join } from 'path';
-import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
-import ssrDevServerExecutor from '../ssr-dev-server/ssr-dev-server.impl';
 import {
   combineAsyncIterables,
   createAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
-import { existsSync } from 'fs';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { startRemoteIterators } from '@nx/module-federation/src/executors/utils';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import { existsSync } from 'fs';
+import { extname, join } from 'path';
+import ssrDevServerExecutor from '../ssr-dev-server/ssr-dev-server.impl';
+import { normalizeOptions, startRemotes } from './lib';
 import { ModuleFederationSsrDevServerOptions } from './schema';
-import { getBuildOptions, normalizeOptions, startRemotes } from './lib';
 
 export default async function* moduleFederationSsrDevServer(
   ssrDevServerOptions: ModuleFederationSsrDevServerOptions,
@@ -20,11 +21,10 @@ export default async function* moduleFederationSsrDevServer(
   const iter = ssrDevServerExecutor(options, context);
   const projectConfig =
     context.projectsConfigurations.projects[context.projectName];
-  const buildOptions = getBuildOptions(options.browserTarget, context);
 
   let pathToManifestFile = join(
     context.root,
-    projectConfig.sourceRoot,
+    getProjectSourceRoot(projectConfig),
     'assets/module-federation.manifest.json'
   );
 

--- a/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -9,6 +9,14 @@ import {
   combineAsyncIterables,
   createAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { buildStaticRemotes } from '@nx/module-federation/src/executors/utils';
+import {
+  getModuleFederationConfig,
+  getRemotes,
+  parseStaticRemotesConfig,
+  StaticRemotesConfig,
+} from '@nx/module-federation/src/utils';
 import fileServerExecutor from '@nx/web/src/executors/file-server/file-server.impl';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
 import { fork } from 'child_process';
@@ -16,13 +24,6 @@ import type { Express } from 'express';
 import { cpSync, existsSync, readFileSync, rmSync } from 'fs';
 import { ExecutorContext } from 'nx/src/config/misc-interfaces';
 import { basename, extname, join } from 'path';
-import {
-  getModuleFederationConfig,
-  getRemotes,
-  parseStaticRemotesConfig,
-  StaticRemotesConfig,
-} from '@nx/module-federation/src/utils';
-import { buildStaticRemotes } from '@nx/module-federation/src/executors/utils';
 import { ModuleFederationDevServerOptions } from '../module-federation-dev-server/schema';
 import type { RspackExecutorSchema } from '../rspack/schema';
 import { ModuleFederationStaticServerSchema } from './schema';
@@ -46,7 +47,7 @@ function getBuildAndServeOptionsFromServeTarget(
 
   let pathToManifestFile = join(
     context.root,
-    context.projectGraph.nodes[context.projectName].data.sourceRoot,
+    getProjectSourceRoot(context.projectGraph.nodes[context.projectName].data),
     'assets/module-federation.manifest.json'
   );
   if (serveOptions.pathToManifestFile) {

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -1,13 +1,14 @@
 import { ExecutorContext, logger } from '@nx/devkit';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
 import { printDiagnostics, runTypeCheck } from '@nx/js';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { Compiler, MultiCompiler, MultiStats, Stats } from '@rspack/core';
 import { rmSync } from 'fs';
+import { join, resolve } from 'path';
 import { createCompiler, isMultiCompiler } from '../../utils/create-compiler';
 import { isMode } from '../../utils/mode-utils';
-import { RspackExecutorSchema } from './schema';
 import { normalizeOptions } from './lib/normalize-options';
-import { join, resolve } from 'path';
+import { RspackExecutorSchema } from './schema';
 
 export default async function* runExecutor(
   options: RspackExecutorSchema,
@@ -17,7 +18,7 @@ export default async function* runExecutor(
   options.target ??= 'web';
 
   const metadata = context.projectsConfigurations.projects[context.projectName];
-  const sourceRoot = metadata.sourceRoot;
+  const sourceRoot = getProjectSourceRoot(metadata);
 
   const normalizedOptions = normalizeOptions(
     options,

--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -1,25 +1,26 @@
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import {
-  type RspackPluginInstance,
   type Configuration,
+  type RspackPluginInstance,
   type RuleSetRule,
-  LightningCssMinimizerRspackPlugin,
-  DefinePlugin,
   CssExtractRspackPlugin,
+  DefinePlugin,
   EnvironmentPlugin,
-  RspackOptionsNormalized,
   HtmlRspackPlugin,
+  LightningCssMinimizerRspackPlugin,
+  RspackOptionsNormalized,
 } from '@rspack/core';
-import { WriteIndexHtmlPlugin } from '../write-index-html-plugin';
-import { instantiateScriptPlugins } from './instantiate-script-plugins';
 import { join, resolve } from 'path';
+import { WriteIndexHtmlPlugin } from '../write-index-html-plugin';
 import { getOutputHashFormat } from './hash-format';
-import { normalizeExtraEntryPoints } from './normalize-entry';
+import { instantiateScriptPlugins } from './instantiate-script-plugins';
 import {
   getCommonLoadersForCssModules,
   getCommonLoadersForGlobalCss,
   getCommonLoadersForGlobalStyle,
 } from './loaders/stylesheet-loaders';
 import { NormalizedNxAppRspackPluginOptions } from './models';
+import { normalizeExtraEntryPoints } from './normalize-entry';
 
 export function applyWebConfig(
   options: NormalizedNxAppRspackPluginOptions,
@@ -43,7 +44,9 @@ export function applyWebConfig(
     ? join(options.root, options.index)
     : join(
         options.root,
-        options.projectGraph.nodes[options.projectName].data.sourceRoot,
+        getProjectSourceRoot(
+          options.projectGraph.nodes[options.projectName].data
+        ),
         'index.html'
       );
   options.styles ??= [];

--- a/packages/rspack/src/plugins/utils/plugins/normalize-options.ts
+++ b/packages/rspack/src/plugins/utils/plugins/normalize-options.ts
@@ -1,16 +1,17 @@
-import { basename, dirname, join, parse, relative, resolve } from 'path';
-import { statSync } from 'fs';
 import {
   normalizePath,
   parseTargetString,
   readCachedProjectGraph,
   workspaceRoot,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { statSync } from 'fs';
+import { basename, dirname, join, parse, relative, resolve } from 'path';
 import {
   AssetGlobPattern,
   FileReplacement,
-  NxAppRspackPluginOptions,
   NormalizedNxAppRspackPluginOptions,
+  NxAppRspackPluginOptions,
 } from '../models';
 
 export function normalizeOptions(
@@ -74,7 +75,7 @@ export function normalizeOptions(
     );
   }
 
-  const sourceRoot = projectNode.data.sourceRoot ?? projectNode.data.root;
+  const sourceRoot = getProjectSourceRoot(projectNode.data);
 
   if (!combinedPluginAndMaybeExecutorOptions.main) {
     throw new Error(

--- a/packages/rspack/src/utils/config.ts
+++ b/packages/rspack/src/utils/config.ts
@@ -4,9 +4,9 @@ import {
   readProjectsConfigurationFromProjectGraph,
   workspaceRoot,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { Configuration } from '@rspack/core';
 import { readNxJson } from 'nx/src/config/configuration';
-
 import { NormalizedRspackExecutorSchema } from '../executors/rspack/schema';
 
 export const nxRspackComposablePlugin = 'nxRspackComposablePlugin';
@@ -93,7 +93,7 @@ function ensureNxRspackExecutionContext(ctx: NxRspackExecutionContext): void {
   ctx.options ??= {
     root: workspaceRoot,
     projectRoot: projectNode.data.root,
-    sourceRoot: projectNode.data.sourceRoot ?? projectNode.data.root,
+    sourceRoot: getProjectSourceRoot(projectNode.data),
     // These aren't actually needed since NxRspackPlugin and withNx both support them being undefined.
     assets: undefined,
     outputFileName: undefined,

--- a/packages/vue/src/generators/library/lib/normalize-options.ts
+++ b/packages/vue/src/generators/library/lib/normalize-options.ts
@@ -93,11 +93,7 @@ export async function normalizeOptions(
       );
     }
 
-    const appSourceRoot = getProjectSourceRoot(
-      host,
-      appProjectConfig.sourceRoot,
-      appProjectConfig.root
-    );
+    const appSourceRoot = getProjectSourceRoot(appProjectConfig, host);
 
     try {
       normalized.appMain = appProjectConfig.targets.build.options.main;

--- a/packages/vue/src/generators/stories/lib/component-story.ts
+++ b/packages/vue/src/generators/stories/lib/component-story.ts
@@ -1,11 +1,12 @@
 import {
   generateFiles,
-  getProjects,
   joinPathFragments,
   normalizePath,
+  readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { StorybookStoriesSchema } from '../stories';
 import {
   camelCase,
@@ -23,8 +24,8 @@ export function createComponentStories(
   if (!tsModule) {
     tsModule = ensureTypescript();
   }
-  const proj = getProjects(host).get(project);
-  const sourceRoot = proj.sourceRoot;
+  const proj = readProjectConfiguration(host, project);
+  const sourceRoot = getProjectSourceRoot(proj);
 
   const componentFilePath = joinPathFragments(sourceRoot, componentPath);
 

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -5,7 +5,9 @@ import {
   targetToTargetString,
 } from '@nx/devkit';
 import { eachValueFrom } from '@nx/devkit/src/utils/rxjs-for-await';
-import type { Configuration, Stats } from 'webpack';
+import { getRootTsConfigPath } from '@nx/js';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { resolve } from 'path';
 import { from, of } from 'rxjs';
 import {
   bufferCount,
@@ -14,22 +16,16 @@ import {
   switchMap,
   tap,
 } from 'rxjs/operators';
-import { resolve } from 'path';
-import { runWebpack } from './lib/run-webpack';
+import type { Configuration, Stats } from 'webpack';
+import { isNxWebpackComposablePlugin } from '../../utils/config';
 import { deleteOutputDir } from '../../utils/fs';
 import { resolveUserDefinedWebpackConfig } from '../../utils/webpack/resolve-user-defined-webpack-config';
+import { normalizeOptions } from './lib/normalize-options';
+import { runWebpack } from './lib/run-webpack';
 import type {
   NormalizedWebpackExecutorOptions,
   WebpackExecutorOptions,
 } from './schema';
-import { normalizeOptions } from './lib/normalize-options';
-import {
-  composePluginsSync,
-  isNxWebpackComposablePlugin,
-} from '../../utils/config';
-import { withNx } from '../../utils/with-nx';
-import { getRootTsConfigPath } from '@nx/js';
-import { withWeb } from '../../utils/with-web';
 
 async function getWebpackConfigs(
   options: NormalizedWebpackExecutorOptions,
@@ -94,7 +90,7 @@ export async function* webpackExecutor(
   process.env['NODE_ENV'] ||= 'production';
 
   const metadata = context.projectsConfigurations.projects[context.projectName];
-  const sourceRoot = metadata.sourceRoot;
+  const sourceRoot = getProjectSourceRoot(metadata);
   const options = normalizeOptions(
     _options,
     context.root,

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/normalize-options.ts
@@ -1,11 +1,12 @@
-import { basename, dirname, join, parse, relative, resolve } from 'path';
-import { existsSync, statSync } from 'fs';
 import {
   normalizePath,
   parseTargetString,
   readCachedProjectGraph,
   workspaceRoot,
 } from '@nx/devkit';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { statSync } from 'fs';
+import { basename, dirname, join, parse, relative, resolve } from 'path';
 import {
   AssetGlobPattern,
   FileReplacement,
@@ -74,11 +75,7 @@ export function normalizeOptions(
     );
   }
 
-  const sourceRoot =
-    projectNode.data.sourceRoot ??
-    (existsSync(join(workspaceRoot, projectNode.data.root, 'src'))
-      ? join(projectNode.data.root, 'src')
-      : projectNode.data.root);
+  const sourceRoot = getProjectSourceRoot(projectNode.data);
 
   if (!combinedPluginAndMaybeExecutorOptions.main) {
     throw new Error(

--- a/packages/webpack/src/utils/config.ts
+++ b/packages/webpack/src/utils/config.ts
@@ -4,10 +4,10 @@ import {
   readProjectsConfigurationFromProjectGraph,
   workspaceRoot,
 } from '@nx/devkit';
-import { Configuration } from 'webpack';
-
-import { NormalizedWebpackExecutorOptions } from '../executors/webpack/schema';
+import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { readNxJson } from 'nx/src/config/configuration';
+import { Configuration } from 'webpack';
+import { NormalizedWebpackExecutorOptions } from '../executors/webpack/schema';
 
 export const nxWebpackComposablePlugin = 'nxWebpackComposablePlugin';
 
@@ -93,7 +93,7 @@ function ensureNxWebpackExecutionContext(ctx: NxWebpackExecutionContext): void {
   ctx.options ??= {
     root: workspaceRoot,
     projectRoot: projectNode.data.root,
-    sourceRoot: projectNode.data.sourceRoot ?? projectNode.data.root,
+    sourceRoot: getProjectSourceRoot(projectNode.data),
     // These aren't actually needed since NxWebpackPlugin and withNx both support them being undefined.
     assets: undefined,
     outputPath: undefined,

--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
@@ -6,6 +6,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { NormalizedSchema } from '../schema';
+import { getProjectSourceRoot } from '../../utils/project-config';
 
 export function createProjectConfigurationInNewDestination(
   tree: Tree,
@@ -75,10 +76,11 @@ export function createProjectConfigurationInNewDestination(
 
   // Original sourceRoot is typically 'src' or 'app', but it could be any folder.
   // Make sure it is updated to be under the new destination.
-  if (isRootProject && projectConfig.sourceRoot) {
+  const sourceRoot = getProjectSourceRoot(projectConfig, tree);
+  if (isRootProject && sourceRoot) {
     newProject.sourceRoot = joinPathFragments(
       schema.relativeToRootDestination,
-      projectConfig.sourceRoot
+      sourceRoot
     );
   }
 

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -22,6 +22,7 @@ import { ensureTypescript } from '../../../utilities/typescript';
 import { NormalizedSchema } from '../schema';
 import { normalizePathSlashes } from './utils';
 import { isUsingTsSolutionSetup } from '../../../utilities/typescript/ts-solution-setup';
+import { getProjectSourceRoot } from '../../utils/project-config';
 
 let tsModule: typeof import('typescript');
 
@@ -56,8 +57,7 @@ export function updateImports(
   let serverEntryPointImportPath: string;
   if (tree.exists(tsConfigPath)) {
     tsConfig = readJson(tree, tsConfigPath);
-    const sourceRoot =
-      project.sourceRoot ?? joinPathFragments(project.root, 'src');
+    const sourceRoot = getProjectSourceRoot(project, tree);
 
     mainEntryPointImportPath = Object.keys(
       tsConfig.compilerOptions?.paths ?? {}

--- a/packages/workspace/src/generators/utils/project-config.ts
+++ b/packages/workspace/src/generators/utils/project-config.ts
@@ -4,17 +4,25 @@ import {
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { FsTree } from 'nx/src/generators/tree';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 export function getProjectSourceRoot(
   project: ProjectConfiguration,
   tree?: Tree
 ): string {
-  tree ??= new FsTree(workspaceRoot, false);
+  if (tree) {
+    return (
+      project.sourceRoot ??
+      (tree.exists(joinPathFragments(project.root, 'src'))
+        ? joinPathFragments(project.root, 'src')
+        : project.root)
+    );
+  }
 
   return (
     project.sourceRoot ??
-    (tree.exists(joinPathFragments(project.root, 'src'))
+    (existsSync(join(workspaceRoot, project.root, 'src'))
       ? joinPathFragments(project.root, 'src')
       : project.root)
   );

--- a/packages/workspace/src/generators/utils/project-config.ts
+++ b/packages/workspace/src/generators/utils/project-config.ts
@@ -1,0 +1,21 @@
+import {
+  joinPathFragments,
+  workspaceRoot,
+  type ProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { FsTree } from 'nx/src/generators/tree';
+
+export function getProjectSourceRoot(
+  project: ProjectConfiguration,
+  tree?: Tree
+): string {
+  tree ??= new FsTree(workspaceRoot, false);
+
+  return (
+    project.sourceRoot ??
+    (tree.exists(joinPathFragments(project.root, 'src'))
+      ? joinPathFragments(project.root, 'src')
+      : project.root)
+  );
+}


### PR DESCRIPTION
## Current Behavior

The `sourceRoot` project configuration property is optional. Several places in the codebase do not properly handle this, which can result in issues.

## Expected Behavior

A missing `sourceRoot` project configuration property should be handled correctly throughout the codebase.

## Related Issue(s)

Fixes #30638 
