### PR TITLE
fix(core): derive graph node type correctly when `projectType` is not set

### DIFF
--- a/e2e/release/src/circular-dependencies.test.ts
+++ b/e2e/release/src/circular-dependencies.test.ts
@@ -139,7 +139,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "dependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -152,7 +152,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "devDependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -321,7 +321,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "dependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -334,7 +334,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "devDependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -504,7 +504,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "dependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -517,7 +517,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "devDependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -681,7 +681,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         }
         +
@@ -807,7 +807,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "dependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -820,7 +820,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "devDependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -992,7 +992,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
-        "scripts": {
+        "exports": {
 
         "dependencies": {
         -     "@proj/{project-name}": "1.0.0"
@@ -1005,7 +1005,7 @@ xdescribe('nx release circular dependencies', () => {
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.0.1",
-        "scripts": {
+        "exports": {
 
         "devDependencies": {
         -     "@proj/{project-name}": "1.0.0"

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -134,7 +134,7 @@ describe('nx release - independent projects', () => {
         "name": "@proj/{project-name}",
         -   "version": "0.0.0",
         +   "version": "999.9.9-package.1",
-        "scripts": {
+        "exports": {
 
 
         NX   Staging changed files with git
@@ -162,7 +162,7 @@ describe('nx release - independent projects', () => {
         "name": "@proj/{project-name}",
         -   "version": "0.0.0",
         +   "version": "999.9.9-package.2",
-        "scripts": {
+        "exports": {
 
         }
         +
@@ -200,13 +200,13 @@ describe('nx release - independent projects', () => {
         "name": "@proj/{project-name}",
         -   "version": "0.0.0",
         +   "version": "999.9.9-package.3",
-        "scripts": {
+        "exports": {
 
 
         "name": "@proj/{project-name}",
         -   "version": "999.9.9-package.2",
         +   "version": "999.9.9",
-        "scripts": {
+        "exports": {
 
         "dependencies": {
         -     "@proj/{project-name}": "0.0.0"
@@ -249,7 +249,7 @@ describe('nx release - independent projects', () => {
         "name": "@proj/{project-name}",
         -   "version": "999.9.9-version-git-operations-test.1",
         +   "version": "999.9.9-version-git-operations-test.2",
-        "scripts": {
+        "exports": {
 
 
         Skipped lock file update because {package-manager} workspaces are not enabled.
@@ -340,19 +340,19 @@ describe('nx release - independent projects', () => {
         "name": "@proj/{project-name}",
         -   "version": "999.9.9-package.3",
         +   "version": "999.9.9-version-git-operations-test.3",
-        "scripts": {
+        "exports": {
 
 
         "name": "@proj/{project-name}",
         -   "version": "999.9.9-version-git-operations-test.2",
         +   "version": "999.9.9-version-git-operations-test.3",
-        "scripts": {
+        "exports": {
 
 
         "name": "@proj/{project-name}",
         -   "version": "999.9.9",
         +   "version": "999.9.9-version-git-operations-test.3",
-        "scripts": {
+        "exports": {
 
         "dependencies": {
         -     "@proj/{project-name}": "999.9.9-package.3"

--- a/e2e/release/src/multiple-release-branches.test.ts
+++ b/e2e/release/src/multiple-release-branches.test.ts
@@ -143,19 +143,19 @@ describe('nx release multiple release branches', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.0.7",
-      "scripts": {
+      "exports": {
 
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.0.7",
-      "scripts": {
+      "exports": {
 
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.0.7",
-      "scripts": {
+      "exports": {
 
 
       NX   Committing changes with git
@@ -189,7 +189,7 @@ describe('nx release multiple release branches', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.7",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
 
       }
       +
@@ -198,13 +198,13 @@ describe('nx release multiple release branches', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.7",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
 
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.7",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
 
 
       NX   Committing changes with git
@@ -238,19 +238,19 @@ describe('nx release multiple release branches', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.7",
       +   "version": "0.0.8",
-      "scripts": {
+      "exports": {
 
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.7",
       +   "version": "0.0.8",
-      "scripts": {
+      "exports": {
 
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.7",
       +   "version": "0.0.8",
-      "scripts": {
+      "exports": {
 
 
       NX   Committing changes with git
@@ -328,7 +328,7 @@ describe('nx release multiple release branches', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
 
       }
       +
@@ -337,13 +337,13 @@ describe('nx release multiple release branches', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
 
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
 
 
       NX   Committing changes with git
@@ -377,13 +377,13 @@ describe('nx release multiple release branches', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "1.0.0",
-      "scripts": {
+      "exports": {
 
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "1.0.0",
-      "scripts": {
+      "exports": {
 
       }
       +
@@ -392,7 +392,7 @@ describe('nx release multiple release branches', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "1.0.0",
-      "scripts": {
+      "exports": {
 
 
       NX   Committing changes with git

--- a/e2e/release/src/preserve-local-dependency-protocols.test.ts
+++ b/e2e/release/src/preserve-local-dependency-protocols.test.ts
@@ -148,11 +148,11 @@ describe('nx release preserve local dependency protocols', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
       "dependencies": {
       -     "@proj/{project-name}": "workspace:*"
       +     "@proj/{project-name}": "0.1.0"
@@ -193,11 +193,11 @@ describe('nx release preserve local dependency protocols', () => {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
       +   "version": "0.1.0",
-      "scripts": {
+      "exports": {
       }
       +
       NX   Updating PM lock file
@@ -219,6 +219,10 @@ describe('nx release preserve local dependency protocols', () => {
         {
           dependencies: {
             @proj/{project-name}: workspace:*,
+          },
+          exports: {
+            .: ./index.js,
+            ./package.json: ./package.json,
           },
           name: @proj/{project-name},
           scripts: {
@@ -288,6 +292,10 @@ describe('nx release preserve local dependency protocols', () => {
         {
           dependencies: {
             @proj/{project-name}: workspace:*,
+          },
+          exports: {
+            .: ./index.js,
+            ./package.json: ./package.json,
           },
           name: @proj/{project-name},
           scripts: {

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -282,12 +282,19 @@ export function getProjectType(
     return 'library';
   if (tree.exists(joinPathFragments(projectRoot, 'tsconfig.app.json')))
     return 'application';
-  // If there are no exports, assume it is an application since both buildable and non-buildable libraries have exports.
+  // If it doesn't have any common library entry points, assume it is an application
   const packageJsonPath = joinPathFragments(projectRoot, 'package.json');
   const packageJson = tree.exists(packageJsonPath)
     ? readJson(tree, joinPathFragments(projectRoot, 'package.json'))
     : null;
-  if (!packageJson?.exports) return 'application';
+  if (
+    !packageJson?.exports &&
+    !packageJson?.main &&
+    !packageJson?.module &&
+    !packageJson?.bin
+  ) {
+    return 'application';
+  }
   return 'library';
 }
 

--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
@@ -1,11 +1,15 @@
-import { ProjectGraphProjectNode } from '../../config/project-graph';
-import { ProjectGraphBuilder } from '../project-graph-builder';
-import { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ProjectGraphProjectNode } from '../../config/project-graph';
+import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import { readJsonFile } from '../../utils/fileutils';
 import { findMatchingProjects } from '../../utils/find-matching-projects';
-import { CreateDependenciesContext } from '../plugins';
+import type { PackageJson } from '../../utils/package-json';
+import type { CreateDependenciesContext } from '../plugins';
+import type { ProjectGraphBuilder } from '../project-graph-builder';
 
 export async function normalizeProjectNodes(
-  { projects }: CreateDependenciesContext,
+  { projects, workspaceRoot }: CreateDependenciesContext,
   builder: ProjectGraphBuilder
 ) {
   // Sorting projects by name to make sure that the order of projects in the graph is deterministic.
@@ -43,12 +47,12 @@ export async function normalizeProjectNodes(
     p.targets ??= {};
 
     // TODO: remove in v16
-    const projectType =
-      p.projectType === 'application'
-        ? key.endsWith('-e2e') || key === 'e2e'
-          ? 'e2e'
-          : 'app'
-        : 'lib';
+    const projectType = getProjectType(
+      key,
+      p.projectType,
+      workspaceRoot,
+      p.root
+    );
     const tags = p.tags || [];
 
     toAdd.push({
@@ -119,4 +123,40 @@ export function normalizeImplicitDependencies(
   // This is what allows using a negative implicit dep to remove a dependency
   // detected by createDependencies.
   return deps.concat(alwaysIgnoredDeps.map((x) => '!' + x)) as string[];
+}
+
+function getProjectType(
+  projectName: string,
+  projectType: 'library' | 'application' | undefined,
+  workspaceRoot: string,
+  projectRoot: string
+): 'lib' | 'app' | 'e2e' {
+  if (projectType) {
+    if (projectType === 'library') {
+      return 'lib';
+    }
+    if (projectName.endsWith('-e2e') || projectName === 'e2e') {
+      return 'e2e';
+    }
+    return 'app';
+  }
+
+  if (existsSync(join(workspaceRoot, projectRoot, 'tsconfig.lib.json'))) {
+    return 'lib';
+  }
+
+  if (existsSync(join(workspaceRoot, projectRoot, 'tsconfig.app.json'))) {
+    return 'app';
+  }
+
+  // If there are no exports, assume it is an application since both buildable and non-buildable libraries have exports.
+  const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json');
+  try {
+    const packageJson = readJsonFile<PackageJson>(packageJsonPath);
+    if (!packageJson.exports) {
+      return 'app';
+    }
+  } catch {}
+
+  return 'lib';
 }

--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
@@ -149,11 +149,16 @@ function getProjectType(
     return 'app';
   }
 
-  // If there are no exports, assume it is an application since both buildable and non-buildable libraries have exports.
+  // If it doesn't have any common library entry points, assume it is an application
   const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json');
   try {
     const packageJson = readJsonFile<PackageJson>(packageJsonPath);
-    if (!packageJson.exports) {
+    if (
+      !packageJson.exports &&
+      !packageJson.main &&
+      !packageJson.module &&
+      !packageJson.bin
+    ) {
       return 'app';
     }
   } catch {}

--- a/packages/workspace/src/generators/npm-package/npm-package.spec.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.spec.ts
@@ -49,6 +49,10 @@ describe('@nx/workspace:npm-package', () => {
       "{
         "name": "@proj/my-package",
         "version": "0.0.0",
+        "exports": {
+          ".": "./index.js",
+          "./package.json": "./package.json"
+        },
         "scripts": {
           "test": "node index.js"
         }

--- a/packages/workspace/src/generators/npm-package/npm-package.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.ts
@@ -50,6 +50,10 @@ function addFiles(
   writeJson(tree, packageJsonPath, {
     name: options.importPath,
     version: '0.0.0',
+    exports: {
+      '.': './index.js',
+      './package.json': './package.json',
+    },
     scripts: {
       test: 'node index.js',
     },

--- a/packages/workspace/src/utils/ts-solution-setup.ts
+++ b/packages/workspace/src/utils/ts-solution-setup.ts
@@ -9,11 +9,18 @@ export function getProjectType(
   if (projectType) return projectType;
   if (joinPathFragments(projectRoot, 'tsconfig.lib.json')) return 'library';
   if (joinPathFragments(projectRoot, 'tsconfig.app.json')) return 'application';
-  // If there are no exports, assume it is an application since both buildable and non-buildable libraries have exports.
+  // If it doesn't have any common library entry points, assume it is an application
   const packageJsonPath = joinPathFragments(projectRoot, 'package.json');
   const packageJson = tree.exists(packageJsonPath)
     ? readJson(tree, joinPathFragments(projectRoot, 'package.json'))
     : null;
-  if (!packageJson?.exports) return 'application';
+  if (
+    !packageJson?.exports &&
+    !packageJson?.main &&
+    !packageJson?.module &&
+    !packageJson?.bin
+  ) {
+    return 'application';
+  }
   return 'library';
 }


### PR DESCRIPTION
## Current Behavior

When building the project graph nodes, the node `type` is always inferred as `lib` when `projectType` is not set.

## Expected Behavior

When building the project graph nodes, the node `type` should be derived correctly using the same logic used by generators when `projectType` is not set.

## Related Issue(s)

Fixes #31983 
