### PR TITLE
fix(rspack): abide by rspacks watch configuration

### DIFF
--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -47,7 +47,9 @@ export default async function* runExecutor(
     success: boolean;
     outfile?: string;
   }>(async ({ next, done }) => {
-    if (options.watch) {
+    const watch = compiler instanceof Compiler ? compiler.options.watch : compiler.options[0].watch;
+
+    if (watch) {
       const watcher = compiler.watch(
         {},
         async (err, stats: Stats | MultiStats) => {

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -48,9 +48,9 @@ export default async function* runExecutor(
     outfile?: string;
   }>(async ({ next, done }) => {
     const watch =
-      compiler instanceof Compiler
+      (compiler instanceof Compiler
         ? compiler.options.watch
-        : compiler.options[0].watch;
+        : compiler.options[0].watch) ?? options.watch;
 
     if (watch) {
       const watcher = compiler.watch(

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -47,7 +47,10 @@ export default async function* runExecutor(
     success: boolean;
     outfile?: string;
   }>(async ({ next, done }) => {
-    const watch = compiler instanceof Compiler ? compiler.options.watch : compiler.options[0].watch;
+    const watch =
+      compiler instanceof Compiler
+        ? compiler.options.watch
+        : compiler.options[0].watch;
 
     if (watch) {
       const watcher = compiler.watch(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

As it currently stands, there is no (easy) way to get HMR support working with Rspack + Nest by using the `@nx/rspack:rspack` build executor and `@nx/js:node` serve executor because we need to turn `watch: false` in the serve executor (as we don't want it to watch and call the build again) but that in turn makes the rspack build executor not use `compiler.watch` this only building once.

Due to the way options are passed through to the executor (via `runExecutor`) even if we do:

```
"options": {
    "buildTarget": "myapp:build",
    "buildTargetOptions": {
        "watch": true
    },
    "watch": false
}
```

The `watch: false` overwrites it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should be able to have the Rspack executor abide by whatever the `watch` configuration is that is returned from our `rspack.config.ts` file for the application.

There is precedent for abiding by the tools configuration file vs the executor option, the Webpack executor already does it.

The Webpack compiler is started in watch mode if the `watch` flag is true in the webpack config itself vs. strictly abiding by the executors options. Based on https://github.com/nrwl/nx/issues/1992#issuecomment-2826664777 I could do what I want, but I am using Rspack not Webpack.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

https://github.com/nrwl/nx/issues/1992

Fixes #
