### PR TITLE
fix(gradle): normalize project root paths

### DIFF
--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -8,6 +8,7 @@ import {
   CreateNodesFunction,
   workspaceRoot,
   ProjectGraphExternalNode,
+  normalizePath,
 } from '@nx/devkit';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { existsSync } from 'node:fs';
@@ -107,11 +108,12 @@ export const makeCreateNodesForGradleConfigFile =
     if (!project) {
       return {};
     }
-    project.root = projectRoot;
+    const normalizedProjectRoot = normalizePath(projectRoot);
+    project.root = normalizedProjectRoot;
 
     return {
       projects: {
-        [projectRoot]: project,
+        [normalizedProjectRoot]: project,
       },
       externalNodes: externalNodes,
     };


### PR DESCRIPTION
## Current Behavior

The Gradle plugin does not normalize project root paths when creating project nodes, which can lead to inconsistent path handling across different operating systems and file systems.

## Expected Behavior

Project root paths should be normalized using `normalizePath` from `@nx/devkit` to ensure consistent path handling regardless of the operating system or file system.

## Related Issue(s)

This is a general improvement to prevent potential path-related issues in Gradle project detection and configuration.