### PR TITLE
fix(react): remote generator should normalize names

### DIFF
--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -19,7 +19,7 @@
       "name": {
         "type": "string",
         "description": "The name of the Producer (remote) application to generate the Module Federation configuration",
-        "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
+        "pattern": "^[a-zA-Z][^:]*$",
         "x-priority": "important"
       },
       "dynamic": {

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -17,7 +17,7 @@ import { addModuleFederationFiles } from './lib/add-module-federation-files';
 import {
   normalizeRemoteDirectory,
   normalizeRemoteName,
-} from './lib/normalize-remote';
+} from '../../utils/normalize-remote';
 import { setupSsrForHost } from './lib/setup-ssr-for-host';
 import { updateModuleFederationE2eProject } from './lib/update-module-federation-e2e-project';
 import { NormalizedSchema, Schema } from './schema';

--- a/packages/react/src/generators/remote/__snapshots__/remote.rspack.spec.ts.snap
+++ b/packages/react/src/generators/remote/__snapshots__/remote.rspack.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`remote generator bundler=rspack should create the remote with the correct config files 1`] = `
 "const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');

--- a/packages/react/src/generators/remote/remote.rspack.spec.ts
+++ b/packages/react/src/generators/remote/remote.rspack.spec.ts
@@ -369,12 +369,30 @@ describe('remote generator', () => {
           typescriptConfiguration: true,
           bundler: 'rspack',
         })
-      ).rejects.toMatchInlineSnapshot(`
-        [Error: Invalid remote name: my-app. Remote project names must:
-        - Start with a letter, dollar sign ($) or underscore (_)
-        - Followed by any valid character (letters, digits, underscores, or dollar signs)
-        The regular expression used is ^[a-zA-Z_$][a-zA-Z_$0-9]*$.]
-      `);
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: Invalid remote name provided: my-app. The name can only contain letters, digits, underscores, and dollar signs.]`
+      );
+    });
+
+    it('should handle app names in ts proj ref workspaces', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await expect(
+        remote(tree, {
+          directory: 'test/myapp',
+          devServerPort: 4209,
+          e2eTestRunner: 'cypress',
+          linter: 'eslint',
+          skipFormat: false,
+          style: 'css',
+          unitTestRunner: 'jest',
+          ssr: true,
+          typescriptConfiguration: true,
+          bundler: 'rspack',
+        })
+        // Verify that no error occurs
+        // Resolves.not.toThrow() will cause spawnSync error
+        // As the Generator Callback will try to run
+      ).resolves.toMatchInlineSnapshot(`[Function]`);
     });
   });
 });

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -19,7 +19,7 @@
     "name": {
       "type": "string",
       "description": "The name of the Producer (remote) application to generate the Module Federation configuration",
-      "pattern": "^[a-zA-Z_$][a-zA-Z_$0-9]*$",
+      "pattern": "^[a-zA-Z][^:]*$",
       "x-priority": "important"
     },
     "dynamic": {

--- a/packages/react/src/utils/normalize-remote.ts
+++ b/packages/react/src/utils/normalize-remote.ts
@@ -1,11 +1,10 @@
 import { joinPathFragments, Tree } from '@nx/devkit';
 import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/project-name-and-root-utils';
-import { NormalizedSchema } from '../schema';
 
 export async function normalizeRemoteName(
   tree: Tree,
   remote: string,
-  options: NormalizedSchema
+  options: { directory: string }
 ) {
   const { projectName: remoteName } = await determineProjectNameAndRootOptions(
     tree,
@@ -21,7 +20,7 @@ export async function normalizeRemoteName(
 
 export function normalizeRemoteDirectory(
   remote: string,
-  options: NormalizedSchema
+  options: { directory: string; appProjectRoot: string }
 ) {
   /**
    * With the `as-provided` format, the provided directory would be the root


### PR DESCRIPTION
## Current Behavior
Running the `@nx/react:remote` generator as a standalone generator in a TS Proj Workspace will result in the generator throwing an error that `@org/remoteName` is invalid. 

## Expected Behavior
Ensure we normalize the project name early to disregard the scope that is added.
This matches the behaviour of the host generator.

## Related Issue(s)

Fixes #30807
