### PR TITLE
fix(react): normalize paths correctly when generating stories

### DIFF
--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -118,7 +118,10 @@ export async function createAllStories(
 
   await Promise.all(
     componentPaths.map(async (componentPath) => {
-      const relativeCmpDir = componentPath.replace(`${sourceRoot}/`, '');
+      const relativeCmpDir = componentPath.replace(
+        `${sourceRoot.replace(/^\.\//, '')}/`,
+        ''
+      );
 
       if (!containsComponentDeclaration(tree, componentPath)) {
         return;


### PR DESCRIPTION
## Current Behavior

When generating stories, the generation can fail due to a bad path normalization with:

```bash
 NX   Failed to read src/src/app/app.tsx

Pass --verbose to see the stacktrace.
```

## Expected Behavior

Generating stories should work correctly.