### PR TITLE
fix(webpack): add missing serveStaticTargetName alternatives to webpack init generator

### DIFF
--- a/packages/webpack/src/generators/init/init.ts
+++ b/packages/webpack/src/generators/init/init.ts
@@ -60,6 +60,13 @@ export async function webpackInitGeneratorInternal(tree: Tree, schema: Schema) {
           'webpack:watch-deps',
           'webpack-watch-deps',
         ],
+        serveStaticTargetName: [
+          'serve-static',
+          'webpack:serve-static',
+          'serve-static:webpack',
+          'webpack-serve-static',
+          'serve-static-webpack',
+        ],
       },
       schema.updatePackageScripts
     );


### PR DESCRIPTION
- Added serveStaticTargetName options array with 5 alternative names
- Fixes conflicts when Angular module federation projects create serve-static targets
- Allows webpack plugin to work with existing Angular setups without manual nx.json editing

Fixes #32267 
Fixes #31384
