### PR TITLE
chore(repo): ensure cypress browsers are installed in nightly e2e

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cypress
+  NX_NIGHTLY_TEST_RUN: 'true'
 
 permissions: { }
 jobs:

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -136,7 +136,7 @@ export const packageManagerLockFile = {
 
 export function ensureCypressInstallation() {
   // Skip Cypress installation on CI where it's pre-installed in agents.yaml
-  if (isCI) {
+  if (isCI && process.env.NX_NIGHTLY_TEST_RUN !== 'true') {
     e2eConsoleLogger('Running on CI - Cypress pre-installed via agents.yaml');
     return;
   }
@@ -167,7 +167,7 @@ export function ensureCypressInstallation() {
 
 export function ensurePlaywrightBrowsersInstallation() {
   // Skip browser installation on CI where browsers are pre-installed in agents.yaml
-  if (isCI) {
+  if (isCI && process.env.NX_NIGHTLY_TEST_RUN !== 'true') {
     e2eConsoleLogger(
       'Running on CI - Playwright browsers pre-installed via agents.yaml'
     );


### PR DESCRIPTION
## Current Behavior

Cypress nightly e2e tests for pnpm are failing due to missing Cypress browsers.

Failing run: https://github.com/nrwl/nx/actions/runs/16928038580/job/47967766466

## Expected Behavior

Cypress nightly e2e tests should succeed.

Passing run: https://github.com/nrwl/nx/actions/runs/16938135801/job/47999869854