### PR TITLE
docs(nx-dev): add credit pricing reference & update navigation

### DIFF
--- a/docs/generated/manifests/ci.json
+++ b/docs/generated/manifests/ci.json
@@ -2033,6 +2033,17 @@
         "tags": []
       },
       {
+        "id": "credits-pricing",
+        "name": "Credit Pricing",
+        "description": "",
+        "mediaImage": "",
+        "file": "nx-cloud/reference/nx-cloud-credits-pricing",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/ci/reference/credits-pricing",
+        "tags": []
+      },
+      {
         "id": "release-notes",
         "name": "Release Notes",
         "description": "",
@@ -2112,6 +2123,17 @@
     "itemList": [],
     "isExternal": false,
     "path": "/ci/reference/env-vars",
+    "tags": []
+  },
+  "/ci/reference/credits-pricing": {
+    "id": "credits-pricing",
+    "name": "Credit Pricing",
+    "description": "",
+    "mediaImage": "",
+    "file": "nx-cloud/reference/nx-cloud-credits-pricing",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/ci/reference/credits-pricing",
     "tags": []
   },
   "/ci/reference/release-notes": {

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -7337,6 +7337,14 @@
             "disableCollapsible": false
           },
           {
+            "name": "Credit Pricing",
+            "path": "/ci/reference/credits-pricing",
+            "id": "credits-pricing",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
             "name": "Release Notes",
             "path": "/ci/reference/release-notes",
             "id": "release-notes",

--- a/docs/map.json
+++ b/docs/map.json
@@ -2912,6 +2912,11 @@
               "file": "nx-cloud/reference/env-vars"
             },
             {
+              "name": "Credit Pricing",
+              "id": "credits-pricing",
+              "file": "nx-cloud/reference/nx-cloud-credits-pricing"
+            },
+            {
               "name": "Release Notes",
               "id": "release-notes",
               "file": "nx-cloud/reference/release-notes"

--- a/docs/nx-cloud/reference/nx-cloud-credits-pricing.md
+++ b/docs/nx-cloud/reference/nx-cloud-credits-pricing.md
@@ -1,0 +1,55 @@
+# Nx Cloud Credit Pricing Reference
+
+## Overview
+
+Credits are the Nx Cloud currency that enables usage-based pricing. This system allows for transparent cost tracking and flexible billing based on actual consumption of resources.
+
+## What Are Credits?
+
+Credits represent the computational resources consumed during CI/CD operations. They account for:
+
+- CPU usage
+- Memory consumption
+- Setup and provisioning costs
+- Storage operations
+- Task execution time
+- AI computation
+
+## Credit pricing
+
+### Non-compute pricing
+
+- **CI Pipeline Execution: 500 credits per execution**. A CI Pipeline Execution is a CI run or a Workflow run (depending on your CI provider). For instance, running a PR or running CI on the main branch are CI Pipeline Executions.
+- **AI-Powered Self-Healing CI: 6555 credits per 1M input tokens, 32700 credits per 1M output tokens**. Credits are consumed by the fix-ci command.
+
+### Agents resource classes
+
+#### Docker / Linux AMD64
+
+| Resource Class | Specifications    | Credits/min |
+| -------------- | ----------------- | ----------- |
+| Small          | 1 vCPU, 2GB RAM   | 5           |
+| Medium         | 2 vCPU, 4GB RAM   | 10          |
+| Medium +       | 3 vCPU, 6GB RAM   | 15          |
+| Large          | 4 vCPU, 8GB RAM   | 20          |
+| Large +        | 4 vCPU, 10GB RAM  | 30          |
+| Extra large    | 8 vCPU, 16GB RAM  | 40          |
+| Extra large +  | 10 vCPU, 20GB RAM | 60          |
+
+#### Docker / Linux ARM64
+
+| Resource Class | Specifications   | Credits/min |
+| -------------- | ---------------- | ----------- |
+| Medium         | 2 vCPU, 8GB RAM  | 13          |
+| Large          | 4 vCPU, 16GB RAM | 26          |
+| Extra large    | 8 vCPU, 32GB RAM | 52          |
+
+#### Docker / Windows
+
+| Resource Class | Specifications  | Credits/min |
+| -------------- | --------------- | ----------- |
+| Medium         | 3 vCPU, 6GB RAM | 40          |
+
+---
+
+_Note: Prices do not include applicable taxes. Credit pricing and allocations subject to change._

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -884,6 +884,7 @@
     - [Assignment Rules](/ci/reference/assignment-rules)
     - [Custom Steps](/ci/reference/custom-steps)
     - [Environment Variables](/ci/reference/env-vars)
+    - [Credit Pricing](/ci/reference/credits-pricing)
     - [Release Notes](/ci/reference/release-notes)
   - [Troubleshooting](/ci/troubleshooting)
     - [CI Execution Failed](/ci/troubleshooting/ci-execution-failed)

--- a/nx-dev/nx-dev/pages/nx-cloud/index.tsx
+++ b/nx-dev/nx-dev/pages/nx-cloud/index.tsx
@@ -5,6 +5,7 @@ import { NextSeo } from 'next-seo';
 import {
   CallToAction,
   CiBottleneck,
+  CreditPricing,
   CustomerMetrics,
   Faq,
   Features,

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -1470,6 +1470,11 @@ const gettingStartedRedirects = {
   '/getting-started/why-nx': '/getting-started/intro',
 };
 
+// Pricing page: 07/08/25
+const pricingRedirects = {
+  '/pricing': '/nx-cloud#plans',
+};
+
 /**
  * Public export API
  */
@@ -1510,4 +1515,5 @@ module.exports = {
   nxRecipesRedirects,
   nxModuleFederationConceptsRedirects,
   gettingStartedRedirects,
+  pricingRedirects,
 };

--- a/nx-dev/ui-cloud/src/lib/faq.tsx
+++ b/nx-dev/ui-cloud/src/lib/faq.tsx
@@ -52,18 +52,6 @@ export function Faq(): ReactElement {
       ),
     },
     {
-      question: 'What are credits?',
-      answerJson:
-        'Credits are the currency of Nx Cloud. A determined number of credits are included in each plan. These credits are used to pay for Nx Cloud platform usage in real time.',
-      answerUi: (
-        <p>
-          Credits are the currency of Nx Cloud. A determined number of credits
-          are included in each plan. These credits are used to pay for Nx Cloud
-          platform usage in real time.
-        </p>
-      ),
-    },
-    {
       question: 'How much does it cost per individual credit?',
       answerJson:
         "On the Team Plan, each credit costs $0.00055, which is $5.50 for 10,000 credits to help you visualize the pricing. However, you don't need to purchase credits in fixed amounts—we only charge you for the exact number of additional credits you use beyond your included credits. Overages are prorated, so you'll only pay for what you actually consume.",
@@ -102,18 +90,6 @@ export function Faq(): ReactElement {
       ),
     },
     {
-      question: 'What is an active contributor?',
-      answerJson:
-        'Active contributors are calculated based on any person or actor that has triggered a CI Pipeline Execution within the current billing cycle.',
-      answerUi: (
-        <p>
-          Active contributors are calculated based on any person or actor that
-          has triggered a CI Pipeline Execution within the current billing
-          cycle.
-        </p>
-      ),
-    },
-    {
       question: 'What is a concurrent connection?',
       answerJson:
         'Concurrent connections are unique machines that connect to Nx Cloud from a CI environment. If you are using Distributed Task Execution, you should expect to have one concurrent connection from your orchestrator job, and one additional concurrent connection for each live agent that is helping perform work.',
@@ -124,20 +100,6 @@ export function Faq(): ReactElement {
           you should expect to have one concurrent connection from your
           orchestrator job, and one additional concurrent connection for each
           live agent that is helping perform work.
-        </p>
-      ),
-    },
-    {
-      question:
-        "I thought I was on the Pro plan, but I don't see it listed anymore. Does it still exist?",
-      answerJson:
-        "Yes, the Pro plan still exists for users who were grandfathered in. If you're already on the Pro plan, you will continue to receive support without any changes. However, this plan is no longer available to new users.",
-      answerUi: (
-        <p>
-          Yes, the Pro plan still exists for users who were grandfathered in. If
-          you're already on the Pro plan, you will continue to receive support
-          without any changes. However, this plan is no longer available to new
-          users.
         </p>
       ),
     },
@@ -165,91 +127,6 @@ export function Faq(): ReactElement {
       ),
     },
     {
-      question: 'Do I need a credit card to create an account?',
-      answerJson:
-        'No, you can set up a workspace with Nx Cloud completely for free, without entering any billing information.',
-      answerUi: (
-        <p>
-          No, you can set up a workspace with Nx Cloud completely for free,
-          without entering any billing information.
-        </p>
-      ),
-    },
-    {
-      question:
-        'What happens if I consume all my credits while on the Hobby plan?',
-      answerJson:
-        'The Hobby plan allows you to configure and run a small project at no cost. If you consume all the credits, your organization will be disabled until you upgrade to Team or wait for the next billing cycle.',
-      answerUi: (
-        <p>
-          The Hobby plan allows you to configure and run a small project at no
-          cost. If you consume all the credits, your organization will be
-          disabled until you upgrade to Team or wait for the next billing cycle.
-        </p>
-      ),
-    },
-    {
-      question: 'What is a CI Pipeline Execution?',
-      answerJson:
-        'A CI Pipeline Execution is a CI run or a Workflow run (depending on your CI provider). For instance, running a PR or running CI on the main branch are CI Pipeline Executions.',
-      answerUi: (
-        <p>
-          A CI Pipeline Execution is a CI run or a Workflow run (depending on
-          your CI provider). For instance, running a PR or running CI on the
-          main branch are CI Pipeline Executions.
-        </p>
-      ),
-    },
-    {
-      question: 'What is the Team Plan?',
-      answerJson:
-        'The Team Plan is our new offering that provides flexible pricing, designed to better meet the needs of teams of all sizes. The Team Plan replaced the Pro Plan in 2024. ',
-      answerUi: (
-        <p>
-          The Team Plan is our new offering that provides flexible pricing,
-          designed to better meet the needs of teams of all sizes. The Team Plan
-          replaced the Pro Plan in 2024.
-        </p>
-      ),
-    },
-    {
-      question: 'How does the Team Plan differ from the previous Pro Plan?',
-      answerJson:
-        'The Team Plan offers a lower base price with the ability to add contributors and credits as needed, whereas the Pro Plan had a higher base price with fixed allowances.',
-      answerUi: (
-        <p>
-          The Team Plan offers a lower base price with the ability to add
-          contributors and credits as needed, whereas the Pro Plan had a higher
-          base price with fixed allowances.
-        </p>
-      ),
-    },
-    {
-      question:
-        'I think I am on the Pro Plan but don’t see it offered, does it still exist?',
-      answerJson:
-        'Existing Pro Plan users have been grandfathered into their existing plan and can expect no changes. This plan is no longer available to new users. ',
-      answerUi: (
-        <p>
-          Existing Pro Plan users have been grandfathered into their existing
-          plan and can expect no changes. This plan is no longer available to
-          new users.
-        </p>
-      ),
-    },
-    {
-      question: 'Can existing Pro organizations switch to the new Team Plan?',
-      answerJson:
-        'Yes! If the new Team Plan better fits your needs, you can reach out to cloud-support@nrwl.io. If you upgrade to a new plan, please note that you will not be able to switch back to a legacy plan. ',
-      answerUi: (
-        <p>
-          Yes! If the new Team Plan better fits your needs, you can reach out to
-          cloud-support@nrwl.io. If you upgrade to a new plan, please note that
-          you will not be able to switch back to a legacy plan.
-        </p>
-      ),
-    },
-    {
       question: 'Is there a plan for open source projects?',
       answerJson:
         'Yes, we are happy to collaborate with open source projects. Please complete this form, and we will review your request and get back to you: https://nx.dev/pricing/special-offer',
@@ -265,41 +142,6 @@ export function Faq(): ReactElement {
           >
             https://nx.dev/pricing/special-offer
           </Link>
-        </p>
-      ),
-    },
-    {
-      question: 'What if I need help picking the right plan?',
-      answerJson:
-        'We have a helpful comparison above. If you have additional questions, or these plans don’t fit your needs please reach out to https://nx.dev/contact/sales and we will do our best to help.',
-      answerUi: (
-        <p>
-          We have a helpful comparison above. If you have additional questions,
-          or these plans don’t fit your needs please reach out to
-          https://nx.dev/contact/sales and we will do our best to help.
-        </p>
-      ),
-    },
-    {
-      question: 'What if I need more than 30 active contributors?',
-      answerJson: 'Please reach out to https://nx.dev/contact/sales',
-      answerUi: (
-        <p>
-          Please reach out to{' '}
-          <Link href="/contact/sales" title="Contact us" className="underline">
-            https://nx.dev/contact/sales
-          </Link>
-        </p>
-      ),
-    },
-    {
-      question: 'What payment methods do you accept?',
-      answerJson:
-        'We accept Visa, Mastercard, American Express, and Discover from customers worldwide.',
-      answerUi: (
-        <p>
-          We accept Visa, Mastercard, American Express, and Discover from
-          customers worldwide.
         </p>
       ),
     },

