### PR TITLE
feat(core): add nx mcp command

### DIFF
--- a/docs/generated/cli/mcp.md
+++ b/docs/generated/cli/mcp.md
@@ -1,0 +1,52 @@
+---
+title: 'mcp - CLI command'
+description: 'Starts the Nx MCP server.'
+---
+
+# mcp
+
+Starts the Nx MCP server. The Nx MCP server gives LLMs deep access to your monorepo’s structure as well as Nx Cloud.
+
+## Usage
+
+```shell
+nx mcp [workspacePath] [options]
+```
+
+## Positionals
+
+### workspacePath, w
+
+Type: `string`
+
+Path to the Nx workspace root. Will default to the current cwd if not provided.
+
+## Options
+
+### transport
+
+Type: `string`
+Default: `stdio`
+Choices: `stdio`, `sse`, `http`
+
+The transport protocol to use.
+
+### port, p
+
+Type: `number`
+Default: `9921`
+
+Port to use for the HTTP/SSE server.
+
+### disableTelemetry
+
+Type: `boolean`
+Default: `false`
+
+Disable sending of telemetry data.
+
+### help
+
+Type: `boolean`
+
+Show help.

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5614,6 +5614,14 @@
                         "disableCollapsible": false
                       },
                       {
+                        "id": "mcp",
+                        "path": "/reference/core-api/nx/documents/mcp",
+                        "name": "mcp",
+                        "children": [],
+                        "isExternal": false,
+                        "disableCollapsible": false
+                      },
+                      {
                         "id": "login",
                         "path": "/reference/core-api/nx/documents/login",
                         "name": "login",

--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -3343,6 +3343,17 @@
         "tags": ["add"],
         "originalFilePath": "generated/cli/add"
       },
+      "/reference/core-api/nx/documents/mcp": {
+        "id": "mcp",
+        "name": "mcp",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/mcp",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/reference/core-api/nx/documents/mcp",
+        "tags": ["mcp"],
+        "originalFilePath": "generated/cli/mcp"
+      },
       "/reference/core-api/nx/documents/login": {
         "id": "login",
         "name": "login",

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -1662,6 +1662,15 @@
       "path": "/reference/core-api/nx/documents/affected"
     }
   ],
