### PR TITLE
fix(vite): add tslib as a dep for @nx/vite and remove @swc/helpers

### DIFF
--- a/packages/angular-rspack-compiler/.eslintrc.json
+++ b/packages/angular-rspack-compiler/.eslintrc.json
@@ -37,6 +37,7 @@
         "@nx/dependency-checks": [
           "error",
           {
+            "buildTargets": ["build-base"],
             "ignoredFiles": [
               "{projectRoot}/.eslintrc.json",
               "{projectRoot}/vite.config.{js,ts,mjs,mts}"
@@ -45,8 +46,7 @@
               "@angular/core",
               "jsonc-eslint-parser",
               "vitest",
-              "memfs",
-              "tslib"
+              "memfs"
             ]
           }
         ]

--- a/packages/angular-rspack/.eslintrc.json
+++ b/packages/angular-rspack/.eslintrc.json
@@ -37,6 +37,7 @@
         "@nx/dependency-checks": [
           "error",
           {
+            "buildTargets": ["build-base"],
             "ignoredFiles": [
               "{projectRoot}/.eslintrc.json",
               "{projectRoot}/vite.config.{js,ts,mjs,mts}"
@@ -46,7 +47,6 @@
               "jsonc-eslint-parser",
               "vitest",
               "memfs",
-              "tslib",
               // it's only a type import, so it won't be required at runtime
               "sass",
               // shown as unused because it's required using `createRequire`

--- a/packages/angular/.eslintrc.json
+++ b/packages/angular/.eslintrc.json
@@ -51,7 +51,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "@angular-devkit/architect",
               "@angular-devkit/schematics",
               "@nx/cypress",

--- a/packages/create-nx-plugin/.eslintrc.json
+++ b/packages/create-nx-plugin/.eslintrc.json
@@ -41,7 +41,7 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": ["tslib"]
+            "ignoredDependencies": []
           }
         ]
       }

--- a/packages/create-nx-workspace/.eslintrc.json
+++ b/packages/create-nx-workspace/.eslintrc.json
@@ -33,7 +33,7 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": ["tslib"]
+            "ignoredDependencies": []
           }
         ]
       }

--- a/packages/cypress/.eslintrc.json
+++ b/packages/cypress/.eslintrc.json
@@ -34,7 +34,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               // Type imports only

--- a/packages/detox/.eslintrc.json
+++ b/packages/detox/.eslintrc.json
@@ -23,7 +23,7 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": ["nx", "tslib", "typescript", "detox"]
+            "ignoredDependencies": ["nx", "typescript", "detox"]
           }
         ]
       }

--- a/packages/devkit/.eslintrc.json
+++ b/packages/devkit/.eslintrc.json
@@ -69,7 +69,6 @@
               "nx",
               "typescript",
               "prettier",
-              "tslib",
               // Installed to workspace by plugins
               "rxjs",
               "@angular-devkit/core",

--- a/packages/esbuild/.eslintrc.json
+++ b/packages/esbuild/.eslintrc.json
@@ -45,7 +45,7 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": ["nx", "tslib", "typescript", "esbuild"]
+            "ignoredDependencies": ["nx", "typescript", "esbuild"]
           }
         ]
       }

--- a/packages/eslint-plugin/.eslintrc.json
+++ b/packages/eslint-plugin/.eslintrc.json
@@ -32,7 +32,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               // Installed to workspace by plugins

--- a/packages/eslint/.eslintrc.json
+++ b/packages/eslint/.eslintrc.json
@@ -34,7 +34,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "@nx/jest",
               "typescript",

--- a/packages/expo/.eslintrc.json
+++ b/packages/expo/.eslintrc.json
@@ -24,7 +24,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "@nx/jest",
               "@nx/rollup",

--- a/packages/express/.eslintrc.json
+++ b/packages/express/.eslintrc.json
@@ -44,7 +44,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "@nx/eslint",
               "typescript",

--- a/packages/gradle/.eslintrc.json
+++ b/packages/gradle/.eslintrc.json
@@ -21,7 +21,7 @@
         "@nx/dependency-checks": [
           "error",
           {
-            "ignoredDependencies": ["nx", "tslib"]
+            "ignoredDependencies": ["nx"]
           }
         ]
       }

--- a/packages/jest/.eslintrc.json
+++ b/packages/jest/.eslintrc.json
@@ -36,7 +36,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               "prettier",

--- a/packages/js/.eslintrc.json
+++ b/packages/js/.eslintrc.json
@@ -53,7 +53,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "prettier",
               "typescript",

--- a/packages/module-federation/.eslintrc.json
+++ b/packages/module-federation/.eslintrc.json
@@ -30,7 +30,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "eslint",
               "typescript",

--- a/packages/nest/.eslintrc.json
+++ b/packages/nest/.eslintrc.json
@@ -44,7 +44,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               "eslint",

--- a/packages/next/.eslintrc.json
+++ b/packages/next/.eslintrc.json
@@ -90,7 +90,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "@nx/webpack",
               "@nx/cypress",

--- a/packages/node/.eslintrc.json
+++ b/packages/node/.eslintrc.json
@@ -43,7 +43,7 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": ["nx", "tslib", "typescript", "@nx/webpack"]
+            "ignoredDependencies": ["nx", "typescript", "@nx/webpack"]
           }
         ]
       }

