### PR TITLE
fix(bundling): ensure lockfile creation doesnt error with bun

### DIFF
--- a/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
+++ b/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
@@ -25,17 +25,30 @@ export default async function pruneLockfileExecutor(
   logger.log('Pruning lockfile...');
   const outputDirectory = getOutputDir(schema, context);
   const packageJson = getPackageJson(schema, context);
-  const { lockfileName, lockFile } = createPrunedLockfile(
-    packageJson,
-    context.projectGraph
-  );
-  const lockfileOutputPath = join(outputDirectory, lockfileName);
-  writeFileSync(lockfileOutputPath, lockFile);
-  writeFileSync(
-    join(outputDirectory, 'package.json'),
-    JSON.stringify(packageJson, null, 2)
-  );
-  logger.log(`Lockfile pruned: ${lockfileOutputPath}`);
+  const packageManager = detectPackageManager(workspaceRoot);
+
+  if (packageManager === 'bun') {
+    logger.warn(
+      'Bun lockfile generation is not supported. Only package.json will be generated. Run "bun install" in the output directory if needed.'
+    );
+    writeFileSync(
+      join(outputDirectory, 'package.json'),
+      JSON.stringify(packageJson, null, 2)
+    );
+  } else {
+    const { lockfileName, lockFile } = createPrunedLockfile(
+      packageJson,
+      context.projectGraph
+    );
+    const lockfileOutputPath = join(outputDirectory, lockfileName);
+    writeFileSync(lockfileOutputPath, lockFile);
+    writeFileSync(
+      join(outputDirectory, 'package.json'),
+      JSON.stringify(packageJson, null, 2)
+    );
+    logger.log(`Lockfile pruned: ${lockfileOutputPath}`);
+  }
+
   return {
     success: true,
   };

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -94,18 +94,25 @@ export default async function buildExecutor(
 
   if (options.generateLockfile) {
     const packageManager = detectPackageManager(context.root);
-    const lockFile = createLockFile(
-      builtPackageJson,
-      context.projectGraph,
-      packageManager
-    );
-    writeFileSync(
-      `${options.outputPath}/${getLockFileName(packageManager)}`,
-      lockFile,
-      {
-        encoding: 'utf-8',
-      }
-    );
+
+    if (packageManager === 'bun') {
+      logger.warn(
+        'Bun lockfile generation is not supported. The generated package.json will not include a lockfile. Run "bun install" in the output directory after deployment if needed.'
+      );
+    } else {
+      const lockFile = createLockFile(
+        builtPackageJson,
+        context.projectGraph,
+        packageManager
+      );
+      writeFileSync(
+        `${options.outputPath}/${getLockFileName(packageManager)}`,
+        lockFile,
+        {
+          encoding: 'utf-8',
+        }
+      );
+    }
   }
 
   // If output path is different from source path, then copy over the config and public files.

--- a/packages/nx/src/plugins/js/lock-file/lock-file.ts
+++ b/packages/nx/src/plugins/js/lock-file/lock-file.ts
@@ -235,6 +235,7 @@ export function createLockFile(
         title:
           "Unable to create bun lock files. Run bun install it's just as quick",
       });
+      return '';
     }
   } catch (e) {
     if (!isPostInstallProcess()) {

--- a/packages/remix/src/executors/build/build.impl.ts
+++ b/packages/remix/src/executors/build/build.impl.ts
@@ -84,18 +84,25 @@ export default async function buildExecutor(
 
   if (options.generateLockfile) {
     const packageManager = detectPackageManager(context.root);
-    const lockFile = createLockFile(
-      packageJson,
-      context.projectGraph,
-      packageManager
-    );
-    writeFileSync(
-      `${options.outputPath}/${getLockFileName(packageManager)}`,
-      lockFile,
-      {
-        encoding: 'utf-8',
-      }
-    );
+
+    if (packageManager === 'bun') {
+      logger.warn(
+        'Bun lockfile generation is not supported. The generated package.json will not include a lockfile. Run "bun install" in the output directory after deployment if needed.'
+      );
+    } else {
+      const lockFile = createLockFile(
+        packageJson,
+        context.projectGraph,
+        packageManager
+      );
+      writeFileSync(
+        `${options.outputPath}/${getLockFileName(packageManager)}`,
+        lockFile,
+        {
+          encoding: 'utf-8',
+        }
+      );
+    }
   }
 
   // If output path is different from source path, then copy over the config and public files.

--- a/packages/rspack/src/plugins/generate-package-json-plugin.ts
+++ b/packages/rspack/src/plugins/generate-package-json-plugin.ts
@@ -77,12 +77,21 @@ export class GeneratePackageJsonPlugin implements RspackPluginInstance {
             new sources.RawSource(serializeJson(packageJson))
           );
           const packageManager = detectPackageManager(this.context.root);
-          compilation.emitAsset(
-            getLockFileName(packageManager),
-            new sources.RawSource(
-              createLockFile(packageJson, this.projectGraph, packageManager)
-            )
-          );
+
+          if (packageManager === 'bun') {
+            compilation
+              .getLogger('GeneratePackageJsonPlugin')
+              .warn(
+                'Bun lockfile generation is not supported. Only package.json will be generated.'
+              );
+          } else {
+            compilation.emitAsset(
+              getLockFileName(packageManager),
+              new sources.RawSource(
+                createLockFile(packageJson, this.projectGraph, packageManager)
+              )
+            );
+          }
         }
       );
     });

