### PR TITLE
fix(angular): generate ngrx facade spec file correctly

### DIFF
--- a/e2e/angular/src/ngrx.test.ts
+++ b/e2e/angular/src/ngrx.test.ts
@@ -1,7 +1,6 @@
 import {
   cleanupProject,
   expectTestsPass,
-  getSelectedPackageManager,
   newProject,
   readJson,
   runCLI,
@@ -43,10 +42,7 @@ describe('Angular Package', () => {
 
       expect(runCLI(`build ${myapp}`)).toMatch(/main-[a-zA-Z0-9]+\.js/);
       expectTestsPass(await runCLIAsync(`test ${myapp} --no-watch`));
-      // TODO: remove this condition
-      if (getSelectedPackageManager() !== 'pnpm') {
-        expectTestsPass(await runCLIAsync(`test ${mylib} --no-watch`));
-      }
+      expectTestsPass(await runCLIAsync(`test ${mylib} --no-watch`));
     }, 1000000);
 
     it('should work with creators', async () => {
@@ -78,10 +74,7 @@ describe('Angular Package', () => {
 
       expect(runCLI(`build ${myapp}`)).toMatch(/main-[a-zA-Z0-9]+\.js/);
       expectTestsPass(await runCLIAsync(`test ${myapp} --no-watch`));
-      // TODO: remove this condition
-      if (getSelectedPackageManager() !== 'pnpm') {
-        expectTestsPass(await runCLIAsync(`test ${mylib} --no-watch`));
-      }
+      expectTestsPass(await runCLIAsync(`test ${mylib} --no-watch`));
     }, 1000000);
 
     it('should work with creators using --module', async () => {
@@ -113,10 +106,7 @@ describe('Angular Package', () => {
 
       expect(runCLI(`build ${myapp}`)).toMatch(/main-[a-zA-Z0-9]+\.js/);
       expectTestsPass(await runCLIAsync(`test ${myapp} --no-watch`));
-      // TODO: remove this condition
-      if (getSelectedPackageManager() !== 'pnpm') {
-        expectTestsPass(await runCLIAsync(`test ${mylib} --no-watch`));
-      }
+      expectTestsPass(await runCLIAsync(`test ${mylib} --no-watch`));
     }, 1000000);
   });
 });

--- a/packages/angular/src/generators/ngrx-feature-store/__snapshots__/ngrx-feature-store.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx-feature-store/__snapshots__/ngrx-feature-store.spec.ts.snap
@@ -246,7 +246,7 @@ exports[`ngrx-feature-store NgModule should generate the files with the correct 
 import { TestBed } from '@angular/core/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule, Store } from '@ngrx/store';
-import { readFirst } from '@nx/angular/testing';
+import { firstValueFrom } from 'rxjs';
 
 import * as UsersActions from './users.actions';
 import { UsersEffects } from './users.effects';
@@ -301,16 +301,16 @@ describe('UsersFacade', () => {
      * The initially generated facade::loadAll() returns empty array
      */
     it('loadAll() should return empty list with loaded == true', async () => {
-      let list = await readFirst(facade.allUsers$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await firstValueFrom(facade.allUsers$);
+      let isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
 
       facade.init();
 
-      list = await readFirst(facade.allUsers$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await firstValueFrom(facade.allUsers$);
+      isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(true);
@@ -320,8 +320,8 @@ describe('UsersFacade', () => {
      * Use \`loadUsersSuccess\` to manually update list
      */
     it('allUsers$ should return the loaded list; and loaded flag == true', async () => {
-      let list = await readFirst(facade.allUsers$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await firstValueFrom(facade.allUsers$);
+      let isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
@@ -332,8 +332,8 @@ describe('UsersFacade', () => {
         })
       );
 
-      list = await readFirst(facade.allUsers$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await firstValueFrom(facade.allUsers$);
+      isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(2);
       expect(isLoaded).toBe(true);
@@ -702,7 +702,7 @@ exports[`ngrx-feature-store Standalone APIs should generate the files with the c
 import { TestBed } from '@angular/core/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule, Store } from '@ngrx/store';
-import { readFirst } from '@nx/angular/testing';
+import { firstValueFrom } from 'rxjs';
 
 import * as UsersActions from './users.actions';
 import { UsersEffects } from './users.effects';
@@ -757,16 +757,16 @@ describe('UsersFacade', () => {
      * The initially generated facade::loadAll() returns empty array
      */
     it('loadAll() should return empty list with loaded == true', async () => {
-      let list = await readFirst(facade.allUsers$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await firstValueFrom(facade.allUsers$);
+      let isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
 
       facade.init();
 
-      list = await readFirst(facade.allUsers$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await firstValueFrom(facade.allUsers$);
+      isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(true);
@@ -776,8 +776,8 @@ describe('UsersFacade', () => {
      * Use \`loadUsersSuccess\` to manually update list
      */
     it('allUsers$ should return the loaded list; and loaded flag == true', async () => {
-      let list = await readFirst(facade.allUsers$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await firstValueFrom(facade.allUsers$);
+      let isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
@@ -789,8 +789,8 @@ describe('UsersFacade', () => {
         ]})
       );
 
-      list = await readFirst(facade.allUsers$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await firstValueFrom(facade.allUsers$);
+      isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(2);
       expect(isLoaded).toBe(true);

--- a/packages/angular/src/generators/ngrx-feature-store/files/__directory__/__fileName__.facade.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx-feature-store/files/__directory__/__fileName__.facade.spec.ts__tmpl__
@@ -2,7 +2,11 @@ import { NgModule } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule, Store } from '@ngrx/store';
-import { readFirst } from '@nx/angular/testing';
+<%_ if (isRxJs7) { _%>
+import { firstValueFrom } from 'rxjs';
+<%_ } else { _%>
+import { first } from 'rxjs/operators';
+<%_ } _%>
 
 import * as <%= className %>Actions from './<%= relativeFileName %>.actions';
 import { <%= className %>Effects } from './<%= relativeFileName %>.effects';
@@ -57,16 +61,16 @@ describe('<%= className %>Facade', () => {
      * The initially generated facade::loadAll() returns empty array
      */
     it('loadAll() should return empty list with loaded == true', async () => {
-      let list = await readFirst(facade.all<%= className %>$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await <% if (isRxJs7) { %>firstValueFrom(facade.all<%= className %>$)<% } else { %>facade.all<%= className %>$.pipe(first()).toPromise()<% } %>;
+      let isLoaded = await <% if (isRxJs7) { %>firstValueFrom(facade.loaded$)<% } else { %>facade.loaded$.pipe(first()).toPromise()<% } %>;
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
 
       facade.init();
 
-      list = await readFirst(facade.all<%= className %>$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await <% if (isRxJs7) { %>firstValueFrom(facade.all<%= className %>$)<% } else { %>facade.all<%= className %>$.pipe(first()).toPromise()<% } %>;
+      isLoaded = await <% if (isRxJs7) { %>firstValueFrom(facade.loaded$)<% } else { %>facade.loaded$.pipe(first()).toPromise()<% } %>;
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(true);
@@ -76,8 +80,8 @@ describe('<%= className %>Facade', () => {
      * Use `load<%= className %>Success` to manually update list
      */
     it('all<%= className %>$ should return the loaded list; and loaded flag == true', async () => {
-      let list = await readFirst(facade.all<%= className %>$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await <% if (isRxJs7) { %>firstValueFrom(facade.all<%= className %>$)<% } else { %>facade.all<%= className %>$.pipe(first()).toPromise()<% } %>;
+      let isLoaded = await <% if (isRxJs7) { %>firstValueFrom(facade.loaded$)<% } else { %>facade.loaded$.pipe(first()).toPromise()<% } %>;
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
@@ -89,8 +93,8 @@ describe('<%= className %>Facade', () => {
         ]})
       );
 
-      list = await readFirst(facade.all<%= className %>$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await <% if (isRxJs7) { %>firstValueFrom(facade.all<%= className %>$)<% } else { %>facade.all<%= className %>$.pipe(first()).toPromise()<% } %>;
+      isLoaded = await <% if (isRxJs7) { %>firstValueFrom(facade.loaded$)<% } else { %>facade.loaded$.pipe(first()).toPromise()<% } %>;
 
       expect(list.length).toBe(2);
       expect(isLoaded).toBe(true);

--- a/packages/angular/src/generators/ngrx-feature-store/lib/generate-files.ts
+++ b/packages/angular/src/generators/ngrx-feature-store/lib/generate-files.ts
@@ -22,6 +22,7 @@ export function generateFilesFromTemplates(
       fileName,
       relativeFileName: projectNames.fileName,
       importFromOperators: lt(options.rxjsVersion, '7.2.0'),
+      isRxJs7: options.rxjsMajorVersion >= 7,
       tmpl: '',
     }
   );

--- a/packages/angular/src/generators/ngrx-feature-store/lib/normalize-options.ts
+++ b/packages/angular/src/generators/ngrx-feature-store/lib/normalize-options.ts
@@ -2,6 +2,7 @@ import type { Tree } from '@nx/devkit';
 import { joinPathFragments, names, readJson } from '@nx/devkit';
 import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
 import { dirname } from 'path';
+import { major } from 'semver';
 import { rxjsVersion as defaultRxjsVersion } from '../../../utils/versions';
 import type { Schema } from '../schema';
 
@@ -9,6 +10,7 @@ export type NormalizedNgRxFeatureStoreGeneratorOptions = Schema & {
   parentDirectory: string;
   subdirectory: string;
   rxjsVersion: string;
+  rxjsMajorVersion: number;
 };
 
 export function normalizeOptions(
@@ -24,6 +26,7 @@ export function normalizeOptions(
   } catch {
     rxjsVersion = checkAndCleanWithSemver('rxjs', defaultRxjsVersion);
   }
+  const rxjsMajorVersion = major(rxjsVersion);
 
   const { subdirectory, name } = determineSubdirectoryAndName(options.name);
 
@@ -35,6 +38,7 @@ export function normalizeOptions(
     route: options.route === '' ? `''` : options.route ?? `''`,
     directory: names(options.directory).fileName,
     rxjsVersion,
+    rxjsMajorVersion,
   };
 }
 

--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
@@ -46,7 +46,7 @@ exports[`ngrx NgModule Syntax generated unit tests should generate specs for the
 import { TestBed } from '@angular/core/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule, Store } from '@ngrx/store';
-import { readFirst } from '@nx/angular/testing';
+import { firstValueFrom } from 'rxjs';
 
 import * as SuperUsersActions from './super-users.actions';
 import { SuperUsersEffects } from './super-users.effects';
@@ -101,16 +101,16 @@ describe('SuperUsersFacade', () => {
      * The initially generated facade::loadAll() returns empty array
      */
     it('loadAll() should return empty list with loaded == true', async () => {
-      let list = await readFirst(facade.allSuperUsers$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await firstValueFrom(facade.allSuperUsers$);
+      let isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
 
       facade.init();
 
-      list = await readFirst(facade.allSuperUsers$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await firstValueFrom(facade.allSuperUsers$);
+      isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(true);
@@ -120,8 +120,8 @@ describe('SuperUsersFacade', () => {
      * Use \`loadSuperUsersSuccess\` to manually update list
      */
     it('allSuperUsers$ should return the loaded list; and loaded flag == true', async () => {
-      let list = await readFirst(facade.allSuperUsers$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await firstValueFrom(facade.allSuperUsers$);
+      let isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
@@ -133,8 +133,8 @@ describe('SuperUsersFacade', () => {
         ]})
       );
 
-      list = await readFirst(facade.allSuperUsers$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await firstValueFrom(facade.allSuperUsers$);
+      isLoaded = await firstValueFrom(facade.loaded$);
 
       expect(list.length).toBe(2);
       expect(isLoaded).toBe(true);

--- a/packages/angular/src/generators/ngrx/files/__directory__/__fileName__.facade.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/__directory__/__fileName__.facade.spec.ts__tmpl__
@@ -2,7 +2,11 @@ import { NgModule } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule, Store } from '@ngrx/store';
-import { readFirst } from '@nx/angular/testing';
+<%_ if (isRxJs7) { _%>
+import { firstValueFrom } from 'rxjs';
+<%_ } else { _%>
+import { first } from 'rxjs/operators';
+<%_ } _%>
 
 import * as <%= className %>Actions from './<%= fileName %>.actions';
 import { <%= className %>Effects } from './<%= fileName %>.effects';
@@ -57,16 +61,16 @@ describe('<%= className %>Facade', () => {
      * The initially generated facade::loadAll() returns empty array
      */
     it('loadAll() should return empty list with loaded == true', async () => {
-      let list = await readFirst(facade.all<%= className %>$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await <% if (isRxJs7) { %>firstValueFrom(facade.all<%= className %>$)<% } else { %>facade.all<%= className %>$.pipe(first()).toPromise()<% } %>;
+      let isLoaded = await <% if (isRxJs7) { %>firstValueFrom(facade.loaded$)<% } else { %>facade.loaded$.pipe(first()).toPromise()<% } %>;
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
 
       facade.init();
 
-      list = await readFirst(facade.all<%= className %>$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await <% if (isRxJs7) { %>firstValueFrom(facade.all<%= className %>$)<% } else { %>facade.all<%= className %>$.pipe(first()).toPromise()<% } %>;
+      isLoaded = await <% if (isRxJs7) { %>firstValueFrom(facade.loaded$)<% } else { %>facade.loaded$.pipe(first()).toPromise()<% } %>;
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(true);
@@ -76,8 +80,8 @@ describe('<%= className %>Facade', () => {
      * Use `load<%= className %>Success` to manually update list
      */
     it('all<%= className %>$ should return the loaded list; and loaded flag == true', async () => {
-      let list = await readFirst(facade.all<%= className %>$);
-      let isLoaded = await readFirst(facade.loaded$);
+      let list = await <% if (isRxJs7) { %>firstValueFrom(facade.all<%= className %>$)<% } else { %>facade.all<%= className %>$.pipe(first()).toPromise()<% } %>;
+      let isLoaded = await <% if (isRxJs7) { %>firstValueFrom(facade.loaded$)<% } else { %>facade.loaded$.pipe(first()).toPromise()<% } %>;
 
       expect(list.length).toBe(0);
       expect(isLoaded).toBe(false);
@@ -89,8 +93,8 @@ describe('<%= className %>Facade', () => {
         ]})
       );
 
-      list = await readFirst(facade.all<%= className %>$);
-      isLoaded = await readFirst(facade.loaded$);
+      list = await <% if (isRxJs7) { %>firstValueFrom(facade.all<%= className %>$)<% } else { %>facade.all<%= className %>$.pipe(first()).toPromise()<% } %>;
+      isLoaded = await <% if (isRxJs7) { %>firstValueFrom(facade.loaded$)<% } else { %>facade.loaded$.pipe(first()).toPromise()<% } %>;
 
       expect(list.length).toBe(2);
       expect(isLoaded).toBe(true);

--- a/packages/angular/src/generators/ngrx/lib/generate-files.ts
+++ b/packages/angular/src/generators/ngrx/lib/generate-files.ts
@@ -21,6 +21,7 @@ export function generateNgrxFilesFromTemplates(
       ...options,
       ...projectNames,
       importFromOperators: lt(options.rxjsVersion, '7.2.0'),
+      isRxJs7: options.rxjsMajorVersion >= 7,
       tmpl: '',
     }
   );

--- a/packages/angular/src/generators/ngrx/lib/normalize-options.ts
+++ b/packages/angular/src/generators/ngrx/lib/normalize-options.ts
@@ -1,12 +1,14 @@
 import { names, readJson, Tree } from '@nx/devkit';
 import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
 import { dirname } from 'path';
+import { major } from 'semver';
 import { rxjsVersion as defaultRxjsVersion } from '../../../utils/versions';
 import type { NgRxGeneratorOptions } from '../schema';
 
 export type NormalizedNgRxGeneratorOptions = NgRxGeneratorOptions & {
   parentDirectory: string;
   rxjsVersion: string;
+  rxjsMajorVersion: number;
 };
 
 export function normalizeOptions(
@@ -22,6 +24,7 @@ export function normalizeOptions(
   } catch {
     rxjsVersion = checkAndCleanWithSemver('rxjs', defaultRxjsVersion);
   }
+  const rxjsMajorVersion = major(rxjsVersion);
 
   return {
     ...options,
@@ -33,5 +36,6 @@ export function normalizeOptions(
     route: options.route === '' ? `''` : options.route ?? `''`,
     directory: names(options.directory).fileName,
     rxjsVersion,
+    rxjsMajorVersion,
   };
 }

--- a/packages/angular/src/generators/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.spec.ts
@@ -729,5 +729,113 @@ export const appRoutes: Routes = [{ path: 'home', component: NxWelcome }];
         tree.read('myapp/src/app/+state/users.effects.ts', 'utf-8')
       ).toMatchSnapshot();
     });
+
+    it('should generate the ngrx facade tests using the "first" operator', async () => {
+      await ngrxGenerator(tree, { ...defaultOptions, facade: true });
+
+      expect(tree.read('myapp/src/app/+state/users.facade.spec.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { NgModule } from '@angular/core';
+        import { TestBed } from '@angular/core/testing';
+        import { EffectsModule } from '@ngrx/effects';
+        import { StoreModule, Store } from '@ngrx/store';
+        import { first } from 'rxjs/operators';
+
+        import * as UsersActions from './users.actions';
+        import { UsersEffects } from './users.effects';
+        import { UsersFacade } from './users.facade';
+        import { UsersEntity } from './users.models';
+        import {
+          USERS_FEATURE_KEY,
+          UsersState,
+          initialUsersState,
+          usersReducer
+        } from './users.reducer';
+        import * as UsersSelectors from './users.selectors';
+
+        interface TestSchema {
+          users: UsersState;
+        }
+
+        describe('UsersFacade', () => {
+          let facade: UsersFacade;
+          let store: Store<TestSchema>;
+          const createUsersEntity = (id: string, name = ''): UsersEntity => ({
+            id,
+            name: name || \`name-\${id}\`
+          });
+
+          describe('used in NgModule', () => {
+            beforeEach(() => {
+              @NgModule({
+                imports: [
+                  StoreModule.forFeature(USERS_FEATURE_KEY, usersReducer),
+                  EffectsModule.forFeature([UsersEffects])
+                ],
+                providers: [UsersFacade]
+              })
+              class CustomFeatureModule {}
+
+              @NgModule({
+                imports: [
+                  StoreModule.forRoot({}),
+                  EffectsModule.forRoot([]),
+                  CustomFeatureModule,
+                ]
+              })
+              class RootModule {}
+              TestBed.configureTestingModule({ imports: [RootModule] });
+
+              store = TestBed.inject(Store);
+              facade = TestBed.inject(UsersFacade);
+            });
+
+            /**
+             * The initially generated facade::loadAll() returns empty array
+             */
+            it('loadAll() should return empty list with loaded == true', async () => {
+              let list = await facade.allUsers$.pipe(first()).toPromise();
+              let isLoaded = await facade.loaded$.pipe(first()).toPromise();
+
+              expect(list.length).toBe(0);
+              expect(isLoaded).toBe(false);
+
+              facade.init();
+
+              list = await facade.allUsers$.pipe(first()).toPromise();
+              isLoaded = await facade.loaded$.pipe(first()).toPromise();
+
+              expect(list.length).toBe(0);
+              expect(isLoaded).toBe(true);
+            });
+
+            /**
+             * Use \`loadUsersSuccess\` to manually update list
+             */
+            it('allUsers$ should return the loaded list; and loaded flag == true', async () => {
+              let list = await facade.allUsers$.pipe(first()).toPromise();
+              let isLoaded = await facade.loaded$.pipe(first()).toPromise();
+
+              expect(list.length).toBe(0);
+              expect(isLoaded).toBe(false);
+
+              store.dispatch(UsersActions.loadUsersSuccess({
+                users: [
+                  createUsersEntity('AAA'),
+                  createUsersEntity('BBB')
+                ]})
+              );
+
+              list = await facade.allUsers$.pipe(first()).toPromise();
+              isLoaded = await facade.loaded$.pipe(first()).toPromise();
+
+              expect(list.length).toBe(2);
+              expect(isLoaded).toBe(true);
+            });
+          });
+        });
+        "
+      `);
+    });
   });
 });


### PR DESCRIPTION
## Current Behavior

When generating a facade with the NgRx generators, the spec file imports a non-existent `readFirst` from `@nx/angular/testing`. That helper was deprecated for a long time and removed in Nx v21, but this usage was missed, causing those tests to fail.

The e2e tests that cover this were disabled for the pnpm package manager, so it was not caught in the PR/main CI pipeline. It was correctly failing in the Nightly CI pipeline. The tests are now enabled for all package managers.

Nightly failure: https://staging.nx.app/runs/uRlR20Fzt9/task/e2e-angular%3Ae2e-local

## Expected Behavior

When generating a facade with the NgRx generators, the spec file for the facade should be correct.

## Related Issue(s)

Fixes #
