### PR TITLE
fix(core): move bin and scripts fields to nxConfig in package.json

### DIFF
--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -20,9 +20,6 @@
     "Playwright",
     "CLI"
   ],
-  "bin": {
-    "create-nx-workspace": "./bin/index.js"
-  },
   "author": "Victor Savkin",
   "license": "MIT",
   "bugs": {
@@ -41,5 +38,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "nxConfig": {
+    "bin": {
+      "create-nx-workspace": "./bin/index.js"
+    }
   }
 }

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -8,9 +8,6 @@
     "url": "https://github.com/nrwl/nx.git",
     "directory": "packages/nx"
   },
-  "scripts": {
-    "postinstall": "node ./bin/post-install || exit 0"
-  },
   "keywords": [
     "Monorepo",
     "Angular",
@@ -26,10 +23,6 @@
     "Backend",
     "Mobile"
   ],
-  "bin": {
-    "nx": "./bin/nx.js",
-    "nx-cloud": "./bin/nx-cloud.js"
-  },
   "author": "Victor Savkin",
   "license": "MIT",
   "bugs": {
@@ -147,6 +140,15 @@
   "builders": "./executors.json",
   "publishConfig": {
     "access": "public"
+  },
+  "nxConfig": {
+    "bin": {
+      "nx": "./bin/nx.js",
+      "nx-cloud": "./bin/nx-cloud.js"
+    },
+    "scripts": {
+      "postinstall": "node ./bin/post-install"
+    }
   },
   "napi": {
     "binaryName": "nx",


### PR DESCRIPTION
### Currently

When we run `pnpm i` install the Nx repo we get logs and warnings due to the local nx package running it's post-install script

```shell
 WARN  Failed to create bin at /../nx/node_modules/.bin/nx. ENOENT: no such file or directory, open '../packages/nx/bin/nx.js'
 WARN  Failed to create bin at ../e2e/plugin/node_modules/.bin/nx-cloud. ENOENT: no such file or directory, open '../packages/nx/bin/nx-cloud.js'
 WARN  Failed to create bin at /../e2e/angular/node_modules/.bin/nx. ENOENT: no such file or directory, open '/../packages/nx/bin/nx.js'
```

### Expected

We should restrict local packages post-install from being run in this context.

