### PR TITLE
feat(js): add esm support for esbuild and running serve with the node executor

### DIFF
--- a/e2e/js/src/js-esm-support.test.ts
+++ b/e2e/js/src/js-esm-support.test.ts
@@ -1,0 +1,421 @@
+import { stripIndents } from '@nx/devkit';
+import { execSync } from 'child_process';
+import {
+  checkFilesExist,
+  cleanupProject,
+  getPackageManagerCommand,
+  getSelectedPackageManager,
+  newProject,
+  runCLI,
+  runCLIAsync,
+  runCommand,
+  runCommandUntil,
+  promisifiedTreeKill,
+  tmpProjPath,
+  uniq,
+  updateFile,
+  updateJson,
+} from '@nx/e2e/utils';
+
+function configureAsEsm(projectPath: string, isLibrary = false) {
+  // Update project.json to configure build target for ESM
+  const projectJsonPath = `${projectPath}/project.json`;
+  updateJson(projectJsonPath, (config) => {
+    if (config.targets?.build?.options) {
+      // Configure build executor to output ESM format
+      config.targets.build.options.format = ['esm'];
+    }
+    return config;
+  });
+
+  // Also update TypeScript config to match ESM
+  const tsconfigPath = isLibrary
+    ? `${projectPath}/tsconfig.lib.json`
+    : `${projectPath}/tsconfig.app.json`;
+
+  updateJson(tsconfigPath, (config) => {
+    if (config.compilerOptions) {
+      config.compilerOptions.module = 'ES2022';
+      config.compilerOptions.target = 'ES2022';
+    }
+    return config;
+  });
+}
+
+describe('JS ESM/CJS Support', () => {
+  const selectedPm = getSelectedPackageManager();
+  beforeAll(() => {
+    newProject({
+      packages: ['@nx/node', '@nx/js', '@nx/esbuild'],
+      packageManager: selectedPm === 'npm' ? 'pnpm' : selectedPm,
+    });
+  });
+
+  afterAll(() => {
+    cleanupProject();
+  });
+
+  describe('CommonJS Applications', () => {
+    it('should run CommonJS app with CommonJS dependencies', async () => {
+      const nodeapp = uniq('nodeapp-cjs');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          const fs = require('fs');
+          console.log('CommonJS app running');
+          console.log('fs module type:', typeof fs.readFileSync);
+        `
+      );
+
+      await runCLIAsync(`build ${nodeapp}`);
+      checkFilesExist(`dist/apps/${nodeapp}/main.js`);
+
+      const result = execSync(`node dist/apps/${nodeapp}/main.js`, {
+        cwd: tmpProjPath(),
+      }).toString();
+      expect(result).toContain('CommonJS app running');
+      expect(result).toContain('fs module type: function');
+    }, 600000);
+
+    it('should run CommonJS app with ESM-only dependencies', async () => {
+      const nodeapp = uniq('nodeapp-cjs-esm');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package)
+      const pmc = getPackageManagerCommand();
+      runCommand(`${pmc.addDev} node-fetch@3.3.0`);
+
+      // Create a CommonJS app that imports ESM-only package
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          async function main() {
+            console.log('CommonJS app with ESM dependency starting');
+            try {
+              const { default: fetch } = await import('node-fetch');
+              console.log('Successfully imported node-fetch');
+              console.log('fetch type:', typeof fetch);
+            } catch (error) {
+              console.error('Failed to import node-fetch:', error.message);
+            }
+          }
+          main();
+        `
+      );
+
+      await runCLIAsync(`build ${nodeapp}`);
+      checkFilesExist(`dist/apps/${nodeapp}/main.js`);
+
+      const result = execSync(`node dist/apps/${nodeapp}/main.js`, {
+        cwd: tmpProjPath(),
+      }).toString();
+      expect(result).toContain('CommonJS app with ESM dependency starting');
+      expect(result).toContain('Successfully imported node-fetch');
+      expect(result).toContain('fetch type: function');
+    }, 600000);
+  });
+
+  describe('ESM Applications', () => {
+    it('should run ESM app with ESM dependencies', async () => {
+      const nodeapp = uniq('nodeapp-esm');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      configureAsEsm(`apps/${nodeapp}`);
+
+      // Install node-fetch (ESM-only package)
+      const pmc = getPackageManagerCommand();
+      runCommand(`${pmc.addDev} node-fetch@3.3.0`);
+
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          import fetch from 'node-fetch';
+          import { readFileSync } from 'fs';
+          
+          console.log('ESM app running');
+          console.log('fetch type:', typeof fetch);
+          console.log('readFileSync type:', typeof readFileSync);
+        `
+      );
+
+      await runCLIAsync(`build ${nodeapp}`);
+      checkFilesExist(`dist/apps/${nodeapp}/main.js`);
+
+      const result = execSync(`node dist/apps/${nodeapp}/main.js`, {
+        cwd: tmpProjPath(),
+      }).toString();
+      expect(result).toContain('ESM app running');
+      expect(result).toContain('fetch type: function');
+      expect(result).toContain('readFileSync type: function');
+    }, 600000);
+
+    it('should run ESM app with normal .js output', async () => {
+      const nodeapp = uniq('nodeapp-esm-js');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      configureAsEsm(`apps/${nodeapp}`);
+
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          import { readFileSync } from 'fs';
+          console.log('ESM app with .js output running');
+          console.log('readFileSync type:', typeof readFileSync);
+        `
+      );
+
+      await runCLIAsync(`build ${nodeapp}`);
+      checkFilesExist(`dist/apps/${nodeapp}/main.js`);
+
+      const result = execSync(`node dist/apps/${nodeapp}/main.js`, {
+        cwd: tmpProjPath(),
+      }).toString();
+      expect(result).toContain('ESM app with .js output running');
+      expect(result).toContain('readFileSync type: function');
+    }, 600000);
+
+    it('should run ESM app by detecting TypeScript module settings', async () => {
+      const nodeapp = uniq('nodeapp-esm-ts');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      updateJson(`apps/${nodeapp}/tsconfig.app.json`, (config) => {
+        config.compilerOptions.module = 'ES2022';
+        config.compilerOptions.target = 'ES2022';
+        return config;
+      });
+
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          import { readFileSync } from 'fs';
+          console.log('ESM app detected via TypeScript config');
+          console.log('readFileSync type:', typeof readFileSync);
+        `
+      );
+
+      await runCLIAsync(`build ${nodeapp}`);
+      checkFilesExist(`dist/apps/${nodeapp}/main.js`);
+
+      const result = execSync(`node dist/apps/${nodeapp}/main.js`, {
+        cwd: tmpProjPath(),
+      }).toString();
+      expect(result).toContain('ESM app detected via TypeScript config');
+      expect(result).toContain('readFileSync type: function');
+    }, 600000);
+  });
+
+  describe('Mixed Module Applications', () => {
+    it('should run mixed app with workspace libraries', async () => {
+      const nodeapp = uniq('nodeapp-mixed');
+      const cjsLib = uniq('cjslib');
+      const esmLib = uniq('esmlib');
+
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+      runCLI(
+        `generate @nx/js:lib libs/${cjsLib} --buildable --bundler=esbuild`
+      );
+      runCLI(
+        `generate @nx/js:lib libs/${esmLib} --buildable --bundler=esbuild`
+      );
+
+      // Set up CJS library
+      updateFile(
+        `libs/${cjsLib}/src/lib/${cjsLib}.ts`,
+        stripIndents`
+          export function getCjsMessage() {
+            return 'Message from CJS library';
+          }
+        `
+      );
+
+      configureAsEsm(`libs/${esmLib}`, true);
+
+      updateFile(
+        `libs/${esmLib}/src/lib/${esmLib}.ts`,
+        stripIndents`
+          export function getEsmMessage() {
+            return 'Message from ESM library';
+          }
+        `
+      );
+
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          import { getCjsMessage } from '@proj/${cjsLib}';
+          import { getEsmMessage } from '@proj/${esmLib}';
+          
+          console.log('Mixed app running');
+          console.log('CJS lib:', getCjsMessage());
+          console.log('ESM lib:', getEsmMessage());
+        `
+      );
+
+      await runCLIAsync(`build ${cjsLib}`);
+      await runCLIAsync(`build ${esmLib}`);
+      await runCLIAsync(`build ${nodeapp}`);
+
+      checkFilesExist(`dist/apps/${nodeapp}/main.js`);
+      checkFilesExist(`dist/libs/${cjsLib}/index.cjs`);
+      checkFilesExist(`dist/libs/${esmLib}/index.mjs`);
+
+      const result = execSync(`node dist/apps/${nodeapp}/main.js`, {
+        cwd: tmpProjPath(),
+      }).toString();
+      expect(result).toContain('Mixed app running');
+      expect(result).toContain('CJS lib: Message from CJS library');
+      expect(result).toContain('ESM lib: Message from ESM library');
+    }, 600000);
+  });
+
+  describe('Node Executor ESM/CJS Detection', () => {
+    it('should serve CommonJS apps', async () => {
+      const nodeapp = uniq('nodeapp-serve-cjs');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          const http = require('http');
+          const server = http.createServer((req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end('CommonJS server running');
+          });
+          server.listen(3000, () => {
+            console.log('Server running on port 3000');
+          });
+        `
+      );
+
+      await runCLIAsync(`build ${nodeapp}`);
+      checkFilesExist(`dist/apps/${nodeapp}/main.js`);
+
+      // Test that the built app can run (start server and capture initial output)
+      const result = execSync(
+        `node dist/apps/${nodeapp}/main.js & PID=$!; sleep 1; kill $PID 2>/dev/null || true; wait $PID 2>/dev/null || true`,
+        {
+          cwd: tmpProjPath(),
+          timeout: 5000,
+        }
+      ).toString();
+      expect(result).toContain('Server running on port 3000');
+    }, 600000);
+
+    it('should serve ESM apps', async () => {
+      const nodeapp = uniq('nodeapp-serve-esm');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Configure build target to output ESM format
+      configureAsEsm(`apps/${nodeapp}`);
+
+      // Create a simple ESM server
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          import { createServer } from 'http';
+          const server = createServer((req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end('ESM server running');
+          });
+          server.listen(3001, () => {
+            console.log('ESM server running on port 3001');
+          });
+        `
+      );
+
+      runCLI(`build ${nodeapp}`);
+      checkFilesExist(`dist/apps/${nodeapp}/main.js`);
+
+      const serveProcess = await runCommandUntil(`serve ${nodeapp}`, (output) =>
+        output.includes('ESM server running on port 3001')
+      );
+
+      await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
+    }, 600000);
+
+    it('should serve CommonJS app', async () => {
+      const nodeapp = uniq('nodeapp-serve-cjs-live');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Create a simple server that logs a message we can detect
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          const http = require('http');
+          console.log('CommonJS server starting');
+          const server = http.createServer((req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end('Hello from CommonJS');
+          });
+          server.listen(3100, () => {
+            console.log('CommonJS server ready on port 3100');
+          });
+        `
+      );
+
+      const serveProcess = await runCommandUntil(
+        `serve ${nodeapp}`,
+        (output) => {
+          return output.includes('CommonJS server ready on port 3100');
+        }
+      );
+
+      await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
+    }, 600000);
+
+    it('should serve ESM app', async () => {
+      const nodeapp = uniq('nodeapp-serve-esm-live');
+      runCLI(
+        `generate @nx/node:app apps/${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Configure build target to output ESM format
+      configureAsEsm(`apps/${nodeapp}`);
+
+      // Create a simple ESM server that logs a message we can detect
+      updateFile(
+        `apps/${nodeapp}/src/main.ts`,
+        stripIndents`
+          import { createServer } from 'http';
+          console.log('ESM server starting');
+          const server = createServer((req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end('Hello from ESM');
+          });
+          server.listen(3101, () => {
+            console.log('ESM server ready on port 3101');
+          });
+        `
+      );
+
+      const serveProcess = await runCommandUntil(
+        `serve ${nodeapp}`,
+        (output) => {
+          return output.includes('ESM server ready on port 3101');
+        }
+      );
+
+      await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
+    }, 600000);
+  });
+});

