### PR TITLE
fix(module-federation): move dep to peerDep in angular and react

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -50,7 +50,6 @@
     "@nx/devkit": "workspace:*",
     "@nx/eslint": "workspace:*",
     "@nx/js": "workspace:*",
-    "@nx/module-federation": "workspace:*",
     "@nx/rspack": "workspace:*",
     "@nx/web": "workspace:*",
     "@nx/webpack": "workspace:*",
@@ -74,6 +73,7 @@
     "@angular-devkit/build-angular": ">= 18.0.0 < 21.0.0",
     "@angular-devkit/core": ">= 18.0.0 < 21.0.0",
     "@angular-devkit/schematics": ">= 18.0.0 < 21.0.0",
+    "@nx/module-federation": "workspace:*",
     "@schematics/angular": ">= 18.0.0 < 21.0.0",
     "ng-packagr": ">= 18.0.0 < 21.0.0",
     "rxjs": "^6.5.3 || ^7.5.0"
@@ -83,6 +83,9 @@
       "optional": true
     },
     "@angular-devkit/build-angular": {
+      "optional": true
+    },
+    "@nx/module-federation": {
       "optional": true
     },
     "ng-packagr": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,7 +43,6 @@
     "@nx/eslint": "workspace:*",
     "@nx/web": "workspace:*",
     "@nx/vite": "workspace:*",
-    "@nx/module-federation": "workspace:*",
     "@nx/rollup": "workspace:*",
     "express": "^4.21.2",
     "http-proxy-middleware": "^3.0.3",
@@ -51,6 +50,14 @@
   },
   "devDependencies": {
     "nx": "workspace:*"
+  },
+  "peerDependencies": {
+    "@nx/module-federation": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@nx/module-federation": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Current Behavior
The `@nx/module-federation` package is a direct dependency in `@nx/angular` and `@nx/react`.
This can cause some issues and isn't truly reflective of `@nx/module-federation` place in those packages.

## Expected Behavior
Move `@nx/module-federation` to be an optional peer dependency of the packages. 
It should only be required when a user chooses to use Module Federation. The packages will install the `@nx/module-federation` at this point.
