### PR TITLE
fix(release): only delete version plans that are used #31327

### DIFF
--- a/e2e/release/src/version-plans-filtered-release.test.ts
+++ b/e2e/release/src/version-plans-filtered-release.test.ts
@@ -1,0 +1,164 @@
+import { existsSync } from 'fs';
+import { ensureDir, writeFile } from 'fs-extra';
+import { join } from 'path';
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  runCommandAsync,
+  tmpProjPath,
+  uniq,
+  updateJson,
+} from '@nx/e2e-utils';
+
+describe('nx release with version plans and project filter', () => {
+  let pkg1: string;
+  let pkg2: string;
+  let pkg3: string;
+
+  const exists = (filePath: string) => existsSync(filePath);
+
+  beforeAll(async () => {
+    newProject({
+      packages: ['@nx/js'],
+    });
+
+    pkg1 = uniq('my-pkg-1');
+    runCLI(`generate @nx/js:library ${pkg1} --publishable`);
+
+    pkg2 = uniq('my-pkg-2');
+    runCLI(`generate @nx/js:library ${pkg2} --publishable`);
+
+    pkg3 = uniq('my-pkg-3');
+    runCLI(`generate @nx/js:library ${pkg3} --publishable`);
+
+    // Enable independent versioning with version plans
+    updateJson('nx.json', (nxJson) => {
+      nxJson.release = {
+        ...nxJson.release,
+        projectsRelationship: 'independent',
+        versionPlans: true,
+        version: {
+          conventionalCommits: false,
+          generatorOptions: {
+            specifierSource: 'version-plans',
+          },
+        },
+        changelog: {
+          workspaceChangelog: false,
+          projectChangelogs: {
+            createRelease: false,
+          },
+        },
+      };
+      return nxJson;
+    });
+
+    await runCommandAsync(`git add .`);
+    await runCommandAsync(`git commit -m "chore: initial setup"`);
+  }, 120000);
+
+  afterAll(() => cleanupProject());
+
+  it('should only delete version plans that exclusively apply to filtered projects', async () => {
+    const versionPlansDir = tmpProjPath('.nx/version-plans');
+    await ensureDir(versionPlansDir);
+
+    // Create version plan for pkg1 only
+    await writeFile(
+      join(versionPlansDir, 'bump-pkg1.md'),
+      `---
+${pkg1}: minor
+---
+
+Update package 1 with a minor bump
+`
+    );
+
+    // Create version plan for pkg2 only
+    await writeFile(
+      join(versionPlansDir, 'bump-pkg2.md'),
+      `---
+${pkg2}: patch
+---
+
+Update package 2 with a patch bump
+`
+    );
+
+    // Create version plan for pkg3 only
+    await writeFile(
+      join(versionPlansDir, 'bump-pkg3.md'),
+      `---
+${pkg3}: major
+---
+
+Update packages 3 with major
+`
+    );
+
+    await runCommandAsync(`git add ${versionPlansDir}`);
+    await runCommandAsync(`git commit -m "chore: add version plans"`);
+
+    // Verify all version plans exist before release
+    expect(exists(join(versionPlansDir, 'bump-pkg1.md'))).toBeTruthy();
+    expect(exists(join(versionPlansDir, 'bump-pkg2.md'))).toBeTruthy();
+    expect(exists(join(versionPlansDir, 'bump-pkg3.md'))).toBeTruthy();
+
+    // Run release with filter for only pkg1
+    const result = runCLI(`release -p ${pkg1} --skip-publish --verbose`, {
+      silenceError: true,
+    });
+
+    // Verify pkg1 was versioned
+    expect(result).toContain(`${pkg1} ❓ Applied`);
+
+    // Verify pkg2 and pkg3 were NOT versioned
+    expect(result).not.toContain(`${pkg2} ❓ Applied`);
+    expect(result).not.toContain(`${pkg3} ❓ Applied`);
+
+    // - bump-pkg1.md should be deleted (only affects pkg1, which is in the filter)
+    expect(exists(join(versionPlansDir, 'bump-pkg1.md'))).toBeFalsy();
+
+    // - bump-pkg2.md should be preserved (affects pkg2, which is not in the filter)
+    expect(exists(join(versionPlansDir, 'bump-pkg2.md'))).toBeTruthy();
+
+    // - bump-pkg3.md should be preserved (affects pkg3, which is not in the filter)
+    expect(exists(join(versionPlansDir, 'bump-pk3.md'))).toBeTruthy();
+  }, 120000);
+
+  it('should error if version plan contains packages not in the filter', async () => {
+    const versionPlansDir = tmpProjPath('.nx/version-plans');
+    await ensureDir(versionPlansDir);
+
+    // Create a version plan that affects multiple packages
+    await writeFile(
+      join(versionPlansDir, 'bump-multiple.md'),
+      `---
+${pkg1}: minor
+${pkg2}: patch
+---
+
+Update multiple packages
+`
+    );
+
+    await runCommandAsync(`git add ${versionPlansDir}`);
+    await runCommandAsync(
+      `git commit -m "chore: add multi-package version plan"`
+    );
+
+    // Try to release only pkg1 when version plan affects both pkg1 and pkg2
+    // EXPECTED: Should error because version plan contains pkg2 which is not in filter
+    const result = runCLI(`release -p ${pkg1} --skip-publish`, {
+      silenceError: true,
+    });
+
+    expect(result).toContain(
+      'version plan contains projects not included in the release filter'
+    );
+
+    // Version plan should NOT be deleted since release failed
+    expect(exists(join(versionPlansDir, 'bump-multiple.md'))).toBeTruthy();
+  }, 120000);
+});

