### PR TITLE
chore(core): add env flag to only install packages when running wrapper

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -88,6 +88,11 @@
       "version": "21.1.0-beta.2",
       "description": "Adds **/nx-rules.mdc and **/nx.instructions.md to .gitignore if not present",
       "implementation": "./src/migrations/update-21-1-0/add-gitignore-entry"
+    },
+    "21-3-7-update-nx-wrapper": {
+      "version": "21.3.7",
+      "description": "Updates the nx wrapper.",
+      "implementation": "./src/migrations/update-17-3-0/update-nxw"
     }
   }
 }

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -92,7 +92,7 @@
     "21-3-7-update-nx-wrapper": {
       "version": "21.3.7",
       "description": "Updates the nx wrapper.",
-      "implementation": "./src/migrations/update-17-3-0/update-nxw"
+      "implementation": "./src/migrations/update-21-3-7/update-nxw"
     }
   }
 }

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -144,5 +144,7 @@ function ensureUpToDateInstallation() {
 if (!process.env.NX_WRAPPER_SKIP_INSTALL) {
   ensureUpToDateInstallation();
 }
-// eslint-disable-next-line no-restricted-modules
-require('./installation/node_modules/nx/bin/nx');
+if (!process.env.NX_WRAPPER_INSTALL_ONLY) {
+  // eslint-disable-next-line no-restricted-modules
+  require('./installation/node_modules/nx/bin/nx');
+}


### PR DESCRIPTION
## Current Behavior
When `nxw.js` is ran, it always invokes the underlying Nx CLI.

## Expected Behavior
There is an env flag (`NX_WRAPPER_INSTALL_ONLY`) to only run the installation step.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
