### PR TITLE
fix(docker): format current date to UTC

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -137,6 +137,9 @@ rust-toolchain.toml @nrwl/nx-native-reviewers
 /packages/storybook/** @nrwl/nx-storybook-reviewers
 /e2e/storybook/** @nrwl/nx-storybook-reviewers
 
+# Docker
+/packages/docker/** @nrwl/nx-core-reviewers @Coly010
+
 ## Devkit
 /docs/generated/devkit/** @nrwl/nx-devkit-reviewers @nrwl/nx-docs-reviewers
 /docs/generated/packages/devkit/** @nrwl/nx-devkit-reviewers @nrwl/nx-docs-reviewers
@@ -174,7 +177,7 @@ rust-toolchain.toml @nrwl/nx-native-reviewers
 
 # Misc
 /e2e/lerna-smoke-tests/** @vsavkin @JamesHenry
-/e2e/utils/** @meeroslav @nrwl/nx-testing-tools-reviewers @vsavkin @mandarini
+/e2e/utils/** @meeroslav @nrwl/nx-testing-tools-reviewers @vsavkin
 /community @nrwl/nx-docs-reviewers
 /CONTRIBUTING.md @FrozenPandaz @isaacplmann
 /CODE_OF_CONDUCT.md @FrozenPandaz @isaacplmann

--- a/packages/docker/src/release/version-pattern-utils.ts
+++ b/packages/docker/src/release/version-pattern-utils.ts
@@ -18,12 +18,12 @@ export interface PatternTokens {
 const tokenRegex = /\{([^|{}]+)(?:\|([^{}]+))?\}/g;
 
 function formatDate(date: Date, format: string) {
-  const year = String(date.getFullYear());
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
+  const year = String(date.getUTCFullYear());
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
 
   return format
     .replace(/YYYY/g, year)


### PR DESCRIPTION
## Current Behavior
Docker Version Utils will interpolate `{currentDate|YY.MM.DD}` with the local timezone.

## Expected Behavior
Force the formatting to be UTC

