### PR TITLE
fix(tui): preserve scroll position when tasks complete and scroll faster

### DIFF
--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -1716,7 +1716,7 @@ impl App {
         let terminal_pane_data = &mut self.terminal_pane_data[pane_idx];
         terminal_pane_data.is_continuous = task_continuous;
         let in_progress = task_status == TaskStatus::InProgress;
-        if !in_progress {
+        if !in_progress && terminal_pane_data.is_interactive() {
             terminal_pane_data.set_interactive(false);
         }
 

--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -57,13 +57,13 @@ impl TerminalPaneData {
                 KeyCode::Char('u')
                     if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_interactive =>
                 {
-                    self.scroll(ScrollDirection::Up);
+                    pty_mut.scroll_up(12);
                     return Ok(None);
                 }
                 KeyCode::Char('d')
                     if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_interactive =>
                 {
-                    self.scroll(ScrollDirection::Down);
+                    pty_mut.scroll_down(12);
                     return Ok(None);
                 }
                 // Handle 'c' for copying when not in interactive mode

--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -15,6 +15,7 @@ use tracing::debug;
 use tui_term::widget::PseudoTerminal;
 
 use crate::native::tui::components::tasks_list::TaskStatus;
+use crate::native::tui::scroll_momentum::{ScrollDirection, ScrollMomentum};
 use crate::native::tui::theme::THEME;
 use crate::native::tui::{action::Action, pty::PtyInstance};
 
@@ -23,6 +24,8 @@ pub struct TerminalPaneData {
     pub is_interactive: bool,
     pub is_continuous: bool,
     pub can_be_interactive: bool,
+    // Momentum scrolling state
+    scroll_momentum: ScrollMomentum,
 }
 
 impl TerminalPaneData {
@@ -32,6 +35,7 @@ impl TerminalPaneData {
             is_interactive: false,
             is_continuous: false,
             can_be_interactive: false,
+            scroll_momentum: ScrollMomentum::new(),
         }
     }
 
@@ -42,30 +46,24 @@ impl TerminalPaneData {
                 // Scrolling keybindings (up/down arrow keys or 'k'/'j') are only handled if we're not in interactive mode.
                 // If interactive, the event falls through to be forwarded to the PTY so that we can support things like interactive prompts within tasks.
                 KeyCode::Up | KeyCode::Char('k') if !self.is_interactive => {
-                    pty_mut.scroll_up();
+                    self.scroll(ScrollDirection::Up);
                     return Ok(None);
                 }
                 KeyCode::Down | KeyCode::Char('j') if !self.is_interactive => {
-                    pty_mut.scroll_down();
+                    self.scroll(ScrollDirection::Down);
                     return Ok(None);
                 }
                 // Handle ctrl+u and ctrl+d for scrolling when not in interactive mode
                 KeyCode::Char('u')
                     if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_interactive =>
                 {
-                    // Scroll up a somewhat arbitrary "chunk" (12 lines)
-                    for _ in 0..12 {
-                        pty_mut.scroll_up();
-                    }
+                    self.scroll(ScrollDirection::Up);
                     return Ok(None);
                 }
                 KeyCode::Char('d')
                     if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_interactive =>
                 {
-                    // Scroll down a somewhat arbitrary "chunk" (12 lines)
-                    for _ in 0..12 {
-                        pty_mut.scroll_down();
-                    }
+                    self.scroll(ScrollDirection::Down);
                     return Ok(None);
                 }
                 // Handle 'c' for copying when not in interactive mode
@@ -135,10 +133,10 @@ impl TerminalPaneData {
             } else {
                 match event.kind {
                     MouseEventKind::ScrollUp => {
-                        pty_mut.scroll_up();
+                        self.scroll(ScrollDirection::Up);
                     }
                     MouseEventKind::ScrollDown => {
-                        pty_mut.scroll_down();
+                        self.scroll(ScrollDirection::Down);
                     }
                     _ => {}
                 }
@@ -149,10 +147,25 @@ impl TerminalPaneData {
 
     pub fn set_interactive(&mut self, interactive: bool) {
         self.is_interactive = interactive;
+        // Reset scroll momentum when changing modes
+        self.scroll_momentum.reset();
     }
 
     pub fn is_interactive(&self) -> bool {
         self.is_interactive
+    }
+
+    /// Scroll with momentum in the given direction
+    fn scroll(&mut self, direction: ScrollDirection) {
+        if let Some(pty) = &self.pty {
+            let mut pty_mut = pty.as_ref().clone();
+            let scroll_amount = self.scroll_momentum.calculate_momentum(direction);
+
+            match direction {
+                ScrollDirection::Up => pty_mut.scroll_up(scroll_amount),
+                ScrollDirection::Down => pty_mut.scroll_down(scroll_amount),
+            }
+        }
     }
 }
 

--- a/packages/nx/src/native/tui/mod.rs
+++ b/packages/nx/src/native/tui/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod graph_utils;
 pub mod lifecycle;
 pub mod pty;
+pub mod scroll_momentum;
 pub mod status_icons;
 pub mod theme;
 #[allow(clippy::module_inception)]

--- a/packages/nx/src/native/tui/pty.rs
+++ b/packages/nx/src/native/tui/pty.rs
@@ -228,7 +228,7 @@ impl PtyInstance {
             if current > 0 {
                 parser
                     .screen_mut()
-                    .set_scrollback(current - amount as usize);
+                    .set_scrollback(current.saturating_sub(amount as usize));
             }
         }
     }

--- a/packages/nx/src/native/tui/pty.rs
+++ b/packages/nx/src/native/tui/pty.rs
@@ -1,3 +1,4 @@
+use super::scroll_momentum::{ScrollDirection, ScrollMomentum};
 use super::utils::normalize_newlines;
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
 use parking_lot::Mutex;
@@ -34,6 +35,7 @@ pub struct PtyInstance {
     writer: Option<Arc<Mutex<Box<dyn Write + Send>>>>,
     rows: u16,
     cols: u16,
+    scroll_momentum: Arc<Mutex<ScrollMomentum>>,
 }
 
 impl PtyInstance {
@@ -48,6 +50,7 @@ impl PtyInstance {
             writer: Some(writer),
             rows,
             cols,
+            scroll_momentum: Arc::new(Mutex::new(ScrollMomentum::new())),
         }
     }
 
@@ -61,6 +64,7 @@ impl PtyInstance {
             writer: None,
             rows,
             cols,
+            scroll_momentum: Arc::new(Mutex::new(ScrollMomentum::new())),
         }
     }
 
@@ -103,7 +107,8 @@ impl PtyInstance {
                 // If we lost height and were scrolled up, try to maintain scroll position
                 if old_scrollback > 0 {
                     // Adjust scrollback to account for lost rows
-                    let adjusted_scrollback = old_scrollback.saturating_sub((old_rows - rows) as usize);
+                    let adjusted_scrollback =
+                        old_scrollback.saturating_sub((old_rows - rows) as usize);
                     new_parser.screen_mut().set_scrollback(adjusted_scrollback);
                 } else {
                     // If we weren't scrolled, keep at bottom
@@ -139,10 +144,18 @@ impl PtyInstance {
         if !alternative_screen {
             match event.code {
                 KeyCode::Up => {
-                    self.scroll_up();
+                    let amount = self
+                        .scroll_momentum
+                        .lock()
+                        .calculate_momentum(ScrollDirection::Up);
+                    self.scroll_up(amount);
                 }
                 KeyCode::Down => {
-                    self.scroll_down();
+                    let amount = self
+                        .scroll_momentum
+                        .lock()
+                        .calculate_momentum(ScrollDirection::Down);
+                    self.scroll_down(amount);
                 }
                 _ => {}
             }
@@ -165,10 +178,18 @@ impl PtyInstance {
         if !alternative_screen {
             match event.kind {
                 MouseEventKind::ScrollUp => {
-                    self.scroll_up();
+                    let amount = self
+                        .scroll_momentum
+                        .lock()
+                        .calculate_momentum(ScrollDirection::Up);
+                    self.scroll_up(amount);
                 }
                 MouseEventKind::ScrollDown => {
-                    self.scroll_down();
+                    let amount = self
+                        .scroll_momentum
+                        .lock()
+                        .calculate_momentum(ScrollDirection::Down);
+                    self.scroll_down(amount);
                 }
                 _ => {}
             }
@@ -192,18 +213,22 @@ impl PtyInstance {
             .map(|guard| PtyScreenRef { _guard: guard })
     }
 
-    pub fn scroll_up(&mut self) {
+    pub fn scroll_up(&mut self, amount: u8) {
         if let Ok(mut parser) = self.parser.write() {
             let current = parser.screen().scrollback();
-            parser.screen_mut().set_scrollback(current + 1);
+            parser
+                .screen_mut()
+                .set_scrollback(current + amount as usize);
         }
     }
 
-    pub fn scroll_down(&mut self) {
+    pub fn scroll_down(&mut self, amount: u8) {
         if let Ok(mut parser) = self.parser.write() {
             let current = parser.screen().scrollback();
             if current > 0 {
-                parser.screen_mut().set_scrollback(current - 1);
+                parser
+                    .screen_mut()
+                    .set_scrollback(current - amount as usize);
             }
         }
     }

--- a/packages/nx/src/native/tui/scroll_momentum.rs
+++ b/packages/nx/src/native/tui/scroll_momentum.rs
@@ -1,0 +1,101 @@
+use std::time::Instant;
+use tracing::trace;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ScrollDirection {
+    Up,
+    Down,
+}
+
+pub struct ScrollMomentum {
+    last_scroll_time: Option<Instant>,
+    momentum: f32,
+    last_direction: Option<ScrollDirection>,
+    scroll_count: u32, // Track how many consecutive scrolls in same direction
+}
+
+impl ScrollMomentum {
+    pub fn new() -> Self {
+        Self {
+            last_scroll_time: None,
+            momentum: 1.0,
+            last_direction: None,
+            scroll_count: 0,
+        }
+    }
+
+    /// Calculate scroll momentum based on time between consecutive scrolls
+    /// Returns the number of lines to scroll with acceleration
+    pub fn calculate_momentum(&mut self, direction: ScrollDirection) -> u8 {
+        const MOMENTUM_TIMEOUT_MS: u128 = 200; // Time window for momentum to build
+        const ACCELERATION_FACTOR: f32 = 1.2; // Exponential growth factor
+        const INITIAL_MOMENTUM: f32 = 1.0;
+        const SUSTAINED_SCROLL_THRESHOLD: u32 = 20; // After this many scrolls, increase max dramatically
+
+        // Check if direction changed and reset momentum if it did
+        if let Some(last_dir) = self.last_direction {
+            if last_dir != direction {
+                trace!("Direction changed from {:?} to {:?}", last_dir, direction);
+                self.momentum = INITIAL_MOMENTUM;
+                self.last_scroll_time = None;
+                self.scroll_count = 0;
+            }
+        }
+        self.last_direction = Some(direction);
+
+        let now = Instant::now();
+
+        if let Some(last_time) = self.last_scroll_time {
+            let elapsed = now.duration_since(last_time).as_millis();
+
+            if elapsed < MOMENTUM_TIMEOUT_MS {
+                // Accelerate momentum exponentially
+                self.momentum *= ACCELERATION_FACTOR;
+                self.scroll_count += 1;
+
+                // Dynamic max based on sustained scrolling
+                let max_momentum = if self.scroll_count > SUSTAINED_SCROLL_THRESHOLD {
+                    // Allow much higher speeds for sustained scrolling (up to 100 lines)
+                    100.0
+                } else {
+                    // Standard max for initial scrolling
+                    25.0
+                };
+
+                self.momentum = self.momentum.min(max_momentum);
+
+                trace!(
+                    "Accelerated momentum: {:.1} (count: {})",
+                    self.momentum, self.scroll_count
+                );
+            } else {
+                // Reset momentum if timeout exceeded
+                trace!("Resetting scroll momentum due to timeout");
+                self.momentum = INITIAL_MOMENTUM;
+                self.scroll_count = 0;
+            }
+        } else {
+            // First scroll
+            self.momentum = INITIAL_MOMENTUM;
+            self.scroll_count = 1;
+        }
+
+        self.last_scroll_time = Some(now);
+        self.momentum.round() as u8
+    }
+
+    /// Reset momentum (e.g., when changing modes or contexts)
+    pub fn reset(&mut self) {
+        trace!("Resetting scroll momentum");
+        self.momentum = 1.0;
+        self.last_scroll_time = None;
+        self.last_direction = None;
+        self.scroll_count = 0;
+    }
+}
+
+impl Default for ScrollMomentum {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Scroll position gets reset when unrelated tasks finish. Additionally, scrolling is just really slow.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This pull request introduces momentum-based scrolling and improves scroll position preservation across terminal panes and pseudo-terminal instances (`PtyInstance`). It also adds a new `ScrollMomentum` module to manage scrolling behavior dynamically based on user input patterns. The changes enhance user experience by making scrolling smoother and more intuitive, especially during rapid or sustained scrolling.

### Scroll Momentum Enhancements:
* Added the `ScrollMomentum` module to calculate dynamic scrolling behavior based on time intervals and direction changes, allowing for accelerated scrolling during sustained input. (`packages/nx/src/native/tui/scroll_momentum.rs`, [packages/nx/src/native/tui/scroll_momentum.rsR1-R101](diffhunk://#diff-60e4cfcd0a48b7d32e565a9254f89f142587e07a37536ca103b1ae76a760135eR1-R101))
* Integrated momentum-based scrolling into `TerminalPaneData` and `PtyInstance`, replacing static scroll methods with dynamic ones (`scroll_up` and `scroll_down`) that use calculated momentum values. (`packages/nx/src/native/tui/components/terminal_pane.rs`, [[1]](diffhunk://#diff-494d587e52e864f34496326a7453461a9a15e5c136d504a54db36a59cae7c446L45-R66); `packages/nx/src/native/tui/pty.rs`, [[2]](diffhunk://#diff-1e180729578f1157895b8cd0df25b87ba902ac7804e3a944601d28d3cf437b14L122-R158) [[3]](diffhunk://#diff-1e180729578f1157895b8cd0df25b87ba902ac7804e3a944601d28d3cf437b14L148-R192) [[4]](diffhunk://#diff-1e180729578f1157895b8cd0df25b87ba902ac7804e3a944601d28d3cf437b14L175-R231)

### Scroll Position Preservation:
* Enhanced `PtyInstance` to preserve scroll position during terminal resize operations, ensuring better continuity when dimensions change. (`packages/nx/src/native/tui/pty.rs`, [[1]](diffhunk://#diff-1e180729578f1157895b8cd0df25b87ba902ac7804e3a944601d28d3cf437b14L76-R91) [[2]](diffhunk://#diff-1e180729578f1157895b8cd0df25b87ba902ac7804e3a944601d28d3cf437b14L91-R120)

### Code Improvements:
* Added momentum reset logic when switching interactive modes or changing scroll direction to avoid abrupt changes in scrolling behavior. (`packages/nx/src/native/tui/components/terminal_pane.rs`, [[1]](diffhunk://#diff-494d587e52e864f34496326a7453461a9a15e5c136d504a54db36a59cae7c446R150-R169); `packages/nx/src/native/tui/scroll_momentum.rs`, [[2]](diffhunk://#diff-60e4cfcd0a48b7d32e565a9254f89f142587e07a37536ca103b1ae76a760135eR1-R101)
* Updated `TerminalPaneData` and `PtyInstance` constructors to initialize `ScrollMomentum` instances for consistent scrolling state management. (`packages/nx/src/native/tui/components/terminal_pane.rs`, [[1]](diffhunk://#diff-494d587e52e864f34496326a7453461a9a15e5c136d504a54db36a59cae7c446R38); `packages/nx/src/native/tui/pty.rs`, [[2]](diffhunk://#diff-1e180729578f1157895b8cd0df25b87ba902ac7804e3a944601d28d3cf437b14R53) [[3]](diffhunk://#diff-1e180729578f1157895b8cd0df25b87ba902ac7804e3a944601d28d3cf437b14R67)

These changes collectively improve the usability of terminal panes and pseudo-terminal instances by making scrolling more responsive and preserving user context during resize events.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
