### PR TITLE
fix(release): filter dependents to only include those that are in allProjectsToProcess

### DIFF
--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -1544,9 +1544,13 @@ Valid values are: ${validReleaseVersionPrefixes
     // Only update dependencies for dependents if the group's updateDependents is 'auto'
     if (updateDependents === 'auto') {
       const dependents = this.getNonImplicitDependentsForProject(projectName);
-      await this.updateDependenciesForDependents(dependents);
+      // Filter dependents to only include those that are in allProjectsToProcess
+      const filteredDependents = dependents.filter((dep) =>
+        this.allProjectsToProcess.has(dep)
+      );
+      await this.updateDependenciesForDependents(filteredDependents);
 
-      for (const dependent of dependents) {
+      for (const dependent of filteredDependents) {
         if (
           this.allProjectsToProcess.has(dependent) &&
           !this.bumpedProjects.has(dependent)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
from this bug: https://github.com/nrwl/nx/issues/31273
The nx release version -g "customer" command crashed with the error:
`NX   Unable to find project "admin-portal" in allProjectsToProcess`

  - In the example, admin-portal depends on customer-portal.
  - While processing customer-portal, Nx found admin-portal as a dependent project
  - The code called getNonImplicitDependentsForProject() which returned ALL dependents, including those from filtered-out groups
  - It then tried to process admin-portal via updateDependenciesForDependents()

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
  - When using -g "customer", Nx correctly filtered projects to only include those in the "customer" group
  - allProjectsToProcess only contained customer-portal
  - admin-portal was properly excluded from processing

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/31273
