### PR TITLE
fix(nextjs): infer relevant tasks with the typescript sync generator when using ts project references

### DIFF
--- a/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
 [
@@ -37,6 +37,9 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
                 "{workspaceRoot}/my-app/.next/!(cache)/**/*",
                 "{workspaceRoot}/my-app/.next/!(cache)",
               ],
+              "syncGenerators": [
+                "@nx/js:typescript-sync",
+              ],
             },
             "my-serve": {
               "command": "next dev",
@@ -44,6 +47,9 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
               "options": {
                 "cwd": "my-app",
               },
+              "syncGenerators": [
+                "@nx/js:typescript-sync",
+              ],
             },
             "my-serve-static": {
               "command": "next start",
@@ -112,6 +118,9 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
                 "{projectRoot}/.next/!(cache)/**/*",
                 "{projectRoot}/.next/!(cache)",
               ],
+              "syncGenerators": [
+                "@nx/js:typescript-sync",
+              ],
             },
             "build-deps": {
               "dependsOn": [
@@ -124,6 +133,9 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
               "options": {
                 "cwd": ".",
               },
+              "syncGenerators": [
+                "@nx/js:typescript-sync",
+              ],
             },
             "serve-static": {
               "command": "next start",


### PR DESCRIPTION
## Current Behavior

When using the TS solution setup, tasks inferred by the `@nx/next/plugin` do not have the `@nx/js:typescript-sync` generator set.

## Expected Behavior

When using the TS solution setup, tasks inferred by the `@nx/next/plugin` should have the `@nx/js:typescript-sync` generator set.

## Related Issue(s)

Fixes #31983 
