### PR TITLE
fix(core): provide hint that vite will be used when selecting React Router

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -1501,7 +1501,7 @@ async function determineReactRouter(
       choices: [
         {
           name: 'Yes',
-          hint: 'I want to use React Router',
+          hint: 'I want to use React Router. (Vite will be selected as the bundler)',
         },
         {
           name: 'No',


### PR DESCRIPTION
## Current Behavior
React Router requires using a Vite plugin. This means that during the CNW flow, if a user selects `Yes` to the prompt for `React Router for SSR`, we do not prompt them for `bundler`.
This can be confusing for users that expect to be able to select bundler.

## Expected Behavior
Clarify during the prompt for React Router for SSR that Vite will be selected as the bundler.
