### PR TITLE
fix(core): don't throw during migrate ui execution if migrations.json is gitignored

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate-ui-api.ts
+++ b/packages/nx/src/command-line/migrate/migrate-ui-api.ts
@@ -224,10 +224,14 @@ export async function runSingleMigration(
     );
 
     if (gitRefBefore !== gitRefAfter) {
-      execSync('git add migrations.json', {
-        cwd: workspacePath,
-        encoding: 'utf-8',
-      });
+      try {
+        execSync('git add migrations.json', {
+          cwd: workspacePath,
+          encoding: 'utf-8',
+        });
+      } catch (e) {
+        // do nothing, this will fail if it's gitignored
+      }
       execSync('git commit --amend --no-verify --no-edit', {
         cwd: workspacePath,
         encoding: 'utf-8',
@@ -266,10 +270,14 @@ export async function runSingleMigration(
       removeRunningMigration(migration.id)
     );
 
-    execSync('git add migrations.json', {
-      cwd: workspacePath,
-      encoding: 'utf-8',
-    });
+    try {
+      execSync('git add migrations.json', {
+        cwd: workspacePath,
+        encoding: 'utf-8',
+      });
+    } catch (e) {
+      // do nothing, this will fail if it's gitignored
+    }
   }
 }
 


### PR DESCRIPTION

## Current Behavior
if your `migrations.json` is gitignored, the step to add it to the staging area will fail.

## Expected Behavior
the migrate UI should work whether the file is gitignored or not

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
