### PR TITLE
fix(testing): when we generate a random port we should start from 1024

### DIFF
--- a/e2e/node/src/node-ts-solution-esbuild.test.ts
+++ b/e2e/node/src/node-ts-solution-esbuild.test.ts
@@ -2,9 +2,9 @@ import { names } from '@nx/devkit';
 import {
   cleanupProject,
   getPackageManagerCommand,
+  getRandomPort,
   getSelectedPackageManager,
   newProject,
-  readFile,
   runCLI,
   runCommand,
   uniq,
@@ -85,7 +85,3 @@ describe('Node Esbuild Applications', () => {
     );
   });
 });
-
-function getRandomPort() {
-  return Math.floor(1000 + Math.random() * 7000);
-}

--- a/e2e/node/src/node-ts-solution.test.ts
+++ b/e2e/node/src/node-ts-solution.test.ts
@@ -14,6 +14,7 @@ import {
   uniq,
   updateFile,
   updateJson,
+  getRandomPort,
 } from '@nx/e2e/utils';
 import { execSync } from 'child_process';
 import * as http from 'http';
@@ -324,10 +325,6 @@ describe('Node Applications', () => {
     );
   }, 300_000);
 });
-
-function getRandomPort() {
-  return Math.floor(1000 + Math.random() * 9000);
-}
 
 function getData(port, path = '/api'): Promise<any> {
   return new Promise((resolve) => {

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -6,8 +6,8 @@ import {
   cleanupProject,
   createFile,
   detectPackageManager,
-  expectJestTestsToPass,
   getPackageManagerCommand,
+  getRandomPort,
   killPorts,
   newProject,
   packageInstall,
@@ -30,10 +30,6 @@ import { satisfies } from 'semver';
 import { join } from 'path';
 
 let originalEnvPort;
-
-function getRandomPort() {
-  return Math.floor(1000 + Math.random() * 9000);
-}
 
 function getData(port, path = '/api'): Promise<any> {
   return new Promise((resolve) => {

--- a/e2e/utils/process-utils.ts
+++ b/e2e/utils/process-utils.ts
@@ -56,3 +56,11 @@ export async function killProcessAndPorts(
     expect(err).toBeFalsy();
   }
 }
+
+/**
+ * Generates a random port number between 1024 and 9999.
+ * Ports below 1024 are reserved for system services.
+ */
+export function getRandomPort() {
+  return Math.floor(1024 + Math.random() * 8976);
+}


### PR DESCRIPTION
When we generate a random port in our node e2e tests we should ensure that the random generation port generation range starts from 1024.

Also, move the `getRandomPort` function to `e2e-utils` so that other tests benefit from this change.
