### PR TITLE
docs(misc): make sure "npx nx@latest" is used when calling init or coonnect

### DIFF
--- a/docs/blog/2022-05-25-lerna-used-to-walk-now-it-can-fly.md
+++ b/docs/blog/2022-05-25-lerna-used-to-walk-now-it-can-fly.md
@@ -53,7 +53,7 @@ Finally, add the following to your `lerna.json`.
 
 That's mostly it. You can continue using the usual Lerna commands, but at this point Lerna would delegate its operations to Nx underneath.
 
-To get more out of it, you might want to create a small `nx.json` file (or run `npx nx init` to generate one) for going into some more details on configuring the cacheable operations:
+To get more out of it, you might want to create a small `nx.json` file (or run `npx nx@latest init` to generate one) for going into some more details on configuring the cacheable operations:
 
 ```json5 {% fileName="nx.json" %}
 {
@@ -88,7 +88,7 @@ By having Nx integrated, you not just get faster builds but also some other Nx's
 **Distributed caching** — Right now when you enable `useNx` in your existing Lerna repo, you will get local caching, meaning the cache sits in a local folder on your machine. You get much more value out of it when you start distributing and sharing it with your teammates but especially in CI. This can be done by adding Nx Cloud, which comes with a no-credit card, 500 hours free / month offer which is more than what most workspaces need. Adding that is easy and can be done by adding `@nrwl/nx-cloud` to your root-level `package.json` and then by running:
 
 ```shell
-npx nx connect-to-nx-cloud
+npx nx@latest connect-to-nx-cloud
 ```
 
 **Distributed task execution** — Distribution of the cache is one thing, but the real speed improvements come from also [distributing the task execution](/ci/features/distribute-task-execution) to speed up your CI. Having the Nx project graph and as well as the cache and historical data about previous runs, Nx Cloud DTE is able to maximize the CI agent utilization by evenly distributing tasks based on their (historical) duration as well as based on their topological order. In addition, the DTE process makes sure to properly move cached assets between the agents. Setting up DTE is straightforward, read more on our [Nx Cloud docs](/ci/features/distribute-task-execution). Hint: we also have a CI generator in Nx (you need the `@nrwl/workspace` package) that allows you to generate your CI setup using a single command: `npx nx generate @nrwl/workspace:ci-workflow --ci=github`

--- a/docs/blog/2022-06-09-nx-14-2-angular-v14-storybook-update-lightweight-nx-and-more.md
+++ b/docs/blog/2022-06-09-nx-14-2-angular-v14-storybook-update-lightweight-nx-and-more.md
@@ -75,7 +75,7 @@ In v14 we already simplified Nx (we have a whole section in [our release blog po
 Whenever you need to fine-tune the default settings you can run the following command to get a `nx.json` generated or you can obviously create it by hand:
 
 ```shell
-npx nx init
+npx nx@latest init
 ```
 
 ## Run Nx graph on any monorepo!

--- a/docs/blog/2023-01-12-react-vite-and-typescript-get-started-in-under-2-minutes.md
+++ b/docs/blog/2023-01-12-react-vite-and-typescript-get-started-in-under-2-minutes.md
@@ -509,7 +509,7 @@ If you're currently on a [CRA](https://create-react-app.dev/) setup, you can eas
 {% youtube src="https://youtu.be/zvYb7XCLQzU" /%}
 
 ```shell
-npx nx init
+npx nx@latest init
 ```
 
 Read more on the Nx docs: [/recipes/adopting-nx/adding-to-existing-project](/recipes/adopting-nx/adding-to-existing-project)

--- a/docs/blog/2024-02-06-nuxt-js-support-in-nx.md
+++ b/docs/blog/2024-02-06-nuxt-js-support-in-nx.md
@@ -65,7 +65,7 @@ When you run `nx init` in your existing Nuxt.js project, Nx does the following:
 To begin the integration process, simply navigate to the root of your existing Nuxt.js project and run:
 
 ```shell
