### PR TITLE
fix(module-federation): use asyncStartup for ssr configuration

### DIFF
--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
@@ -59,8 +59,8 @@ export async function withModuleFederationForSSR(
              */
             ...(configOverride ? configOverride : {}),
             experiments: {
-              federationRuntime: 'hoisted',
-              // We should allow users to override federationRuntime
+              asyncStartup: true,
+              // We should allow users to override experiments
               ...(configOverride?.experiments ?? {}),
             },
             runtimePlugins:

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
@@ -53,8 +53,8 @@ export async function withModuleFederationForSSR(
            */
           ...(configOverride ? configOverride : {}),
           experiments: {
-            federationRuntime: 'hoisted',
-            // We should allow users to override federationRuntime
+            asyncStartup: true,
+            // We should allow users to override experiments
             ...(configOverride?.experiments ?? {}),
           },
           runtimePlugins:

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
@@ -48,8 +48,8 @@ export async function withModuleFederationForSSR(
            */
           ...(configOverride ? configOverride : {}),
           experiments: {
-            federationRuntime: 'hoisted',
-            // We should allow users to override federationRuntime
+            asyncStartup: true,
+            // We should allow users to override experiments
             ...(configOverride?.experiments ?? {}),
           },
           runtimePlugins:


### PR DESCRIPTION
The federationRuntime option not longer exists in experiments, use asyncStartup to enable asynchronous container startup.

## Current Behavior
When creating a new project with module federation (`nx g @nx/angular:host host --remotes=remote1,remote2 --ssr`) and then try to to run the `serve-ssr` target (`nx serve-ssr host`) you get this error:
<img width="1615" height="511" alt="image" src="https://github.com/user-attachments/assets/19819020-821b-4422-83ae-88203018b981" />


## Expected Behavior
It should serve the application using SSR.
