### PR TITLE
fix(core): install stylus security placeholder while package is no longer available on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,7 +400,8 @@
   },
   "resolutions": {
     "minimist": "^1.2.6",
-    "underscore": "^1.12.1"
+    "underscore": "^1.12.1",
+    "stylus": "0.0.1-security"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -56,7 +56,7 @@
     "sass-loader": "^16.0.4",
     "source-map-loader": "^5.0.0",
     "style-loader": "^3.3.0",
-    "stylus": "^0.64.0",
+    "stylus": "0.0.1-security",
     "stylus-loader": "^7.1.0",
     "terser-webpack-plugin": "^5.3.3",
     "ts-loader": "^9.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   minimist: ^1.2.6
   underscore: ^1.12.1
+  stylus: 0.0.1-security
 
 patchedDependencies:
   '@tutorialkit/react':
@@ -185,7 +186,7 @@ importers:
         version: 0.2001.0(chokidar@3.6.0)
       '@angular-devkit/build-angular':
         specifier: ~20.1.0
-        version: 20.1.0(89f3d7b9b55613132809ed40b3b7cd81)
+        version: 20.1.0(62585e4a0b00259cd9fa46c08472852e)
       '@angular-devkit/core':
         specifier: ~20.1.0
         version: 20.1.0(chokidar@3.6.0)
@@ -203,7 +204,7 @@ importers:
         version: 20.0.0(eslint@8.57.0)(typescript@5.8.3)
       '@angular/build':
         specifier: ~20.1.0
-        version: 20.1.0(b1545f5794ff02cb6e21135ada012136)
+        version: 20.1.0(5f53fde980468d08bd336085cadb86e7)
       '@angular/cli':
         specifier: ~20.1.0
         version: 20.1.0(@types/node@20.16.10)(chokidar@3.6.0)
@@ -230,7 +231,7 @@ importers:
         version: 0.7.0(prettier-plugin-astro@0.14.1)(prettier@2.8.8)(typescript@5.8.3)
       '@astrojs/react':
         specifier: ^3.6.2
-        version: 3.6.3(@types/node@20.16.10)(@types/react-dom@18.3.0)(@types/react@18.3.1)(less@4.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
+        version: 3.6.3(@types/node@20.16.10)(@types/react-dom@18.3.0)(@types/react@18.3.1)(less@4.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
       '@babel/core':
         specifier: ^7.23.2
         version: 7.28.0
@@ -329,7 +330,7 @@ importers:
         version: 3.17.6
       '@nx/angular':
         specifier: 21.4.0-beta.0
-        version: 21.4.0-beta.0(fd32c48f9a9cf74862ce326916a6740e)
+        version: 21.4.0-beta.0(0eeba5333542e3a7f870c29b24b796c8)
       '@nx/conformance':
         specifier: 3.0.0
         version: 3.0.0(@nx/js@21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0)))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
@@ -365,7 +366,7 @@ importers:
         version: 3.0.0
       '@nx/next':
         specifier: 21.4.0-beta.0
-        version: 21.4.0-beta.0(c92698ad86b49125b09cf27f1e563725)
+        version: 21.4.0-beta.0(7c19fee2d822a5072bf7b94b0a653047)
       '@nx/playwright':
         specifier: 21.4.0-beta.0
         version: 21.4.0-beta.0(@babel/traverse@7.28.0)(@playwright/test@1.54.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
@@ -374,7 +375,7 @@ importers:
         version: 3.0.0
       '@nx/react':
         specifier: 21.4.0-beta.0
-        version: 21.4.0-beta.0(d73a9c6dc81b0c1809c10cabeca94e95)
+        version: 21.4.0-beta.0(11515913dda0c56e37dcc4ddff3c3fef)
       '@nx/rsbuild':
         specifier: 21.4.0-beta.0
         version: 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
@@ -386,7 +387,7 @@ importers:
         version: 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@zkochan/js-yaml@0.0.7)(cypress@14.3.0)(eslint@8.57.0)(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
       '@nx/vite':
         specifier: 21.4.0-beta.0
-        version: 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+        version: 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@nx/web':
         specifier: 21.4.0-beta.0
         version: 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
@@ -410,7 +411,7 @@ importers:
         version: 1.9.0(react-redux@8.0.5(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
       '@remix-run/dev':
         specifier: ^2.14.0
-        version: 2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)
+        version: 2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)
       '@remix-run/node':
         specifier: ^2.14.0
         version: 2.16.8(typescript@5.8.3)
@@ -458,7 +459,7 @@ importers:
         version: 9.0.16(@types/react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))
       '@storybook/react-vite':
         specifier: 9.0.6
-        version: 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.44.2)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+        version: 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.44.2)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@storybook/react-webpack5':
         specifier: 9.0.6
         version: 9.0.6(@rspack/core@1.3.9(@swc/helpers@0.5.11))(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(typescript@5.8.3)(webpack-cli@5.1.4)
@@ -491,13 +492,13 @@ importers:
         version: 15.0.6(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tutorialkit/astro':
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.16.10)(@types/react-dom@18.3.0)(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3))(less@4.1.3)(postcss@8.4.38)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+        version: 1.5.0(@types/node@20.16.10)(@types/react-dom@18.3.0)(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3))(less@4.1.3)(postcss@8.4.38)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@tutorialkit/react':
         specifier: 1.5.0
-        version: 1.5.0(patch_hash=0565a97dd74124a40392026eb37726a1a0566f9d594653066a3086f23b051732)(@types/react-dom@18.3.0)(@types/react@18.3.1)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+        version: 1.5.0(patch_hash=0565a97dd74124a40392026eb37726a1a0566f9d594653066a3086f23b051732)(@types/react-dom@18.3.0)(@types/react@18.3.1)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@tutorialkit/theme':
         specifier: 1.5.0
