### PR TITLE
doc: inputs is an array

### DIFF
--- a/docs/shared/reference/inputs.md
+++ b/docs/shared/reference/inputs.md
@@ -29,12 +29,12 @@ Changing source code will often change the behavior of a task. Nx can consider t
 Source file inputs are defined like this:
 
 ```jsonc
-"inputs": {
+"inputs": [
   "{projectRoot}/**/*", // All files in a project
   "{workspaceRoot}/.gitignore", // A specific file in the workspace
   "{projectRoot}/**/*.ts", // A glob pattern for files
   "!{projectRoot}/**/*.spec.ts", // Excluding files matching a glob pattern
-}
+]
 ```
 
 Source file inputs must be prefixed with either `{projectRoot}` or `{workspaceRoot}` to distinguish where the paths should be resolved from. `{workspaceRoot}` should only appear in the beginning of an input but `{projectRoot}` and `{projectName}` can be specified later in the input to interpolate the root or name of the project into the input location.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

Simple doc fix. `inputs` is expecting an array, not an object. Or at least not in the way it's written in the doc
