### PR TITLE
docs(nx-cloud): update refs to old /ci/intro pages

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -6500,7 +6500,7 @@
         "children": [
           {
             "name": "CI Documentation",
-            "path": "/ci/intro/ci-with-nx",
+            "path": "/ci/features",
             "id": "ci",
             "isExternal": true,
             "children": [],

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -13774,7 +13774,7 @@
         "file": "",
         "itemList": [],
         "isExternal": true,
-        "path": "/ci/intro/ci-with-nx",
+        "path": "/ci/features",
         "tags": ["cache-task-results", "distribute-task-execution"]
       },
       {
@@ -13859,7 +13859,7 @@
     "path": "/see-also",
     "tags": []
   },
-  "/ci/intro/ci-with-nx": {
+  "/ci/features": {
     "id": "ci",
     "name": "CI Documentation",
     "description": "",
@@ -13867,7 +13867,7 @@
     "file": "",
     "itemList": [],
     "isExternal": true,
-    "path": "/ci/intro/ci-with-nx",
+    "path": "/ci/features",
     "tags": ["cache-task-results", "distribute-task-execution"]
   },
   "/nx-api/nx/documents/affected#skip-nx-cache": {

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -272,7 +272,7 @@
       "file": "",
       "id": "ci",
       "name": "CI Documentation",
-      "path": "/ci/intro/ci-with-nx"
+      "path": "/ci/features"
     },
     {
       "description": "",
@@ -1545,7 +1545,7 @@
       "file": "",
       "id": "ci",
       "name": "CI Documentation",
-      "path": "/ci/intro/ci-with-nx"
+      "path": "/ci/features"
     },
     {
       "description": "",

--- a/docs/map.json
+++ b/docs/map.json
@@ -2277,7 +2277,7 @@
               "id": "ci",
               "file": "",
               "tags": ["cache-task-results", "distribute-task-execution"],
-              "path": "/ci/intro/ci-with-nx",
+              "path": "/ci/features",
               "isExternal": true
             },
             {

--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -11,7 +11,7 @@ const navigation = {
   ],
   nxCloud: [
     { name: 'App', href: 'https://cloud.nx.app' },
-    { name: 'Docs', href: '/ci/intro/ci-with-nx' },
+    { name: 'Docs', href: '/ci/features' },
     { name: 'Pricing', href: '/pricing' },
     { name: 'Terms', href: 'https://cloud.nx.app/terms' },
   ],

--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -94,7 +94,7 @@ export function DocumentationHeader({
     { name: 'Nx', href: '/getting-started/intro', current: isNx },
     {
       name: 'CI',
-      href: '/ci/intro/ci-with-nx',
+      href: '/ci/features',
       current: isCI,
     },
     {

--- a/nx-dev/ui-common/src/lib/sidebar.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar.tsx
@@ -313,7 +313,7 @@ export function SidebarMobile({
       { name: 'Nx', href: '/getting-started/intro', current: isNx },
       {
         name: 'CI',
-        href: '/ci/intro/ci-with-nx',
+        href: '/ci/features',
         current: isCI,
       },
       {

--- a/nx-dev/ui-enterprise/src/lib/solutions/management/cut-down-engineering-waste.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/management/cut-down-engineering-waste.tsx
@@ -18,7 +18,7 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href="/ci/intro/ci-with-nx"
+            href="/ci/features"
             title="Learn how to speed up CI"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-enterprise/src/lib/solutions/platform/easy-to-adapt-easy-to-maintain.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/platform/easy-to-adapt-easy-to-maintain.tsx
@@ -30,7 +30,7 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href="/ci/intro/ci-with-nx"
+            href="/ci/recipes/set-up"
             title="Get started with your existing CI provider"
             prefetch={false}
             className="text-sm/6 font-semibold"

--- a/nx-dev/ui-enterprise/src/lib/solutions/platform/reliable-by-design.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/platform/reliable-by-design.tsx
@@ -41,7 +41,7 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href="/ci/intro/ci-with-nx"
+            href="/ci/features"
             title="Learn how to speed up CI"
             prefetch={false}
             className="text-sm/6 font-semibold"

--- a/nx-dev/ui-home/src/lib/ci-for-monorepos.tsx
+++ b/nx-dev/ui-home/src/lib/ci-for-monorepos.tsx
@@ -413,7 +413,7 @@ export function IntegratesToYouCurrentCiProvider(): JSX.Element {
           </p>
           <div className="mt-4 flex items-center">
             <Link
-              href="/ci/intro/connect-to-nx-cloud?utm_source=homepage&utm_medium=website&utm_campaign=homepage_links&utm_content=cta_ci_for_monorepos"
+              href="/ci/recipes/set-up?utm_source=homepage&utm_medium=website&utm_campaign=homepage_links&utm_content=cta_ci_for_monorepos"
               title="Add Nx Cloud to your CI workflow"
               prefetch={false}
               className="group font-semibold leading-6 text-slate-950 dark:text-white"


### PR DESCRIPTION
update links pointing to deprecated /ci/intro pages