### PR TITLE
fix(angular): add missing config properties to adapter whitelist

### DIFF
--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -45,6 +45,8 @@ export const allowedProjectExtensions = [
   'release',
   'includedScripts',
   'metadata',
+  'owners',
+  'nxCloudImplicitDependencies',
 ] as const;
 
 // If we pass props on the workspace that angular doesn't know about,
@@ -84,6 +86,7 @@ export const allowedWorkspaceExtensions = [
   'useLegacyCache',
   'maxCacheSize',
   'tui',
+  'owners',
 ] as const;
 
 if (!patched) {


### PR DESCRIPTION
## Current Behavior

Running tasks for Angular projects that use Angular CLI builders can result in validation errors when the project or workspace configurations contain Nx-specific properties.

## Expected Behavior

Running tasks for Angular projects that use Angular CLI builders shouldn't result in validation errors when the project or workspace configurations contain Nx-specific properties.