### PR TITLE
fix(vite): bump @analogjs/vite-plugin-angular to 1.19.x

### DIFF
--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -4953,6 +4953,16 @@
       }
     },
     "migrations": {
+      "/technologies/build-tools/vite/api/migrations/21.3.0-package-updates": {
+        "description": "",
+        "file": "generated/packages/vite/migrations/21.3.0-package-updates.json",
+        "hidden": false,
+        "name": "21.3.0-package-updates",
+        "version": "21.3.0-beta.3",
+        "originalFilePath": "/packages/vite",
+        "path": "/technologies/build-tools/vite/api/migrations/21.3.0-package-updates",
+        "type": "migration"
+      },
       "/technologies/build-tools/vite/api/migrations/21.2.0-package-updates": {
         "description": "",
         "file": "generated/packages/vite/migrations/21.2.0-package-updates.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -5323,6 +5323,16 @@
     "migrations": [
       {
         "description": "",
+        "file": "generated/packages/vite/migrations/21.3.0-package-updates.json",
+        "hidden": false,
+        "name": "21.3.0-package-updates",
+        "version": "21.3.0-beta.3",
+        "originalFilePath": "/packages/vite",
+        "path": "vite/migrations/21.3.0-package-updates",
+        "type": "migration"
+      },
+      {
+        "description": "",
         "file": "generated/packages/vite/migrations/21.2.0-package-updates.json",
         "hidden": false,
         "name": "21.2.0-package-updates",

--- a/docs/generated/packages/vite/migrations/21.3.0-package-updates.json
+++ b/docs/generated/packages/vite/migrations/21.3.0-package-updates.json
@@ -1,0 +1,21 @@
+{
+  "name": "21.3.0-package-updates",
+  "version": "21.3.0-beta.3",
+  "packages": {
+    "@analogjs/vite-plugin-angular": {
+      "version": "~1.19.1",
+      "alwaysAddToPackageJson": false
+    },
+    "@analogjs/vitest-angular": {
+      "version": "~1.19.1",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/vite",
+  "schema": null,
+  "type": "migration"
+}

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -84,6 +84,19 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "21.3.0": {
+      "version": "21.3.0-beta.3",
+      "packages": {
+        "@analogjs/vite-plugin-angular": {
+          "version": "~1.19.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@analogjs/vitest-angular": {
+          "version": "~1.19.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -13,7 +13,7 @@ export const happyDomVersion = '~9.20.3';
 export const edgeRuntimeVmVersion = '~3.0.2';
 export const jitiVersion = '2.4.2';
 
-export const analogVitestAngular = '~1.17.1';
+export const analogVitestAngular = '~1.19.1';
 
 // Coverage providers
 export const vitestCoverageV8Version = '^3.0.5';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

AnalogJS installs 1.16.1 for Vitest support

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

AnalogJS installs 1.19.1 for Vitest support

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
