### PR TITLE
feat(core): add tsBuildInfoFile option all packages tsconfig.lib.json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -283,7 +283,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 3,
+  "bust": 1,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/packages/angular/tsconfig.lib.json
+++ b/packages/angular/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "outDir": "../../dist/packages/angular",
     "types": ["node"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "tsBuildInfoFile": "../../dist/packages/angular/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/create-nx-plugin/tsconfig.lib.json
+++ b/packages/create-nx-plugin/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/create-nx-plugin",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/create-nx-plugin/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/create-nx-workspace/tsconfig.lib.json
+++ b/packages/create-nx-workspace/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/create-nx-workspace",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/create-nx-workspace/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/cypress/tsconfig.lib.json
+++ b/packages/cypress/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/cypress",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/cypress/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "include": ["**/*.ts", "**/*.json"],

--- a/packages/detox/tsconfig.lib.json
+++ b/packages/detox/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/detox",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/detox/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "include": ["**/*.ts", "**/*.json"],

--- a/packages/devkit/tsconfig.lib.json
+++ b/packages/devkit/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/devkit",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/devkit/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/esbuild/tsconfig.lib.json
+++ b/packages/esbuild/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/esbuild",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/esbuild/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/eslint-plugin/tsconfig.lib.json
+++ b/packages/eslint-plugin/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "types": ["node"],
     "moduleResolution": "node16",
     "module": "node16",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "tsBuildInfoFile": "../../dist/packages/eslint-plugin/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/eslint/tsconfig.lib.json
+++ b/packages/eslint/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/eslint",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/eslint/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/expo/tsconfig.lib.json
+++ b/packages/expo/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "outDir": "../../dist/packages/expo",
     "types": ["node"],
-    "noEmit": false
+    "noEmit": false,
+    "tsBuildInfoFile": "../../dist/packages/expo/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "include": ["**/*.ts", "**/*.json"],

--- a/packages/express/tsconfig.lib.json
+++ b/packages/express/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/express",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/express/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/gradle/tsconfig.lib.json
+++ b/packages/gradle/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/gradle",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/gradle/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/jest/tsconfig.lib.json
+++ b/packages/jest/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/jest",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/jest/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "include": ["**/*.ts", "**/*.json"],

--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -133,7 +133,7 @@ export class CopyAssetsHandler {
           dot: true, // enable hidden files
           expandDirectories: false,
           // Ignore common directories that should not be copied or processed
-          ignore: ['**/node_modules/**', '**/dist/**', '**/build/**'],
+          ignore: ['**/node_modules/**', '**/.git/**'],
         });
 
         this.callback(this.filesToEvent(files, ag));
@@ -150,12 +150,7 @@ export class CopyAssetsHandler {
         cwd: this.rootDir,
         dot: true, // enable hidden files
         expandDirectories: false,
-        ignore: [
-          '**/node_modules/**',
-          '**/.git/**',
-          '**/dist/**',
-          '**/build/**',
-        ],
+        ignore: ['**/node_modules/**', '**/.git/**'],
       });
 
       this.callback(this.filesToEvent(files, ag));

