### PR TITLE
docs(docker): fix config for releaseTagPattern to be valid

### DIFF
--- a/docs/shared/recipes/nx-release/release-docker-images.md
+++ b/docs/shared/recipes/nx-release/release-docker-images.md
@@ -74,9 +74,7 @@ Configure Docker applications in a separate release group called `apps` so it do
 ```jsonc {% fileName="nx.json" %}
 {
   "release": {
-    "releaseTagPattern": {
-      "pattern": "release/{projectName}/{version}"
-    },
+    "releaseTagPattern": "release/{projectName}/{version}",
     "groups": {
       "apps": {
         "projects": ["api"],


### PR DESCRIPTION
This PR fixes an invalid config for Docker release that didn't end up being implemented.