### PR TITLE
fix(core): swap from gray -> dark gray for light theme secondary foreground

### DIFF
--- a/packages/nx/src/native/tui/theme.rs
+++ b/packages/nx/src/native/tui/theme.rs
@@ -50,7 +50,7 @@ impl Theme {
         Self {
             is_dark_mode: false,
             primary_fg: Color::Black,
-            secondary_fg: Color::Gray,
+            secondary_fg: Color::DarkGray,
             error: Color::Red,
             success: Color::Green,
             warning: Color::Yellow,


### PR DESCRIPTION
## Current Behavior
Gray for secondary light foreground has low contrast in light themes

## Expected Behavior
This pull request includes a small change to the `Theme` implementation in the `packages/nx/src/native/tui/theme.rs` file. The change updates the `secondary_fg` color from `Color::Gray` to `Color::DarkGray` to improve visual contrast.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