--- a/packages/rspack/src/plugins/utils/plugins/generate-package-json-plugin.ts
+++ b/packages/rspack/src/plugins/utils/plugins/generate-package-json-plugin.ts
@@ -80,16 +80,25 @@ export class GeneratePackageJsonPlugin implements RspackPluginInstance {
             new sources.RawSource(serializeJson(packageJson))
           );
           const packageManager = detectPackageManager(this.options.root);
-          compilation.emitAsset(
-            getLockFileName(packageManager),
-            new sources.RawSource(
-              createLockFile(
-                packageJson,
-                this.options.projectGraph,
-                packageManager
+
+          if (packageManager === 'bun') {
+            compilation
+              .getLogger('GeneratePackageJsonPlugin')
+              .warn(
+                'Bun lockfile generation is not supported. Only package.json will be generated.'
+              );
+          } else {
+            compilation.emitAsset(
+              getLockFileName(packageManager),
+              new sources.RawSource(
+                createLockFile(
+                  packageJson,
+                  this.options.projectGraph,
+                  packageManager
+                )
               )
-            )
-          );
+            );
+          }
         }
       );
     });

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -168,18 +168,24 @@ export async function* viteBuildExecutor(
       );
       const packageManager = detectPackageManager(context.root);
 
-      const lockFile = createLockFile(
-        builtPackageJson,
-        context.projectGraph,
-        packageManager
-      );
-      writeFileSync(
-        `${outDirRelativeToWorkspaceRoot}/${getLockFileName(packageManager)}`,
-        lockFile,
-        {
-          encoding: 'utf-8',
-        }
-      );
+      if (packageManager === 'bun') {
+        logger.warn(
+          'Bun lockfile generation is not supported. The generated package.json will not include a lockfile. Run "bun install" in the output directory after deployment if needed.'
+        );
+      } else {
+        const lockFile = createLockFile(
+          builtPackageJson,
+          context.projectGraph,
+          packageManager
+        );
+        writeFileSync(
+          `${outDirRelativeToWorkspaceRoot}/${getLockFileName(packageManager)}`,
+          lockFile,
+          {
+            encoding: 'utf-8',
+          }
+        );
+      }
     }
     // For buildable libs, copy package.json if it exists.
     else if (

--- a/packages/webpack/src/plugins/generate-package-json-plugin.ts
+++ b/packages/webpack/src/plugins/generate-package-json-plugin.ts
@@ -76,16 +76,25 @@ export class GeneratePackageJsonPlugin implements WebpackPluginInstance {
             new sources.RawSource(serializeJson(packageJson))
           );
           const packageManager = detectPackageManager(this.options.root);
-          compilation.emitAsset(
-            getLockFileName(packageManager),
-            new sources.RawSource(
-              createLockFile(
-                packageJson,
-                this.options.projectGraph,
-                packageManager
+
+          if (packageManager === 'bun') {
+            compilation
+              .getLogger('GeneratePackageJsonPlugin')
+              .warn(
+                'Bun lockfile generation is not supported. Only package.json will be generated.'
+              );
+          } else {
+            compilation.emitAsset(
+              getLockFileName(packageManager),
+              new sources.RawSource(
+                createLockFile(
+                  packageJson,
+                  this.options.projectGraph,
+                  packageManager
+                )
               )
-            )
-          );
+            );
+          }
         }
       );
     });


### PR DESCRIPTION
## Current Behavior

  When using bun as a package manager with Nx bundling operations (webpack, vite,
   etc.), lockfile creation was failing with various errors:

  - "Unable to create bun lock files" warnings
  - "argument 'value' must be either string or Buffer" errors
  - External dependencies not being found (next, webpack-cli, etc.)
  - Build failures when using generatePackageJson option
  - Project graph issues with bun text-based lockfiles

  This affected multiple bundlers and scenarios across the Nx ecosystem.

 ## Expected Behavior

  Bun lockfile creation should work seamlessly across all Nx bundling operations
  without errors. Users should be able to use bun with any Nx bundler (webpack,
  vite, esbuild) and the generatePackageJson option without encountering
  lockfile-related build failures.

 ## Related Issues

  Fixes #30568
  Fixes #26640