### PR TITLE
fix(core): ensure non-pty tasks have output in terminal pane when finish

### DIFF
--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -495,6 +495,35 @@ impl<'a> StatefulWidget for TerminalPane<'a> {
             return;
         }
 
+        // If the task completed successfully but has no PTY output (e.g., nx:noop tasks), show completion message
+        if matches!(
+            state.task_status,
+            TaskStatus::Success
+                | TaskStatus::LocalCache
+                | TaskStatus::LocalCacheKeptExisting
+                | TaskStatus::RemoteCache
+        ) && !state.has_pty
+        {
+            let message_style = if state.is_focused {
+                self.get_base_style(state.task_status)
+            } else {
+                self.get_base_style(state.task_status)
+                    .add_modifier(Modifier::DIM)
+            };
+            let message = vec![Line::from(vec![Span::styled(
+                "Task completed successfully",
+                message_style,
+            )])];
+
+            let paragraph = Paragraph::new(message)
+                .block(block)
+                .alignment(Alignment::Center)
+                .style(Style::default());
+
+            Widget::render(paragraph, safe_area, buf);
+            return;
+        }
+
         let inner_area = block.inner(safe_area);
 
         if let Some(pty_data) = &self.pty_data {


### PR DESCRIPTION
## Current Behavior

When a task with no PTY (e.g. a task using the `nx:noop` executor) has its output pane open and it finishes successfully, no output is shown, and there's a blank space to the right of the task list where the output pane is meant to be.

<img width="1366" height="413" alt="image" src="https://github.com/user-attachments/assets/fc34cc18-1bed-4d73-9b94-5a25069e8a3d" />

## Expected Behavior

When a task with no PTY (e.g. a task using the `nx:noop` executor) has its output pane open and it finishes successfully, the output pane should be correctly rendered in a successful status.

<img width="1365" height="411" alt="image" src="https://github.com/user-attachments/assets/cb8862d5-f1c2-4aa6-a098-f710020e64f4" />