### PR TITLE
chore(repo): install cypress browsers in nightly ci workflow

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -82,7 +82,11 @@ jobs:
       - name: Install packages
         run: |
           pnpm install --frozen-lockfile
-          pnpm playwright install --with-deps
+
+      - name: Install Browsers
+        run: |
+          pnpm exec cypress install
+          pnpm exec playwright install --with-deps
 
       - name: Homebrew cache directory path
         if: ${{ matrix.os == 'macos-latest' }}
@@ -186,7 +190,11 @@ jobs:
       - name: Install packages
         run: |
           pnpm install --frozen-lockfile
-          pnpm playwright install --with-deps
+
+      - name: Install Browsers
+        run: |
+          pnpm exec cypress install
+          pnpm exec playwright install --with-deps
 
       - name: Cleanup
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
## Current Behavior

Cypress e2e tests are failing in Nightly due to missing browsers.

## Expected Behavior

Cypress e2e tests should pass in Nightly.