### PR TITLE
fix(misc): improve the generation of storybook stories

### DIFF
--- a/docs/shared/recipes/storybook/plugin-angular.md
+++ b/docs/shared/recipes/storybook/plugin-angular.md
@@ -118,6 +118,7 @@ const meta: Meta<MyButton> = {
   title: 'MyButton',
 };
 export default meta;
+
 type Story = StoryObj<MyButton>;
 
 export const Primary: Story = {
@@ -136,7 +137,7 @@ export const Heading: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    expect(canvas.getByText(/my-button works!/gi)).toBeTruthy();
+    expect(canvas.getByText(/my-button/gi)).toBeTruthy();
   },
 };
 ```

--- a/docs/shared/recipes/storybook/plugin-react.md
+++ b/docs/shared/recipes/storybook/plugin-react.md
@@ -102,16 +102,17 @@ export default MyButton;
 The [`@nx/react:storybook-configuration` generator](/technologies/react/api/generators/storybook-configuration) would generate a Story file that looks like this:
 
 ```typescript {% fileName="libs/feature/ui/src/lib/my-button/my-button.stories.tsx" %}
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { MyButton } from './my-button';
 import { within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 
-const meta: Meta<typeof MyButton> = {
+const meta = {
   component: MyButton,
   title: 'MyButton',
-};
+} satisfies Meta<typeof MyButton>;
 export default meta;
+
 type Story = StoryObj<typeof MyButton>;
 
 export const Primary = {
@@ -120,9 +121,9 @@ export const Primary = {
     padding: 0,
     disabled: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     text: '',
     padding: 0,
@@ -130,9 +131,9 @@ export const Heading: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    expect(canvas.getByText(/Welcome to MyButton!/gi)).toBeTruthy();
+    expect(canvas.getByText(/MyButton!/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 ```
 
 Notice the interaction test on the second story, inside the `play` function. This just tests if the default text that appears on generated components exists in the rendered component. You can edit this test to suit your needs. You can read more about interaction tests [here](https://storybook.js.org/docs/react/writing-tests/interaction-testing).

--- a/packages/angular/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
+++ b/packages/angular/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
@@ -9,6 +9,7 @@ const meta: Meta<TestButtonComponent> = {
   title: 'TestButtonComponent',
 };
 export default meta;
+
 type Story = StoryObj<TestButtonComponent>;
 
 export const Primary: Story = {

--- a/packages/angular/src/generators/component-story/files/__componentFileName__.stories.ts__tmpl__
+++ b/packages/angular/src/generators/component-story/files/__componentFileName__.stories.ts__tmpl__
@@ -9,6 +9,7 @@ const meta: Meta<<%= componentName %>> = {
   title: '<%= componentName %>',
 };
 export default meta;
+
 type Story = StoryObj<<%=componentName%>>;
 
 export const Primary: Story = {
@@ -16,14 +17,14 @@ export const Primary: Story = {
     <%= prop.name %>: <%- prop.defaultValue %>,<% } %>
   },
 };
-
 <%_ if ( interactionTests ) { _%>
+
 export const Heading: Story = {
   args: {<% for (let prop of props) { %>
     <%= prop.name %>: <%- prop.defaultValue %>,<% } %>
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/<%=componentNameSimple%> works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/<%=componentNameSimple%>/gi)).toBeTruthy();
   },
 };
 <%_ } _%>

--- a/packages/angular/src/generators/stories/__snapshots__/stories-app.spec.ts.snap
+++ b/packages/angular/src/generators/stories/__snapshots__/stories-app.spec.ts.snap
@@ -10,6 +10,7 @@ const meta: Meta<MyScam> = {
   title: 'MyScam',
 };
 export default meta;
+
 type Story = StoryObj<MyScam>;
 
 export const Primary: Story = {
@@ -21,7 +22,7 @@ export const Heading: Story = {
   args: {
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/my-scam works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/my-scam/gi)).toBeTruthy();
   },
 };
 "
@@ -37,6 +38,7 @@ const meta: Meta<App> = {
   title: 'App',
 };
 export default meta;
+
 type Story = StoryObj<App>;
 
 export const Primary: Story = {
@@ -46,7 +48,7 @@ export const Primary: Story = {
 export const Heading: Story = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/app works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/app/gi)).toBeTruthy();
   },
 };
 "
@@ -62,6 +64,7 @@ const meta: Meta<ComponentB> = {
   title: 'ComponentB',
 };
 export default meta;
+
 type Story = StoryObj<ComponentB>;
 
 export const Primary: Story = {
@@ -73,7 +76,7 @@ export const Heading: Story = {
   args: {
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/component-b works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/component-b/gi)).toBeTruthy();
   },
 };
 "
@@ -89,6 +92,7 @@ const meta: Meta<Component> = {
   title: 'Component',
 };
 export default meta;
+
 type Story = StoryObj<Component>;
 
 export const Primary: Story = {
@@ -100,7 +104,7 @@ export const Heading: Story = {
   args: {
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/component works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/component/gi)).toBeTruthy();
   },
 };
 "

--- a/packages/angular/src/generators/stories/__snapshots__/stories-lib.spec.ts.snap
+++ b/packages/angular/src/generators/stories/__snapshots__/stories-lib.spec.ts.snap
@@ -10,6 +10,7 @@ const meta: Meta<Standalone> = {
   title: 'Standalone',
 };
 export default meta;
+
 type Story = StoryObj<Standalone>;
 
 export const Primary: Story = {
@@ -19,7 +20,7 @@ export const Primary: Story = {
 export const Heading: Story = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/standalone works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/standalone/gi)).toBeTruthy();
   },
 };
 "
@@ -35,6 +36,7 @@ const meta: Meta<SecondaryStandalone> = {
   title: 'SecondaryStandalone',
 };
 export default meta;
+
 type Story = StoryObj<SecondaryStandalone>;
 
 export const Primary: Story = {
@@ -44,9 +46,7 @@ export const Primary: Story = {
 export const Heading: Story = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(
-      canvas.getByText(/secondary-standalone works!/gi)
-    ).toBeTruthy();
+    await expect(canvas.getByText(/secondary-standalone/gi)).toBeTruthy();
   },
 };
 "
@@ -62,6 +62,7 @@ const meta: Meta<TestButton> = {
   title: 'TestButton',
 };
 export default meta;
+
 type Story = StoryObj<TestButton>;
 
 export const Primary: Story = {
@@ -81,7 +82,7 @@ export const Heading: Story = {
     isOn: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/test-button works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/test-button/gi)).toBeTruthy();
   },
 };
 "
@@ -97,6 +98,7 @@ const meta: Meta<TestButton> = {
   title: 'TestButton',
 };
 export default meta;
+
 type Story = StoryObj<TestButton>;
 
 export const Primary: Story = {
@@ -116,7 +118,7 @@ export const Heading: Story = {
     isOn: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/test-button works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/test-button/gi)).toBeTruthy();
   },
 };
 "

--- a/packages/angular/src/generators/stories/stories-lib.spec.ts
+++ b/packages/angular/src/generators/stories/stories-lib.spec.ts
@@ -122,6 +122,7 @@ describe('angularStories generator: libraries', () => {
           title: 'SecondaryButtonComponent',
         };
         export default meta;
+
         type Story = StoryObj<SecondaryButtonComponent>;
 
         export const Primary: Story = {
@@ -131,7 +132,7 @@ describe('angularStories generator: libraries', () => {
         export const Heading: Story = {
           args: {},
           play: async ({ canvas }) => {
-            await expect(canvas.getByText(/secondary-button works!/gi)).toBeTruthy();
+            await expect(canvas.getByText(/secondary-button/gi)).toBeTruthy();
           },
         };
         "

--- a/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
+++ b/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
@@ -40,6 +40,7 @@ const meta: Meta<TestButton> = {
   title: 'TestButton',
 };
 export default meta;
+
 type Story = StoryObj<TestButton>;
 
 export const Primary: Story = {
@@ -59,7 +60,7 @@ export const Heading: Story = {
     isOn: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/test-button works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/test-button/gi)).toBeTruthy();
   },
 };
 "
@@ -75,6 +76,7 @@ const meta: Meta<TestOther> = {
   title: 'TestOther',
 };
 export default meta;
+
 type Story = StoryObj<TestOther>;
 
 export const Primary: Story = {
@@ -84,7 +86,7 @@ export const Primary: Story = {
 export const Heading: Story = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/test-other works!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/test-other/gi)).toBeTruthy();
   },
 };
 "

--- a/packages/react/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
+++ b/packages/react/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
@@ -1,15 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: PureComponent class & then default export new JSX transform should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -17,30 +18,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: PureComponent class & then default export should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -48,30 +50,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: arrow function should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -79,30 +82,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: arrow function without {..} should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -110,30 +114,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: component class & then default export new JSX transform should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -141,30 +146,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: component class & then default export should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -172,30 +178,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: default export function should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -203,30 +210,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: direct export of component class new JSX transform should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -234,30 +242,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: direct export of component class should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -265,30 +274,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with DEFAULT export React component defined as: function and then export should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -296,30 +306,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export React component defined as: no default PureComponent class & then default export new JSX transform should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -327,30 +338,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export React component defined as: no default PureComponent class & then default export should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -358,30 +370,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export React component defined as: no default arrow function should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -389,30 +402,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export React component defined as: no default arrow function without {..} should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -420,30 +434,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export React component defined as: no default component class should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -451,30 +466,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export React component defined as: no default direct export of component class new JSX transform should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -482,30 +498,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export React component defined as: no default direct export of component class should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -513,30 +530,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export React component defined as: no default simple export function should properly setup the controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -544,112 +562,116 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export should create stories for all components in a file with no default export 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { One } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof One> = {
+const meta = {
   component: One,
   title: 'One',
-};
+} satisfies Meta<typeof One>;
 export default meta;
+
 type Story = StoryObj<typeof One>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to One!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/One/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export should create stories for all components in a file with no default export 2`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Two } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Two> = {
+const meta = {
   component: Two,
   title: 'Two',
-};
+} satisfies Meta<typeof Two>;
 export default meta;
+
 type Story = StoryObj<typeof Two>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Two!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Two/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup Other types of component definitions Component files with NO DEFAULT export should create stories for all components in a file with no default export 3`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Three } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Three> = {
+const meta = {
   component: Three,
   title: 'Three',
-};
+} satisfies Meta<typeof Three>;
 export default meta;
+
 type Story = StoryObj<typeof Three>;
 
 export const Primary = {
   args: {
     name: '',
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Three!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Three/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup component with props and actions should setup controls based on the component props 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
   argTypes: {
     someAction: { action: 'someAction executed!' },
   },
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -658,31 +680,32 @@ export const Primary = {
     displayAge: false,
     style: '',
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
     style: '',
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup component with props should setup controls based on the component destructured props defined in an inline literal type 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -690,30 +713,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup component with props should setup controls based on the component destructured props without type 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -721,30 +745,31 @@ export const Primary = {
     name: '',
     displayAge: '',
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: '',
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup component with props should setup controls based on the component props defined in a literal type 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -752,30 +777,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup component with props should setup controls based on the component props defined in an inline literal type 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -783,30 +809,31 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup component with props should setup controls based on the component props defined in an interface 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -814,67 +841,69 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup component without any props defined should create a story without controls 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:component-story default setup default component setup should properly set up the story 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { TestUiLib } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof TestUiLib> = {
+const meta = {
   component: TestUiLib,
   title: 'TestUiLib',
-};
+} satisfies Meta<typeof TestUiLib>;
 export default meta;
+
 type Story = StoryObj<typeof TestUiLib>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to TestUiLib!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/TestUiLib/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
@@ -900,18 +929,19 @@ export const Heading: Story = {
 `;
 
 exports[`react:component-story using eslint - not using interaction tests should properly set up the story 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { TestUiLib } from './test-ui-lib';
 
-const meta: Meta<typeof TestUiLib> = {
+const meta = {
   component: TestUiLib,
   title: 'TestUiLib',
-};
+} satisfies Meta<typeof TestUiLib>;
 export default meta;
+
 type Story = StoryObj<typeof TestUiLib>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 "
 `;

--- a/packages/react/src/generators/component-story/component-story.ts
+++ b/packages/react/src/generators/component-story/component-story.ts
@@ -14,6 +14,7 @@ import {
   getComponentNode,
 } from '../../utils/ast-utils';
 import { getComponentPropDefaults } from '../../utils/component-props';
+import { getUiFramework } from '../../utils/framework';
 
 let tsModule: typeof import('typescript');
 
@@ -21,12 +22,18 @@ export interface CreateComponentStoriesFileSchema {
   project: string;
   componentPath: string;
   interactionTests?: boolean;
+  uiFramework?: string;
   skipFormat?: boolean;
 }
 
 export function createComponentStoriesFile(
   host: Tree,
-  { project, componentPath, interactionTests }: CreateComponentStoriesFileSchema
+  {
+    project,
+    componentPath,
+    interactionTests,
+    uiFramework,
+  }: CreateComponentStoriesFileSchema
 ) {
   if (!tsModule) {
     tsModule = ensureTypescript();
@@ -79,6 +86,7 @@ export function createComponentStoriesFile(
           componentDirectory,
           name,
           interactionTests,
+          uiFramework,
           isPlainJs,
           componentNodes.length > 1
         );
@@ -96,6 +104,7 @@ export function createComponentStoriesFile(
       componentDirectory,
       name,
       interactionTests,
+      uiFramework,
       isPlainJs
     );
   }
@@ -108,6 +117,7 @@ export function findPropsAndGenerateFile(
   componentDirectory: string,
   name: string,
   interactionTests: boolean,
+  uiFramework: string,
   isPlainJs: boolean,
   fromNodeArray?: boolean
 ) {
@@ -130,6 +140,7 @@ export function findPropsAndGenerateFile(
       argTypes,
       componentName: (cmpDeclaration as any).name.text,
       interactionTests,
+      uiFramework,
     }
   );
 }
@@ -141,6 +152,7 @@ export async function componentStoryGenerator(
   createComponentStoriesFile(host, {
     ...schema,
     interactionTests: schema.interactionTests ?? true,
+    uiFramework: schema.uiFramework ?? getUiFramework(host, schema.project),
   });
 
   if (!schema.skipFormat) {

--- a/packages/react/src/generators/component-story/files/tsx/__componentFileName__.stories.tsx__tmpl__
+++ b/packages/react/src/generators/component-story/files/tsx/__componentFileName__.stories.tsx__tmpl__
@@ -1,33 +1,35 @@
-import type { Meta, StoryObj } from 'storybook/internal/types';
+import type { Meta, StoryObj } from '<%= uiFramework %>';
 import { <%= componentName %>  } from './<%= componentImportFileName %>';
 <%_ if ( interactionTests ) { _%>
 import { expect } from 'storybook/test';
 <%_ } _%>
 
-const meta: Meta<typeof <%= componentName %>> = {
+const meta = {
   component: <%= componentName %>,
-  title: '<%= componentName %>',<% if ( argTypes && argTypes.length > 0 ) { %> 
+  title: '<%= componentName %>',
+  <%_ if ( argTypes && argTypes.length > 0 ) { _%> 
   argTypes: {<% for (let argType of argTypes) { %>
-    <%= argType.name %>: { <%- argType.type %> : "<%- argType.actionText %>" },<% } %>
-}
-   <% } %> 
-};
+    <%= argType.name %>: { <%- argType.type %>: "<%- argType.actionText %>" },<% } %>
+  }
+  <%_ } _%> 
+} satisfies Meta<typeof <%= componentName %>>;
 export default meta;
+
 type Story = StoryObj<typeof <%= componentName %>>;
 
 export const Primary = {
   args: {<% for (let prop of props) { %>
-    <%= prop.name %>:  <%- prop.defaultValue %>,<% } %>
+    <%= prop.name %>: <%- prop.defaultValue %>,<% } %>
   },
-};
-
+} satisfies Story;
 <%_ if ( interactionTests ) { _%>
-export const Heading: Story = {
+
+export const Heading = {
   args: {<% for (let prop of props) { %>
-    <%= prop.name %>:  <%- prop.defaultValue %>,<% } %>
+    <%= prop.name %>: <%- prop.defaultValue %>,<% } %>
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to <%=componentName%>!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/<%=componentName%>/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 <% } %>

--- a/packages/react/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
+++ b/packages/react/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
@@ -1,44 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`react:stories for applications should create the stories with interaction tests 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { NxWelcome } from './nx-welcome';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof NxWelcome> = {
+const meta = {
   component: NxWelcome,
   title: 'NxWelcome',
-};
+} satisfies Meta<typeof NxWelcome>;
 export default meta;
+
 type Story = StoryObj<typeof NxWelcome>;
 
 export const Primary = {
   args: {
     title: '',
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     title: '',
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to NxWelcome!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/NxWelcome/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:stories for applications should create the stories with interaction tests 2`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Test } from './another-cmp';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -46,48 +48,50 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:stories for applications should create the stories without interaction tests 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { NxWelcome } from './nx-welcome';
 
-const meta: Meta<typeof NxWelcome> = {
+const meta = {
   component: NxWelcome,
   title: 'NxWelcome',
-};
+} satisfies Meta<typeof NxWelcome>;
 export default meta;
+
 type Story = StoryObj<typeof NxWelcome>;
 
 export const Primary = {
   args: {
     title: '',
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:stories for applications should create the stories without interaction tests 2`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Test } from './another-cmp';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -95,7 +99,7 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 "
 `;
 

--- a/packages/react/src/generators/stories/__snapshots__/stories.lib.spec.ts.snap
+++ b/packages/react/src/generators/stories/__snapshots__/stories.lib.spec.ts.snap
@@ -1,40 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`react:stories for libraries should create the stories with interaction tests 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { TestUiLib } from './test-ui-lib';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof TestUiLib> = {
+const meta = {
   component: TestUiLib,
   title: 'TestUiLib',
-};
+} satisfies Meta<typeof TestUiLib>;
 export default meta;
+
 type Story = StoryObj<typeof TestUiLib>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to TestUiLib!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/TestUiLib/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:stories for libraries should create the stories with interaction tests 2`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './another-cmp';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -42,46 +44,48 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: '',
     displayAge: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to Test!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/Test/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:stories for libraries should create the stories without interaction tests 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { TestUiLib } from './test-ui-lib';
 
-const meta: Meta<typeof TestUiLib> = {
+const meta = {
   component: TestUiLib,
   title: 'TestUiLib',
-};
+} satisfies Meta<typeof TestUiLib>;
 export default meta;
+
 type Story = StoryObj<typeof TestUiLib>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 "
 `;
 
 exports[`react:stories for libraries should create the stories without interaction tests 2`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Test } from './another-cmp';
 
-const meta: Meta<typeof Test> = {
+const meta = {
   component: Test,
   title: 'Test',
-};
+} satisfies Meta<typeof Test>;
 export default meta;
+
 type Story = StoryObj<typeof Test>;
 
 export const Primary = {
@@ -89,6 +93,6 @@ export const Primary = {
     name: '',
     displayAge: false,
   },
-};
+} satisfies Story;
 "
 `;

--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -17,6 +17,7 @@ import {
   findExportDeclarationsForJsx,
   getComponentNode,
 } from '../../utils/ast-utils';
+import { getUiFramework } from '../../utils/framework';
 import componentStoryGenerator from '../component-story/component-story';
 
 let tsModule: typeof import('typescript');
@@ -26,6 +27,7 @@ export interface StorybookStoriesSchema {
   interactionTests?: boolean;
   js?: boolean;
   ignorePaths?: string[];
+  uiFramework?: string;
   skipFormat?: boolean;
 }
 
@@ -80,16 +82,12 @@ export function containsComponentDeclaration(
 
 export async function createAllStories(
   tree: Tree,
-  projectName: string,
-  interactionTests: boolean,
-  js: boolean,
-  projects: Map<string, ProjectConfiguration>,
-  projectConfiguration: ProjectConfiguration,
-  ignorePaths?: string[]
+  schema: StorybookStoriesSchema,
+  projectConfiguration: ProjectConfiguration
 ) {
   const { isTheFileAStory } = await import('@nx/storybook/src/utils/utilities');
 
-  const { sourceRoot, root } = projectConfiguration;
+  const sourceRoot = getProjectSourceRoot(projectConfiguration, tree);
   let componentPaths: string[] = [];
 
   const projectPath = await projectRootPath(tree, projectConfiguration);
@@ -97,7 +95,7 @@ export async function createAllStories(
     // Ignore private files starting with "_".
     if (basename(path).startsWith('_')) return;
 
-    if (ignorePaths?.some((pattern) => minimatch(path, pattern))) return;
+    if (schema.ignorePaths?.some((pattern) => minimatch(path, pattern))) return;
 
     if (
       (path.endsWith('.tsx') && !path.endsWith('.spec.tsx')) ||
@@ -120,10 +118,7 @@ export async function createAllStories(
 
   await Promise.all(
     componentPaths.map(async (componentPath) => {
-      const relativeCmpDir = componentPath.replace(
-        join(sourceRoot ?? root, '/'),
-        ''
-      );
+      const relativeCmpDir = componentPath.replace(`${sourceRoot}/`, '');
 
       if (!containsComponentDeclaration(tree, componentPath)) {
         return;
@@ -131,9 +126,10 @@ export async function createAllStories(
 
       await componentStoryGenerator(tree, {
         componentPath: relativeCmpDir,
-        project: projectName,
+        project: schema.project,
+        interactionTests: schema.interactionTests,
+        uiFramework: schema.uiFramework,
         skipFormat: true,
-        interactionTests,
       });
     })
   );
@@ -146,15 +142,8 @@ export async function storiesGenerator(
   const projects = getProjects(host);
   const projectConfiguration = projects.get(schema.project);
   schema.interactionTests = schema.interactionTests ?? true;
-  await createAllStories(
-    host,
-    schema.project,
-    schema.interactionTests,
-    schema.js,
-    projects,
-    projectConfiguration,
-    schema.ignorePaths
-  );
+  schema.uiFramework ??= getUiFramework(host, schema.project);
+  await createAllStories(host, schema, projectConfiguration);
 
   if (!schema.skipFormat) {
     await formatFiles(host);

--- a/packages/react/src/generators/storybook-configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/react/src/generators/storybook-configuration/__snapshots__/configuration.spec.ts.snap
@@ -30,27 +30,28 @@ export default config;
 `;
 
 exports[`react:storybook-configuration should generate stories for components 1`] = `
-"import type { Meta, StoryObj } from 'storybook/internal/types';
+"import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { MyComponent } from './my-component';
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof MyComponent> = {
+const meta = {
   component: MyComponent,
   title: 'MyComponent',
-};
+} satisfies Meta<typeof MyComponent>;
 export default meta;
+
 type Story = StoryObj<typeof MyComponent>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to MyComponent!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/MyComponent/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 

--- a/packages/react/src/utils/framework.ts
+++ b/packages/react/src/utils/framework.ts
@@ -1,0 +1,39 @@
+import {
+  joinPathFragments,
+  readProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+
+export function getUiFramework(
+  tree: Tree,
+  project: string
+): '@storybook/react-vite' | '@storybook/react-webpack5' {
+  const projectConfig = readProjectConfiguration(tree, project);
+
+  if (
+    findWebpackConfig(tree, projectConfig.root) ||
+    projectConfig.targets?.['build']?.executor === '@nx/rollup:rollup' ||
+    projectConfig.targets?.['build']?.executor === '@nx/expo:build'
+  ) {
+    return '@storybook/react-webpack5';
+  }
+
+  return '@storybook/react-vite';
+}
+
+function findWebpackConfig(
+  tree: Tree,
+  projectRoot: string
+): string | undefined {
+  const allowsExt = ['js', 'mjs', 'ts', 'cjs', 'mts', 'cts'];
+
+  for (const ext of allowsExt) {
+    const webpackConfigPath = joinPathFragments(
+      projectRoot,
+      `webpack.config.${ext}`
+    );
+    if (tree.exists(webpackConfigPath)) {
+      return webpackConfigPath;
+    }
+  }
+}

--- a/packages/vue/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
+++ b/packages/vue/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
@@ -1,42 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`vue:stories for applications should create the stories with interaction tests 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import NxWelcome from './NxWelcome.vue';
 
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof NxWelcome> = {
+const meta = {
   component: NxWelcome,
   title: 'NxWelcome',
-};
+} satisfies Meta<typeof NxWelcome>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to NxWelcome!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/NxWelcome/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`vue:stories for applications should create the stories with interaction tests 2`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import anotherCmp from './another-cmp.vue';
 
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof anotherCmp> = {
+const meta = {
   component: anotherCmp,
   title: 'anotherCmp',
-};
+} satisfies Meta<typeof anotherCmp>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
@@ -45,47 +47,49 @@ export const Primary = {
     displayAge: false,
     age: 0,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: 'name',
     displayAge: false,
     age: 0,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to anotherCmp!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/anotherCmp/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`vue:stories for applications should create the stories without interaction tests 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import NxWelcome from './NxWelcome.vue';
 
-const meta: Meta<typeof NxWelcome> = {
+const meta = {
   component: NxWelcome,
   title: 'NxWelcome',
-};
+} satisfies Meta<typeof NxWelcome>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 "
 `;
 
 exports[`vue:stories for applications should create the stories without interaction tests 2`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import anotherCmp from './another-cmp.vue';
 
-const meta: Meta<typeof anotherCmp> = {
+const meta = {
   component: anotherCmp,
   title: 'anotherCmp',
-};
+} satisfies Meta<typeof anotherCmp>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
@@ -94,7 +98,7 @@ export const Primary = {
     displayAge: false,
     age: 0,
   },
-};
+} satisfies Story;
 "
 `;
 

--- a/packages/vue/src/generators/stories/__snapshots__/stories.lib.spec.ts.snap
+++ b/packages/vue/src/generators/stories/__snapshots__/stories.lib.spec.ts.snap
@@ -1,42 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`vue:stories for libraries should create the stories with interaction tests 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import testUiLib from './test-ui-lib.vue';
 
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof testUiLib> = {
+const meta = {
   component: testUiLib,
   title: 'testUiLib',
-};
+} satisfies Meta<typeof testUiLib>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {},
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to testUiLib!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/testUiLib/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`vue:stories for libraries should create the stories with interaction tests 2`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import anotherCmp from './another-cmp.vue';
 
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof anotherCmp> = {
+const meta = {
   component: anotherCmp,
   title: 'anotherCmp',
-};
+} satisfies Meta<typeof anotherCmp>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
@@ -45,47 +47,49 @@ export const Primary = {
     displayAge: false,
     age: 0,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: 'name',
     displayAge: false,
     age: 0,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to anotherCmp!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/anotherCmp/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`vue:stories for libraries should create the stories without interaction tests 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import testUiLib from './test-ui-lib.vue';
 
-const meta: Meta<typeof testUiLib> = {
+const meta = {
   component: testUiLib,
   title: 'testUiLib',
-};
+} satisfies Meta<typeof testUiLib>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
   args: {},
-};
+} satisfies Story;
 "
 `;
 
 exports[`vue:stories for libraries should create the stories without interaction tests 2`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import anotherCmp from './another-cmp.vue';
 
-const meta: Meta<typeof anotherCmp> = {
+const meta = {
   component: anotherCmp,
   title: 'anotherCmp',
-};
+} satisfies Meta<typeof anotherCmp>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
@@ -94,6 +98,6 @@ export const Primary = {
     displayAge: false,
     age: 0,
   },
-};
+} satisfies Story;
 "
 `;

--- a/packages/vue/src/generators/stories/lib/__snapshots__/component-story.spec.ts.snap
+++ b/packages/vue/src/generators/stories/lib/__snapshots__/component-story.spec.ts.snap
@@ -1,109 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`vue:component-story default setup component with other syntax of props defined should create a story with controls 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import testUiLib from './test-ui-lib.vue';
 
 import { expect } from 'storybook/test';
 
 
-const meta: Meta<typeof testUiLib> = {
+const meta = {
   component: testUiLib,
   title: 'testUiLib',
-};
+} satisfies Meta<typeof testUiLib>;
 export default meta;
-type Story = StoryObj<typeof meta>;
 
+type Story = StoryObj<typeof meta>;
 
 export const Primary = {
   args: {
-    name:  'name',
-    displayAge:  false,
-    age:  0,
+    name: 'name',
+    displayAge: false,
+    age: 0,
   },
-};
+} satisfies Story;
 
-
-export const Heading: Story = {
+export const Heading = {
   args: {
-    name:  'name',
-    displayAge:  false,
-    age:  0,
+    name: 'name',
+    displayAge: false,
+    age: 0,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to testUiLib!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/testUiLib/gi)).toBeTruthy();
   },
-};
-
+} satisfies Story;
 "
 `;
 
 exports[`vue:component-story default setup component with props defined should create a story with controls 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import testUiLib from './test-ui-lib.vue';
 
 import { expect } from 'storybook/test';
 
 
-const meta: Meta<typeof testUiLib> = {
+const meta = {
   component: testUiLib,
   title: 'testUiLib',
-};
+} satisfies Meta<typeof testUiLib>;
 export default meta;
-type Story = StoryObj<typeof meta>;
 
+type Story = StoryObj<typeof meta>;
 
 export const Primary = {
   args: {
-    name:  'name',
-    displayAge:  false,
-    age:  0,
+    name: 'name',
+    displayAge: false,
+    age: 0,
   },
-};
+} satisfies Story;
 
-
-export const Heading: Story = {
+export const Heading = {
   args: {
-    name:  'name',
-    displayAge:  false,
-    age:  0,
+    name: 'name',
+    displayAge: false,
+    age: 0,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to testUiLib!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/testUiLib/gi)).toBeTruthy();
   },
-};
-
+} satisfies Story;
 "
 `;
 
 exports[`vue:component-story default setup default component setup should properly set up the story 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import testUiLib from './test-ui-lib.vue';
 
 import { expect } from 'storybook/test';
 
 
-const meta: Meta<typeof testUiLib> = {
+const meta = {
   component: testUiLib,
   title: 'testUiLib',
-};
+} satisfies Meta<typeof testUiLib>;
 export default meta;
-type Story = StoryObj<typeof meta>;
 
+type Story = StoryObj<typeof meta>;
 
 export const Primary = {
   args: {
   },
-};
+} satisfies Story;
 
-
-export const Heading: Story = {
+export const Heading = {
   args: {
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to testUiLib!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/testUiLib/gi)).toBeTruthy();
   },
-};
-
+} satisfies Story;
 "
 `;

--- a/packages/vue/src/generators/stories/lib/files/ts/__componentFileName__.stories.ts__tmpl__
+++ b/packages/vue/src/generators/stories/lib/files/ts/__componentFileName__.stories.ts__tmpl__
@@ -1,30 +1,30 @@
-import type { Meta, StoryObj } from '@storybook/vue3';
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import <%= componentName %> from './<%= componentImportFileName %>';
 <% if ( interactionTests ) { %>
 import { expect } from 'storybook/test';
 <% } %>
 
-const meta: Meta<typeof <%= componentName %>> = {
+const meta = {
   component: <%= componentName %>,
   title: '<%= componentName %>',
-};
+} satisfies Meta<typeof <%= componentName %>>;
 export default meta;
-type Story = StoryObj<typeof meta>;
 
+type Story = StoryObj<typeof meta>;
 
 export const Primary = {
   args: {<% for (let prop of props) { %>
-    <%= prop.name %>:  <%- prop.defaultValue %>,<% } %>
+    <%= prop.name %>: <%- prop.defaultValue %>,<% } %>
   },
-};
+} satisfies Story;
+<%_ if ( interactionTests ) { _%>
 
-<% if ( interactionTests ) { %>
-export const Heading: Story = {
+export const Heading = {
   args: {<% for (let prop of props) { %>
-    <%= prop.name %>:  <%- prop.defaultValue %>,<% } %>
+    <%= prop.name %>: <%- prop.defaultValue %>,<% } %>
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to <%=componentName%>!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/<%=componentName%>/gi)).toBeTruthy();
   },
-};
-<% } %>
+} satisfies Story;
+<%_ } _%>

--- a/packages/vue/src/generators/storybook-configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vue/src/generators/storybook-configuration/__snapshots__/configuration.spec.ts.snap
@@ -30,16 +30,17 @@ export default config;
 `;
 
 exports[`vue:storybook-configuration should generate stories for components 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import myComponent from './my-component.vue';
 
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof myComponent> = {
+const meta = {
   component: myComponent,
   title: 'myComponent',
-};
+} satisfies Meta<typeof myComponent>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
@@ -48,32 +49,33 @@ export const Primary = {
     displayAge: false,
     age: 0,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: 'name',
     displayAge: false,
     age: 0,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to myComponent!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/myComponent/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`vue:storybook-configuration should generate stories for components for app 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import myComponent from './my-component.vue';
 
 import { expect } from 'storybook/test';
 
-const meta: Meta<typeof myComponent> = {
+const meta = {
   component: myComponent,
   title: 'myComponent',
-};
+} satisfies Meta<typeof myComponent>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
@@ -82,30 +84,31 @@ export const Primary = {
     displayAge: false,
     age: 0,
   },
-};
+} satisfies Story;
 
-export const Heading: Story = {
+export const Heading = {
   args: {
     name: 'name',
     displayAge: false,
     age: 0,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText(/Welcome to myComponent!/gi)).toBeTruthy();
+    await expect(canvas.getByText(/myComponent/gi)).toBeTruthy();
   },
-};
+} satisfies Story;
 "
 `;
 
 exports[`vue:storybook-configuration should generate stories for components without interaction tests 1`] = `
-"import type { Meta, StoryObj } from '@storybook/vue3';
+"import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import myComponent from './my-component.vue';
 
-const meta: Meta<typeof myComponent> = {
+const meta = {
   component: myComponent,
   title: 'myComponent',
-};
+} satisfies Meta<typeof myComponent>;
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary = {
@@ -114,6 +117,6 @@ export const Primary = {
     displayAge: false,
     age: 0,
   },
-};
+} satisfies Story;
 "
 `;


### PR DESCRIPTION
Improve the generation of Storybook stories:

- Import relevant types from the appropriate packages
- Use TypeScript `satisfies` operator
- Simplify the selector in the generated interaction test example
- Fix an issue when source root is not set in the project configuration