### PR TITLE
feat(docker): add support for {env.VAR_NAME}

### DIFF
--- a/docs/shared/recipes/nx-release/release-docker-images.md
+++ b/docs/shared/recipes/nx-release/release-docker-images.md
@@ -196,12 +196,15 @@ You can customize Docker version schemes in your `nx.json` to match your deploym
   "release": {
     "dockerVersionScheme": {
       "production": "{currentDate|YYMM.DD}.{shortCommitSha}",
-      "staging": "{currentDate|YYMM.DD}-staging.{shortCommitSha}"
+      "staging": "{currentDate|YYMM.DD}-staging.{shortCommitSha}",
+      "ci": "{env:BUILD_NUMBER}-{shortCommitSha}"
     }
   }
 }
 ```
 
-The above configuration swaps `hotfix` scheme for `staging`. You can customize this list to fit your needs, and you can also change the patterns for each scheme.
+The above configuration swaps `hotfix` scheme for `staging` and adds a `ci` scheme that uses an environment variable. You can customize this list to fit your needs, and you can also change the patterns for each scheme.
+
+Version patterns can include environment variables using the `{env:VAR_NAME}` syntax, allowing you to inject CI/CD pipeline information like build numbers or deployment environments directly into your Docker tags.
 
 See the [`docker.versionScheme` documentation](/reference/nx-json#version-scheme-syntax) for more details on how to customize the tag pattern.

--- a/docs/shared/recipes/nx-release/release-docker-images.md
+++ b/docs/shared/recipes/nx-release/release-docker-images.md
@@ -197,7 +197,7 @@ You can customize Docker version schemes in your `nx.json` to match your deploym
     "dockerVersionScheme": {
       "production": "{currentDate|YYMM.DD}.{shortCommitSha}",
       "staging": "{currentDate|YYMM.DD}-staging.{shortCommitSha}",
-      "ci": "{env:BUILD_NUMBER}-{shortCommitSha}"
+      "ci": "{env.BUILD_NUMBER}-{shortCommitSha}"
     }
   }
 }
@@ -205,6 +205,6 @@ You can customize Docker version schemes in your `nx.json` to match your deploym
 
 The above configuration swaps `hotfix` scheme for `staging` and adds a `ci` scheme that uses an environment variable. You can customize this list to fit your needs, and you can also change the patterns for each scheme.
 
-Version patterns can include environment variables using the `{env:VAR_NAME}` syntax, allowing you to inject CI/CD pipeline information like build numbers or deployment environments directly into your Docker tags.
+Version patterns can include environment variables using the `{env.VAR_NAME}` syntax, allowing you to inject CI/CD pipeline information like build numbers or deployment environments directly into your Docker tags.
 
 See the [`docker.versionScheme` documentation](/reference/nx-json#version-scheme-syntax) for more details on how to customize the tag pattern.

--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -601,15 +601,15 @@ Docker version schemes support calendar-based patterns using the following place
   - `ss` - 2-digit seconds (00-59)
 - `{shortCommitSha}` - First 7 characters of the current commit SHA
 - `{commitSha}` - Full commit SHA
-- `{env:VAR_NAME}` - The value of the environment variable VAR_NAME
+- `{env.VAR_NAME}` - The value of the environment variable VAR_NAME
 
 Example patterns:
 
 - `{currentDate|YYMM.DD}.{shortCommitSha}` - Results in: 2501.30.a1b2c3d
 - `{projectName}-{currentDate|YYYY.MM.DD}` - Results in: api-2025.01.30
 - `{currentDate|YY.MM.DD.HHmm}-{commitSha}` - Results in: 25.01.30.1430-abcdef1234567890
-- `{env:BUILD_NUMBER}-{projectName}` - Results in: 123-api (when BUILD_NUMBER=123)
-- `{env:STAGE}-{currentDate|YYMM.DD}` - Results in: production-2501.30 (when STAGE=production)
+- `{env.BUILD_NUMBER}-{projectName}` - Results in: 123-api (when BUILD_NUMBER=123)
+- `{env.STAGE}-{currentDate|YYMM.DD}` - Results in: production-2501.30 (when STAGE=production)
 
 #### Group-Level Docker Configuration
 

--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -601,12 +601,15 @@ Docker version schemes support calendar-based patterns using the following place
   - `ss` - 2-digit seconds (00-59)
 - `{shortCommitSha}` - First 7 characters of the current commit SHA
 - `{commitSha}` - Full commit SHA
+- `{env:VAR_NAME}` - The value of the environment variable VAR_NAME
 
 Example patterns:
 
 - `{currentDate|YYMM.DD}.{shortCommitSha}` - Results in: 2501.30.a1b2c3d
 - `{projectName}-{currentDate|YYYY.MM.DD}` - Results in: api-2025.01.30
 - `{currentDate|YY.MM.DD.HHmm}-{commitSha}` - Results in: 25.01.30.1430-abcdef1234567890
+- `{env:BUILD_NUMBER}-{projectName}` - Results in: 123-api (when BUILD_NUMBER=123)
+- `{env:STAGE}-{currentDate|YYMM.DD}` - Results in: production-2501.30 (when STAGE=production)
 
 #### Group-Level Docker Configuration
 

--- a/packages/docker/src/release/version-pattern-utils.spec.ts
+++ b/packages/docker/src/release/version-pattern-utils.spec.ts
@@ -199,7 +199,7 @@ describe('version-pattern-utils', () => {
       it('should interpolate environment variables', () => {
         process.env.BUILD_NUMBER = '123';
         const result = interpolateVersionPattern(
-          'build-{env:BUILD_NUMBER}',
+          'build-{env.BUILD_NUMBER}',
           {}
         );
         expect(result).toBe('build-123');
@@ -209,7 +209,7 @@ describe('version-pattern-utils', () => {
         process.env.STAGE = 'QA';
         process.env.BUILD_NUMBER = '456';
         const result = interpolateVersionPattern(
-          'build-{env:STAGE}.{env:BUILD_NUMBER}',
+          'build-{env.STAGE}.{env.BUILD_NUMBER}',
           {}
         );
         expect(result).toBe('build-QA.456');
@@ -217,16 +217,16 @@ describe('version-pattern-utils', () => {
 
       it('should keep unknown environment variables as-is', () => {
         const result = interpolateVersionPattern(
-          'build-{env:NON_EXISTENT_VAR}',
+          'build-{env.NON_EXISTENT_VAR}',
           {}
         );
-        expect(result).toBe('build-{env:NON_EXISTENT_VAR}');
+        expect(result).toBe('build-{env.NON_EXISTENT_VAR}');
       });
 
       it('should combine environment variables with other tokens', () => {
         process.env.TASK = 'builder';
         const result = interpolateVersionPattern(
-          '{projectName}-{env:TASK}-{shortCommitSha}',
+          '{projectName}-{env.TASK}-{shortCommitSha}',
           {
             projectName: 'api',
           }
@@ -236,14 +236,14 @@ describe('version-pattern-utils', () => {
 
       it('should handle environment variables with underscores and numbers', () => {
         process.env.MY_VAR_123 = 'test-value';
-        const result = interpolateVersionPattern('prefix-{env:MY_VAR_123}', {});
+        const result = interpolateVersionPattern('prefix-{env.MY_VAR_123}', {});
         expect(result).toBe('prefix-test-value');
       });
 
       it('should handle empty environment variable values', () => {
         process.env.EMPTY_VAR = '';
         const result = interpolateVersionPattern(
-          'prefix-{env:EMPTY_VAR}-suffix',
+          'prefix-{env.EMPTY_VAR}-suffix',
           {}
         );
         expect(result).toBe('prefix--suffix');
@@ -254,7 +254,7 @@ describe('version-pattern-utils', () => {
         process.env.ENVIRONMENT = 'production';
         const testDate = new Date('2024-01-15T10:30:45.000Z');
         const result = interpolateVersionPattern(
-          '{env:VERSION}-{projectName}-{env:ENVIRONMENT}-{currentDate|YYYY.MM.DD}',
+          '{env.VERSION}-{projectName}-{env.ENVIRONMENT}-{currentDate|YYYY.MM.DD}',
           {
             projectName: 'webapp',
             currentDate: testDate,
@@ -266,10 +266,10 @@ describe('version-pattern-utils', () => {
       it('should handle undefined environment variables', () => {
         delete process.env.UNDEFINED_VAR;
         const result = interpolateVersionPattern(
-          'build-{env:UNDEFINED_VAR}',
+          'build-{env.UNDEFINED_VAR}',
           {}
         );
-        expect(result).toBe('build-{env:UNDEFINED_VAR}');
+        expect(result).toBe('build-{env.UNDEFINED_VAR}');
       });
     });
   });

--- a/packages/docker/src/release/version-pattern-utils.spec.ts
+++ b/packages/docker/src/release/version-pattern-utils.spec.ts
@@ -184,5 +184,93 @@ describe('version-pattern-utils', () => {
       );
       expect(result).toBe('2024-01-05 03:07:09');
     });
+
+    describe('environment variable interpolation', () => {
+      const originalEnv = process.env;
+
+      beforeEach(() => {
+        process.env = { ...originalEnv };
+      });
+
+      afterEach(() => {
+        process.env = originalEnv;
+      });
+
+      it('should interpolate environment variables', () => {
+        process.env.BUILD_NUMBER = '123';
+        const result = interpolateVersionPattern(
+          'build-{env:BUILD_NUMBER}',
+          {}
+        );
+        expect(result).toBe('build-123');
+      });
+
+      it('should handle multiple environment variables', () => {
+        process.env.STAGE = 'QA';
+        process.env.BUILD_NUMBER = '456';
+        const result = interpolateVersionPattern(
+          'build-{env:STAGE}.{env:BUILD_NUMBER}',
+          {}
+        );
+        expect(result).toBe('build-QA.456');
+      });
+
+      it('should keep unknown environment variables as-is', () => {
+        const result = interpolateVersionPattern(
+          'build-{env:NON_EXISTENT_VAR}',
+          {}
+        );
+        expect(result).toBe('build-{env:NON_EXISTENT_VAR}');
+      });
+
+      it('should combine environment variables with other tokens', () => {
+        process.env.TASK = 'builder';
+        const result = interpolateVersionPattern(
+          '{projectName}-{env:TASK}-{shortCommitSha}',
+          {
+            projectName: 'api',
+          }
+        );
+        expect(result).toBe('api-builder-abc1234');
+      });
+
+      it('should handle environment variables with underscores and numbers', () => {
+        process.env.MY_VAR_123 = 'test-value';
+        const result = interpolateVersionPattern('prefix-{env:MY_VAR_123}', {});
+        expect(result).toBe('prefix-test-value');
+      });
+
+      it('should handle empty environment variable values', () => {
+        process.env.EMPTY_VAR = '';
+        const result = interpolateVersionPattern(
+          'prefix-{env:EMPTY_VAR}-suffix',
+          {}
+        );
+        expect(result).toBe('prefix--suffix');
+      });
+
+      it('should handle environment variables in complex patterns', () => {
+        process.env.VERSION = '2.1.0';
+        process.env.ENVIRONMENT = 'production';
+        const testDate = new Date('2024-01-15T10:30:45.000Z');
+        const result = interpolateVersionPattern(
+          '{env:VERSION}-{projectName}-{env:ENVIRONMENT}-{currentDate|YYYY.MM.DD}',
+          {
+            projectName: 'webapp',
+            currentDate: testDate,
+          }
+        );
+        expect(result).toBe('2.1.0-webapp-production-2024.01.15');
+      });
+
+      it('should handle undefined environment variables', () => {
+        delete process.env.UNDEFINED_VAR;
+        const result = interpolateVersionPattern(
+          'build-{env:UNDEFINED_VAR}',
+          {}
+        );
+        expect(result).toBe('build-{env:UNDEFINED_VAR}');
+      });
+    });
   });
 });

--- a/packages/docker/src/release/version-pattern-utils.ts
+++ b/packages/docker/src/release/version-pattern-utils.ts
@@ -7,6 +7,7 @@ import { getLatestCommitSha } from 'nx/src/utils/git-utils';
  * {currentDate|DATE FORMAT} - the current date with custom format such as YYMM.DD
  * {commitSha} - The full commit sha for the current commit
  * {shortCommitSha} - The seven character commit sha for the current commit
+ * {env:VAR_NAME} - The value of the environment variable VAR_NAME
  */
 export interface PatternTokens {
   projectName: string;
@@ -15,7 +16,7 @@ export interface PatternTokens {
   shortCommitSha: string;
 }
 
-const tokenRegex = /\{([^|{}]+)(?:\|([^{}]+))?\}/g;
+const tokenRegex = /\{(env:([^}]+)|([^|{}]+)(?:\|([^{}]+))?)\}/g;
 
 function formatDate(date: Date, format: string) {
   const year = String(date.getUTCFullYear());
@@ -47,22 +48,32 @@ export function interpolateVersionPattern(
     shortCommitSha: data.shortCommitSha ?? commitSha.slice(0, 7),
   };
 
-  return versionPattern.replace(tokenRegex, (match, identifier, format) => {
-    const value = substitutions[identifier];
-
-    if (value === undefined) {
-      return match; // Keep original token if no data
-    }
-
-    // Handle date formatting
-    if (identifier === 'currentDate') {
-      if (format) {
-        return formatDate(value, format);
-      } else {
-        return (value as Date).toISOString();
+  return versionPattern.replace(
+    tokenRegex,
+    (match, fullMatch, envVarName, identifier, format) => {
+      // Handle environment variables
+      if (envVarName) {
+        const envValue = process.env[envVarName];
+        return envValue !== undefined ? envValue : match;
       }
-    }
 
-    return value;
-  });
+      // Handle other tokens
+      const value = substitutions[identifier];
+
+      if (value === undefined) {
+        return match; // Keep original token if no data
+      }
+
+      // Handle date formatting
+      if (identifier === 'currentDate') {
+        if (format) {
+          return formatDate(value, format);
+        } else {
+          return (value as Date).toISOString();
+        }
+      }
+
+      return value;
+    }
+  );
 }

--- a/packages/docker/src/release/version-pattern-utils.ts
+++ b/packages/docker/src/release/version-pattern-utils.ts
@@ -7,7 +7,7 @@ import { getLatestCommitSha } from 'nx/src/utils/git-utils';
  * {currentDate|DATE FORMAT} - the current date with custom format such as YYMM.DD
  * {commitSha} - The full commit sha for the current commit
  * {shortCommitSha} - The seven character commit sha for the current commit
- * {env:VAR_NAME} - The value of the environment variable VAR_NAME
+ * {env.VAR_NAME} - The value of the environment variable VAR_NAME
  */
 export interface PatternTokens {
   projectName: string;
@@ -16,7 +16,7 @@ export interface PatternTokens {
   shortCommitSha: string;
 }
 
-const tokenRegex = /\{(env:([^}]+)|([^|{}]+)(?:\|([^{}]+))?)\}/g;
+const tokenRegex = /\{(env\.([^}]+)|([^|{}]+)(?:\|([^{}]+))?)\}/g;
 
 function formatDate(date: Date, format: string) {
   const year = String(date.getUTCFullYear());


### PR DESCRIPTION
## Current Behavior
We currently do not have a method for interpolating Environment Variables into the `versionSchemes` for Docker Release.

## Expected Behavior
We allow the usage of `{env.VAR_NAME}` to interpolate Environment Variables
