### PR TITLE
fix(gradle): should handle custom gradle files

### DIFF
--- a/packages/gradle/package.json
+++ b/packages/gradle/package.json
@@ -35,7 +35,8 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@nx/devkit": "file:../devkit"
+    "@nx/devkit": "file:../devkit",
+    "minimatch": "9.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gradle/src/plugin-v1/dependencies.ts
+++ b/packages/gradle/src/plugin-v1/dependencies.ts
@@ -9,7 +9,7 @@ import {
 import { basename, dirname } from 'node:path';
 
 import { getCurrentGradleReport } from './utils/get-gradle-report';
-import { GRADLE_BUILD_FILES } from '../utils/split-config-files';
+import { isGradleBuildFile } from '../utils/split-config-files';
 
 export const createDependencies: CreateDependencies = async (
   _,
@@ -86,7 +86,7 @@ function findGradleFiles(fileMap: FileMap): string[] {
 
   for (const [_, files] of Object.entries(fileMap.projectFileMap)) {
     for (const file of files) {
-      if (GRADLE_BUILD_FILES.has(basename(file.file))) {
+      if (isGradleBuildFile(basename(file.file))) {
         gradleFiles.push(file.file);
       }
     }

--- a/packages/gradle/src/plugin/dependencies.ts
+++ b/packages/gradle/src/plugin/dependencies.ts
@@ -15,7 +15,7 @@ import {
   populateProjectGraph,
 } from './utils/get-project-graph-from-gradle-plugin';
 import { GradlePluginOptions } from './utils/gradle-plugin-options';
-import { GRALDEW_FILES, splitConfigFiles } from '../utils/split-config-files';
+import { GRADLEW_FILES, splitConfigFiles } from '../utils/split-config-files';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { existsSync } from 'node:fs';
 
@@ -27,7 +27,7 @@ export const createDependencies: CreateDependencies<
 ) => {
   const files = await globWithWorkspaceContext(
     workspaceRoot,
-    Array.from(GRALDEW_FILES)
+    Array.from(GRADLEW_FILES)
   );
   const { gradlewFiles } = splitConfigFiles(files);
   await populateProjectGraph(

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -64,7 +64,9 @@ export async function newGenerator(tree: Tree, opts: Schema) {
 
   return async () => {
     if (!options.skipInstall) {
-      const pmc = getPackageManagerCommand(options.packageManager as PackageManager);
+      const pmc = getPackageManagerCommand(
+        options.packageManager as PackageManager
+      );
       if (pmc.preInstall) {
         execSync(pmc.preInstall, {
           cwd: joinPathFragments(tree.root, options.directory),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
for repo like spring-frameworks, the gradle file is spring-websocket.gradle, not build.gradle.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
need to get all *.gradle files, but not settings.gradle file to get all build files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
