### PR TITLE
fix(plugin): handle directory paths correctly in executor and generator generators

### DIFF
--- a/packages/plugin/src/generators/executor/executor.spec.ts
+++ b/packages/plugin/src/generators/executor/executor.spec.ts
@@ -256,4 +256,65 @@ describe('NxPlugin Executor Generator', () => {
       );
     });
   });
+
+  describe('directory path handling', () => {
+    it('should create subdirectory when path looks like a directory', async () => {
+      await executorGenerator(tree, {
+        name: 'artifact-upload',
+        path: 'my-plugin/src/executors/artifact-upload',
+        unitTestRunner: 'jest',
+        includeHasher: false,
+      });
+
+      // Should create files in a subdirectory named after the artifact
+      expect(
+        tree.exists('my-plugin/src/executors/artifact-upload/artifact-upload.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/executors/artifact-upload/artifact-upload.spec.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/executors/artifact-upload/schema.d.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/executors/artifact-upload/schema.json')
+      ).toBeTruthy();
+
+      const executorsJson = readJson(tree, 'my-plugin/executors.json');
+      expect(executorsJson.executors['artifact-upload'].implementation).toEqual(
+        './src/executors/artifact-upload/artifact-upload'
+      );
+      expect(executorsJson.executors['artifact-upload'].schema).toEqual(
+        './src/executors/artifact-upload/schema.json'
+      );
+    });
+
+    it('should handle explicit file path correctly', async () => {
+      await executorGenerator(tree, {
+        name: 'artifact-upload',
+        path: 'my-plugin/src/executors/artifact-upload/my-executor',
+        unitTestRunner: 'jest',
+        includeHasher: false,
+      });
+
+      // Should create files with the explicit filename
+      expect(
+        tree.exists('my-plugin/src/executors/artifact-upload/my-executor.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/executors/artifact-upload/my-executor.spec.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/executors/artifact-upload/schema.d.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/executors/artifact-upload/schema.json')
+      ).toBeTruthy();
+
+      const executorsJson = readJson(tree, 'my-plugin/executors.json');
+      expect(executorsJson.executors['artifact-upload'].implementation).toEqual(
+        './src/executors/artifact-upload/my-executor'
+      );
+    });
+  });
 });