-npx nx init
+npx nx@latest init
 ```
 
 This approach offers several key benefits for teams looking to adopt Nx:

--- a/docs/blog/2024-08-28-nxcloud-improved-ci-log.md
+++ b/docs/blog/2024-08-28-nxcloud-improved-ci-log.md
@@ -33,7 +33,7 @@ If you prefer the previous log view in your CI, you can opt-out of the new table
 If you're not on Nx Cloud yet, you can **connect your Nx workspace** by running:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 This command will guide you through the setup. We recently introduced a [new Hobby plan](/pricing), which lets you experiment with all the Nx Cloud features for free. This is a great way to see if it's a good fit for your team.

--- a/docs/blog/2025-03-17-modern-angular-testing-with-nx.md
+++ b/docs/blog/2025-03-17-modern-angular-testing-with-nx.md
@@ -106,7 +106,7 @@ If you view the `my-app-e2e` project (`npx nx show project my-app-e2e`), you wil
 When run on a single machine, `e2e-ci` will be slower because it starts multiple Playwright processes, which is why we only allow it to run through distribution. To [enable distribution](/ci/features/split-e2e-tasks#enable-automated-e2e-task-splitting), you must connect your workspace to [Nx Cloud](/nx-cloud). This is easily done with the `connect` command.
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 Follow the onboarding steps and you should be connected within five minutes. For more information, check out our [setup guides](/ci/recipes/set-up) for all supported CI providers (GitHub, GitLab, Azure, etc.).

--- a/docs/blog/2025-03-18-architecting-angular-applications.md
+++ b/docs/blog/2025-03-18-architecting-angular-applications.md
@@ -161,7 +161,7 @@ It uses Nx for running and building your project. Nx relies on the Angular Devki
 If you have an existing Angular CLI project, you can also [add Nx support to it](/technologies/angular/migration/angular) by running:
 
 ```shell