+  "mcp": [
+    {
+      "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+      "file": "generated/packages/nx/documents/mcp",
+      "id": "mcp",
+      "name": "mcp",
+      "path": "/reference/core-api/nx/documents/mcp"
+    }
+  ],
   "nx-cloud": [
     {
       "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -3606,6 +3606,17 @@
         "originalFilePath": "generated/cli/add"
       },
       {
+        "id": "mcp",
+        "name": "mcp",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/mcp",
+        "itemList": [],
+        "isExternal": false,
+        "path": "nx/documents/mcp",
+        "tags": ["mcp"],
+        "originalFilePath": "generated/cli/mcp"
+      },
+      {
         "id": "login",
         "name": "login",
         "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",

--- a/docs/generated/packages/nx/documents/mcp.md
+++ b/docs/generated/packages/nx/documents/mcp.md
@@ -1,0 +1,52 @@
+---
+title: 'mcp - CLI command'
+description: 'Starts the Nx MCP server.'
+---
+
+# mcp
+
+Starts the Nx MCP server. The Nx MCP server gives LLMs deep access to your monorepo’s structure as well as Nx Cloud.
+
+## Usage
+
+```shell
+nx mcp [workspacePath] [options]
+```
+
+## Positionals
+
+### workspacePath, w
+
+Type: `string`
+
+Path to the Nx workspace root. Will default to the current cwd if not provided.
+
+## Options
+
+### transport
+
+Type: `string`
+Default: `stdio`
+Choices: `stdio`, `sse`, `http`
+
+The transport protocol to use.
+
+### port, p
+
+Type: `number`
+Default: `9921`
+
+Port to use for the HTTP/SSE server.
+
+### disableTelemetry
+
+Type: `boolean`
+Default: `false`
+
+Disable sending of telemetry data.
+
+### help
+
+Type: `boolean`
+
+Show help.

--- a/docs/map.json
+++ b/docs/map.json
@@ -3098,6 +3098,12 @@
               "file": "generated/cli/add"
             },
             {
+              "name": "mcp",
+              "id": "mcp",
+              "tags": ["mcp"],
+              "file": "generated/cli/mcp"
+            },
+            {
               "name": "login",
               "id": "login",
               "tags": ["login"],

--- a/docs/shared/cli/mcp.md
+++ b/docs/shared/cli/mcp.md
@@ -1,0 +1,52 @@
+---
+title: 'mcp - CLI command'
+description: 'Starts the Nx MCP server.'
+---
+
+# mcp
+
+Starts the Nx MCP server. The Nx MCP server gives LLMs deep access to your monorepo’s structure as well as Nx Cloud.
+
+## Usage
+
+```shell
+nx mcp [workspacePath] [options]
+```
+
+## Positionals
+
+### workspacePath, w
+
+Type: `string`
+
+Path to the Nx workspace root. Will default to the current cwd if not provided.
+
+## Options
+
+### transport
+
+Type: `string`
+Default: `stdio`
+Choices: `stdio`, `sse`, `http`
+
+The transport protocol to use.
+
+### port, p
+
+Type: `number`
+Default: `9921`
+
+Port to use for the HTTP/SSE server.
+
+### disableTelemetry
+
+Type: `boolean`
+Default: `false`
+
+Disable sending of telemetry data.
+
+### help
+
+Type: `boolean`
+
+Show help.

--- a/docs/shared/reference/commands.md
+++ b/docs/shared/reference/commands.md
@@ -315,6 +315,15 @@ nx daemon
 {% link-card title="Nx Daemon" type="Concept" url="/concepts/nx-daemon" /%}
 {% /cards %}
 
+### mcp
+
+Starts the Nx [MCP server](https://modelcontextprotocol.io/introduction) for exposing Nx tools to various AI systems (VSCode, Cursor, Claude, ...)
+
+{% cards %}
+{% link-card title="MCP" type="API Reference" url="/reference/core-api/nx/documents/mcp" /%}
+{% link-card title="Enhance Your LLM" type="Feature" url="/features/enhance-AI" /%}
+{% /cards %}
+
 ## Integrate with Nx Cloud
 
 ### connect

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -678,6 +678,7 @@
           - [view-logs](/reference/core-api/nx/documents/view-logs)
           - [release](/reference/core-api/nx/documents/release)
           - [add](/reference/core-api/nx/documents/add)
+          - [mcp](/reference/core-api/nx/documents/mcp)
           - [login](/reference/core-api/nx/documents/login)
           - [logout](/reference/core-api/nx/documents/logout)
           - [fix-ci](/reference/core-api/nx/documents/fix-ci)

--- a/packages/nx/src/command-line/mcp/command-object.ts
+++ b/packages/nx/src/command-line/mcp/command-object.ts
@@ -1,0 +1,24 @@
+import { CommandModule } from 'yargs';
+
+export const yargsMcpCommand: CommandModule = {
+  command: 'mcp',
+  describe: 'Starts the Nx MCP server.',
+  builder: (y) =>
+    y
+      .version(false)
+      .strict(false)
+      .parserConfiguration({
+        'unknown-options-as-args': true,
+        'populate--': true,
+      })
+      .usage('')
+      .help(false)
+      .showHelp(async () => {
+        await (await import('./mcp')).showHelp();
+        process.exit(0);
+      }),
+  handler: async (args: any) => {
+    await (await import('./mcp')).mcpHandler(args);
+    process.exit(0);
+  },
+};

--- a/packages/nx/src/command-line/mcp/mcp.ts
+++ b/packages/nx/src/command-line/mcp/mcp.ts
@@ -1,0 +1,31 @@
+import { spawnSync } from 'child_process';
+import { getPackageManagerCommand } from '../../utils/package-manager';
+import { workspaceRoot } from '../../utils/workspace-root';
+
+export async function mcpHandler(args: any) {
+  const packageManagerCommands = getPackageManagerCommand();
+
+  spawnSync(
+    packageManagerCommands.dlx,
+    ['-y', 'nx-mcp@latest', , ...args['_']],
+    {
+      stdio: 'inherit',
+      cwd: workspaceRoot,
+    }
+  );
+}
+
+export async function showHelp() {
+  const packageManagerCommands = getPackageManagerCommand();
+
+  const helpOutput = spawnSync(
+    packageManagerCommands.dlx,
+    ['-y', 'nx-mcp@latest', '--help'],
+    {
+      cwd: workspaceRoot,
+      encoding: 'utf-8',
+    }
+  );
+
+  console.log(helpOutput.stdout?.toString().replaceAll('nx-mcp', 'nx mcp'));
+}

--- a/packages/nx/src/command-line/mcp/mcp.ts
+++ b/packages/nx/src/command-line/mcp/mcp.ts
@@ -5,14 +5,10 @@ import { workspaceRoot } from '../../utils/workspace-root';
 export async function mcpHandler(args: any) {
   const packageManagerCommands = getPackageManagerCommand();
 
-  spawnSync(
-    packageManagerCommands.dlx,
-    ['-y', 'nx-mcp@latest', , ...args['_']],
-    {
-      stdio: 'inherit',
-      cwd: workspaceRoot,
-    }
-  );
+  spawnSync(packageManagerCommands.dlx, ['-y', 'nx-mcp@latest', ...args['_']], {
+    stdio: 'inherit',
+    cwd: workspaceRoot,
+  });
 }
 
 export async function showHelp() {

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -49,6 +49,7 @@ import {
 } from './deprecated/command-objects';
 import { yargsSyncCheckCommand, yargsSyncCommand } from './sync/command-object';
 import { output } from '../utils/output';
+import { yargsMcpCommand } from './mcp/command-object';
 
 // Ensure that the output takes up the available width of the terminal.
 yargs.wrap(yargs.terminalWidth());
@@ -107,6 +108,7 @@ export const commandsObject = yargs
   .command(yargsRecordCommand)
   .command(yargsStartCiRunCommand)
   .command(yargsFixCiCommand)
+  .command(yargsMcpCommand)
   .command(resolveConformanceCommandObject())
   .command(resolveConformanceCheckCommandObject())
   .scriptName('nx')

--- a/scripts/documentation/generators/generate-cli-data.ts
+++ b/scripts/documentation/generators/generate-cli-data.ts
@@ -1,5 +1,5 @@
 import * as chalk from 'chalk';
-import { readFileSync } from 'fs';
+import { copyFileSync, readFileSync } from 'fs';
 import { codeBlock, h1, h2, h3, lines } from 'markdown-factory';
 import { join } from 'path';
 
@@ -25,6 +25,8 @@ const hiddenCommands = [
   // TODO: Introduce custom formatting for such commands, instead of hiding them
   'conformance',
   'conformance:check',
+  // the mcp command only patches through to nx-mcp so there is no relevant information in here
+  'mcp',
 ];
 
 export async function generateCliDocumentation(
@@ -142,6 +144,11 @@ description: "${command.description}"
         templateObject
       );
     })
+  );
+
+  copyFileSync(
+    join(__dirname, '../../../docs/shared/cli/mcp.md'),
+    join(__dirname, '../../../docs/generated/cli/mcp.md')
   );
 
   delete process.env.NX_GENERATE_DOCS_PROCESS;


### PR DESCRIPTION
## Current Behavior
To spin up the MCP server, you have to use the `nx-mcp` package or Nx Console.

## Expected Behavior
As an important feature, it should be possible to spin up the MCP server directly via the `nx` CLI.

