### PR TITLE
fix(js): check package.json for name when project.json exists but has no name

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -3167,6 +3167,18 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     "@nx/js:typescript-sync",
                   ],
                 },
+                "build-deps": {
+                  "dependsOn": [
+                    "^build",
+                  ],
+                },
+                "watch-deps": {
+                  "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                  "continuous": true,
+                  "dependsOn": [
+                    "build-deps",
+                  ],
+                },
               },
             },
           },
@@ -3309,6 +3321,18 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   ],
                   "syncGenerators": [
                     "@nx/js:typescript-sync",
+                  ],
+                },
+                "build-deps": {
+                  "dependsOn": [
+                    "^build",
+                  ],
+                },
+                "watch-deps": {
+                  "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                  "continuous": true,
+                  "dependsOn": [
+                    "build-deps",
                   ],
                 },
               },

--- a/packages/js/src/plugins/typescript/util.ts
+++ b/packages/js/src/plugins/typescript/util.ts
@@ -36,7 +36,9 @@ export function addBuildAndWatchDepsTargets(
   if (existsSync(projectJsonPath)) {
     const projectJson = readJsonFile(projectJsonPath);
     projectName = projectJson.name;
-  } else if (existsSync(packageJsonPath)) {
+  }
+
+  if (!projectName && existsSync(packageJsonPath)) {
     const packageJson = readJsonFile(packageJsonPath);
     projectName = packageJson.nx?.name ?? packageJson.name;
   }


### PR DESCRIPTION
## Current Behavior

When a project has a `project.json` file but no `name` field, the `addBuildAndWatchDepsTargets` function in `packages/js/src/plugins/typescript/util.ts` returns early without creating build and watch deps targets, even if the project has a valid name in its `package.json`.

## Expected Behavior

The function should fall back to checking `package.json` for the project name when `project.json` exists but has no `name` field, allowing the build and watch deps targets to be created properly.

## Related Issue(s)

This fixes an issue where projects with `project.json` files missing the `name` field would not get proper build and watch dependency targets generated.

🤖 Generated with [Claude Code](https://claude.ai/code)