### PR TITLE
fix(vite): fix rollup replace files

### DIFF
--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -44,7 +44,7 @@ export function replaceFiles(replacements: FileReplacement[]): {
         try {
           // return new file content
           return {
-            id: foundReplace.with,
+            id: resolved.id.replace(foundReplace.replace, foundReplace.with),
           };
         } catch (err) {
           console.error(err);


### PR DESCRIPTION
use resolved module as base path for the file replacement, making sure the path will be absolute

## Current Behavior
file are replaced using the relative path written on the "with" key.
Using AnalogJs I have problems on using the fileReplacement feature using vite dev server.
```ts
 mode === 'development' &&
      replaceFiles([
        {
          replace: './src/environments/environment.ts',
          with: './src/environments/environment.development.ts',
        },
      ]),
```
this is not working because modules are resolved with their absolute path, so this piece of code:
```ts
const foundReplace = replacements.find((replacement) =>
      resolved?.id?.endsWith(replacement.replace)
);
```
is not finding anything with the leading './' (no log on console for replacement).

Changing to this:
```ts
 mode === 'development' &&
      replaceFiles([
        {
          replace: 'src/environments/environment.ts',
          with: 'src/environments/environment.development.ts',
        },
      ]),
```
logs `replace "src/environments/environment.ts" with "src/environments/environment.development.ts"` but vite throws an error cause it doesn't find the module.
My solution ensures that files are replaced using the base path from the existing module, replacing only the involved substring.

## Expected Behavior
correct file replacement 
