### PR TITLE
fix(gradle): handle custom build gradle files

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/data/GradleNodeReport.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/data/GradleNodeReport.kt
@@ -7,5 +7,6 @@ import org.gradle.api.tasks.Nested
 data class GradleNodeReport(
     @Nested val nodes: Map<String, ProjectNode>,
     @Input val dependencies: Set<Dependency>,
-    @Nested val externalNodes: Map<String, ExternalNode>
+    @Nested val externalNodes: Map<String, ExternalNode>,
+    @Input val buildFiles: List<String>
 ) : Serializable

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -1,6 +1,7 @@
 package dev.nx.gradle.utils
 
 import dev.nx.gradle.data.*
+import java.io.File
 import java.util.*
 import org.gradle.api.Project
 
@@ -49,7 +50,8 @@ fun createNodeForProject(
     nodes = emptyMap()
     externalNodes = emptyMap()
   }
-  return GradleNodeReport(nodes, dependencies, externalNodes)
+  val buildFileRelativePath = project.buildFile.relativeTo(File(workspaceRoot)).path
+  return GradleNodeReport(nodes, dependencies, externalNodes, listOf(buildFileRelativePath))
 }
 
 /**

--- a/packages/gradle/src/plugin/__snapshots__/nodes.spec.ts.snap
+++ b/packages/gradle/src/plugin/__snapshots__/nodes.spec.ts.snap
@@ -463,6 +463,43 @@ exports[`@nx/gradle/plugin/nodes should create nodes with atomized tests targets
       },
     },
   ],
+  [
+    "proj/build.gradle",
+    {
+      "externalNodes": {},
+      "projects": {
+        "proj": {
+          "metadata": {
+            "targetGroups": {
+              "help": [
+                "buildEnvironment",
+              ],
+            },
+            "technologies": [
+              "gradle",
+            ],
+          },
+          "name": "gradle-tutorial",
+          "root": "proj",
+          "targets": {
+            "buildEnvironment": {
+              "cache": true,
+              "command": "./gradlew :buildEnvironment",
+              "metadata": {
+                "description": "Displays all buildscript dependencies declared in root project 'gradle-tutorial'.",
+                "technologies": [
+                  "gradle",
+                ],
+              },
+              "options": {
+                "cwd": "proj",
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
 ]
 `;
 
@@ -839,6 +876,43 @@ exports[`@nx/gradle/plugin/nodes should not create nodes with atomized tests tar
                 "{projectRoot}/build/generated/sources/headers/java/test",
                 "{projectRoot}/build/tmp/compileTestJava/previous-compilation-data.bin",
               ],
+            },
+          },
+        },
+      },
+    },
+  ],
+  [
+    "proj/build.gradle",
+    {
+      "externalNodes": {},
+      "projects": {
+        "proj": {
+          "metadata": {
+            "targetGroups": {
+              "help": [
+                "buildEnvironment",
+              ],
+            },
+            "technologies": [
+              "gradle",
+            ],
+          },
+          "name": "gradle-tutorial",
+          "root": "proj",
+          "targets": {
+            "buildEnvironment": {
+              "cache": true,
+              "command": "./gradlew :buildEnvironment",
+              "metadata": {
+                "description": "Displays all buildscript dependencies declared in root project 'gradle-tutorial'.",
+                "technologies": [
+                  "gradle",
+                ],
+              },
+              "options": {
+                "cwd": "proj",
+              },
             },
           },
         },

--- a/packages/gradle/src/plugin/utils/__mocks__/gradle_composite.json
+++ b/packages/gradle/src/plugin/utils/__mocks__/gradle_composite.json
@@ -1,4 +1,5 @@
 {
+  "buildFiles": ["nested/nested/proj/build.gradle"],
   "nodes": {
     "nested/nested/proj": {
       "targets": {

--- a/packages/gradle/src/plugin/utils/__mocks__/gradle_tutorial.json
+++ b/packages/gradle/src/plugin/utils/__mocks__/gradle_tutorial.json
@@ -1,4 +1,5 @@
 {
+  "buildFiles": ["proj/build.gradle"],
   "nodes": {
     "proj": {
       "targets": {

--- a/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
@@ -25,6 +25,7 @@ export interface ProjectGraphReport {
   };
   dependencies: Array<StaticDependency>;
   externalNodes?: Record<string, ProjectGraphExternalNode>;
+  buildFiles?: string[];
 }
 
 export interface ProjectGraphReportCache extends ProjectGraphReport {
@@ -80,6 +81,11 @@ export function getCurrentProjectGraphReport(): ProjectGraphReport {
     );
   }
   return projectGraphReportCache;
+}
+
+export function getCurrentBuildFiles(): string[] {
+  const report = getCurrentProjectGraphReport();
+  return report.buildFiles || [];
 }
 
 /**
@@ -168,6 +174,8 @@ export function processNxProjectGraph(
     dependencies: [],
     externalNodes: {},
   };
+  const allBuildFiles = new Set<string>();
+
   while (index < projectGraphLines.length) {
     const line = projectGraphLines[index].trim();
     if (line.startsWith('> Task ') && line.endsWith(':nxProjectGraph')) {
@@ -195,9 +203,17 @@ export function processNxProjectGraph(
           ...projectGraphReportJson.externalNodes,
         };
       }
+      if (projectGraphReportJson.buildFiles) {
+        projectGraphReportJson.buildFiles.forEach((buildFile) =>
+          allBuildFiles.add(buildFile)
+        );
+      }
     }
     index++;
   }
+
+  // Convert Set to array for the final result
+  projectGraphReportForAllProjects.buildFiles = Array.from(allBuildFiles);
 
   return projectGraphReportForAllProjects;
 }

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -64,7 +64,9 @@ export async function newGenerator(tree: Tree, opts: Schema) {
 
   return async () => {
     if (!options.skipInstall) {
-      const pmc = getPackageManagerCommand(options.packageManager as PackageManager);
+      const pmc = getPackageManagerCommand(
+        options.packageManager as PackageManager
+      );
       if (pmc.preInstall) {
         execSync(pmc.preInstall, {
           cwd: joinPathFragments(tree.root, options.directory),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
for spring-framework
```
rootProject.children.each {project ->
	project.buildFileName = "${project.name}.gradle"
}
```
it got custom build file name

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- change nxProjectGraph plugin, add buildFiles in the output json like:
```
{
  "nodes": {},
...
  "buildFiles": ["build.gradle"]
}
```
then, it get the build files from reports, combine build files from build.gradle and custom build files from reports.
```
    const allBuildFiles = Array.from(
      new Set([...buildFilesFromSplitConfigFiles, ...buildFiles])
    );
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