--- a/packages/plugin/src/generators/executor/executor.spec.ts
+++ b/packages/plugin/src/generators/executor/executor.spec.ts
@@ -268,10 +268,14 @@ describe('NxPlugin Executor Generator', () => {
 
       // Should create files in a subdirectory named after the artifact
       expect(
-        tree.exists('my-plugin/src/executors/artifact-upload/artifact-upload.ts')
+        tree.exists(
+          'my-plugin/src/executors/artifact-upload/artifact-upload.ts'
+        )
       ).toBeTruthy();
       expect(
-        tree.exists('my-plugin/src/executors/artifact-upload/artifact-upload.spec.ts')
+        tree.exists(
+          'my-plugin/src/executors/artifact-upload/artifact-upload.spec.ts'
+        )
       ).toBeTruthy();
       expect(
         tree.exists('my-plugin/src/executors/artifact-upload/schema.d.ts')
@@ -302,7 +306,9 @@ describe('NxPlugin Executor Generator', () => {
         tree.exists('my-plugin/src/executors/artifact-upload/my-executor.ts')
       ).toBeTruthy();
       expect(
-        tree.exists('my-plugin/src/executors/artifact-upload/my-executor.spec.ts')
+        tree.exists(
+          'my-plugin/src/executors/artifact-upload/my-executor.spec.ts'
+        )
       ).toBeTruthy();
       expect(
         tree.exists('my-plugin/src/executors/artifact-upload/schema.d.ts')

--- a/packages/plugin/src/generators/executor/executor.ts
+++ b/packages/plugin/src/generators/executor/executor.ts
@@ -174,10 +174,14 @@ async function normalizeOptions(
   const normalizedPath = options.path.replace(/^\.?\//, '').replace(/\/$/, '');
   const pathSegments = normalizedPath.split('/');
   const lastSegment = pathSegments[pathSegments.length - 1];
-  
-  // If the last segment doesn't contain a file extension and matches the artifact name,
+
+  // If the last segment doesn't end with a known file extension and matches the artifact name,
   // it's likely a directory path, so we should create a subdirectory
-  if (!lastSegment.includes('.') && lastSegment === name) {
+  const knownFileExtensions = ['.ts', '.js', '.jsx', '.tsx'];
+  const hasKnownFileExtension = knownFileExtensions.some((ext) =>
+    lastSegment.endsWith(ext)
+  );
+  if (!hasKnownFileExtension && lastSegment === name) {
     directory = joinPathFragments(initialDirectory, name);
   }
 

--- a/packages/plugin/src/generators/executor/executor.ts
+++ b/packages/plugin/src/generators/executor/executor.ts
@@ -158,7 +158,7 @@ async function normalizeOptions(
 ): Promise<NormalizedSchema> {
   const {
     artifactName: name,
-    directory,
+    directory: initialDirectory,
     fileName,
     project,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
@@ -167,6 +167,19 @@ async function normalizeOptions(
     allowedFileExtensions: ['ts'],
     fileExtension: 'ts',
   });
+
+  // Check if the path looks like a directory path (doesn't end with a filename)
+  // If so, include the artifact name as a subdirectory
+  let directory = initialDirectory;
+  const normalizedPath = options.path.replace(/^\.?\//, '').replace(/\/$/, '');
+  const pathSegments = normalizedPath.split('/');
+  const lastSegment = pathSegments[pathSegments.length - 1];
+  
+  // If the last segment doesn't contain a file extension and matches the artifact name,
+  // it's likely a directory path, so we should create a subdirectory
+  if (!lastSegment.includes('.') && lastSegment === name) {
+    directory = joinPathFragments(initialDirectory, name);
+  }
 
   const { className, propertyName } = names(name);
 

--- a/packages/plugin/src/generators/generator/generator.spec.ts
+++ b/packages/plugin/src/generators/generator/generator.spec.ts
@@ -314,4 +314,63 @@ describe('NxPlugin Generator Generator', () => {
       ).toEqual(true);
     });
   });
+
+  describe('directory path handling', () => {
+    it('should create subdirectory when path looks like a directory', async () => {
+      await generatorGenerator(tree, {
+        name: 'component-generator',
+        path: 'my-plugin/src/generators/component-generator',
+        unitTestRunner: 'jest',
+      });
+
+      // Should create files in a subdirectory named after the artifact
+      expect(
+        tree.exists('my-plugin/src/generators/component-generator/component-generator.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/generators/component-generator/component-generator.spec.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/generators/component-generator/schema.d.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/generators/component-generator/schema.json')
+      ).toBeTruthy();
+
+      const generatorsJson = readJson(tree, 'my-plugin/generators.json');
+      expect(generatorsJson.generators['component-generator'].factory).toEqual(
+        './src/generators/component-generator/component-generator'
+      );
+      expect(generatorsJson.generators['component-generator'].schema).toEqual(
+        './src/generators/component-generator/schema.json'
+      );
+    });
+
+    it('should handle explicit file path correctly', async () => {
+      await generatorGenerator(tree, {
+        name: 'component-generator',
+        path: 'my-plugin/src/generators/component-generator/my-generator',
+        unitTestRunner: 'jest',
+      });
+
+      // Should create files with the explicit filename
+      expect(
+        tree.exists('my-plugin/src/generators/component-generator/my-generator.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/generators/component-generator/my-generator.spec.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/generators/component-generator/schema.d.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('my-plugin/src/generators/component-generator/schema.json')
+      ).toBeTruthy();
+
+      const generatorsJson = readJson(tree, 'my-plugin/generators.json');
+      expect(generatorsJson.generators['component-generator'].factory).toEqual(
+        './src/generators/component-generator/my-generator'
+      );
+    });
+  });
 });

--- a/packages/plugin/src/generators/generator/generator.spec.ts
+++ b/packages/plugin/src/generators/generator/generator.spec.ts
@@ -325,10 +325,14 @@ describe('NxPlugin Generator Generator', () => {
 
       // Should create files in a subdirectory named after the artifact
       expect(
-        tree.exists('my-plugin/src/generators/component-generator/component-generator.ts')
+        tree.exists(
+          'my-plugin/src/generators/component-generator/component-generator.ts'
+        )
       ).toBeTruthy();
       expect(
-        tree.exists('my-plugin/src/generators/component-generator/component-generator.spec.ts')
+        tree.exists(
+          'my-plugin/src/generators/component-generator/component-generator.spec.ts'
+        )
       ).toBeTruthy();
       expect(
         tree.exists('my-plugin/src/generators/component-generator/schema.d.ts')
@@ -355,10 +359,14 @@ describe('NxPlugin Generator Generator', () => {
 
       // Should create files with the explicit filename
       expect(
-        tree.exists('my-plugin/src/generators/component-generator/my-generator.ts')
+        tree.exists(
+          'my-plugin/src/generators/component-generator/my-generator.ts'
+        )
       ).toBeTruthy();
       expect(
-        tree.exists('my-plugin/src/generators/component-generator/my-generator.spec.ts')
+        tree.exists(
+          'my-plugin/src/generators/component-generator/my-generator.spec.ts'
+        )
       ).toBeTruthy();
       expect(
         tree.exists('my-plugin/src/generators/component-generator/schema.d.ts')

--- a/packages/plugin/src/generators/generator/generator.ts
+++ b/packages/plugin/src/generators/generator/generator.ts
@@ -37,7 +37,7 @@ async function normalizeOptions(
 ): Promise<NormalizedSchema> {
   const {
     artifactName: name,
-    directory,
+    directory: initialDirectory,
     fileName,
     project,
   } = await determineArtifactNameAndDirectoryOptions(tree, {
@@ -46,6 +46,19 @@ async function normalizeOptions(
     allowedFileExtensions: ['ts'],
     fileExtension: 'ts',
   });
+
+  // Check if the path looks like a directory path (doesn't end with a filename)
+  // If so, include the artifact name as a subdirectory
+  let directory = initialDirectory;
+  const normalizedPath = options.path.replace(/^\.?\//, '').replace(/\/$/, '');
+  const pathSegments = normalizedPath.split('/');
+  const lastSegment = pathSegments[pathSegments.length - 1];
+  
+  // If the last segment doesn't contain a file extension and matches the artifact name,
+  // it's likely a directory path, so we should create a subdirectory
+  if (!lastSegment.includes('.') && lastSegment === name) {
+    directory = joinPathFragments(initialDirectory, name);
+  }
 
   const { className, propertyName } = names(name);
 

--- a/packages/plugin/src/generators/generator/generator.ts
+++ b/packages/plugin/src/generators/generator/generator.ts
@@ -53,10 +53,14 @@ async function normalizeOptions(
   const normalizedPath = options.path.replace(/^\.?\//, '').replace(/\/$/, '');
   const pathSegments = normalizedPath.split('/');
   const lastSegment = pathSegments[pathSegments.length - 1];
-  
-  // If the last segment doesn't contain a file extension and matches the artifact name,
+
+  // If the last segment doesn't end with a known file extension and matches the artifact name,
   // it's likely a directory path, so we should create a subdirectory
-  if (!lastSegment.includes('.') && lastSegment === name) {
+  const knownFileExtensions = ['.ts', '.js', '.jsx', '.tsx'];
+  const hasKnownFileExtension = knownFileExtensions.some((ext) =>
+    lastSegment.endsWith(ext)
+  );
+  if (!hasKnownFileExtension && lastSegment === name) {
     directory = joinPathFragments(initialDirectory, name);
   }
 


### PR DESCRIPTION
Fixes path handling issue in @nx/plugin generators where the last folder name in the path was being ignored.

The executor and generator generators were not creating subdirectories as expected when provided with directory paths. This fix detects when the path looks like a directory path and adjusts the directory to include the artifact name as a subdirectory.

**Changes:**
- Modified normalizeOptions in both executor and generator generators to detect directory paths
- Added logic to create subdirectories when the path segment matches the artifact name
- Added comprehensive tests to verify the fix works correctly
- Ensures backward compatibility with existing file path usage

Fixes #31803
Fixes #31776

Generated with [Claude Code](https://claude.ai/code)