### PR TITLE
fix(linter): refactor checking if the identifier is a function via tsquery

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "@typescript-eslint/type-utils": "^8.0.0",
     "@typescript-eslint/utils": "^8.0.0",
     "chalk": "^4.1.0",

--- a/packages/eslint-plugin/src/rules/nx-plugin-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/nx-plugin-checks.spec.ts
@@ -1,0 +1,118 @@
+import 'nx/src/internal-testing-utils/mock-fs';
+import { vol } from 'memfs';
+import { checkIfIdentifierIsFunction } from './nx-plugin-checks';
+
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual<any>('@nx/devkit'),
+  workspaceRoot: '/root',
+}));
+
+jest.mock('nx/src/utils/workspace-root', () => ({
+  workspaceRoot: '/root',
+}));
+
+describe('checkIfIdentifierIsFunction', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('should detect export function', () => {
+    const filePath = '/root/src/generator.ts';
+    vol.fromJSON({
+      [filePath]: `
+        export function myGenerator() {
+          console.log('generator');
+        }
+      `,
+    });
+
+    const result = checkIfIdentifierIsFunction(filePath, 'myGenerator');
+    expect(result).toBe(true);
+  });
+
+  it('should detect async export function', () => {
+    const filePath = '/root/src/generator.ts';
+    vol.fromJSON({
+      [filePath]: `
+        export async function myGenerator() {
+          await Promise.resolve();
+        }
+      `,
+    });
+
+    const result = checkIfIdentifierIsFunction(filePath, 'myGenerator');
+    expect(result).toBe(true);
+  });
+
+  it('should detect variable export (arrow function)', () => {
+    const filePath = '/root/src/generator.ts';
+    vol.fromJSON({
+      [filePath]: `
+        export const myGenerator = () => {
+          console.log('generator');
+        };
+      `,
+    });
+
+    const result = checkIfIdentifierIsFunction(filePath, 'myGenerator');
+    expect(result).toBe(true);
+  });
+
+  it('should detect variable export (function expression)', () => {
+    const filePath = '/root/src/generator.ts';
+    vol.fromJSON({
+      [filePath]: `
+        export const myGenerator = function() {
+          console.log('generator');
+        };
+      `,
+    });
+
+    const result = checkIfIdentifierIsFunction(filePath, 'myGenerator');
+    expect(result).toBe(true);
+  });
+
+  it('should detect export default function', () => {
+    const filePath = '/root/src/generator.ts';
+    vol.fromJSON({
+      [filePath]: `
+        export default function myGenerator() {
+          console.log('generator');
+        }
+      `,
+    });
+
+    const result = checkIfIdentifierIsFunction(filePath, 'myGenerator');
+    expect(result).toBe(true);
+  });
+
+  it('should return false for non-function export', () => {
+    const filePath = '/root/src/generator.ts';
+    vol.fromJSON({
+      [filePath]: `
+        export const myGenerator = 'not a function';
+      `,
+    });
+
+    const result = checkIfIdentifierIsFunction(filePath, 'myGenerator');
+    expect(result).toBe(false);
+  });
+
+  it('should return false for non-existent identifier', () => {
+    const filePath = '/root/src/generator.ts';
+    vol.fromJSON({
+      [filePath]: `
+        export function otherFunction() {
+          console.log('other');
+        }
+      `,
+    });
+
+    const result = checkIfIdentifierIsFunction(filePath, 'myGenerator');
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR addresses the issue where the `eslint-plugin` rules fail to `require()` modules during development when working with ts source files. The problem occurs because `require.resolve()` finds .js paths in package.json exports, but the actual .js files don't exist in development mode - only .ts files are present. 

So when you `require()` and the file is loaded NodeJS throws an error because the `.js` imports cannot be resolved.
This can occur in a ts solution workspace environment where the failure is not accommodating. 

Instead, we can use `tsquery` to check if the file has a valid named function export.