### PR TITLE
fix(jest): revert back to Jest 30 after synckit compatibility fix

### DIFF
--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = require('../../package.json').version;
-export const jestVersion = '^29.5.12';
-export const babelJestVersion = '^29.7.0';
-export const jestTypesVersion = '^29.5.0';
+export const jestVersion = '^30.0.2';
+export const babelJestVersion = '^30.0.2';
+export const jestTypesVersion = '^30.0.0';
 export const tsJestVersion = '^29.4.0';
 export const tslibVersion = '^2.3.0';
 export const swcJestVersion = '~0.2.38';


### PR DESCRIPTION
## Current Behavior

Jest is currently pinned to version 29 due to compatibility issues with synckit@0.11.10 that caused TypeErrors in Jest tests.

## Expected Behavior

With the synckit compatibility issue resolved in v0.11.11, Jest can be safely upgraded back to version 30, providing users with the latest Jest features and improvements.

## Related Issue(s)

The underlying synckit compatibility issue has been fixed: https://github.com/un-ts/synckit/issues/252

This reverts the temporary downgrade that was applied in #31981.

Fixes the Jest version regression by restoring Jest 30 support.