### PR TITLE
fix(core): resolve package.json for @nx/js to improve plugin detection

### DIFF
--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -239,7 +239,7 @@ export function readTargetsFromPackageJson(
 function hasNxJsPlugin(projectRoot: string, workspaceRoot: string) {
   try {
     // nx-ignore-next-line
-    require.resolve('@nx/js', {
+    require.resolve('@nx/js/package.json', {
       paths: [projectRoot, ...getNxRequirePaths(workspaceRoot), __dirname],
     });
     return true;


### PR DESCRIPTION
This PR updates the package.json inferred target to resolve package.json instead of the entry file.