### PR TITLE
docs(nx-dev): add Nx Essentials workshop announcement

### DIFF
--- a/docs/shared/getting-started/intro.md
+++ b/docs/shared/getting-started/intro.md
@@ -5,6 +5,12 @@ description: 'Nx is an AI-first build platform that connects everything from you
 
 # What is Nx?
 
+{% callout type="announcement" title="Nx Essentials Online Workshop - July 29-30" %}
+Join us for an interactive deep-dive into Nx covering everything from foundational concepts to more advanced enterprise techniques. Early bird pricing available until July 18th.
+
+[Save your seat today!](https://bit.ly/44AfKAb)
+{% /callout %}
+
 Nx is a powerful, open source, technology-agnostic build platform designed to efficiently manage codebases of any scale. From small single projects to large enterprise monorepos, Nx is designed to **streamline your development workflows**, **minimize errors** and **dramatically reduce waste** by [saving engineering time](https://youtu.be/2BLqiNnBPuU) and cutting compute costs.
 
 {% youtube

--- a/docs/shared/getting-started/quick-start.md
+++ b/docs/shared/getting-started/quick-start.md
@@ -5,6 +5,12 @@ description: Get up and running with Nx in minutes - install Nx, set up your edi
 
 # Getting Started
 
+{% callout type="announcement" title="Nx Essentials Online Workshop - July 29-30" %}
+Join us for an interactive deep-dive into Nx covering everything from foundational concepts to more advanced enterprise techniques. Early bird pricing available until July 18th.
+
+[Save your seat today!](https://bit.ly/44AfKAb)
+{% /callout %}
+
 Get up and running with Nx in just a few minutes by following these simple steps.
 
 {% steps %}


### PR DESCRIPTION
Inserted an announcement callout highlighting the upcoming Nx Essentials Online Workshop (July 29-30) in the Getting Started and Quick Start documentation pages. Includes a link for registration and early bird details.