### PR TITLE
fix(node): prune targets should depend on build

### DIFF
--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -221,6 +221,9 @@ describe('app', () => {
               },
               "copy-workspace-modules": {
                 "cache": true,
+                "dependsOn": [
+                  "build",
+                ],
                 "executor": "@nx/js:copy-workspace-modules",
                 "options": {
                   "buildTarget": "build",
@@ -239,6 +242,9 @@ describe('app', () => {
               },
               "prune-lockfile": {
                 "cache": true,
+                "dependsOn": [
+                  "build",
+                ],
                 "executor": "@nx/js:prune-lockfile",
                 "options": {
                   "buildTarget": "build",
@@ -419,6 +425,9 @@ describe('app', () => {
             },
             "copy-workspace-modules": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:copy-workspace-modules",
               "options": {
                 "buildTarget": "build",
@@ -437,6 +446,9 @@ describe('app', () => {
             },
             "prune-lockfile": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:prune-lockfile",
               "options": {
                 "buildTarget": "build",

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -55,6 +55,9 @@ describe('application generator', () => {
           },
           "copy-workspace-modules": {
             "cache": true,
+            "dependsOn": [
+              "build",
+            ],
             "executor": "@nx/js:copy-workspace-modules",
             "options": {
               "buildTarget": "build",
@@ -70,6 +73,9 @@ describe('application generator', () => {
           },
           "prune-lockfile": {
             "cache": true,
+            "dependsOn": [
+              "build",
+            ],
             "executor": "@nx/js:prune-lockfile",
             "options": {
               "buildTarget": "build",
@@ -268,6 +274,9 @@ describe('application generator', () => {
               },
               "copy-workspace-modules": {
                 "cache": true,
+                "dependsOn": [
+                  "build",
+                ],
                 "executor": "@nx/js:copy-workspace-modules",
                 "options": {
                   "buildTarget": "build",
@@ -283,6 +292,9 @@ describe('application generator', () => {
               },
               "prune-lockfile": {
                 "cache": true,
+                "dependsOn": [
+                  "build",
+                ],
                 "executor": "@nx/js:prune-lockfile",
                 "options": {
                   "buildTarget": "build",
@@ -456,6 +468,9 @@ describe('application generator', () => {
             },
             "copy-workspace-modules": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:copy-workspace-modules",
               "options": {
                 "buildTarget": "build",
@@ -471,6 +486,9 @@ describe('application generator', () => {
             },
             "prune-lockfile": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:prune-lockfile",
               "options": {
                 "buildTarget": "build",

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -44,6 +44,9 @@ describe('app', () => {
           "targets": {
             "copy-workspace-modules": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:copy-workspace-modules",
               "options": {
                 "buildTarget": "build",
@@ -59,6 +62,9 @@ describe('app', () => {
             },
             "prune-lockfile": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:prune-lockfile",
               "options": {
                 "buildTarget": "build",
@@ -279,6 +285,9 @@ describe('app', () => {
             },
             "copy-workspace-modules": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:copy-workspace-modules",
               "options": {
                 "buildTarget": "build",
@@ -294,6 +303,9 @@ describe('app', () => {
             },
             "prune-lockfile": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:prune-lockfile",
               "options": {
                 "buildTarget": "build",
@@ -665,6 +677,9 @@ describe('app', () => {
             "targets": {
               "copy-workspace-modules": {
                 "cache": true,
+                "dependsOn": [
+                  "build",
+                ],
                 "executor": "@nx/js:copy-workspace-modules",
                 "options": {
                   "buildTarget": "build",
@@ -680,6 +695,9 @@ describe('app', () => {
               },
               "prune-lockfile": {
                 "cache": true,
+                "dependsOn": [
+                  "build",
+                ],
                 "executor": "@nx/js:prune-lockfile",
                 "options": {
                   "buildTarget": "build",
@@ -958,6 +976,9 @@ describe('app', () => {
           "targets": {
             "copy-workspace-modules": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:copy-workspace-modules",
               "options": {
                 "buildTarget": "build",
@@ -973,6 +994,9 @@ describe('app', () => {
             },
             "prune-lockfile": {
               "cache": true,
+              "dependsOn": [
+                "build",
+              ],
               "executor": "@nx/js:prune-lockfile",
               "options": {
                 "buildTarget": "build",

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -134,6 +134,7 @@ export function getPruneTargets(buildTarget: string): {
 } {
   return {
     'prune-lockfile': {
+      dependsOn: ['build'],
       cache: true,
       executor: '@nx/js:prune-lockfile',
       options: {
@@ -141,6 +142,7 @@ export function getPruneTargets(buildTarget: string): {
       },
     },
     'copy-workspace-modules': {
+      dependsOn: ['build'],
       cache: true,
       executor: '@nx/js:copy-workspace-modules',
       options: {


### PR DESCRIPTION
## Current Behavior
Task ordering for running `prune` was not correct as the `prune-lockfile` and `copy-workspace-modules` targets need the build to have succeeded first.

## Expected Behavior
Ensure `prune-lockfile` and `copy-workspace-modules` depends on `build`
