### PR TITLE
test(node): disable failing esbuild e2e test

### DIFF
--- a/e2e/node/src/node-ts-solution-esbuild.test.ts
+++ b/e2e/node/src/node-ts-solution-esbuild.test.ts
@@ -27,7 +27,8 @@ describe('Node Esbuild Applications', () => {
     cleanupProject();
   });
 
-  it('it should generate an app that cosumes a non-buildable ts library', () => {
+  // TODO: Re-enable this test once https://github.com/pinojs/pino/issues/2253 is resolved
+  it.skip('it should generate an app that cosumes a non-buildable ts library', () => {
     const nodeapp = uniq('nodeapp');
     const lib = uniq('lib');
     const port = getRandomPort();


### PR DESCRIPTION
## Current Behavior

The esbuild e2e test `it should generate an app that cosumes a non-buildable ts library` is failing and causing CI issues.

## Expected Behavior

The test should be temporarily disabled until the underlying issue is resolved.

## Related Issue(s)

The test failure is due to https://github.com/pinojs/pino/issues/2253. This test should be re-enabled once that pino issue is resolved.

## Changes

- Added `.skip` to the failing test
- Added a TODO comment referencing the pino issue for when to re-enable the test