### PR TITLE
fix(core): prevent error.log from generating during create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/src/utils/child-process-utils.ts
+++ b/packages/create-nx-workspace/src/utils/child-process-utils.ts
@@ -32,17 +32,25 @@ export function spawnAndWait(command: string, args: string[], cwd: string) {
   });
 }
 
-export function execAndWait(command: string, cwd: string) {
+export function execAndWait(
+  command: string,
+  cwd: string,
+  silenceErrors = false
+) {
   return new Promise<{ code: number; stdout: string }>((res, rej) => {
     exec(
       command,
       { cwd, env: { ...process.env, NX_DAEMON: 'false' }, windowsHide: false },
       (error, stdout, stderr) => {
         if (error) {
-          const logFile = join(cwd, 'error.log');
-          writeFileSync(logFile, `${stdout}\n${stderr}`);
-          const message = stderr && stderr.trim().length ? stderr : stdout;
-          rej(new CreateNxWorkspaceError(message, error.code, logFile));
+          if (silenceErrors) {
+            rej();
+          } else {
+            const logFile = join(cwd, 'error.log');
+            writeFileSync(logFile, `${stdout}\n${stderr}`);
+            const message = stderr && stderr.trim().length ? stderr : stdout;
+            rej(new CreateNxWorkspaceError(message, error.code, logFile));
+          }
         } else {
           res({ code: 0, stdout });
         }

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { deduceDefaultBase } from './default-base';
 import { output } from '../output';
 import { execAndWait, spawnAndWait } from '../child-process-utils';
@@ -117,7 +118,8 @@ export async function initializeGitRepo(
   }
   const insideRepo = await execAndWait(
     'git rev-parse --is-inside-work-tree',
-    directory
+    directory,
+    true
   ).then(
     () => true,
     () => false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Running `npx create-nx-workspace` always results in `error.log` in the new workspace.

## Expected Behavior
No `error.log`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