--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -77,10 +77,13 @@ export class CopyAssetsHandler {
     this.ignore = ignore();
     const gitignore = pathPosix.join(opts.rootDir, '.gitignore');
     const nxignore = pathPosix.join(opts.rootDir, '.nxignore');
-    if (existsSync(gitignore))
+
+    if (existsSync(gitignore)) {
       this.ignore.add(readFileSync(gitignore).toString());
-    if (existsSync(nxignore))
+    }
+    if (existsSync(nxignore)) {
       this.ignore.add(readFileSync(nxignore).toString());
+    }
 
     this.assetGlobs = opts.assets.map((f) => {
       let isGlob = false;
@@ -129,6 +132,8 @@ export class CopyAssetsHandler {
           cwd: this.rootDir,
           dot: true, // enable hidden files
           expandDirectories: false,
+          // Ignore common directories that should not be copied or processed
+          ignore: ['**/node_modules/**', '**/dist/**', '**/build/**'],
         });
 
         this.callback(this.filesToEvent(files, ag));
@@ -145,6 +150,12 @@ export class CopyAssetsHandler {
         cwd: this.rootDir,
         dot: true, // enable hidden files
         expandDirectories: false,
+        ignore: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/dist/**',
+          '**/build/**',
+        ],
       });
 
       this.callback(this.filesToEvent(files, ag));
@@ -173,11 +184,15 @@ export class CopyAssetsHandler {
   }
 
   async processWatchEvents(events: ChangedFile[]): Promise<void> {
+    if (events.length === 0) return;
+
     const fileEvents: FileEvent[] = [];
+
     for (const event of events) {
       const pathFromRoot = event.path.startsWith(this.rootDir)
         ? path.relative(this.rootDir, event.path)
         : event.path;
+
       for (const ag of this.assetGlobs) {
         if (
           picomatch(ag.pattern)(pathFromRoot) &&

--- a/packages/js/tsconfig.lib.json
+++ b/packages/js/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/js",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/js/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/module-federation/tsconfig.lib.json
+++ b/packages/module-federation/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/module-federation",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/module-federation/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "references": [

--- a/packages/nest/tsconfig.lib.json
+++ b/packages/nest/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/nest",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/nest/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/next/tsconfig.lib.json
+++ b/packages/next/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/next",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/next/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/node/tsconfig.lib.json
+++ b/packages/node/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/node",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/node/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/nuxt/tsconfig.lib.json
+++ b/packages/nuxt/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/nuxt",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/nuxt/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/playwright/tsconfig.lib.json
+++ b/packages/playwright/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/playwright",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/playwright/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],

--- a/packages/plugin/tsconfig.lib.json
+++ b/packages/plugin/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/plugin",
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "tsBuildInfoFile": "../../dist/packages/plugin/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/react-native/tsconfig.lib.json
+++ b/packages/react-native/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/react-native",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/react-native/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "include": ["**/*.ts", "**/*.json"],

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/react",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/react/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/remix/tsconfig.lib.json
+++ b/packages/remix/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "outDir": "../../dist/packages/remix",
     "types": ["node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "tsBuildInfoFile": "../../dist/packages/remix/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "include": ["**/*.ts", "**/*.json"],

--- a/packages/rollup/tsconfig.lib.json
+++ b/packages/rollup/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/rollup",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/rollup/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/rsbuild/tsconfig.lib.json
+++ b/packages/rsbuild/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/rsbuild",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/rsbuild/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/rspack/tsconfig.lib.json
+++ b/packages/rspack/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "resolveJsonModule": true,
     "outDir": "../../dist/packages/rspack",
     "esModuleInterop": true,
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/rspack/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/storybook/tsconfig.lib.json
+++ b/packages/storybook/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/storybook",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/storybook/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/vite/tsconfig.lib.json
+++ b/packages/vite/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/vite",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/vite/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/vue/tsconfig.lib.json
+++ b/packages/vue/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/vue",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/vue/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/web/tsconfig.lib.json
+++ b/packages/web/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/web",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/web/tsconfig.tsbuildinfo"
   },
   "exclude": [
     "**/*.spec.ts",

--- a/packages/webpack/tsconfig.lib.json
+++ b/packages/webpack/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/packages/webpack",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/webpack/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts", "**/*.json"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/workspace/tsconfig.lib.json
+++ b/packages/workspace/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/packages/workspace",
-    "types": ["node"]
+    "types": ["node"],
+    "tsBuildInfoFile": "../../dist/packages/workspace/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "include": ["**/*.ts", "*.json"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3621,6 +3621,9 @@ importers:
       '@nx/eslint':
         specifier: workspace:*
         version: link:../../packages/eslint
+      '@nx/js':
+        specifier: workspace:*
+        version: link:../../packages/js
       '@nx/plugin':
         specifier: workspace:*
         version: link:../../packages/plugin

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -8,6 +8,7 @@
     "@nx/devkit": "workspace:*",
     "@nx/eslint": "workspace:*",
     "@nx/plugin": "workspace:*",
+    "@nx/js": "workspace:*",
     "nx": "workspace:*",
     "tslib": "^2.3.0"
   },

--- a/tools/workspace-plugin/tsconfig.json
+++ b/tools/workspace-plugin/tsconfig.json
@@ -10,13 +10,16 @@
       "path": "../../packages/nx"
     },
     {
+      "path": "../../packages/js"
+    },
+    {
       "path": "../../packages/plugin"
     },
     {
-      "path": "../../packages/devkit"
+      "path": "../../packages/eslint"
     },
     {
-      "path": "../../packages/eslint"
+      "path": "../../packages/devkit"
     },
     {
       "path": "./tsconfig.lib.json"

--- a/tools/workspace-plugin/tsconfig.lib.json
+++ b/tools/workspace-plugin/tsconfig.lib.json
@@ -4,13 +4,17 @@
     "outDir": "../../dist/workspace-plugin",
     "declaration": true,
     "types": ["node"],
-    "composite": true
+    "composite": true,
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "references": [
     {
       "path": "../../packages/nx/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/js/tsconfig.lib.json"
     },
     {
       "path": "../../packages/plugin/tsconfig.lib.json"


### PR DESCRIPTION
### Changes
- add `tsBuildInfoFile` option all packages `tsconfig.lib.json`
- fix `legacy-post-build` executor via `copy-asset-handler` to ignore dirs that we won't be copying from to improve glob search efficiency.