### PR TITLE
fix(release): use top-level releaseTagPattern as the default for release groups

### DIFF
--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -12315,6 +12315,37 @@ describe('createNxReleaseConfig()', () => {
       `);
     });
 
+    it('should use releaseTagPattern from base config for independent release groups as long as {projectName} is used', async () => {
+      let res = await createNxReleaseConfig(projectGraph, projectFileMap, {
+        releaseTagPattern: 'release/{projectName}/{version}',
+        groups: {
+          'group-1': {
+            projects: 'lib-a',
+            projectsRelationship: 'independent',
+          },
+        },
+      });
+
+      expect(res.nxReleaseConfig.groups['group-1'].releaseTagPattern).toEqual(
+        'release/{projectName}/{version}'
+      );
+
+      // The specified pattern may conflict between independent projects, so use the default independent tag pattern.
+      res = await createNxReleaseConfig(projectGraph, projectFileMap, {
+        releaseTagPattern: 'v{version}',
+        groups: {
+          'group-1': {
+            projects: 'lib-a',
+            projectsRelationship: 'independent',
+          },
+        },
+      });
+
+      expect(res.nxReleaseConfig.groups['group-1'].releaseTagPattern).toEqual(
+        '{projectName}@{version}'
+      );
+    });
+
     /**
      * TODO: make this the default behavior in v20 (it's a breaking change)
      */

--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -493,7 +493,11 @@ export async function createNxReleaseConfig(
     releaseTagPattern:
       // The appropriate group default releaseTagPattern is dependent upon the projectRelationships
       groupProjectsRelationship === 'independent'
-        ? defaultIndependentReleaseTagPattern
+        ? // If the default pattern contains {projectName} then it will create unique release tags for each project.
+          // Otherwise, use the default value to guarantee unique tags
+          WORKSPACE_DEFAULTS.releaseTagPattern?.includes('{projectName}')
+          ? WORKSPACE_DEFAULTS.releaseTagPattern
+          : defaultIndependentReleaseTagPattern
         : WORKSPACE_DEFAULTS.releaseTagPattern,
     releaseTagPatternCheckAllBranchesWhen:
       userConfig.releaseTagPatternCheckAllBranchesWhen ?? undefined,
@@ -785,12 +789,15 @@ export async function createNxReleaseConfig(
               releaseGroup.changelog || {}
             )
           : false,
-
       releaseTagPattern:
         releaseGroup.releaseTagPattern ||
         // The appropriate group default releaseTagPattern is dependent upon the projectRelationships
         (projectsRelationship === 'independent'
-          ? defaultIndependentReleaseTagPattern
+          ? // If the default pattern contains {projectName} then it will create unique release tags for each project.
+            // Otherwise, use the default value to guarantee unique tags
+            userConfig.releaseTagPattern?.includes('{projectName}')
+            ? userConfig.releaseTagPattern
+            : defaultIndependentReleaseTagPattern
           : userConfig.releaseTagPattern || defaultFixedReleaseTagPattern),
       releaseTagPatternCheckAllBranchesWhen:
         releaseGroup.releaseTagPatternCheckAllBranchesWhen ??


### PR DESCRIPTION
## Current Behavior

When using `nx release` with Docker projects, the `release.releaseTagPattern` defined at the root level is not inherited by release groups. Users must explicitly specify the `releaseTagPattern` at both the root level AND within `release.groups.<group>.releaseTagPattern` for it to work correctly when using 'independent' releases.

Example configuration that doesn't work as expected:
```json
{
  "release": {
    "releaseTagPattern": "release/{projectName}/{version}",
    "groups": {
      "apps": {
          "projectsRelationship": "independent",
          // releaseTagPattern is not inherited here
      }
    }
  }
}
```

## Expected Behavior

The `release.releaseTagPattern` should be automatically inherited by group configurations, following the same inheritance pattern as other release configuration properties. Users should only need to specify the pattern once at the root level unless they want to override it for specific groups.

With this fix, the above configuration will work correctly, and the docker releases will use the `release/{projectName}/{version}` pattern for git tags.

## Related Issue(s)

Fixes #