### PR TITLE
fix(core): handle undefined packageJson.dependencies

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/npm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.ts
@@ -434,7 +434,7 @@ function mapWorkspaceModules(
 ) {
   const output: Record<string, NpmDependencyV3 & NpmDependencyV1> = {};
   for (const [pkgName, pkgVersion] of Object.entries(
-    packageJson.dependencies
+    packageJson.dependencies ?? {}
   )) {
     if (workspaceModules.has(pkgName)) {
       let workspaceModuleDefinition: NpmDependencyV3 & NpmDependencyV1;
@@ -481,7 +481,7 @@ function mapPackageJsonWithWorkspaceModules(
   packageJson: NormalizedPackageJson
 ) {
   for (const [pkgName, pkgVersion] of Object.entries(
-    packageJson.dependencies
+    packageJson.dependencies ?? {}
   )) {
     if (pkgVersion.startsWith('workspace:') || pkgVersion.startsWith('file:')) {
       packageJson.dependencies[pkgName] = `workspace_modules/${pkgName}`;


### PR DESCRIPTION
## Current Behavior
`npm-parser` for lockfile pruning is trying to run `Object.entries` on a potentially null or undefined object (packageJson.dependencies).

## Expected Behavior
Ensure `?? {}` is used when evaluating `Object.entries`
