### PR TITLE
fix(node): outputs should be in the correct format for prune and copy-workspace-modules targets

### DIFF
--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -229,7 +229,7 @@ describe('app', () => {
                   "buildTarget": "build",
                 },
                 "outputs": [
-                  "myapp/dist/workspace_modules",
+                  "{workspaceRoot}/myapp/dist/workspace_modules",
                 ],
               },
               "lint": {
@@ -252,8 +252,8 @@ describe('app', () => {
                   "buildTarget": "build",
                 },
                 "outputs": [
-                  "myapp/dist/package.json",
-                  "myapp/dist/package-lock.json",
+                  "{workspaceRoot}/myapp/dist/package.json",
+                  "{workspaceRoot}/myapp/dist/package-lock.json",
                 ],
               },
               "serve": {
@@ -439,7 +439,7 @@ describe('app', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "myapp/dist/workspace_modules",
+                "{workspaceRoot}/myapp/dist/workspace_modules",
               ],
             },
             "lint": {
@@ -462,8 +462,8 @@ describe('app', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "myapp/dist/package.json",
-                "myapp/dist/package-lock.json",
+                "{workspaceRoot}/myapp/dist/package.json",
+                "{workspaceRoot}/myapp/dist/package-lock.json",
               ],
             },
             "serve": {

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -63,7 +63,7 @@ describe('application generator', () => {
               "buildTarget": "build",
             },
             "outputs": [
-              "dist/my-node-app/workspace_modules",
+              "{workspaceRoot}/dist/my-node-app/workspace_modules",
             ],
           },
           "prune": {
@@ -83,8 +83,8 @@ describe('application generator', () => {
               "buildTarget": "build",
             },
             "outputs": [
-              "dist/my-node-app/package.json",
-              "dist/my-node-app/package-lock.json",
+              "{workspaceRoot}/dist/my-node-app/package.json",
+              "{workspaceRoot}/dist/my-node-app/package-lock.json",
             ],
           },
           "serve": {
@@ -288,7 +288,7 @@ describe('application generator', () => {
                   "buildTarget": "build",
                 },
                 "outputs": [
-                  "myapp/dist/workspace_modules",
+                  "{workspaceRoot}/myapp/dist/workspace_modules",
                 ],
               },
               "prune": {
@@ -308,8 +308,8 @@ describe('application generator', () => {
                   "buildTarget": "build",
                 },
                 "outputs": [
-                  "myapp/dist/package.json",
-                  "myapp/dist/package-lock.json",
+                  "{workspaceRoot}/myapp/dist/package.json",
+                  "{workspaceRoot}/myapp/dist/package-lock.json",
                 ],
               },
               "serve": {
@@ -488,7 +488,7 @@ describe('application generator', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "myapp/dist/workspace_modules",
+                "{workspaceRoot}/myapp/dist/workspace_modules",
               ],
             },
             "prune": {
@@ -508,8 +508,8 @@ describe('application generator', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "myapp/dist/package.json",
-                "myapp/dist/package-lock.json",
+                "{workspaceRoot}/myapp/dist/package.json",
+                "{workspaceRoot}/myapp/dist/package-lock.json",
               ],
             },
             "serve": {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -52,7 +52,7 @@ describe('app', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "dist/my-node-app/workspace_modules",
+                "{workspaceRoot}/dist/my-node-app/workspace_modules",
               ],
             },
             "prune": {
@@ -72,8 +72,8 @@ describe('app', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "dist/my-node-app/package.json",
-                "dist/my-node-app/package-lock.json",
+                "{workspaceRoot}/dist/my-node-app/package.json",
+                "{workspaceRoot}/dist/my-node-app/package-lock.json",
               ],
             },
             "serve": {
@@ -299,7 +299,7 @@ describe('app', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "dist/my-dir/my-node-app/workspace_modules",
+                "{workspaceRoot}/dist/my-dir/my-node-app/workspace_modules",
               ],
             },
             "prune": {
@@ -319,8 +319,8 @@ describe('app', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "dist/my-dir/my-node-app/package.json",
-                "dist/my-dir/my-node-app/package-lock.json",
+                "{workspaceRoot}/dist/my-dir/my-node-app/package.json",
+                "{workspaceRoot}/dist/my-dir/my-node-app/package-lock.json",
               ],
             },
             "serve": {
@@ -697,7 +697,7 @@ describe('app', () => {
                   "buildTarget": "build",
                 },
                 "outputs": [
-                  "myapp/dist/workspace_modules",
+                  "{workspaceRoot}/myapp/dist/workspace_modules",
                 ],
               },
               "prune": {
@@ -717,8 +717,8 @@ describe('app', () => {
                   "buildTarget": "build",
                 },
                 "outputs": [
-                  "myapp/dist/package.json",
-                  "myapp/dist/package-lock.json",
+                  "{workspaceRoot}/myapp/dist/package.json",
+                  "{workspaceRoot}/myapp/dist/package-lock.json",
                 ],
               },
               "serve": {
@@ -1002,7 +1002,7 @@ describe('app', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "myapp/dist/workspace_modules",
+                "{workspaceRoot}/myapp/dist/workspace_modules",
               ],
             },
             "prune": {
@@ -1022,8 +1022,8 @@ describe('app', () => {
                 "buildTarget": "build",
               },
               "outputs": [
-                "myapp/dist/package.json",
-                "myapp/dist/package-lock.json",
+                "{workspaceRoot}/myapp/dist/package.json",
+                "{workspaceRoot}/myapp/dist/package-lock.json",
               ],
             },
             "serve": {

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -145,8 +145,8 @@ export function getPruneTargets(
       cache: true,
       executor: '@nx/js:prune-lockfile',
       outputs: [
-        joinPathFragments(outputPath, 'package.json'),
-        joinPathFragments(outputPath, lockFileName),
+        `{workspaceRoot}/${joinPathFragments(outputPath, 'package.json')}`,
+        `{workspaceRoot}/${joinPathFragments(outputPath, lockFileName)}`,
       ],
       options: {
         buildTarget,
@@ -155,7 +155,9 @@ export function getPruneTargets(
     'copy-workspace-modules': {
       dependsOn: ['build'],
       cache: true,
-      outputs: [joinPathFragments(outputPath, 'workspace_modules')],
+      outputs: [
+        `{workspaceRoot}/${joinPathFragments(outputPath, 'workspace_modules')}`,
+      ],
       executor: '@nx/js:copy-workspace-modules',
       options: {
         buildTarget,


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When running `nx prune api` it fails with:

```
 NX   The following outputs are invalid: 

 - apps/api/dist/package.json
 - apps/api/dist/package-lock.json
```
## Expected Behavior
Prune should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
