### PR TITLE
fix(core): adding `customProxyConfigPath` support to default runner

### DIFF
--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -77,6 +77,7 @@ export const allowedWorkspaceExtensions = [
   'nxCloudId',
   'nxCloudUrl',
   'nxCloudEncryptionKey',
+  'customProxyConfigPath',
   'parallel',
   'cacheDirectory',
   'useDaemonProcess',

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -746,6 +746,11 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
   nxCloudEncryptionKey?: string;
 
   /**
+   * Specifies the path to a custom proxy configuration file.
+   */
+  customProxyConfigPath?: string;
+
+  /**
    * Specifies how many tasks can be run in parallel.
    */
   parallel?: number;

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -1231,6 +1231,10 @@ export function getRunnerOptions(
     result.cacheDirectory ??= nxJson.cacheDirectory;
   }
 
+  if (nxJson.customProxyConfigPath) {
+    result.customProxyConfigPath ??= nxJson.customProxyConfigPath;
+  }
+
   if (defaultCacheableOperations.length) {
     result.cacheableOperations ??= [];
     result.cacheableOperations = result.cacheableOperations.concat(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Users migrating to Nx 21 that were using custom task runners had support for a `customProxyConfigPath` option that is not supported at the top level of nx.json config (however most others now are)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Users should be able to list a `customProxyConfigPath` that is now applied as expected to the default runner.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
