### PR TITLE
chore(repo): add commit-msg hook for immediate commit validation

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+node ./scripts/commit-lint.js "$1"


### PR DESCRIPTION
## Current Behavior

Commit message validation only happens during the pre-push hook, which means developers don't get feedback about incorrect commit message format until they try to push their changes to the remote repository.

## Expected Behavior

Commit messages should be validated immediately when creating a commit, providing instant feedback and preventing incorrectly formatted commits from being created in the first place.

## Changes Made

- **Add `.husky/commit-msg` hook** - Validates commit messages before commit creation
- **Enhance `scripts/commit-lint.js`** - Support both commit-msg hook and existing pre-push validation
- **Add WIP support** - Allow "wip" messages to bypass format validation for work-in-progress commits
- **Maintain backward compatibility** - Existing pre-push validation continues to work

## Benefits

- Immediate feedback on commit message format
- Prevents bad commits from being created
- Supports WIP commits for development workflow  
- No disruption to existing validation process

## Related Issue(s)

This improves the developer experience by catching commit message format issues earlier in the workflow.