### PR TITLE
fix(misc): loose and fix the ts solution setup requirements and use it when there is no root tsconfig file

### DIFF
--- a/e2e/workspace-create/src/create-nx-workspace-npm.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-npm.test.ts
@@ -29,7 +29,7 @@ describe('create-nx-workspace --preset=npm', () => {
 
   afterEach(() => {
     // cleanup previous projects
-    runCommand(`rm -rf packages/** tsconfig.base.json`);
+    runCommand(`rm -rf packages/** tsconfig.base.json tsconfig.json`);
   });
 
   afterAll(() => {
@@ -80,11 +80,14 @@ describe('create-nx-workspace --preset=npm', () => {
     expect(() =>
       runCLI(`generate @nx/js:library packages/${libName} --no-interactive`)
     ).not.toThrow();
-    checkFilesExist('tsconfig.base.json');
-    const tsconfig = readJson(`tsconfig.base.json`);
-    expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${wsName}/${libName}`]: [`packages/${libName}/src/index.ts`],
-    });
+    checkFilesExist('tsconfig.base.json', 'tsconfig.json');
+    const tsconfigBase = readJson(`tsconfig.base.json`);
+    expect(tsconfigBase.compilerOptions.paths).toBeUndefined();
+    const tsconfig = readJson(`tsconfig.json`);
+    expect(tsconfig.extends).toBe('./tsconfig.base.json');
+    expect(tsconfig.references).toStrictEqual([
+      { path: `./packages/${libName}` },
+    ]);
   });
 
   it('should add web application', () => {
@@ -117,11 +120,14 @@ describe('create-nx-workspace --preset=npm', () => {
     expect(() => {
       runCLI(`generate @nx/react:lib packages/${libName} --no-interactive`);
     }).not.toThrow();
-    checkFilesExist('tsconfig.base.json');
-    const tsconfig = readJson(`tsconfig.base.json`);
-    expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${wsName}/${libName}`]: [`packages/${libName}/src/index.ts`],
-    });
+    checkFilesExist('tsconfig.base.json', 'tsconfig.json');
+    const tsconfigBase = readJson(`tsconfig.base.json`);
+    expect(tsconfigBase.compilerOptions.paths).toBeUndefined();
+    const tsconfig = readJson(`tsconfig.json`);
+    expect(tsconfig.extends).toBe('./tsconfig.base.json');
+    expect(tsconfig.references).toStrictEqual([
+      { path: `./packages/${libName}` },
+    ]);
   });
 
   it('should add next application', () => {
@@ -143,12 +149,14 @@ describe('create-nx-workspace --preset=npm', () => {
     expect(() => {
       runCLI(`generate @nx/next:lib packages/${libName} --no-interactive`);
     }).not.toThrow();
-    checkFilesExist('tsconfig.base.json');
-    const tsconfig = readJson(`tsconfig.base.json`);
-    expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${wsName}/${libName}`]: [`packages/${libName}/src/index.ts`],
-      [`@${wsName}/${libName}/server`]: [`packages/${libName}/src/server.ts`],
-    });
+    checkFilesExist('tsconfig.base.json', 'tsconfig.json');
+    const tsconfigBase = readJson(`tsconfig.base.json`);
+    expect(tsconfigBase.compilerOptions.paths).toBeUndefined();
+    const tsconfig = readJson(`tsconfig.json`);
+    expect(tsconfig.extends).toBe('./tsconfig.base.json');
+    expect(tsconfig.references).toStrictEqual([
+      { path: `./packages/${libName}` },
+    ]);
   });
 
   it('should add react-native application', () => {
@@ -174,11 +182,14 @@ describe('create-nx-workspace --preset=npm', () => {
         `generate @nx/react-native:lib packages/${libName} --no-interactive`
       );
     }).not.toThrow();
-    checkFilesExist('tsconfig.base.json');
-    const tsconfig = readJson(`tsconfig.base.json`);
-    expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${wsName}/${libName}`]: [`packages/${libName}/src/index.ts`],
-    });
+    checkFilesExist('tsconfig.base.json', 'tsconfig.json');
+    const tsconfigBase = readJson(`tsconfig.base.json`);
+    expect(tsconfigBase.compilerOptions.paths).toBeUndefined();
+    const tsconfig = readJson(`tsconfig.json`);
+    expect(tsconfig.extends).toBe('./tsconfig.base.json');
+    expect(tsconfig.references).toStrictEqual([
+      { path: `./packages/${libName}` },
+    ]);
   });
 
   it('should add node application', () => {
@@ -200,11 +211,14 @@ describe('create-nx-workspace --preset=npm', () => {
     expect(() => {
       runCLI(`generate @nx/node:lib packages/${libName} --no-interactive`);
     }).not.toThrow();
-    checkFilesExist('tsconfig.base.json');
-    const tsconfig = readJson(`tsconfig.base.json`);
-    expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${wsName}/${libName}`]: [`packages/${libName}/src/index.ts`],
-    });
+    checkFilesExist('tsconfig.base.json', 'tsconfig.json');
+    const tsconfigBase = readJson(`tsconfig.base.json`);
+    expect(tsconfigBase.compilerOptions.paths).toBeUndefined();
+    const tsconfig = readJson(`tsconfig.json`);
+    expect(tsconfig.extends).toBe('./tsconfig.base.json');
+    expect(tsconfig.references).toStrictEqual([
+      { path: `./packages/${libName}` },
+    ]);
   });
 
   it('should add nest application', () => {
@@ -226,11 +240,14 @@ describe('create-nx-workspace --preset=npm', () => {
     expect(() => {
       runCLI(`generate @nx/nest:lib packages/${libName} --no-interactive`);
     }).not.toThrow();
-    checkFilesExist('tsconfig.base.json');
-    const tsconfig = readJson(`tsconfig.base.json`);
-    expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${wsName}/${libName}`]: [`packages/${libName}/src/index.ts`],
-    });
+    checkFilesExist('tsconfig.base.json', 'tsconfig.json');
+    const tsconfigBase = readJson(`tsconfig.base.json`);
+    expect(tsconfigBase.compilerOptions.paths).toBeUndefined();
+    const tsconfig = readJson(`tsconfig.json`);
+    expect(tsconfig.extends).toBe('./tsconfig.base.json');
+    expect(tsconfig.references).toStrictEqual([
+      { path: `./packages/${libName}` },
+    ]);
   });
 
   it('should add express application', () => {

--- a/packages/detox/src/generators/application/application.ts
+++ b/packages/detox/src/generators/application/application.ts
@@ -11,6 +11,7 @@ import { Schema } from './schema';
 import { ensureDependencies } from './lib/ensure-dependencies';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -27,7 +28,9 @@ export async function detoxApplicationGeneratorInternal(
   host: Tree,
   schema: Schema
 ) {
+  const addTsPlugin = shouldConfigureTsSolutionSetup(host, schema.addPlugin);
   const jsInitTask = await jsInitGenerator(host, {
+    addTsPlugin,
     skipFormat: true,
   });
 

--- a/packages/expo/src/generators/application/application.ts
+++ b/packages/expo/src/generators/application/application.ts
@@ -8,6 +8,7 @@ import {
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
@@ -42,10 +43,15 @@ export async function expoApplicationGeneratorInternal(
   schema: Schema
 ): Promise<GeneratorCallback> {
   const tasks: GeneratorCallback[] = [];
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    host,
+    schema.addPlugin,
+    schema.useTsSolution
+  );
   const jsInitTask = await jsInitGenerator(host, {
     ...schema,
     skipFormat: true,
-    addTsPlugin: schema.useTsSolution,
+    addTsPlugin,
     formatter: schema.formatter,
     platform: 'web',
   });

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -29,6 +29,7 @@ import { initRootBabelConfig } from '../../utils/init-root-babel-config';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -56,8 +57,10 @@ export async function expoLibraryGeneratorInternal(
 ): Promise<GeneratorCallback> {
   const tasks: GeneratorCallback[] = [];
 
+  const addTsPlugin = shouldConfigureTsSolutionSetup(host, schema.addPlugin);
   const jsInitTask = await jsInitGenerator(host, {
     ...schema,
+    addTsPlugin,
     skipFormat: true,
   });
   tasks.push(jsInitTask);

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -52,6 +52,7 @@ import {
   addProjectToTsSolutionWorkspace,
   isUsingTsSolutionSetup,
   isUsingTypeScriptPlugin,
+  shouldConfigureTsSolutionSetup,
 } from '../../utils/typescript/ts-solution-setup';
 import {
   esbuildVersion,
@@ -91,12 +92,14 @@ export async function libraryGeneratorInternal(
 ) {
   const tasks: GeneratorCallback[] = [];
 
+  const addTsPlugin = shouldConfigureTsSolutionSetup(tree, schema.addPlugin);
   tasks.push(
     await jsInitGenerator(tree, {
       ...schema,
       skipFormat: true,
       tsConfigName: schema.rootProject ? 'tsconfig.json' : 'tsconfig.base.json',
       addTsConfigBase: true,
+      addTsPlugin,
       // In the new setup, Prettier is prompted for and installed during `create-nx-workspace`.
       formatter: isUsingTsSolutionSetup(tree) ? 'none' : 'prettier',
     })

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -48,13 +48,16 @@ export function shouldConfigureTsSolutionSetup(
       nxJson.useInferencePlugins !== false;
   }
 
-  // if the user didn't explicitly disabled adding plugins and there are no
-  // root tsconfig files, we should configure the TS solution setup
-  return (
-    addPlugins &&
-    !tree.exists('tsconfig.base.json') &&
-    !tree.exists('tsconfig.json')
-  );
+  if (!addPlugins) {
+    return false;
+  }
+
+  if (!isUsingPackageManagerWorkspaces(tree)) {
+    return false;
+  }
+
+  // if there are no root tsconfig files, we should configure the TS solution setup
+  return !tree.exists('tsconfig.base.json') && !tree.exists('tsconfig.json');
 }
 
 export function isUsingTsSolutionSetup(tree?: Tree): boolean {

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -32,6 +32,31 @@ export function isUsingTypeScriptPlugin(tree: Tree): boolean {
   );
 }
 
+export function shouldConfigureTsSolutionSetup(
+  tree: Tree,
+  addPlugins: boolean,
+  addTsPlugin?: boolean
+): boolean {
+  if (addTsPlugin !== undefined) {
+    return addTsPlugin;
+  }
+
+  if (addPlugins === undefined) {
+    const nxJson = readNxJson(tree);
+    addPlugins =
+      process.env.NX_ADD_PLUGINS !== 'false' &&
+      nxJson.useInferencePlugins !== false;
+  }
+
+  // if the user didn't explicitly disabled adding plugins and there are no
+  // root tsconfig files, we should configure the TS solution setup
+  return (
+    addPlugins &&
+    !tree.exists('tsconfig.base.json') &&
+    !tree.exists('tsconfig.json')
+  );
+}
+
 export function isUsingTsSolutionSetup(tree?: Tree): boolean {
   tree ??= new FsTree(workspaceRoot, false);
 
@@ -41,6 +66,15 @@ export function isUsingTsSolutionSetup(tree?: Tree): boolean {
   );
 }
 
+/**
+ * The TS solution setup requires:
+ * - `tsconfig.base.json`: TS config with common compiler options needed by the
+ *    majority of projects in the workspace. It's meant to be extended by other
+ *    tsconfig files in the workspace to reuse them.
+ * - `tsconfig.json`: TS solution config file that references all other projects
+ *    in the repo. It shouldn't include any file and it's not meant to be
+ *    extended or define any common compiler options.
+ */
 function isWorkspaceSetupWithTsSolution(tree: Tree): boolean {
   if (!tree.exists('tsconfig.base.json') || !tree.exists('tsconfig.json')) {
     return false;
@@ -52,31 +86,33 @@ function isWorkspaceSetupWithTsSolution(tree: Tree): boolean {
   }
 
   /**
-   * New setup:
-   * - `files` is defined and set to an empty array
-   * - `references` is defined and set to an empty array
-   * - `include` is not defined or is set to an empty array
+   * TS solution setup requires:
+   * - One of `files` or `include` defined
+   * - If set, they must be empty arrays
+   *
+   * Note: while the TS solution setup uses TS project references, in the initial
+   * state of the workspace, where there are no projects, `references` is not
+   * required to be defined.
    */
   if (
-    !tsconfigJson.files ||
-    tsconfigJson.files.length > 0 ||
-    !tsconfigJson.references ||
-    !!tsconfigJson.include?.length
+    (!tsconfigJson.files && !tsconfigJson.include) ||
+    tsconfigJson.files?.length > 0 ||
+    tsconfigJson.include?.length > 0
   ) {
     return false;
   }
 
+  /**
+   * TS solution setup requires:
+   * - `compilerOptions.composite`: true
+   * - `compilerOptions.declaration`: true or not set (default to true)
+   */
   const baseTsconfigJson = readJson(tree, 'tsconfig.base.json');
   if (
     !baseTsconfigJson.compilerOptions ||
     !baseTsconfigJson.compilerOptions.composite ||
     baseTsconfigJson.compilerOptions.declaration === false
   ) {
-    return false;
-  }
-
-  const { compilerOptions, ...rest } = baseTsconfigJson;
-  if (Object.keys(rest).length > 0) {
     return false;
   }
 

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -6,7 +6,10 @@ import {
 import { getNpmScope } from '@nx/js/src/utils/package-json/get-npm-scope';
 import type { LibraryGeneratorSchema as JsLibraryGeneratorSchema } from '@nx/js/src/generators/library/schema';
 import type { LibraryGeneratorOptions, NormalizedOptions } from '../schema';
-import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import {
+  isUsingTsSolutionSetup,
+  shouldConfigureTsSolutionSetup,
+} from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export async function normalizeOptions(
   tree: Tree,
@@ -38,7 +41,12 @@ export async function normalizeOptions(
     ? options.tags.split(',').map((s) => s.trim())
     : [];
 
-  const isUsingTsSolutionsConfig = isUsingTsSolutionSetup(tree);
+  // this helper is called before the jsLibraryGenerator is called, so, if the
+  // TS solution setup is not configured, we additionally check if the TS
+  // solution setup will be configured by the jsLibraryGenerator
+  const isUsingTsSolutionsConfig =
+    isUsingTsSolutionSetup(tree) ||
+    shouldConfigureTsSolutionSetup(tree, addPlugin);
   const normalized: NormalizedOptions = {
     ...options,
     strict: options.strict ?? true,

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -31,6 +31,7 @@ import { tsLibVersion } from '../../utils/versions';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -47,19 +48,24 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
 
 export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
-  const options = await normalizeOptions(host, schema);
 
-  showPossibleWarnings(host, options);
-
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    host,
+    schema.addPlugin,
+    schema.useTsSolution
+  );
   const jsInitTask = await jsInitGenerator(host, {
-    js: options.js,
-    skipPackageJson: options.skipPackageJson,
+    js: schema.js,
+    skipPackageJson: schema.skipPackageJson,
     skipFormat: true,
-    addTsPlugin: options.isTsSolutionSetup,
-    formatter: options.formatter,
+    addTsPlugin,
+    formatter: schema.formatter,
     platform: 'web',
   });
   tasks.push(jsInitTask);
+
+  const options = await normalizeOptions(host, schema);
+  showPossibleWarnings(host, options);
 
   const nextTask = await nextInitGenerator(host, {
     ...options,

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -22,6 +22,7 @@ import {
   isUsingTsSolutionSetup,
   addProjectToTsSolutionWorkspace,
   updateTsconfigFiles,
+  shouldConfigureTsSolutionSetup,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
 
@@ -34,16 +35,21 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
 }
 
 export async function libraryGeneratorInternal(host: Tree, rawOptions: Schema) {
-  const options = await normalizeOptions(host, rawOptions);
   const tasks: GeneratorCallback[] = [];
 
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    host,
+    rawOptions.addPlugin
+  );
   const jsInitTask = await jsInitGenerator(host, {
-    js: options.js,
-    skipPackageJson: options.skipPackageJson,
+    js: rawOptions.js,
+    addTsPlugin,
+    skipPackageJson: rawOptions.skipPackageJson,
     skipFormat: true,
   });
   tasks.push(jsInitTask);
 
+  const options = await normalizeOptions(host, rawOptions);
   const initTask = await nextInitGenerator(host, {
     ...options,
     skipFormat: true,

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -14,6 +14,7 @@ import { configurationGenerator } from '@nx/jest';
 import { initGenerator as jsInitGenerator, tsConfigBaseOptions } from '@nx/js';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -73,11 +74,16 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
 
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    tree,
+    schema.addPlugin,
+    schema.useTsSolution
+  );
   const jsInitTask = await jsInitGenerator(tree, {
     ...schema,
     tsConfigName: schema.rootProject ? 'tsconfig.json' : 'tsconfig.base.json',
     skipFormat: true,
-    addTsPlugin: schema.useTsSolution,
+    addTsPlugin,
   });
   tasks.push(jsInitTask);
 

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -32,6 +32,7 @@ import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-default
 import {
   addProjectToTsSolutionWorkspace,
   isUsingTsSolutionSetup,
+  shouldConfigureTsSolutionSetup,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
 
@@ -164,7 +165,12 @@ async function normalizeOptions(
     ? options.tags.split(',').map((s) => s.trim())
     : [];
 
-  const isUsingTsSolutionConfig = isUsingTsSolutionSetup(tree);
+  // this helper is called before the jsLibraryGenerator is called, so, if the
+  // TS solution setup is not configured, we additionally check if the TS
+  // solution setup will be configured by the jsLibraryGenerator
+  const isUsingTsSolutionConfig =
+    isUsingTsSolutionSetup(tree) ||
+    shouldConfigureTsSolutionSetup(tree, options.addPlugin);
   return {
     ...options,
     fileName,

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -33,6 +33,7 @@ import {
 } from 'nx/src/nx-cloud/utilities/onboarding';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -48,11 +49,16 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
 
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    tree,
+    true, // nuxt always adds plugins
+    schema.useTsSolution
+  );
   const jsInitTask = await jsInitGenerator(tree, {
     ...schema,
     tsConfigName: schema.rootProject ? 'tsconfig.json' : 'tsconfig.base.json',
     skipFormat: true,
-    addTsPlugin: schema.useTsSolution,
+    addTsPlugin,
     platform: 'web',
   });
   tasks.push(jsInitTask);

--- a/packages/plugin/src/generators/create-package/utils/normalize-schema.ts
+++ b/packages/plugin/src/generators/create-package/utils/normalize-schema.ts
@@ -5,7 +5,10 @@ import {
   normalizeLinterOption,
   normalizeUnitTestRunnerOption,
 } from '@nx/js/src/utils/generator-prompts';
-import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import {
+  isUsingTsSolutionSetup,
+  shouldConfigureTsSolutionSetup,
+} from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { CreatePackageSchema } from '../schema';
 
 export interface NormalizedSchema extends CreatePackageSchema {
@@ -45,7 +48,13 @@ export async function normalizeSchema(
     directory: schema.directory,
   });
 
-  const isTsSolutionSetup = isUsingTsSolutionSetup(host);
+  // this helper is called before the other generators that end up calling the
+  // jsLibraryGenerator, so, if the TS solution setup is not configured, we
+  // additionally check if the TS solution setup will be configured by the
+  // jsLibraryGenerator
+  const isTsSolutionSetup =
+    isUsingTsSolutionSetup(host) ||
+    shouldConfigureTsSolutionSetup(host, schema.addPlugin);
   const nxJson = readNxJson(host);
   const addPlugin =
     schema.addPlugin ??

--- a/packages/plugin/src/generators/plugin/utils/normalize-schema.ts
+++ b/packages/plugin/src/generators/plugin/utils/normalize-schema.ts
@@ -8,7 +8,10 @@ import {
   normalizeLinterOption,
   normalizeUnitTestRunnerOption,
 } from '@nx/js/src/utils/generator-prompts';
-import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import {
+  isUsingTsSolutionSetup,
+  shouldConfigureTsSolutionSetup,
+} from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { Schema } from '../schema';
 
 export interface NormalizedSchema extends Schema {
@@ -38,7 +41,12 @@ export async function normalizeOptions(
     ['jest', 'vitest']
   );
 
-  const isTsSolutionSetup = isUsingTsSolutionSetup(host);
+  // this helper is called before the jsLibraryGenerator is called, so, if the
+  // TS solution setup is not configured, we additionally check if the TS
+  // solution setup will be configured by the jsLibraryGenerator
+  const isTsSolutionSetup =
+    isUsingTsSolutionSetup(host) ||
+    shouldConfigureTsSolutionSetup(host, options.addPlugin);
   const nxJson = readNxJson(host);
   const addPlugin =
     options.addPlugin ??

--- a/packages/plugin/src/generators/preset/generator.ts
+++ b/packages/plugin/src/generators/preset/generator.ts
@@ -1,13 +1,11 @@
 import {
   formatFiles,
   names,
-  readNxJson,
   runTasksInSerial,
   updateJson,
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
-import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { createPackageGenerator } from '../create-package/create-package';
 import { pluginGenerator } from '../plugin/plugin';
@@ -32,7 +30,7 @@ export async function presetGeneratorInternal(
   rawOptions: PresetGeneratorSchema
 ) {
   const tasks: GeneratorCallback[] = [];
-  const options = normalizeOptions(tree, rawOptions);
+  const options = normalizeOptions(rawOptions);
 
   const pluginTask = await pluginGenerator(tree, {
     compiler: 'tsc',
@@ -89,18 +87,8 @@ function moveNxPluginToDevDeps(tree: Tree) {
 }
 
 function normalizeOptions(
-  tree: Tree,
   options: PresetGeneratorSchema
 ): NormalizedPresetGeneratorOptions {
-  const isTsSolutionSetup = isUsingTsSolutionSetup(tree);
-
-  const nxJson = readNxJson(tree);
-  const addPlugin =
-    options.addPlugin ??
-    (isTsSolutionSetup &&
-      process.env.NX_ADD_PLUGINS !== 'false' &&
-      nxJson.useInferencePlugins !== false);
-
   return {
     ...options,
     pluginName: names(
@@ -112,8 +100,6 @@ function normalizeOptions(
       options.createPackageName === 'false' // for command line in e2e, it is passed as a string
         ? undefined
         : options.createPackageName,
-    addPlugin,
-    useProjectJson: options.useProjectJson ?? !isTsSolutionSetup,
   };
 }
 

--- a/packages/plugin/src/generators/preset/schema.d.ts
+++ b/packages/plugin/src/generators/preset/schema.d.ts
@@ -8,6 +8,4 @@ export interface PresetGeneratorSchema {
 export interface NormalizedPresetGeneratorOptions
   extends PresetGeneratorSchema {
   createPackageName: string;
-  useProjectJson: boolean;
-  addPlugin: boolean;
 }

--- a/packages/react-native/src/generators/application/application.ts
+++ b/packages/react-native/src/generators/application/application.ts
@@ -27,6 +27,7 @@ import { syncDeps } from '../../executors/sync-deps/sync-deps.impl';
 import { PackageJson } from 'nx/src/utils/package-json';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -47,10 +48,15 @@ export async function reactNativeApplicationGeneratorInternal(
   schema: Schema
 ): Promise<GeneratorCallback> {
   const tasks: GeneratorCallback[] = [];
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    host,
+    schema.addPlugin,
+    schema.useTsSolution
+  );
   const jsInitTask = await jsInitGenerator(host, {
     ...schema,
     skipFormat: true,
-    addTsPlugin: schema.useTsSolution,
+    addTsPlugin,
     formatter: schema.formatter,
     platform: 'web',
   });

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -32,6 +32,7 @@ import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -64,8 +65,10 @@ export async function reactNativeLibraryGeneratorInternal(
 ): Promise<GeneratorCallback> {
   const tasks: GeneratorCallback[] = [];
 
+  const addTsPlugin = shouldConfigureTsSolutionSetup(host, schema.addPlugin);
   const jsInitTask = await jsInitGenerator(host, {
     ...schema,
+    addTsPlugin,
     skipFormat: true,
   });
   tasks.push(jsInitTask);

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -12,6 +12,7 @@ import { initGenerator as jsInitGenerator } from '@nx/js';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { extractTsConfigBase } from '../../utils/create-ts-config';
@@ -63,11 +64,16 @@ export async function applicationGeneratorInternal(
 ): Promise<GeneratorCallback> {
   const tasks = [];
 
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    tree,
+    schema.addPlugin,
+    schema.useTsSolution
+  );
   const jsInitTask = await jsInitGenerator(tree, {
     ...schema,
     tsConfigName: schema.rootProject ? 'tsconfig.json' : 'tsconfig.base.json',
     skipFormat: true,
-    addTsPlugin: schema.useTsSolution,
+    addTsPlugin,
     formatter: schema.formatter,
     platform: 'web',
   });

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -26,6 +26,7 @@ import {
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { shouldUseLegacyVersioning } from 'nx/src/command-line/release/config/use-legacy-versioning';
@@ -57,8 +58,10 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
 export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
 
+  const addTsPlugin = shouldConfigureTsSolutionSetup(host, schema.addPlugin);
   const jsInitTask = await jsInitGenerator(host, {
     ...schema,
+    addTsPlugin,
     skipFormat: true,
   });
   tasks.push(jsInitTask);

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -44,6 +44,7 @@ import {
 import { NxRemixGeneratorSchema } from './schema';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -63,6 +64,11 @@ export async function remixApplicationGeneratorInternal(
   tree: Tree,
   _options: NxRemixGeneratorSchema
 ) {
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    tree,
+    _options.addPlugin,
+    _options.useTsSolution
+  );
   const tasks: GeneratorCallback[] = [
     await initGenerator(tree, {
       skipFormat: true,
@@ -70,7 +76,7 @@ export async function remixApplicationGeneratorInternal(
     }),
     await jsInitGenerator(tree, {
       skipFormat: true,
-      addTsPlugin: _options.useTsSolution,
+      addTsPlugin,
       formatter: _options.formatter,
       platform: 'web',
     }),

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -11,6 +11,7 @@ import {
 import type { NxRemixGeneratorSchema } from './schema';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -31,17 +32,20 @@ export async function remixLibraryGeneratorInternal(
   schema: NxRemixGeneratorSchema
 ) {
   const tasks: GeneratorCallback[] = [];
+
+  const addTsPlugin = shouldConfigureTsSolutionSetup(tree, schema.addPlugin);
+  const jsInitTask = await jsInitGenerator(tree, {
+    js: schema.js,
+    addTsPlugin,
+    skipFormat: true,
+  });
+  tasks.push(jsInitTask);
+
   const options = await normalizeOptions(tree, schema);
 
   if (options.isUsingTsSolutionConfig) {
     await addProjectToTsSolutionWorkspace(tree, options.projectRoot);
   }
-
-  const jsInitTask = await jsInitGenerator(tree, {
-    js: options.js,
-    skipFormat: true,
-  });
-  tasks.push(jsInitTask);
 
   const libGenTask = await libraryGenerator(tree, {
     directory: options.directory,

--- a/packages/vue/src/generators/application/application.ts
+++ b/packages/vue/src/generators/application/application.ts
@@ -23,6 +23,7 @@ import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
@@ -41,6 +42,11 @@ export async function applicationGeneratorInternal(
   _options: Schema
 ): Promise<GeneratorCallback> {
   const tasks: GeneratorCallback[] = [];
+  const addTsPlugin = shouldConfigureTsSolutionSetup(
+    tree,
+    _options.addPlugin,
+    _options.useTsSolution
+  );
   tasks.push(
     await jsInitGenerator(tree, {
       ..._options,
@@ -48,7 +54,7 @@ export async function applicationGeneratorInternal(
         ? 'tsconfig.json'
         : 'tsconfig.base.json',
       skipFormat: true,
-      addTsPlugin: _options.useTsSolution,
+      addTsPlugin,
       formatter: _options.formatter,
       platform: 'web',
     })

--- a/packages/vue/src/generators/library/library.ts
+++ b/packages/vue/src/generators/library/library.ts
@@ -23,6 +23,7 @@ import {
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
 import {
   addProjectToTsSolutionWorkspace,
+  shouldConfigureTsSolutionSetup,
   updateTsconfigFiles,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { shouldUseLegacyVersioning } from 'nx/src/command-line/release/config/use-legacy-versioning';
@@ -50,14 +51,22 @@ export function libraryGenerator(tree: Tree, schema: Schema) {
 export async function libraryGeneratorInternal(tree: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
 
-  const options = await normalizeOptions(tree, schema);
-  if (options.publishable === true && !schema.importPath) {
+  if (schema.publishable === true && !schema.importPath) {
     throw new Error(
       `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
     );
   }
 
-  tasks.push(await jsInitGenerator(tree, { ...options, skipFormat: true }));
+  const addTsPlugin = shouldConfigureTsSolutionSetup(tree, schema.addPlugin);
+  tasks.push(
+    await jsInitGenerator(tree, {
+      ...schema,
+      addTsPlugin,
+      skipFormat: true,
+    })
+  );
+
+  const options = await normalizeOptions(tree, schema);
 
   // If we are using the new TS solution
   // We need to update the workspace file (package.json or pnpm-workspaces.yaml) to include the new project

--- a/packages/workspace/src/utilities/typescript/ts-solution-setup.ts
+++ b/packages/workspace/src/utilities/typescript/ts-solution-setup.ts
@@ -31,6 +31,15 @@ function isWorkspacesEnabled(tree: Tree): boolean {
   return false;
 }
 
+/**
+ * The TS solution setup requires:
+ * - `tsconfig.base.json`: TS config with common compiler options needed by the
+ *    majority of projects in the workspace. It's meant to be extended by other
+ *    tsconfig files in the workspace to reuse them.
+ * - `tsconfig.json`: TS solution config file that references all other projects
+ *    in the repo. It shouldn't include any file and it's not meant to be
+ *    extended or define any common compiler options.
+ */
 function isWorkspaceSetupWithTsSolution(tree: Tree): boolean {
   if (!tree.exists('tsconfig.base.json') || !tree.exists('tsconfig.json')) {
     return false;
@@ -42,31 +51,33 @@ function isWorkspaceSetupWithTsSolution(tree: Tree): boolean {
   }
 
   /**
-   * New setup:
-   * - `files` is defined and set to an empty array
-   * - `references` is defined and set to an empty array
-   * - `include` is not defined or is set to an empty array
+   * TS solution setup requires:
+   * - One of `files` or `include` defined
+   * - If set, they must be empty arrays
+   *
+   * Note: while the TS solution setup uses TS project references, in the initial
+   * state of the workspace, where there are no projects, `references` is not
+   * required to be defined.
    */
   if (
-    !tsconfigJson.files ||
-    tsconfigJson.files.length > 0 ||
-    !tsconfigJson.references ||
-    !!tsconfigJson.include?.length
+    (!tsconfigJson.files && !tsconfigJson.include) ||
+    tsconfigJson.files?.length > 0 ||
+    tsconfigJson.include?.length > 0
   ) {
     return false;
   }
 
+  /**
+   * TS solution setup requires:
+   * - `compilerOptions.composite`: true
+   * - `compilerOptions.declaration`: true or not set (default to true)
+   */
   const baseTsconfigJson = readJson(tree, 'tsconfig.base.json');
   if (
     !baseTsconfigJson.compilerOptions ||
     !baseTsconfigJson.compilerOptions.composite ||
-    !baseTsconfigJson.compilerOptions.declaration
+    baseTsconfigJson.compilerOptions.declaration === false
   ) {
-    return false;
-  }
-
-  const { compilerOptions, ...rest } = baseTsconfigJson;
-  if (Object.keys(rest).length > 0) {
     return false;
   }
 


### PR DESCRIPTION
## Current Behavior

- The logic to detect whether the workspace uses the TS solution setup restricts the top-level properties in the `tsconfig.base.json` file and only allows `compilerOptions`. This prevents extending from other tsconfig files in the `tsconfig.base.json` file.
- Generating projects in a workspace without any known root tsconfig files (`tsconfig.json`, `tsconfig.base.json`) results in the old setup being generated. Workspaces without root TS configuration should be able to use the TS solution setup.

## Expected Behavior

- The logic to detect whether the workspace uses the TS solution should not restrict the top-level properties in the `tsconfig.base.json` file. The only things required for the TS solution setup are to have `composite: true` and `declarations` enabled.
- The TS solution setup should be used when generating projects in a workspace without any known root tsconfig files (`tsconfig.json`, `tsconfig.base.json`).

## Related Issue(s)

Fixes #32134 