### PR TITLE
fix(react): Ensure react-router e2e test are generated with the correct config

### DIFF
--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -5,7 +5,6 @@ import {
   newProject,
   uniq,
   updateFile,
-  readFile,
 } from '@nx/e2e/utils';
 
 describe('React Playwright e2e tests', () => {
@@ -32,50 +31,6 @@ describe('React Playwright e2e tests', () => {
         `Successfully ran target e2e for project ${appName}-e2e`
       );
     }
-  });
-
-  it('should generate a playwright config with the default options', () => {
-    const testAppName = uniq('pw-test-app');
-    runCLI(
-      `generate @nx/react:app ${testAppName} --e2eTestRunner=playwright --bundler=vite --no-interactive`
-    );
-
-    const configContent = readFile(`${testAppName}-e2e/playwright.config.ts`);
-
-    //  imports
-    expect(configContent).toContain(
-      "import { defineConfig, devices } from '@playwright/test';"
-    );
-    expect(configContent).toContain(
-      "import { nxE2EPreset } from '@nx/playwright/preset';"
-    );
-    expect(configContent).toContain(
-      "import { workspaceRoot } from '@nx/devkit';"
-    );
-
-    //  baseURL configuration
-    expect(configContent).toContain(
-      "const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';"
-    );
-
-    // defineConfig
-    expect(configContent).toContain('export default defineConfig({');
-    expect(configContent).toContain(
-      "...nxE2EPreset(__filename, { testDir: './src' })"
-    );
-
-    //  webServer configuration
-    expect(configContent).toContain('use: {');
-    expect(configContent).toContain('baseURL,');
-    expect(configContent).toContain("trace: 'on-first-retry',");
-
-    expect(configContent).toContain('webServer: {');
-    expect(configContent).toContain(
-      `command: 'npx nx run ${testAppName}:preview'`
-    );
-    expect(configContent).toContain("url: 'http://localhost:4200'");
-    expect(configContent).toContain('reuseExistingServer: true');
-    expect(configContent).toContain('cwd: workspaceRoot');
   });
 
   it('should execute e2e tests using playwright with a library used in the app', () => {

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -5,6 +5,7 @@ import {
   newProject,
   uniq,
   updateFile,
+  readFile,
 } from '@nx/e2e/utils';
 
 describe('React Playwright e2e tests', () => {
@@ -31,6 +32,50 @@ describe('React Playwright e2e tests', () => {
         `Successfully ran target e2e for project ${appName}-e2e`
       );
     }
+  });
+
+  it('should generate a playwright config with the default options', () => {
+    const testAppName = uniq('pw-test-app');
+    runCLI(
+      `generate @nx/react:app ${testAppName} --e2eTestRunner=playwright --bundler=vite --no-interactive`
+    );
+
+    const configContent = readFile(`${testAppName}-e2e/playwright.config.ts`);
+
+    //  imports
+    expect(configContent).toContain(
+      "import { defineConfig, devices } from '@playwright/test';"
+    );
+    expect(configContent).toContain(
+      "import { nxE2EPreset } from '@nx/playwright/preset';"
+    );
+    expect(configContent).toContain(
+      "import { workspaceRoot } from '@nx/devkit';"
+    );
+
+    //  baseURL configuration
+    expect(configContent).toContain(
+      "const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';"
+    );
+
+    // defineConfig
+    expect(configContent).toContain('export default defineConfig({');
+    expect(configContent).toContain(
+      "...nxE2EPreset(__filename, { testDir: './src' })"
+    );
+
+    //  webServer configuration
+    expect(configContent).toContain('use: {');
+    expect(configContent).toContain('baseURL,');
+    expect(configContent).toContain("trace: 'on-first-retry',");
+
+    expect(configContent).toContain('webServer: {');
+    expect(configContent).toContain(
+      `command: 'npx nx run ${testAppName}:preview'`
+    );
+    expect(configContent).toContain("url: 'http://localhost:4200'");
+    expect(configContent).toContain('reuseExistingServer: true');
+    expect(configContent).toContain('cwd: workspaceRoot');
   });
 
   it('should execute e2e tests using playwright with a library used in the app', () => {

--- a/e2e/react/src/react-router.test.ts
+++ b/e2e/react/src/react-router.test.ts
@@ -2,9 +2,11 @@ import {
   checkFilesExist,
   cleanupProject,
   ensureCypressInstallation,
+  ensurePlaywrightBrowsersInstallation,
   newProject,
   readFile,
   runCLI,
+  runE2ETests,
   uniq,
 } from '@nx/e2e/utils';
 
@@ -13,9 +15,9 @@ describe('React Router Applications', () => {
     const appName = uniq('app');
     beforeAll(() => {
       newProject({ packages: ['@nx/react'] });
-      ensureCypressInstallation();
+      ensurePlaywrightBrowsersInstallation();
       runCLI(
-        `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --no-interactive`
+        `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --no-interactive`
       );
     });
 
@@ -36,18 +38,15 @@ describe('React Router Applications', () => {
       checkFilesExist(`${appName}/vite.config.ts`);
     });
 
-    it('should be able to build a react-router application', async () => {
+    it('should be able to build, lint, test and typecheck a react-router application', async () => {
       const buildResult = runCLI(`build ${appName}`);
-      expect(buildResult).toContain('Successfully ran target build');
-    });
-
-    it('should be able to lint a react-router application', async () => {
       const lintResult = runCLI(`lint ${appName}`);
-      expect(lintResult).toContain('Successfully ran target lint');
-    });
-
-    it('should be able to test and typecheck a react-router application', async () => {
+      const testResult = runCLI(`test ${appName}`);
       const typeCheckResult = runCLI(`typecheck ${appName}`);
+
+      expect(buildResult).toContain('Successfully ran target build');
+      expect(lintResult).toContain('Successfully ran target lint');
+      expect(testResult).toContain('Successfully ran target test');
       expect(typeCheckResult).toContain('Successfully ran target typecheck');
     });
 
@@ -62,15 +61,38 @@ describe('React Router Applications', () => {
 
       const typeCheckResult = runCLI(`typecheck ${jestApp}`);
       expect(typeCheckResult).toContain('Successfully ran target typecheck');
+    });
+
+    it('should execute e2e tests using playwright', () => {
+      if (runE2ETests()) {
+        const result = runCLI(`e2e ${appName}-e2e --verbose`);
+        expect(result).toContain(
+          `Successfully ran target e2e for project ${appName}-e2e`
+        );
+      }
+    });
+
+    it('should execute e2e tests using cypress', () => {
+      const cypressAppName = uniq('cypress-app');
+      ensureCypressInstallation();
+      runCLI(
+        `generate @nx/react:app ${cypressAppName} --use-react-router --routing --linter=eslint --unit-test-runner=none  --no-interactive`
+      );
+      if (runE2ETests()) {
+        const result = runCLI(`e2e ${cypressAppName}-e2e --verbose`);
+        expect(result).toContain(
+          `Successfully ran target e2e for project ${cypressAppName}-e2e`
+        );
+      }
     });
   });
   describe('TS Solution', () => {
     const appName = uniq('app');
     beforeAll(() => {
       newProject({ preset: 'ts', packages: ['@nx/react'] });
-      ensureCypressInstallation();
+      ensurePlaywrightBrowsersInstallation();
       runCLI(
-        `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --no-interactive`
+        `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --no-interactive`
       );
     });
 
@@ -91,24 +113,17 @@ describe('React Router Applications', () => {
       checkFilesExist(`${appName}/vite.config.ts`);
     });
 
-    it('should be able to build a react-router application', async () => {
+    it('should be able to build, lint, test and typecheck a react-router application', async () => {
       const buildResult = runCLI(`build ${appName}`);
-      expect(buildResult).toContain('Successfully ran target build');
-    });
-
-    it('should be able to lint a react-router application', async () => {
       const lintResult = runCLI(`lint ${appName}`);
-      expect(lintResult).toContain('Successfully ran target lint');
-    });
-
-    it('should be able to test and typecheck a react-router application', async () => {
       const testResult = runCLI(`test ${appName}`);
-      expect(testResult).toContain('Successfully ran target test');
-
       const typeCheckResult = runCLI(`typecheck ${appName}`);
+
+      expect(buildResult).toContain('Successfully ran target build');
+      expect(lintResult).toContain('Successfully ran target lint');
+      expect(testResult).toContain('Successfully ran target test');
       expect(typeCheckResult).toContain('Successfully ran target typecheck');
     });
-
     it('should be able to test and typecheck a react-router application with jest', async () => {
       const jestApp = uniq('jestApp');
       runCLI(
@@ -120,6 +135,29 @@ describe('React Router Applications', () => {
 
       const typeCheckResult = runCLI(`typecheck ${jestApp}`);
       expect(typeCheckResult).toContain('Successfully ran target typecheck');
+    });
+
+    it('should execute e2e tests using playwright', () => {
+      if (runE2ETests()) {
+        const result = runCLI(`e2e ${appName}-e2e --verbose`);
+        expect(result).toContain(
+          `Successfully ran target e2e for project ${appName}-e2e`
+        );
+      }
+    });
+
+    it('should execute e2e tests using cypress', () => {
+      const cypressAppName = uniq('cypress-app');
+      ensureCypressInstallation();
+      runCLI(
+        `generate @nx/react:app ${cypressAppName} --use-react-router --routing --linter=eslint --unit-test-runner=none  --no-interactive`
+      );
+      if (runE2ETests()) {
+        const result = runCLI(`e2e ${cypressAppName}-e2e --verbose`);
+        expect(result).toContain(
+          `Successfully ran target e2e for project ${cypressAppName}-e2e`
+        );
+      }
     });
   });
 });

--- a/packages/react/src/generators/application/lib/add-e2e.ts
+++ b/packages/react/src/generators/application/lib/add-e2e.ts
@@ -37,7 +37,7 @@ export async function addE2e(
     e2eCiWebServerCommand: `${getPackageManagerCommand().exec} nx run ${
       options.projectName
     }:serve-static`,
-    e2eCiBaseUrl: `http://localhost:${options.port ?? 4300}`,
+    e2eCiBaseUrl: `http://localhost:${options.port ?? 4200}`,
     e2eDevServerTarget: `${options.projectName}:serve`,
   };
 

--- a/packages/vite/src/utils/e2e-web-server-info-utils.ts
+++ b/packages/vite/src/utils/e2e-web-server-info-utils.ts
@@ -66,7 +66,7 @@ export async function getReactRouterE2EWebServerInfo(
       defaultServeTargetName: 'dev',
       defaultServeStaticTargetName: 'dev',
       defaultE2EWebServerAddress: `http://localhost:${e2ePort}`,
-      defaultE2ECiBaseUrl: `http://localhost:${e2eCIPortOverride ?? 4300}`,
+      defaultE2ECiBaseUrl: `http://localhost:${e2eCIPortOverride ?? 4200}`,
       defaultE2EPort: e2ePort,
     },
     isPluginBeingAdded


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When we generate a router-router app the e2e test generated expects the server to be ran on port `4300`.
Which fails because react-router serves from only one port and it's the dev port which is defaults to `4200`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This should work out of the box

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
