### PR TITLE
fix(docker): add docker target group for pdv

### DIFF
--- a/graph/ui-project-details/.storybook/main.ts
+++ b/graph/ui-project-details/.storybook/main.ts
@@ -20,6 +20,9 @@ const config: StorybookConfig = {
       plugins: [nxViteTsPaths()],
     });
   },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+  },
 
   docs: {},
 };

--- a/graph/ui-project-details/src/lib/project-details/project-details.stories.tsx
+++ b/graph/ui-project-details/src/lib/project-details/project-details.stories.tsx
@@ -111,12 +111,29 @@ export const Primary = {
             options: { lintFilePatterns: ['packages/jest'] },
             configurations: {},
           },
+          'docker:build': {
+            command: 'docker build .',
+            metadata: {
+              technologies: ['docker'],
+            },
+          },
+          'docker:run': {
+            command: 'docker {args} run .',
+            metadata: {
+              technologies: ['docker'],
+            },
+          },
         },
         $schema: '../../node_modules/nx/schemas/project-schema.json',
         sourceRoot: 'packages/jest',
         projectType: 'library',
         implicitDependencies: [],
         tags: [],
+        metadata: {
+          targetGroups: {
+            Docker: ['docker:build', 'docker:run'],
+          },
+        },
       },
     },
     sourceMap: {

--- a/graph/ui-project-details/src/lib/target-technologies/target-technologies.stories.tsx
+++ b/graph/ui-project-details/src/lib/target-technologies/target-technologies.stories.tsx
@@ -11,6 +11,7 @@ type Story = StoryObj<typeof TargetTechnologies>;
 
 export const Simple: Story = {
   args: {
-    technologies: ['react', 'angular'],
+    technologies: ['react', 'angular', 'docker'],
+    showTooltip: false,
   },
 };

--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -50,7 +50,15 @@ describe('@nx/docker', () => {
           {
             "projects": {
               "proj": {
-                "metadata": {},
+                "metadata": {
+                  "targetGroups": {
+                    "Docker": [
+                      "docker:build",
+                      "docker:run",
+                      "nx-release-publish",
+                    ],
+                  },
+                },
                 "root": "proj",
                 "targets": {
                   "docker:build": {
@@ -149,7 +157,15 @@ describe('@nx/docker', () => {
           {
             "projects": {
               "proj": {
-                "metadata": {},
+                "metadata": {
+                  "targetGroups": {
+                    "Docker": [
+                      "docker:build",
+                      "docker:run",
+                      "nx-release-publish",
+                    ],
+                  },
+                },
                 "root": "proj",
                 "targets": {
                   "docker:build": {
@@ -244,7 +260,15 @@ describe('@nx/docker', () => {
           {
             "projects": {
               "proj": {
-                "metadata": {},
+                "metadata": {
+                  "targetGroups": {
+                    "Docker": [
+                      "build-docker",
+                      "run-docker",
+                      "nx-release-publish",
+                    ],
+                  },
+                },
                 "root": "proj",
                 "targets": {
                   "build-docker": {
@@ -336,7 +360,15 @@ describe('@nx/docker', () => {
           {
             "projects": {
               "apps/api": {
-                "metadata": {},
+                "metadata": {
+                  "targetGroups": {
+                    "Docker": [
+                      "docker:build",
+                      "docker:run",
+                      "nx-release-publish",
+                    ],
+                  },
+                },
                 "root": "apps/api",
                 "targets": {
                   "docker:build": {
@@ -485,7 +517,15 @@ describe('@nx/docker', () => {
           {
             "projects": {
               ".": {
-                "metadata": {},
+                "metadata": {
+                  "targetGroups": {
+                    "Docker": [
+                      "docker:build",
+                      "docker:run",
+                      "nx-release-publish",
+                    ],
+                  },
+                },
                 "root": ".",
                 "targets": {
                   "docker:build": {

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -113,6 +113,15 @@ async function createDockerTargets(
 
   const namedInputs = getNamedInputs(projectRoot, context);
   const targets: Record<string, TargetConfiguration> = {};
+  const metadata = {
+    targetGroups: {
+      ['Docker']: [
+        `${options.buildTarget}`,
+        `${options.runTarget}`,
+        'nx-release-publish',
+      ],
+    },
+  };
 
   targets[options.buildTarget] = {
     command: `docker build .`,
@@ -169,7 +178,7 @@ async function createDockerTargets(
     executor: '@nx/docker:release-publish',
   };
 
-  return { targets, metadata: {} };
+  return { targets, metadata };
 }
 
 function normalizePluginOptions(


### PR DESCRIPTION
## Current Behavior
The Docker targets are not grouped

## Expected Behavior
Icon for Docker in PDV
Docker targets are grouped
<img width="145" height="82" alt="image" src="https://github.com/user-attachments/assets/b0e36f32-d402-4826-a970-24c14c4ad946" />

<img width="968" height="390" alt="image" src="https://github.com/user-attachments/assets/1fe61a16-64a9-4639-ba63-e9d4260fda57" />
