### PR TITLE
fix(core): lockfile pruning uess project name to identify workspace nodes

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -32,8 +32,8 @@ export function pruneProjectGraph(
     builder
   );
 
-  for (const nodeName of workspacePackages.keys()) {
-    const node = graph.nodes[nodeName];
+  for (const project of workspacePackages.values()) {
+    const node = graph.nodes[project.name];
     builder.addNode(node);
   }
 


### PR DESCRIPTION
## Current Behavior
The workspace packages logic for pruning lockfile assumes the jsPackageName is the same as the node name.
This is not always the case.

## Expected Behavior
Ensure the actual node name is used to reference the node in the project graph
