### PR TITLE
fix(core): run task hasher in serial instead of parallel

### DIFF
--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -110,7 +110,6 @@ impl TaskHasher {
                     .iter()
                     .map(move |instruction| (task_id, instruction))
             })
-            .par_bridge()
             .try_for_each(|(task_id, instruction)| {
                 let hash_detail = self.hash_instruction(
                     task_id,


### PR DESCRIPTION
## Current Behavior

The task hasher currently uses parallel processing via `.par_bridge()` to hash task instructions concurrently.

## Expected Behavior

This PR changes the task hasher to run serially by removing the `.par_bridge()` call, making the processing sequential instead of parallel.

## Related Issue(s)

This change is being made to test performance impact and debug potential thread-related issues with the task hasher.

## Test Plan

- Build the native module with `nx build nx`
- Run existing tests to ensure functionality is preserved
- Performance testing can be done to compare serial vs parallel hashing times

🤖 Generated with [Claude Code](https://claude.ai/code)