### PR TITLE
fix(release): handle git_protocol https when getting auth token #31828

### DIFF
--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
@@ -19,6 +19,7 @@ import {
 
 // axios types and values don't seem to match
 import _axios = require('axios');
+
 const axios = _axios as any as (typeof _axios)['default'];
 
 export interface GithubRepoData extends RemoteRepoData {}
@@ -118,10 +119,11 @@ export class GithubRemoteReleaseClient extends RemoteReleaseClient<GithubRemoteR
         if (ghCLIConfig[hostname].oauth_token) {
           return ghCLIConfig[hostname].oauth_token;
         }
-        // SSH based session (we need to dynamically resolve a token using the CLI)
+        // SSH/HTTPS based session (we need to dynamically resolve a token using the CLI)
         if (
           ghCLIConfig[hostname].user &&
-          ghCLIConfig[hostname].git_protocol === 'ssh'
+          (ghCLIConfig[hostname].git_protocol === 'ssh' ||
+            ghCLIConfig[hostname].git_protocol === 'https')
         ) {
           const token = execSync(`gh auth token`, {
             encoding: 'utf8',


### PR DESCRIPTION
## Current Behavior
When resolving token data for creating the GitHubReleaseClient, The GH CLI supports `https` option for `git_protocol` and it is not being handled.
This results in no token data being resolved.

Further API requests that require a `Bearer` token in the headers fail.

## Expected Behavior
Ensure `https` protocol is also handled.
`gh auth token` still operates and produces a token that can be used.

## Related Issue(s)

Fixes #31828
