### PR TITLE
fix(linter): update lint executor to correctly handle `--fix` and `--quiet`

### DIFF
--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -183,14 +183,14 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     );
   }
 
+  // output fixes to disk, if applicable based on the options
+  await ESLint.outputFixes(lintResults);
+
   // if quiet, only show errors
   if (normalizedOptions.quiet) {
     console.debug('Quiet mode enabled - filtering out warnings\n');
     lintResults = ESLint.getErrorResults(lintResults);
   }
-
-  // output fixes to disk, if applicable based on the options
-  await ESLint.outputFixes(lintResults);
 
   const formatter = await eslint.loadFormatter(normalizedOptions.format);
 

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -22,7 +22,9 @@ export async function resolveAndInstantiateESLint(
   // ruleFilter exist only in eslint 9+, remove this type when eslint 8 support dropped
   const eslintOptions: ESLint.Options & { ruleFilter?: Function } = {
     overrideConfigFile: eslintConfigPath,
-    fix: !!options.fix,
+    fix:
+      !!options.fix &&
+      (options.quiet ? (message) => message.severity === 2 : true),
     cache: !!options.cache,
     cacheLocation: options.cacheLocation || undefined,
     cacheStrategy: options.cacheStrategy || undefined,


### PR DESCRIPTION
## Current Behavior

When running ESLint using the `@nx/eslint:lint` executor with `--quiet` and `--fix`, and there are errors, no fix is made, and the task incorrectly succeeds.

This is a regression introduced by https://github.com/nrwl/nx/commit/9406d2bfdb15e33ad85345533f96f6136130e817, which updated the executor to not fix warnings when `--quiet` is used, but the solution was incorrect.

## Expected Behavior

When running ESLint using the `@nx/eslint:lint` executor with `--quiet` and `--fix`, and there are errors, fixes should be applied, and the task should succeed if there are no remaining errors. It should not fix warnings.

## Related Issue(s)

Fixes #31868 
