### PR TITLE
fix(core): ensure task details are always stored in the task history

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle-old.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle-old.ts
@@ -64,7 +64,7 @@ export class LegacyTaskHistoryLifeCycle implements LifeCycle {
   }
 
   printFlakyTasksMessage() {
-    if (this.flakyTasks.length > 0) {
+    if (this.flakyTasks?.length > 0) {
       output.warn({
         title: `Nx detected ${
           this.flakyTasks.length === 1 ? 'a flaky task' : ' flaky tasks'

--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
@@ -6,8 +6,6 @@ import { getTaskHistory, TaskHistory } from '../../utils/task-history';
 import { isTuiEnabled } from '../is-tui-enabled';
 import { LifeCycle, TaskResult } from '../life-cycle';
 import { LegacyTaskHistoryLifeCycle } from './task-history-life-cycle-old';
-import { isNxCloudUsed } from '../../utils/nx-cloud-utils';
-import { readNxJson } from '../../config/nx-json';
 
 interface TaskRun extends NativeTaskRun {
   target: Task['target'];
@@ -17,18 +15,15 @@ let tasksHistoryLifeCycle: TaskHistoryLifeCycle | LegacyTaskHistoryLifeCycle;
 
 export function getTasksHistoryLifeCycle():
   | TaskHistoryLifeCycle
-  | LegacyTaskHistoryLifeCycle
-  | null {
-  if (!isNxCloudUsed(readNxJson())) {
-    if (!tasksHistoryLifeCycle) {
-      tasksHistoryLifeCycle =
-        process.env.NX_DISABLE_DB !== 'true' && !IS_WASM
-          ? new TaskHistoryLifeCycle()
-          : new LegacyTaskHistoryLifeCycle();
-    }
-    return tasksHistoryLifeCycle;
+  | LegacyTaskHistoryLifeCycle {
+  if (!tasksHistoryLifeCycle) {
+    tasksHistoryLifeCycle =
+      process.env.NX_DISABLE_DB !== 'true' && !IS_WASM
+        ? new TaskHistoryLifeCycle()
+        : new LegacyTaskHistoryLifeCycle();
   }
-  return null;
+
+  return tasksHistoryLifeCycle;
 }
 
 export class TaskHistoryLifeCycle implements LifeCycle {
@@ -85,7 +80,7 @@ export class TaskHistoryLifeCycle implements LifeCycle {
   }
 
   printFlakyTasksMessage() {
-    if (this.flakyTasks.length > 0) {
+    if (this.flakyTasks?.length > 0) {
       output.warn({
         title: `Nx detected ${
           this.flakyTasks.length === 1 ? 'a flaky task' : ' flaky tasks'

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.spec.ts
@@ -7,11 +7,13 @@ import { TaskStatus as NativeTaskStatus } from '../../native';
 
 let originalHrTime;
 let originalColumns;
+let originalDbEnabled;
 
 describe('getTuiTerminalSummaryLifeCycle', () => {
   beforeAll(() => {
     originalHrTime = process.hrtime;
     originalColumns = process.stdout.columns;
+    originalDbEnabled = process.env.NX_DISABLE_DB;
     process.stdout.columns = 80;
     process.hrtime = ((x) => {
       if (x !== undefined) {
@@ -19,11 +21,14 @@ describe('getTuiTerminalSummaryLifeCycle', () => {
       }
       return [22229415, 668399708];
     }) as any;
+    // Disable DB to avoid issues when running tests
+    process.env.NX_DISABLE_DB = 'true';
   });
 
   afterAll(() => {
     process.hrtime = originalHrTime;
     process.stdout.columns = originalColumns;
+    process.env.NX_DISABLE_DB = originalDbEnabled;
   });
 
   beforeEach(() => {});

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -139,7 +139,7 @@ export function getTuiTerminalSummaryLifeCycle({
         cancelled,
       });
     }
-    getTasksHistoryLifeCycle()?.printFlakyTasksMessage();
+    getTasksHistoryLifeCycle().printFlakyTasksMessage();
   };
 
   const printRunOneSummary = ({

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -1047,9 +1047,7 @@ export function constructLifeCycles(lifeCycle: LifeCycle): LifeCycle[] {
     lifeCycles.push(new TaskProfilingLifeCycle(process.env.NX_PROFILE));
   }
   const historyLifeCycle = getTasksHistoryLifeCycle();
-  if (historyLifeCycle) {
-    lifeCycles.push(historyLifeCycle);
-  }
+  lifeCycles.push(historyLifeCycle);
   return lifeCycles;
 }
 


### PR DESCRIPTION
## Current Behavior

When Nx Cloud is enabled, task details are not stored in the task history. This results in features like local flaky task detection or displaying estimated task durations in the TUI not working.

## Expected Behavior

Task details should always be stored in the task history regardless of Nx Cloud being enabled.