### PR TITLE
docs(misc): update cookiebot consent check so it works when cookiebot is blocked

### DIFF
--- a/nx-dev/feature-analytics/src/lib/google-analytics.ts
+++ b/nx-dev/feature-analytics/src/lib/google-analytics.ts
@@ -24,7 +24,7 @@ export function sendPageViewEvent(data: {
   if (
     typeof window !== 'undefined' &&
     window.Cookiebot &&
-    !window.Cookiebot.consent.statistics
+    !window.Cookiebot.consent?.statistics
   ) {
     return;
   }
@@ -57,7 +57,7 @@ export function sendCustomEvent(
   if (
     typeof window !== 'undefined' &&
     window.Cookiebot &&
-    !window.Cookiebot.consent.statistics
+    !window.Cookiebot.consent?.statistics
   ) {
     return;
   }

--- a/nx-dev/ui-common/src/lib/hubspot-form.tsx
+++ b/nx-dev/ui-common/src/lib/hubspot-form.tsx
@@ -124,12 +124,12 @@ export class HubspotForm extends Component<
     };
 
     // Check if Cookiebot is loaded and consent is given
-    if (window.Cookiebot && window.Cookiebot.consent.marketing) {
+    if (window.Cookiebot && window.Cookiebot.consent?.marketing) {
       initialize();
     } else {
       // Listen for consent acceptance
       window.addEventListener('CookiebotOnAccept', () => {
-        if (window.Cookiebot && window.Cookiebot.consent.marketing) {
+        if (window.Cookiebot && window.Cookiebot.consent?.marketing) {
           initialize();
         }
       });


### PR DESCRIPTION
The website should still function when Brave shield is up.


`window.Cookiebot` defaults to `<script id="Cookiebot">` when the script is blocked... so the original check is not fully correct.






