### PR TITLE
fix(docker): add release support when registryUrl is set to docker.io

### DIFF
--- a/packages/docker/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/docker/src/executors/release-publish/release-publish.impl.ts
@@ -81,8 +81,12 @@ function readVersionFromFile(projectRoot: string) {
 async function checkDockerImageExistsLocally(imageRef: string) {
   try {
     return await new Promise((res) => {
+      // If the ref starts with 'docker.io/', then we need to strip it since it is the default value and Docker CLI will not find it.
+      const normalizedImageRef = imageRef.startsWith('docker.io/')
+        ? imageRef.split('docker.io/')[1]
+        : imageRef;
       const childProcess = exec(
-        `docker images --filter "reference=${imageRef}" --quiet`,
+        `docker images --filter "reference=${normalizedImageRef}" --quiet`,
         { encoding: 'utf8' }
       );
       let result = '';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
If user sets `registryUrl` to `docker.io` then release fails.

## Expected Behavior
We should support setting it to `docker.io` even though it's not necessary.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
