### PR TITLE
docs(nx-dev): add breadcrumbs

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
         PageFrame: './src/components/layout/PageFrame.astro',
         Sidebar: './src/components/layout/Sidebar.astro',
         TwoColumnContent: './src/components/layout/TwoColumnContent.astro',
+        PageTitle: './src/components/layout/PageTitle.astro',
       },
     }),
     react(),

--- a/astro-docs/src/components/layout/Breadcrumbs.astro
+++ b/astro-docs/src/components/layout/Breadcrumbs.astro
@@ -1,0 +1,68 @@
+---
+import { Icon } from '@astrojs/starlight/components';
+import { getCollection } from 'astro:content';
+
+const { pathname } = Astro.url;
+
+const cleanedPath = pathname.split('?')[0];
+
+const allDocs = await getCollection('docs');
+
+const pathSegments = cleanedPath.split('/').filter(Boolean);
+
+type Crumb = {
+  id: string;
+  name: string;
+  href: string;
+  current: boolean;
+}
+
+function findDocByPath (path: string) {
+  return allDocs.find(d => d.id === `${path}.mdoc`)
+      ?? allDocs.find(d => d.id === `${path}/index.mdoc`);
+}
+
+function createNameFromSegment(segment: string): string {
+    segment = segment.split('#')[0];
+    return segment
+        .split('-')
+        .map(s => s.charAt(0).toUpperCase() + s.slice(1))
+        .join(' ');
+}
+
+const crumbs: Crumb[] = pathSegments.map((segment, index) => {
+  const docPath = pathSegments.slice(0, index + 1).join('/');
+  const doc = findDocByPath(docPath);
+  const name = doc?.data?.sidebar?.label || doc?.data?.title || createNameFromSegment(segment);
+  return {
+    id: segment,
+    name,
+    href: `/${docPath}`,
+    current: index === pathSegments.length - 1,
+  };
+});
+---
+
+
+<nav class="not-content flex mb-4" aria-label="Breadcrumb">
+  <ol role="list" class="flex m-0 p-0 flex-wrap items-center space-x-2 text-sm">
+    {crumbs.map((crumb, index) => (
+      <li class="flex items-center">
+        {index > 0 && (
+          <Icon name="right-caret" class="w-5 h-5 ml-2 mr-2"/>
+        )}
+        <a
+          href={crumb.href}
+          class={`no-underline text-sm font-medium${
+            crumb.current 
+              ? 'hover:text-slate-600 text-slate-600'
+          : 'hover:text-slate-600 text-slate-400'
+          } font-medium transition-colors`}
+          aria-current={crumb.current ? 'page' : undefined}
+        >
+          {crumb.name}
+        </a>
+      </li>
+    ))}
+  </ol>
+</nav>

--- a/astro-docs/src/components/layout/PageTitle.astro
+++ b/astro-docs/src/components/layout/PageTitle.astro
@@ -1,0 +1,8 @@
+---
+import Default from '@astrojs/starlight/components/PageTitle.astro';
+import Breadcrumbs from './Breadcrumbs.astro';
+---
+
+<Breadcrumbs />
+
+<Default><slot /></Default>

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -3,7 +3,7 @@ title: What is Nx?
 description: 'Nx is an AI-first build platform that connects everything from your editor to CI Helping you deliver fast, without breaking things.'
 sidebar:
   order: 1
-  label: Intro
+  label: Introduction
 ---
 
 Nx is a powerful, open source, technology-agnostic build platform designed to efficiently manage codebases of any scale. From small single projects to large enterprise monorepos, Nx provides the platform to **efficiently get from starting a feature in your editor to a green PR**.


### PR DESCRIPTION
## Current Behavior
The Astro docs site doesn't display breadcrumbs at the top of the page content, making navigation context unclear.

## Expected Behavior
Breadcrumbs should appear at the top of each page content (after the page title) showing the navigation hierarchy, matching the behavior from the original Next.js app.


<img width="1343" height="361" alt="Screenshot 2025-08-15 at 2 47 19 PM" src="https://github.com/user-attachments/assets/8f2c983a-710f-4d0b-aa6e-b2303884596a" />
