### PR TITLE
feat(core): improve Cursor editor detection and extension installation

### DIFF
--- a/packages/nx/src/native/ide/install.rs
+++ b/packages/nx/src/native/ide/install.rs
@@ -171,9 +171,14 @@ pub fn get_install_command() -> Option<&'static str> {
             {
                 Some("cursor.cmd")
             }
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(target_os = "macos")]
             {
                 Some("cursor")
+            }
+            #[cfg(target_os = "linux")]
+            {
+                debug!("Cursor extension installation not supported on Linux");
+                None
             }
         }
         SupportedEditor::Windsurf => {

--- a/packages/nx/src/native/ide/install.rs
+++ b/packages/nx/src/native/ide/install.rs
@@ -165,6 +165,17 @@ pub fn get_install_command() -> Option<&'static str> {
                 Some("code")
             }
         }
+        SupportedEditor::Cursor => {
+            debug!("Installing Nx Console extension for Cursor");
+            #[cfg(target_os = "windows")]
+            {
+                Some("cursor.cmd")
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                Some("cursor")
+            }
+        }
         SupportedEditor::Windsurf => {
             debug!("Installing Nx Console extension for Windsurf");
             #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary
- Add CURSOR_TRACE_ID environment variable detection for Cursor
- Simplify get_env_var to be purely map-based for better testability  
- Add Cursor support to extension installation logic
- Add test case for CURSOR_TRACE_ID detection

## Test plan
- [x] All existing tests pass
- [x] New test case for CURSOR_TRACE_ID detection passes
- [x] Rust code compiles and passes clippy checks
- [x] Prepush validation passes

This ensures Nx Console extension can be properly installed in Cursor when the CURSOR_TRACE_ID environment variable is present, providing better support for Cursor users.

Fixes #[ISSUE_NUMBER]