### PR TITLE
fix(node): set projectType to application in package.json when useProjectJson is false

### DIFF
--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -194,6 +194,7 @@ describe('app', () => {
         {
           "name": "@proj/myapp",
           "nx": {
+            "projectType": "application",
             "targets": {
               "build": {
                 "configurations": {

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -227,6 +227,7 @@ describe('application generator', () => {
         {
           "name": "@proj/myapp",
           "nx": {
+            "projectType": "application",
             "targets": {
               "build": {
                 "configurations": {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -618,6 +618,7 @@ describe('app', () => {
         {
           "name": "@proj/myapp",
           "nx": {
+            "projectType": "application",
             "targets": {
               "serve": {
                 "configurations": {
@@ -742,6 +743,23 @@ describe('app', () => {
           "nx",
         ]
       `);
+    });
+
+    it('should set projectType to application in package.json when useProjectJson is false', async () => {
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        bundler: 'webpack',
+        unitTestRunner: 'jest',
+        addPlugin: true,
+        useProjectJson: false,
+      });
+
+      const packageJson = readJson(tree, 'myapp/package.json');
+      expect(packageJson.nx.projectType).toBe('application');
+
+      // Also verify that the project is properly recognized as an application
+      const projectConfig = readProjectConfiguration(tree, '@proj/myapp');
+      expect(projectConfig.projectType).toBe('application');
     });
 
     it('should use @swc/jest for jest', async () => {

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -49,6 +49,7 @@ export function addProject(tree: Tree, options: NormalizedSchema) {
   if (!options.useProjectJson) {
     packageJson.nx = {
       name: options.name !== options.importPath ? options.name : undefined,
+      projectType: project.projectType,
       targets: project.targets,
       tags: project.tags?.length ? project.tags : undefined,
     };


### PR DESCRIPTION
## Current Behavior

When generating Node applications with `useProjectJson=false` (package-based workspaces), the `projectType` was not being set in the `nx` object in package.json. This caused Node applications to appear as "lib projects" instead of "app projects" in `nx graph`.

## Expected Behavior

Node applications should be properly classified as "application" type projects and appear under "app projects" in the project graph when using package-based workspaces.

## Related Issue(s)

Fixes #31412