### PR TITLE
fix(module-federation): ensure react deps are eagerly loaded #31612

### DIFF
--- a/packages/module-federation/src/utils/framework-detection.spec.ts
+++ b/packages/module-federation/src/utils/framework-detection.spec.ts
@@ -1,0 +1,96 @@
+import { ProjectGraph } from '@nx/devkit';
+import { isReactProject } from './framework-detection';
+
+describe('framework-detection', () => {
+  let projectGraph: ProjectGraph;
+
+  beforeEach(() => {
+    projectGraph = {
+      nodes: {
+        'react-app': {
+          name: 'react-app',
+          type: 'app',
+          data: {
+            root: 'apps/react-app',
+            sourceRoot: 'apps/react-app/src',
+            projectType: 'application',
+          },
+        },
+        'angular-app': {
+          name: 'angular-app',
+          type: 'app',
+          data: {
+            root: 'apps/angular-app',
+            sourceRoot: 'apps/angular-app/src',
+            projectType: 'application',
+          },
+        },
+        'vanilla-app': {
+          name: 'vanilla-app',
+          type: 'app',
+          data: {
+            root: 'apps/vanilla-app',
+            sourceRoot: 'apps/vanilla-app/src',
+            projectType: 'application',
+          },
+        },
+      },
+      dependencies: {
+        'react-app': [
+          { target: 'npm:react', source: 'react-app', type: 'static' },
+          { target: 'npm:react-dom', source: 'react-app', type: 'static' },
+          {
+            target: 'npm:react-router-dom',
+            source: 'react-app',
+            type: 'static',
+          },
+        ],
+        'angular-app': [
+          {
+            target: 'npm:@angular/core',
+            source: 'angular-app',
+            type: 'static',
+          },
+          {
+            target: 'npm:@angular/common',
+            source: 'angular-app',
+            type: 'static',
+          },
+          {
+            target: 'npm:@angular/platform-browser',
+            source: 'angular-app',
+            type: 'static',
+          },
+        ],
+        'vanilla-app': [
+          { target: 'npm:lodash', source: 'vanilla-app', type: 'static' },
+        ],
+      },
+    };
+  });
+
+  describe('isReactProject', () => {
+    it('should return true for React projects', () => {
+      expect(isReactProject('react-app', projectGraph)).toBe(true);
+    });
+
+    it('should return false for Angular projects', () => {
+      expect(isReactProject('angular-app', projectGraph)).toBe(false);
+    });
+
+    it('should return false for vanilla projects', () => {
+      expect(isReactProject('vanilla-app', projectGraph)).toBe(false);
+    });
+
+    it('should return false for non-existent projects', () => {
+      expect(isReactProject('non-existent', projectGraph)).toBe(false);
+    });
+
+    it('should return true if project has @types/react dependency', () => {
+      projectGraph.dependencies['react-app'] = [
+        { target: 'npm:@types/react', source: 'react-app', type: 'static' },
+      ];
+      expect(isReactProject('react-app', projectGraph)).toBe(true);
+    });
+  });
+});

--- a/packages/module-federation/src/utils/framework-detection.ts
+++ b/packages/module-federation/src/utils/framework-detection.ts
@@ -1,0 +1,29 @@
+import { ProjectGraph } from '@nx/devkit';
+import { getDependentPackagesForProject } from './dependencies';
+
+export function isReactProject(
+  projectName: string,
+  projectGraph: ProjectGraph
+): boolean {
+  const project = projectGraph.nodes[projectName];
+  if (!project) return false;
+
+  // Check if the project has React dependencies
+  const { npmPackages } = getDependentPackagesForProject(
+    projectGraph,
+    projectName
+  );
+
+  // Check for React-related packages
+  const reactPackages = [
+    'react',
+    'react-dom',
+    '@types/react',
+    '@types/react-dom',
+  ];
+  const hasReactDependencies = reactPackages.some((pkg) =>
+    npmPackages.includes(pkg)
+  );
+
+  return hasReactDependencies;
+}

