### PR TITLE
fix(core): improve parent gitignore handling for nested Nx workspaces

### DIFF
--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -158,6 +158,22 @@ where
     receiver_thread.join().unwrap()
 }
 
+/// Find the nearest git repository root by walking up the directory tree
+fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
+    let mut current_path = start_path.as_ref();
+
+    loop {
+        if current_path.join(".git").exists() {
+            return Some(current_path.to_path_buf());
+        }
+
+        match current_path.parent() {
+            Some(parent) => current_path = parent,
+            None => return None,
+        }
+    }
+}
+
 fn create_walker<P>(directory: P, use_ignores: bool) -> WalkBuilder
 where
     P: AsRef<Path>,
@@ -176,8 +192,42 @@ where
     let mut walker = WalkBuilder::new(&directory);
     walker.require_git(false);
     walker.hidden(false);
-    walker.git_ignore(use_ignores);
+
     if use_ignores {
+        // Find the nearest git root to determine ignore file behavior
+        let git_root = find_git_root(&directory);
+
+        match git_root {
+            Some(git_root_path) if git_root_path == directory => {
+                // The workspace IS the git root - don't use parent gitignores
+                walker.parents(false);
+            }
+            Some(git_root_path) => {
+                // The workspace is nested within a git repo - disable automatic parents
+                // and manually add ignore files only up to the git root
+                walker.parents(false);
+
+                // Manually add .gitignore files from parent directories up to the git root
+                let mut current_path = directory.parent();
+                while let Some(path) = current_path {
+                    let gitignore_path = path.join(".gitignore");
+                    if gitignore_path.exists() {
+                        walker.add_ignore(gitignore_path);
+                    }
+
+                    // Stop when we reach the git root (after processing it)
+                    if path == git_root_path {
+                        break;
+                    }
+                    current_path = path.parent();
+                }
+            }
+            None => {
+                // No git repository found - use all parent ignores (backwards compatibility)
+                walker.parents(true);
+            }
+        }
+
         walker.add_custom_ignore_filename(".nxignore");
     }
 
@@ -314,5 +364,109 @@ nested/child-two/
                 "v1/packages/pkg-b/pkg-b.txt"
             )
         );
+    }
+
+    #[test]
+    fn ignores_parent_gitignore_when_workspace_is_git_root() {
+        let parent_temp = assert_fs::TempDir::new().unwrap();
+        parent_temp.child(".gitignore").write_str("*").unwrap();
+        parent_temp.child("workspace/.git").touch().unwrap();
+        parent_temp
+            .child("workspace/file1.txt")
+            .write_str("test")
+            .unwrap();
+        parent_temp
+            .child("workspace/project.json")
+            .write_str("test")
+            .unwrap();
+
+        let workspace_path = parent_temp.path().join("workspace");
+        let mut files: Vec<_> = nx_walker(&workspace_path, true)
+            .map(|f| f.normalized_path)
+            .collect();
+        files.sort();
+
+        assert_eq!(
+            files,
+            vec!["file1.txt".to_string(), "project.json".to_string()]
+        );
+    }
+
+    #[test]
+    fn respects_gitignore_within_git_repo_but_not_above() {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+
+        // Create a .gitignore file above the git repository (should be ignored)
+        temp_dir
+            .child(".gitignore")
+            .write_str("ignored_by_parent.txt")
+            .unwrap();
+
+        // Create the git repository root
+        temp_dir.child("repo/.git").touch().unwrap();
+
+        // Create a .gitignore file within the git repository (should be respected)
+        temp_dir
+            .child("repo/.gitignore")
+            .write_str("ignored_by_repo.txt")
+            .unwrap();
+
+        // Create test files
+        temp_dir
+            .child("repo/workspace/file1.txt")
+            .write_str("test")
+            .unwrap();
+        temp_dir
+            .child("repo/workspace/project.json")
+            .write_str("test")
+            .unwrap();
+        temp_dir
+            .child("repo/workspace/ignored_by_parent.txt")
+            .write_str("test")
+            .unwrap();
+        temp_dir
+            .child("repo/workspace/ignored_by_repo.txt")
+            .write_str("test")
+            .unwrap();
+
+        let workspace_path = temp_dir.path().join("repo/workspace");
+        let mut files: Vec<_> = nx_walker(&workspace_path, true)
+            .map(|f| f.normalized_path)
+            .collect();
+        files.sort();
+
+        // Should include ignored_by_parent.txt (parent .gitignore is ignored)
+        // Should exclude ignored_by_repo.txt (repo .gitignore is respected)
+        assert_eq!(
+            files,
+            vec![
+                "file1.txt".to_string(),
+                "ignored_by_parent.txt".to_string(),
+                "project.json".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn respects_parent_gitignore_when_no_git_repo_found() {
+        let parent_temp = assert_fs::TempDir::new().unwrap();
+        parent_temp.child(".gitignore").write_str("*").unwrap();
+        parent_temp
+            .child("workspace/file1.txt")
+            .write_str("test")
+            .unwrap();
+        parent_temp
+            .child("workspace/project.json")
+            .write_str("test")
+            .unwrap();
+
+        let workspace_path = parent_temp.path().join("workspace");
+        let mut files: Vec<_> = nx_walker(&workspace_path, true)
+            .map(|f| f.normalized_path)
+            .collect();
+        files.sort();
+
+        // All files should be ignored by parent .gitignore since no git repo was found
+        assert!(files.is_empty());
     }
 }


### PR DESCRIPTION
## Current Behavior

When an Nx workspace exists inside a subdirectory of another git repository or when parent directories contain `.gitignore` files, those ignore patterns can affect file traversal within the Nx workspace, making project resolution non-deterministic.

For example, if a workspace is inside a directory with `*` in its `.gitignore`, Nx fails to properly traverse workspace files.

## Expected Behavior

Nx should respect `.gitignore` files in a smart way:
- **Workspace is git root**: Ignores all parent gitignore files 
- **Workspace nested in git repo**: Respects gitignore files within the git repository but ignores any gitignore files above the git root
- **No git repo found**: Respects all parent gitignore files (backwards compatibility)

This ensures deterministic project resolution regardless of where the workspace is located.

## Related Issue(s)

Fixes #27368, #28000, #27295, #28123, #29413

Supersedes #29245 (incorporates feedback from @Cammisuli and @adamalton)

## Implementation Details

The fix implements smart gitignore boundary detection that:

1. **Finds the nearest git repository root** by walking up the directory tree
2. **Uses built-in git ignore handling** for maximum compatibility  
3. **Disables automatic parent discovery** and manually adds only relevant `.gitignore` files
4. **Stops at git repository boundaries** to prevent external gitignore files from affecting the workspace

This approach addresses the feedback from the original PR #29245 to handle both:
- Standalone workspaces (where workspace root = git root)
- Workspaces nested within larger git repositories

The solution leverages the `ignore` crate's existing functionality while providing precise control over which ignore files are considered.

## Test Plan

- [x] Unit tests covering all three scenarios
- [x] Workspace is git root: ignores parent gitignores
- [x] Workspace nested in git repo: respects repo gitignores, ignores external ones  
- [x] No git repo: uses all parent gitignores (backwards compatibility)
- [x] All existing walker tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)