### PR TITLE
fix(js): resolve relative imports correctly in nested projects

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -367,6 +367,36 @@ describe('TargetProjectLocator', () => {
       expect(res5).toEqual('rootProj');
     });
 
+    it('should be able to resolve a module by using relative paths within a nested project', () => {
+      // Test resolving "./" import from child-project (nested 1 level under parent-project)
+      const res1 = targetProjectLocator.findProjectFromImport(
+        './index.ts',
+        'libs/parent-path/child-path/src/index.ts'
+      );
+      expect(res1).toEqual('child-project');
+
+      // Test resolving "../" import from child-project back to parent-project
+      const res2 = targetProjectLocator.findProjectFromImport(
+        '../index.ts',
+        'libs/parent-path/child-path/index.ts'
+      );
+      expect(res2).toEqual('parent-project');
+
+      // Test resolving "./" import within the same nested project
+      const res3 = targetProjectLocator.findProjectFromImport(
+        './utils.ts',
+        'libs/parent-path/child-path/index.ts'
+      );
+      expect(res3).toEqual('child-project');
+
+      // Test resolving "./" import within the same nested project
+      const res4 = targetProjectLocator.findProjectFromImport(
+        './',
+        'libs/parent-path/child-path/module.ts'
+      );
+      expect(res4).toEqual('child-project');
+    });
+
     it('should be able to resolve a module by using tsConfig paths', () => {
       const proj2 = targetProjectLocator.findProjectFromImport(
         '@proj/my-second-proj',

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -432,9 +432,13 @@ export class TargetProjectLocator {
     ) {
       return undefined;
     }
-    const normalizedResolvedModule = resolvedModule.startsWith('./')
+    let normalizedResolvedModule = resolvedModule.startsWith('./')
       ? resolvedModule.substring(2)
       : resolvedModule;
+    // Remove trailing slash to ensure proper project matching
+    if (normalizedResolvedModule.endsWith('/')) {
+      normalizedResolvedModule = normalizedResolvedModule.slice(0, -1);
+    }
     const importedProject = this.findMatchingProjectFiles(
       normalizedResolvedModule
     );


### PR DESCRIPTION
## Current Behavior

When resolving "./" imports from a nested project, the target project locator incorrectly resolves to the parent project instead of the current project.

For example, given:
- `parent-project` at `libs/parent-path`
- `child-project` at `libs/parent-path/child-path` (nested 1 level under parent)

When importing "./" from `libs/parent-path/child-path/module.ts`, it incorrectly resolves to `parent-project` instead of `child-project`.

## Expected Behavior

"./" imports from within a nested project should resolve to that project, not its parent.

## Related Issue(s)

Fixes #31980