### PR TITLE
fix(core): improve tui minimal view display and prevent flashing scrollbar

### DIFF
--- a/packages/nx/src/native/tui/components/dependency_view.rs
+++ b/packages/nx/src/native/tui/components/dependency_view.rs
@@ -168,13 +168,19 @@ impl DependencyViewState {
 pub struct DependencyView<'a> {
     status_map: &'a HashMap<String, TaskStatus>,
     task_graph: &'a TaskGraph,
+    is_minimal: bool,
 }
 
 impl<'a> DependencyView<'a> {
-    pub fn new(status_map: &'a HashMap<String, TaskStatus>, task_graph: &'a TaskGraph) -> Self {
+    pub fn new(
+        status_map: &'a HashMap<String, TaskStatus>,
+        task_graph: &'a TaskGraph,
+        is_minimal: bool,
+    ) -> Self {
         Self {
             status_map,
             task_graph,
+            is_minimal,
         }
     }
 
@@ -375,17 +381,23 @@ impl<'a> StatefulWidget for DependencyView<'a> {
             ),
         ];
 
-        let block = Block::default()
-            .title(title)
-            .title_alignment(Alignment::Left)
-            .borders(Borders::ALL)
-            .border_type(if state.is_focused {
-                BorderType::Thick
-            } else {
-                BorderType::Plain
-            })
-            .border_style(border_style)
-            .padding(Padding::new(2, 2, 1, 1));
+        let block = if self.is_minimal {
+            Block::default()
+                .borders(Borders::NONE)
+                .padding(Padding::new(2, 2, 1, 1))
+        } else {
+            Block::default()
+                .title(title)
+                .title_alignment(Alignment::Left)
+                .borders(Borders::ALL)
+                .border_type(if state.is_focused {
+                    BorderType::Thick
+                } else {
+                    BorderType::Plain
+                })
+                .border_style(border_style)
+                .padding(Padding::new(2, 2, 1, 1))
+        };
 
         let inner_area = block.inner(area);
         block.render(area, buf);


### PR DESCRIPTION
## Current Behavior

- When the minimal view in the TUI is shown, some borders are initially shown for a fraction of a second.
- When rendering terminal panes, the scrollbar can be wrongly shown for a fraction of a second when the PTY dimensions are stale. This looks like the scrollbar flashes.

## Expected Behavior

- When the minimal view in the TUI is shown, no borders should ever be shown.
- The scrollbar should only be shown when rendering terminal panes when needed.