### PR TITLE
fix(testing): support NX_CACHE_PROJECT_GRAPH when reading inferred config from jest cache file

### DIFF
--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -53,7 +53,9 @@ export interface JestPluginOptions {
 type JestTargets = Awaited<ReturnType<typeof buildJestTargets>>;
 
 function readTargetsCache(cachePath: string): Record<string, JestTargets> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
+  return process.env.NX_CACHE_PROJECT_GRAPH !== 'false' && existsSync(cachePath)
+    ? readJsonFile(cachePath)
+    : {};
 }
 
 function writeTargetsToCache(


### PR DESCRIPTION
## Current Behavior

The Jest plugin does not use `NX_CACHE_PROJECT_GRAPH` in its implementation. Unlike other plugins (e.g., ESLint, TypeScript), it does not provide a way to control or disable its internal caching behavior.

## Expected Behavior

The Jest plugin should leverage `NX_CACHE_PROJECT_GRAPH`, ensuring consistent caching behavior across Nx plugins. This would make it easier to manage or override caching strategies when building higher-order plugins that extend Nx core functionality.

## Related Issue(s)

Fixes #

---

### Additional Context

* When creating higher-order plugins that extend Nx core plugins, it’s often useful to manage cache differently. Without this, concurrency issues can occur if `createNodesV2` is invoked multiple times in parallel.
* This highlights a broader need for improved plugin extensibility:

  * Instead of re-invoking `createNodesV2` (which handles multiple files, cache, etc.), it would be helpful to expose lower-level functions responsible only for generating configuration.
  * This would give plugin authors more granular control while reducing unintended side effects.