### PR TITLE
fix(jest): revert version back to 29

### DIFF
--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = require('../../package.json').version;
-export const jestVersion = '^30.0.2';
-export const babelJestVersion = '^30.0.2';
-export const jestTypesVersion = '^30.0.0';
+export const jestVersion = '^29.5.12';
+export const babelJestVersion = '^29.7.0';
+export const jestTypesVersion = '^29.5.0';
 export const tsJestVersion = '^29.4.0';
 export const tslibVersion = '^2.3.0';
 export const swcJestVersion = '~0.2.38';


### PR DESCRIPTION
### Changes

Newly create projects fail when using jest v30 so lets revert this for now