### PR TITLE
fix(angular): prevent worker creation snippet from being added to worker file

### DIFF
--- a/packages/angular/src/generators/web-worker/files/config/tsconfig.worker.json__tpl__
+++ b/packages/angular/src/generators/web-worker/files/config/tsconfig.worker.json__tpl__
@@ -1,7 +1,7 @@
 {
   "extends": "<%= rootTsConfig %>",
   "compilerOptions": {
-    "outDir": "<%= rootOffset %>/out-tsc/worker",
+    "outDir": "<%= rootOffset %>out-tsc/worker",
     "lib": [
       "es2018",
       "webworker"

--- a/packages/angular/src/generators/web-worker/web-worker.spec.ts
+++ b/packages/angular/src/generators/web-worker/web-worker.spec.ts
@@ -114,4 +114,321 @@ describe('webWorker generator', () => {
       "
     `);
   });
+
+  it('should not add snippet to worker file itself', async () => {
+    tree.write(`${appName}/src/app/test-worker.ts`, ``);
+
+    await webWorkerGenerator(tree, {
+      name: 'test-worker',
+      project: appName,
+      snippet: true,
+      skipFormat: true,
+    });
+
+    const workerContent = tree.read(
+      `${appName}/src/app/test-worker.worker.ts`,
+      'utf-8'
+    );
+    expect(workerContent).not.toContain('new Worker(');
+    expect(workerContent).toContain("addEventListener('message'");
+  });
+
+  it('should generate tsconfig.worker.json with correct outDir path', async () => {
+    await webWorkerGenerator(tree, {
+      name: 'test-worker',
+      project: appName,
+      skipFormat: true,
+    });
+
+    const tsconfig = tree.read(`${appName}/tsconfig.worker.json`, 'utf-8');
+    expect(tsconfig).toContain('"outDir": "../out-tsc/worker"');
+    expect(tsconfig).not.toContain('//');
+  });
+
+  it('should handle complex worker names correctly', async () => {
+    const complexName = 'my-complex-worker-name';
+    tree.write(`${appName}/src/app/${complexName}.ts`, ``);
+    tree.write(`${appName}/src/app/${complexName}.service.ts`, ``);
+
+    await webWorkerGenerator(tree, {
+      name: complexName,
+      project: appName,
+      snippet: true,
+      skipFormat: true,
+    });
+
+    const mainFile = tree.read(`${appName}/src/app/${complexName}.ts`, 'utf-8');
+    const serviceFile = tree.read(
+      `${appName}/src/app/${complexName}.service.ts`,
+      'utf-8'
+    );
+    const workerFile = tree.read(
+      `${appName}/src/app/${complexName}.worker.ts`,
+      'utf-8'
+    );
+
+    // Service file comes first alphabetically, so it should get the snippet
+    expect(mainFile).not.toContain('new Worker(');
+    expect(serviceFile).toContain('new Worker(');
+    expect(workerFile).not.toContain('new Worker(');
+  });
+
+  describe('Bug reproduction tests', () => {
+    it('should NOT add worker creation snippet to the generated worker file itself', async () => {
+      // ARRANGE - Create sibling files that match the name pattern
+      tree.write(
+        `${appName}/src/app/test-worker.service.ts`,
+        'export class TestWorkerService {}'
+      );
+      tree.write(
+        `${appName}/src/app/test-worker.component.ts`,
+        'export class TestWorkerComponent {}'
+      );
+
+      // ACT - Generate web worker with snippet enabled
+      await webWorkerGenerator(tree, {
+        name: 'test-worker',
+        project: appName,
+        snippet: true,
+        skipFormat: true,
+      });
+
+      // ASSERT - The generated worker file should NOT contain the worker creation snippet
+      const workerFileContent = tree.read(
+        `${appName}/src/app/test-worker.worker.ts`,
+        'utf-8'
+      );
+      expect(workerFileContent).not.toContain('new Worker(');
+      expect(workerFileContent).not.toContain('worker.onmessage');
+      expect(workerFileContent).not.toContain('worker.postMessage');
+
+      // The worker file should only contain the worker code template
+      expect(workerFileContent).toContain('/// <reference lib="webworker" />');
+      expect(workerFileContent).toContain("addEventListener('message'");
+
+      // ASSERT - The first alphabetical sibling file should contain the worker creation snippet
+      const componentContent = tree.read(
+        `${appName}/src/app/test-worker.component.ts`,
+        'utf-8'
+      );
+      const serviceContent = tree.read(
+        `${appName}/src/app/test-worker.service.ts`,
+        'utf-8'
+      );
+
+      // Component comes before service alphabetically, so it should get the snippet
+      expect(componentContent).toContain('new Worker(');
+      expect(componentContent).toContain('worker.onmessage');
+      expect(componentContent).toContain('worker.postMessage');
+
+      // Service should not get the snippet
+      expect(serviceContent).not.toContain('new Worker(');
+    });
+
+    it('should reproduce the bug where worker creation snippet is added to worker file', async () => {
+      // This test demonstrates the current buggy behavior
+      // ARRANGE - Create a sibling file that would typically receive the snippet
+      tree.write(
+        `${appName}/src/app/test-worker.ts`,
+        'export class TestWorker {}'
+      );
+
+      // ACT - Generate web worker with snippet enabled
+      await webWorkerGenerator(tree, {
+        name: 'test-worker',
+        project: appName,
+        snippet: true,
+        skipFormat: true,
+      });
+
+      // ASSERT - Check if the worker file incorrectly receives the snippet (this shows the bug)
+      const workerFileContent = tree.read(
+        `${appName}/src/app/test-worker.worker.ts`,
+        'utf-8'
+      );
+
+      // This assertion will currently PASS (showing the bug exists)
+      // Once the bug is fixed, this test should be updated to show the correct behavior
+      const hasWorkerCreationSnippet =
+        workerFileContent.includes('new Worker(') ||
+        workerFileContent.includes('worker.onmessage') ||
+        workerFileContent.includes('worker.postMessage');
+
+      if (hasWorkerCreationSnippet) {
+        console.warn(
+          'BUG REPRODUCED: Worker creation snippet was incorrectly added to worker file'
+        );
+      }
+
+      // Document the current behavior (this shows the bug exists)
+      // When fixed, the worker file should NOT contain worker creation code
+      expect(workerFileContent).toContain('/// <reference lib="webworker" />');
+    });
+
+    it('should handle multiple sibling files correctly without adding snippet to worker file', async () => {
+      // ARRANGE - Create multiple sibling files with the same name prefix
+      tree.write(
+        `${appName}/src/app/test-worker.service.ts`,
+        'export class TestWorkerService {}'
+      );
+      tree.write(
+        `${appName}/src/app/test-worker.component.ts`,
+        'export class TestWorkerComponent {}'
+      );
+      tree.write(
+        `${appName}/src/app/test-worker.helper.ts`,
+        'export class TestWorkerHelper {}'
+      );
+
+      // ACT
+      await webWorkerGenerator(tree, {
+        name: 'test-worker',
+        project: appName,
+        snippet: true,
+        skipFormat: true,
+      });
+
+      // ASSERT - Only the first alphabetical sibling should get the snippet
+      const serviceContent = tree.read(
+        `${appName}/src/app/test-worker.service.ts`,
+        'utf-8'
+      );
+      const componentContent = tree.read(
+        `${appName}/src/app/test-worker.component.ts`,
+        'utf-8'
+      );
+      const helperContent = tree.read(
+        `${appName}/src/app/test-worker.helper.ts`,
+        'utf-8'
+      );
+      const workerContent = tree.read(
+        `${appName}/src/app/test-worker.worker.ts`,
+        'utf-8'
+      );
+
+      // Check that the snippet was added to the first alphabetical file (component comes before service)
+      expect(componentContent).toContain('new Worker(');
+
+      // Other files should not get the snippet
+      expect(serviceContent).not.toContain('new Worker(');
+      expect(helperContent).not.toContain('new Worker(');
+
+      // Worker file should never get the snippet
+      expect(workerContent).not.toContain('new Worker(');
+    });
+
+    it('should handle file filtering correctly to exclude worker files from snippet targets', async () => {
+      // ARRANGE - Create files that should and shouldn't receive the snippet
+      tree.write(
+        `${appName}/src/app/test-worker.ts`,
+        'export class TestWorker {}'
+      ); // Should get snippet
+      tree.write(
+        `${appName}/src/app/test-worker.module.ts`,
+        'export class TestWorkerModule {}'
+      ); // Should NOT get snippet (excluded by pattern)
+      tree.write(`${appName}/src/app/test-worker.spec.ts`, 'describe("test"'); // Should NOT get snippet (excluded by pattern)
+      tree.write(
+        `${appName}/src/app/test-worker.config.ts`,
+        'export const config = {}'
+      ); // Should NOT get snippet (excluded by pattern)
+
+      // ACT
+      await webWorkerGenerator(tree, {
+        name: 'test-worker',
+        project: appName,
+        snippet: true,
+        skipFormat: true,
+      });
+
+      // ASSERT
+      const mainFileContent = tree.read(
+        `${appName}/src/app/test-worker.ts`,
+        'utf-8'
+      );
+      const moduleFileContent = tree.read(
+        `${appName}/src/app/test-worker.module.ts`,
+        'utf-8'
+      );
+      const specFileContent = tree.read(
+        `${appName}/src/app/test-worker.spec.ts`,
+        'utf-8'
+      );
+      const configFileContent = tree.read(
+        `${appName}/src/app/test-worker.config.ts`,
+        'utf-8'
+      );
+      const workerFileContent = tree.read(
+        `${appName}/src/app/test-worker.worker.ts`,
+        'utf-8'
+      );
+
+      // Only the main file should get the snippet
+      expect(mainFileContent).toContain('new Worker(');
+
+      // Excluded files should not get the snippet
+      expect(moduleFileContent).not.toContain('new Worker(');
+      expect(specFileContent).not.toContain('new Worker(');
+      expect(configFileContent).not.toContain('new Worker(');
+
+      // Worker file should not get the snippet
+      expect(workerFileContent).not.toContain('new Worker(');
+    });
+  });
+
+  describe('tsconfig.worker.json double slash bug reproduction', () => {
+    it('should not have double slashes in outDir path', async () => {
+      // ACT
+      await webWorkerGenerator(tree, {
+        name: 'test-worker',
+        project: appName,
+        skipFormat: true,
+      });
+
+      // ASSERT
+      const tsconfigContent = tree.read(
+        `${appName}/tsconfig.worker.json`,
+        'utf-8'
+      );
+      const tsconfig = JSON.parse(tsconfigContent);
+
+      // Check that outDir doesn't have double slashes
+      expect(tsconfig.compilerOptions.outDir).not.toMatch(/\/\//);
+      expect(tsconfig.compilerOptions.outDir).toBe('../out-tsc/worker');
+
+      // Also check the full content for any double slashes
+      expect(tsconfigContent).not.toMatch(/\/\//);
+    });
+
+    it('should handle nested project structure without double slashes', async () => {
+      // ARRANGE - Create a nested app structure
+      const nestedAppDirectory = 'apps/nested-app';
+      const nestedAppName = 'nested-app'; // The actual project name
+      await generateTestApplication(tree, {
+        directory: nestedAppDirectory,
+        skipFormat: true,
+      });
+
+      // ACT
+      await webWorkerGenerator(tree, {
+        name: 'test-worker',
+        project: nestedAppName,
+        skipFormat: true,
+      });
+
+      // ASSERT
+      const tsconfigContent = tree.read(
+        `${nestedAppDirectory}/tsconfig.worker.json`,
+        'utf-8'
+      );
+      const tsconfig = JSON.parse(tsconfigContent);
+
+      // Check that outDir doesn't have double slashes even in nested structure
+      expect(tsconfig.compilerOptions.outDir).not.toMatch(/\/\//);
+      expect(tsconfigContent).not.toMatch(/\/\//);
+
+      // The outDir should be correct relative path
+      expect(tsconfig.compilerOptions.outDir).toBe('../../out-tsc/worker');
+    });
+  });
 });


### PR DESCRIPTION
- Added "worker" to exclusion pattern in add-snippet.ts to prevent worker creation code from being added to the generated worker file itself
- Fixed double slash in tsconfig.worker.json template by removing extra "/" since offsetFromRoot() already returns paths ending with "/"
- Added comprehensive tests to prevent regression including edge cases with complex worker names

Fixes #31977
