### PR TITLE
fix(rspack): update installed version of rspack to be same as @nx/rspack

### DIFF
--- a/packages/rspack/src/utils/versions.ts
+++ b/packages/rspack/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = require('../../package.json').version;
-export const rspackCoreVersion = '1.3.8';
+export const rspackCoreVersion = '^1.3.8';
 export const rspackDevServerVersion = '1.1.1';
 
 export const rspackPluginReactRefreshVersion = '^1.0.0';


### PR DESCRIPTION
We should match the version which we install of `@rspack/core` to be the same as `@nx/rspack` as the mismatch can cause errors:
https://staging.nx.app/runs/McxmSeecWa/task/e2e-rspack%3Ae2e-local
```
> rspack build --node-env=production

●  ━━━━━━━━━━━━━━━━━━━━━━━━━ (10%) building builtin:swc-loader??ruleSet[1].rules[2].use[0]!/../my-rspack-react/apps/my-rspack-react/src/../repos/my-rspack-react/node_modules/@nx/rspack/node_modules/@rspack/core/dist/cssExtractLoader.js:141
            }) : result, dependencies.length > 0 && this.__internal__setParseMeta(PLUGIN_NAME, JSON.stringify(dependencies)), callback(null, resultSource, void 0, data);
                                                         ^

TypeError: this.__internal__setParseMeta is not a function
    at /../my-rspack-react/node_modules/@nx/rspack/node_modules/@rspack/core/dist/cssExtractLoader.js:141:58
    at ../my-rspack-react/node_modules/@nx/rspack/node_modules/@rspack/core/dist/cssExtractLoader.js:142:11
    at /../my-rspack-react/node_modules/@rspack/core/dist/index.js:3435:255
    at /../my-rspack-react/node_modules/@rspack/core/dist/index.js:3431:120

Node.js v22.16.0
```

This version is also the same as in our migrations for `@nx/rspack`.

References:
https://github.com/nrwl/nx/blob/master/packages/rspack/package.json#L32
https://github.com/nrwl/nx/blob/master/packages/rspack/migrations.json#L81

