### PR TITLE
fix(nx-dev): update pricing link in launch templates

### DIFF
--- a/docs/nx-cloud/reference/launch-templates.md
+++ b/docs/nx-cloud/reference/launch-templates.md
@@ -59,7 +59,7 @@ The following resource classes are available:
 - `docker_linux_arm64/extra_large`
 - `windows/medium`
 
-See their detailed description and pricing at [credits pricing](/ci/reference/credits-pricing?utm_source=nx.dev&utm_medium=launch-templates).
+See their detailed description and pricing in the [credits pricing reference](/ci/reference/credits-pricing?utm_source=nx.dev&utm_medium=launch-templates).
 
 ### `launch-templates.<template-name>.image`
 

--- a/docs/nx-cloud/reference/launch-templates.md
+++ b/docs/nx-cloud/reference/launch-templates.md
@@ -59,7 +59,7 @@ The following resource classes are available:
 - `docker_linux_arm64/extra_large`
 - `windows/medium`
 
-See their detailed description and pricing at [nx.dev/pricing](/pricing#plan-detail?sutm_source=nx.dev&utm_medium=launch-templates).
+See their detailed description and pricing at [credits pricing](/ci/reference/credits-pricing?utm_source=nx.dev&utm_medium=launch-templates).
 
 ### `launch-templates.<template-name>.image`
 


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->



## Current Behavior
The current link points to [https://nx.dev/nx-cloud#plans]


**_"See their detailed description and pricing at [nx.dev/pricing](https://nx.dev/pricing#plan-detail?sutm_source=nx.dev&utm_medium=launch-templates)."_**

## Expected Behavior
Updated the link to point to [https://nx.dev/ci/reference/credits-pricing]

**_"See their detailed description and pricing at [credits pricing](/ci/reference/credits-pricing?utm_source=nx.dev&utm_medium=launch-templates)."_**

## Related Issue(s)
https://linear.app/nxdev/issue/CLOUD-3383/update-launch-template-pricing-docs-link

