### PR TITLE
fix(react-native): app creation should sync deps

### DIFF
--- a/e2e/react-native/src/react-native-legacy.test.ts
+++ b/e2e/react-native/src/react-native-legacy.test.ts
@@ -54,6 +54,25 @@ describe('@nx/react-native (legacy)', () => {
     expect(() => runCLI(`build ${appName}`)).not.toThrow();
   });
 
+  it('should have dependencies synced after React Native app creation', () => {
+    // Check that the app's package.json exists
+    checkFilesExist(`apps/${appName}/package.json`);
+
+    // Read the app's package.json
+    const appPackageJson = readJson(`apps/${appName}/package.json`);
+
+    // Verify that the app package.json has dependencies section
+    expect(appPackageJson.dependencies).toBeDefined();
+
+    // Verify that essential React Native dependencies are automatically synced
+    expect(appPackageJson.dependencies).toEqual(
+      expect.objectContaining({
+        react: '*',
+        'react-native': '*',
+      })
+    );
+  });
+
   it('should test and lint', async () => {
     const componentName = uniq('Component');
     runCLI(

--- a/e2e/react-native/src/react-native.test.ts
+++ b/e2e/react-native/src/react-native.test.ts
@@ -10,6 +10,7 @@ import {
   checkFilesExist,
   runE2ETests,
   updateFile,
+  readJson,
 } from 'e2e/utils';
 
 describe('@nx/react-native', () => {
@@ -43,6 +44,25 @@ describe('@nx/react-native', () => {
   it('should test and lint', async () => {
     expect(() => runCLI(`test ${appName}`)).not.toThrow();
     expect(() => runCLI(`lint ${appName}`)).not.toThrow();
+  });
+
+  it('should have dependencies synced after React Native app creation', () => {
+    // Check that the app's package.json exists
+    checkFilesExist(`${appName}/package.json`);
+
+    // Read the app's package.json
+    const appPackageJson = readJson(`${appName}/package.json`);
+
+    // Verify that the app package.json has dependencies section
+    expect(appPackageJson.dependencies).toBeDefined();
+
+    // Verify that React Native specific dependencies are synced
+    expect(appPackageJson.dependencies).toEqual(
+      expect.objectContaining({
+        react: '*',
+        'react-native': '*',
+      })
+    );
   });
 
   it('should bundle the app', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
currently, when options.install=true (need to do pod install), it only syncs deps.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
make it sync deps regardless of options.install, so when developers choose to run `pod-install` after, it will work right away.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
