### PR TITLE
feat(js): add plugin option to skip build checks when inferring the build task

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -5395,6 +5395,80 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
     });
 
+    it('should consider a package buildable when main points to source file when skipBuildCheck is true', async () => {
+      await applyFilesToTempFsAndContext(tempFs, context, {
+        'libs/my-lib/tsconfig.json': '{}',
+        'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+          compilerOptions: { outDir: 'dist' },
+          include: ['src/**/*.ts'],
+        }),
+        'libs/my-lib/package.json': JSON.stringify({
+          main: 'src/index.ts',
+        }),
+        'libs/my-lib/src/index.ts': 'export const hello = "world";',
+      });
+
+      expect(
+        await invokeCreateNodesOnMatchingFiles(context, {
+          typecheck: false,
+          build: {
+            skipBuildCheck: true,
+          },
+        })
+      ).toMatchInlineSnapshot(`
+        {
+          "projects": {
+            "libs/my-lib": {
+              "projectType": "library",
+              "targets": {
+                "build": {
+                  "cache": true,
+                  "command": "tsc --build tsconfig.lib.json",
+                  "dependsOn": [
+                    "^build",
+                  ],
+                  "inputs": [
+                    "{projectRoot}/package.json",
+                    "{projectRoot}/tsconfig.lib.json",
+                    "{projectRoot}/src/**/*.ts",
+                    "^production",
+                    {
+                      "externalDependencies": [
+                        "typescript",
+                      ],
+                    },
+                  ],
+                  "metadata": {
+                    "description": "Builds the project with \`tsc\`.",
+                    "help": {
+                      "command": "npx tsc --build --help",
+                      "example": {
+                        "args": [
+                          "--force",
+                        ],
+                      },
+                    },
+                    "technologies": [
+                      "typescript",
+                    ],
+                  },
+                  "options": {
+                    "cwd": "libs/my-lib",
+                  },
+                  "outputs": [
+                    "{projectRoot}/dist",
+                  ],
+                  "syncGenerators": [
+                    "@nx/js:typescript-sync",
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
+
     it('should handle relative paths correctly when main points to transpiled output', async () => {
       await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -61,6 +61,7 @@ export interface TscPluginOptions {
         configName?: string;
         buildDepsName?: string;
         watchDepsName?: string;
+        skipBuildCheck?: boolean;
       };
   verboseOutput?: boolean;
 }
@@ -78,6 +79,7 @@ interface NormalizedPluginOptions {
         configName: string;
         buildDepsName?: string;
         watchDepsName?: string;
+        skipBuildCheck?: boolean;
       };
   verboseOutput: boolean;
 }
@@ -469,11 +471,12 @@ function buildTscTargets(
         );
         if (
           context.configFiles.some((f) => f === buildConfigPath) &&
-          isValidPackageJsonBuildConfig(
-            retrieveTsConfigFromCache(buildConfigPath, context.workspaceRoot),
-            context.workspaceRoot,
-            projectRoot
-          )
+          (options.build.skipBuildCheck ||
+            isValidPackageJsonBuildConfig(
+              retrieveTsConfigFromCache(buildConfigPath, context.workspaceRoot),
+              context.workspaceRoot,
+              projectRoot
+            ))
         ) {
           dependsOn.unshift(options.build.targetName);
         }
@@ -519,7 +522,12 @@ function buildTscTargets(
   if (
     options.build &&
     basename(configFilePath) === options.build.configName &&
-    isValidPackageJsonBuildConfig(tsConfig, context.workspaceRoot, projectRoot)
+    (options.build.skipBuildCheck ||
+      isValidPackageJsonBuildConfig(
+        tsConfig,
+        context.workspaceRoot,
+        projectRoot
+      ))
   ) {
     internalProjectReferences ??= resolveInternalProjectReferences(
       tsConfig,
@@ -1302,6 +1310,7 @@ function normalizePluginOptions(
     configName: defaultBuildConfigName,
     buildDepsName: 'build-deps',
     watchDepsName: 'watch-deps',
+    skipBuildCheck: false,
   };
   // Build target is not enabled by default
   if (!pluginOptions.build) {
@@ -1312,6 +1321,7 @@ function normalizePluginOptions(
       configName: pluginOptions.build.configName ?? defaultBuildConfigName,
       buildDepsName: pluginOptions.build.buildDepsName ?? 'build-deps',
       watchDepsName: pluginOptions.build.watchDepsName ?? 'watch-deps',
+      skipBuildCheck: pluginOptions.build.skipBuildCheck ?? false,
     };
   }
 


### PR DESCRIPTION
Add a new option `skipBuildCheck` to the `@nx/js/typescript` plugin build options to allow skipping the check for a buildable setup and always infer a build task.