### PR TITLE
fix(testing): normalize spec files correctly in jest `replace-removed-matcher-aliases` migration

### DIFF
--- a/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.ts
+++ b/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.ts
@@ -3,9 +3,8 @@ import { tsquery } from '@phenomnomnominal/tsquery';
 import { SearchSource } from 'jest';
 import { readConfig } from 'jest-config';
 import Runtime from 'jest-runtime';
+import { join, posix, relative } from 'path';
 import type { Identifier } from 'typescript';
-import { join } from 'path';
-import { relative } from 'node:path/posix';
 
 const matcherAliasesMap = new Map<string, string>([
   ['toBeCalled', 'toHaveBeenCalled'],
@@ -70,7 +69,7 @@ async function getTestFilePaths(tree: Tree): Promise<string[]> {
       config.projectConfig
     );
     for (const testPath of specs.tests) {
-      testFilePaths.add(relative(tree.root, testPath.path));
+      testFilePaths.add(posix.normalize(relative(tree.root, testPath.path)));
     }
   }
 


### PR DESCRIPTION
## Current Behavior

When running the Jest `replace-removed-matcher-aliases` migration on Windows, it resolves the spec files incorrectly and fails.

## Expected Behavior

Running the Jest `replace-removed-matcher-aliases` migration should work correctly regardless the OS.

## Related Issue(s)

Fixes #31991 
