### PR TITLE
docs(misc): fix command in self-healing ci blog post

### DIFF
--- a/docs/blog/2025-06-23-nx-self-healing-ci.md
+++ b/docs/blog/2025-06-23-nx-self-healing-ci.md
@@ -157,7 +157,7 @@ jobs:
 
       - run: npx nx affected -t lint test build
 
-      - run: npx nx cloud fix-ci
+      - run: npx nx-cloud fix-ci
         if: always()
 ```
 


### PR DESCRIPTION
The command shown in the blog post is incorrect.

Should be `npx nx-cloud fix-ci` not `npx nx cloud fix-ci`.

Post: https://nx.dev/blog/nx-self-healing-ci#2-configure-your-ci-pipeline