### PR TITLE
fix(testing): update yarn integration tests for remix and enable previously skipped tests

### DIFF
--- a/e2e/remix/src/nx-remix.test.ts
+++ b/e2e/remix/src/nx-remix.test.ts
@@ -35,7 +35,10 @@ describe('Remix E2E Tests', () => {
   });
   describe('--integrated (yarn)', () => {
     beforeAll(async () => {
-      newProject({ packages: ['@nx/remix', '@nx/react'] });
+      newProject({
+        packages: ['@nx/remix', '@nx/react'],
+        packageManager: 'yarn',
+      });
     });
 
     afterAll(() => {
@@ -103,8 +106,7 @@ describe('Remix E2E Tests', () => {
         expect(result).toContain(`Successfully ran target test`);
       }, 120_000);
 
-      // TODO(nicholas): This test is failing. It doesn't look like the yarn usage is correct.
-      xit('should generate a library with jest and test correctly', async () => {
+      it('should generate a library with jest and test correctly', async () => {
         const reactapp = uniq('react');
         runCLI(
           `generate @nx/react:application ${reactapp} --unitTestRunner=jest --linter=eslint`
@@ -122,8 +124,7 @@ describe('Remix E2E Tests', () => {
       }, 120_000);
     });
 
-    // TODO(nicholas): These test are failing. It doesn't look like the yarn usage is correct.
-    xdescribe('error checking', () => {
+    describe('error checking', () => {
       const plugin = uniq('remix');
 
       beforeAll(async () => {
@@ -148,8 +149,6 @@ describe('Remix E2E Tests', () => {
         ).not.toThrow();
       }, 120000);
 
-      // This is expecting yarn v1, or else there will be complaints of lockfile errors.
-      // TODO(nicholas): The workspace is created with npm, but we're running `yarn nx` which causes lockfile errors in yarn 2/3/4. I think we need to create with yarn instead?
       it('should pass un-escaped dollar signs in routes with skipChecks flag', async () => {
         await runCommandAsync(
           `someWeirdUseCase=route-segment && yarn nx generate @nx/remix:route --path="apps/${plugin}/app/routes/my.route.$someWeirdUseCase.tsx" --force`


### PR DESCRIPTION
These tests were skipped previously, we should re-enable them so that we have coverage.