### PR TITLE
feat(core): log out-of-sync details returned by sync generators when running `nx sync:check`

### DIFF
--- a/packages/nx/src/command-line/sync/sync.ts
+++ b/packages/nx/src/command-line/sync/sync.ts
@@ -86,7 +86,11 @@ export function syncHandler(options: SyncOptions): Promise<number> {
     if (options.check) {
       output.error({
         title: 'The workspace is out of sync',
-        bodyLines: resultBodyLines,
+        bodyLines: [
+          ...resultBodyLines,
+          '',
+          'Run `nx sync` to sync the workspace.',
+        ],
       });
 
       if (anySyncGeneratorsFailed) {

--- a/packages/nx/src/command-line/sync/sync.ts
+++ b/packages/nx/src/command-line/sync/sync.ts
@@ -78,7 +78,11 @@ export function syncHandler(options: SyncOptions): Promise<number> {
       return 1;
     }
 
-    const resultBodyLines = getSyncGeneratorSuccessResultsMessageLines(results);
+    const resultBodyLines = getSyncGeneratorSuccessResultsMessageLines(
+      results,
+      // log the out of sync details if the user is running `nx sync --check`
+      options.check
+    );
     if (options.check) {
       output.error({
         title: 'The workspace is out of sync',

--- a/packages/nx/src/daemon/server/handle-get-sync-generator-changes.ts
+++ b/packages/nx/src/daemon/server/handle-get-sync-generator-changes.ts
@@ -14,6 +14,7 @@ export async function handleGetSyncGeneratorChanges(
           generatorName: change.generatorName,
           changes: change.changes.map((c) => ({ ...c, content: null })),
           outOfSyncMessage: change.outOfSyncMessage,
+          outOfSyncDetails: change.outOfSyncDetails,
         }
   );
 

--- a/packages/nx/src/utils/sync-generators.ts
+++ b/packages/nx/src/utils/sync-generators.ts
@@ -25,6 +25,7 @@ import chalk = require('chalk');
 export type SyncGeneratorResult = void | {
   callback?: GeneratorCallback;
   outOfSyncMessage?: string;
+  outOfSyncDetails?: string[];
 };
 
 export type SyncGenerator = (
@@ -36,6 +37,7 @@ export type SyncGeneratorRunSuccessResult = {
   changes: FileChange[];
   callback?: GeneratorCallback;
   outOfSyncMessage?: string;
+  outOfSyncDetails?: string[];
 };
 
 // Error is not serializable, so we use a simple object instead
@@ -150,9 +152,11 @@ export async function runSyncGenerator(
 
     let callback: GeneratorCallback | undefined;
     let outOfSyncMessage: string | undefined;
+    let outOfSyncDetails: string[] | undefined;
     if (result && typeof result === 'object') {
       callback = result.callback;
       outOfSyncMessage = result.outOfSyncMessage;
+      outOfSyncDetails = result.outOfSyncDetails;
     }
 
     performance.mark(`run-sync-generator:${generatorSpecifier}:end`);
@@ -167,6 +171,7 @@ export async function runSyncGenerator(
       generatorName: generatorSpecifier,
       callback,
       outOfSyncMessage,
+      outOfSyncDetails,
     };
   } catch (e) {
     return {
@@ -258,7 +263,8 @@ export function collectRegisteredGlobalSyncGenerators(
 }
 
 export function getSyncGeneratorSuccessResultsMessageLines(
-  results: SyncGeneratorRunResult[]
+  results: SyncGeneratorRunResult[],
+  logOutOfSyncDetails = false
 ): string[] {
   const messageLines: string[] = [];
 
@@ -272,6 +278,10 @@ export function getSyncGeneratorSuccessResultsMessageLines(
         result.outOfSyncMessage ?? `Some files are out of sync.`
       }`
     );
+
+    if (logOutOfSyncDetails && result.outOfSyncDetails?.length) {
+      messageLines.push(...result.outOfSyncDetails);
+    }
   }
 
   return messageLines;


### PR DESCRIPTION
## Current Behavior

The `@nx/js:typescript-sync` generator does not provide details about the out-of-sync files. It only returns a generic message.

<img width="1155" height="107" alt="image" src="https://github.com/user-attachments/assets/6fc170cc-6aab-49cd-b17d-764da57b840a" />

## Expected Behavior

The `nx sync:check` command should display additional details about the out-of-sync files if provided by the sync generators. The `@nx/js:typescript-sync` generator should provide details about the out-of-sync files.

<img width="1140" height="214" alt="image" src="https://github.com/user-attachments/assets/3c74df6c-7dc3-4462-b0c9-75bce5bf81b4" />

Note:  the `nx sync` command will still only display the generic message to avoid cluttering the logs and the details can be seen in the changes made to files.