--- a/e2e/js/src/js-esm-support.test.ts
+++ b/e2e/js/src/js-esm-support.test.ts
@@ -15,7 +15,7 @@ import {
   uniq,
   updateFile,
   updateJson,
-} from '@nx/e2e/utils';
+} from '@nx/e2e-utils';
 
 function configureAsEsm(projectPath: string, isLibrary = false) {
   // Update project.json to configure build target for ESM

--- a/e2e/js/src/js-esm-support.test.ts
+++ b/e2e/js/src/js-esm-support.test.ts
@@ -271,7 +271,7 @@ describe('JS ESM/CJS Support', () => {
 
       checkFilesExist(`dist/apps/${nodeapp}/main.js`);
       checkFilesExist(`dist/libs/${cjsLib}/index.cjs`);
-      checkFilesExist(`dist/libs/${esmLib}/index.mjs`);
+      checkFilesExist(`dist/libs/${esmLib}/index.js`);
 
       const result = execSync(`node dist/apps/${nodeapp}/main.js`, {
         cwd: tmpProjPath(),

--- a/e2e/node/src/node-esm-support.test.ts
+++ b/e2e/node/src/node-esm-support.test.ts
@@ -14,7 +14,7 @@ import {
   updateFile,
   updateJson,
   detectPackageManager,
-} from '@nx/e2e/utils';
+} from '@nx/e2e-utils';
 import { execSync } from 'child_process';
 
 function configureAsEsm(projectPath: string) {

--- a/e2e/node/src/node-esm-support.test.ts
+++ b/e2e/node/src/node-esm-support.test.ts
@@ -1,0 +1,576 @@
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import {
+  checkFilesExist,
+  cleanupProject,
+  getPackageManagerCommand,
+  newProject,
+  runCLI,
+  runCLIAsync,
+  runCommand,
+  runCommandUntil,
+  promisifiedTreeKill,
+  tmpProjPath,
+  uniq,
+  updateFile,
+  updateJson,
+  detectPackageManager,
+} from '@nx/e2e/utils';
+import { execSync } from 'child_process';
+
+function configureAsEsm(projectPath: string) {
+  // Update project.json to configure build target for ESM
+  const projectJsonPath = `${projectPath}/project.json`;
+  updateJson(projectJsonPath, (config) => {
+    if (config.targets?.build?.options) {
+      // Configure build executor to output ESM format
+      config.targets.build.options.format = ['esm'];
+    }
+    return config;
+  });
+
+  // Also update TypeScript config to match ESM
+  const tsconfigPath = `${projectPath}/tsconfig.app.json`;
+  updateJson(tsconfigPath, (config) => {
+    if (config.compilerOptions) {
+      config.compilerOptions.module = 'ES2022';
+      config.compilerOptions.target = 'ES2022';
+    }
+    return config;
+  });
+}
+
+const selectedPm = detectPackageManager();
+
+describe('Node.js Framework ESM Support', () => {
+  beforeAll(() => {
+    newProject({
+      packages: ['@nx/node'],
+      packageManager: selectedPm === 'npm' ? 'pnpm' : selectedPm,
+    });
+  });
+
+  afterAll(() => {
+    cleanupProject();
+  });
+
+  describe('Express Framework with ESM', () => {
+    it('should build and run Express app with ESM modules', async () => {
+      const expressApp = uniq('express-esm');
+      runCLI(
+        `generate @nx/node:app apps/${expressApp} --framework=express --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package)
+      const pmc = getPackageManagerCommand();
+      runCommand(`${pmc.addDev} node-fetch@3.3.0`);
+
+      // Configure as ESM
+      configureAsEsm(`apps/${expressApp}`);
+
+      // Update the Express app to use ESM imports
+      updateFile(
+        `apps/${expressApp}/src/main.ts`,
+        stripIndents`
+          import express from 'express';
+          import fetch from 'node-fetch';
+          
+          const app = express();
+          
+          app.get('/api', (req, res) => {
+            res.json({ 
+              message: 'Welcome to ${expressApp}!',
+              framework: 'express',
+              fetch_available: typeof fetch === 'function'
+            });
+          });
+          
+          console.log('Express ESM app starting');
+          console.log('fetch type:', typeof fetch);
+          
+          const port = process.env.PORT || 3000;
+          const server = app.listen(port, () => {
+            console.log('Express ESM server ready on port ' + port);
+          });
+          server.on('error', console.error);
+        `
+      );
+
+      await runCLIAsync(`build ${expressApp}`);
+      checkFilesExist(`dist/apps/${expressApp}/main.js`);
+
+      const result = execSync(
+        `node dist/apps/${expressApp}/main.js & PID=$!; sleep 1; kill $PID 2>/dev/null || true; wait $PID 2>/dev/null || true`,
+        {
+          cwd: tmpProjPath(),
+          timeout: 10000,
+        }
+      ).toString();
+      expect(result).toContain('Express ESM app starting');
+      expect(result).toContain('Express ESM server ready on port');
+      expect(result).toContain('fetch type: function');
+    }, 600000);
+
+    it('should serve Express app with ESM modules', async () => {
+      const expressApp = uniq('express-esm-serve');
+      runCLI(
+        `generate @nx/node:app apps/${expressApp} --framework=express --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package)
+      const pmc = getPackageManagerCommand();
+      runCommand(`${pmc.addDev} node-fetch@3.3.0`);
+
+      // Configure as ESM
+      configureAsEsm(`apps/${expressApp}`);
+
+      // Create Express server with ESM imports
+      updateFile(
+        `apps/${expressApp}/src/main.ts`,
+        stripIndents`
+          import express from 'express';
+          import fetch from 'node-fetch';
+          
+          const app = express();
+          
+          console.log('Express ESM serve starting');
+          console.log('fetch type:', typeof fetch);
+          
+          app.get('/api', (req, res) => {
+            res.json({ message: 'Express ESM serve working' });
+          });
+          
+          const port = process.env.PORT || 3000;
+          const server = app.listen(port, () => {
+            console.log('Express ESM serve ready on port ' + port);
+          });
+          server.on('error', console.error);
+        `
+      );
+
+      const serveProcess = await runCommandUntil(
+        `serve ${expressApp}`,
+        (output) => {
+          return output.includes('Express ESM serve ready on port');
+        }
+      );
+
+      await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
+    }, 600000);
+  });
+
+  describe('Fastify Framework with ESM', () => {
+    it('should build and run Fastify app with ESM modules', async () => {
+      const fastifyApp = uniq('fastify-esm');
+      runCLI(
+        `generate @nx/node:app apps/${fastifyApp} --framework=fastify --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package)
+      const pmc = getPackageManagerCommand();
+      runCommand(`${pmc.addDev} node-fetch@3.3.0`);
+
+      // Configure as ESM
+      configureAsEsm(`apps/${fastifyApp}`);
+
+      // Update the Fastify app to use ESM imports
+      updateFile(
+        `apps/${fastifyApp}/src/main.ts`,
+        stripIndents`
+          import Fastify from 'fastify';
+          import fetch from 'node-fetch';
+          
+          const fastify = Fastify({
+            logger: false
+          });
+          
+          fastify.get('/api', async (request, reply) => {
+            return { 
+              message: 'Welcome to ${fastifyApp}!',
+              framework: 'fastify',
+              fetch_available: typeof fetch === 'function'
+            };
+          });
+          
+          console.log('Fastify ESM app starting');
+          console.log('fetch type:', typeof fetch);
+          
+          const start = async () => {
+            try {
+              const port = +(process.env.PORT || 3000);
+              await fastify.listen({ port });
+              console.log('Fastify ESM server ready on port ' + port);
+            } catch (err) {
+              fastify.log.error(err);
+              process.exit(1);
+            }
+          };
+          start();
+        `
+      );
+
+      await runCLIAsync(`build ${fastifyApp}`);
+      checkFilesExist(`dist/apps/${fastifyApp}/main.js`);
+
+      const result = execSync(
+        `node dist/apps/${fastifyApp}/main.js & PID=$!; sleep 1; kill $PID 2>/dev/null || true; wait $PID 2>/dev/null || true`,
+        {
+          cwd: tmpProjPath(),
+          timeout: 10000,
+        }
+      ).toString();
+      expect(result).toContain('Fastify ESM app starting');
+      expect(result).toContain('Fastify ESM server ready on port');
+      expect(result).toContain('fetch type: function');
+    }, 600000);
+
+    it('should serve Fastify app with ESM modules', async () => {
+      const fastifyApp = uniq('fastify-esm-serve');
+      runCLI(
+        `generate @nx/node:app apps/${fastifyApp} --framework=fastify --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package)
+      const pmc = getPackageManagerCommand();
+      runCommand(`${pmc.addDev} node-fetch@3.3.0`);
+
+      // Configure as ESM
+      configureAsEsm(`apps/${fastifyApp}`);
+
+      // Create Fastify server with ESM imports
+      updateFile(
+        `apps/${fastifyApp}/src/main.ts`,
+        stripIndents`
+          import Fastify from 'fastify';
+          import fetch from 'node-fetch';
+          
+          const fastify = Fastify({ logger: false });
+          
+          console.log('Fastify ESM serve starting');
+          console.log('fetch type:', typeof fetch);
+          
+          fastify.get('/api', async (request, reply) => {
+            return { message: 'Fastify ESM serve working' };
+          });
+          
+          const start = async () => {
+            try {
+              const port = +(process.env.PORT || 3000);
+              await fastify.listen({ port });
+              console.log('Fastify ESM serve ready on port ' + port);
+            } catch (err) {
+              process.exit(1);
+            }
+          };
+          start();
+        `
+      );
+
+      const serveProcess = await runCommandUntil(
+        `serve ${fastifyApp}`,
+        (output) => {
+          return output.includes('Fastify ESM serve ready on port');
+        }
+      );
+
+      await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
+    }, 600000);
+  });
+
+  describe('Koa Framework with ESM', () => {
+    it('should build and run Koa app with ESM modules', async () => {
+      const koaApp = uniq('koa-esm');
+      runCLI(
+        `generate @nx/node:app apps/${koaApp} --framework=koa --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package) and koa router
+      const pmc = getPackageManagerCommand();
+      runCommand(
+        `${pmc.addDev} node-fetch@3.3.0 @koa/router @types/koa__router`
+      );
+
+      // Configure as ESM
+      configureAsEsm(`apps/${koaApp}`);
+
+      // Update the Koa app to use ESM imports
+      updateFile(
+        `apps/${koaApp}/src/main.ts`,
+        stripIndents`
+          import Koa from 'koa';
+          import Router from '@koa/router';
+          import fetch from 'node-fetch';
+          
+          const app = new Koa();
+          const router = new Router();
+          
+          router.get('/api', (ctx) => {
+            ctx.body = { 
+              message: 'Welcome to ${koaApp}!',
+              framework: 'koa',
+              fetch_available: typeof fetch === 'function'
+            };
+          });
+          
+          app.use(router.routes()).use(router.allowedMethods());
+          
+          console.log('Koa ESM app starting');
+          console.log('fetch type:', typeof fetch);
+          
+          const port = +(process.env.PORT || 3000);
+          const server = app.listen(port, () => {
+            console.log('Koa ESM server ready on port ' + port);
+          });
+          server.on('error', console.error);
+        `
+      );
+
+      await runCLIAsync(`build ${koaApp}`);
+      checkFilesExist(`dist/apps/${koaApp}/main.js`);
+
+      const result = execSync(
+        `node dist/apps/${koaApp}/main.js & PID=$!; sleep 1; kill $PID 2>/dev/null || true; wait $PID 2>/dev/null || true`,
+        {
+          cwd: tmpProjPath(),
+          timeout: 10000,
+        }
+      ).toString();
+      expect(result).toContain('Koa ESM app starting');
+      expect(result).toContain('Koa ESM server ready on port');
+      expect(result).toContain('fetch type: function');
+    }, 600000);
+
+    it('should serve Koa app with ESM modules', async () => {
+      const koaApp = uniq('koa-esm-serve');
+      runCLI(
+        `generate @nx/node:app apps/${koaApp} --framework=koa --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package) and koa router
+      const pmc = getPackageManagerCommand();
+      runCommand(
+        `${pmc.addDev} node-fetch@3.3.0 @koa/router @types/koa__router`
+      );
+
+      // Configure as ESM
+      configureAsEsm(`apps/${koaApp}`);
+
+      // Create Koa server with ESM imports
+      updateFile(
+        `apps/${koaApp}/src/main.ts`,
+        stripIndents`
+          import Koa from 'koa';
+          import Router from '@koa/router';
+          import fetch from 'node-fetch';
+          
+          const app = new Koa();
+          const router = new Router();
+          
+          console.log('Koa ESM serve starting');
+          console.log('fetch type:', typeof fetch);
+          
+          router.get('/api', (ctx) => {
+            ctx.body = { message: 'Koa ESM serve working' };
+          });
+          
+          app.use(router.routes()).use(router.allowedMethods());
+          
+          const port = +(process.env.PORT || 3000);
+          const server = app.listen(port, () => {
+            console.log('Koa ESM serve ready on port ' + port);
+          });
+          server.on('error', console.error);
+        `
+      );
+
+      const serveProcess = await runCommandUntil(
+        `serve ${koaApp}`,
+        (output) => {
+          return output.includes('Koa ESM serve ready on port');
+        }
+      );
+
+      await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
+    }, 600000);
+  });
+
+  describe('Nest Framework with ESM', () => {
+    it('should build and run Nest app with ESM modules', async () => {
+      const nestApp = uniq('nest-esm');
+      runCLI(
+        `generate @nx/node:app apps/${nestApp} --framework=nest --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package)
+      const pmc = getPackageManagerCommand();
+      runCommand(`${pmc.addDev} node-fetch@3.3.0`);
+
+      // Configure as ESM
+      configureAsEsm(`apps/${nestApp}`);
+
+      // Update the Nest app to use ESM imports
+      updateFile(
+        `apps/${nestApp}/src/main.ts`,
+        stripIndents`
+          import { NestFactory } from '@nestjs/core';
+          import { AppModule } from './app/app.module';
+          
+          async function bootstrap() {
+            console.log('Nest ESM app starting');
+            
+            try {
+              // Test ESM-only package import
+              const { default: fetch } = await import('node-fetch');
+              console.log('fetch type:', typeof fetch);
+            } catch (error) {
+              console.error('Failed to import node-fetch:', error.message);
+            }
+            
+            const app = await NestFactory.create(AppModule);
+            const globalPrefix = 'api';
+            app.setGlobalPrefix(globalPrefix);
+            const port = process.env.PORT || 3000;
+            await app.listen(port);
+            console.log('Nest ESM server ready on port ' + port);
+          }
+          
+          bootstrap();
+        `
+      );
+
+      await runCLIAsync(`build ${nestApp}`);
+      checkFilesExist(`dist/apps/${nestApp}/main.js`);
+
+      const result = execSync(
+        `node dist/apps/${nestApp}/main.js & PID=$!; sleep 1; kill $PID 2>/dev/null || true; wait $PID 2>/dev/null || true`,
+        {
+          cwd: tmpProjPath(),
+          timeout: 10000,
+        }
+      ).toString();
+      expect(result).toContain('Nest ESM app starting');
+      expect(result).toContain('Nest ESM server ready on port');
+      expect(result).toContain('fetch type: function');
+    }, 600000);
+
+    it('should serve Nest app with ESM modules', async () => {
+      const nestApp = uniq('nest-esm-serve');
+      runCLI(
+        `generate @nx/node:app apps/${nestApp} --framework=nest --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install node-fetch (ESM-only package) and ajv@8 to fix dependency conflicts
+      const pmc = getPackageManagerCommand();
+      runCommand(`${pmc.addDev} node-fetch@3.3.0`);
+      runCommand(`${pmc.addDev} ajv@^8.17.1`);
+
+      // Configure as ESM
+      configureAsEsm(`apps/${nestApp}`);
+
+      // Create Nest server with ESM imports
+      updateFile(
+        `apps/${nestApp}/src/main.ts`,
+        stripIndents`
+          import { NestFactory } from '@nestjs/core';
+          import { AppModule } from './app/app.module';
+          
+          async function bootstrap() {
+            console.log('Nest ESM serve starting');
+            
+            try {
+              const { default: fetch } = await import('node-fetch');
+              console.log('fetch type:', typeof fetch);
+            } catch (error) {
+              console.error('Failed to import node-fetch:', error.message);
+            }
+            
+            const app = await NestFactory.create(AppModule);
+            const globalPrefix = 'api';
+            app.setGlobalPrefix(globalPrefix);
+            const port = process.env.PORT || 3000;
+            await app.listen(port);
+            console.log('Nest ESM serve ready on port ' + port);
+          }
+          
+          bootstrap();
+        `
+      );
+
+      const serveProcess = await runCommandUntil(
+        `serve ${nestApp}`,
+        (output) => {
+          return output.includes('Nest ESM serve ready on port');
+        }
+      );
+
+      await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
+    }, 600000);
+  });
+
+  describe('Mixed Imports across Node.js Frameworks', () => {
+    it('should handle CommonJS and ESM packages together', async () => {
+      const nodeApp = uniq('node-mixed-imports');
+      runCLI(
+        `generate @nx/node:app apps/${nodeApp} --framework=express --linter=eslint --unitTestRunner=jest`
+      );
+
+      // Install packages with different module formats
+      const pmc = getPackageManagerCommand();
+      runCommand(
+        `${pmc.addDev} express @types/express node-fetch@3.3.0 lodash @types/lodash`
+      );
+
+      // Create an Express app that uses both CommonJS (lodash) and ESM (node-fetch) packages
+      updateFile(
+        `apps/${nodeApp}/src/main.ts`,
+        stripIndents`
+          import express from 'express';
+          import * as lodash from 'lodash';
+          
+          const app = express();
+          
+          app.get('/api', async (req, res) => {
+            try {
+              // Import ESM-only package dynamically
+              const { default: fetch } = await import('node-fetch');
+              
+              // Use CommonJS package (lodash)
+              const data = lodash.pick({ a: 1, b: 2, c: 3 }, ['a', 'b']);
+              
+              res.json({ 
+                message: 'Welcome to ${nodeApp}!',
+                data,
+                fetch_available: typeof fetch === 'function',
+                lodash_available: typeof lodash.pick === 'function'
+              });
+            } catch (error) {
+              res.status(500).json({ error: error.message });
+            }
+          });
+          
+          console.log('Mixed imports Node.js app starting');
+          console.log('lodash.pick type:', typeof lodash.pick);
+          
+          const port = process.env.PORT || 3000;
+          const server = app.listen(port, () => {
+            console.log('Mixed imports server ready on port ' + port);
+          });
+          server.on('error', console.error);
+        `
+      );
+
+      await runCLIAsync(`build ${nodeApp}`);
+      checkFilesExist(`dist/apps/${nodeApp}/main.js`);
+
+      const result = execSync(
+        `node dist/apps/${nodeApp}/main.js & PID=$!; sleep 1; kill $PID 2>/dev/null || true; wait $PID 2>/dev/null || true`,
+        {
+          cwd: tmpProjPath(),
+          timeout: 10000,
+        }
+      ).toString();
+      expect(result).toContain('Mixed imports Node.js app starting');
+      expect(result).toContain('Mixed imports server ready on port');
+      expect(result).toContain('lodash.pick type: function');
+    }, 600000);
+  });
+});

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -95,7 +95,8 @@ export async function* esbuildExecutor(
       // TODO(jack): make types generate with esbuild
       skipTypings: true,
       generateLockfile: true,
-      outputFileExtensionForCjs: getOutExtension('cjs', options),
+      outputFileExtensionForCjs: getOutExtension('cjs', options, context),
+      outputFileExtensionForEsm: getOutExtension('esm', options, context),
       excludeLibsInPackageJson: !options.thirdParty,
       // TODO(jack): Remove the need to pass updateBuildableProjectDepsInPackageJson option when overrideDependencies or extraDependencies are passed.
       // Add this back to fix a regression.

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -92,6 +92,7 @@ export async function* esbuildExecutor(
 
     const cpjOptions: CopyPackageJsonOptions = {
       ...options,
+      format: options.format,
       // TODO(jack): make types generate with esbuild
       skipTypings: true,
       generateLockfile: true,

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -15,7 +15,7 @@ import { NormalizedEsBuildExecutorOptions } from '../schema';
 import { getEntryPoints } from '../../../utils/get-entry-points';
 import { join, relative } from 'path';
 
-const ESM_FILE_EXTENSION = '.js'; // Changed from .mjs to match package.json exports
+const ESM_FILE_EXTENSION = '.js';
 const CJS_FILE_EXTENSION = '.cjs';
 
 export function buildEsbuildOptions(
@@ -267,21 +267,15 @@ export function getOutExtension(
   const userDefinedExt = options.userDefinedBuildOptions?.outExtension?.['.js'];
   // Allow users to change the output extensions from default CJS and ESM extensions.
   // CJS -> .js
-  // ESM -> .mjs for libraries, .js for applications
+  // ESM -> .mjs
 
-  if (userDefinedExt === '.js' && format === 'cjs') {
-    return '.js';
-  }
-
-  if (userDefinedExt === '.mjs' && format === 'esm') {
-    return '.mjs';
-  }
-
-  if (format === 'esm') {
-    return '.js';
-  }
-
-  return CJS_FILE_EXTENSION;
+  return userDefinedExt === '.js' && format === 'cjs'
+    ? '.js'
+    : userDefinedExt === '.mjs' && format === 'esm'
+    ? '.mjs'
+    : format === 'esm'
+    ? ESM_FILE_EXTENSION
+    : CJS_FILE_EXTENSION;
 }
 
 export function getOutfile(
@@ -397,7 +391,7 @@ const __dirname = dirname(__filename);
 const distPath = __dirname;
 const manifest = ${JSON.stringify(manifest)};
 
-// Simple ESM resolver for workspace libraries
+// Resolver for workspace libs
 const originalResolve = import.meta.resolve;
 if (originalResolve) {
   import.meta.resolve = function(specifier, parent) {

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -15,7 +15,7 @@ import { NormalizedEsBuildExecutorOptions } from '../schema';
 import { getEntryPoints } from '../../../utils/get-entry-points';
 import { join, relative } from 'path';
 
-const ESM_FILE_EXTENSION = '.js';
+const ESM_FILE_EXTENSION = '.js'; // Changed from .mjs to match package.json exports
 const CJS_FILE_EXTENSION = '.cjs';
 
 export function buildEsbuildOptions(
@@ -23,7 +23,7 @@ export function buildEsbuildOptions(
   options: NormalizedEsBuildExecutorOptions,
   context: ExecutorContext
 ): esbuild.BuildOptions {
-  const outExtension = getOutExtension(format, options);
+  const outExtension = getOutExtension(format, options, context);
 
   const esbuildOptions: esbuild.BuildOptions = {
     ...options.userDefinedBuildOptions,
@@ -74,7 +74,7 @@ export function buildEsbuildOptions(
     esbuildOptions.entryPoints = entryPoints;
   } else if (options.platform === 'node' && format === 'cjs') {
     // When target platform Node and target format is CJS, then also transpile workspace libs used by the app.
-    // Provide a `require` override in the main entry file so workspace libs can be loaded when running the app.
+    // Provide a loader override in the main entry file so workspace libs can be loaded when running the app.
     const paths = options.isTsSolutionSetup
       ? createPathsFromTsConfigReferences(context)
       : getTsConfigCompilerPaths(context);
@@ -91,7 +91,13 @@ export function buildEsbuildOptions(
 
     esbuildOptions.entryPoints = [
       // Write a main entry file that registers workspace libs and then calls the user-defined main.
-      writeTmpEntryWithRequireOverrides(paths, outExtension, options, context),
+      writeTmpEntryWithRequireOverrides(
+        paths,
+        outExtension,
+        options,
+        context,
+        format
+      ),
       ...entryPointsFromProjects.map((f) => {
         /**
          * Maintain same directory structure as the workspace, so that other workspace libs may be used by the project.
@@ -255,19 +261,27 @@ function getProjectEntryPoint(projectPkgJson: any, projectPath: string) {
 
 export function getOutExtension(
   format: 'cjs' | 'esm',
-  options: Pick<NormalizedEsBuildExecutorOptions, 'userDefinedBuildOptions'>
+  options: Pick<NormalizedEsBuildExecutorOptions, 'userDefinedBuildOptions'>,
+  context?: ExecutorContext
 ): '.cjs' | '.mjs' | '.js' {
   const userDefinedExt = options.userDefinedBuildOptions?.outExtension?.['.js'];
   // Allow users to change the output extensions from default CJS and ESM extensions.
   // CJS -> .js
-  // ESM -> .mjs
-  return userDefinedExt === '.js' && format === 'cjs'
-    ? '.js'
-    : userDefinedExt === '.mjs' && format === 'esm'
-    ? '.mjs'
-    : format === 'esm'
-    ? ESM_FILE_EXTENSION
-    : CJS_FILE_EXTENSION;
+  // ESM -> .mjs for libraries, .js for applications
+
+  if (userDefinedExt === '.js' && format === 'cjs') {
+    return '.js';
+  }
+
+  if (userDefinedExt === '.mjs' && format === 'esm') {
+    return '.mjs';
+  }
+
+  if (format === 'esm') {
+    return '.js';
+  }
+
+  return CJS_FILE_EXTENSION;
 }
 
 export function getOutfile(
@@ -275,7 +289,7 @@ export function getOutfile(
   options: NormalizedEsBuildExecutorOptions,
   context: ExecutorContext
 ) {
-  const ext = getOutExtension(format, options);
+  const ext = getOutExtension(format, options, context);
   const candidate = joinPathFragments(
     context.target.options.outputPath,
     options.outputFileName
@@ -288,7 +302,8 @@ function writeTmpEntryWithRequireOverrides(
   paths: Record<string, string[]>,
   outExtension: '.cjs' | '.js' | '.mjs',
   options: NormalizedEsBuildExecutorOptions,
-  context: ExecutorContext
+  context: ExecutorContext,
+  format: 'cjs' | 'esm' = 'cjs'
 ): { in: string; out: string } {
   const project = context.projectGraph?.nodes[context.projectName];
   // Write a temp main entry source that registers workspace libs.
@@ -309,7 +324,7 @@ function writeTmpEntryWithRequireOverrides(
 
   writeFileSync(
     mainWithRequireOverridesInPath,
-    getRegisterFileContent(project, paths, mainFile, outExtension)
+    getRegisterFileContent(project, paths, mainFile, outExtension, format)
   );
 
   let mainWithRequireOverridesOutPath: string;
@@ -335,7 +350,8 @@ export function getRegisterFileContent(
   project: ProjectGraphProjectNode,
   paths: Record<string, string[]>,
   mainFile: string,
-  outExtension = '.js'
+  outExtension = '.js',
+  format: 'cjs' | 'esm' = 'cjs'
 ) {
   mainFile = normalizePath(mainFile);
 
@@ -364,7 +380,58 @@ export function getRegisterFileContent(
     return acc;
   }, []);
 
-  return `
+  if (format === 'esm') {
+    return `
+/**
+ * IMPORTANT: Do not modify this file.
+ * This file allows the app to run without bundling in workspace libraries.
+ * Must be contained in the ".nx" folder inside the output path.
+ */
+import { pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const distPath = __dirname;
+const manifest = ${JSON.stringify(manifest)};
+
+// Simple ESM resolver for workspace libraries
+const originalResolve = import.meta.resolve;
+if (originalResolve) {
+  import.meta.resolve = function(specifier, parent) {
+    const matchingEntry = manifest.find(
+      (entry) => specifier === entry.module || specifier.startsWith(entry.module + '/')
+    );
+    
+    if (matchingEntry) {
+      if (matchingEntry.exactMatch) {
+        const candidate = join(distPath, matchingEntry.exactMatch);
+        if (existsSync(candidate)) {
+          return pathToFileURL(candidate).href;
+        }
+      } else {
+        const re = new RegExp(matchingEntry.module.replace(/\\*$/, "(?<rest>.*)"));
+        const match = specifier.match(re);
+        if (match?.groups) {
+          const candidate = join(distPath, matchingEntry.pattern.replace("*", ""), match.groups.rest);
+          if (existsSync(candidate)) {
+            return pathToFileURL(candidate).href;
+          }
+        }
+      }
+    }
+    
+    return originalResolve.call(this, specifier, parent);
+  };
+}
+
+// Call the user-defined main.
+await import(pathToFileURL(join(distPath, '${mainFile}')).href);
+`;
+  } else {
+    return `
 /**
  * IMPORTANT: Do not modify this file.
  * This file allows the app to run without bundling in workspace libraries.
@@ -420,6 +487,7 @@ function isFile(s) {
 // Call the user-defined main.
 module.exports = require('${mainFile}');
 `;
+  }
 }
 
 function getPrefixLength(pattern: string): number {
@@ -438,8 +506,13 @@ function getPrefixLength(pattern: string): number {
 function getTsConfigCompilerPaths(context: ExecutorContext): {
   [key: string]: string[];
 } {
+  const rootTsConfigPath = getRootTsConfigPath(context);
+  if (!rootTsConfigPath) {
+    return {};
+  }
+
   const tsconfigPaths = require('tsconfig-paths');
-  const tsConfigResult = tsconfigPaths.loadConfig(getRootTsConfigPath(context));
+  const tsConfigResult = tsconfigPaths.loadConfig(rootTsConfigPath);
   if (tsConfigResult.resultType !== 'success') {
     throw new Error('Cannot load tsconfig file');
   }
@@ -454,7 +527,5 @@ function getRootTsConfigPath(context: ExecutorContext): string | null {
     }
   }
 
-  throw new Error(
-    'Could not find a root tsconfig.json or tsconfig.base.json file.'
-  );
+  return null;
 }

--- a/packages/js/src/executors/node/lib/detect-module-format.spec.ts
+++ b/packages/js/src/executors/node/lib/detect-module-format.spec.ts
@@ -1,0 +1,288 @@
+import { detectModuleFormat } from './detect-module-format';
+import { readTsConfig } from '../../../utils/typescript/ts-config';
+import * as ts from 'typescript';
+import { TempFs } from '@nx/devkit/internal-testing-utils';
+import { join } from 'path';
+
+jest.mock('../../../utils/typescript/ts-config');
+
+const mockReadTsConfig = readTsConfig as jest.MockedFunction<
+  typeof readTsConfig
+>;
+
+describe('detectModuleFormat', () => {
+  let tempFs: TempFs;
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    tempFs = new TempFs('detect-module-format');
+    workspaceRoot = tempFs.tempDir;
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+  });
+
+  describe('build executor format option detection', () => {
+    it('should detect ESM from build options with ESM format', () => {
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+        buildOptions: { format: ['esm'] },
+      });
+
+      expect(result).toBe('esm');
+    });
+
+    it('should detect CJS from build options with CJS format', () => {
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+        buildOptions: { format: ['cjs'] },
+      });
+
+      expect(result).toBe('cjs');
+    });
+
+    it('should prefer ESM when build options contain both formats', () => {
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+        buildOptions: { format: ['cjs', 'esm'] },
+      });
+
+      expect(result).toBe('esm');
+    });
+
+    it('should handle single format string (not array)', () => {
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+        buildOptions: { format: 'esm' },
+      });
+
+      expect(result).toBe('esm');
+    });
+  });
+
+  describe('file extension detection', () => {
+    it('should detect ESM from .mjs extension', () => {
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.mjs',
+      });
+
+      expect(result).toBe('esm');
+    });
+
+    it('should detect CJS from .cjs extension', () => {
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.cjs',
+      });
+
+      expect(result).toBe('cjs');
+    });
+
+    it('should not override build options with file extension', () => {
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.cjs', // CJS extension
+        buildOptions: { format: ['esm'] }, // But build options say ESM
+      });
+
+      expect(result).toBe('esm'); // Build options should win
+    });
+  });
+
+  describe('package.json type field detection', () => {
+    it('should detect ESM from package.json type: "module"', () => {
+      tempFs.createFilesSync({
+        'apps/test/package.json': JSON.stringify({ type: 'module' }),
+      });
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+      });
+
+      expect(result).toBe('esm');
+    });
+
+    it('should detect CJS from package.json type: "commonjs"', () => {
+      tempFs.createFilesSync({
+        'apps/test/package.json': JSON.stringify({ type: 'commonjs' }),
+      });
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+      });
+
+      expect(result).toBe('cjs');
+    });
+
+    it('should handle missing package.json gracefully', () => {
+      // Don't create any files - package.json doesn't exist
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+      });
+
+      expect(result).toBe('cjs'); // Should fallback to CJS
+    });
+
+    it('should handle package.json read errors gracefully', () => {
+      tempFs.createFilesSync({
+        'apps/test/package.json': 'invalid json {', // Invalid JSON to trigger parse error
+      });
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+      });
+
+      expect(result).toBe('cjs'); // Should fallback to CJS
+    });
+  });
+
+  describe('TypeScript configuration detection', () => {
+    it('should detect ESM from TypeScript ES2022 module', () => {
+      tempFs.createFilesSync({
+        'apps/test/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.ES2022 },
+      } as any);
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+        tsConfig: join(workspaceRoot, 'apps/test/tsconfig.json'),
+      });
+
+      expect(result).toBe('esm');
+    });
+
+    it('should detect ESM from TypeScript ESNext module', () => {
+      tempFs.createFilesSync({
+        'apps/test/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.ESNext },
+      } as any);
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+        tsConfig: join(workspaceRoot, 'apps/test/tsconfig.json'),
+      });
+
+      expect(result).toBe('esm');
+    });
+
+    it('should default to CJS for NodeNext module', () => {
+      tempFs.createFilesSync({
+        'apps/test/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.NodeNext },
+      } as any);
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+        tsConfig: join(workspaceRoot, 'apps/test/tsconfig.json'),
+      });
+
+      expect(result).toBe('cjs'); // NodeNext defaults to CJS when no package.json type
+    });
+
+    it('should handle missing TypeScript config gracefully', () => {
+      // Don't create tsconfig.json file
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+        tsConfig: join(workspaceRoot, 'apps/test/tsconfig.json'),
+      });
+
+      expect(result).toBe('cjs'); // Should fallback to CJS
+    });
+  });
+
+  describe('default behavior', () => {
+    it('should default to CJS when no detection method succeeds', () => {
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.js',
+      });
+
+      expect(result).toBe('cjs');
+    });
+  });
+
+  describe('detection priority', () => {
+    it('should prioritize build options over all other methods', () => {
+      tempFs.createFilesSync({
+        'apps/test/package.json': JSON.stringify({ type: 'module' }), // package.json says ESM
+        'apps/test/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.ES2022 },
+      } as any); // TypeScript says ESM
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.mjs', // File extension says ESM
+        tsConfig: join(workspaceRoot, 'apps/test/tsconfig.json'),
+        buildOptions: { format: ['cjs'] }, // But build options say CJS
+      });
+
+      expect(result).toBe('cjs'); // Build options should win
+    });
+
+    it('should prioritize file extension over package.json and TypeScript', () => {
+      tempFs.createFilesSync({
+        'apps/test/package.json': JSON.stringify({ type: 'commonjs' }), // package.json says CJS
+        'apps/test/tsconfig.json': '{}',
+      });
+
+      mockReadTsConfig.mockReturnValue({
+        options: { module: ts.ModuleKind.CommonJS },
+      } as any); // TypeScript says CJS
+
+      const result = detectModuleFormat({
+        projectRoot: 'apps/test',
+        workspaceRoot,
+        main: 'main.mjs', // But file extension says ESM
+        tsConfig: join(workspaceRoot, 'apps/test/tsconfig.json'),
+      });
+
+      expect(result).toBe('esm'); // File extension should win
+    });
+  });
+});

--- a/packages/js/src/executors/node/lib/detect-module-format.ts
+++ b/packages/js/src/executors/node/lib/detect-module-format.ts
@@ -1,0 +1,84 @@
+import { readJsonFile } from '@nx/devkit';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { readTsConfig } from '../../../utils/typescript/ts-config';
+import * as ts from 'typescript';
+
+export type ModuleFormat = 'cjs' | 'esm';
+
+export interface ModuleFormatDetectionOptions {
+  projectRoot: string;
+  workspaceRoot: string;
+  tsConfig?: string;
+  main: string;
+  buildOptions?: any;
+}
+
+export function detectModuleFormat(
+  options: ModuleFormatDetectionOptions
+): ModuleFormat {
+  if (options.buildOptions?.format) {
+    const formats = Array.isArray(options.buildOptions.format)
+      ? options.buildOptions.format
+      : [options.buildOptions.format];
+
+    if (formats.includes('esm')) {
+      return 'esm';
+    }
+
+    if (formats.includes('cjs')) {
+      return 'cjs';
+    }
+  }
+
+  if (options.main.endsWith('.mjs')) {
+    return 'esm';
+  }
+  if (options.main.endsWith('.cjs')) {
+    return 'cjs';
+  }
+
+  const packageJsonPath = join(
+    options.workspaceRoot,
+    options.projectRoot,
+    'package.json'
+  );
+  if (existsSync(packageJsonPath)) {
+    try {
+      const packageJson = readJsonFile(packageJsonPath);
+      if (packageJson.type === 'module') {
+        return 'esm';
+      }
+      if (packageJson.type === 'commonjs') {
+        return 'cjs';
+      }
+    } catch {
+      // Continue to next detection method
+    }
+  }
+
+  if (options.tsConfig && existsSync(options.tsConfig)) {
+    try {
+      const tsConfig = readTsConfig(options.tsConfig);
+      if (
+        tsConfig.options.module === ts.ModuleKind.ES2015 ||
+        tsConfig.options.module === ts.ModuleKind.ES2020 ||
+        tsConfig.options.module === ts.ModuleKind.ES2022 ||
+        tsConfig.options.module === ts.ModuleKind.ESNext ||
+        tsConfig.options.module === ts.ModuleKind.NodeNext
+      ) {
+        // For NodeNext, we need to check moduleResolution
+        if (tsConfig.options.module === ts.ModuleKind.NodeNext) {
+          // NodeNext uses package.json type field, which we already checked
+          // Default to CJS if no type field
+          return 'cjs';
+        }
+        return 'esm';
+      }
+    } catch {
+      // Continue to default
+    }
+  }
+
+  return 'cjs';
+}

--- a/packages/js/src/executors/node/lib/esm-loader.spec.ts
+++ b/packages/js/src/executors/node/lib/esm-loader.spec.ts
@@ -1,0 +1,161 @@
+import { resolve } from './esm-loader';
+import { pathToFileURL } from 'node:url';
+import { TempFs } from '@nx/devkit/internal-testing-utils';
+import { setupWorkspaceContext } from 'nx/src/utils/workspace-context';
+
+describe('ESM Loader', () => {
+  let tempFs: TempFs;
+  let cwd: string;
+  const mockContext = {};
+  const mockNextResolve = jest.fn();
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    tempFs = new TempFs('esm-loader');
+    process.chdir(tempFs.tempDir);
+    setupWorkspaceContext(tempFs.tempDir);
+    jest.clearAllMocks();
+    delete process.env.NX_MAPPINGS;
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+    process.chdir(cwd);
+    jest.resetModules();
+  });
+
+  describe('resolve', () => {
+    it('should resolve workspace library mappings', async () => {
+      const distPath = `${tempFs.tempDir}/dist/libs/lib1`;
+      await tempFs.createFiles({
+        'dist/libs/lib1/index.js': 'export default {};',
+        'dist/libs/lib2/index.js': 'export default {};',
+      });
+
+      process.env.NX_MAPPINGS = JSON.stringify({
+        '@myorg/lib1': distPath,
+        '@myorg/lib2': `${tempFs.tempDir}/dist/libs/lib2`,
+      });
+
+      await resolve('@myorg/lib1', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith(
+        pathToFileURL(`${distPath}/index.js`).href,
+        mockContext
+      );
+    });
+
+    it('should resolve workspace library subpaths', async () => {
+      const distPath = `${tempFs.tempDir}/dist/libs/lib1`;
+      await tempFs.createFiles({
+        'dist/libs/lib1/utils/helper.js': 'export default {};',
+      });
+
+      process.env.NX_MAPPINGS = JSON.stringify({
+        '@myorg/lib1': distPath,
+      });
+
+      await resolve('@myorg/lib1/utils/helper', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith(
+        pathToFileURL(`${distPath}/utils/helper.js`).href,
+        mockContext
+      );
+    });
+
+    it('should try index.js when directory exists', async () => {
+      const distPath = `${tempFs.tempDir}/dist/libs/lib1`;
+      await tempFs.createFiles({
+        'dist/libs/lib1/utils/index.js': 'export default {};',
+      });
+
+      process.env.NX_MAPPINGS = JSON.stringify({
+        '@myorg/lib1': distPath,
+      });
+
+      await resolve('@myorg/lib1/utils', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith(
+        pathToFileURL(`${distPath}/utils/index.js`).href,
+        mockContext
+      );
+    });
+
+    it('should try .js extension when file has no extension', async () => {
+      const distPath = `${tempFs.tempDir}/dist/libs/lib1`;
+      await tempFs.createFiles({
+        'dist/libs/lib1/helper.js': 'export default {};',
+      });
+
+      process.env.NX_MAPPINGS = JSON.stringify({
+        '@myorg/lib1': distPath,
+      });
+
+      await resolve('@myorg/lib1/helper', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith(
+        pathToFileURL(`${distPath}/helper.js`).href,
+        mockContext
+      );
+    });
+
+    it('should try .mjs extension when other resolutions fail', async () => {
+      const distPath = `${tempFs.tempDir}/dist/libs/lib1`;
+      await tempFs.createFiles({
+        'dist/libs/lib1/helper.mjs': 'export default {};',
+      });
+
+      process.env.NX_MAPPINGS = JSON.stringify({
+        '@myorg/lib1': distPath,
+      });
+
+      await resolve('@myorg/lib1/helper', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith(
+        pathToFileURL(`${distPath}/helper.mjs`).href,
+        mockContext
+      );
+    });
+
+    it('should fall back to default resolution when mapping not found', async () => {
+      const distPath = `${tempFs.tempDir}/dist/libs/lib1`;
+
+      process.env.NX_MAPPINGS = JSON.stringify({
+        '@myorg/lib1': distPath,
+      });
+
+      await resolve('express', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith('express', mockContext);
+    });
+
+    it('should fall back to default resolution when no file found', async () => {
+      const distPath = `${tempFs.tempDir}/dist/libs/lib1`;
+
+      process.env.NX_MAPPINGS = JSON.stringify({
+        '@myorg/lib1': distPath,
+      });
+
+      await resolve('@myorg/lib1/nonexistent', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith(
+        '@myorg/lib1/nonexistent',
+        mockContext
+      );
+    });
+
+    it('should handle empty mappings', async () => {
+      process.env.NX_MAPPINGS = '{}';
+
+      await resolve('@myorg/lib1', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith('@myorg/lib1', mockContext);
+    });
+
+    it('should handle missing NX_MAPPINGS env var', async () => {
+      await resolve('@myorg/lib1', mockContext, mockNextResolve);
+
+      expect(mockNextResolve).toHaveBeenCalledWith('@myorg/lib1', mockContext);
+    });
+  });
+});

--- a/packages/js/src/executors/node/lib/esm-loader.ts
+++ b/packages/js/src/executors/node/lib/esm-loader.ts
@@ -1,0 +1,62 @@
+import { pathToFileURL } from 'node:url';
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Custom ESM resolver for Node.js that handles Nx workspace library mappings.
+ *
+ * This resolver is necessary because:
+ * 1. Node.js ESM resolution doesn't understand TypeScript path mappings (e.g., @myorg/mylib)
+ * 2. Nx workspace libraries need to be resolved to their actual built output locations
+ * 3. The built output might be in different formats (.js, .mjs) or locations (index.js)
+ *
+ * The resolver intercepts import requests for workspace libraries and maps them to their
+ * actual file system locations based on the NX_MAPPINGS environment variable set by
+ * the Node executor.
+ */
+export async function resolve(
+  specifier: string,
+  context: any,
+  nextResolve: any
+) {
+  // Parse mappings on each call to ensure we get the latest values
+  const mappings = JSON.parse(process.env.NX_MAPPINGS || '{}');
+  const mappingKeys = Object.keys(mappings);
+
+  // Check if this is a workspace library mapping
+  const matchingKey = mappingKeys.find(
+    (key) => specifier === key || specifier.startsWith(key + '/')
+  );
+
+  if (matchingKey) {
+    const mappedPath = mappings[matchingKey];
+    const restOfPath = specifier.slice(matchingKey.length);
+    const fullPath = join(mappedPath, restOfPath);
+
+    // Try to resolve the mapped path as a file first
+    if (existsSync(fullPath)) {
+      const stats = statSync(fullPath);
+      if (stats.isFile()) {
+        return nextResolve(pathToFileURL(fullPath).href, context);
+      }
+    }
+
+    // Try with index.js
+    const indexPath = join(fullPath, 'index.js');
+    if (existsSync(indexPath)) {
+      return nextResolve(pathToFileURL(indexPath).href, context);
+    }
+
+    const jsPath = fullPath + '.js';
+    if (existsSync(jsPath)) {
+      return nextResolve(pathToFileURL(jsPath).href, context);
+    }
+
+    const mjsPath = fullPath + '.mjs';
+    if (existsSync(mjsPath)) {
+      return nextResolve(pathToFileURL(mjsPath).href, context);
+    }
+  }
+
+  return nextResolve(specifier, context);
+}

--- a/packages/js/src/executors/node/node-with-esm-loader.ts
+++ b/packages/js/src/executors/node/node-with-esm-loader.ts
@@ -21,7 +21,7 @@ async function main() {
     await dynamicImportEsm(pathToFileURL(fileToRun).href);
   } catch (error) {
     console.error('ESM loader error:', error);
-    throw error;
+    process.exit(1);
   }
 }
 

--- a/packages/js/src/executors/node/node-with-esm-loader.ts
+++ b/packages/js/src/executors/node/node-with-esm-loader.ts
@@ -1,0 +1,31 @@
+const { pathToFileURL } = require('node:url');
+const { register } = require('node:module');
+const path = require('node:path');
+
+// Dynamic import helper to prevent TypeScript from transforming it
+const dynamicImportEsm = new Function('specifier', 'return import(specifier)');
+
+async function main() {
+  try {
+    // Register ESM loader for workspace path mappings
+    register(
+      path.join(__dirname, 'lib', 'esm-loader.js'),
+      pathToFileURL(__filename)
+    );
+
+    // Import and run the file
+    const fileToRun = process.env.NX_FILE_TO_RUN;
+    if (!fileToRun) {
+      throw new Error('NX_FILE_TO_RUN environment variable not set');
+    }
+    await dynamicImportEsm(pathToFileURL(fileToRun).href);
+  } catch (error) {
+    console.error('ESM loader error:', error);
+    throw error;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
This PR enables the Node.js executor to run ESM-only packages (like `node-fetch`@3) alongside CommonJS modules.

### Changes:

- ESM loader: Implemented custom ESM resolver to handle Nx workspace library mappings in ESM contexts
- Dynamic execution: Node executor now switches between CommonJS and ESM loaders based on the detected module format
- esbuild updates: Enhanced esbuild executor to properly handle ESM output formats and creating a proper `package.json`

closes: #10296

