### PR TITLE
fix(node): ensure cwd is set in target correctly

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -43,6 +43,7 @@ describe('application generator', () => {
                 "args": [
                   "--node-env=development",
                 ],
+                "cwd": "my-node-app"
               },
             },
             "executor": "nx:run-commands",

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -43,7 +43,6 @@ describe('application generator', () => {
                 "args": [
                   "--node-env=development",
                 ],
-                "cwd": "my-node-app"
               },
             },
             "executor": "nx:run-commands",
@@ -52,6 +51,7 @@ describe('application generator', () => {
                 "--node-env=production",
               ],
               "command": "webpack-cli build",
+              "cwd": "my-node-app",
             },
           },
           "copy-workspace-modules": {
@@ -278,6 +278,7 @@ describe('application generator', () => {
                     "--node-env=production",
                   ],
                   "command": "webpack-cli build",
+                  "cwd": "myapp",
                 },
               },
               "copy-workspace-modules": {
@@ -479,6 +480,7 @@ describe('application generator', () => {
                   "--node-env=production",
                 ],
                 "command": "webpack-cli build",
+                "cwd": "myapp",
               },
             },
             "copy-workspace-modules": {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1132,6 +1132,7 @@ describe('app', () => {
       expect(buildTarget.executor).toBe('nx:run-commands');
       expect(buildTarget.options.command).toBe('webpack-cli build');
       expect(buildTarget.options.args).toEqual(['--node-env=production']);
+      expect(buildTarget.options.cwd).toEqual(project.sourceRoot)
       expect(buildTarget.configurations.development.args).toEqual([
         '--node-env=development',
       ]);

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1132,7 +1132,7 @@ describe('app', () => {
       expect(buildTarget.executor).toBe('nx:run-commands');
       expect(buildTarget.options.command).toBe('webpack-cli build');
       expect(buildTarget.options.args).toEqual(['--node-env=production']);
-      expect(buildTarget.options.cwd).toEqual(project.sourceRoot);
+      expect(buildTarget.options.cwd).toEqual(project.root);
       expect(buildTarget.configurations.development.args).toEqual([
         '--node-env=development',
       ]);

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1132,7 +1132,7 @@ describe('app', () => {
       expect(buildTarget.executor).toBe('nx:run-commands');
       expect(buildTarget.options.command).toBe('webpack-cli build');
       expect(buildTarget.options.args).toEqual(['--node-env=production']);
-      expect(buildTarget.options.cwd).toEqual(project.sourceRoot)
+      expect(buildTarget.options.cwd).toEqual(project.sourceRoot);
       expect(buildTarget.configurations.development.args).toEqual([
         '--node-env=development',
       ]);

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -40,7 +40,7 @@ export function addProject(
     } else if (options.isNest) {
       // If we are using Nest that has the webpack plugin we need to override the
       // build target so that node-env can be set to production or development so the serve target can be run in development mode
-      project.targets.build = getNestWebpackBuildConfig();
+      project.targets.build = getNestWebpackBuildConfig(project);
     }
   }
   project.targets = {

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -114,7 +114,9 @@ export function getServeConfig(options: NormalizedSchema): TargetConfiguration {
   };
 }
 
-export function getNestWebpackBuildConfig(project: ProjectConfiguration): TargetConfiguration {
+export function getNestWebpackBuildConfig(
+  project: ProjectConfiguration
+): TargetConfiguration {
   return {
     executor: 'nx:run-commands',
     options: {

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -114,12 +114,13 @@ export function getServeConfig(options: NormalizedSchema): TargetConfiguration {
   };
 }
 
-export function getNestWebpackBuildConfig(): TargetConfiguration {
+export function getNestWebpackBuildConfig(project: ProjectConfiguration): TargetConfiguration {
   return {
     executor: 'nx:run-commands',
     options: {
       command: 'webpack-cli build',
       args: ['--node-env=production'],
+      cwd: project.sourceRoot,
     },
     configurations: {
       development: {

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -122,7 +122,7 @@ export function getNestWebpackBuildConfig(
     options: {
       command: 'webpack-cli build',
       args: ['--node-env=production'],
-      cwd: project.sourceRoot,
+      cwd: project.root,
     },
     configurations: {
       development: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The Nest.js webpack build target configuration was generating webpack-cli arguments without the required cwd in build.options.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The Nest.js webpack build target should generate proper webpack-cli arguments with the cwd as part of the build.options
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31863
