### PR TITLE
fix(module-federation): module federation does not depend on static remotes port

### DIFF
--- a/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -111,9 +111,10 @@ export async function* moduleFederationSsrDevServerExecutor(
           return;
         }
         try {
-          const portsToWaitFor = staticRemotesIter
-            ? [options.staticRemotesPort, ...remotes.remotePorts]
-            : [...remotes.remotePorts];
+          const portsToWaitFor =
+            staticRemotesIter && options.staticRemotesPort
+              ? [options.staticRemotesPort, ...remotes.remotePorts]
+              : [...remotes.remotePorts];
           await Promise.all(
             portsToWaitFor.map((port) =>
               waitForPortOpen(port, {

--- a/packages/module-federation/src/utils/get-remotes-for-host.ts
+++ b/packages/module-federation/src/utils/get-remotes-for-host.ts
@@ -184,16 +184,18 @@ export function getRemotes(
     (r) => context.projectGraph.nodes[r].data.targets['serve'].options.port
   );
   const staticRemotePort =
-    Math.max(
-      ...([
-        ...remotePorts,
-        ...staticRemotes.map(
-          (r) =>
-            context.projectGraph.nodes[r].data.targets['serve'].options.port
-        ),
-      ] as number[])
-    ) +
-    (remotesToSkip.size + 1);
+    staticRemotes.length === 0 && remotePorts.length === 0
+      ? undefined
+      : Math.max(
+          ...([
+            ...remotePorts,
+            ...staticRemotes.map(
+              (r) =>
+                context.projectGraph.nodes[r].data.targets['serve'].options.port
+            ),
+          ] as number[])
+        ) +
+        (remotesToSkip.size + 1);
 
   return {
     staticRemotes,

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -89,9 +89,10 @@ export default async function* moduleFederationDevServer(
           const baseUrl = `http${options.ssl ? 's' : ''}://${host}:${
             options.port
           }`;
-          const portsToWaitFor = staticRemotesIter
-            ? [options.staticRemotesPort, ...remotes.remotePorts]
-            : [...remotes.remotePorts];
+          const portsToWaitFor =
+            staticRemotesIter && options.staticRemotesPort
+              ? [options.staticRemotesPort, ...remotes.remotePorts]
+              : [...remotes.remotePorts];
           await Promise.all(
             portsToWaitFor.map((port) =>
               waitForPortOpen(port, {

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -89,9 +89,10 @@ export default async function* moduleFederationSsrDevServer(
         }
 
         try {
-          const portsToWaitFor = staticRemotesIter
-            ? [options.staticRemotesPort, ...remotes.remotePorts]
-            : [...remotes.remotePorts];
+          const portsToWaitFor =
+            staticRemotesIter && options.staticRemotesPort
+              ? [options.staticRemotesPort, ...remotes.remotePorts]
+              : [...remotes.remotePorts];
 
           await Promise.all(
             portsToWaitFor.map((port) =>

--- a/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -363,9 +363,10 @@ export default async function* moduleFederationStaticServer(
         }
 
         try {
-          const portsToWaitFor = staticFileServerIter
-            ? [options.serveOptions.staticRemotesPort, ...remotes.remotePorts]
-            : [...remotes.remotePorts];
+          const portsToWaitFor =
+            staticFileServerIter && options.serveOptions.staticRemotesPort
+              ? [options.serveOptions.staticRemotesPort, ...remotes.remotePorts]
+              : [...remotes.remotePorts];
           await Promise.all(
             portsToWaitFor.map((port) =>
               waitForPortOpen(port, {

--- a/packages/rspack/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -89,9 +89,10 @@ export default async function* moduleFederationDevServer(
           const baseUrl = `http${options.ssl ? 's' : ''}://${host}:${
             options.port
           }`;
-          const portsToWaitFor = staticRemotesIter
-            ? [options.staticRemotesPort, ...remotes.remotePorts]
-            : [...remotes.remotePorts];
+          const portsToWaitFor =
+            staticRemotesIter && options.staticRemotesPort
+              ? [options.staticRemotesPort, ...remotes.remotePorts]
+              : [...remotes.remotePorts];
           await Promise.all(
             portsToWaitFor.map((port) =>
               waitForPortOpen(port, {

--- a/packages/rspack/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -81,9 +81,10 @@ export default async function* moduleFederationSsrDevServer(
           const baseUrl = `http${options.ssl ? 's' : ''}://${host}:${
             options.port
           }`;
-          const portsToWaitFor = staticRemotesIter
-            ? [options.staticRemotesPort, ...remotes.remotePorts]
-            : [...remotes.remotePorts];
+          const portsToWaitFor =
+            staticRemotesIter && options.staticRemotesPort
+              ? [options.staticRemotesPort, ...remotes.remotePorts]
+              : [...remotes.remotePorts];
 
           await Promise.all(
             portsToWaitFor.map((port) =>

--- a/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -367,9 +367,10 @@ export default async function* moduleFederationStaticServer(
         }
 
         try {
-          const portsToWaitFor = staticFileServerIter
-            ? [options.serveOptions.staticRemotesPort, ...remotes.remotePorts]
-            : [...remotes.remotePorts];
+          const portsToWaitFor =
+            staticFileServerIter && options.serveOptions.staticRemotesPort
+              ? [options.serveOptions.staticRemotesPort, ...remotes.remotePorts]
+              : [...remotes.remotePorts];
           await Promise.all(
             portsToWaitFor.map((port) =>
               waitForPortOpen(port, {


### PR DESCRIPTION
## Current Behavior
If a host does not have any remotes, it fails to serve as the `staticRemotesPort` returns as `-Infinity`.

## Expected Behavior
When a host has no remotes, set `staticRemotesPort` to `undefined` and use this to determine whether we should wait for it.
