### PR TITLE
fix(vite): set name property for test to project name #32163

### DIFF
--- a/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/nuxt/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`app generated files content - as-provided - my-app general application should add nuxt entries in .gitignore 1`] = `
 "# Nuxt dev/build outputs
@@ -173,6 +173,7 @@ export default defineConfig(() => ({
   //  plugins: [ nxViteTsPaths() ],
   // },
   test: {
+    name: 'my-app',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -566,6 +567,7 @@ export default defineConfig(() => ({
   //  plugins: [ nxViteTsPaths() ],
   // },
   test: {
+    name: 'myApp',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`app --bundler=rsbuild should generate valid rsbuild config files for @emotion/styled 1`] = `
 "import styled from '@emotion/styled';
@@ -445,6 +445,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'my-app',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -508,6 +509,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'my-app',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1115,6 +1115,7 @@ describe('app', () => {
             },
           },
           test: {
+            name: 'my-app',
             watch: false,
             globals: true,
             environment: 'jsdom',

--- a/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/react/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`lib --bundler none, unit test runner vitest should configure vite 1`] = `
 "
@@ -16,6 +16,7 @@ export default defineConfig(() => ({
   //  plugins: [ nxViteTsPaths() ],
   // },
   test: {
+    'name': 'my-lib',
     'watch': false,
     'globals': true,
     'environment': "jsdom",
@@ -135,6 +136,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'my-lib',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -1017,6 +1017,7 @@ module.exports = withNx(
             },
           },
           test: {
+            name: '@proj/mylib',
             watch: false,
             globals: true,
             environment: 'jsdom',

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Remix Application Integrated Repo --directory should create the application correctly 1`] = `
 "import {
@@ -262,6 +262,7 @@ export default defineConfig(() => ({
   // },
   test: {
     setupFiles: ['test-setup.ts'],
+    name: 'test',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -465,6 +466,7 @@ export default defineConfig(() => ({
   // },
   test: {
     setupFiles: ['test-setup.ts'],
+    name: 'test',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
+++ b/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Remix Library Generator --unitTestRunner should create the correct config files for testing with jest 1`] = `
 "export default {
@@ -38,6 +38,7 @@ export default defineConfig(() => ({
   // },
   test: {
     setupFiles: ['./src/test-setup.ts'],
+    name: 'test',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/remix/src/generators/storybook-configuration/__snapshots__/storybook-configuration.impl.spec.ts.snap
+++ b/packages/remix/src/generators/storybook-configuration/__snapshots__/storybook-configuration.impl.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Storybook Configuration it should create a storybook configuration and use react-vite framework with testing framework jest 1`] = `
 "/// <reference types="vitest" />
@@ -102,6 +102,7 @@ export default defineConfig(() => ({
   // },
   test: {
     setupFiles: ['./src/test-setup.ts'],
+    name: 'storybook-test',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`@nx/vite:configuration js library with --bundler=vite should add build and test targets with vite and vitest 1`] = `
 "/// <reference types='vitest' />
@@ -48,6 +48,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'my-lib',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -273,6 +274,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'react-lib-nonb-jest',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -484,6 +486,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'my-test-react-app',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`vitest generator angular should generate src/test-setup.ts 1`] = `
 "import '@angular/compiler';
@@ -33,6 +33,7 @@ export default defineConfig(() => ({
   //  plugins: [ nxViteTsPaths() ],
   // },
   test: {
+    name: 'my-test-angular-app',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -67,6 +68,7 @@ export default defineConfig(() => ({
     'import.meta.vitest': undefined,
   },
   test: {
+    name: 'my-test-react-app',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -106,6 +108,7 @@ export default defineConfig(() => ({
   //  plugins: [ nxViteTsPaths() ],
   // },
   test: {
+    name: 'react-lib-nonb-jest',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -136,6 +139,7 @@ export default defineConfig(() => ({
   //  plugins: [ nxViteTsPaths() ],
   // },
   test: {
+    name: 'my-test-react-app',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/vite/src/utils/generator-utils.spec.ts
+++ b/packages/vite/src/utils/generator-utils.spec.ts
@@ -181,6 +181,7 @@ describe('generator utils', () => {
             'import.meta.vitest': undefined
           },
           test: {
+            name: 'myproj',
             watch: false,
             globals: true,
             environment: 'jsdom',
@@ -324,6 +325,7 @@ describe('generator utils', () => {
             'import.meta.vitest': undefined
           },
           test: {
+            name: 'myproj',
             watch: false,
             globals: true,
             environment: 'jsdom',

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -472,6 +472,7 @@ export function createOrEditViteConfig(
 
   const testOption = options.includeVitest
     ? `  test: {
+    name: '${options.project}',
     watch: false,
     globals: true,
     environment: '${options.testEnvironment ?? 'jsdom'}',

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`application generator should set up project correctly for cypress 1`] = `
 "{
@@ -71,6 +71,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'test',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -162,6 +163,7 @@ export default defineConfig(() => ({
   //  plugins: [ nxViteTsPaths() ],
   // },
   test: {
+    name: 'test',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -281,6 +283,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'test',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/vue/src/generators/application/application.spec.ts
+++ b/packages/vue/src/generators/application/application.spec.ts
@@ -214,6 +214,7 @@ describe('application generator', () => {
             },
           },
           test: {
+            name: '@proj/test',
             watch: false,
             globals: true,
             environment: 'jsdom',

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`library --publishable should add build targets 1`] = `
 "/// <reference types='vitest' />
@@ -50,6 +50,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'my-lib',
     watch: false,
     globals: true,
     environment: 'jsdom',
@@ -142,6 +143,7 @@ export default defineConfig(() => ({
     },
   },
   test: {
+    name: 'my-lib',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/vue/src/generators/library/library.spec.ts
+++ b/packages/vue/src/generators/library/library.spec.ts
@@ -552,6 +552,7 @@ module.exports = [
           //  plugins: [ nxViteTsPaths() ],
           // },
           test: {
+            name: '@proj/my-lib',
             watch: false,
             globals: true,
             environment: 'jsdom',


### PR DESCRIPTION
## Current Behavior
The `name` property is not set for vitest configs. Vitest will therefore infer the name for the test suite based off the directory name.
In a monorepo this can cause issues as the directory name may be repeated but for different contexts.

## Expected Behavior
Set the project name as the name in the test config

## Related Issue(s)

Fixes #32163
