### PR TITLE
fix(core): include nested library dependencies in generated package.json

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 
 import * as configModule from '../../../config/configuration';
 import {
+  DependencyType,
   FileData,
   FileDataDependency,
   ProjectFileMap,
@@ -999,6 +1000,154 @@ describe('createPackageJson', () => {
           bar: '1.0.0',
         },
       });
+    });
+  });
+
+  describe('nested library dependencies', () => {
+    it('should include dependencies from nested libraries (App -> lib1 -> lib2)', () => {
+      const mockFilterUsingGlobPatterns = jest.spyOn(
+        hashModule,
+        'filterUsingGlobPatterns'
+      );
+      const mockGetTargetInputs = jest.spyOn(hashModule, 'getTargetInputs');
+      const mockReadNxJson = jest.spyOn(configModule, 'readNxJson');
+
+      // Mock restrictive patterns that would miss nested dependencies
+      mockGetTargetInputs.mockReturnValue({
+        selfInputs: ['production'],
+        dependencyInputs: ['^production'],
+      });
+
+      mockReadNxJson.mockReturnValue({
+        namedInputs: {
+          production: [
+            'default',
+            '!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)',
+          ],
+        },
+      } as any);
+
+      mockFilterUsingGlobPatterns.mockImplementation(
+        (root, files, patterns) => {
+          if (root === 'apps/myapp') {
+            return files.filter((f) => f.file.includes('main.ts'));
+          }
+
+          if (root === 'libs/lib1' && patterns.includes('^production')) {
+            return files.filter((f) => f.file.includes('index.ts'));
+          }
+
+          if (root === 'libs/lib1' && patterns.includes('{projectRoot}/**/*')) {
+            return files;
+          }
+
+          if (root === 'libs/lib2' && patterns.includes('^production')) {
+            return [];
+          }
+          if (root === 'libs/lib2' && patterns.includes('{projectRoot}/**/*')) {
+            return files; // This is the fix - broad patterns find all files
+          }
+          return files;
+        }
+      );
+
+      const graph: ProjectGraph = {
+        nodes: {
+          myapp: {
+            type: 'app',
+            name: 'myapp',
+            data: {
+              targets: { build: {} },
+              root: 'apps/myapp',
+            },
+          },
+          lib1: {
+            type: 'lib',
+            name: 'lib1',
+            data: {
+              targets: { build: {} },
+              root: 'libs/lib1',
+            },
+          },
+          lib2: {
+            type: 'lib',
+            name: 'lib2',
+            data: {
+              targets: { build: {} },
+              root: 'libs/lib2',
+            },
+          },
+        },
+        externalNodes: {
+          'npm:lodash': {
+            type: 'npm',
+            name: 'npm:lodash',
+            data: { version: '4.17.21', hash: '', packageName: 'lodash' },
+          },
+          'npm:axios': {
+            type: 'npm',
+            name: 'npm:axios',
+            data: { version: '1.0.0', hash: '', packageName: 'axios' },
+          },
+        },
+        dependencies: {
+          myapp: [
+            { source: 'myapp', target: 'lib1', type: DependencyType.static },
+          ],
+          lib1: [
+            { source: 'lib1', target: 'lib2', type: DependencyType.static },
+          ],
+          lib2: [],
+        },
+      };
+
+      const fileMap: ProjectFileMap = {
+        myapp: [
+          createFile('apps/myapp/src/main.ts', [
+            ['apps/myapp/src/main.ts', 'lib1', DependencyType.static],
+          ]),
+        ],
+        lib1: [
+          createFile('libs/lib1/src/index.ts', [
+            ['libs/lib1/src/index.ts', 'lib2', DependencyType.static],
+            ['libs/lib1/src/index.ts', 'npm:axios', DependencyType.static],
+          ]),
+        ],
+        lib2: [
+          createFile('libs/lib2/src/index.ts', [
+            ['libs/lib2/src/index.ts', 'npm:lodash', DependencyType.static],
+          ]),
+          createFile('libs/lib2/src/utils.ts', [
+            ['libs/lib2/src/utils.ts', 'npm:lodash', DependencyType.static],
+          ]),
+        ],
+      };
+
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      jest.spyOn(fileutilsModule, 'readJsonFile').mockReturnValue({
+        name: 'root-package',
+        dependencies: {},
+      });
+
+      const result = createPackageJson(
+        'myapp',
+        graph,
+        {
+          target: 'build',
+          root: '',
+          isProduction: true,
+        },
+        fileMap
+      );
+
+      expect(result.dependencies).toEqual({
+        axios: '1.0.0',
+        lodash: '4.17.21',
+      });
+
+      mockFilterUsingGlobPatterns.mockRestore();
+      mockGetTargetInputs.mockRestore();
+      mockReadNxJson.mockRestore();
     });
   });
 });

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -282,7 +282,8 @@ export function findProjectsNpmDependencies(
     seen,
     ignoredDependencies,
     dependencyInputs,
-    selfInputs
+    selfInputs,
+    false
   );
 
   return npmDeps;
@@ -296,7 +297,8 @@ function findAllNpmDeps(
   seen: Set<string>,
   ignoredDependencies: string[],
   dependencyPatterns: string[],
-  rootPatterns?: string[]
+  rootPatterns?: string[],
+  isTransitiveDependency = false
 ): void {
   if (seen.has(projectNode.name)) return;
 
@@ -305,7 +307,9 @@ function findAllNpmDeps(
   const projectFiles = filterUsingGlobPatterns(
     projectNode.data.root,
     projectFileMap[projectNode.name] || [],
-    rootPatterns ?? dependencyPatterns
+    isTransitiveDependency
+      ? ['{projectRoot}/**/*']
+      : rootPatterns ?? dependencyPatterns
   );
 
   const projectDependencies = new Set<string>();
@@ -347,7 +351,9 @@ function findAllNpmDeps(
           npmDeps,
           seen,
           ignoredDependencies,
-          dependencyPatterns
+          dependencyPatterns,
+          undefined,
+          true
         );
       }
     }


### PR DESCRIPTION
When using build targets with nested library dependencies (App -> lib1 -> lib2),
dependencies from the deepest libraries were not being included in the generated
package.json due to restrictive target input patterns.

This fix adds an isTransitiveDependency parameter to findAllNpmDeps function that
uses broader file patterns ({projectRoot}/**/*) when processing transitive
project dependencies instead of the restrictive build target patterns.

Fixes #30895