-npx nx init
+npx nx@latest init
 ```
 
 If you already know you want to go straight to an Nx monorepo, you can add the `--integrated` flag to the `nx init` command.

--- a/docs/blog/2025-03-19-using-angular-with-rspack.md
+++ b/docs/blog/2025-03-19-using-angular-with-rspack.md
@@ -72,7 +72,7 @@ The steps are very simple:
 2. Run `nx g @nx/angular:convert-to-rspack` to migrate your Angular application to Rspack.
 
 There is also a [guide in our documentation](/technologies/angular/angular-rspack/recipes/migrate-from-webpack) that walks you through the process step-by-step.
-Even if you're currently using the Angular CLI, it's as simple as first running `npx nx init` in your workspace and then running `npx nx g convert-to-rspack`.
+Even if you're currently using the Angular CLI, it's as simple as first running `npx nx@latest init` in your workspace and then running `npx nx g convert-to-rspack`.
 
 ## Using Angular Rspack
 

--- a/docs/blog/2025-06-23-nx-self-healing-ci.md
+++ b/docs/blog/2025-06-23-nx-self-healing-ci.md
@@ -99,7 +99,7 @@ To enable Self-Healing CI on your workspace:
 If you haven't already connected to Nx Cloud:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 You can [start with the free Hobby plan](/pricing) and play around with the new AI features.
@@ -179,7 +179,7 @@ Self-Healing CI completes Nx Cloud's comprehensive approach to eliminating CI fr
 - **Built on proven infrastructure**: Uses the same robust Nx Cloud infrastructure that powers distributed task execution
 - **Part of a broader vision**: Continues our mission to optimize "time to green" and eliminate developer workflow friction
 
-**Ready to try it?** Self-Healing CI is rolling out as an early access feature and is available to everyone right now—no special approval or signup required. If you don't have an Nx Cloud account yet, you can quickly [start with the Hobby plan](/pricing), connect your workspace with `npx nx connect`, and get going immediately.
+**Ready to try it?** Self-Healing CI is rolling out as an early access feature and is available to everyone right now—no special approval or signup required. If you don't have an Nx Cloud account yet, you can quickly [start with the Hobby plan](/pricing), connect your workspace with `npx nx@latest connect`, and get going immediately.
 
 **For enterprise teams:** If you're already using Nx Cloud and want to learn more about how AI features like Self-Healing CI can enhance your existing setup, [reach out to us](/contact). We'd love to help you leverage these capabilities in your organization.
 

--- a/docs/blog/2025-06-25-nx-cloud-mcp-ci-optimization.md
+++ b/docs/blog/2025-06-25-nx-cloud-mcp-ci-optimization.md
@@ -125,7 +125,7 @@ Then update the JSON configuration as follows, making sure the `cwd` points to t
 If you haven't already connected your Nx workspace to Nx Cloud, run:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 This command will walk you through connecting your existing Nx workspace to a new Nx Cloud account. **There's a [free hobby plan](/pricing)**. Run it for a couple of weeks and then try out these conversational analytics features.

--- a/docs/nx-cloud/features/flaky-tasks.md
+++ b/docs/nx-cloud/features/flaky-tasks.md
@@ -11,7 +11,7 @@ Flaky Task Detection is enabled by default if your workspace is connected to Nx 
 To connect your workspace to Nx Cloud run:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 See the [connect to Nx Cloud recipe](/ci/intro/connect-to-nx-cloud) for all the details.

--- a/docs/nx-cloud/features/split-e2e-tasks.md
+++ b/docs/nx-cloud/features/split-e2e-tasks.md
@@ -23,7 +23,7 @@ Manually splitting large e2e test projects can be complex and require ongoing ma
 To use **automated e2e task splitting**, you need to connect your workspace to Nx Cloud (if you haven't already).
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 See the [connect to Nx Cloud recipe](/ci/intro/connect-to-nx-cloud) for all the details.

--- a/docs/nx-cloud/intro/ci-with-nx.md
+++ b/docs/nx-cloud/intro/ci-with-nx.md
@@ -19,7 +19,7 @@ Your CI pipeline with Nx can:
 [Create an account on Nx Cloud](https://cloud.nx.app) and connect your repository.
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 ## Learn about Nx on CI

--- a/docs/nx-cloud/intro/connect-to-cloud.md
+++ b/docs/nx-cloud/intro/connect-to-cloud.md
@@ -11,7 +11,7 @@ Here's how you get set up.
 To connect your workspace, **push it to GitHub** (or your respective source control provider) and then run:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 ## Step 2: Configure your CI script

--- a/docs/shared/features/cache-task-results.md
+++ b/docs/shared/features/cache-task-results.md
@@ -68,7 +68,7 @@ By default, Nx caches task results locally. The biggest benefit of caching comes
 To enable remote caching, connect your workspace to [Nx Cloud](/nx-cloud) by running the following command:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 Learn more about [remote caching with Nx Cloud](/ci/features/remote-cache).

--- a/docs/shared/features/distribute-task-execution.md
+++ b/docs/shared/features/distribute-task-execution.md
@@ -29,7 +29,7 @@ Nx Agents offer several key advantages:
 To enable task distribution with Nx Agents, make sure your Nx workspace is connected to Nx Cloud. If you haven't connected your workspace to Nx Cloud yet, run the following command:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 Check out the [connect to Nx Cloud recipe](/ci/intro/connect-to-nx-cloud) for more details.

--- a/docs/shared/features/remote-cache.md
+++ b/docs/shared/features/remote-cache.md
@@ -27,7 +27,7 @@ Nx **restores terminal output, along with the files and artifacts** created from
 To use **Nx Replay**, you need to connect your workspace to Nx Cloud (if you haven't already).
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 See the [connect to Nx Cloud recipe](/ci/intro/connect-to-nx-cloud) for all the details.

--- a/docs/shared/features/self-healing-ci.md
+++ b/docs/shared/features/self-healing-ci.md
@@ -25,7 +25,7 @@ To enable Self-Healing CI in your workspace, you'll need to connect to Nx Cloud 
 If you haven't already connected to Nx Cloud, run the following command:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 Next, check the Nx Cloud workspace settings in the Nx Cloud web application to ensure that "Self-Healing CI" is enabled (it should be enabled by default).

--- a/docs/shared/getting-started/quick-start.md
+++ b/docs/shared/getting-started/quick-start.md
@@ -63,7 +63,7 @@ npx create-nx-workspace@latest
 **Add to an existing project: (recommended also for non-JS projects)**
 
 ```shell
