### PR TITLE
fix(gradle): fix gradle bootRun continuous

### DIFF
--- a/docs/generated/packages/gradle/executors/gradle.json
+++ b/docs/generated/packages/gradle/executors/gradle.json
@@ -30,6 +30,12 @@
         "description": "If true, the tasks will not execute its dependsOn tasks (e.g. pass --exclude-task args to gradle command). If false, the task will execute its dependsOn tasks.",
         "default": true,
         "x-priority": "internal"
+      },
+      "__unparsed__": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Additional arguments to pass to the gradle command (automatically populated by Nx).",
+        "x-priority": "internal"
       }
     },
     "required": ["taskName"],

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -65,9 +65,14 @@ fun processTask(
   target["metadata"] = metadata
 
   target["options"] =
-      mapOf(
-          "taskName" to "${projectBuildPath}:${task.name}",
-          "excludeDependsOn" to shouldExcludeDependsOn(task))
+      if (continuous) {
+        mapOf(
+            "taskName" to "${projectBuildPath}:${task.name}",
+            "continuous" to true,
+            "excludeDependsOn" to shouldExcludeDependsOn(task))
+      } else {
+        mapOf("taskName" to "${projectBuildPath}:${task.name}")
+      }
 
   return target
 }

--- a/packages/gradle/src/executors/gradle/gradle.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle.impl.ts
@@ -24,6 +24,26 @@ export default async function gradleExecutor(
     args.push(`--tests`, options.testClassName);
   }
 
+  // Pass any additional options not defined in the schema as gradle arguments
+  const knownOptions = new Set([
+    'taskName',
+    'testClassName',
+    'args',
+    'excludeDependsOn',
+    '__unparsed__',
+  ]);
+  Object.entries(options).forEach(([key, value]) => {
+    if (!knownOptions.has(key) && value !== undefined && value !== false) {
+      if (value === true) {
+        // Boolean flags like --continuous
+        args.push(`--${key}`);
+      } else {
+        // Flags with values like --max-workers=4
+        args.push(`--${key}=${value}`);
+      }
+    }
+  });
+
   if (options.excludeDependsOn) {
     getExcludeTasks(
       new Set([`${context.projectName}:${context.targetName}`]),
@@ -41,7 +61,7 @@ export default async function gradleExecutor(
         command: `${gradlewPath} ${options.taskName}`,
         cwd: dirname(gradlewPath),
         args: args,
-        __unparsed__: [],
+        __unparsed__: options.__unparsed__ || [],
       },
       context
     );

--- a/packages/gradle/src/executors/gradle/schema.d.ts
+++ b/packages/gradle/src/executors/gradle/schema.d.ts
@@ -3,4 +3,5 @@ export interface GradleExecutorSchema {
   testClassName?: string;
   args?: string[] | string;
   excludeDependsOn: boolean;
+  __unparsed__?: string[];
 }

--- a/packages/gradle/src/executors/gradle/schema.json
+++ b/packages/gradle/src/executors/gradle/schema.json
@@ -33,6 +33,14 @@
       "description": "If true, the tasks will not execute its dependsOn tasks (e.g. pass --exclude-task args to gradle command). If false, the task will execute its dependsOn tasks.",
       "default": true,
       "x-priority": "internal"
+    },
+    "__unparsed__": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Additional arguments to pass to the gradle command (automatically populated by Nx).",
+      "x-priority": "internal"
     }
   },
   "required": ["taskName"]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
when running gradle command with args, it requires to use --args="--continutous"
for bootRun, which is continuous, i got an error
```
Execution failed for task ':bootRun'.
> Failed to query the value of task ':bootRun' property 'mainClass'.
   > Querying the mapped value of task ':resolveMainClassName' property 'outputFile' before task ':resolveMainClassName' has completed is not supported
 ```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
change it when just running `nx run demo:bootRun --continuous`, it will pass --continuous directly to ./gradlew. 
any args not in the list
```
new Set([
    'taskName',
    'testClassName',
    'args',
    'excludeDependsOn',
    '__unparsed__',
  ]);
  ```
  will passed as arga to the ./gradlew 
  i try to add `__unparsed__`, but it is always empty.
  
  for bootRun, i add excludeDependsOn as false in nx.json and that error goes away.
  ```
      "bootRun": {
      "options": {
        "excludeDependsOn": false
      }
    }
    ```
    
    so for all continuous task, i changed excludeDependsOn as false in the option


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
