### PR TITLE
fix(core): make watch command work with all and initialRun specified

### DIFF
--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -48,11 +48,11 @@ export class BatchFunctionRunner {
       this.pendingFiles.add(fileChange.path);
     });
 
-    return this.process();
+    return this.process(true);
   }
 
-  private async process() {
-    if (!this.running && this.hasPending) {
+  private async process(runAnyway: boolean) {
+    if (!this.running && (this.hasPending || runAnyway)) {
       this.running = true;
 
       // Clone the pending projects and files before clearing
@@ -65,7 +65,7 @@ export class BatchFunctionRunner {
 
       return this.callback(projects, files).then(() => {
         this.running = false;
-        this.process();
+        this.process(false);
       });
     } else {
       this._verbose &&


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

If you specify both the `all` and `initialRun` options when running `nx watch`, `initialRun` have no effect.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The command should be called once at the beginning even if there are no file changes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32281