-        version: 1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+        version: 1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@tutorialkit/types':
         specifier: 1.5.0
         version: 1.5.0
@@ -584,7 +585,7 @@ importers:
         version: 8.36.0(eslint@8.57.0)(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.6.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+        version: 4.6.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@webcontainer/api':
         specifier: 1.5.1
         version: 1.5.1
@@ -611,7 +612,7 @@ importers:
         version: 20.0.0(chokidar@3.6.0)(eslint@8.57.0)(typescript-eslint@8.36.0(eslint@8.57.0)(typescript@5.8.3))(typescript@5.8.3)
       astro:
         specifier: 4.15.0
-        version: 4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)
+        version: 4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)
       autoprefixer:
         specifier: 10.4.13
         version: 10.4.13(postcss@8.4.38)
@@ -884,7 +885,7 @@ importers:
         version: 11.0.1
       nuxt:
         specifier: ^3.10.0
-        version: 3.17.6(@parcel/watcher@2.5.1)(@types/node@20.16.10)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@8.57.0)(ioredis@5.6.1)(less@4.1.3)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)
+        version: 3.17.6(@parcel/watcher@2.5.1)(@types/node@20.16.10)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@8.57.0)(ioredis@5.6.1)(less@4.1.3)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)
       nx:
         specifier: 21.4.0-beta.0
         version: 21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
@@ -1052,10 +1053,10 @@ importers:
         version: 6.0.5(encoding@0.1.13)(typanion@3.14.0)
       vite:
         specifier: 6.2.0
-        version: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+        version: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       webpack:
         specifier: 5.99.9
         version: 5.99.9(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4)
@@ -2098,7 +2099,7 @@ importers:
     dependencies:
       '@angular-devkit/build-angular':
         specifier: '>= 18.0.0 < 21.0.0'
-        version: 20.1.0(d70dc18ae7bd614927c32b82e879dcf8)
+        version: 20.1.0(74fac17c150dde57517840d05286920d)
       '@angular-devkit/core':
         specifier: '>= 18.0.0 < 21.0.0'
         version: 20.1.0(chokidar@4.0.3)
@@ -2107,7 +2108,7 @@ importers:
         version: 20.1.0(chokidar@4.0.3)
       '@angular/build':
         specifier: '>= 18.0.0 < 21.0.0'
-        version: 20.1.0(729dc699c0ced7bc1c56fe1393b93045)
+        version: 20.1.0(73c36bd526f97a2e955792001d4a3c16)
       '@nx/devkit':
         specifier: workspace:*
         version: link:../devkit
@@ -3147,7 +3148,7 @@ importers:
         version: 5.0.1(typescript@5.8.3)
       '@remix-run/dev':
         specifier: ^2.14.0
-        version: 2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)
+        version: 2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)
       tslib:
         specifier: ^2.3.1
         version: 2.8.1
@@ -3407,10 +3408,10 @@ importers:
         version: 4.2.0
       vite:
         specifier: ^5.0.0 || ^6.0.0
-        version: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+        version: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       vitest:
         specifier: ^1.3.1 || ^2.0.0 || ^3.0.0
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     devDependencies:
       nx:
         specifier: workspace:*
@@ -3556,11 +3557,11 @@ importers:
         specifier: ^3.3.0
         version: 3.3.4(webpack@5.99.9)
       stylus:
-        specifier: ^0.64.0
-        version: 0.64.0
+        specifier: 0.0.1-security
+        version: 0.0.1-security
       stylus-loader:
         specifier: ^7.1.0
-        version: 7.1.3(stylus@0.64.0)(webpack@5.99.9)
+        version: 7.1.3(stylus@0.0.1-security)(webpack@5.99.9)
       terser-webpack-plugin:
         specifier: ^5.3.3
         version: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack@5.99.9)
@@ -3651,9 +3652,6 @@ packages:
 
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
-
-  '@adobe/css-tools@4.3.3':
-    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
 
   '@adobe/css-tools@4.4.3':
     resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
@@ -20882,13 +20880,11 @@ packages:
     resolution: {integrity: sha512-TY0SKwiY7D2kMd3UxaWKSf3xHF0FFN/FAfsSqfrhxRT/koXTwffq2cgEWDkLQz7VojMu7qEEHt5TlMjkPx9UDw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      stylus: '>=0.52.4'
+      stylus: 0.0.1-security
       webpack: ^5.0.0
 
-  stylus@0.64.0:
-    resolution: {integrity: sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==}
-    engines: {node: '>=16'}
-    hasBin: true
+  stylus@0.0.1-security:
+    resolution: {integrity: sha512-qTLX5NJwuj5dqdJyi1eAjXGE4HfjWDoPLbSIpYWn/rAEdiyZnsngS/Yj0BRjM7wC41e/+spK4QCXFqz7LM0fFQ==}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -22120,7 +22116,7 @@ packages:
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
-      stylus: '*'
+      stylus: 0.0.1-security
       sugarss: '*'
       terser: ^5.4.0
     peerDependenciesMeta:
@@ -22152,7 +22148,7 @@ packages:
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
-      stylus: '*'
+      stylus: 0.0.1-security
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
@@ -22192,7 +22188,7 @@ packages:
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
-      stylus: '*'
+      stylus: 0.0.1-security
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
@@ -22232,7 +22228,7 @@ packages:
       lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
+      stylus: 0.0.1-security
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
@@ -23007,8 +23003,6 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
-  '@adobe/css-tools@4.3.3': {}
-
   '@adobe/css-tools@4.4.3': {}
 
   '@ai-sdk/provider-utils@1.0.22(zod@3.25.76)':
@@ -23199,13 +23193,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@20.1.0(89f3d7b9b55613132809ed40b3b7cd81)':
+  '@angular-devkit/build-angular@20.1.0(62585e4a0b00259cd9fa46c08472852e)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2001.0(chokidar@3.6.0)
       '@angular-devkit/build-webpack': 0.2001.0(chokidar@3.6.0)(webpack-dev-server@5.2.2(webpack-cli@5.1.4)(webpack@5.99.9))(webpack@5.99.9)
       '@angular-devkit/core': 20.1.0(chokidar@3.6.0)
-      '@angular/build': 20.1.0(a333a619fd6a087202c78e7ca7a5e2d1)
+      '@angular/build': 20.1.0(4d90956f7fd55f12bac62110cc0c61da)
       '@angular/compiler-cli': 20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3)
       '@babel/core': 7.27.7
       '@babel/generator': 7.27.5
