### PR TITLE
chore(repo): include fix-ci command in the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
             wait "$pid"
           done
         timeout-minutes: 100
+      - name: Fix CI
+        run: pnpm nx-cloud fix-ci
+        if: always()
 
   main-macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         timeout-minutes: 100
       - name: Fix CI
         run: pnpm nx-cloud fix-ci
-        if: always()
+        if: failed()
 
   main-macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         timeout-minutes: 100
       - name: Fix CI
         run: pnpm nx-cloud fix-ci
-        if: failed()
+        if: failure()
 
   main-macos:
     runs-on: macos-latest


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When `nx-cloud record` commands fail, Self-Healing CI will not be run to fix those errors.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx-cloud fix-ci` will now be run on the main ci workflow, and enable fixes for `nx-cloud record` (and other non-dte failures) 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
