### PR TITLE
docs(misc): update docs showing module boundaries eslint rule to show flat config by default

### DIFF
--- a/docs/generated/packages/eslint-plugin/documents/dependency-checks.md
+++ b/docs/generated/packages/eslint-plugin/documents/dependency-checks.md
@@ -23,6 +23,33 @@ Library generators from `@nx` packages will configure this rule automatically wh
 
 To set it up manually for existing libraries, you need to add the `dependency-checks` rule to your project's ESLint configuration:
 
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="<your-project-root>/eslint.config.mjs" %}
+import nxPlugin from '@nx/eslint-plugin';
+import jsoncParser from 'jsonc-eslint-parser';
+
+export default [
+  ...nxPlugin.configs['flat/base'],
+  ...nxPlugin.configs['flat/typescript'],
+  ...nxPlugin.configs['flat/javascript'],
+  {
+    files: ['**/*.json'],
+    languageOptions: {
+      parser: jsoncParser,
+    },
+    rules: {
+      '@nx/dependency-checks': 'error',
+    },
+  },
+  // ... more ESLint config here
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
+
 ```jsonc {% fileName="<your-project-root>/.eslintrc.json" %}
 {
   // ... more ESLint config here
@@ -38,6 +65,9 @@ To set it up manually for existing libraries, you need to add the `dependency-ch
   ]
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 Additionally, you need to adjust your `lintFilePatterns` to include the project's `package.json` file::
 
@@ -64,6 +94,36 @@ Additionally, you need to adjust your `lintFilePatterns` to include the project'
 
 Sometimes we intentionally want to add or remove a dependency from our `package.json` despite what the rule suggests. We can use the rule's options to override default behavior:
 
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="eslint.config.mjs" %}
+export default [
+  // ... other config
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          buildTargets: ['build', 'custom-build'], // add non standard build target names
+          checkMissingDependencies: true, // toggle to disable
+          checkObsoleteDependencies: true, // toggle to disable
+          checkVersionMismatches: true, // toggle to disable
+          ignoredDependencies: ['lodash'], // these libs will be omitted from checks
+          ignoredFiles: ['webpack.config.js', 'eslint.config.mjs'], // list of files that should be skipped for check
+          includeTransitiveDependencies: true, // collect dependencies transitively from children
+          useLocalPathsForWorkspaceDependencies: true, // toggle to disable
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
+
 ```jsonc {% fileName=".eslintrc.json" %}
 {
   "@nx/dependency-checks": [
@@ -81,6 +141,9 @@ Sometimes we intentionally want to add or remove a dependency from our `package.
   ]
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 ## Options
 

--- a/docs/generated/packages/eslint-plugin/documents/enforce-module-boundaries.md
+++ b/docs/generated/packages/eslint-plugin/documents/enforce-module-boundaries.md
@@ -12,7 +12,34 @@ different projects in the repository. Enforcing strict boundaries helps to preve
 
 You can use the `enforce-module-boundaries` rule by adding it to your ESLint rules configuration:
 