@@ -23288,13 +23282,13 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-angular@20.1.0(d70dc18ae7bd614927c32b82e879dcf8)':
+  '@angular-devkit/build-angular@20.1.0(74fac17c150dde57517840d05286920d)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2001.0(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.2001.0(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack-cli@5.1.4(webpack-dev-server@5.2.1)(webpack@5.99.9))(webpack@5.99.9(@swc/core@1.5.7(@swc/helpers@0.5.17))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.1)(webpack@5.99.9))))(webpack@5.99.9(@swc/core@1.5.7(@swc/helpers@0.5.17))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.1)(webpack@5.99.9)))
       '@angular-devkit/core': 20.1.0(chokidar@4.0.3)
-      '@angular/build': 20.1.0(729dc699c0ced7bc1c56fe1393b93045)
+      '@angular/build': 20.1.0(73c36bd526f97a2e955792001d4a3c16)
       '@angular/compiler-cli': 20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3)
       '@babel/core': 7.27.7
       '@babel/generator': 7.27.5
@@ -23572,61 +23566,7 @@ snapshots:
       eslint: 8.57.0
       typescript: 5.8.3
 
-  '@angular/build@20.1.0(729dc699c0ced7bc1c56fe1393b93045)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2001.0(chokidar@4.0.3)
-      '@angular/compiler': 20.1.0
-      '@angular/compiler-cli': 20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3)
-      '@babel/core': 7.27.7
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.13(@types/node@20.16.10)
-      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
-      beasties: 0.3.4
-      browserslist: 4.25.1
-      esbuild: 0.25.5
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      listr2: 8.3.3
-      magic-string: 0.30.17
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 7.1.0
-      picomatch: 4.0.2
-      piscina: 5.1.2
-      rollup: 4.44.1
-      sass: 1.89.2
-      semver: 7.7.2
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.14
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      watchpack: 2.4.4
-    optionalDependencies:
-      '@angular/core': 20.1.0(@angular/compiler@20.1.0)(rxjs@7.8.2)
-      '@angular/platform-browser': 20.1.0(@angular/common@20.1.0(@angular/core@20.1.0(@angular/compiler@20.1.0)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.1.0(@angular/compiler@20.1.0)(rxjs@7.8.2))
-      less: 4.3.0
-      lmdb: 3.4.1
-      ng-packagr: 20.1.0(@angular/compiler-cli@20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3))(tailwindcss@3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.8.3)))(tslib@2.8.1)(typescript@5.8.3)
-      postcss: 8.5.6
-      tailwindcss: 3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.8.3))
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@angular/build@20.1.0(a333a619fd6a087202c78e7ca7a5e2d1)':
+  '@angular/build@20.1.0(4d90956f7fd55f12bac62110cc0c61da)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2001.0(chokidar@3.6.0)
@@ -23636,7 +23576,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.13(@types/node@20.16.10)
-      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       beasties: 0.3.4
       browserslist: 4.25.1
       esbuild: 0.25.5
@@ -23656,7 +23596,7 @@ snapshots:
       tinyglobby: 0.2.14
       tslib: 2.8.1
       typescript: 5.8.3
-      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       watchpack: 2.4.4
     optionalDependencies:
       '@angular/core': 20.1.0(@angular/compiler@20.1.0)(rxjs@7.8.2)
@@ -23666,7 +23606,7 @@ snapshots:
       ng-packagr: 20.1.0(@angular/compiler-cli@20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3))(tailwindcss@3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3)))(tslib@2.8.1)(typescript@5.8.3)
       postcss: 8.5.6
       tailwindcss: 3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3))
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -23680,7 +23620,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@20.1.0(b1545f5794ff02cb6e21135ada012136)':
+  '@angular/build@20.1.0(5f53fde980468d08bd336085cadb86e7)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2001.0(chokidar@3.6.0)
@@ -23690,7 +23630,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.13(@types/node@20.16.10)
-      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       beasties: 0.3.4
       browserslist: 4.25.1
       esbuild: 0.25.5
@@ -23710,7 +23650,7 @@ snapshots:
       tinyglobby: 0.2.14
       tslib: 2.8.1
       typescript: 5.8.3
-      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       watchpack: 2.4.4
     optionalDependencies:
       '@angular/core': 20.1.0(@angular/compiler@20.1.0)(rxjs@7.8.2)
