### PR TITLE
fix(js): handle npm 11 warnings in stderr during registry version resolution

### DIFF
--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -111,7 +111,15 @@ export default class JsVersionActions extends VersionActions {
             if (error) {
               return reject(error);
             }
-            if (stderr) {
+            // Only reject on stderr if it contains actual errors, not just npm warnings
+            // npm 11+ writes "npm warn" messages to stderr even on successful commands
+            if (
+              stderr &&
+              !stderr
+                .trim()
+                .split('\n')
+                .every((line) => line.startsWith('npm warn'))
+            ) {
               return reject(stderr);
             }
             return resolve(stdout.trim());


### PR DESCRIPTION
## Current Behaviour

E2e tests fail with Node 24 because npm 11 writes deprecation warnings to stderr even on successful commands, causing registry version resolution to fail.

## Expected Behaviour

Registry version resolution should work with npm 11 warnings in stderr.

## References
```
 NX   Unable to resolve the current version from the registry: "registry=http://localhost:4873" tag=latest. Please ensure that the package exists in the registry in order to use the "registry" currentVersionResolver. Alternatively, you can use the --first-release option or set "release.version.fallbackCurrentVersionResolver" to "disk" in order to fallback to the version on disk when the registry lookup fails.
```
https://staging.nx.app/runs/l9kRV3E6ST