--- a/packages/nuxt/.eslintrc.json
+++ b/packages/nuxt/.eslintrc.json
@@ -30,7 +30,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "eslint",
               "typescript",

--- a/packages/nx/.eslintrc.json
+++ b/packages/nx/.eslintrc.json
@@ -102,7 +102,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               "@nrwl/angular",

--- a/packages/playwright/.eslintrc.json
+++ b/packages/playwright/.eslintrc.json
@@ -30,7 +30,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               "@playwright/test",

--- a/packages/plugin/.eslintrc.json
+++ b/packages/plugin/.eslintrc.json
@@ -55,7 +55,7 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": ["nx", "tslib", "typescript", "eslint"]
+            "ignoredDependencies": ["nx", "typescript", "eslint"]
           }
         ]
       }

--- a/packages/react-native/.eslintrc.json
+++ b/packages/react-native/.eslintrc.json
@@ -24,7 +24,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "eslint",
               "prettier",

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -48,7 +48,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "eslint",
               "prettier",

--- a/packages/remix/.eslintrc.json
+++ b/packages/remix/.eslintrc.json
@@ -37,7 +37,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "eslint",
               "prettier",

--- a/packages/rollup/.eslintrc.json
+++ b/packages/rollup/.eslintrc.json
@@ -42,7 +42,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               "@swc/core", // Installed to workspace and only used in swc() plugin

--- a/packages/rsbuild/.eslintrc.json
+++ b/packages/rsbuild/.eslintrc.json
@@ -30,7 +30,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "eslint",
               "typescript",

--- a/packages/rspack/.eslintrc.json
+++ b/packages/rspack/.eslintrc.json
@@ -38,7 +38,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               // Used in require.resolve calls

--- a/packages/storybook/.eslintrc.json
+++ b/packages/storybook/.eslintrc.json
@@ -39,7 +39,7 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": ["nx", "tslib", "typescript", "@nx/web"]
+            "ignoredDependencies": ["nx", "typescript", "@nx/web"]
           }
         ]
       }

--- a/packages/vite/.eslintrc.json
+++ b/packages/vite/.eslintrc.json
@@ -38,11 +38,9 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               "vite",
-              "@swc/helpers",
               // we only check if the package is installed
               "eslint",
               // we ensure it is installed and only use it when eslint is installed

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -32,12 +32,12 @@
   "dependencies": {
     "@nx/devkit": "workspace:*",
     "@phenomnomnominal/tsquery": "~5.0.1",
-    "@swc/helpers": "~0.5.0",
     "enquirer": "~2.3.6",
     "@nx/js": "workspace:*",
     "picomatch": "4.0.2",
     "tsconfig-paths": "^4.1.2",
     "semver": "^7.6.3",
+    "tslib": "^2.3.0",
     "ajv": "^8.0.0"
   },
   "devDependencies": {

--- a/packages/vue/.eslintrc.json
+++ b/packages/vue/.eslintrc.json
@@ -38,7 +38,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               "@nx/cypress",

--- a/packages/web/.eslintrc.json
+++ b/packages/web/.eslintrc.json
@@ -48,7 +48,6 @@
           {
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
-              "tslib",
               "nx",
               "typescript",
               "eslint",

--- a/packages/webpack/.eslintrc.json
+++ b/packages/webpack/.eslintrc.json
@@ -41,7 +41,6 @@
               "nx",
               "typescript",
               "eslint",
-              "tslib",
               // Used in require.resolve calls
               "@babel/core",
               "css-loader",

--- a/packages/workspace/.eslintrc.json
+++ b/packages/workspace/.eslintrc.json
@@ -47,7 +47,6 @@
             "ignoredDependencies": [
               "nx",
               "prettier",
-              "tslib",
               "typescript",
               "@angular-devkit/schematics",
               "@angular-devkit/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3776,9 +3776,6 @@ importers:
       '@phenomnomnominal/tsquery':
         specifier: ~5.0.1
         version: 5.0.1(typescript@5.8.3)
-      '@swc/helpers':
-        specifier: ~0.5.0
-        version: 0.5.11
       ajv:
         specifier: ^8.0.0
         version: 8.17.1
@@ -3794,6 +3791,9 @@ importers:
       tsconfig-paths:
         specifier: ^4.1.2
         version: 4.2.0
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
       vite:
         specifier: ^5.0.0 || ^6.0.0
         version: 6.2.0(@types/node@24.2.0)(jiti@2.4.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.85.1)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(yaml@2.8.0)


### PR DESCRIPTION
When we switched to the TS solution setup with inferred `tsc` builds, we didn't update the dependencies for `@nx/vite` to use `tslib` instead of `@swc/helpers`. It was previously using `@nx/js:swc` executor, but now `build-base` target is inferred as `tsc -b`.

It did not cause issues since other packages including `nx` always install tslib, but technically it is incorrect, and we were ignoring the errors by adding `tslib` and `@swc/helpers` to be ignored in `.eslintrc.json`.

This PR also cleans up the eslint config for all other packages since we do not need to ignore `tslib` for `@nx/dependency-checks` to pass.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
`@nx/vite` is missing `tslib` dependency even though the built JS file uses it.

## Expected Behavior
Should have `tslib` as a dependency and not `@swc/helpers`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
