### PR TITLE
fix(angular): update migration target version for `jest-preset-angular` v15 package update

### DIFF
--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -399,14 +399,14 @@
       }
     },
     "migrations": {
-      "/technologies/angular/api/migrations/21.3.4-jest-package-updates": {
+      "/technologies/angular/api/migrations/21.3.5-jest-package-updates": {
         "description": "",
-        "file": "generated/packages/angular/migrations/21.3.4-jest-package-updates.json",
+        "file": "generated/packages/angular/migrations/21.3.5-jest-package-updates.json",
         "hidden": false,
-        "name": "21.3.4-jest-package-updates",
-        "version": "21.3.4-beta.0",
+        "name": "21.3.5-jest-package-updates",
+        "version": "21.3.5-beta.0",
         "originalFilePath": "/packages/angular",
-        "path": "/technologies/angular/api/migrations/21.3.4-jest-package-updates",
+        "path": "/technologies/angular/api/migrations/21.3.5-jest-package-updates",
         "type": "migration"
       },
       "/technologies/angular/api/migrations/update-angular-cli-version-20-1-0": {

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -441,12 +441,12 @@
     "migrations": [
       {
         "description": "",
-        "file": "generated/packages/angular/migrations/21.3.4-jest-package-updates.json",
+        "file": "generated/packages/angular/migrations/21.3.5-jest-package-updates.json",
         "hidden": false,
-        "name": "21.3.4-jest-package-updates",
-        "version": "21.3.4-beta.0",
+        "name": "21.3.5-jest-package-updates",
+        "version": "21.3.5-beta.0",
         "originalFilePath": "/packages/angular",
-        "path": "angular/migrations/21.3.4-jest-package-updates",
+        "path": "angular/migrations/21.3.5-jest-package-updates",
         "type": "migration"
       },
       {

--- a/docs/generated/packages/angular/migrations/21.3.5-jest-package-updates.json
+++ b/docs/generated/packages/angular/migrations/21.3.5-jest-package-updates.json
@@ -1,6 +1,6 @@
 {
-  "name": "21.3.4-jest-package-updates",
-  "version": "21.3.4-beta.0",
+  "name": "21.3.5-jest-package-updates",
+  "version": "21.3.5-beta.0",
   "requires": {
     "@angular/compiler-cli": ">=18.0.0 <21.0.0",
     "@angular/core": ">=18.0.0 <21.0.0",

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1884,8 +1884,8 @@
         }
       }
     },
-    "21.3.4-jest": {
-      "version": "21.3.4-beta.0",
+    "21.3.5-jest": {
+      "version": "21.3.5-beta.0",
       "requires": {
         "@angular/compiler-cli": ">=18.0.0 <21.0.0",
         "@angular/core": ">=18.0.0 <21.0.0",


### PR DESCRIPTION
Update the migration target version for `jest-preset-angular` v15 package update.