### PR TITLE
fix(core): pnpm lockfile parser handles undefined dependencies

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -595,7 +595,9 @@ function mapRootSnapshot(
           for (const [importerPath, importerSnapshot] of Object.entries(
             rootImporters
           )) {
-            const workspaceDep = importerSnapshot.dependencies[packageName];
+            const workspaceDep =
+              importerSnapshot.dependencies &&
+              importerSnapshot.dependencies[packageName];
             if (workspaceDep) {
               const workspaceDepImporterPath = workspaceDep.replace(
                 'link:',


### PR DESCRIPTION
## Current Behavior
The `pnpm-parser` does not handle when `importerSnapshot.dependencies` is undefined and is trying to access indexes of the object.

## Expected Behavior
Add a check to make usre `importerSnapshot.dependencies` exists before accessing values within it

