### PR TITLE
fix(node): preserve existing test target options

### DIFF
--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -243,9 +243,14 @@ describe('app', () => {
                 },
               },
               "test": {
+                "executor": "@nx/jest:jest",
                 "options": {
+                  "jestConfig": "myapp/jest.config.ts",
                   "passWithNoTests": true,
                 },
+                "outputs": [
+                  "{projectRoot}/test-output/jest/coverage",
+                ],
               },
             },
           },
@@ -414,9 +419,14 @@ describe('app', () => {
               },
             },
             "test": {
+              "executor": "@nx/jest:jest",
               "options": {
+                "jestConfig": "myapp/jest.config.ts",
                 "passWithNoTests": true,
               },
+              "outputs": [
+                "{projectRoot}/test-output/jest/coverage",
+              ],
             },
           },
         }

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -173,7 +173,11 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
     const projectConfig = readProjectConfiguration(tree, options.name);
     projectConfig.targets ??= {};
     projectConfig.targets.test = {
-      options: { passWithNoTests: true },
+      ...projectConfig.targets.test,
+      options: {
+        ...projectConfig.targets.test?.options,
+        passWithNoTests: true,
+      },
     };
     updateProjectConfiguration(tree, options.name, projectConfig);
   } else {


### PR DESCRIPTION
We should preserve the test target options if they are provided.