### PR TITLE
fix(bundling): normalize Windows paths for additionalEntryPoints

### DIFF
--- a/packages/js/src/utils/package-json/create-entry-points.ts
+++ b/packages/js/src/utils/package-json/create-entry-points.ts
@@ -1,5 +1,5 @@
 import { globSync } from 'tinyglobby';
-import { logger } from '@nx/devkit';
+import { logger, normalizePath } from '@nx/devkit';
 
 export function createEntryPoints(
   additionalEntryPoints: undefined | string[],
@@ -13,12 +13,13 @@ export function createEntryPoints(
   // Performance impact should be negligible since there shouldn't be that many entry points.
   // Benchmarks show only 1-3% difference in execution time.
   for (const pattern of additionalEntryPoints) {
-    const matched = globSync([pattern], {
+    const normalizedPattern = normalizePath(pattern);
+    const matched = globSync([normalizedPattern], {
       cwd: root,
       expandDirectories: false,
     });
     if (!matched.length)
-      logger.warn(`The pattern ${pattern} did not match any files.`);
+      logger.warn(`The pattern ${normalizedPattern} did not match any files.`);
     files.push(...matched);
   }
   return files;

--- a/packages/rollup/src/plugins/with-nx/normalize-options.spec.ts
+++ b/packages/rollup/src/plugins/with-nx/normalize-options.spec.ts
@@ -83,4 +83,28 @@ describe('normalizeOptions', () => {
       tsConfig: 'pkg/tsconfig.json',
     });
   });
+
+  describe('Windows path handling', () => {
+    it('should normalize Windows paths for additionalEntryPoints', () => {
+      const windowsPath = './src\\entrypoints\\*.ts';
+      const options = {
+        main: './src/main.ts',
+        additionalEntryPoints: [windowsPath],
+        outputPath: '../dist/test-lib',
+        tsConfig: './tsconfig.json',
+      };
+
+      const result = normalizeOptions(
+        'libs/test-lib',
+        'libs/test-lib/src',
+        options
+      );
+
+      expect(result.additionalEntryPoints).toBeDefined();
+      result.additionalEntryPoints.forEach((entry) => {
+        expect(entry).not.toContain('\\');
+        expect(entry).toMatch(/^libs\/test-lib\/src\/entrypoints\/\*\.ts$/);
+      });
+    });
+  });
 });

--- a/packages/rollup/src/plugins/with-nx/normalize-options.ts
+++ b/packages/rollup/src/plugins/with-nx/normalize-options.ts
@@ -98,11 +98,11 @@ function normalizeRelativePaths(
 ): void {
   for (const [fieldName, fieldValue] of Object.entries(options)) {
     if (isRelativePath(fieldValue)) {
-      options[fieldName] = join(projectRoot, fieldValue);
+      options[fieldName] = normalizePath(join(projectRoot, fieldValue));
     } else if (Array.isArray(fieldValue)) {
       for (let i = 0; i < fieldValue.length; i++) {
         if (isRelativePath(fieldValue[i])) {
-          fieldValue[i] = join(projectRoot, fieldValue[i]);
+          fieldValue[i] = normalizePath(join(projectRoot, fieldValue[i]));
         }
       }
     }

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -1,5 +1,6 @@
 import {
   logger,
+  normalizePath,
   type ProjectGraph,
   readCachedProjectGraph,
   readJsonFile,
@@ -353,9 +354,11 @@ function createInput(
   if (global.NX_GRAPH_CREATION) return {};
   const mainEntryFileName = options.outputFileName || options.main;
   const input: Record<string, string> = {};
-  input[parse(mainEntryFileName).name] = join(workspaceRoot, options.main);
+  input[parse(mainEntryFileName).name] = normalizePath(
+    join(workspaceRoot, options.main)
+  );
   options.additionalEntryPoints?.forEach((entry) => {
-    input[parse(entry).name] = join(workspaceRoot, entry);
+    input[parse(entry).name] = normalizePath(join(workspaceRoot, entry));
   });
   return input;
 }


### PR DESCRIPTION
The additionalEntryPoints option was failing on Windows because tinyglobby
expects POSIX-style paths but was receiving Windows-style paths with backslashes.
This fix applies normalizePath to ensure cross-platform compatibility.

Fixes #29690
