### PR TITLE
fix(gradle): fix bootJar, add excludeDependsOn to false

### DIFF
--- a/e2e/gradle/src/gradle.test.ts
+++ b/e2e/gradle/src/gradle.test.ts
@@ -43,6 +43,9 @@ describe('Gradle', () => {
         buildOutput = runCLI('build app --batch', { verbose: true });
         expect(buildOutput).toContain(':list:classes');
         expect(buildOutput).toContain(':utilities:classes');
+
+        const bootJarOutput = runCLI('bootJar app', { verbose: true });
+        expect(bootJarOutput).toContain(':app:bootJar');
       });
 
       it('should track dependencies for new app', () => {

--- a/e2e/gradle/src/utils/create-gradle-project.ts
+++ b/e2e/gradle/src/utils/create-gradle-project.ts
@@ -78,6 +78,10 @@ export function createGradleProject(
     join(cwd, `buildSrc/settings.gradle${type === 'kotlin' ? '.kts' : ''}`)
   );
 
+  addSpringBootPlugin(
+    join(cwd, `app/build.gradle${type === 'kotlin' ? '.kts' : ''}`)
+  );
+
   e2eConsoleLogger(
     execSync(
       `${gradleCommand} :project-graph:publishToMavenLocal -PskipSign=true`,
@@ -100,5 +104,25 @@ function addLocalPluginManagement(filePath: string) {
     }
 }
 ` + content;
+  writeFileSync(filePath, content);
+}
+
+function addSpringBootPlugin(filePath: string) {
+  let content = readFileSync(filePath).toString();
+  const isKotlin = filePath.endsWith('.kts');
+
+  // Find the plugins block and add Spring Boot plugin
+  if (content.includes('plugins {')) {
+    const pluginLine = isKotlin
+      ? '    id("org.springframework.boot") version "+"'
+      : "    id 'org.springframework.boot' version '+'";
+
+    content = content.replace(
+      /plugins\s*\{/,
+      `plugins {
+${pluginLine}`
+    );
+  }
+
   writeFileSync(filePath, content);
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -64,7 +64,10 @@ fun processTask(
           task.description ?: "Run ${projectBuildPath}.${task.name}", projectBuildPath, task.name)
   target["metadata"] = metadata
 
-  target["options"] = mapOf("taskName" to "${projectBuildPath}:${task.name}")
+  target["options"] =
+      mapOf(
+          "taskName" to "${projectBuildPath}:${task.name}",
+          "excludeDependsOn" to shouldExcludeDependsOn(task))
 
   return target
 }
@@ -367,4 +370,10 @@ private val nonCacheableTasks = setOf("bootRun", "run")
 
 fun isCacheable(task: Task): Boolean {
   return !nonCacheableTasks.contains(task.name)
+}
+
+private val tasksWithDependsOn = setOf("bootRun", "bootJar")
+
+fun shouldExcludeDependsOn(task: Task): Boolean {
+  return !tasksWithDependsOn.contains(task.name)
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

when run bootJar and bootRun, i got this error:
```
> Querying the mapped value of task ':application:resolveMainClassName' property 'outputFile' before task ':application:resolveMainClassName' has completed is not supported
```

both bootJar and bootRun dependsOn resolveMainClassName. however, when it runs with excludeDependsOn, the gradlew command will be `./gradlew :app:bootRun --exclude-task :app:resolveMainClassName`. when running the command like that, it will cause an issue

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
for bootJar and bootRun, hardcode excludeDependsOn to false

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
