### PR TITLE
fix(plugin): fix e2e-project generator when the e2e target is inferred

### DIFF
--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -143,6 +143,38 @@ describe('NxPlugin e2e-project Generator', () => {
     `);
   });
 
+  it('should not update create e2e target if target covered by existing plugin', async () => {
+    updateJson(tree, 'nx.json', (json) => {
+      return {
+        ...(json ?? {}),
+        plugins: [
+          ...(json.plugins ?? []),
+          {
+            plugin: '@nx/jest/plugin',
+            include: ['e2e/**/*'],
+            options: {
+              targetName: 'e2e',
+              ciTargetName: 'e2e-ci',
+            },
+          },
+        ],
+      };
+    });
+
+    await e2eProjectGenerator(tree, {
+      pluginName: 'my-plugin',
+      pluginOutputPath: `dist/libs/my-plugin`,
+      npmPackageName: '@proj/my-plugin',
+      addPlugin: true,
+    });
+
+    const project = readProjectConfiguration(tree, 'my-plugin-e2e');
+
+    expect(project).toBeTruthy();
+    expect(project.root).toEqual('my-plugin-e2e');
+    expect(project.targets.e2e).toBeFalsy();
+  });
+
   it('should add jest support', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',

--- a/packages/plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.ts
@@ -168,18 +168,20 @@ async function addJest(host: Tree, options: NormalizedSchema) {
 
   const project = readProjectConfiguration(host, options.projectName);
   project.targets ??= {};
-  const e2eTarget = project.targets.e2e;
+  if (project.targets.e2e) {
+    const e2eTarget = project.targets.e2e;
 
-  project.targets.e2e = {
-    ...e2eTarget,
-    dependsOn: [`^build`],
-    options: {
-      ...e2eTarget.options,
-      runInBand: true,
-    },
-  };
+    project.targets.e2e = {
+      ...e2eTarget,
+      dependsOn: [`^build`],
+      options: {
+        ...e2eTarget.options,
+        runInBand: true,
+      },
+    };
 
-  updateProjectConfiguration(host, options.projectName, project);
+    updateProjectConfiguration(host, options.projectName, project);
+  }
 
   return jestTask;
 }


### PR DESCRIPTION
## Description

The `@nx/plugin:e2e-project` generator includes a step that runs `configurationGenerator` to apply Jest configuration to the E2E project. Depending on the workspace context, this step may result in different outcomes.

https://github.com/nrwl/nx/blob/157a34ae408dd40f2192150471a53292bfa2e3e2/packages/plugin/src/generators/e2e-project/e2e.ts#L142

For instance, if the `nx.json` includes a plugin that infers the `e2e` target, the generator will **not** create a static `e2e` target in `project.json` or `package.json`.

https://github.com/nrwl/nx/blob/157a34ae408dd40f2192150471a53292bfa2e3e2/packages/jest/src/generators/configuration/configuration.ts#L118

However, immediately after configuring Jest, the generator continues with logic that assumes the `e2e` target exists statically. It does not account for cases where the target is inferred and therefore missing, which leads to runtime errors.

https://github.com/nrwl/nx/blob/157a34ae408dd40f2192150471a53292bfa2e3e2/packages/plugin/src/generators/e2e-project/e2e.ts#L173

## Current Behavior

When running `@nx/plugin:e2e-project` in a workspace that uses a plugin to infer the `e2e` target—for example:

```json
{
  "plugin": "@nx/jest/plugin",
  "include": ["e2e/**/*"],
  "options": {
    "targetName": "e2e",
    "ciTargetName": "e2e-ci"
  }
}
```

The following error occurs:

```
Cannot read properties of undefined (reading 'options')
TypeError: Cannot read properties of undefined (reading 'options')
    at addJest (/Users/jgelin/dev/nx/packages/plugin/src/generators/e2e-project/e2e.ts:177:20)
    at async e2eProjectGeneratorInternal (/Users/jgelin/dev/nx/packages/plugin/src/generators/e2e-project/e2e.ts:234:14)
    at async e2eProjectGenerator (/Users/jgelin/dev/nx/packages/plugin/src/generators/e2e-project/e2e.ts:216:10)
    at async Object.<anonymous> (/Users/jgelin/dev/nx/packages/plugin/src/generators/e2e-project/e2e.spec.ts:164:5)
```

> You can easily reproduce it if you remove my fix and run the unit test

## Expected Behavior

The `@nx/plugin:e2e-project` generator should support workspaces where the `e2e` target is inferred and not statically defined. It should gracefully handle the absence of the target instead of throwing an error.

