### PR TITLE
docs(eslint): add comprehensive documentation for ESLint configurations

### DIFF
--- a/docs/generated/packages/eslint-plugin/documents/overview.md
+++ b/docs/generated/packages/eslint-plugin/documents/overview.md
@@ -8,6 +8,8 @@ The `@nx/eslint-plugin` package is an ESLint plugin that contains a collection o
 - [enforce-module-boundaries](#enforce-module-boundaries-rule)
 - [dependency-checks](#dependency-checks-rule)
 
+For detailed information about the available ESLint configurations and their design philosophy, see the [ESLint Configurations guide](/technologies/eslint/eslint-plugin/recipes/configurations).
+
 ## Setting Up ESLint Plugin
 
 ### Installation

--- a/docs/shared/eslint.md
+++ b/docs/shared/eslint.md
@@ -1,15 +1,148 @@
 ---
 title: 'Configuring ESLint with TypeScript'
-description: 'Learn how to properly configure ESLint with TypeScript in your Nx workspace, including setting up type-checking and managing parser options for optimal performance.'
+description: 'Learn how to properly configure ESLint with TypeScript in your Nx workspace, including understanding Nx\'s ESLint configurations, setting up type-checking, and managing parser options for optimal performance.'
 ---
 
 # Configuring ESLint with TypeScript
 
 ESLint is powerful linter by itself, able to work on the syntax of your source files and assert things about based on the rules you configure. It gets even more powerful, however, when TypeScript type-checker is layered on top of it when analyzing TypeScript files, which is something that `@typescript-eslint` allows us to do.
 
-By default, Nx sets up your ESLint configs with performance in mind - we want your linting to run as fast as possible. Because creating the necessary so called TypeScript `Program`s required to create the type-checker behind the scenes is relatively expensive compared to pure syntax analysis, you should only configure the `parserOptions.project` option in your project's `.eslintrc.json` when you need to use rules requiring type information (and you should not configure `parserOptions.project` in your workspace's root `.eslintrc.json`).
+## Nx ESLint Configurations
+
+Nx provides several pre-configured ESLint configurations out of the box. These configs are designed to provide sensible defaults while maintaining flexibility for customization.
+
+### Available Configurations
+
+{% tabs %}
+{% tab label="Flat Config (Default)" %}
+
+```javascript {% fileName="eslint.config.mjs" %}
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {
+      // Your custom rules here
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy .eslintrc" %}
+
+```json
+{
+  "extends": ["plugin:@nx/typescript"],
+  "rules": {
+    // Your custom rules here
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+### Purpose of Nx Configurations
+
+- **`@nx/eslint-plugin` base config**: Provides the foundation for all Nx workspaces, including the Nx ESLint plugin and ignoring the `.nx` cache directory
+- **TypeScript config**: Applies TypeScript-specific rules and parser configuration for `.ts` and `.tsx` files, including recommended rules from `@typescript-eslint`
+- **JavaScript config**: Configures ESLint for `.js` and `.jsx` files with appropriate parser settings and globals for both browser and Node.js environments
+- **React configs**: Adds React-specific rules and JSX support (available as `flat/react`, `flat/react-base`, etc.)
+- **Angular configs**: Provides Angular-specific linting rules for components and templates
+
+### Customizing Rules
+
+You can override any rules provided by the Nx configurations by adding them after the spread configurations:
+
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="eslint.config.mjs" %}
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {
+      // Override or add custom rules
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+      // Add your own custom rules
+      'no-console': 'warn',
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy .eslintrc" %}
+
+```json
+{
+  "extends": ["plugin:@nx/typescript"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
+    "no-console": "warn"
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Performance Considerations
+
+Nx optimizes ESLint performance by default. Only set `parserOptions.project` when using rules that require type information, as TypeScript's type-checker is expensive to run. Never configure `parserOptions.project` in your workspace's root configuration.
 
 Let's take an example of an ESLint config that Nx might generate for you out of the box for a Next.js project called `tuskdesk`:
+
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="apps/tuskdesk/eslint.config.mjs" %}
+import nx from '@nx/eslint-plugin';
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  ...nx.configs['flat/react'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy .eslintrc" %}
 
 ```jsonc {% fileName="apps/tuskdesk/.eslintrc.json" %}
 {
@@ -32,9 +165,43 @@ Let's take an example of an ESLint config that Nx might generate for you out of 
 }
 ```
 
+{% /tab %}
+{% /tabs %}
+
 Here we do _not_ have `parserOptions.project`, which is appropriate because we are not leveraging any rules which require type information.
 
 If we now come in and add a rule which does require type information, for example `@typescript-eslint/await-thenable`, our config will look as follows:
+
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="apps/tuskdesk/eslint.config.mjs" %}
+import nx from '@nx/eslint-plugin';
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  ...nx.configs['flat/react'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      // This rule requires the TypeScript type checker to be present when it runs
+      '@typescript-eslint/await-thenable': 'error',
+    },
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy .eslintrc" %}
 
 ```jsonc {% fileName="apps/tuskdesk/.eslintrc.json" %}
 {
@@ -60,6 +227,9 @@ If we now come in and add a rule which does require type information, for exampl
 }
 ```
 
+{% /tab %}
+{% /tabs %}
+
 Now if we try and run `nx lint tuskdesk` we will get an error
 
 ```{% command="nx lint tuskdesk" %}
@@ -71,11 +241,48 @@ Linting "tuskdesk"...
     TypeScript type-checker to be available, but you do not have
     `parserOptions.project` configured to point at your project
     tsconfig.json files in the relevant TypeScript file "overrides"
-    block of your project ESLint config `apps/tuskdesk/.eslintrc.json`
+    block of your project ESLint config
 
 ```
 
 The solution is to update our config once more, this time to set `parserOptions.project` to appropriately point at our various tsconfig.json files which belong to our project:
+
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="apps/tuskdesk/eslint.config.mjs" %}
+import nx from '@nx/eslint-plugin';
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  ...nx.configs['flat/react'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    // We set parserOptions.project for the project to allow TypeScript to create the type-checker behind the scenes when we run linting
+    languageOptions: {
+      parserOptions: {
+        project: ['tsconfig.*?.json'],
+        tsconfigRootDir: import.meta.dirname
+      },
+    },
+    rules: {
+      '@typescript-eslint/await-thenable': 'error',
+    },
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy .eslintrc" %}
 
 ```jsonc {% fileName="apps/tuskdesk/.eslintrc.json" %}
 {
@@ -103,6 +310,9 @@ The solution is to update our config once more, this time to set `parserOptions.
   ]
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 And that's it! Now any rules requiring type information will run correctly when we run `nx lint tuskdesk`.
 

--- a/docs/shared/packages/eslint/eslint-plugin.md
+++ b/docs/shared/packages/eslint/eslint-plugin.md
@@ -8,6 +8,8 @@ The `@nx/eslint-plugin` package is an ESLint plugin that contains a collection o
 - [enforce-module-boundaries](#enforce-module-boundaries-rule)
 - [dependency-checks](#dependency-checks-rule)
 
+For detailed information about the available ESLint configurations and their design philosophy, see the [ESLint Configurations guide](/technologies/eslint/recipes/eslint).
+
 ## Setting Up ESLint Plugin
 
 ### Installation


### PR DESCRIPTION
update ESLint config guide to use flat configs by default and expand on the content

## Current Behavior

Nx provides base ESLint configurations through @nx/eslint-plugin (e.g., nx.configs["flat/base"], nx.configs["flat/typescript"]), but their purpose and design philosophy are undocumented. Developers must look at source code to understand what these configurations do.

Expand more on the content of the eslint config and how to customize.
Also show flat configs by default since all new workspaces will use
that, and leave legacy rc format as a second tab.

Fixes #29093

🤖 Generated with [Claude Code](https://claude.ai/code)