### PR TITLE
fix(core): only traverse workspace node when it exists

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -135,7 +135,9 @@ export function addNodesAndDependencies(
     } else if (workspacePackages.has(name)) {
       // Workspace Node
       const node = graph.nodes[name];
-      traverseWorkspaceNode(graph, builder, node);
+      if (node) {
+        traverseWorkspaceNode(graph, builder, node);
+      }
     }
   });
 }


### PR DESCRIPTION
## Current Behavior
There is a runtime issue in project graph pruning where we attempt to eagerly traverse workspace nodes when they may not exist.

## Expected Behavior
Ensure the workspace node exists before traversing it.
