### PR TITLE
feat(release): allow custom nx-release-publish executors to read versionData

### DIFF
--- a/astro-docs/src/content/docs/features/manage-releases.mdoc
+++ b/astro-docs/src/content/docs/features/manage-releases.mdoc
@@ -121,6 +121,9 @@ import * as yargs from 'yargs';
   const publishResults = await releasePublish({
     dryRun: options.dryRun,
     verbose: options.verbose,
+    // You can optionally pass through the version data (e.g. if you are using a custom publish executor that needs to be aware of versions)
+    // This is not required for the default @nx/js publish executor
+    versionData: projectsVersionData,
   });
 
   process.exit(

--- a/astro-docs/src/content/docs/features/manage-releases.mdoc
+++ b/astro-docs/src/content/docs/features/manage-releases.mdoc
@@ -122,6 +122,7 @@ import * as yargs from 'yargs';
     dryRun: options.dryRun,
     verbose: options.verbose,
     // You can optionally pass through the version data (e.g. if you are using a custom publish executor that needs to be aware of versions)
+    // It will then be provided to the publish executor options as `nxReleaseVersionData`
     // This is not required for the default @nx/js publish executor
     versionData: projectsVersionData,
   });

--- a/docs/shared/features/manage-releases.md
+++ b/docs/shared/features/manage-releases.md
@@ -120,6 +120,7 @@ import * as yargs from 'yargs';
     dryRun: options.dryRun,
     verbose: options.verbose,
     // You can optionally pass through the version data (e.g. if you are using a custom publish executor that needs to be aware of versions)
+    // It will then be provided to the publish executor options as `nxReleaseVersionData`
     // This is not required for the default @nx/js publish executor
     versionData: projectsVersionData,
   });

