### PR TITLE
fix(gradle): keep original gradle name

### DIFF
--- a/e2e/gradle/project.json
+++ b/e2e/gradle/project.json
@@ -3,7 +3,11 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "e2e/gradle",
   "projectType": "application",
-  "implicitDependencies": ["gradle"],
+  "implicitDependencies": [
+    "gradle",
+    "gradle-project-graph",
+    "gradle-batch-runner"
+  ],
   "// targets": "to see all targets run: nx show project e2e-gradle --web",
   "targets": {}
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -40,7 +40,9 @@ fun createNodeForProject(
             targets = gradleTargets.targets,
             metadata =
                 NodeMetadata(gradleTargets.targetGroups, listOf("gradle"), project.description),
-            name = project.name)
+            name =
+                if (project.buildTreePath.isEmpty() || project.buildTreePath == ":") project.name
+                else project.buildTreePath)
     nodes = mapOf(projectRoot to projectNode)
     externalNodes = gradleTargets.externalNodes
     logger.info(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
currently, the project name is just last part to full gradle path, for example:
- gradle path for :parent-path:project-name, it currently takes only project-name
this might create duplicates in a large project

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- change the name to match gradle path exactly, then the project name would just be the gradle path
- for example, the gradle command would be `./gradlew :parent-path:project-name:build`, nx command would be `nx run :parent-path:project-name:build`

https://linear.app/nxdev/issue/NXC-2917/fix-terminal-ui-compatibility-with-gradle-naming need to be fixed before this pr

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
