### PR TITLE
fix(react): update default CI base URL to use default dev port

### DIFF
--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -5,6 +5,7 @@ import {
   newProject,
   uniq,
   updateFile,
+  readFile,
 } from '@nx/e2e/utils';
 
 describe('React Playwright e2e tests', () => {
@@ -31,6 +32,50 @@ describe('React Playwright e2e tests', () => {
         `Successfully ran target e2e for project ${appName}-e2e`
       );
     }
+  });
+
+  it('should generate a playwright config with the default options', () => {
+    const testAppName = uniq('pw-test-app');
+    runCLI(
+      `generate @nx/react:app ${testAppName} --e2eTestRunner=playwright --bundler=vite --no-interactive`
+    );
+
+    const configContent = readFile(`${testAppName}-e2e/playwright.config.ts`);
+
+    //  imports
+    expect(configContent).toContain(
+      "import { defineConfig, devices } from '@playwright/test';"
+    );
+    expect(configContent).toContain(
+      "import { nxE2EPreset } from '@nx/playwright/preset';"
+    );
+    expect(configContent).toContain(
+      "import { workspaceRoot } from '@nx/devkit';"
+    );
+
+    //  baseURL configuration
+    expect(configContent).toContain(
+      "const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';"
+    );
+
+    // defineConfig
+    expect(configContent).toContain('export default defineConfig({');
+    expect(configContent).toContain(
+      "...nxE2EPreset(__filename, { testDir: './src' })"
+    );
+
+    //  webServer configuration
+    expect(configContent).toContain('use: {');
+    expect(configContent).toContain('baseURL,');
+    expect(configContent).toContain("trace: 'on-first-retry',");
+
+    expect(configContent).toContain('webServer: {');
+    expect(configContent).toContain(
+      `command: 'npx nx run ${testAppName}:preview'`
+    );
+    expect(configContent).toContain("url: 'http://localhost:4200'");
+    expect(configContent).toContain('reuseExistingServer: true');
+    expect(configContent).toContain('cwd: workspaceRoot');
   });
 
   it('should execute e2e tests using playwright with a library used in the app', () => {

--- a/packages/react/src/generators/application/lib/add-e2e.ts
+++ b/packages/react/src/generators/application/lib/add-e2e.ts
@@ -37,7 +37,7 @@ export async function addE2e(
     e2eCiWebServerCommand: `${getPackageManagerCommand().exec} nx run ${
       options.projectName
     }:serve-static`,
-    e2eCiBaseUrl: `http://localhost:${options.port ?? 4300}`,
+    e2eCiBaseUrl: `http://localhost:${options.port ?? 4200}`,
     e2eDevServerTarget: `${options.projectName}:serve`,
   };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, we generate an e2e app with the fallback port of `4300`.

This will fail because the default dev port generated is `4200`. So running the e2e test will fail.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running a newly generated e2e app should work out of the box.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