@@ -23720,7 +23660,61 @@ snapshots:
       ng-packagr: 20.1.0(@angular/compiler-cli@20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3))(tailwindcss@3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3)))(tslib@2.8.1)(typescript@5.8.3)
       postcss: 8.4.38
       tailwindcss: 3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3))
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - chokidar
+      - jiti
+      - lightningcss
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  '@angular/build@20.1.0(73c36bd526f97a2e955792001d4a3c16)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.2001.0(chokidar@4.0.3)
+      '@angular/compiler': 20.1.0
+      '@angular/compiler-cli': 20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3)
+      '@babel/core': 7.27.7
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@inquirer/confirm': 5.1.13(@types/node@20.16.10)
+      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
+      beasties: 0.3.4
+      browserslist: 4.25.1
+      esbuild: 0.25.5
+      https-proxy-agent: 7.0.6
+      istanbul-lib-instrument: 6.0.3
+      jsonc-parser: 3.3.1
+      listr2: 8.3.3
+      magic-string: 0.30.17
+      mrmime: 2.0.1
+      parse5-html-rewriting-stream: 7.1.0
+      picomatch: 4.0.2
+      piscina: 5.1.2
+      rollup: 4.44.1
+      sass: 1.89.2
+      semver: 7.7.2
+      source-map-support: 0.5.21
+      tinyglobby: 0.2.14
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      watchpack: 2.4.4
+    optionalDependencies:
+      '@angular/core': 20.1.0(@angular/compiler@20.1.0)(rxjs@7.8.2)
+      '@angular/platform-browser': 20.1.0(@angular/common@20.1.0(@angular/core@20.1.0(@angular/compiler@20.1.0)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.1.0(@angular/compiler@20.1.0)(rxjs@7.8.2))
+      less: 4.3.0
+      lmdb: 3.4.1
+      ng-packagr: 20.1.0(@angular/compiler-cli@20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3))(tailwindcss@3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.8.3)))(tslib@2.8.1)(typescript@5.8.3)
+      postcss: 8.5.6
+      tailwindcss: 3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.8.3))
+      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -23918,12 +23912,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@3.1.9(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3))':
+  '@astrojs/mdx@3.1.9(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 5.3.0
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       acorn: 8.15.0
-      astro: 4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)
+      astro: 4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       gray-matter: 4.0.3
@@ -23942,15 +23936,15 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@3.6.3(@types/node@20.16.10)(@types/react-dom@18.3.0)(@types/react@18.3.1)(less@4.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)':
+  '@astrojs/react@3.6.3(@types/node@20.16.10)(@types/react-dom@18.3.0)(@types/react@18.3.1)(less@4.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)':
     dependencies:
       '@types/react': 18.3.1
       '@types/react-dom': 18.3.0
