### PR TITLE
fix(react): host generator should not add loadRemote helper when no remotes

### DIFF
--- a/packages/react/src/generators/host/files/common-ts/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/host/files/common-ts/src/app/__fileName__.tsx__tmpl__
@@ -3,7 +3,7 @@ import * as React from 'react';
 import NxWelcome from "./nx-welcome";
 <%_ } _%>
 import { Link, Route, Routes } from 'react-router-dom';
-<%_ if (dynamic) { _%>
+<%_ if (dynamic && remotes.length > 0) { _%>
 import { loadRemote } from '@module-federation/enhanced/runtime';
 <%_ } _%>
 

--- a/packages/react/src/generators/host/files/common/src/app/__fileName__.js__tmpl__
+++ b/packages/react/src/generators/host/files/common/src/app/__fileName__.js__tmpl__
@@ -3,7 +3,7 @@ import * as React from 'react';
 import NxWelcome from "./nx-welcome";
 <%_ } _%>
 import { Link, Route, Routes } from 'react-router-dom';
-<%_ if (dynamic) { _%>
+<%_ if (dynamic && remotes.length > 0) { _%>
 import { loadRemote } from '@module-federation/enhanced/runtime';
 <%_ } _%>
 

--- a/packages/react/src/generators/host/files/rspack-common/src/app/__fileName__.jsx__tmpl__
+++ b/packages/react/src/generators/host/files/rspack-common/src/app/__fileName__.jsx__tmpl__
@@ -4,7 +4,7 @@ import NxWelcome from "./nx-welcome";
 <%_ } _%>
 import { Link, Route, Routes } from 'react-router-dom';
 
-<%_ if (dynamic) { _%>
+<%_ if (dynamic && remotes.length > 0) { _%>
 import { loadRemote } from '@module-federation/enhanced/runtime';
 <%_ } _%>
 

--- a/packages/react/src/generators/host/host.rspack.spec.ts
+++ b/packages/react/src/generators/host/host.rspack.spec.ts
@@ -125,6 +125,12 @@ describe('hostGenerator', () => {
       expect(tree.exists('test/src/bootstrap.jsx')).toBeTruthy();
       expect(tree.exists('test/src/main.jsx')).toBeTruthy();
       expect(tree.exists('test/src/app/app.jsx')).toBeTruthy();
+      // as no remotes provided, dynamic federation helper should not be included
+      expect(tree.read('test/src/app/app.jsx', 'utf-8')).not.toEqual(
+        expect.stringContaining(
+          `import { loadRemote } from '@module-federation/enhanced/runtime';`
+        )
+      );
     });
 
     it('should generate host files and configs when --js=false', async () => {


### PR DESCRIPTION
## Current Behavior
When `nx g @nx/react:host` is used and 0 `--remotes` are passed, we still add the `loadRemote` helper from `@module-federation/enhanced/runtime`.
This causes a typecheck error as it is unused.

## Expected Behavior
Only add the helper when it is needed (i.e. >0 remotes).

