### PR TITLE
fix(angular): update `jest-preset-angular` to v15

### DIFF
--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -399,6 +399,16 @@
       }
     },
     "migrations": {
+      "/technologies/angular/api/migrations/21.3.4-jest-package-updates": {
+        "description": "",
+        "file": "generated/packages/angular/migrations/21.3.4-jest-package-updates.json",
+        "hidden": false,
+        "name": "21.3.4-jest-package-updates",
+        "version": "21.3.4-beta.0",
+        "originalFilePath": "/packages/angular",
+        "path": "/technologies/angular/api/migrations/21.3.4-jest-package-updates",
+        "type": "migration"
+      },
       "/technologies/angular/api/migrations/update-angular-cli-version-20-1-0": {
         "description": "Update the @angular/cli package version to ~20.1.0.",
         "file": "generated/packages/angular/migrations/update-angular-cli-version-20-1-0.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -440,6 +440,16 @@
     ],
     "migrations": [
       {
+        "description": "",
+        "file": "generated/packages/angular/migrations/21.3.4-jest-package-updates.json",
+        "hidden": false,
+        "name": "21.3.4-jest-package-updates",
+        "version": "21.3.4-beta.0",
+        "originalFilePath": "/packages/angular",
+        "path": "angular/migrations/21.3.4-jest-package-updates",
+        "type": "migration"
+      },
+      {
         "description": "Update the @angular/cli package version to ~20.1.0.",
         "file": "generated/packages/angular/migrations/update-angular-cli-version-20-1-0.json",
         "hidden": false,

--- a/docs/generated/packages/angular/migrations/21.3.4-jest-package-updates.json
+++ b/docs/generated/packages/angular/migrations/21.3.4-jest-package-updates.json
@@ -1,0 +1,23 @@
+{
+  "name": "21.3.4-jest-package-updates",
+  "version": "21.3.4-beta.0",
+  "requires": {
+    "@angular/compiler-cli": ">=18.0.0 <21.0.0",
+    "@angular/core": ">=18.0.0 <21.0.0",
+    "@angular/platform-browser-dynamic": ">=18.0.0 <21.0.0",
+    "jest": "^30.0.0"
+  },
+  "packages": {
+    "jest-preset-angular": {
+      "version": "~15.0.0",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/angular",
+  "schema": null,
+  "type": "migration"
+}

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1883,6 +1883,21 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "21.3.4-jest": {
+      "version": "21.3.4-beta.0",
+      "requires": {
+        "@angular/compiler-cli": ">=18.0.0 <21.0.0",
+        "@angular/core": ">=18.0.0 <21.0.0",
+        "@angular/platform-browser-dynamic": ">=18.0.0 <21.0.0",
+        "jest": "^30.0.0"
+      },
+      "packages": {
+        "jest-preset-angular": {
+          "version": "~15.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -28,7 +28,7 @@ export const autoprefixerVersion = '^10.4.0';
 export const tsNodeVersion = '10.9.1';
 export const lessVersion = '^4.3.0';
 
-export const jestPresetAngularVersion = '~14.6.0';
+export const jestPresetAngularVersion = '~15.0.0';
 export const typesNodeVersion = '18.16.9';
 export const jasmineMarblesVersion = '^0.9.2';
 


### PR DESCRIPTION
## Current Behavior

Angular projects use `jest-preset-angular` v14, which doesn't support Jest v30.

Note: When support for Jest v30 was added, `jest-preset-angular` didn't have a version explicitly supporting it.

## Expected Behavior

Angular projects should use `jest-preset-angular` v15, which supports Jest v30.

## Related Issue(s)

Fixes #32024 