-      '@vitejs/plugin-react': 4.6.0(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1))
+      '@vitejs/plugin-react': 4.6.0(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       ultrahtml: 1.6.0
-      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -23962,15 +23956,15 @@ snapshots:
       - supports-color
       - terser
 
-  '@astrojs/react@3.6.3(@types/node@20.16.10)(@types/react-dom@18.3.0)(@types/react@18.3.23)(less@4.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)':
+  '@astrojs/react@3.6.3(@types/node@20.16.10)(@types/react-dom@18.3.0)(@types/react@18.3.23)(less@4.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)':
     dependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.0
-      '@vitejs/plugin-react': 4.6.0(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1))
+      '@vitejs/plugin-react': 4.6.0(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       ultrahtml: 1.6.0
-      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -27022,12 +27016,12 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.0(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.0(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.17
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -28371,11 +28365,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@2.6.2(magicast@0.3.5)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@nuxt/devtools-kit@2.6.2(magicast@0.3.5)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@nuxt/kit': 3.17.6(magicast@0.3.5)
       execa: 8.0.1
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - magicast
 
@@ -28390,12 +28384,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.2
 
-  '@nuxt/devtools@2.6.2(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
+  '@nuxt/devtools@2.6.2(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
-      '@nuxt/devtools-kit': 2.6.2(magicast@0.3.5)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@nuxt/devtools-kit': 2.6.2(magicast@0.3.5)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@nuxt/devtools-wizard': 2.6.2
       '@nuxt/kit': 3.17.6(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.7(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
+      '@vue/devtools-core': 7.7.7(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
       '@vue/devtools-kit': 7.7.7
       birpc: 2.4.0
       consola: 3.4.2
@@ -28420,9 +28414,9 @@ snapshots:
       sirv: 3.0.1
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.14
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      vite-plugin-inspect: 11.3.0(@nuxt/kit@3.17.6(magicast@0.3.5))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
-      vite-plugin-vue-tracer: 1.0.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      vite-plugin-inspect: 11.3.0(@nuxt/kit@3.17.6(magicast@0.3.5))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
+      vite-plugin-vue-tracer: 1.0.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -28483,12 +28477,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@3.17.6(@types/node@20.16.10)(eslint@8.57.0)(less@4.1.3)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.8.0)':
+  '@nuxt/vite-builder@3.17.6(@types/node@20.16.10)(eslint@8.57.0)(less@4.1.3)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.8.0)':
     dependencies:
       '@nuxt/kit': 3.17.6(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.44.2)
-      '@vitejs/plugin-vue': 5.2.4(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
-      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
+      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.0.7(postcss@8.5.6)
@@ -28513,9 +28507,9 @@ snapshots:
       std-env: 3.9.0
       ufo: 1.6.1
       unenv: 2.0.0-rc.18
-      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      vite-plugin-checker: 0.9.3(eslint@8.57.0)(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      vite-plugin-checker: 0.9.3(eslint@8.57.0)(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       vue: 3.5.17(typescript@5.8.3)
       vue-bundle-renderer: 2.1.1
     transitivePeerDependencies:
@@ -28551,7 +28545,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nx/angular@21.4.0-beta.0(fd32c48f9a9cf74862ce326916a6740e)':
+  '@nx/angular@21.4.0-beta.0(0eeba5333542e3a7f870c29b24b796c8)':
     dependencies:
       '@angular-devkit/core': 20.1.0(chokidar@3.6.0)
       '@angular-devkit/schematics': 20.1.0(chokidar@3.6.0)
@@ -28575,8 +28569,8 @@ snapshots:
       tslib: 2.8.1
       webpack-merge: 5.10.0
     optionalDependencies:
-      '@angular-devkit/build-angular': 20.1.0(89f3d7b9b55613132809ed40b3b7cd81)
-      '@angular/build': 20.1.0(b1545f5794ff02cb6e21135ada012136)
+      '@angular-devkit/build-angular': 20.1.0(62585e4a0b00259cd9fa46c08472852e)
+      '@angular/build': 20.1.0(5f53fde980468d08bd336085cadb86e7)
       ng-packagr: 20.1.0(@angular/compiler-cli@20.1.0(@angular/compiler@20.1.0)(typescript@5.8.3))(tailwindcss@3.4.4(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3)))(tslib@2.8.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -28935,13 +28929,13 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/next@21.4.0-beta.0(c92698ad86b49125b09cf27f1e563725)':
+  '@nx/next@21.4.0-beta.0(7c19fee2d822a5072bf7b94b0a653047)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.0)
       '@nx/devkit': 21.4.0-beta.0(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/eslint': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/react': 21.4.0-beta.0(d73a9c6dc81b0c1809c10cabeca94e95)
+      '@nx/react': 21.4.0-beta.0(11515913dda0c56e37dcc4ddff3c3fef)
       '@nx/web': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
       '@nx/webpack': 21.4.0-beta.0(@babel/traverse@7.28.0)(@rspack/core@1.3.9(@swc/helpers@0.5.11))(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(html-webpack-plugin@5.5.0(webpack@5.99.9))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(webpack-cli@5.1.4)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
@@ -29119,14 +29113,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@nx/react@21.4.0-beta.0(d73a9c6dc81b0c1809c10cabeca94e95)':
+  '@nx/react@21.4.0-beta.0(11515913dda0c56e37dcc4ddff3c3fef)':
     dependencies:
       '@nx/devkit': 21.4.0-beta.0(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/eslint': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
       '@nx/module-federation': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)(esbuild@0.25.0)(next@14.2.28(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.55.0))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(webpack-cli@5.1.4)
       '@nx/rollup': 21.4.0-beta.0(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/babel__core@7.20.5)(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vite': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@nx/vite': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@nx/web': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       '@svgr/webpack': 8.1.0(typescript@5.8.3)
@@ -29298,7 +29292,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@nx/vite@21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.8.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@nx/devkit': 21.4.0-beta.0(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/js': 21.4.0-beta.0(@babel/traverse@7.28.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@21.4.0-beta.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
@@ -29309,8 +29303,8 @@ snapshots:
       picomatch: 4.0.2
       semver: 7.7.2
       tsconfig-paths: 4.2.0
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -29368,8 +29362,8 @@ snapshots:
       sass-loader: 16.0.5(@rspack/core@1.3.9(@swc/helpers@0.5.11))(sass-embedded@1.85.1)(sass@1.89.2)(webpack@5.99.9)
       source-map-loader: 5.0.0(webpack@5.99.9)
       style-loader: 3.3.4(webpack@5.99.9)
-      stylus: 0.64.0
-      stylus-loader: 7.1.3(stylus@0.64.0)(webpack@5.99.9)
+      stylus: 0.0.1-security
+      stylus-loader: 7.1.3(stylus@0.0.1-security)(webpack@5.99.9)
       terser-webpack-plugin: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack@5.99.9)
       ts-loader: 9.5.2(typescript@5.8.3)(webpack@5.99.9)
       tsconfig-paths-webpack-plugin: 4.0.0
@@ -30687,7 +30681,7 @@ snapshots:
       react: 18.3.1
       react-redux: 8.0.5(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)
 
-  '@remix-run/dev@2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)':
+  '@remix-run/dev@2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/generator': 7.28.0
@@ -30704,7 +30698,7 @@ snapshots:
       '@remix-run/router': 1.23.0
       '@remix-run/server-runtime': 2.16.8(typescript@5.8.3)
       '@types/mdx': 2.0.13
-      '@vanilla-extract/integration': 6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
+      '@vanilla-extract/integration': 6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -30744,11 +30738,11 @@ snapshots:
       tar-fs: 2.1.3
       tsconfig-paths: 4.2.0
       valibot: 0.41.0(typescript@5.8.3)
-      vite-node: 3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       ws: 7.5.10
     optionalDependencies:
       typescript: 5.8.3
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -30768,7 +30762,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@remix-run/dev@2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)':
+  '@remix-run/dev@2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.8.3))(typescript@5.8.3)(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/generator': 7.28.0
@@ -30785,7 +30779,7 @@ snapshots:
       '@remix-run/router': 1.23.0
       '@remix-run/server-runtime': 2.16.8(typescript@5.8.3)
       '@types/mdx': 2.0.13
-      '@vanilla-extract/integration': 6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)
+      '@vanilla-extract/integration': 6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -30825,11 +30819,11 @@ snapshots:
       tar-fs: 2.1.3
       tsconfig-paths: 4.2.0
       valibot: 0.41.0(typescript@5.8.3)
-      vite-node: 3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       ws: 7.5.10
     optionalDependencies:
       typescript: 5.8.3
-      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -31487,12 +31481,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/builder-vite@9.0.6(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@storybook/builder-vite@9.0.6(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@storybook/csf-plugin': 9.0.6(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))
       storybook: 9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8)
       ts-dedent: 2.2.0
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
 
   '@storybook/builder-webpack5@9.0.6(@rspack/core@1.3.9(@swc/helpers@0.5.11))(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(typescript@5.8.3)(webpack-cli@5.1.4)':
     dependencies:
@@ -31609,11 +31603,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8)
 
-  '@storybook/react-vite@9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.44.2)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@storybook/react-vite@9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.44.2)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.0(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.0(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
-      '@storybook/builder-vite': 9.0.6(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@storybook/builder-vite': 9.0.6(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@storybook/react': 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8))(typescript@5.8.3)
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -31623,7 +31617,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 9.0.6(@testing-library/dom@10.4.0)(prettier@2.8.8)
       tsconfig-paths: 4.2.0
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -32051,23 +32045,23 @@ snapshots:
       '@tufjs/canonical-json': 2.0.0
       minimatch: 9.0.5
 
-  '@tutorialkit/astro@1.5.0(@types/node@20.16.10)(@types/react-dom@18.3.0)(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3))(less@4.1.3)(postcss@8.4.38)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@tutorialkit/astro@1.5.0(@types/node@20.16.10)(@types/react-dom@18.3.0)(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3))(less@4.1.3)(postcss@8.4.38)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
-      '@astrojs/mdx': 3.1.9(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3))
-      '@astrojs/react': 3.6.3(@types/node@20.16.10)(@types/react-dom@18.3.0)(@types/react@18.3.23)(less@4.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
+      '@astrojs/mdx': 3.1.9(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3))
+      '@astrojs/react': 3.6.3(@types/node@20.16.10)(@types/react-dom@18.3.0)(@types/react@18.3.23)(less@4.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
       '@expressive-code/plugin-collapsible-sections': 0.35.6
       '@expressive-code/plugin-line-numbers': 0.35.6
       '@nanostores/react': 0.7.2(nanostores@0.10.3)(react@18.3.1)
       '@stackblitz/sdk': 1.11.0
-      '@tutorialkit/react': 1.5.0(patch_hash=0565a97dd74124a40392026eb37726a1a0566f9d594653066a3086f23b051732)(@types/react-dom@18.3.0)(@types/react@18.3.23)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@tutorialkit/react': 1.5.0(patch_hash=0565a97dd74124a40392026eb37726a1a0566f9d594653066a3086f23b051732)(@types/react-dom@18.3.0)(@types/react@18.3.23)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@tutorialkit/runtime': 1.5.0
-      '@tutorialkit/theme': 1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@tutorialkit/theme': 1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@tutorialkit/types': 1.5.0
       '@types/react': 18.3.23
       '@unocss/reset': 0.62.4
       '@webcontainer/api': 1.5.1
-      astro: 4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)
-      astro-expressive-code: 0.35.6(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3))
+      astro: 4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)
+      astro-expressive-code: 0.35.6(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3))
       chokidar: 3.6.0
       fast-glob: 3.3.3
       front-matter: 4.0.2
@@ -32081,7 +32075,7 @@ snapshots:
       remark-directive: 3.0.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      unocss: 0.59.4(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      unocss: 0.59.4(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       zod: 3.23.8
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -32100,7 +32094,7 @@ snapshots:
       - terser
       - vite
 
-  '@tutorialkit/react@1.5.0(patch_hash=0565a97dd74124a40392026eb37726a1a0566f9d594653066a3086f23b051732)(@types/react-dom@18.3.0)(@types/react@18.3.1)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@tutorialkit/react@1.5.0(patch_hash=0565a97dd74124a40392026eb37726a1a0566f9d594653066a3086f23b051732)(@types/react-dom@18.3.0)(@types/react@18.3.1)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.1
@@ -32125,7 +32119,7 @@ snapshots:
       '@radix-ui/react-dialog': 1.1.14(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@replit/codemirror-lang-svelte': 6.0.0(@codemirror/autocomplete@6.18.6)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.4)(@codemirror/language@6.11.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.0)(@lezer/common@1.2.3)(@lezer/highlight@1.2.1)(@lezer/javascript@1.5.1)(@lezer/lr@1.4.2)
       '@tutorialkit/runtime': 1.5.0
-      '@tutorialkit/theme': 1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@tutorialkit/theme': 1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@webcontainer/api': 1.5.1
       '@xterm/addon-fit': 0.10.0(@xterm/xterm@5.5.0)
       '@xterm/addon-web-links': 0.11.0(@xterm/xterm@5.5.0)
@@ -32147,7 +32141,7 @@ snapshots:
       - supports-color
       - vite
 
-  '@tutorialkit/react@1.5.0(patch_hash=0565a97dd74124a40392026eb37726a1a0566f9d594653066a3086f23b051732)(@types/react-dom@18.3.0)(@types/react@18.3.23)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@tutorialkit/react@1.5.0(patch_hash=0565a97dd74124a40392026eb37726a1a0566f9d594653066a3086f23b051732)(@types/react-dom@18.3.0)(@types/react@18.3.23)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.1
@@ -32172,7 +32166,7 @@ snapshots:
       '@radix-ui/react-dialog': 1.1.14(@types/react-dom@18.3.0)(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@replit/codemirror-lang-svelte': 6.0.0(@codemirror/autocomplete@6.18.6)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.4)(@codemirror/language@6.11.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.0)(@lezer/common@1.2.3)(@lezer/highlight@1.2.1)(@lezer/javascript@1.5.1)(@lezer/lr@1.4.2)
       '@tutorialkit/runtime': 1.5.0
-      '@tutorialkit/theme': 1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@tutorialkit/theme': 1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@webcontainer/api': 1.5.1
       '@xterm/addon-fit': 0.10.0(@xterm/xterm@5.5.0)
       '@xterm/addon-web-links': 0.11.0(@xterm/xterm@5.5.0)
@@ -32201,12 +32195,12 @@ snapshots:
       nanostores: 0.10.3
       picomatch: 4.0.2
 
-  '@tutorialkit/theme@1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@tutorialkit/theme@1.5.0(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@iconify-json/ph': 1.2.2
       '@iconify-json/svg-spinners': 1.2.2
       fast-glob: 3.3.3
-      unocss: 0.59.4(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      unocss: 0.59.4(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
     transitivePeerDependencies:
       - '@unocss/webpack'
       - postcss
@@ -32766,13 +32760,13 @@ snapshots:
       unhead: 2.0.12
       vue: 3.5.17(typescript@5.8.3)
 
-  '@unocss/astro@0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@unocss/astro@0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@unocss/core': 0.59.4
       '@unocss/reset': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@unocss/vite': 0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
     optionalDependencies:
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - rollup
 
@@ -32905,7 +32899,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.59.4
 
-  '@unocss/vite@0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@unocss/vite@0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
@@ -32917,7 +32911,7 @@ snapshots:
       chokidar: 3.6.0
       fast-glob: 3.3.3
       magic-string: 0.30.17
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - rollup
 
@@ -33010,7 +33004,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@vanilla-extract/integration@6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)':
+  '@vanilla-extract/integration@6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.0)
@@ -33023,8 +33017,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.7.4
       outdent: 0.8.0
-      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
-      vite-node: 1.6.1(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
+      vite-node: 1.6.1(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -33037,7 +33031,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/integration@6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)':
+  '@vanilla-extract/integration@6.5.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.0)
@@ -33050,8 +33044,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.7.4
       outdent: 0.8.0
-      vite: 5.4.19(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)
-      vite-node: 1.6.1(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)
+      vite-node: 1.6.1(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -33247,27 +33241,15 @@ snapshots:
       minimatch: 7.4.6
       semver: 7.6.3
 
-  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
-      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
 
-  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
-      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
 
-  '@vitejs/plugin-react@4.6.0(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1))':
-    dependencies:
-      '@babel/core': 7.28.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
-      '@rolldown/pluginutils': 1.0.0-beta.19
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitejs/plugin-react@4.6.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@vitejs/plugin-react@4.6.0(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -33275,24 +33257,36 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.19
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
+  '@vitejs/plugin-react@4.6.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
+      '@rolldown/pluginutils': 1.0.0-beta.19
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@rolldown/pluginutils': 1.0.0-beta.26
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.28.0)
-      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       vue: 3.5.17(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
-      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       vue: 3.5.17(typescript@5.8.3)
 
   '@vitest/expect@3.0.5':
@@ -33309,21 +33303,21 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@vitest/mocker@3.0.5(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
 
-  '@vitest/mocker@3.0.5(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))':
+  '@vitest/mocker@3.0.5(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.0.5':
     dependencies:
@@ -33489,14 +33483,14 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.7.7(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
+  '@vue/devtools-core@7.7.7(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
       mitt: 3.0.1
       nanoid: 5.1.5
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      vite-hot-client: 2.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       vue: 3.5.17(typescript@5.8.3)
     transitivePeerDependencies:
       - vite
@@ -34202,12 +34196,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.35.6(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)):
+  astro-expressive-code@0.35.6(astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)):
     dependencies:
-      astro: 4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)
+      astro: 4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)
       rehype-expressive-code: 0.35.6
 
-  astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3):
+  astro@4.15.0(@types/node@20.16.10)(less@4.1.3)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.4.1
@@ -34266,8 +34260,8 @@ snapshots:
       tsconfck: 3.1.6(typescript@5.8.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
-      vitefu: 0.2.5(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1))
+      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
+      vitefu: 0.2.5(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1))
       which-pm: 3.0.1
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -42704,15 +42698,15 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@3.17.6(@parcel/watcher@2.5.1)(@types/node@20.16.10)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@8.57.0)(ioredis@5.6.1)(less@4.1.3)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0):
+  nuxt@3.17.6(@parcel/watcher@2.5.1)(@types/node@20.16.10)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@8.57.0)(ioredis@5.6.1)(less@4.1.3)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0):
     dependencies:
       '@nuxt/cli': 3.25.1(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.6.2(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
+      '@nuxt/devtools': 2.6.2(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
       '@nuxt/kit': 3.17.6(magicast@0.3.5)
       '@nuxt/schema': 3.17.6
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.17.6(@types/node@20.16.10)(eslint@8.57.0)(less@4.1.3)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.8.0)
+      '@nuxt/vite-builder': 3.17.6(@types/node@20.16.10)(eslint@8.57.0)(less@4.1.3)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.8.0)
       '@unhead/vue': 2.0.12(vue@3.5.17(typescript@5.8.3))
       '@vue/shared': 3.5.17
       c12: 3.0.4(magicast@0.3.5)
@@ -45696,7 +45690,8 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.1
 
-  sax@1.4.1: {}
+  sax@1.4.1:
+    optional: true
 
   saxes@6.0.0:
     dependencies:
@@ -46572,22 +46567,14 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
-  stylus-loader@7.1.3(stylus@0.64.0)(webpack@5.99.9):
+  stylus-loader@7.1.3(stylus@0.0.1-security)(webpack@5.99.9):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       webpack: 5.99.9(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  stylus@0.64.0:
-    dependencies:
-      '@adobe/css-tools': 4.3.3
-      debug: 4.4.1(supports-color@8.1.1)
-      glob: 10.4.5
-      sax: 1.4.1
-      source-map: 0.7.4
-    transitivePeerDependencies:
-      - supports-color
+  stylus@0.0.1-security: {}
 
   sucrase@3.35.0:
     dependencies:
@@ -47619,9 +47606,9 @@ snapshots:
     dependencies:
       normalize-path: 2.1.1
 
-  unocss@0.59.4(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)):
+  unocss@0.59.4(postcss@8.4.38)(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
-      '@unocss/astro': 0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@unocss/astro': 0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@unocss/cli': 0.59.4(rollup@4.44.2)
       '@unocss/core': 0.59.4
       '@unocss/extractor-arbitrary-variants': 0.59.4
@@ -47640,9 +47627,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.59.4
       '@unocss/transformer-directives': 0.59.4
       '@unocss/transformer-variant-group': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@unocss/vite': 0.59.4(rollup@4.44.2)(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
     optionalDependencies:
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -47991,41 +47978,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-dev-rpc@1.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)):
+  vite-dev-rpc@1.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
       birpc: 2.4.0
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      vite-hot-client: 2.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      vite-hot-client: 2.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
 
-  vite-hot-client@2.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)):
+  vite-hot-client@2.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
 
-  vite-node@1.6.1(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1(supports-color@8.1.1)
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@1.6.1(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1):
+  vite-node@1.6.1(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.19(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -48037,13 +48006,31 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.0.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite-node@1.6.1(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1(supports-color@8.1.1)
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.19(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@3.0.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -48058,13 +48045,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.0.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite-node@3.0.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -48079,13 +48066,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -48100,13 +48087,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -48121,7 +48108,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.9.3(eslint@8.57.0)(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)):
+  vite-plugin-checker@0.9.3(eslint@8.57.0)(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chokidar: 4.0.3
@@ -48131,14 +48118,14 @@ snapshots:
       strip-ansi: 7.1.0
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.14
-      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 8.57.0
       optionator: 0.9.4
       typescript: 5.8.3
 
-  vite-plugin-inspect@11.3.0(@nuxt/kit@3.17.6(magicast@0.3.5))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)):
+  vite-plugin-inspect@11.3.0(@nuxt/kit@3.17.6(magicast@0.3.5))(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
       ansis: 4.1.0
       debug: 4.4.1(supports-color@8.1.1)
@@ -48148,24 +48135,24 @@ snapshots:
       perfect-debounce: 1.0.0
       sirv: 3.0.1
       unplugin-utils: 0.2.4
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      vite-dev-rpc: 1.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      vite-dev-rpc: 1.1.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
     optionalDependencies:
       '@nuxt/kit': 3.17.6(magicast@0.3.5)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.0.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3)):
+  vite-plugin-vue-tracer@1.0.0(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
       magic-string: 0.30.17
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       vue: 3.5.17(typescript@5.8.3)
 
-  vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1):
+  vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -48176,10 +48163,10 @@ snapshots:
       less: 4.1.3
       sass: 1.55.0
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.43.1
 
-  vite@5.4.19(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1):
+  vite@5.4.19(@types/node@20.16.10)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -48190,10 +48177,10 @@ snapshots:
       less: 4.3.0
       sass: 1.89.2
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.43.1
 
-  vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.6
@@ -48205,11 +48192,11 @@ snapshots:
       less: 4.1.3
       sass: 1.55.0
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.43.1
       yaml: 2.8.0
 
-  vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.6
@@ -48221,11 +48208,11 @@ snapshots:
       less: 4.3.0
       sass: 1.89.2
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.43.1
       yaml: 2.8.0
 
-  vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.6(picomatch@4.0.2)
@@ -48240,11 +48227,11 @@ snapshots:
       less: 4.1.3
       sass: 1.55.0
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.43.1
       yaml: 2.8.0
 
-  vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite@6.3.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.6(picomatch@4.0.2)
@@ -48259,12 +48246,12 @@ snapshots:
       less: 4.3.0
       sass: 1.89.2
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.43.1
       yaml: 2.8.0
     optional: true
 
-  vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.6(picomatch@4.0.2)
@@ -48279,11 +48266,11 @@ snapshots:
       less: 4.1.3
       sass: 1.89.2
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.43.1
       yaml: 2.8.0
 
-  vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vite@7.0.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.6(picomatch@4.0.2)
@@ -48298,18 +48285,18 @@ snapshots:
       less: 4.3.0
       sass: 1.89.2
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.43.1
       yaml: 2.8.0
 
-  vitefu@0.2.5(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)):
+  vitefu@0.2.5(vite@5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)):
     optionalDependencies:
-      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.16.10)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)
 
-  vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@vitest/mocker': 3.0.5(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
@@ -48325,8 +48312,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      vite-node: 3.0.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      vite-node: 3.0.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -48346,10 +48333,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0):
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.16.10)(jiti@2.4.2)(jsdom@26.1.0)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0))
+      '@vitest/mocker': 3.0.5(vite@6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
@@ -48365,8 +48352,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
-      vite-node: 3.0.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.2.0(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
+      vite-node: 3.0.5(@types/node@20.16.10)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.0.1-security)(terser@5.43.1)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
The `stylus` package on the npm registry has been removed by npm themselves as it was deemed to be compromised. There is nothing we can do for now other than install their security placeholder to unblock installations.

Stylus will not work until this is resolved between the stylus project and npm, thread here: https://github.com/stylus/stylus/issues/2938

On the Nx side, we had actually intended to remove stylus support by now, because it is not widely used: https://github.com/nrwl/nx/pull/32035

Fixes #32031 