### PR TITLE
fix(core): adjust artifacts path for publish

### DIFF
--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -51,7 +51,7 @@
     },
     "artifacts": {
       "dependsOn": ["copy-native-package-directories"],
-      "command": "pnpm napi artifacts --package-json-path dist/packages/nx/package.json -d packages/nx/src/native --npm-dir dist/packages"
+      "command": "pnpm napi artifacts --package-json-path dist/packages/nx/package.json -d ./artifacts --npm-dir dist/packages"
     },
     "echo": {
       "command": "echo hi"


### PR DESCRIPTION
Update native `.wasm` paths to be `./artifacts`