-```jsonc
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="eslint.config.mjs" %}
+import nxPlugin from '@nx/eslint-plugin';
+
+export default [
+  ...nxPlugin.configs['flat/base'],
+  ...nxPlugin.configs['flat/typescript'],
+  ...nxPlugin.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          // ...rule specific configuration
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
+
+```jsonc {% fileName=".eslintrc.json" %}
 {
   // ... more ESLint config here
   "overrides": [
@@ -31,6 +58,9 @@ You can use the `enforce-module-boundaries` rule by adding it to your ESLint rul
   ]
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 ## Options
 

--- a/docs/shared/concepts/decisions/project-dependency-rules.md
+++ b/docs/shared/concepts/decisions/project-dependency-rules.md
@@ -111,7 +111,55 @@ export { formatCurrency } from './src/format-currency';
 
 ## Enforce Project Dependency Rules
 
-In order to enforce the dependency constraints that were listed for each type, you can add the following rule in the root `.eslintrc.json` file:
+In order to enforce the dependency constraints that were listed for each type, you can add the following rule in your ESLint configuration:
+
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="/eslint.config.mjs" %}
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    ignores: ['**/dist'],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          allow: [],
+          depConstraints: [
+            {
+              sourceTag: 'type:feature',
+              onlyDependOnLibsWithTags: [
+                'type:feature',
+                'type:ui',
+                'type:util',
+              ],
+            },
+            {
+              sourceTag: 'type:ui',
+              onlyDependOnLibsWithTags: ['type:ui', 'type:util'],
+            },
+            {
+              sourceTag: 'type:util',
+              onlyDependOnLibsWithTags: ['type:util'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
 
 ```json {% fileName="/.eslintrc.json" %}
 {
@@ -151,6 +199,9 @@ In order to enforce the dependency constraints that were listed for each type, y
   ]
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 ## Other Types
 

--- a/docs/shared/features/enforce-module-boundaries.md
+++ b/docs/shared/features/enforce-module-boundaries.md
@@ -24,7 +24,34 @@ To set up the lint rule, install these dependencies:
 nx add @nx/eslint-plugin @nx/devkit
 ```
 
-And configure the rule in your root `.eslintrc.json` file:
+And configure the rule in your ESLint configuration:
+
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="eslint.config.mjs" %}
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          /* options */
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
 
 ```jsonc {% fileName=".eslintrc.json" %}
 {
@@ -40,6 +67,9 @@ And configure the rule in your root `.eslintrc.json` file:
   }
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tags
 
@@ -104,9 +134,52 @@ First, use your project configuration (in `project.json` or `package.json`) to a
 {% /tab %}
 {% /tabs %}
 
-Next, you should update your root lint configuration:
+Next, you should update your root ESLint configuration to set up `depConstraints` based on your tags:
 
-- If you are using **ESLint** you should look for an existing rule entry in your root `.eslintrc.json` called `@nx/enforce-module-boundaries` and you should update the `depConstraints`:
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="eslint.config.mjs" %}
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    ignores: ['**/dist'],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          allow: [],
+          // update depConstraints based on your tags
+          depConstraints: [
+            {
+              sourceTag: 'scope:shared',
+              onlyDependOnLibsWithTags: ['scope:shared'],
+            },
+            {
+              sourceTag: 'scope:admin',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:admin'],
+            },
+            {
+              sourceTag: 'scope:client',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:client'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
 
 ```jsonc {% fileName=".eslintrc.json" %}
 {
@@ -138,6 +211,9 @@ Next, you should update your root lint configuration:
   // ... more ESLint config here
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 With these constraints in place, `scope:client` projects can only depend on projects with `scope:client` or `scope:shared`. And `scope:admin` projects can only depend on projects with `scope:admin` or `scope:shared`. So `scope:client` and `scope:admin` cannot depend on each other.
 

--- a/docs/shared/packages/eslint/dependency-checks.md
+++ b/docs/shared/packages/eslint/dependency-checks.md
@@ -23,6 +23,33 @@ Library generators from `@nx` packages will configure this rule automatically wh
 
 To set it up manually for existing libraries, you need to add the `dependency-checks` rule to your project's ESLint configuration:
 
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="<your-project-root>/eslint.config.mjs" %}
+import nxPlugin from '@nx/eslint-plugin';
+import jsoncParser from 'jsonc-eslint-parser';
+
+export default [
+  ...nxPlugin.configs['flat/base'],
+  ...nxPlugin.configs['flat/typescript'],
+  ...nxPlugin.configs['flat/javascript'],
+  {
+    files: ['**/*.json'],
+    languageOptions: {
+      parser: jsoncParser,
+    },
+    rules: {
+      '@nx/dependency-checks': 'error',
+    },
+  },
+  // ... more ESLint config here
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
+
 ```jsonc {% fileName="<your-project-root>/.eslintrc.json" %}
 {
   // ... more ESLint config here
@@ -38,6 +65,9 @@ To set it up manually for existing libraries, you need to add the `dependency-ch
   ]
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 Additionally, you need to adjust your `lintFilePatterns` to include the project's `package.json` file::
 
@@ -64,6 +94,36 @@ Additionally, you need to adjust your `lintFilePatterns` to include the project'
 
 Sometimes we intentionally want to add or remove a dependency from our `package.json` despite what the rule suggests. We can use the rule's options to override default behavior:
 
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="eslint.config.mjs" %}
+export default [
+  // ... other config
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          buildTargets: ['build', 'custom-build'], // add non standard build target names
+          checkMissingDependencies: true, // toggle to disable
+          checkObsoleteDependencies: true, // toggle to disable
+          checkVersionMismatches: true, // toggle to disable
+          ignoredDependencies: ['lodash'], // these libs will be omitted from checks
+          ignoredFiles: ['webpack.config.js', 'eslint.config.mjs'], // list of files that should be skipped for check
+          includeTransitiveDependencies: true, // collect dependencies transitively from children
+          useLocalPathsForWorkspaceDependencies: true, // toggle to disable
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
+
 ```jsonc {% fileName=".eslintrc.json" %}
 {
   "@nx/dependency-checks": [
@@ -81,6 +141,9 @@ Sometimes we intentionally want to add or remove a dependency from our `package.
   ]
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 ## Options
 

--- a/docs/shared/packages/eslint/enforce-module-boundaries.md
+++ b/docs/shared/packages/eslint/enforce-module-boundaries.md
@@ -12,7 +12,34 @@ different projects in the repository. Enforcing strict boundaries helps to preve
 
 You can use the `enforce-module-boundaries` rule by adding it to your ESLint rules configuration:
 
-```jsonc
+{% tabs %}
+{% tab label="Flat Config" %}
+
+```javascript {% fileName="eslint.config.mjs" %}
+import nxPlugin from '@nx/eslint-plugin';
+
+export default [
+  ...nxPlugin.configs['flat/base'],
+  ...nxPlugin.configs['flat/typescript'],
+  ...nxPlugin.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          // ...rule specific configuration
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tab %}
+{% tab label="Legacy (.eslintrc.json)" %}
+
+```jsonc {% fileName=".eslintrc.json" %}
 {
   // ... more ESLint config here
   "overrides": [
@@ -31,6 +58,9 @@ You can use the `enforce-module-boundaries` rule by adding it to your ESLint rul
   ]
 }
 ```
+
+{% /tab %}
+{% /tabs %}
 
 ## Options
 


### PR DESCRIPTION
We currently only show the legacy `.eslintrc.json` file format even though new workspaces will only use flat config. This PR shows flat config by default but users can switch to the legacy config tab if they are in an older workspace that have not converted yet.

Previews:
- https://nx-dev-git-docs-enforce-module-boundaries-nrwl.vercel.app/features/enforce-module-boundaries
- https://nx-dev-git-docs-enforce-module-boundaries-nrwl.vercel.app/recipes/enforce-module-boundaries/tag-multiple-dimensions
- https://nx-dev-git-docs-enforce-module-boundaries-nrwl.vercel.app/recipes/enforce-module-boundaries/ban-external-imports
- https://nx-dev-git-docs-enforce-module-boundaries-nrwl.vercel.app/concepts/decisions/project-dependency-rules
- https://nx-dev-git-docs-enforce-module-boundaries-nrwl.vercel.app/technologies/eslint/eslint-plugin/recipes/enforce-module-boundaries
- https://nx-dev-git-docs-enforce-module-boundaries-nrwl.vercel.app/technologies/eslint/eslint-plugin/recipes/dependency-checks
- https://nx-dev-git-docs-enforce-module-boundaries-nrwl.vercel.app/technologies/eslint/recipes/eslint