### PR TITLE
fix(misc): validate workspace names to reject names starting with numbers

### DIFF
--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -21,6 +21,15 @@ describe('create-nx-workspace', () => {
 
   afterEach(() => cleanupProject());
 
+  it('should reject workspace names starting with numbers', () => {
+    expect(() => {
+      runCreateWorkspace('4invalidname', {
+        preset: 'apps',
+        packageManager,
+      });
+    }).toThrow();
+  });
+
   it('should create a workspace with a single angular app at the root without routing', () => {
     const wsName = uniq('angular');
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.spec.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.spec.ts
@@ -1,0 +1,59 @@
+import { validateWorkspaceName } from './create-nx-workspace';
+
+// Mock the output module and process.exit
+jest.mock('../src/utils/output', () => ({
+  output: {
+    error: jest.fn(),
+  },
+}));
+
+jest.spyOn(process, 'exit').mockImplementation(() => {
+  throw new Error('process.exit called');
+});
+
+describe('validateWorkspaceName', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should allow names starting with a letter', () => {
+    expect(() => validateWorkspaceName('myapp')).not.toThrow();
+    expect(() => validateWorkspaceName('MyApp')).not.toThrow();
+    expect(() => validateWorkspaceName('my-app')).not.toThrow();
+    expect(() => validateWorkspaceName('my_app')).not.toThrow();
+    expect(() => validateWorkspaceName('app123')).not.toThrow();
+  });
+
+  it('should reject names starting with a number', () => {
+    expect(() => validateWorkspaceName('4name')).toThrow('process.exit called');
+    expect(() => validateWorkspaceName('123app')).toThrow(
+      'process.exit called'
+    );
+    expect(() => validateWorkspaceName('0test')).toThrow('process.exit called');
+  });
+
+  it('should reject names starting with special characters', () => {
+    expect(() => validateWorkspaceName('-app')).toThrow('process.exit called');
+    expect(() => validateWorkspaceName('_app')).toThrow('process.exit called');
+    expect(() => validateWorkspaceName('@app')).toThrow('process.exit called');
+  });
+
+  it('should call output.error with correct message for invalid names', () => {
+    const { output } = require('../src/utils/output');
+
+    try {
+      validateWorkspaceName('4name');
+    } catch (e) {
+      // Expected to throw
+    }
+
+    expect(output.error).toHaveBeenCalledWith({
+      title: 'Invalid workspace name',
+      bodyLines: [
+        'The workspace name "4name" is invalid.',
+        'Workspace names must start with a letter.',
+        'Examples of valid names: myapp, MyApp, my-app, my_app',
+      ],
+    });
+  });
+});

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -351,13 +351,32 @@ function invariant(
   }
 }
 
+export function validateWorkspaceName(name: string): void {
+  const pattern = /^[a-zA-Z]/;
+  if (!pattern.test(name)) {
+    output.error({
+      title: 'Invalid workspace name',
+      bodyLines: [
+        `The workspace name "${name}" is invalid.`,
+        `Workspace names must start with a letter.`,
+        `Examples of valid names: myapp, MyApp, my-app, my_app`,
+      ],
+    });
+    process.exit(1);
+  }
+}
+
 async function determineFolder(
   parsedArgs: yargs.Arguments<Arguments>
 ): Promise<string> {
   const folderName: string = parsedArgs._[0]
     ? parsedArgs._[0].toString()
     : parsedArgs.name;
-  if (folderName) return folderName;
+
+  if (folderName) {
+    validateWorkspaceName(folderName);
+    return folderName;
+  }
   const reply = await enquirer.prompt<{ folderName: string }>([
     {
       name: 'folderName',
@@ -372,6 +391,8 @@ async function determineFolder(
     title: 'Invalid folder name',
     bodyLines: [`Folder name cannot be empty`],
   });
+
+  validateWorkspaceName(reply.folderName);
 
   invariant(!existsSync(reply.folderName), {
     title: 'That folder is already taken',


### PR DESCRIPTION
## Summary

Fixes #31602 by adding validation to `create-nx-workspace` to reject workspace names that start with numbers, preventing confusing errors later in the workspace generation process.

## Changes Made

- **Added `validateWorkspaceName()` function** - Validates that workspace names start with letters
- **Integrated validation into workspace creation flow** - Validates both command-line arguments and interactive input
- **Clear error messaging** - Provides helpful error message with examples of valid names


🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>