--- a/nx-dev/ui-cloud/src/lib/pricing.tsx
+++ b/nx-dev/ui-cloud/src/lib/pricing.tsx
@@ -9,7 +9,7 @@ import { PlusIcon } from '@heroicons/react/24/outline';
 export function Pricing(): ReactElement {
   return (
     <section
-      id="pricing"
+      id="plans"
       className="scroll-mt-24 border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900"
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -404,8 +404,14 @@ export function Pricing(): ReactElement {
           </div>
           <div className="mt-4 text-center">
             <p className="text-sm font-medium opacity-80">
-              Looking for the Pro plan?{' '}
-              <Link href="#faq">Checkout our FAQ ↓</Link>
+              See{' '}
+              <Link
+                href="/ci/reference/credits-pricing"
+                className="font-semibold underline"
+              >
+                Credit Pricing
+              </Link>{' '}
+              for credit consumption and resource class.{' '}
             </p>
           </div>
         </div>

--- a/nx-dev/ui-cloud/src/lib/time-to-green.tsx
+++ b/nx-dev/ui-cloud/src/lib/time-to-green.tsx
@@ -25,23 +25,23 @@ export function TimeToGreen(): ReactElement {
         <h3 className="text-xl font-semibold">Average Time To Green</h3>
 
         <div className="mt-2">
-          <div className="relative grid grid-cols-1 rounded-lg text-xs font-medium shadow ring-1 ring-black/5 sm:h-12 sm:grid-cols-12 dark:bg-slate-950 dark:ring-white/10">
-            <div className="flex h-12 items-center justify-center rounded-t-lg bg-blue-600 text-white sm:col-span-2 sm:h-auto sm:rounded-l-lg sm:rounded-r-none">
+          <div className="relative grid grid-cols-1 rounded-lg bg-slate-50 text-xs font-medium text-slate-900 ring-1 ring-slate-200 sm:h-12 sm:grid-cols-12 dark:bg-slate-900 dark:text-slate-100 dark:ring-white/10">
+            <div className="flex h-12 items-center justify-center rounded-t-lg bg-blue-400/40 sm:col-span-2 sm:h-auto sm:rounded-l-lg sm:rounded-r-none dark:bg-blue-600/40">
               <span className="px-2">Write Code</span>
             </div>
-            <div className="relative flex h-12 items-center justify-center bg-red-600 text-white  sm:col-span-2 sm:h-auto">
+            <div className="relative flex h-12 items-center justify-center bg-red-500/40 sm:col-span-2  sm:h-auto dark:bg-red-500/40">
               <span className="px-2">Run CI (Flaky Test Failure)</span>
             </div>
-            <div className="flex h-12 items-center justify-center bg-red-800 text-white sm:col-span-3 sm:h-auto">
+            <div className="flex h-12 items-center justify-center bg-red-200/40 sm:col-span-3 sm:h-auto dark:bg-red-950/40">
               <span className="px-2">Switch Focus</span>
             </div>
-            <div className="relative flex h-12 items-center justify-center bg-red-600 text-white sm:col-span-2 sm:h-auto">
+            <div className="relative flex h-12 items-center justify-center bg-red-500/40  sm:col-span-2 sm:h-auto dark:bg-red-500/40">
               <span className="px-2">Re-Run CI (Code Error)</span>
             </div>
-            <div className="flex h-12 items-center justify-center bg-red-700 text-white sm:col-span-1 sm:h-auto">
+            <div className="flex h-12 items-center justify-center bg-red-400/40 sm:col-span-1 sm:h-auto dark:bg-red-800/40">
               <span className="px-2">Fix Code</span>
             </div>
-            <div className="flex h-12 items-center justify-center rounded-b-lg bg-green-600 text-white sm:col-span-2 sm:h-auto sm:rounded-b-none sm:rounded-r-lg">
+            <div className="flex h-12 items-center justify-center rounded-b-lg bg-green-400/40 sm:col-span-2 sm:h-auto sm:rounded-b-none sm:rounded-r-lg dark:bg-green-600/40">
               <span className="px-2">Re-Run CI</span>
             </div>
           </div>
@@ -50,12 +50,12 @@ export function TimeToGreen(): ReactElement {
           <h3 className="text-xl font-semibold">Time To Green with Nx Cloud</h3>
           <div className="mt-2 grid grid-cols-1 sm:h-12 sm:grid-cols-12">
             <div className="col-span-4 grid grid-cols-1 sm:grid-cols-6">
-              <div className="grid grid-cols-1 rounded-lg text-xs font-medium shadow ring-1 ring-black/5 sm:col-span-5 sm:grid-cols-10 dark:bg-slate-950 dark:ring-white/10">
-                <div className="flex h-12 items-center justify-center rounded-t-lg bg-blue-600 text-white sm:col-span-6 sm:h-auto sm:rounded-l-lg sm:rounded-r-none">
+              <div className="grid grid-cols-1 rounded-lg bg-slate-50 text-xs font-medium text-slate-900 ring-1 ring-slate-200 sm:col-span-5 sm:grid-cols-10 dark:bg-slate-900 dark:text-slate-100 dark:ring-white/10">
+                <div className="flex h-12 items-center justify-center rounded-t-lg bg-blue-400/40 sm:col-span-6 sm:h-auto sm:rounded-l-lg sm:rounded-r-none dark:bg-blue-600/40">
                   <span className="px-2">Write Code</span>
                 </div>
 
-                <div className="flex h-12 items-center justify-center rounded-b-lg bg-green-600 text-white sm:col-span-4 sm:h-auto sm:rounded-b-none sm:rounded-r-lg">
+                <div className="flex h-12 items-center justify-center rounded-b-lg bg-green-400/40 sm:col-span-4 sm:h-auto sm:rounded-b-none sm:rounded-r-lg dark:bg-green-600/40">
                   <span className="px-2">CI + Self-Healing</span>
                 </div>
               </div>

--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -322,14 +322,6 @@ export function DocumentationHeader({
             >
               Nx Cloud
             </Link>
-            <Link
-              href="/pricing"
-              title="Pricing"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
-              prefetch={false}
-            >
-              Pricing
-            </Link>
             <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
             <Link
               href="/enterprise"

--- a/nx-dev/ui-common/src/lib/headers/header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/header.tsx
@@ -228,14 +228,6 @@ export function Header({ ctaButtons }: HeaderProps): ReactElement {
             >
               Nx Cloud
             </Link>
-            <Link
-              href="/pricing"
-              title="Pricing"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
-              prefetch={false}
-            >
-              Pricing
-            </Link>
             <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
             {/*ENTERPRISE*/}
             <Link
@@ -495,14 +487,6 @@ export function Header({ ctaButtons }: HeaderProps): ReactElement {
                             prefetch={false}
                           >
                             Nx Cloud
-                          </Link>
-                          <Link
-                            href="/pricing"
-                            title="Pricing"
-                            className="flex w-full gap-2 py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
-                            prefetch={false}
-                          >
-                            Pricing
                           </Link>
                           <Disclosure as="div">
                             {({ open }) => (


### PR DESCRIPTION
Introduced a new "Credit Pricing" reference page for Nx Cloud, detailing credit consumption and pricing metrics. Updated documentation structure, menus, sitemap, and headers to integrate the new page. Removed outdated FAQ entries and replaced the "Pricing" reference with the new "Credits Pricing" link in navigation. Adjusted related redirects and UI components for consistency.