### PR TITLE
feat(core): add argv field to Pre/Post Tasks Execution contexts

### DIFF
--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -266,6 +266,7 @@ async function runPublishOnProjects(
   await runPreTasksExecution({
     workspaceRoot,
     nxJsonConfiguration: nxJson,
+    argv: process.argv,
   });
 
   /**
@@ -300,6 +301,7 @@ async function runPublishOnProjects(
     taskResults,
     workspaceRoot,
     nxJsonConfiguration: nxJson,
+    argv: process.argv,
   });
 
   return publishProjectsResult;

--- a/packages/nx/src/project-graph/plugins/public-api.ts
+++ b/packages/nx/src/project-graph/plugins/public-api.ts
@@ -192,11 +192,13 @@ export type NxPluginV2<TOptions = unknown> = {
 export type PreTasksExecutionContext = {
   readonly workspaceRoot: string;
   readonly nxJsonConfiguration: NxJsonConfiguration;
+  readonly argv: string[];
 };
 export type PostTasksExecutionContext = {
   readonly workspaceRoot: string;
   readonly nxJsonConfiguration: NxJsonConfiguration;
   readonly taskResults: TaskResults;
+  readonly argv: string[];
 };
 
 export type PreTasksExecution<TOptions = unknown> = (

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -437,6 +437,7 @@ export async function runCommand(
       await runPreTasksExecution({
         workspaceRoot,
         nxJsonConfiguration: nxJson,
+        argv: process.argv,
       });
 
       const { taskResults, completed } = await runCommandForTasks(
@@ -469,6 +470,7 @@ export async function runCommand(
         taskResults,
         workspaceRoot,
         nxJsonConfiguration: nxJson,
+        argv: process.argv,
       });
 
       return exitCode;


### PR DESCRIPTION
## Current Behavior

The new Pre/Post Tasks Execution API was missing command information that was available in the old `StoreRunInformationLifeCycle` system. This made it impossible to track the original command that initiated task execution, particularly problematic for complex commands like `nx affected` and `nx run-many`.

## Expected Behavior

With this change, both `PreTasksExecutionContext` and `PostTasksExecutionContext` now include an `argv: string[]` field containing the complete raw command line arguments from `process.argv`.

## Related Issue(s)

Addresses the missing command information discussed in https://github.com/nrwl/nx/discussions/29637

## Changes Made

- **Add `argv: string[]` field** to `PreTasksExecutionContext` interface
- **Add `argv: string[]` field** to `PostTasksExecutionContext` interface
- **Pass `process.argv` directly** to both execution contexts
- **Remove command parsing functions** (no longer needed)

## Benefits

- **Complete Raw Data**: Provides full `process.argv` including node executable path, script path, and all arguments
- **No Information Loss**: Every argument preserved exactly as passed to the process
- **Better Analysis**: Consumers can parse/analyze arguments however needed
- **Simpler Implementation**: No parsing required - just pass `process.argv` directly

## Example

Instead of missing command information, plugins now receive:

```typescript
{
  workspaceRoot: '/path/to/workspace',
  nxJsonConfiguration: { ... },
  argv: [
    "/usr/bin/node",
    "/usr/local/bin/nx", 
    "affected",
    "--target=build",
    "--head=HEAD~1"
  ]
  // ... other fields
}
```

This is especially valuable for tracking complex commands like `nx affected` and `nx run-many` where the original command context was previously lost.