### PR TITLE
docs(nx-cloud): update self-healing CI setup to always require fix-ci command

### DIFF
--- a/docs/blog/2025-06-23-nx-self-healing-ci.md
+++ b/docs/blog/2025-06-23-nx-self-healing-ci.md
@@ -113,47 +113,20 @@ Once connected, enable AI features in your [Nx Cloud dashboard](https://nx.app):
 
 ### 2. Configure Your CI Pipeline
 
-If you're using Nx Agents, Self-Healing CI is automatically enabled. Here's an example GitHub Actions configuration with Nx Agents:
+Add the `fix-ci` step to your pipeline. **Important**: This step must run at the end with `if: always()` to ensure it executes even when previous steps fail (which is exactly when you need the fix):
 
-```yaml
+```yaml {% fileName=".github/workflows/ci.yml" highlightLines=[15,16] %}
 name: CI
-
-...
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      ...
-
-      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
       - run: npm ci
-      - uses: nrwl/nx-set-shas@v4
-      - run: npx nx affected -t lint test build
-```
 
-If you're not using Nx Agents yet, you can still enable Self-Healing CI by adding the `fix-ci` step to your pipeline. **Important**: This step must run at the end with `if: always()` to ensure it executes even when previous steps fail (which is exactly when you need the fix):
-
-```yaml
-name: CI
-
-...
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
       ...
-
-      - run: npm ci
-
-      - uses: nrwl/nx-set-shas@v4
 
       - run: npx nx affected -t lint test build
 

--- a/docs/shared/features/self-healing-ci.md
+++ b/docs/shared/features/self-healing-ci.md
@@ -32,18 +32,21 @@ Next, check the Nx Cloud workspace settings in the Nx Cloud web application to e
 
 ### Configure your CI pipeline
 
-**Using [Nx Agents](/ci/features/distribute-task-execution):** There's nothing to be done. You're already good to go.
+Add the `fix-ci` step to your pipeline. **Important:** This step must run at the end with `if: always()` to ensure it executes even when previous steps fail:
 
-**Not using Nx Agents:** Add the `fix-ci` step to your pipeline. Important: this step must run at the end with `if: always()` to ensure it executes even when previous steps fail:
-
-```yaml {% fileName=".github/workflows/ci.yml" highlightLines=[10,11] %}
+```yaml {% fileName=".github/workflows/ci.yml" highlightLines=[15,16] %}
 name: CI
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm ci
+
       ...
+
       - run: npx nx affected -t lint test build
 
       - run: npx nx-cloud fix-ci


### PR DESCRIPTION
## Summary
- Updated documentation to clarify that `nx-cloud fix-ci` command is always required for self-healing CI
- Removed the distinction between Nx Agents and non-Nx Agents setups
- Simplified CI configuration examples

## Details
Previously, the documentation indicated that the `nx-cloud fix-ci` command was only needed when not using Nx Agents. This has been updated to clarify that the fix-ci command is always required for self-healing CI functionality, regardless of whether Nx Agents are being used or not.

### Changes made:
- Updated `docs/shared/features/self-healing-ci.md` to remove Nx Agents distinction
- Updated blog post `docs/blog/2025-06-23-nx-self-healing-ci.md` to show fix-ci is always required
- Simplified CI configuration examples to show proper placement after nx commands

🤖 Generated with [Claude Code](https://claude.ai/code)