### PR TITLE
fix(node): reorder addPlugin in normalizeOptions return object

### DIFF
--- a/packages/node/src/generators/application/lib/normalize-options.ts
+++ b/packages/node/src/generators/application/lib/normalize-options.ts
@@ -33,8 +33,9 @@ export async function normalizeOptions(
 
   const nxJson = readNxJson(host);
   const addPlugin =
-    process.env.NX_ADD_PLUGINS !== 'false' &&
-    nxJson.useInferencePlugins !== false;
+    options.addPlugin ??
+    (process.env.NX_ADD_PLUGINS !== 'false' &&
+      nxJson.useInferencePlugins !== false);
 
   const isUsingTsSolutionConfig = isUsingTsSolutionSetup(host);
   const swcJest = options.swcJest ?? isUsingTsSolutionConfig;
@@ -44,8 +45,8 @@ export async function normalizeOptions(
   const useProjectJson = options.useProjectJson ?? !isUsingTsSolutionConfig;
 
   return {
-    addPlugin,
     ...options,
+    addPlugin,
     name: appProjectName,
     frontendProject: options.frontendProject
       ? names(options.frontendProject).fileName


### PR DESCRIPTION
When creating a node app If you want plugins to be added and  `applicationGeneratorInternal` is called instead of `applicationGenerator` the option will be overwritten by the default `false`.
