### PR TITLE
fix(core): update http-proxy-middleware to resolve vulnerability

### DIFF
--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -2593,6 +2593,16 @@
     "executors": {},
     "generators": {},
     "migrations": {
+      "/technologies/module-federation/api/migrations/21.4.0-package-updates": {
+        "description": "",
+        "file": "generated/packages/module-federation/migrations/21.4.0-package-updates.json",
+        "hidden": false,
+        "name": "21.4.0-package-updates",
+        "version": "21.4.0-beta.8",
+        "originalFilePath": "/packages/module-federation",
+        "path": "/technologies/module-federation/api/migrations/21.4.0-package-updates",
+        "type": "migration"
+      },
       "/technologies/module-federation/api/migrations/21.3.0-package-updates": {
         "description": "",
         "file": "generated/packages/module-federation/migrations/21.3.0-package-updates.json",
@@ -3978,6 +3988,16 @@
       }
     },
     "migrations": {
+      "/technologies/react/api/migrations/21.4.0-package-updates": {
+        "description": "",
+        "file": "generated/packages/react/migrations/21.4.0-package-updates.json",
+        "hidden": false,
+        "name": "21.4.0-package-updates",
+        "version": "21.4.0-beta.8",
+        "originalFilePath": "/packages/react",
+        "path": "/technologies/react/api/migrations/21.4.0-package-updates",
+        "type": "migration"
+      },
       "/technologies/react/api/migrations/update-21-0-0-update-babel-loose": {
         "description": "Replaces `classProperties.loose` option with `loose`.",
         "file": "generated/packages/react/migrations/update-21-0-0-update-babel-loose.json",
@@ -4791,6 +4811,16 @@
       }
     },
     "migrations": {
+      "/technologies/build-tools/rspack/api/migrations/21.4.0-package-updates": {
+        "description": "",
+        "file": "generated/packages/rspack/migrations/21.4.0-package-updates.json",
+        "hidden": false,
+        "name": "21.4.0-package-updates",
+        "version": "21.4.0-beta.8",
+        "originalFilePath": "/packages/rspack",
+        "path": "/technologies/build-tools/rspack/api/migrations/21.4.0-package-updates",
+        "type": "migration"
+      },
       "/technologies/build-tools/rspack/api/migrations/21.3.0-package-updates": {
         "description": "",
         "file": "generated/packages/rspack/migrations/21.3.0-package-updates.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -2844,6 +2844,16 @@
     "migrations": [
       {
         "description": "",
+        "file": "generated/packages/module-federation/migrations/21.4.0-package-updates.json",
+        "hidden": false,
+        "name": "21.4.0-package-updates",
+        "version": "21.4.0-beta.8",
+        "originalFilePath": "/packages/module-federation",
+        "path": "module-federation/migrations/21.4.0-package-updates",
+        "type": "migration"
+      },
+      {
+        "description": "",
         "file": "generated/packages/module-federation/migrations/21.3.0-package-updates.json",
         "hidden": false,
         "name": "21.3.0-package-updates",
@@ -4304,6 +4314,16 @@
     ],
     "migrations": [
       {
+        "description": "",
+        "file": "generated/packages/react/migrations/21.4.0-package-updates.json",
+        "hidden": false,
+        "name": "21.4.0-package-updates",
+        "version": "21.4.0-beta.8",
+        "originalFilePath": "/packages/react",
+        "path": "react/migrations/21.4.0-package-updates",
+        "type": "migration"
+      },
+      {
         "description": "Replaces `classProperties.loose` option with `loose`.",
         "file": "generated/packages/react/migrations/update-21-0-0-update-babel-loose.json",
         "hidden": false,
@@ -5147,6 +5167,16 @@
       }
     ],
     "migrations": [
+      {
+        "description": "",
+        "file": "generated/packages/rspack/migrations/21.4.0-package-updates.json",
+        "hidden": false,
+        "name": "21.4.0-package-updates",
+        "version": "21.4.0-beta.8",
+        "originalFilePath": "/packages/rspack",
+        "path": "rspack/migrations/21.4.0-package-updates",
+        "type": "migration"
+      },
       {
         "description": "",
         "file": "generated/packages/rspack/migrations/21.3.0-package-updates.json",

--- a/docs/generated/packages/module-federation/migrations/21.4.0-package-updates.json
+++ b/docs/generated/packages/module-federation/migrations/21.4.0-package-updates.json
@@ -1,0 +1,17 @@
+{
+  "name": "21.4.0-package-updates",
+  "version": "21.4.0-beta.8",
+  "packages": {
+    "http-proxy-middleware": {
+      "version": "^3.0.5",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/module-federation",
+  "schema": null,
+  "type": "migration"
+}

--- a/docs/generated/packages/react/migrations/21.4.0-package-updates.json
+++ b/docs/generated/packages/react/migrations/21.4.0-package-updates.json
@@ -1,0 +1,17 @@
+{
+  "name": "21.4.0-package-updates",
+  "version": "21.4.0-beta.8",
+  "packages": {
+    "http-proxy-middleware": {
+      "version": "^3.0.5",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/react",
+  "schema": null,
+  "type": "migration"
+}

--- a/docs/generated/packages/rspack/migrations/21.4.0-package-updates.json
+++ b/docs/generated/packages/rspack/migrations/21.4.0-package-updates.json
@@ -1,0 +1,17 @@
+{
+  "name": "21.4.0-package-updates",
+  "version": "21.4.0-beta.8",
+  "packages": {
+    "http-proxy-middleware": {
+      "version": "^3.0.5",
+      "alwaysAddToPackageJson": false
+    }
+  },
+  "aliases": [],
+  "description": "",
+  "hidden": false,
+  "implementation": "",
+  "path": "/packages/rspack",
+  "schema": null,
+  "type": "migration"
+}

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "gpt3-tokenizer": "^1.1.5",
     "handlebars": "4.7.7",
     "html-webpack-plugin": "5.5.0",
-    "http-proxy-middleware": "^3.0.3",
+    "http-proxy-middleware": "^3.0.5",
     "http-server": "14.1.0",
     "husky": "^9.1.5",
     "identity-obj-proxy": "3.0.0",

--- a/packages/module-federation/migrations.json
+++ b/packages/module-federation/migrations.json
@@ -75,6 +75,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "21.4.0": {
+      "version": "21.4.0-beta.8",
+      "packages": {
+        "http-proxy-middleware": {
+          "version": "^3.0.5",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/module-federation/package.json
+++ b/packages/module-federation/package.json
@@ -35,7 +35,7 @@
     "@module-federation/node": "^2.7.9",
     "@module-federation/sdk": "^0.17.0",
     "express": "^4.21.2",
-    "http-proxy-middleware": "^3.0.3"
+    "http-proxy-middleware": "^3.0.5"
   },
   "devDependencies": {
     "nx": "workspace:*"

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -174,6 +174,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "21.4.0": {
+      "version": "21.4.0-beta.8",
+      "packages": {
+        "http-proxy-middleware": {
+          "version": "^3.0.5",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,7 @@
     "@nx/module-federation": "workspace:*",
     "@nx/rollup": "workspace:*",
     "express": "^4.21.2",
-    "http-proxy-middleware": "^3.0.3",
+    "http-proxy-middleware": "^3.0.5",
     "semver": "^7.6.3"
   },
   "devDependencies": {

--- a/packages/rspack/migrations.json
+++ b/packages/rspack/migrations.json
@@ -99,6 +99,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "21.4.0": {
+      "version": "21.4.0-beta.8",
+      "packages": {
+        "http-proxy-middleware": {
+          "version": "^3.0.5",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   },
   "version": "0.1"

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -38,7 +38,7 @@
     "enquirer": "~2.3.6",
     "express": "^4.21.2",
     "ts-checker-rspack-plugin": "^1.1.1",
-    "http-proxy-middleware": "^3.0.3",
+    "http-proxy-middleware": "^3.0.5",
     "less-loader": "^11.1.0",
     "license-webpack-plugin": "^4.0.2",
     "loader-utils": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,7 +758,7 @@ importers:
         specifier: 5.5.0
         version: 5.5.0(webpack@5.99.9)
       http-proxy-middleware:
-        specifier: ^3.0.3
+        specifier: ^3.0.5
         version: 3.0.5
       http-server:
         specifier: 14.1.0
@@ -2768,7 +2768,7 @@ importers:
         specifier: ^4.21.2
         version: 4.21.2
       http-proxy-middleware:
-        specifier: ^3.0.3
+        specifier: ^3.0.5
         version: 3.0.5
       picocolors:
         specifier: ^1.1.0
@@ -3156,7 +3156,7 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.99.9(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4))
       http-proxy-middleware:
-        specifier: ^3.0.3
+        specifier: ^3.0.5
         version: 3.0.5
       minimatch:
         specifier: 9.0.3
@@ -3392,7 +3392,7 @@ importers:
         specifier: ^4.21.2
         version: 4.21.2
       http-proxy-middleware:
-        specifier: ^3.0.3
+        specifier: ^3.0.5
         version: 3.0.5
       less-loader:
         specifier: ^11.1.0


### PR DESCRIPTION
Update http-proxy-middleware to latest. 

This update resolves vulnerability in the package: 

[CVE-2025-32997](https://nvd.nist.gov/vuln/detail/CVE-2025-32997)
[CVE-2025-32996](https://nvd.nist.gov/vuln/detail/CVE-2025-32996)
