### PR TITLE
fix(webpack): use loadPaths instead of includePaths

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -170,7 +170,7 @@ export function applyWebConfig(
             sassOptions: {
               fiber: false,
               precision: 8,
-              includePaths,
+              loadPaths: includePaths,
               ...(sassOptions ?? {}),
             },
           },
@@ -237,7 +237,7 @@ export function applyWebConfig(
               fiber: false,
               // bootstrap-sass requires a minimum precision of 8
               precision: 8,
-              includePaths,
+              loadPaths: includePaths,
               ...(sassOptions ?? {}),
             },
           },
@@ -307,7 +307,7 @@ export function applyWebConfig(
               fiber: false,
               // bootstrap-sass requires a minimum precision of 8
               precision: 8,
-              includePaths,
+              loadPaths: includePaths,
               ...(sassOptions ?? {}),
             },
           },

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-web-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-web-config.ts
@@ -151,7 +151,7 @@ export function applyWebConfig(
             sassOptions: {
               fiber: false,
               precision: 8,
-              includePaths,
+              loadPaths: includePaths,
               ...(sassOptions ?? {}),
             },
           },
@@ -218,7 +218,7 @@ export function applyWebConfig(
               fiber: false,
               // bootstrap-sass requires a minimum precision of 8
               precision: 8,
-              includePaths,
+              loadPaths: includePaths,
               ...(sassOptions ?? {}),
             },
           },
@@ -288,7 +288,7 @@ export function applyWebConfig(
               fiber: false,
               // bootstrap-sass requires a minimum precision of 8
               precision: 8,
-              includePaths,
+              loadPaths: includePaths,
               ...(sassOptions ?? {}),
             },
           },


### PR DESCRIPTION
## Current Behavior
Nx switched to use sass-loader with `modern-compiler` api. However, it did not update to use `loadPaths` instead of `includePaths`.

## Expected Behavior
Use `loadPaths`.

## Related Issue(s)

Fixes #30340