--- a/e2e/release/src/version-plans-filtered-release.test.ts
+++ b/e2e/release/src/version-plans-filtered-release.test.ts
@@ -42,20 +42,10 @@ describe('nx release with version plans and project filter', () => {
     // Enable independent versioning with version plans
     updateJson('nx.json', (nxJson) => {
       nxJson.release = {
-        ...nxJson.release,
         projectsRelationship: 'independent',
         versionPlans: true,
-        version: {
-          conventionalCommits: false,
-          generatorOptions: {
-            specifierSource: 'version-plans',
-          },
-        },
         changelog: {
           workspaceChangelog: false,
-          projectChangelogs: {
-            createRelease: false,
-          },
         },
       };
       return nxJson;

--- a/e2e/release/src/version-plans-filtered-release.test.ts
+++ b/e2e/release/src/version-plans-filtered-release.test.ts
@@ -21,6 +21,7 @@ describe('nx release with version plans and project filter', () => {
   beforeAll(async () => {
     newProject({
       packages: ['@nx/js'],
+      preset: 'ts',
     });
 
     pkg1 = uniq('my-pkg-1');
@@ -161,7 +162,7 @@ Update multiple packages
     });
 
     expect(result).toContain(
-      'version plan contains projects not included in the release filter'
+      'Version plan contains projects not included in the release filter'
     );
 
     // Version plan should NOT be deleted since release failed

--- a/e2e/release/src/version-plans-filtered-release.test.ts
+++ b/e2e/release/src/version-plans-filtered-release.test.ts
@@ -24,13 +24,19 @@ describe('nx release with version plans and project filter', () => {
     });
 
     pkg1 = uniq('my-pkg-1');
-    runCLI(`generate @nx/js:library ${pkg1} --publishable`);
+    runCLI(
+      `generate @nx/js:library ${pkg1} --publishable --importPath=${pkg1}`
+    );
 
     pkg2 = uniq('my-pkg-2');
-    runCLI(`generate @nx/js:library ${pkg2} --publishable`);
+    runCLI(
+      `generate @nx/js:library ${pkg2} --publishable --importPath=${pkg2}`
+    );
 
     pkg3 = uniq('my-pkg-3');
-    runCLI(`generate @nx/js:library ${pkg3} --publishable`);
+    runCLI(
+      `generate @nx/js:library ${pkg3} --publishable --importPath=${pkg3}`
+    );
 
     // Enable independent versioning with version plans
     updateJson('nx.json', (nxJson) => {
@@ -124,7 +130,7 @@ Update packages 3 with major
     expect(exists(join(versionPlansDir, 'bump-pkg2.md'))).toBeTruthy();
 
     // - bump-pkg3.md should be preserved (affects pkg3, which is not in the filter)
-    expect(exists(join(versionPlansDir, 'bump-pk3.md'))).toBeTruthy();
+    expect(exists(join(versionPlansDir, 'bump-pkg3.md'))).toBeTruthy();
   }, 120000);
 
   it('should error if version plan contains packages not in the filter', async () => {

--- a/e2e/release/src/version-plans-filtered-release.test.ts
+++ b/e2e/release/src/version-plans-filtered-release.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import {
   cleanupProject,
   newProject,
+  readJson,
   runCLI,
   runCommandAsync,
   tmpProjPath,
@@ -60,10 +61,13 @@ describe('nx release with version plans and project filter', () => {
   it('should only delete version plans that exclusively apply to filtered projects', async () => {
     const versionPlansDir = tmpProjPath('.nx/version-plans');
     await ensureDir(versionPlansDir);
+    const pkg1VersionPlan = join(versionPlansDir, 'bump-pkg1.md');
+    const pkg2VersionPlan = join(versionPlansDir, 'bump-pkg2.md');
+    const pkg3VersionPlan = join(versionPlansDir, 'bump-pkg3.md');
 
     // Create version plan for pkg1 only
     await writeFile(
-      join(versionPlansDir, 'bump-pkg1.md'),
+      pkg1VersionPlan,
       `---
 ${pkg1}: minor
 ---
@@ -74,7 +78,7 @@ Update package 1 with a minor bump
 
     // Create version plan for pkg2 only
     await writeFile(
-      join(versionPlansDir, 'bump-pkg2.md'),
+      pkg2VersionPlan,
       `---
 ${pkg2}: patch
 ---
@@ -85,7 +89,7 @@ Update package 2 with a patch bump
 
     // Create version plan for pkg3 only
     await writeFile(
-      join(versionPlansDir, 'bump-pkg3.md'),
+      pkg3VersionPlan,
       `---
 ${pkg3}: major
 ---
@@ -98,30 +102,28 @@ Update packages 3 with major
     await runCommandAsync(`git commit -m "chore: add version plans"`);
 
     // Verify all version plans exist before release
-    expect(exists(join(versionPlansDir, 'bump-pkg1.md'))).toBeTruthy();
-    expect(exists(join(versionPlansDir, 'bump-pkg2.md'))).toBeTruthy();
-    expect(exists(join(versionPlansDir, 'bump-pkg3.md'))).toBeTruthy();
+    expect(exists(pkg1VersionPlan)).toBeTruthy();
+    expect(exists(pkg2VersionPlan)).toBeTruthy();
+    expect(exists(pkg3VersionPlan)).toBeTruthy();
 
     // Run release with filter for only pkg1
-    const result = runCLI(`release -p ${pkg1} --skip-publish --verbose`, {
-      silenceError: true,
-    });
+    const result = runCLI(`release -p ${pkg1} --skip-publish --verbose`);
 
     // Verify pkg1 was versioned
-    expect(result).toContain(`${pkg1} ❓ Applied`);
+    expect(readJson(`${pkg1}/package.json`).version).toEqual('0.1.0');
 
     // Verify pkg2 and pkg3 were NOT versioned
-    expect(result).not.toContain(`${pkg2} ❓ Applied`);
-    expect(result).not.toContain(`${pkg3} ❓ Applied`);
+    expect(readJson(`${pkg2}/package.json`).version).toEqual('0.0.1');
+    expect(readJson(`${pkg3}/package.json`).version).toEqual('0.0.1');
 
     // - bump-pkg1.md should be deleted (only affects pkg1, which is in the filter)
-    expect(exists(join(versionPlansDir, 'bump-pkg1.md'))).toBeFalsy();
+    expect(exists(pkg1VersionPlan)).toBeFalsy();
 
     // - bump-pkg2.md should be preserved (affects pkg2, which is not in the filter)
-    expect(exists(join(versionPlansDir, 'bump-pkg2.md'))).toBeTruthy();
+    expect(exists(pkg2VersionPlan)).toBeTruthy();
 
     // - bump-pkg3.md should be preserved (affects pkg3, which is not in the filter)
-    expect(exists(join(versionPlansDir, 'bump-pkg3.md'))).toBeTruthy();
+    expect(exists(pkg3VersionPlan)).toBeTruthy();
   }, 120000);
 
   it('should error if version plan contains packages not in the filter', async () => {

--- a/packages/nx/src/command-line/release/utils/version-plan-utils.spec.ts
+++ b/packages/nx/src/command-line/release/utils/version-plan-utils.spec.ts
@@ -1,0 +1,522 @@
+import {
+  getProjectsAffectedByVersionPlan,
+  areAllVersionPlanProjectsFiltered,
+  getVersionPlanProjectsOutsideFilter,
+  validateResolvedVersionPlansAgainstFilter,
+} from './version-plan-utils';
+import type {
+  GroupVersionPlan,
+  ProjectsVersionPlan,
+} from '../config/version-plans';
+import type { ReleaseGroupWithName } from '../config/filter-release-groups';
+
+describe('version-plan-utils', () => {
+  let mockReleaseGroup: ReleaseGroupWithName;
+
+  beforeEach(() => {
+    mockReleaseGroup = {
+      name: 'test-group',
+      projects: ['project-a', 'project-b', 'project-c'],
+      projectsRelationship: 'independent',
+      changelog: false,
+      version: {
+        conventionalCommits: false,
+        generator: '',
+        generatorOptions: {},
+        groupPreVersionCommand: '',
+      },
+      releaseTagPattern: '',
+      releaseTagPatternCheckAllBranchesWhen: undefined,
+      releaseTagPatternRequireSemver: true,
+      releaseTagPatternStrictPreid: false,
+      versionPlans: true,
+      resolvedVersionPlans: false,
+    };
+  });
+
+  describe('getProjectsAffectedByVersionPlan', () => {
+    it('should return all projects in group for group version bump', () => {
+      const plan: GroupVersionPlan = {
+        groupVersionBump: 'minor',
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const result = getProjectsAffectedByVersionPlan(plan, mockReleaseGroup);
+
+      expect(result).toEqual(new Set(['project-a', 'project-b', 'project-c']));
+    });
+
+    it('should return specific projects for project version bumps', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+          'project-c': 'patch',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const result = getProjectsAffectedByVersionPlan(plan, mockReleaseGroup);
+
+      expect(result).toEqual(new Set(['project-a', 'project-c']));
+    });
+
+    it('should return empty set for version plan without bumps', () => {
+      const plan = {} as any;
+
+      const result = getProjectsAffectedByVersionPlan(plan, mockReleaseGroup);
+
+      expect(result).toEqual(new Set());
+    });
+  });
+
+  describe('areAllVersionPlanProjectsFiltered', () => {
+    it('should return true when all version plan projects are filtered', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+          'project-b': 'patch',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+      const filteredProjects = new Set(['project-a', 'project-b', 'project-c']);
+
+      const result = areAllVersionPlanProjectsFiltered(
+        plan,
+        mockReleaseGroup,
+        filteredProjects
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when some version plan projects are not filtered', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+          'project-b': 'patch',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+      const filteredProjects = new Set(['project-a']); // project-b is not filtered
+
+      const result = areAllVersionPlanProjectsFiltered(
+        plan,
+        mockReleaseGroup,
+        filteredProjects
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when filteredProjects is undefined', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const result = areAllVersionPlanProjectsFiltered(
+        plan,
+        mockReleaseGroup,
+        undefined
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when version plan affects no projects', () => {
+      const plan = {} as any; // Empty plan
+      const filteredProjects = new Set(['project-a']);
+
+      const result = areAllVersionPlanProjectsFiltered(
+        plan,
+        mockReleaseGroup,
+        filteredProjects
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle group version plans correctly', () => {
+      const plan: GroupVersionPlan = {
+        groupVersionBump: 'minor',
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+      const filteredProjects = new Set(['project-a', 'project-b', 'project-c']);
+
+      const result = areAllVersionPlanProjectsFiltered(
+        plan,
+        mockReleaseGroup,
+        filteredProjects
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for group version plans when not all group projects are filtered', () => {
+      const plan: GroupVersionPlan = {
+        groupVersionBump: 'minor',
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+      const filteredProjects = new Set(['project-a', 'project-b']); // missing project-c
+
+      const result = areAllVersionPlanProjectsFiltered(
+        plan,
+        mockReleaseGroup,
+        filteredProjects
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getVersionPlanProjectsOutsideFilter', () => {
+    it('should return projects in version plan that are not filtered', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+          'project-b': 'patch',
+          'project-c': 'minor',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+      const filteredProjects = new Set(['project-a']); // only project-a is filtered
+
+      const result = getVersionPlanProjectsOutsideFilter(
+        plan,
+        mockReleaseGroup,
+        filteredProjects
+      );
+
+      expect(result.sort()).toEqual(['project-b', 'project-c']);
+    });
+
+    it('should return empty array when all version plan projects are filtered', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+          'project-b': 'patch',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+      const filteredProjects = new Set(['project-a', 'project-b', 'project-c']);
+
+      const result = getVersionPlanProjectsOutsideFilter(
+        plan,
+        mockReleaseGroup,
+        filteredProjects
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when filteredProjects is undefined', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const result = getVersionPlanProjectsOutsideFilter(
+        plan,
+        mockReleaseGroup,
+        undefined
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle group version plans correctly', () => {
+      const plan: GroupVersionPlan = {
+        groupVersionBump: 'minor',
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+      const filteredProjects = new Set(['project-a']); // only project-a is filtered
+
+      const result = getVersionPlanProjectsOutsideFilter(
+        plan,
+        mockReleaseGroup,
+        filteredProjects
+      );
+
+      expect(result.sort()).toEqual(['project-b', 'project-c']);
+    });
+  });
+
+  describe('validateResolvedVersionPlansAgainstFilter', () => {
+    it('should return null when all version plan projects are within the filter', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+          'project-b': 'patch',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const releaseGroupWithPlan: ReleaseGroupWithName = {
+        ...mockReleaseGroup,
+        resolvedVersionPlans: [plan],
+      };
+
+      const releaseGroups = [releaseGroupWithPlan];
+      const releaseGroupToFilteredProjects = new Map([
+        [
+          releaseGroupWithPlan,
+          new Set(['project-a', 'project-b', 'project-c']),
+        ],
+      ]);
+
+      const result = validateResolvedVersionPlansAgainstFilter(
+        releaseGroups,
+        releaseGroupToFilteredProjects
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return an error when version plan contains projects outside the filter', () => {
+      const plan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+          'project-b': 'patch',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const releaseGroupWithPlan: ReleaseGroupWithName = {
+        ...mockReleaseGroup,
+        resolvedVersionPlans: [plan],
+      };
+
+      const releaseGroups = [releaseGroupWithPlan];
+      const releaseGroupToFilteredProjects = new Map([
+        [releaseGroupWithPlan, new Set(['project-a'])], // Only project-a is filtered
+      ]);
+
+      const result = validateResolvedVersionPlansAgainstFilter(
+        releaseGroups,
+        releaseGroupToFilteredProjects
+      );
+
+      expect(result).toEqual({
+        title:
+          'Version plan contains projects not included in the release filter',
+        bodyLines: [
+          'The following projects in the version plan are not being released:',
+          '  - project-b',
+          '',
+          'Either include all projects from the version plan in your release command,',
+          'or create separate version plans for different sets of projects.',
+        ],
+      });
+    });
+
+    it('should return an error for group version plans when not all group projects are filtered', () => {
+      const plan: GroupVersionPlan = {
+        groupVersionBump: 'minor',
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const releaseGroupWithPlan: ReleaseGroupWithName = {
+        ...mockReleaseGroup,
+        resolvedVersionPlans: [plan],
+      };
+
+      const releaseGroups = [releaseGroupWithPlan];
+      const releaseGroupToFilteredProjects = new Map([
+        [releaseGroupWithPlan, new Set(['project-a', 'project-b'])], // Missing project-c
+      ]);
+
+      const result = validateResolvedVersionPlansAgainstFilter(
+        releaseGroups,
+        releaseGroupToFilteredProjects
+      );
+
+      expect(result).toEqual({
+        title:
+          'Version plan contains projects not included in the release filter',
+        bodyLines: [
+          'The following projects in the version plan are not being released:',
+          '  - project-c',
+          '',
+          'Either include all projects from the version plan in your release command,',
+          'or create separate version plans for different sets of projects.',
+        ],
+      });
+    });
+
+    it('should skip validation when resolvedVersionPlans is false', () => {
+      const releaseGroupWithoutPlans: ReleaseGroupWithName = {
+        ...mockReleaseGroup,
+        resolvedVersionPlans: false,
+      };
+
+      const releaseGroups = [releaseGroupWithoutPlans];
+      const releaseGroupToFilteredProjects = new Map([
+        [releaseGroupWithoutPlans, new Set(['project-a'])],
+      ]);
+
+      const result = validateResolvedVersionPlansAgainstFilter(
+        releaseGroups,
+        releaseGroupToFilteredProjects
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should skip validation when resolvedVersionPlans is empty', () => {
+      const releaseGroupWithEmptyPlans: ReleaseGroupWithName = {
+        ...mockReleaseGroup,
+        resolvedVersionPlans: [],
+      };
+
+      const releaseGroups = [releaseGroupWithEmptyPlans];
+      const releaseGroupToFilteredProjects = new Map([
+        [releaseGroupWithEmptyPlans, new Set(['project-a'])],
+      ]);
+
+      const result = validateResolvedVersionPlansAgainstFilter(
+        releaseGroups,
+        releaseGroupToFilteredProjects
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should check all release groups and return error for the first invalid one', () => {
+      const validPlan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-a': 'major',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const invalidPlan: ProjectsVersionPlan = {
+        projectVersionBumps: {
+          'project-b': 'patch',
+          'project-c': 'minor',
+        },
+        commit: undefined,
+        message: undefined,
+        absolutePath: undefined,
+        relativePath: undefined,
+        fileName: undefined,
+        createdOnMs: undefined,
+      };
+
+      const group1: ReleaseGroupWithName = {
+        ...mockReleaseGroup,
+        name: 'group1',
+        projects: ['project-a'],
+        resolvedVersionPlans: [validPlan],
+      };
+
+      const group2: ReleaseGroupWithName = {
+        ...mockReleaseGroup,
+        name: 'group2',
+        projects: ['project-b', 'project-c'],
+        resolvedVersionPlans: [invalidPlan],
+      };
+
+      const releaseGroups = [group1, group2];
+      const releaseGroupToFilteredProjects = new Map([
+        [group1, new Set(['project-a'])],
+        [group2, new Set(['project-b'])], // Missing project-c
+      ]);
+
+      const result = validateResolvedVersionPlansAgainstFilter(
+        releaseGroups,
+        releaseGroupToFilteredProjects
+      );
+
+      expect(result).toEqual({
+        title:
+          'Version plan contains projects not included in the release filter',
+        bodyLines: [
+          'The following projects in the version plan are not being released:',
+          '  - project-c',
+          '',
+          'Either include all projects from the version plan in your release command,',
+          'or create separate version plans for different sets of projects.',
+        ],
+      });
+    });
+  });
+});

--- a/packages/nx/src/command-line/release/utils/version-plan-utils.ts
+++ b/packages/nx/src/command-line/release/utils/version-plan-utils.ts
@@ -109,22 +109,6 @@ export function areAllVersionPlanProjectsFiltered(
   );
 }
 
-function checkVersionPlanContainsFilteredProjects(
-  plan: GroupVersionPlan | ProjectsVersionPlan,
-  releaseGroup: ReleaseGroupWithName,
-  filteredProjects: Set<string> | undefined
-) {
-  if (!filteredProjects) {
-    return true;
-  }
-
-  const planProjects = getProjectsAffectedByVersionPlan(plan, releaseGroup);
-
-  return Array.from(filteredProjects).some((project) =>
-    planProjects.has(project)
-  );
-}
-
 /**
  * Finds projects in a version plan that are NOT included in the filtered projects set.
  *
@@ -146,5 +130,29 @@ export function getVersionPlanProjectsOutsideFilter(
 
   return Array.from(planProjects).filter(
     (project) => !filteredProjects.has(project)
+  );
+}
+
+/**
+ * Checks whether the version plan contains any of the filtered projects.
+ *
+ * @param plan - The version plan to check.
+ * @param releaseGroup - The release group associated with the version plan.
+ * @param filteredProjects - Set of projects that are being released (filtered).
+ * @returns Returns true if the version plan contains any of the filtered projects, or if no filtered projects are provided.
+ */
+function checkVersionPlanContainsFilteredProjects(
+  plan: GroupVersionPlan | ProjectsVersionPlan,
+  releaseGroup: ReleaseGroupWithName,
+  filteredProjects: Set<string> | undefined
+): boolean {
+  if (!filteredProjects) {
+    return true;
+  }
+
+  const planProjects = getProjectsAffectedByVersionPlan(plan, releaseGroup);
+
+  return Array.from(filteredProjects).some((project) =>
+    planProjects.has(project)
   );
 }

--- a/packages/nx/src/command-line/release/utils/version-plan-utils.ts
+++ b/packages/nx/src/command-line/release/utils/version-plan-utils.ts
@@ -21,6 +21,17 @@ export function validateResolvedVersionPlansAgainstFilter(
       const filteredProjects = releaseGroupToFilteredProjects.get(releaseGroup);
 
       for (const plan of releaseGroup.resolvedVersionPlans) {
+        // check if version plan applies to filtered projects
+        if (
+          !checkVersionPlanContainsFilteredProjects(
+            plan,
+            releaseGroup,
+            filteredProjects
+          )
+        ) {
+          continue;
+        }
+
         // Check if version plan contains projects outside the filter
         const projectsOutsideFilter = getVersionPlanProjectsOutsideFilter(
           plan,
@@ -95,6 +106,22 @@ export function areAllVersionPlanProjectsFiltered(
   return (
     planProjects.size > 0 &&
     Array.from(planProjects).every((project) => filteredProjects.has(project))
+  );
+}
+
+function checkVersionPlanContainsFilteredProjects(
+  plan: GroupVersionPlan | ProjectsVersionPlan,
+  releaseGroup: ReleaseGroupWithName,
+  filteredProjects: Set<string> | undefined
+) {
+  if (!filteredProjects) {
+    return true;
+  }
+
+  const planProjects = getProjectsAffectedByVersionPlan(plan, releaseGroup);
+
+  return Array.from(filteredProjects).some((project) =>
+    planProjects.has(project)
   );
 }
 

--- a/packages/nx/src/command-line/release/utils/version-plan-utils.ts
+++ b/packages/nx/src/command-line/release/utils/version-plan-utils.ts
@@ -1,0 +1,123 @@
+import { GroupVersionPlan, ProjectsVersionPlan } from '../config/version-plans';
+import { ReleaseGroupWithName } from '../config/filter-release-groups';
+
+/**
+ * Validates that all projects in resolved version plans are included in the filtered projects.
+ * This validation ensures that version plans don't contain projects that aren't being released.
+ *
+ * @param releaseGroups - The release groups to validate
+ * @param releaseGroupToFilteredProjects - Map of release groups to their filtered projects
+ * @returns An error object if validation fails, null otherwise
+ */
+export function validateResolvedVersionPlansAgainstFilter(
+  releaseGroups: ReleaseGroupWithName[],
+  releaseGroupToFilteredProjects: Map<ReleaseGroupWithName, Set<string>>
+): { title: string; bodyLines?: string[] } | null {
+  for (const releaseGroup of releaseGroups) {
+    if (
+      releaseGroup.resolvedVersionPlans &&
+      releaseGroup.resolvedVersionPlans.length > 0
+    ) {
+      const filteredProjects = releaseGroupToFilteredProjects.get(releaseGroup);
+
+      for (const plan of releaseGroup.resolvedVersionPlans) {
+        // Check if version plan contains projects outside the filter
+        const projectsOutsideFilter = getVersionPlanProjectsOutsideFilter(
+          plan,
+          releaseGroup,
+          filteredProjects
+        );
+
+        if (projectsOutsideFilter.length > 0) {
+          // Error if version plan contains projects not in the filter
+          return {
+            title: `Version plan contains projects not included in the release filter`,
+            bodyLines: [
+              `The following projects in the version plan are not being released:`,
+              ...projectsOutsideFilter.map((p) => `  - ${p}`),
+              '',
+              `Either include all projects from the version plan in your release command,`,
+              `or create separate version plans for different sets of projects.`,
+            ],
+          };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Extracts the set of projects that a version plan affects.
+ *
+ * @param plan - The version plan to analyze
+ * @param releaseGroup - The release group containing the version plan
+ * @returns Set of project names that the version plan affects
+ */
+export function getProjectsAffectedByVersionPlan(
+  plan: GroupVersionPlan | ProjectsVersionPlan,
+  releaseGroup: ReleaseGroupWithName
+): Set<string> {
+  const planProjects = new Set<string>();
+
+  // Collect all projects mentioned in this version plan
+  if ('groupVersionBump' in plan && plan.groupVersionBump) {
+    // Version plan applies to the entire group
+    releaseGroup.projects.forEach((p) => planProjects.add(p));
+  } else if ('projectVersionBumps' in plan && plan.projectVersionBumps) {
+    // Version plan has specific project bumps
+    Object.keys(plan.projectVersionBumps).forEach((p) => planProjects.add(p));
+  }
+
+  return planProjects;
+}
+
+/**
+ * Checks if all projects affected by a version plan are included in the filtered projects set.
+ *
+ * @param plan - The version plan to check
+ * @param releaseGroup - The release group containing the version plan
+ * @param filteredProjects - Set of projects that are being released (filtered)
+ * @returns True if ALL projects in the version plan are being filtered/released
+ */
+export function areAllVersionPlanProjectsFiltered(
+  plan: GroupVersionPlan | ProjectsVersionPlan,
+  releaseGroup: ReleaseGroupWithName,
+  filteredProjects: Set<string> | undefined
+): boolean {
+  if (!filteredProjects) {
+    return false;
+  }
+
+  const planProjects = getProjectsAffectedByVersionPlan(plan, releaseGroup);
+
+  // Only return true if the plan affects at least one project and ALL of them are filtered
+  return (
+    planProjects.size > 0 &&
+    Array.from(planProjects).every((project) => filteredProjects.has(project))
+  );
+}
+
+/**
+ * Finds projects in a version plan that are NOT included in the filtered projects set.
+ *
+ * @param plan - The version plan to check
+ * @param releaseGroup - The release group containing the version plan
+ * @param filteredProjects - Set of projects that are being released (filtered)
+ * @returns Array of project names that are in the version plan but not in the filter
+ */
+export function getVersionPlanProjectsOutsideFilter(
+  plan: GroupVersionPlan | ProjectsVersionPlan,
+  releaseGroup: ReleaseGroupWithName,
+  filteredProjects: Set<string> | undefined
+): string[] {
+  if (!filteredProjects) {
+    return [];
+  }
+
+  const planProjects = getProjectsAffectedByVersionPlan(plan, releaseGroup);
+
+  return Array.from(planProjects).filter(
+    (project) => !filteredProjects.has(project)
+  );
+}

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -43,6 +43,7 @@ import { releaseVersionLegacy } from './version-legacy';
 import { ReleaseGroupProcessor } from './version/release-group-processor';
 import { SemverBumpType } from './version/version-actions';
 import { shouldUseLegacyVersioning } from './config/use-legacy-versioning';
+import { validateResolvedVersionPlansAgainstFilter } from './utils/version-plan-utils';
 
 const LARGE_BUFFER = 1024 * 1000000;
 
@@ -170,6 +171,17 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
         Object.keys(projectGraph.nodes),
         args.verbose
       );
+
+      // Validate version plans against the filter after resolution
+      const versionPlanValidationError =
+        validateResolvedVersionPlansAgainstFilter(
+          releaseGroups,
+          releaseGroupToFilteredProjects
+        );
+      if (versionPlanValidationError) {
+        output.error(versionPlanValidationError);
+        process.exit(1);
+      }
     } else {
       if (args.verbose && releaseGroups.some((g) => !!g.versionPlans)) {
         console.log(


### PR DESCRIPTION
## Current Behavior
When using version plans, after running the release command, version plans were deleted.
This happened even if a `project` or `group` filter was supplied and not all version plans were used.


## Expected Behavior
Ensure that:
- Only Version Plans for projects in filter are deleted
- If filtered projects exist in version plans that contain unfiltered projects, hard error

## Related Issue(s)

Fixes #31327
