### PR TITLE
fix(core): prevent --skipInstall from being passed from create-nx-workspace to new generator

### DIFF
--- a/packages/create-nx-workspace/src/create-empty-workspace.ts
+++ b/packages/create-nx-workspace/src/create-empty-workspace.ts
@@ -33,6 +33,11 @@ export async function createEmptyWorkspace<T extends CreateWorkspaceOptions>(
 
   const directory = options.name;
 
+  // Cannot skip install for create-nx-workspace or else it'll fail.
+  // Even though --skipInstall is not an option to create-nx-workspace, we pass through extra options to presets.
+  // See: https://github.com/nrwl/nx/issues/31834
+  delete (options as any).skipInstall;
+
   const args = unparse({
     ...options,
   }).join(' ');


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When you run `npx -y create-nx-workspace@latest nameofmyrepo-monorepo --preset=apps --nxCloud=skip --skip-install --skip-prettier --verbose` it fails because `--skip-install` is passed to the `new` generator (even though it's not an CNW option), which means no `node_modules` to resolve `nx/bin/nx`.

## Expected Behavior
Running CNW should not skip install ever.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31834
