### PR TITLE
fix(node): ensure cache outputs are set for prune and copy workspace modules

### DIFF
--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -228,12 +228,14 @@ describe('app', () => {
                 "options": {
                   "buildTarget": "build",
                 },
+                "outputs": [
+                  "myapp/dist/workspace_modules",
+                ],
               },
               "lint": {
                 "executor": "@nx/eslint:lint",
               },
               "prune": {
-                "cache": true,
                 "dependsOn": [
                   "prune-lockfile",
                   "copy-workspace-modules",
@@ -249,6 +251,10 @@ describe('app', () => {
                 "options": {
                   "buildTarget": "build",
                 },
+                "outputs": [
+                  "myapp/dist/package.json",
+                  "myapp/dist/package-lock.json",
+                ],
               },
               "serve": {
                 "configurations": {
@@ -432,12 +438,14 @@ describe('app', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "myapp/dist/workspace_modules",
+              ],
             },
             "lint": {
               "executor": "@nx/eslint:lint",
             },
             "prune": {
-              "cache": true,
               "dependsOn": [
                 "prune-lockfile",
                 "copy-workspace-modules",
@@ -453,6 +461,10 @@ describe('app', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "myapp/dist/package.json",
+                "myapp/dist/package-lock.json",
+              ],
             },
             "serve": {
               "configurations": {

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -62,9 +62,11 @@ describe('application generator', () => {
             "options": {
               "buildTarget": "build",
             },
+            "outputs": [
+              "dist/my-node-app/workspace_modules",
+            ],
           },
           "prune": {
-            "cache": true,
             "dependsOn": [
               "prune-lockfile",
               "copy-workspace-modules",
@@ -80,6 +82,10 @@ describe('application generator', () => {
             "options": {
               "buildTarget": "build",
             },
+            "outputs": [
+              "dist/my-node-app/package.json",
+              "dist/my-node-app/package-lock.json",
+            ],
           },
           "serve": {
             "configurations": {
@@ -281,9 +287,11 @@ describe('application generator', () => {
                 "options": {
                   "buildTarget": "build",
                 },
+                "outputs": [
+                  "myapp/dist/workspace_modules",
+                ],
               },
               "prune": {
-                "cache": true,
                 "dependsOn": [
                   "prune-lockfile",
                   "copy-workspace-modules",
@@ -299,6 +307,10 @@ describe('application generator', () => {
                 "options": {
                   "buildTarget": "build",
                 },
+                "outputs": [
+                  "myapp/dist/package.json",
+                  "myapp/dist/package-lock.json",
+                ],
               },
               "serve": {
                 "configurations": {
@@ -475,9 +487,11 @@ describe('application generator', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "myapp/dist/workspace_modules",
+              ],
             },
             "prune": {
-              "cache": true,
               "dependsOn": [
                 "prune-lockfile",
                 "copy-workspace-modules",
@@ -493,6 +507,10 @@ describe('application generator', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "myapp/dist/package.json",
+                "myapp/dist/package-lock.json",
+              ],
             },
             "serve": {
               "configurations": {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -51,9 +51,11 @@ describe('app', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "dist/my-node-app/workspace_modules",
+              ],
             },
             "prune": {
-              "cache": true,
               "dependsOn": [
                 "prune-lockfile",
                 "copy-workspace-modules",
@@ -69,6 +71,10 @@ describe('app', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "dist/my-node-app/package.json",
+                "dist/my-node-app/package-lock.json",
+              ],
             },
             "serve": {
               "configurations": {
@@ -292,9 +298,11 @@ describe('app', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "dist/my-dir/my-node-app/workspace_modules",
+              ],
             },
             "prune": {
-              "cache": true,
               "dependsOn": [
                 "prune-lockfile",
                 "copy-workspace-modules",
@@ -310,6 +318,10 @@ describe('app', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "dist/my-dir/my-node-app/package.json",
+                "dist/my-dir/my-node-app/package-lock.json",
+              ],
             },
             "serve": {
               "configurations": {
@@ -684,9 +696,11 @@ describe('app', () => {
                 "options": {
                   "buildTarget": "build",
                 },
+                "outputs": [
+                  "myapp/dist/workspace_modules",
+                ],
               },
               "prune": {
-                "cache": true,
                 "dependsOn": [
                   "prune-lockfile",
                   "copy-workspace-modules",
@@ -702,6 +716,10 @@ describe('app', () => {
                 "options": {
                   "buildTarget": "build",
                 },
+                "outputs": [
+                  "myapp/dist/package.json",
+                  "myapp/dist/package-lock.json",
+                ],
               },
               "serve": {
                 "configurations": {
@@ -983,9 +1001,11 @@ describe('app', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "myapp/dist/workspace_modules",
+              ],
             },
             "prune": {
-              "cache": true,
               "dependsOn": [
                 "prune-lockfile",
                 "copy-workspace-modules",
@@ -1001,6 +1021,10 @@ describe('app', () => {
               "options": {
                 "buildTarget": "build",
               },
+              "outputs": [
+                "myapp/dist/package.json",
+                "myapp/dist/package-lock.json",
+              ],
             },
             "serve": {
               "configurations": {

--- a/packages/node/src/generators/application/lib/add-dependencies.ts
+++ b/packages/node/src/generators/application/lib/add-dependencies.ts
@@ -1,7 +1,9 @@
 import {
   addDependenciesToPackageJson,
   GeneratorCallback,
+  joinPathFragments,
   Tree,
+  updateJson,
 } from '@nx/devkit';
 import { esbuildVersion } from '@nx/js/src/utils/versions';
 import {
@@ -56,6 +58,18 @@ export function addProjectDependencies(
     },
     fastify: {},
   };
+
+  const projectPackageJson = joinPathFragments(
+    options.appProjectRoot,
+    'package.json'
+  );
+  if (tree.exists(projectPackageJson)) {
+    updateJson(tree, projectPackageJson, (json) => {
+      json.dependencies ??= { ...frameworkDependencies };
+      return json;
+    });
+  }
+
   return addDependenciesToPackageJson(
     tree,
     {

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -41,7 +41,7 @@ export function addProject(tree: Tree, options: NormalizedSchema) {
   }
   project.targets = {
     ...project.targets,
-    ...getPruneTargets('build'),
+    ...getPruneTargets('build', options.outputPath),
   };
   project.targets.serve = getServeConfig(options);
 


### PR DESCRIPTION
## Current Behavior
Generating a node application does not set the outputs for the prune and copy workspace modules tasks.

## Expected Behavior
Ensure the outputs are set so that cache can be restored correctly