-npx nx init
+npx nx@latest init
 ```
 
 **Get the complete experience:**

--- a/docs/shared/guides/react-router.md
+++ b/docs/shared/guides/react-router.md
@@ -26,7 +26,7 @@ We'll show you how to create a [React Router](https://reactrouter.com/home) appl
 If you already have an existing React Router application and want to add Nx to it you can do so by running the following command:
 
 ```shell
-npx nx init
+npx nx@latest init
 ```
 
 ## Generate a React Router Application

--- a/docs/shared/migration/adding-to-existing-project.md
+++ b/docs/shared/migration/adding-to-existing-project.md
@@ -315,7 +315,7 @@ Now that we're working on the CI pipeline, it is important for your changes to b
 Now connect your repository to Nx Cloud with the following command:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 A browser window will open to register your repository in your [Nx Cloud](https://cloud.nx.app) account. The link is also printed to the terminal if the windows does not open, or you closed it before finishing the steps. The app will guide you to create a PR to enable Nx Cloud on your repository.

--- a/docs/shared/migration/adding-to-monorepo.md
+++ b/docs/shared/migration/adding-to-monorepo.md
@@ -331,7 +331,7 @@ Now that we're working on the CI pipeline, it is important for your changes to b
 Now connect your repository to Nx Cloud with the following command:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 A browser window will open to register your repository in your [Nx Cloud](https://cloud.nx.app) account. The link is also printed to the terminal if the windows does not open, or you closed it before finishing the steps. The app will guide you to create a PR to enable Nx Cloud on your repository.

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -135,7 +135,7 @@ Now that we're working on the CI pipeline, it is important for your changes to b
 Now connect your repository to Nx Cloud with the following command:
 
 ```shell
-npx nx connect
+npx nx@latest connect
 ```
 
 A browser window will open to register your repository in your [Nx Cloud](https://cloud.nx.app) account. The link is also printed to the terminal if the windows does not open, or you closed it before finishing the steps. The app will guide you to create a PR to enable Nx Cloud on your repository.
@@ -237,7 +237,7 @@ Nx Console no longer supports the Angular CLI. Angular CLI users will receive a 
 If you're not ready to make the change yet, you can come back to this later:
 
 - If you're using Nx Console: open the Vs Code command palette and start typing "Convert Angular CLI to Nx Workspace".
-- Regardless of using Nx Console (or your IDE): run `npx nx init` from the root of your project.
+- Regardless of using Nx Console (or your IDE): run `npx nx@latest init` from the root of your project.
 
 Once the script has run, commit the changes. Reverting this commit will effectively undo the changes made.
 


### PR DESCRIPTION
Documentation instructs users to run `npx nx init` and `npx nx connect`, which may use cached outdated versions of
Nx.

## Expected Behavior

Documentation now uses `npx nx@latest` to ensure users always get the latest version, preventing issues from outdated
cached versions.

Updated 27 command occurrences across 23 documentation files:
- `npx nx init` → `npx nx@latest init`
- `npx nx connect` → `npx nx@latest connect`
- `npx nx connect-to-nx-cloud` → `npx nx@latest connect-to-nx-cloud`

## Related Issue(s)

Fixes #