### PR TITLE
chore(repo): fixes weird post-checkout issue when using worktrees

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,2 +1,12 @@
+# Skip if this is a worktree creation (previous ref is null)
+if [ "$1" = "0000000000000000000000000000000000000000" ]; then
+  exit 0
+fi
+
+# Skip if this is a file checkout (not branch switch) - $3 would be 0
+if [ "$3" = "0" ]; then
+  exit 0
+fi
+
 changedFiles="$(git diff-tree -r --name-only --no-commit-id $1 $2)"
 node ./scripts/notify-lockfile-changes.js $changedFiles


### PR DESCRIPTION
when using worktrees I'm getting an error like

```
❯ git worktree add ../test-feat-a feat-a
Preparing worktree (checking out 'feat-a')
Updating files: 100% (9887/9887), done.
HEAD is now at c14325d3d3 feat(nx-dev): update nx.dev homepage (#32132)
fatal: bad object 0000000000000000000000000000000000000000
husky - post-checkout script failed (code 128)
```

this is due to our post-checkout husky hook. This PR fixes it