### PR TITLE
fix(gradle): allow excludeDependsOn to be false

### DIFF
--- a/packages/gradle/src/executors/gradle/gradle.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle.impl.ts
@@ -24,14 +24,16 @@ export default async function gradleExecutor(
     args.push(`--tests`, options.testClassName);
   }
 
-  getExcludeTasks(
-    new Set([`${context.projectName}:${context.targetName}`]),
-    context.projectGraph.nodes
-  ).forEach((task) => {
-    if (task) {
-      args.push('--exclude-task', task);
-    }
-  });
+  if (options.excludeDependsOn) {
+    getExcludeTasks(
+      new Set([`${context.projectName}:${context.targetName}`]),
+      context.projectGraph.nodes
+    ).forEach((task) => {
+      if (task) {
+        args.push('--exclude-task', task);
+      }
+    });
+  }
 
   try {
     const { success } = await runCommandsImpl(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
excludeDependsOn is true by default, but got this error when running `nx run nx-api:compileTestKotlin`:
```
* What went wrong:
Execution failed for task ':nx-api:compileTestKotlin'.
> Error while evaluating property 'friendPathsSet$kotlin_gradle_plugin_common' of task ':nx-api:compileTestKotlin'.
   > Querying the mapped value of provider(java.util.Set) before task ':nx-api:compileJava' has completed is not supported
   ```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
have a way to turn off excludeDependsOn

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
