### PR TITLE
fix(misc): ignore daemon log file in file watcher

### DIFF
--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -13,6 +13,7 @@ use crate::native::watch::utils::{get_ignore_files, get_nx_ignore, transform_eve
 #[derive(Debug)]
 pub struct WatchFilterer {
     pub nx_ignore: Option<IgnoreFilter>,
+    pub always_ignore: IgnoreFilter,
     pub git_ignore: IgnoreFilterer,
 }
 
@@ -145,6 +146,12 @@ pub(super) async fn create_filter(
         )
         .map_err(anyhow::Error::from)?;
 
+    let mut always_ignore = IgnoreFilter::empty(origin);
+
+    always_ignore
+        .add_globs(&[".nx/workspace-data/d/daemon.log"], Some(&origin.into()))
+        .map_err(anyhow::Error::from)?;
+
     let nx_ignore = if let Some(nx_ignore_file) = nx_ignore_file {
         Some(
             IgnoreFilter::new(origin, &[nx_ignore_file])
@@ -158,5 +165,6 @@ pub(super) async fn create_filter(
     Ok(WatchFilterer {
         git_ignore: IgnoreFilterer(git_ignore),
         nx_ignore,
+        always_ignore,
     })
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Enabling native logging for the file watcher can cause the daemon log to loop because the watcher notices updates to it

## Expected Behavior
The daemon log file is exempt from watching

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
