### PR TITLE
fix(testing): add missing package updates for `ts-jest` and `jest-util` for jest v30 migrations

### DIFF
--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -2218,6 +2218,26 @@
       }
     },
     "migrations": {
+      "/technologies/test-tools/jest/api/migrations/21.3.3-jest-util-package-updates": {
+        "description": "",
+        "file": "generated/packages/jest/migrations/21.3.3-jest-util-package-updates.json",
+        "hidden": false,
+        "name": "21.3.3-jest-util-package-updates",
+        "version": "21.3.3-beta.3",
+        "originalFilePath": "/packages/jest",
+        "path": "/technologies/test-tools/jest/api/migrations/21.3.3-jest-util-package-updates",
+        "type": "migration"
+      },
+      "/technologies/test-tools/jest/api/migrations/21.3.3-package-updates": {
+        "description": "",
+        "file": "generated/packages/jest/migrations/21.3.3-package-updates.json",
+        "hidden": false,
+        "name": "21.3.3-package-updates",
+        "version": "21.3.3-beta.0",
+        "originalFilePath": "/packages/jest",
+        "path": "/technologies/test-tools/jest/api/migrations/21.3.3-package-updates",
+        "type": "migration"
+      },
       "/technologies/test-tools/jest/api/migrations/rename-test-path-pattern": {
         "description": "Rename the CLI option `testPathPattern` to `testPathPatterns`.",
         "file": "generated/packages/jest/migrations/rename-test-path-pattern.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -2403,6 +2403,26 @@
     ],
     "migrations": [
       {
+        "description": "",
+        "file": "generated/packages/jest/migrations/21.3.3-jest-util-package-updates.json",
+        "hidden": false,
+        "name": "21.3.3-jest-util-package-updates",
+        "version": "21.3.3-beta.3",
+        "originalFilePath": "/packages/jest",
+        "path": "jest/migrations/21.3.3-jest-util-package-updates",
+        "type": "migration"
+      },
+      {
+        "description": "",
+        "file": "generated/packages/jest/migrations/21.3.3-package-updates.json",
+        "hidden": false,
+        "name": "21.3.3-package-updates",
+        "version": "21.3.3-beta.0",
+        "originalFilePath": "/packages/jest",
+        "path": "jest/migrations/21.3.3-package-updates",
+        "type": "migration"
+      },
+      {
         "description": "Rename the CLI option `testPathPattern` to `testPathPatterns`.",
         "file": "generated/packages/jest/migrations/rename-test-path-pattern.json",
         "hidden": false,

--- a/docs/generated/packages/jest/migrations/21.3.3-jest-util-package-updates.json
+++ b/docs/generated/packages/jest/migrations/21.3.3-jest-util-package-updates.json
@@ -1,0 +1,15 @@
+{
+  "name": "21.3.3-jest-util-package-updates",
+  "version": "21.3.3-beta.3",
+  "requires": { "jest": ">=30.0.0 <31.0.0", "ts-jest": ">=29.4.0" },
+  "packages": {
+    "jest-util": { "version": "~30.0.0", "addToPackageJson": "devDependencies" }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/jest",
+  "schema": null,
+  "type": "migration"
+}

--- a/docs/generated/packages/jest/migrations/21.3.3-package-updates.json
+++ b/docs/generated/packages/jest/migrations/21.3.3-package-updates.json
@@ -1,0 +1,14 @@
+{
+  "name": "21.3.3-package-updates",
+  "version": "21.3.3-beta.0",
+  "packages": {
+    "ts-jest": { "version": "~29.4.0", "alwaysAddToPackageJson": false }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/jest",
+  "schema": null,
+  "type": "migration"
+}

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -114,6 +114,28 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "21.3.3": {
+      "version": "21.3.3-beta.0",
+      "packages": {
+        "ts-jest": {
+          "version": "~29.4.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "21.3.3-jest-util": {
+      "version": "21.3.3-beta.3",
+      "requires": {
+        "jest": ">=30.0.0 <31.0.0",
+        "ts-jest": ">=29.4.0"
+      },
+      "packages": {
+        "jest-util": {
+          "version": "~30.0.0",
+          "addToPackageJson": "devDependencies"
+        }
+      }
     }
   }
 }

--- a/packages/jest/src/generators/configuration/lib/ensure-dependencies.ts
+++ b/packages/jest/src/generators/configuration/lib/ensure-dependencies.ts
@@ -24,6 +24,8 @@ export function ensureDependencies(
     // jest will throw an error if it's not installed
     // even if not using it in overriding transformers
     'ts-jest': tsJestVersion,
+    // peer dependency of ts-jest
+    'jest-util': jestVersion,
   };
 
   if (options.testEnvironment !== 'none') {


### PR DESCRIPTION
## Current Behavior

The migration for Jest v30 is missing package updates for `ts-jest` and `jest-util`.

## Expected Behavior

The migration for Jest v30 should have package updates for `ts-jest` and `jest-util`.