--- a/packages/module-federation/src/utils/framework-detection.ts
+++ b/packages/module-federation/src/utils/framework-detection.ts
@@ -1,4 +1,4 @@
-import { ProjectGraph } from '@nx/devkit';
+import type { ProjectGraph } from '@nx/devkit';
 import { getDependentPackagesForProject } from './dependencies';
 
 export function isReactProject(

--- a/packages/module-federation/src/with-module-federation/react/utils.spec.ts
+++ b/packages/module-federation/src/with-module-federation/react/utils.spec.ts
@@ -1,0 +1,95 @@
+import { applyDefaultEagerPackages } from './utils';
+import { SharedLibraryConfig } from '../../utils';
+
+describe('React utils', () => {
+  describe('applyDefaultEagerPackages', () => {
+    it('should mark React packages as eager', () => {
+      const sharedConfig: Record<string, SharedLibraryConfig> = {
+        react: { singleton: true, requiredVersion: '^18.0.0' },
+        'react-dom': { singleton: true, requiredVersion: '^18.0.0' },
+        'react-router-dom': { singleton: true, requiredVersion: '^6.0.0' },
+        'react-router': { singleton: true, requiredVersion: '^6.0.0' },
+        lodash: { singleton: true, requiredVersion: '^4.0.0' },
+      };
+
+      applyDefaultEagerPackages(sharedConfig);
+
+      expect(sharedConfig['react']).toEqual({
+        singleton: true,
+        requiredVersion: '^18.0.0',
+        eager: true,
+      });
+      expect(sharedConfig['react-dom']).toEqual({
+        singleton: true,
+        requiredVersion: '^18.0.0',
+        eager: true,
+      });
+      expect(sharedConfig['react-router-dom']).toEqual({
+        singleton: true,
+        requiredVersion: '^6.0.0',
+        eager: true,
+      });
+      expect(sharedConfig['react-router']).toEqual({
+        singleton: true,
+        requiredVersion: '^6.0.0',
+        eager: true,
+      });
+      expect(sharedConfig['lodash']).toEqual({
+        singleton: true,
+        requiredVersion: '^4.0.0',
+      });
+    });
+
+    it('should skip packages that are not in shared config', () => {
+      const sharedConfig: Record<string, SharedLibraryConfig> = {
+        react: { singleton: true, requiredVersion: '^18.0.0' },
+        lodash: { singleton: true, requiredVersion: '^4.0.0' },
+      };
+
+      applyDefaultEagerPackages(sharedConfig);
+
+      expect(sharedConfig['react']).toEqual({
+        singleton: true,
+        requiredVersion: '^18.0.0',
+        eager: true,
+      });
+      expect(sharedConfig['lodash']).toEqual({
+        singleton: true,
+        requiredVersion: '^4.0.0',
+      });
+      expect(sharedConfig['react-dom']).toBeUndefined();
+      expect(sharedConfig['react-router-dom']).toBeUndefined();
+    });
+
+    it('should not modify existing eager settings', () => {
+      const sharedConfig: Record<string, SharedLibraryConfig> = {
+        react: { singleton: true, requiredVersion: '^18.0.0', eager: false },
+        'react-dom': {
+          singleton: true,
+          requiredVersion: '^18.0.0',
+          eager: false,
+        },
+      };
+
+      applyDefaultEagerPackages(sharedConfig);
+
+      expect(sharedConfig['react']).toEqual({
+        singleton: true,
+        requiredVersion: '^18.0.0',
+        eager: true,
+      });
+      expect(sharedConfig['react-dom']).toEqual({
+        singleton: true,
+        requiredVersion: '^18.0.0',
+        eager: true,
+      });
+    });
+
+    it('should work with empty shared config', () => {
+      const sharedConfig: Record<string, SharedLibraryConfig> = {};
+
+      expect(() => applyDefaultEagerPackages(sharedConfig)).not.toThrow();
+      expect(sharedConfig).toEqual({});
+    });
+  });
+});

--- a/packages/module-federation/src/with-module-federation/react/utils.ts
+++ b/packages/module-federation/src/with-module-federation/react/utils.ts
@@ -1,4 +1,4 @@
-import { SharedLibraryConfig } from '../../utils';
+import type { SharedLibraryConfig } from '../../utils';
 
 export function applyDefaultEagerPackages(
   sharedConfig: Record<string, SharedLibraryConfig>

--- a/packages/module-federation/src/with-module-federation/react/utils.ts
+++ b/packages/module-federation/src/with-module-federation/react/utils.ts
@@ -1,0 +1,19 @@
+import { SharedLibraryConfig } from '../../utils';
+
+export function applyDefaultEagerPackages(
+  sharedConfig: Record<string, SharedLibraryConfig>
+) {
+  const DEFAULT_REACT_PACKAGES_TO_LOAD_EAGERLY = [
+    'react',
+    'react-dom',
+    'react-router-dom',
+    'react-router',
+  ];
+
+  for (const pkg of DEFAULT_REACT_PACKAGES_TO_LOAD_EAGERLY) {
+    if (!sharedConfig[pkg]) {
+      continue;
+    }
+    sharedConfig[pkg] = { ...sharedConfig[pkg], eager: true };
+  }
+}

--- a/packages/module-federation/src/with-module-federation/rspack/utils.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/utils.ts
@@ -14,6 +14,8 @@ import {
   mapRemotesForSSR,
   getDependentPackagesForProject,
 } from '../../utils';
+import { applyDefaultEagerPackages as applyReactEagerPackages } from '../react/utils';
+import { isReactProject } from '../../utils/framework-detection';
 
 export function getFunctionDeterminateRemoteUrl(isServer = false) {
   const target = 'serve';
@@ -96,6 +98,11 @@ export function getModuleFederationConfig(
     ...sharedLibraries.getLibraries(project.root),
     ...npmPackages,
   };
+
+  // Apply framework-specific eager packages
+  if (isReactProject(mfConfig.name, projectGraph)) {
+    applyReactEagerPackages(sharedDependencies);
+  }
 
   applySharedFunction(sharedDependencies, mfConfig.shared);
   applyAdditionalShared(

--- a/packages/module-federation/src/with-module-federation/webpack/utils.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/utils.ts
@@ -15,6 +15,8 @@ import {
   readCachedProjectGraph,
 } from '@nx/devkit';
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
+import { applyDefaultEagerPackages as applyReactEagerPackages } from '../react/utils';
+import { isReactProject } from '../../utils/framework-detection';
 
 export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
   const target = 'serve';
@@ -102,6 +104,11 @@ export async function getModuleFederationConfig(
     ...sharedLibraries.getLibraries(project.root),
     ...npmPackages,
   };
+
+  // Apply framework-specific eager packages
+  if (isReactProject(mfConfig.name, projectGraph)) {
+    applyReactEagerPackages(sharedDependencies);
+  }
 
   applySharedFunction(sharedDependencies, mfConfig.shared);
   applyAdditionalShared(


### PR DESCRIPTION
## Current Behavior
The static build for a React Module Federation application can suffer from issues where react is not initialised on load.
This is caused by Module Federation trying to lazily instantiate the library.

## Expected Behavior
Ensure that React deps are marked as eager in the module federation config to allow them to be instantiated on load

## Related Issue(s)

Fixes #31612
