### PR TITLE
fix(nextjs): configure Jest to use tsconfig.json for Next.js apps

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -1256,6 +1256,24 @@ describe('app (legacy)', () => {
         "
       `);
     });
+
+    it('should configure tsconfig.spec.json to reference tsconfig.json as runtime config', async () => {
+      const name = uniq();
+      await applicationGenerator(tree, {
+        directory: name,
+        style: 'css',
+        unitTestRunner: 'jest',
+      });
+
+      const tsConfigSpec = readJson(tree, `${name}/tsconfig.spec.json`);
+
+      // Verify that the runtime tsconfig is properly referenced (tsconfig.json for Next.js apps)
+      expect(tree.exists(`${name}/tsconfig.json`)).toBe(true);
+      expect(tree.exists(`${name}/tsconfig.app.json`)).toBe(false);
+
+      // Verify the jest config and spec config are properly set up
+      expect(tsConfigSpec.compilerOptions.jsx).toBe('react');
+    });
   });
 });
 

--- a/packages/next/src/generators/application/lib/add-jest.ts
+++ b/packages/next/src/generators/application/lib/add-jest.ts
@@ -30,6 +30,7 @@ export async function addJest(
     setupFile: 'none',
     compiler: 'babel',
     skipFormat: true,
+    runtimeTsconfigFileName: 'tsconfig.json',
   });
 
   const tsConfigSpecJson = readJson(


### PR DESCRIPTION
## Current Behavior

When generating a Next.js application with Jest as the unit test runner, Jest configuration fails because it defaults to looking for `tsconfig.app.json` which doesn't exist in Next.js projects. Next.js apps use `tsconfig.json` as their main TypeScript configuration file.

## Expected Behavior

Jest should be configured to use `tsconfig.json` as the runtime TypeScript configuration for Next.js applications, allowing Jest to properly resolve TypeScript configurations.

## Related Issue(s)

Fixes #31555