### PR TITLE
fix(js): node executor handles processes robustly

### DIFF
--- a/packages/js/src/executors/node/lib/coalescing-debounce.ts
+++ b/packages/js/src/executors/node/lib/coalescing-debounce.ts
@@ -1,0 +1,57 @@
+export function createCoalescingDebounce<T>(
+  fn: () => Promise<T>,
+  wait: number
+): { trigger: () => Promise<T>; cancel: () => void } {
+  let timeoutId: NodeJS.Timeout | null = null;
+  let activePromise: Promise<T> | null = null;
+  let nextPromiseResolvers: Array<{
+    resolve: (value: T) => void;
+    reject: (error: any) => void;
+  }> = [];
+
+  return {
+    trigger: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+
+      if (activePromise) {
+        return new Promise<T>((resolve, reject) => {
+          nextPromiseResolvers.push({ resolve, reject });
+        });
+      }
+
+      return new Promise<T>((resolve, reject) => {
+        nextPromiseResolvers.push({ resolve, reject });
+
+        timeoutId = setTimeout(async () => {
+          activePromise = fn();
+          try {
+            const result = await activePromise;
+            for (const { resolve } of nextPromiseResolvers) {
+              resolve(result);
+            }
+          } catch (error) {
+            for (const { reject } of nextPromiseResolvers) {
+              reject(error);
+            }
+          } finally {
+            activePromise = null;
+            nextPromiseResolvers = [];
+          }
+        }, wait);
+      });
+    },
+    cancel: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      for (const { reject } of nextPromiseResolvers) {
+        reject(new Error('Cancelled'));
+      }
+      nextPromiseResolvers = [];
+    },
+  };
+}

--- a/packages/js/src/executors/node/lib/line-aware-stream.ts
+++ b/packages/js/src/executors/node/lib/line-aware-stream.ts
@@ -1,13 +1,13 @@
 export class LineAwareStream {
   private buffer = '';
-  private activeProcessId: string | null = null;
+  private activeTaskId: string | null = null;
 
   get currentProcessId(): string | null {
-    return this.activeProcessId;
+    return this.activeTaskId;
   }
 
-  write(data: Buffer | string, processId: string): void {
-    if (processId !== this.activeProcessId) return;
+  write(data: Buffer | string, taskId: string): void {
+    if (taskId !== this.activeTaskId) return;
 
     const text = data.toString();
     this.buffer += text;
@@ -27,8 +27,8 @@ export class LineAwareStream {
     }
   }
 
-  setActiveProcess(processId: string | null): void {
+  setActiveProcess(taskId: string | null): void {
     this.flush();
-    this.activeProcessId = processId;
+    this.activeTaskId = taskId;
   }
 }

--- a/packages/js/src/executors/node/lib/line-aware-stream.ts
+++ b/packages/js/src/executors/node/lib/line-aware-stream.ts
@@ -1,0 +1,34 @@
+export class LineAwareStream {
+  private buffer = '';
+  private activeProcessId: string | null = null;
+
+  get currentProcessId(): string | null {
+    return this.activeProcessId;
+  }
+
+  write(data: Buffer | string, processId: string): void {
+    if (processId !== this.activeProcessId) return;
+
+    const text = data.toString();
+    this.buffer += text;
+
+    const lines = this.buffer.split('\n');
+    this.buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      process.stdout.write(line + '\n');
+    }
+  }
+
+  flush(): void {
+    if (this.buffer) {
+      process.stdout.write(this.buffer + '\n');
+      this.buffer = '';
+    }
+  }
+
+  setActiveProcess(processId: string | null): void {
+    this.flush();
+    this.activeProcessId = processId;
+  }
+}

--- a/packages/js/src/executors/node/lib/line-aware-writer.ts
+++ b/packages/js/src/executors/node/lib/line-aware-writer.ts
@@ -1,4 +1,4 @@
-export class LineAwareStream {
+export class LineAwareWriter {
   private buffer = '';
   private activeTaskId: string | null = null;
 

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -367,7 +367,9 @@ export async function* nodeExecutor(
         const event = await output.next();
         await addToQueue(null, Promise.resolve(event.value));
         await debouncedProcessQueue.trigger();
-        if (event.done || !options.watch) {
+        if (event.done && !options.watch) {
+          next({ success: true });
+          done();
           break;
         }
       }


### PR DESCRIPTION
## Current Behavior

  The @nx/js:node executor had several process management issues:

  - Multiple concurrent builds could cause overlapping/corrupted console output,
  especially in NestJS projects
  - Process stdout streams weren't properly coordinated between different tasks
  - Rapid file changes could trigger multiple simultaneous rebuilds without
  proper debouncing
  - Console output formatting could break with mixed output from overlapping
  processes

## Expected Behavior

  The node executor should:

  - Handle process output streams cleanly with no overlapping/corrupted output
  - Properly debounce rebuild triggers to prevent resource conflicts
  - Maintain clean console formatting even with rapid file changes
  - Coordinate output between concurrent processes using a global stream manager

## Related Issue(s)

  Fixes #30247 
  Fixes #22999 
  Fixes #22945 