### PR TITLE
fix(release): provide a link to Manage Release page when "nx release"fails

### DIFF
--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -1055,6 +1055,7 @@ export async function handleNxReleaseConfigError(
   error: CreateNxReleaseConfigError,
   useLegacyVersioning: boolean
 ): Promise<never> {
+  const linkMessage = `\nRead more about Nx Release at https://nx.dev/features/manage-releases.`;
   switch (error.code) {
     case 'PROJECTS_AND_GROUPS_DEFINED':
       {
@@ -1064,7 +1065,7 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `"projects" is not valid when explicitly defining release groups, and everything should be expressed within "groups" in that case. If you are using "groups" then you should remove the "projects" property`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1076,7 +1077,7 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `Release group "${error.data.releaseGroupName}" matches no projects. Please ensure all release groups match at least one project:`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1088,7 +1089,7 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `Project "${error.data.project}" matches multiple release groups. Please ensure all projects are part of only one release group:`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1102,7 +1103,7 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `Release group "${error.data.releaseGroupName}" has an invalid releaseTagPattern. Please ensure the pattern contains exactly one instance of the "{version}" placeholder`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1116,7 +1117,7 @@ export async function handleNxReleaseConfigError(
           : 'configuration options';
         output.error({
           title: `You have configured both the shorthand "version.conventionalCommits" and one or more of the related ${text} that it sets for you. Please use one or the other:`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1128,7 +1129,7 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `You have duplicate conflicting git configurations. If you are using the top level 'nx release' command, then remove the 'release.version.git' and 'release.changelog.git' properties in favor of 'release.git'. If you are using the subcommands or the programmatic API, then remove the 'release.git' property in favor of 'release.version.git' and 'release.changelog.git':`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1136,7 +1137,7 @@ export async function handleNxReleaseConfigError(
       const nxJsonMessage = await resolveNxJsonConfigErrorMessage(['release']);
       output.error({
         title: `There was an error when resolving the configured changelog renderer at path: ${error.data.workspaceRelativePath}`,
-        bodyLines: [nxJsonMessage],
+        bodyLines: [nxJsonMessage, linkMessage],
       });
       break;
     }
@@ -1153,7 +1154,7 @@ export async function handleNxReleaseConfigError(
           )
             .map((p) => `"${p}"`)
             .join(', ')}`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1164,7 +1165,7 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `Your "changelog.createRelease" config specifies an invalid hostname "${error.data.hostname}". Please ensure you provide a valid hostname value, such as "example.com"`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1175,7 +1176,7 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `Your "changelog.createRelease" config specifies an invalid apiBaseUrl "${error.data.apiBaseUrl}". Please ensure you provide a valid URL value, such as "https://example.com"`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;
@@ -1186,7 +1187,7 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `The createRelease option for changelogs cannot be enabled when git push is explicitly disabled because the commit needs to be pushed to the remote in order to tie the release to it`,
-          bodyLines: [nxJsonMessage],
+          bodyLines: [nxJsonMessage, linkMessage],
         });
       }
       break;

--- a/packages/nx/src/command-line/release/utils/resolve-nx-json-error-message.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-nx-json-error-message.ts
@@ -20,7 +20,7 @@ export async function resolveNxJsonConfigErrorMessage(
         ? `, line ${errorLines.startLine}`
         : `, lines ${errorLines.startLine}-${errorLines.endLine}`;
   }
-  return nxJsonMessage;
+  return nxJsonMessage + '.';
 }
 
 async function getJsonConfigLinesForErrorMessage(


### PR DESCRIPTION


Currently users running `nx release` without a correct setup will see an unhelpful message:

```
NX   Release group "__default__" matches no projects. Please ensure all release groups match at least one project:

The relevant config is defined here: nx.json
```

This change provides a link to https://nx.dev/features/manage-releases so users can find the correct information to fix their setup.

This is particular useful when users are curious or checking out `nx release` for the first time, and may not realize that there are set up steps.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Error message is not helpful

## Expected Behavior
Provide a link for users to find the info they need

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
