### PR TITLE
fix(linter): handle negative numbers in flat config AST generation

### DIFF
--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -1754,7 +1754,14 @@ export function generateAst<T>(
     return ts.factory.createStringLiteral(input) as T;
   }
   if (typeof input === 'number') {
-    return ts.factory.createNumericLiteral(input) as T;
+    if (input < 0) {
+      return ts.factory.createPrefixUnaryExpression(
+        ts.SyntaxKind.MinusToken,
+        ts.factory.createNumericLiteral(Math.abs(input))
+      ) as T;
+    } else {
+      return ts.factory.createNumericLiteral(input) as T;
+    }
   }
   if (typeof input === 'boolean') {
     return (input ? ts.factory.createTrue() : ts.factory.createFalse()) as T;


### PR DESCRIPTION
## Current Behavior

The ESLint flat config generator crashes with "Debug Failure. False expression: Negative numbers should be created in combination with createPrefixUnaryExpression" when running `nx g @nx/eslint:convert-to-flat-config`.

## Expected Behavior

The generator should handle negative numbers properly and complete without errors.

## Related Issue(s)

Fixes #31955


Generated with [Claude Code](https://claude.ai/code)