### PR TITLE
feat(core): add --initialRun flag to nx watch command

### DIFF
--- a/docs/generated/cli/watch.md
+++ b/docs/generated/cli/watch.md
@@ -42,6 +42,7 @@ Watch all projects (including newly created projects) in the workspace:
 | `--all`                             | boolean | Watch all projects.                                                         |
 | `--help`                            | boolean | Show help.                                                                  |
 | `--includeDependentProjects`, `--d` | boolean | When watching selected projects, include dependent projects as well.        |
+| `--initialRun`, `--i`               | boolean | Run the command once before watching for changes. (Default: `false`)        |
 | `--projects`, `--p`                 | string  | Projects to watch (comma/space delimited).                                  |
 | `--verbose`                         | boolean | Run watch mode in verbose mode, where commands are logged before execution. |
 | `--version`                         | boolean | Show version number.                                                        |

--- a/docs/generated/packages/nx/documents/watch.md
+++ b/docs/generated/packages/nx/documents/watch.md
@@ -42,6 +42,7 @@ Watch all projects (including newly created projects) in the workspace:
 | `--all`                             | boolean | Watch all projects.                                                         |
 | `--help`                            | boolean | Show help.                                                                  |
 | `--includeDependentProjects`, `--d` | boolean | When watching selected projects, include dependent projects as well.        |
+| `--initialRun`, `--i`               | boolean | Run the command once before watching for changes. (Default: `false`)        |
 | `--projects`, `--p`                 | string  | Projects to watch (comma/space delimited).                                  |
 | `--verbose`                         | boolean | Run watch mode in verbose mode, where commands are logged before execution. |
 | `--version`                         | boolean | Show version number.                                                        |

--- a/packages/nx/src/command-line/watch/command-object.ts
+++ b/packages/nx/src/command-line/watch/command-object.ts
@@ -47,6 +47,12 @@ function withWatchOptions(yargs: Argv) {
       description:
         'Run watch mode in verbose mode, where commands are logged before execution.',
     })
+    .option('initialRun', {
+      type: 'boolean',
+      description: 'Run the command once before watching for changes.',
+      alias: 'i',
+      default: false,
+    })
     .conflicts({
       all: 'projects',
     })

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -9,6 +9,7 @@ export interface WatchArguments {
   includeGlobalWorkspaceFiles?: boolean;
   verbose?: boolean;
   command?: string;
+  initialRun?: boolean;
 
   projectNameEnvName?: string;
   fileChangesEnvName?: string;
@@ -189,6 +190,18 @@ export async function watch(args: WatchArguments) {
     args.projectNameEnvName,
     args.fileChangesEnvName
   );
+
+  // Run the command initially if requested
+  if (args.initialRun) {
+    args.verbose && output.logSingleLine('running command initially...');
+
+    const initialProjects = args.all
+      ? [] // When using --all, we don't need to pass specific projects
+      : args.projects || [];
+
+    // Execute the initial run
+    await batchQueue.enqueue(initialProjects, []);
+  }
 
   await daemonClient.registerFileWatcher(
     {


### PR DESCRIPTION
## Current Behavior

The `nx watch` command currently requires a file change before executing the specified command for the first time.

## Expected Behavior

Add support for running the watch command once before watching for changes. This is useful when you want to see results immediately without having to make a file change first.

## Related Issue(s)

N/A - Feature addition

## Implementation Details

- Added a new `--initialRun` flag (alias `-i`) to the `nx watch` command
- When the flag is set to `true`, the command executes once before setting up the file watcher
- Works with both `--all` mode and specific project selections
- Default value is `false` to maintain backward compatibility
- Documentation has been updated to reflect this new option

## Usage Examples

```bash
# Run the command initially, then watch for changes
nx watch --all --initialRun -- echo "Running command"

# Or with the alias
nx watch --projects=myapp -i -- npm run test
```

## Test Plan

- [ ] Manual testing with `--all` flag
- [ ] Manual testing with specific projects
- [ ] Verify command runs initially when flag is set
- [ ] Verify command does not run initially when flag is not set (default behavior)
- [ ] Documentation generated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)