### PR TITLE
fix(misc): ensure generateFiles is called using path.join

### DIFF
--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -37,7 +37,7 @@ import { PackageJson } from 'nx/src/utils/package-json';
 import { addRollupBuildTarget } from '@nx/react/src/generators/library/lib/add-rollup-build-target';
 import { getRelativeCwd } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { expoComponentGenerator } from '../component/component';
-import { relative } from 'path';
+import { relative, join } from 'path';
 import { reactNativeVersion, reactVersion } from '../../utils/versions';
 
 export async function expoLibraryGenerator(
@@ -273,20 +273,12 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
 }
 
 function createFiles(host: Tree, options: NormalizedSchema) {
-  generateFiles(
-    host,
-    joinPathFragments(__dirname, './files/lib'),
-    options.projectRoot,
-    {
-      ...options,
-      tmpl: '',
-      offsetFromRoot: offsetFromRoot(options.projectRoot),
-      rootTsConfigPath: getRelativePathToRootTsConfig(
-        host,
-        options.projectRoot
-      ),
-    }
-  );
+  generateFiles(host, join(__dirname, './files/lib'), options.projectRoot, {
+    ...options,
+    tmpl: '',
+    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    rootTsConfigPath: getRelativePathToRootTsConfig(host, options.projectRoot),
+  });
 
   if (options.js) {
     toJS(host);

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -27,6 +27,7 @@ import { vueTestUtilsVersion, vitePluginVueVersion } from '@nx/vue';
 import { ensureDependencies } from './lib/ensure-dependencies';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { execSync } from 'node:child_process';
+import { join } from 'node:path';
 import {
   getNxCloudAppOnBoardingUrl,
   createNxCloudOnboardingURLForWelcomeApp,
@@ -110,29 +111,24 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
     );
   }
 
-  generateFiles(
-    tree,
-    joinPathFragments(__dirname, './files/base'),
-    options.appProjectRoot,
-    {
-      ...options,
-      offsetFromRoot: projectOffsetFromRoot,
-      relativePathToRootTsConfig: getRelativePathToRootTsConfig(
-        tree,
-        options.appProjectRoot
-      ),
-      title: options.projectName,
-      dot: '.',
-      tmpl: '',
-      style: options.style,
-      projectRoot: options.appProjectRoot,
-      hasVitest: options.unitTestRunner === 'vitest',
-    }
-  );
+  generateFiles(tree, join(__dirname, './files/base'), options.appProjectRoot, {
+    ...options,
+    offsetFromRoot: projectOffsetFromRoot,
+    relativePathToRootTsConfig: getRelativePathToRootTsConfig(
+      tree,
+      options.appProjectRoot
+    ),
+    title: options.projectName,
+    dot: '.',
+    tmpl: '',
+    style: options.style,
+    projectRoot: options.appProjectRoot,
+    hasVitest: options.unitTestRunner === 'vitest',
+  });
 
   generateFiles(
     tree,
-    joinPathFragments(__dirname, './files/nx-welcome', onBoardingStatus),
+    join(__dirname, './files/nx-welcome', onBoardingStatus),
     options.appProjectRoot,
     {
       ...options,

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -346,7 +346,7 @@ function generateReactRouterFiles(
   } else {
     generateFiles(
       tree,
-      joinPathFragments(__dirname, '../files/react-router-ssr/non-root'),
+      join(__dirname, '../files/react-router-ssr/non-root'),
       options.appProjectRoot,
       templateVariables
     );
@@ -355,7 +355,7 @@ function generateReactRouterFiles(
   if (options.isUsingTsSolutionConfig) {
     generateFiles(
       tree,
-      joinPathFragments(__dirname, '../files/react-router-ssr/ts-solution'),
+      join(__dirname, '../files/react-router-ssr/ts-solution'),
       options.appProjectRoot,
       templateVariables
     );

--- a/packages/react/src/generators/component-story/component-story.ts
+++ b/packages/react/src/generators/component-story/component-story.ts
@@ -15,6 +15,7 @@ import {
 } from '../../utils/ast-utils';
 import { getComponentPropDefaults } from '../../utils/component-props';
 import { getUiFramework } from '../../utils/framework';
+import { join } from 'path';
 
 let tsModule: typeof import('typescript');
 
@@ -128,7 +129,7 @@ export function findPropsAndGenerateFile(
 
   generateFiles(
     host,
-    joinPathFragments(__dirname, `./files${isPlainJs ? '/jsx' : '/tsx'}`),
+    join(__dirname, `./files${isPlainJs ? '/jsx' : '/tsx'}`),
     normalizePath(componentDirectory),
     {
       tmpl: '',

--- a/packages/react/src/generators/host/lib/add-module-federation-files.ts
+++ b/packages/react/src/generators/host/lib/add-module-federation-files.ts
@@ -13,6 +13,7 @@ import {
   getDefaultTemplateVariables,
 } from '../../application/lib/create-application-files';
 import { NormalizedSchema } from '../schema';
+import { join } from 'path';
 
 export function addModuleFederationFiles(
   host: Tree,
@@ -80,7 +81,7 @@ export function addModuleFederationFiles(
 
   generateFiles(
     host,
-    joinPathFragments(
+    join(
       __dirname,
       `../files/${
         options.js
@@ -104,7 +105,7 @@ export function addModuleFederationFiles(
   // New entry file is created here.
   generateFiles(
     host,
-    joinPathFragments(__dirname, `../files/${pathToModuleFederationFiles}`),
+    join(__dirname, `../files/${pathToModuleFederationFiles}`),
     options.appProjectRoot,
     templateVariables
   );

--- a/packages/react/src/generators/library/lib/create-files.ts
+++ b/packages/react/src/generators/library/lib/create-files.ts
@@ -11,6 +11,7 @@ import { getRelativePathToRootTsConfig } from '@nx/js';
 
 import { NormalizedSchema } from '../schema';
 import { createTsConfig } from '../../../utils/create-ts-config';
+import { join } from 'path';
 
 export function createFiles(host: Tree, options: NormalizedSchema) {
   const relativePathToRootTsConfig = getRelativePathToRootTsConfig(
@@ -27,7 +28,7 @@ export function createFiles(host: Tree, options: NormalizedSchema) {
 
   generateFiles(
     host,
-    joinPathFragments(__dirname, '../files/common'),
+    join(__dirname, '../files/common'),
     options.projectRoot,
     substitutions
   );
@@ -35,7 +36,7 @@ export function createFiles(host: Tree, options: NormalizedSchema) {
   if (options.bundler === 'vite' || options.unitTestRunner === 'vitest') {
     generateFiles(
       host,
-      joinPathFragments(__dirname, '../files/vite'),
+      join(__dirname, '../files/vite'),
       options.projectRoot,
       substitutions
     );

--- a/packages/vue/src/generators/library/lib/create-library-files.ts
+++ b/packages/vue/src/generators/library/lib/create-library-files.ts
@@ -10,6 +10,7 @@ import {
 import { getRelativePathToRootTsConfig } from '@nx/js';
 import { NormalizedSchema } from '../schema';
 import { createTsConfig } from '../../../utils/create-ts-config';
+import { join } from 'path';
 
 export function createLibraryFiles(host: Tree, options: NormalizedSchema) {
   const relativePathToRootTsConfig = getRelativePathToRootTsConfig(
@@ -26,7 +27,7 @@ export function createLibraryFiles(host: Tree, options: NormalizedSchema) {
 
   generateFiles(
     host,
-    joinPathFragments(__dirname, '../files'),
+    join(__dirname, '../files'),
     options.projectRoot,
     substitutions
   );

--- a/packages/vue/src/generators/stories/lib/component-story.ts
+++ b/packages/vue/src/generators/stories/lib/component-story.ts
@@ -13,6 +13,7 @@ import {
   createDefautPropsObject,
   getDefinePropsObject,
 } from './utils';
+import { join } from 'path';
 
 let tsModule: typeof import('typescript');
 
@@ -44,7 +45,7 @@ export function createComponentStories(
 
   generateFiles(
     host,
-    joinPathFragments(__dirname, `./files${js ? '/js' : '/ts'}`),
+    join(__dirname, `./files${js ? '/js' : '/ts'}`),
     normalizePath(componentDirectory),
     {
       tmpl: '',


### PR DESCRIPTION
## Current Behavior
Using `joinPathFragments` with `generateFiles` is incorrect as we do not take into OS-specific paths with `joinPathFragments`.
This is problematic when trying to read files on the system for Windows users for example.


## Expected Behavior
Use `path.join` to ensure the correct file path is used and passed to `readdirSync`
