### PR TITLE
fix(release): do not require the npm CLI to be installed for publishing JS packages with bun

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -67,8 +67,13 @@ describe('nx release - independent projects', () => {
   let pkg2: string;
   let pkg3: string;
   let e2eRegistryUrl: string;
+  let previousPackageManager: string | undefined;
 
   beforeAll(() => {
+    previousPackageManager = process.env.SELECTED_PM;
+    // Ensure consistent package manager usage in all environments for this file
+    process.env.SELECTED_PM = 'npm';
+
     newProject({
       packages: ['@nx/js'],
     });
@@ -102,7 +107,10 @@ describe('nx release - independent projects', () => {
     // This is the verdaccio instance that the e2e tests themselves are working from
     e2eRegistryUrl = execSync('npm config get registry').toString().trim();
   });
-  afterAll(() => cleanupProject());
+  afterAll(() => {
+    cleanupProject();
+    process.env.SELECTED_PM = previousPackageManager;
+  });
 
   describe('version', () => {
     beforeEach(() => {

--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -83,6 +83,7 @@ describe('release-publish executor', () => {
   describe('npm dist-tag error handling', () => {
     it('returns failure and logs only the dist-tag add error when add fails with empty stdout', async () => {
       mockExecSync
+        .mockReturnValueOnce('11.5.1') // npm version check
         .mockReturnValueOnce(
           Buffer.from(
             JSON.stringify({

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -127,8 +127,17 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
   );
 
   const npmViewCommandSegments = [
-    `npm view ${packageName} versions dist-tags --json --"${registryConfigKey}=${registry}"`,
+    getPackageManagerCommand(pm).view,
+    packageName,
   ];
+
+  // Since only yarn does not support multiple specific fields, we'll then fetch the complete data
+  if (pm !== 'yarn') {
+    npmViewCommandSegments.push('versions dist-tags');
+  }
+  npmViewCommandSegments.push(`--json --"${registryConfigKey}=${registry}"`);
+
+  // Unlike npm, none of the other package managers appear to have a dedicated equivalent to the "npm dist-tag" command for managing tags after publication
   const npmDistTagAddCommandSegments = [
     `npm dist-tag add ${packageName}@${packageJson.version} ${tag} --"${registryConfigKey}=${registry}"`,
   ];

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -226,32 +226,34 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
             try {
               const stdoutData = JSON.parse(err.stdout?.toString() || '{}');
 
-            // If the error is that the package doesn't exist, then we can ignore it because we will be publishing it for the first time in the next step
-            if (
-              !(
-                stdoutData.error?.code?.includes('E404') &&
-                stdoutData.error?.summary?.includes('no such package available')
-              ) &&
-              !(
-                err.stderr?.toString().includes('E404') &&
-                err.stderr?.toString().includes('no such package available')
-              )
-            ) {
-              console.error('npm dist-tag add error:');
-              // npm returns error.summary and error.detail
-              if (stdoutData.error?.summary) {
-                console.error(stdoutData.error.summary);
-              }
-              if (stdoutData.error?.detail) {
-                console.error(stdoutData.error.detail);
-              }
-              // pnpm returns error.code and error.message
-              if (stdoutData.error?.code && !stdoutData.error?.summary) {
-                console.error(`Error code: ${stdoutData.error.code}`);
-              }
-              if (stdoutData.error?.message && !stdoutData.error?.summary) {
-                console.error(stdoutData.error.message);
-              }
+              // If the error is that the package doesn't exist, then we can ignore it because we will be publishing it for the first time in the next step
+              if (
+                !(
+                  stdoutData.error?.code?.includes('E404') &&
+                  stdoutData.error?.summary?.includes(
+                    'no such package available'
+                  )
+                ) &&
+                !(
+                  err.stderr?.toString().includes('E404') &&
+                  err.stderr?.toString().includes('no such package available')
+                )
+              ) {
+                console.error('npm dist-tag add error:');
+                // npm returns error.summary and error.detail
+                if (stdoutData.error?.summary) {
+                  console.error(stdoutData.error.summary);
+                }
+                if (stdoutData.error?.detail) {
+                  console.error(stdoutData.error.detail);
+                }
+                // pnpm returns error.code and error.message
+                if (stdoutData.error?.code && !stdoutData.error?.summary) {
+                  console.error(`Error code: ${stdoutData.error.code}`);
+                }
+                if (stdoutData.error?.message && !stdoutData.error?.summary) {
+                  console.error(stdoutData.error.message);
+                }
 
                 if (context.isVerbose) {
                   console.error('npm dist-tag add stdout:');

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -54,6 +54,7 @@ export interface PackageManagerCommands {
   ) => string;
   // yarn berry doesn't support ignoring scripts via flag
   ignoreScriptsFlag?: string;
+  view: string;
 }
 
 /**
@@ -156,6 +157,7 @@ export function getPackageManagerCommand(
         publish: (packageRoot, registry, registryConfigKey, tag) =>
           `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
         ignoreScriptsFlag: useBerry ? undefined : `--ignore-scripts`,
+        view: 'yarn info',
       };
     },
     pnpm: () => {
@@ -204,6 +206,7 @@ export function getPackageManagerCommand(
             allowRegistryConfigKey ? registryConfigKey : 'registry'
           }=${registry}" --tag=${tag} --no-git-checks`,
         ignoreScriptsFlag: '--ignore-scripts',
+        view: 'pnpm view',
       };
     },
     npm: () => {
@@ -224,6 +227,7 @@ export function getPackageManagerCommand(
         publish: (packageRoot, registry, registryConfigKey, tag) =>
           `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
         ignoreScriptsFlag: '--ignore-scripts',
+        view: 'npm view',
       };
     },
     bun: () => {
@@ -244,6 +248,7 @@ export function getPackageManagerCommand(
         publish: (packageRoot, registry, registryConfigKey, tag) =>
           `bun publish --cwd="${packageRoot}" --json --registry="${registry}" --tag=${tag}`,
         ignoreScriptsFlag: '--ignore-scripts',
+        view: 'bun info',
       };
     },
   };

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -263,11 +263,10 @@ export function getPackageManagerCommand(
  */
 export function getPackageManagerVersion(
   packageManager: PackageManager = detectPackageManager(),
-  cwd = process.cwd(),
-  forceExecPackageManager = false
+  cwd = process.cwd()
 ): string {
   let version: string;
-  if (existsSync(join(cwd, 'package.json')) && !forceExecPackageManager) {
+  if (existsSync(join(cwd, 'package.json'))) {
     const packageManagerEntry = readJsonFile<PackageJson>(
       join(cwd, 'package.json')
     )?.packageManager;
@@ -276,7 +275,7 @@ export function getPackageManagerVersion(
       packageManagerEntry
     );
   }
-  if (!version || forceExecPackageManager) {
+  if (!version) {
     try {
       version = execSync(`${packageManager} --version`, {
         cwd,

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -263,10 +263,11 @@ export function getPackageManagerCommand(
  */
 export function getPackageManagerVersion(
   packageManager: PackageManager = detectPackageManager(),
-  cwd = process.cwd()
+  cwd = process.cwd(),
+  forceExecPackageManager = false
 ): string {
   let version: string;
-  if (existsSync(join(cwd, 'package.json'))) {
+  if (existsSync(join(cwd, 'package.json')) && !forceExecPackageManager) {
     const packageManagerEntry = readJsonFile<PackageJson>(
       join(cwd, 'package.json')
     )?.packageManager;
@@ -275,7 +276,7 @@ export function getPackageManagerVersion(
       packageManagerEntry
     );
   }
-  if (!version) {
+  if (!version || forceExecPackageManager) {
     try {
       version = execSync(`${packageManager} --version`, {
         cwd,


### PR DESCRIPTION
## Current Behavior
`nx release publish` requires the npm package manager to run the hard-coded `npm view ...` command even in a project that doesn't use npm as package manager

## Expected Behavior
`nx release publish` uses the detected package manager of the project (e.g. bun) to run a package manager specific command like `npm view ...` / `bun info ...`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32126

## Notes
While `nx affected --target=e2e` ("No tasks were run") and `nx affected --target=test` ("Successfully ran target test for 43 projects and 2 tasks they depend on") were successful, I was not able to publish a local test version to a local registry - so unfortunately I couldn't manually verify whether this actually fixes the linked issue.