### PR TITLE
fix(node): ensure windows paths are resolved correctly #31992

### DIFF
--- a/packages/nest/src/generators/application/lib/create-files.ts
+++ b/packages/nest/src/generators/application/lib/create-files.ts
@@ -1,12 +1,13 @@
 import type { Tree } from '@nx/devkit';
-import { generateFiles, joinPathFragments } from '@nx/devkit';
+import { generateFiles } from '@nx/devkit';
+import { join } from 'path';
 import type { NormalizedOptions } from '../schema';
 
 export function createFiles(tree: Tree, options: NormalizedOptions): void {
   generateFiles(
     tree,
-    joinPathFragments(__dirname, '..', 'files', 'common'),
-    joinPathFragments(options.appProjectRoot, 'src'),
+    join(__dirname, '..', 'files', 'common'),
+    join(options.appProjectRoot, 'src'),
     {
       tmpl: '',
       name: options.appProjectName,
@@ -16,8 +17,8 @@ export function createFiles(tree: Tree, options: NormalizedOptions): void {
   if (options.unitTestRunner === 'jest') {
     generateFiles(
       tree,
-      joinPathFragments(__dirname, '..', 'files', 'test'),
-      joinPathFragments(options.appProjectRoot, 'src'),
+      join(__dirname, '..', 'files', 'test'),
+      join(options.appProjectRoot, 'src'),
       {
         tmpl: '',
       }

--- a/packages/nest/src/generators/library/lib/create-files.ts
+++ b/packages/nest/src/generators/library/lib/create-files.ts
@@ -5,6 +5,7 @@ import {
   names,
   offsetFromRoot,
 } from '@nx/devkit';
+import { join } from 'path';
 import type { NormalizedOptions } from '../schema';
 
 export function createFiles(tree: Tree, options: NormalizedOptions): void {
@@ -17,7 +18,7 @@ export function createFiles(tree: Tree, options: NormalizedOptions): void {
   };
   generateFiles(
     tree,
-    joinPathFragments(__dirname, '..', 'files', 'common'),
+    join(__dirname, '..', 'files', 'common'),
     options.projectRoot,
     substitutions
   );
@@ -25,7 +26,7 @@ export function createFiles(tree: Tree, options: NormalizedOptions): void {
   if (options.controller) {
     generateFiles(
       tree,
-      joinPathFragments(__dirname, '..', 'files', 'controller'),
+      join(__dirname, '..', 'files', 'controller'),
       options.projectRoot,
       substitutions
     );
@@ -45,7 +46,7 @@ export function createFiles(tree: Tree, options: NormalizedOptions): void {
   if (options.service) {
     generateFiles(
       tree,
-      joinPathFragments(__dirname, '..', 'files', 'service'),
+      join(__dirname, '..', 'files', 'service'),
       options.projectRoot,
       substitutions
     );


### PR DESCRIPTION
## Current Behavior
`joinPathFragments` in nest app generator for the target dir of the template files is incorrect because it makes the path unix-style which does not work for Windows.

## Expected Behavior
Use `path.join`

## Related Issue(s)

Fixes #31992 
