### PR TITLE
fix(core): return current nx init date when no git available yet

### DIFF
--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -44,7 +44,7 @@ function getNxInitDate(): string | null {
     const nxInitDate = new Date(nxInitIso);
     return nxInitDate.toISOString();
   } catch (e) {
-    return null;
+    return new Date().toISOString();
   }
 }
 


### PR DESCRIPTION
## Current Behavior
create-nx-workspace invokes the util function before git is initialized, so the value is null

## Expected Behavior
the value should be equal to current time given that we capture it during the workspace creation
