### PR TITLE
feat(node): add prune target to node apps

### DIFF
--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -219,8 +219,30 @@ describe('app', () => {
                   "{options.outputPath}",
                 ],
               },
+              "copy-workspace-modules": {
+                "cache": true,
+                "executor": "@nx/js:copy-workspace-modules",
+                "options": {
+                  "buildTarget": "build",
+                },
+              },
               "lint": {
                 "executor": "@nx/eslint:lint",
+              },
+              "prune": {
+                "cache": true,
+                "dependsOn": [
+                  "prune-lockfile",
+                  "copy-workspace-modules",
+                ],
+                "executor": "nx:noop",
+              },
+              "prune-lockfile": {
+                "cache": true,
+                "executor": "@nx/js:prune-lockfile",
+                "options": {
+                  "buildTarget": "build",
+                },
               },
               "serve": {
                 "configurations": {
@@ -395,8 +417,30 @@ describe('app', () => {
                 "{options.outputPath}",
               ],
             },
+            "copy-workspace-modules": {
+              "cache": true,
+              "executor": "@nx/js:copy-workspace-modules",
+              "options": {
+                "buildTarget": "build",
+              },
+            },
             "lint": {
               "executor": "@nx/eslint:lint",
+            },
+            "prune": {
+              "cache": true,
+              "dependsOn": [
+                "prune-lockfile",
+                "copy-workspace-modules",
+              ],
+              "executor": "nx:noop",
+            },
+            "prune-lockfile": {
+              "cache": true,
+              "executor": "@nx/js:prune-lockfile",
+              "options": {
+                "buildTarget": "build",
+              },
             },
             "serve": {
               "configurations": {

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -53,6 +53,28 @@ describe('application generator', () => {
               "command": "webpack-cli build",
             },
           },
+          "copy-workspace-modules": {
+            "cache": true,
+            "executor": "@nx/js:copy-workspace-modules",
+            "options": {
+              "buildTarget": "build",
+            },
+          },
+          "prune": {
+            "cache": true,
+            "dependsOn": [
+              "prune-lockfile",
+              "copy-workspace-modules",
+            ],
+            "executor": "nx:noop",
+          },
+          "prune-lockfile": {
+            "cache": true,
+            "executor": "@nx/js:prune-lockfile",
+            "options": {
+              "buildTarget": "build",
+            },
+          },
           "serve": {
             "configurations": {
               "development": {
@@ -244,6 +266,28 @@ describe('application generator', () => {
                   "command": "webpack-cli build",
                 },
               },
+              "copy-workspace-modules": {
+                "cache": true,
+                "executor": "@nx/js:copy-workspace-modules",
+                "options": {
+                  "buildTarget": "build",
+                },
+              },
+              "prune": {
+                "cache": true,
+                "dependsOn": [
+                  "prune-lockfile",
+                  "copy-workspace-modules",
+                ],
+                "executor": "nx:noop",
+              },
+              "prune-lockfile": {
+                "cache": true,
+                "executor": "@nx/js:prune-lockfile",
+                "options": {
+                  "buildTarget": "build",
+                },
+              },
               "serve": {
                 "configurations": {
                   "development": {
@@ -408,6 +452,28 @@ describe('application generator', () => {
                   "--node-env=production",
                 ],
                 "command": "webpack-cli build",
+              },
+            },
+            "copy-workspace-modules": {
+              "cache": true,
+              "executor": "@nx/js:copy-workspace-modules",
+              "options": {
+                "buildTarget": "build",
+              },
+            },
+            "prune": {
+              "cache": true,
+              "dependsOn": [
+                "prune-lockfile",
+                "copy-workspace-modules",
+              ],
+              "executor": "nx:noop",
+            },
+            "prune-lockfile": {
+              "cache": true,
+              "executor": "@nx/js:prune-lockfile",
+              "options": {
+                "buildTarget": "build",
               },
             },
             "serve": {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -42,6 +42,28 @@ describe('app', () => {
           "sourceRoot": "my-node-app/src",
           "tags": [],
           "targets": {
+            "copy-workspace-modules": {
+              "cache": true,
+              "executor": "@nx/js:copy-workspace-modules",
+              "options": {
+                "buildTarget": "build",
+              },
+            },
+            "prune": {
+              "cache": true,
+              "dependsOn": [
+                "prune-lockfile",
+                "copy-workspace-modules",
+              ],
+              "executor": "nx:noop",
+            },
+            "prune-lockfile": {
+              "cache": true,
+              "executor": "@nx/js:prune-lockfile",
+              "options": {
+                "buildTarget": "build",
+              },
+            },
             "serve": {
               "configurations": {
                 "development": {
@@ -254,6 +276,28 @@ describe('app', () => {
               "outputs": [
                 "{options.outputPath}",
               ],
+            },
+            "copy-workspace-modules": {
+              "cache": true,
+              "executor": "@nx/js:copy-workspace-modules",
+              "options": {
+                "buildTarget": "build",
+              },
+            },
+            "prune": {
+              "cache": true,
+              "dependsOn": [
+                "prune-lockfile",
+                "copy-workspace-modules",
+              ],
+              "executor": "nx:noop",
+            },
+            "prune-lockfile": {
+              "cache": true,
+              "executor": "@nx/js:prune-lockfile",
+              "options": {
+                "buildTarget": "build",
+              },
             },
             "serve": {
               "configurations": {
@@ -619,6 +663,28 @@ describe('app', () => {
           "name": "@proj/myapp",
           "nx": {
             "targets": {
+              "copy-workspace-modules": {
+                "cache": true,
+                "executor": "@nx/js:copy-workspace-modules",
+                "options": {
+                  "buildTarget": "build",
+                },
+              },
+              "prune": {
+                "cache": true,
+                "dependsOn": [
+                  "prune-lockfile",
+                  "copy-workspace-modules",
+                ],
+                "executor": "nx:noop",
+              },
+              "prune-lockfile": {
+                "cache": true,
+                "executor": "@nx/js:prune-lockfile",
+                "options": {
+                  "buildTarget": "build",
+                },
+              },
               "serve": {
                 "configurations": {
                   "development": {
@@ -890,6 +956,28 @@ describe('app', () => {
           "sourceRoot": "myapp/src",
           "tags": [],
           "targets": {
+            "copy-workspace-modules": {
+              "cache": true,
+              "executor": "@nx/js:copy-workspace-modules",
+              "options": {
+                "buildTarget": "build",
+              },
+            },
+            "prune": {
+              "cache": true,
+              "dependsOn": [
+                "prune-lockfile",
+                "copy-workspace-modules",
+              ],
+              "executor": "nx:noop",
+            },
+            "prune-lockfile": {
+              "cache": true,
+              "executor": "@nx/js:prune-lockfile",
+              "options": {
+                "buildTarget": "build",
+              },
+            },
             "serve": {
               "configurations": {
                 "development": {

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -14,6 +14,7 @@ import {
   getNestWebpackBuildConfig,
   getServeConfig,
   getWebpackBuildConfig,
+  getPruneTargets,
 } from './create-targets';
 
 export function addProject(tree: Tree, options: NormalizedSchema) {
@@ -38,6 +39,10 @@ export function addProject(tree: Tree, options: NormalizedSchema) {
       project.targets.build = getNestWebpackBuildConfig();
     }
   }
+  project.targets = {
+    ...project.targets,
+    ...getPruneTargets('build'),
+  };
   project.targets.serve = getServeConfig(options);
 
   const packageJson: PackageJson = {

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -126,3 +126,31 @@ export function getNestWebpackBuildConfig(): TargetConfiguration {
     },
   };
 }
+
+export function getPruneTargets(buildTarget: string): {
+  prune: TargetConfiguration;
+  'prune-lockfile': TargetConfiguration;
+  'copy-workspace-modules': TargetConfiguration;
+} {
+  return {
+    'prune-lockfile': {
+      cache: true,
+      executor: '@nx/js:prune-lockfile',
+      options: {
+        buildTarget,
+      },
+    },
+    'copy-workspace-modules': {
+      cache: true,
+      executor: '@nx/js:copy-workspace-modules',
+      options: {
+        buildTarget,
+      },
+    },
+    prune: {
+      cache: true,
+      dependsOn: ['prune-lockfile', 'copy-workspace-modules'],
+      executor: 'nx:noop',
+    },
+  };
+}

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -16,10 +16,10 @@
       "path": "../jest"
     },
     {
-      "path": "../nx"
+      "path": "../devkit"
     },
     {
-      "path": "../devkit"
+      "path": "../nx"
     },
     {
       "path": "./tsconfig.lib.json"

--- a/packages/node/tsconfig.lib.json
+++ b/packages/node/tsconfig.lib.json
@@ -25,10 +25,10 @@
       "path": "../jest/tsconfig.lib.json"
     },
     {
-      "path": "../nx/tsconfig.lib.json"
+      "path": "../devkit/tsconfig.lib.json"
     },
     {
-      "path": "../devkit/tsconfig.lib.json"
+      "path": "../nx/tsconfig.lib.json"
     }
   ]
 }


### PR DESCRIPTION
## Current Behavior
The `@nx/node:app` generator does not set up `prune` as a target to prune the lockfile for TS Solution based repos. Nor does it handle workspace modules that may be used by the application.

## Expected Behavior
Create the following targets when generating a node application
- `copy-workspace-modules`
- `prune-lockfile`
- `prune`

The latter should act as a noop, depending on the other two targets to ensure a fully pruned output
