### PR TITLE
chore(workspace): format new generator code

### DIFF
--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -64,7 +64,9 @@ export async function newGenerator(tree: Tree, opts: Schema) {
 
   return async () => {
     if (!options.skipInstall) {
-      const pmc = getPackageManagerCommand(options.packageManager as PackageManager);
+      const pmc = getPackageManagerCommand(
+        options.packageManager as PackageManager
+      );
       if (pmc.preInstall) {
         execSync(pmc.preInstall, {
           cwd: joinPathFragments(tree.root, options.directory),


### PR DESCRIPTION
## Current Behavior

The getPackageManagerCommand call in the new generator has a long line that doesn't follow the codebase's formatting standards.

## Expected Behavior

The code should be properly formatted with line breaks for better readability.

## Related Issue(s)

Code formatting improvement - no related issue.