--- a/docs/shared/features/manage-releases.md
+++ b/docs/shared/features/manage-releases.md
@@ -119,6 +119,9 @@ import * as yargs from 'yargs';
   const publishResults = await releasePublish({
     dryRun: options.dryRun,
     verbose: options.verbose,
+    // You can optionally pass through the version data (e.g. if you are using a custom publish executor that needs to be aware of versions)
+    // This is not required for the default @nx/js publish executor
+    versionData: projectsVersionData,
   });
 
   process.exit(

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -79,6 +79,8 @@ export type PublishOptions = NxReleaseArgs &
     tag?: string;
     access?: string;
     otp?: number;
+    // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API
+    versionData?: VersionData;
   };
 
 export type PlanOptions = NxReleaseArgs & {

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -223,6 +223,15 @@ async function runPublishOnProjects(
     overrides.firstRelease = args.firstRelease;
   }
 
+  /**
+   * If using the `nx release` command, or possibly via the programmatic API, versionData will be passed through from the version subcommand.
+   * Provide it automatically to the publish executor options with a clear namespace to avoid userland conflicts.
+   * It will be filtered out of the final terminal output lifecycle to avoid cluttering the terminal.
+   */
+  if (args.versionData) {
+    overrides.nxReleaseVersionData = args.versionData;
+  }
+
   const requiredTargetName = 'nx-release-publish';
 
   if (args.graph) {

--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -370,7 +370,10 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     }
 
     if (shouldPublish) {
-      const publishResults = await releasePublish(args);
+      const publishResults = await releasePublish({
+        ...args,
+        versionData: versionResult.projectsVersionData,
+      });
       const allExitOk = Object.values(publishResults).every(
         (result) => result.code === 0
       );

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -342,6 +342,7 @@ export async function createRunManyDynamicOutputRenderer({
       )}`;
       const taskOverridesRows = [];
       const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
         ([flag]) => flag !== 'nxReleaseVersionData'
       );
       if (filteredOverrides.length > 0) {

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -278,6 +278,8 @@ export async function createRunManyDynamicOutputRenderer({
           `${EXTENDED_LEFT_PAD}${output.dim.cyan('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.cyan(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -343,6 +345,8 @@ export async function createRunManyDynamicOutputRenderer({
           `${EXTENDED_LEFT_PAD}${output.dim.green('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.green(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -377,6 +381,8 @@ export async function createRunManyDynamicOutputRenderer({
           `${EXTENDED_LEFT_PAD}${output.dim.red('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.red(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -272,14 +272,16 @@ export async function createRunManyDynamicOutputRenderer({
         tasks
       )}`;
       const taskOverridesRows = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesRows.push('');
         taskOverridesRows.push(
           `${EXTENDED_LEFT_PAD}${output.dim.cyan('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.cyan(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -339,14 +341,15 @@ export async function createRunManyDynamicOutputRenderer({
         tasks
       )}`;
       const taskOverridesRows = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesRows.push('');
         taskOverridesRows.push(
           `${EXTENDED_LEFT_PAD}${output.dim.green('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.green(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -375,14 +378,16 @@ export async function createRunManyDynamicOutputRenderer({
         tasks
       )}`;
       const taskOverridesRows = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesRows.push('');
         taskOverridesRows.push(
           `${EXTENDED_LEFT_PAD}${output.dim.red('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.red(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
@@ -291,6 +291,8 @@ export async function createRunOneDynamicOutputRenderer({
           `${EXTENDED_LEFT_PAD}${output.dim.green('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.green(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -331,6 +333,8 @@ export async function createRunOneDynamicOutputRenderer({
           `${EXTENDED_LEFT_PAD}${output.dim.red('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.red(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
@@ -285,14 +285,16 @@ export async function createRunOneDynamicOutputRenderer({
       )}`;
 
       const taskOverridesLines = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesLines.push('');
         taskOverridesLines.push(
           `${EXTENDED_LEFT_PAD}${output.dim.green('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.green(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -327,14 +329,16 @@ export async function createRunOneDynamicOutputRenderer({
       }
 
       const taskOverridesLines = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesLines.push('');
         taskOverridesLines.push(
           `${EXTENDED_LEFT_PAD}${output.dim.red('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.red(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )

--- a/packages/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
@@ -46,12 +46,14 @@ export class StaticRunManyTerminalOutputLifeCycle implements LifeCycle {
     const bodyLines = this.projectNames.map(
       (affectedProject) => `${output.dim('-')} ${affectedProject}`
     );
-    if (Object.keys(this.taskOverrides).length > 0) {
+    const filteredOverrides = Object.entries(this.taskOverrides).filter(
+      // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+      ([flag]) => flag !== 'nxReleaseVersionData'
+    );
+    if (filteredOverrides.length > 0) {
       bodyLines.push('');
       bodyLines.push(`${output.dim('With additional flags:')}`);
-      Object.entries(this.taskOverrides)
-        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-        .filter(([flag]) => flag !== 'nxReleaseVersionData')
+      filteredOverrides
         .map(([flag, value]) => formatFlags('', flag, value))
         .forEach((arg) => bodyLines.push(arg));
     }

--- a/packages/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
@@ -50,6 +50,8 @@ export class StaticRunManyTerminalOutputLifeCycle implements LifeCycle {
       bodyLines.push('');
       bodyLines.push(`${output.dim('With additional flags:')}`);
       Object.entries(this.taskOverrides)
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        .filter(([flag]) => flag !== 'nxReleaseVersionData')
         .map(([flag, value]) => formatFlags('', flag, value))
         .forEach((arg) => bodyLines.push(arg));
     }

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -169,14 +169,16 @@ export function getTuiTerminalSummaryLifeCycle({
       )}`;
 
       const taskOverridesLines = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesLines.push('');
         taskOverridesLines.push(
           `${EXTENDED_LEFT_PAD}${output.dim.green('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.green(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -208,14 +210,16 @@ export function getTuiTerminalSummaryLifeCycle({
       }
 
       const taskOverridesLines: string[] = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesLines.push('');
         taskOverridesLines.push(
           `${EXTENDED_LEFT_PAD}${output.dim.red('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.red(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -314,14 +318,16 @@ export function getTuiTerminalSummaryLifeCycle({
         tasks
       )}`;
       const taskOverridesRows = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesRows.push('');
         taskOverridesRows.push(
           `${EXTENDED_LEFT_PAD}${output.dim.green('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.green(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -350,14 +356,16 @@ export function getTuiTerminalSummaryLifeCycle({
         cancelled ? 'Cancelled while running' : 'Ran'
       } ${formatTargetsAndProjects(projectNames, targets, tasks)}`;
       const taskOverridesRows: string[] = [];
-      if (Object.keys(overrides).length > 0) {
+      const filteredOverrides = Object.entries(overrides).filter(
+        // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+        ([flag]) => flag !== 'nxReleaseVersionData'
+      );
+      if (filteredOverrides.length > 0) {
         taskOverridesRows.push('');
         taskOverridesRows.push(
           `${EXTENDED_LEFT_PAD}${output.dim.red('With additional flags:')}`
         );
-        Object.entries(overrides)
-          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
-          .filter(([flag]) => flag !== 'nxReleaseVersionData')
+        filteredOverrides
           .map(([flag, value]) =>
             output.dim.red(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -175,6 +175,8 @@ export function getTuiTerminalSummaryLifeCycle({
           `${EXTENDED_LEFT_PAD}${output.dim.green('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.green(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -212,6 +214,8 @@ export function getTuiTerminalSummaryLifeCycle({
           `${EXTENDED_LEFT_PAD}${output.dim.red('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.red(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -316,6 +320,8 @@ export function getTuiTerminalSummaryLifeCycle({
           `${EXTENDED_LEFT_PAD}${output.dim.green('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.green(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )
@@ -350,6 +356,8 @@ export function getTuiTerminalSummaryLifeCycle({
           `${EXTENDED_LEFT_PAD}${output.dim.red('With additional flags:')}`
         );
         Object.entries(overrides)
+          // Don't print the data passed through from the version subcommand to the publish executor options, it could be quite large and it's an implementation detail.
+          .filter(([flag]) => flag !== 'nxReleaseVersionData')
           .map(([flag, value]) =>
             output.dim.red(formatFlags(EXTENDED_LEFT_PAD, flag, value))
           )


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

There is no way for custom `nx-release-publish` executors to know about the versionData from the version step unless they figure out relevant files to read from disk etc.

This data is already available in memory when running the two most common ways:

- `nx release` overall CLI command
- The first-class programmatic API

But it is not exposed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The versionData is exposed automatically in the executor options, alongside other core options like `firstRelease` and `dryRun`. It is namespaced as `nxReleaseVersionData` to make userland conflicts in existing executors far less likely.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
