### PR TITLE
feat(rspack): add support for proxyConfig in the dev-server executor

### DIFF
--- a/docs/generated/packages/rspack/executors/dev-server.json
+++ b/docs/generated/packages/rspack/executors/dev-server.json
@@ -40,6 +40,11 @@
         "type": "string",
         "description": "SSL certificate to use for serving `HTTPS`."
       },
+      "proxyConfig": {
+        "type": "string",
+        "description": "Path to proxy configuration file. For more information, see https://rspack.rs/config/dev-server#devserverproxy.",
+        "x-completion-type": "file"
+      },
       "publicHost": {
         "type": "string",
         "description": "Public URL where the application will be served."

--- a/packages/rspack/src/executors/dev-server/lib/get-dev-server-config.ts
+++ b/packages/rspack/src/executors/dev-server/lib/get-dev-server-config.ts
@@ -72,6 +72,10 @@ export function getDevServerOptions(
     }
   }
 
+  if (serveOptions.proxyConfig) {
+    config.proxy = getProxyConfig(root, serveOptions);
+  }
+
   return config;
 }
 
@@ -80,4 +84,9 @@ function getSslConfig(root: string, options: DevServerExecutorSchema) {
     key: readFileSync(path.resolve(root, options.sslKey), 'utf-8'),
     cert: readFileSync(path.resolve(root, options.sslCert), 'utf-8'),
   };
+}
+
+function getProxyConfig(root: string, options: DevServerExecutorSchema) {
+  const proxyPath = path.resolve(root, options.proxyConfig as string);
+  return require(proxyPath);
 }

--- a/packages/rspack/src/executors/dev-server/schema.d.ts
+++ b/packages/rspack/src/executors/dev-server/schema.d.ts
@@ -8,5 +8,6 @@ export interface DevServerExecutorSchema {
   ssl?: boolean;
   sslKey?: string;
   sslCert?: string;
+  proxyConfig?: string;
   publicHost?: string;
 }

--- a/packages/rspack/src/executors/dev-server/schema.json
+++ b/packages/rspack/src/executors/dev-server/schema.json
@@ -37,6 +37,11 @@
       "type": "string",
       "description": "SSL certificate to use for serving `HTTPS`."
     },
+    "proxyConfig": {
+      "type": "string",
+      "description": "Path to proxy configuration file. For more information, see https://rspack.rs/config/dev-server#devserverproxy.",
+      "x-completion-type": "file"
+    },
     "publicHost": {
       "type": "string",
       "description": "Public URL where the application will be served."


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

This PR adds support for the `proxyConfig` option in the @rspack/dev-server executor, similarly to the existing option in the matching Webpack executor. This new options is another step for allowing simpler migration to Rspack when coming from Webpack, adding to the feature parity of the Rspack executor.

## Current Behavior

The `@nx/rspack:dev-server` executor does not allow for passing a `proxyConfig` as an option, opposed to the matching Webpack executor, that does. 

## Expected Behavior

The `@nx/rspack:dev-server` executor allows for passing a `proxyConfig` option, same as the `@nx/webpack:dev-server` executor.

## Related Issue(s)

None.