### PR TITLE
feat(rspack): add support for converting webpack plugin configs #30292

### DIFF
--- a/docs/generated/packages/rspack/generators/convert-webpack.json
+++ b/docs/generated/packages/rspack/generators/convert-webpack.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-webpack",
-  "alias": "convert-to-rspack",
+  "aliases": ["convert-to-rspack"],
   "factory": "./src/generators/convert-webpack/convert-webpack",
   "schema": {
     "$schema": "http://json-schema.org/schema",
@@ -28,7 +28,6 @@
   },
   "description": "Convert a webpack application to use rspack.",
   "implementation": "/packages/rspack/src/generators/convert-webpack/convert-webpack.ts",
-  "aliases": [],
   "hidden": false,
   "path": "/packages/rspack/src/generators/convert-webpack/schema.json",
   "type": "generator"

--- a/packages/rspack/.eslintrc.json
+++ b/packages/rspack/.eslintrc.json
@@ -46,6 +46,8 @@
               // @nx/workspace is only required in < 15.8
               "@nx/workspace",
               "@nx/react",
+              // Used in spec file only
+              "@nx/nest",
               // Imported types only
               "@module-federation/sdk",
               "@module-federation/enhanced",

--- a/packages/rspack/generators.json
+++ b/packages/rspack/generators.json
@@ -29,7 +29,7 @@
       "x-deprecated": "This generator will be removed in Nx 22. Please use the equivalent generator for your application type instead."
     },
     "convert-webpack": {
-      "alias": "convert-to-rspack",
+      "aliases": ["convert-to-rspack"],
       "factory": "./src/generators/convert-webpack/convert-webpack",
       "schema": "./src/generators/convert-webpack/schema.json",
       "description": "Convert a webpack application to use rspack."

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -57,7 +57,8 @@
     "webpack-node-externals": "^3.0.0"
   },
   "devDependencies": {
-    "nx": "workspace:*"
+    "nx": "workspace:*",
+    "@nx/nest": "workspace:*"
   },
   "peerDependencies": {
     "@module-federation/enhanced": "^0.18.0",

--- a/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
+++ b/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
@@ -3,452 +3,503 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { readProjectConfiguration } from '@nx/devkit';
 // nx-ignore-next-line
 import { applicationGenerator, hostGenerator } from '@nx/react';
+// nx-ignore-next-line
+import { applicationGenerator as nestApplicationGenerator } from '@nx/nest';
 import convertWebpack from './convert-webpack';
 
 describe('Convert webpack', () => {
-  it('should convert basic webpack project to rspack', async () => {
-    // ARRANGE
-    const tree = createTreeWithEmptyWorkspace();
-    await applicationGenerator(tree, {
-      directory: 'demo',
-      bundler: 'webpack',
-      e2eTestRunner: 'playwright',
-      linter: 'none',
-      style: 'css',
-      addPlugin: false,
+  describe('convert webpack config that uses plugin', () => {
+    it('should convert basic nest webpack config to rspack', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      await nestApplicationGenerator(tree, {
+        directory: 'demo',
+        e2eTestRunner: 'none',
+        linter: 'none',
+        addPlugin: true,
+      });
+
+      // ACT
+      await convertWebpack(tree, { project: 'demo' });
+
+      // ASSERT
+      expect(tree.read('demo/rspack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+        const { join } = require('path');
+
+        module.exports = {
+          output: {
+            path: join(__dirname, '../dist/demo'),
+            ...(process.env.NODE_ENV !== 'production' && {
+              devtoolModuleFilenameTemplate: '[absolute-resource-path]',
+            }),
+          },
+          plugins: [
+            new NxAppRspackPlugin({
+              target: 'node',
+              compiler: 'tsc',
+              main: './src/main.ts',
+              tsConfig: './tsconfig.app.json',
+              assets: ['./src/assets'],
+              optimization: false,
+              outputHashing: 'none',
+              generatePackageJson: true,
+              sourceMaps: true,
+            }),
+          ],
+        };
+        "
+      `);
     });
-
-    // ACT
-    await convertWebpack(tree, { project: 'demo' });
-
-    // ASSERT
-    const project = readProjectConfiguration(tree, 'demo');
-
-    expect(tree.exists('demo/rspack.config.js')).toBeTruthy();
-    expect(tree.read('demo/rspack.config.js', 'utf-8')).toMatchInlineSnapshot(`
-      "const { withReact } = require('@nx/rspack');
-      const { withNx } = require('@nx/rspack');
-      const { composePlugins } = require('@nx/rspack');
-
-      // Nx plugins for webpack.
-      module.exports = composePlugins(
-        withNx(),
-        withReact({
-          useLegacyHtmlPlugin: true,
-          // Uncomment this line if you don't want to use SVGR
-          // See: https://react-svgr.com/
-          // svgr: false
-        }),
-        (config) => {
-          // Update the webpack config as needed here.
-          // e.g. \`config.plugins.push(new MyPlugin())\`
-          return config;
-        }
-      );
-      "
-    `);
-    expect(project.targets.build).toMatchInlineSnapshot(`
-      {
-        "configurations": {
-          "development": {
-            "extractLicenses": false,
-            "optimization": false,
-            "sourceMap": true,
-            "vendorChunk": true,
-          },
-          "production": {
-            "extractLicenses": true,
-            "fileReplacements": [
-              {
-                "replace": "demo/src/environments/environment.ts",
-                "with": "demo/src/environments/environment.prod.ts",
-              },
-            ],
-            "namedChunks": false,
-            "optimization": true,
-            "outputHashing": "all",
-            "sourceMap": false,
-            "vendorChunk": false,
-          },
-        },
-        "defaultConfiguration": "production",
-        "executor": "@nx/rspack:rspack",
-        "options": {
-          "assets": [
-            "demo/src/favicon.ico",
-            "demo/src/assets",
-          ],
-          "baseHref": "/",
-          "compiler": "babel",
-          "index": "demo/src/index.html",
-          "main": "demo/src/main.tsx",
-          "outputPath": "dist/demo",
-          "rspackConfig": "demo/rspack.config.js",
-          "scripts": [],
-          "styles": [
-            "demo/src/styles.css",
-          ],
-          "target": "web",
-          "tsConfig": "demo/tsconfig.app.json",
-        },
-        "outputs": [
-          "{options.outputPath}",
-        ],
-      }
-    `);
-    expect(project.targets.serve).toMatchInlineSnapshot(`
-      {
-        "configurations": {
-          "development": {
-            "buildTarget": "demo:build:development",
-          },
-          "production": {
-            "buildTarget": "demo:build:production",
-            "hmr": false,
-          },
-        },
-        "defaultConfiguration": "development",
-        "executor": "@nx/rspack:dev-server",
-        "options": {
-          "buildTarget": "demo:build",
-          "hmr": true,
-        },
-      }
-    `);
   });
+  describe('convert webpack config that uses with* helpers', () => {
+    it('should convert basic webpack project to rspack', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      await applicationGenerator(tree, {
+        directory: 'demo',
+        bundler: 'webpack',
+        e2eTestRunner: 'playwright',
+        linter: 'none',
+        style: 'css',
+        addPlugin: false,
+      });
 
-  it('should convert react module federation webpack projects to rspack', async () => {
-    // ARRANGE
-    const tree = createTreeWithEmptyWorkspace();
-    await hostGenerator(tree, {
-      directory: 'demo',
-      bundler: 'webpack',
-      e2eTestRunner: 'playwright',
-      remotes: ['remote1', 'remote2'],
-      linter: 'none',
-      style: 'css',
-      addPlugin: false,
-      unitTestRunner: 'none',
-      typescriptConfiguration: true,
+      // ACT
+      await convertWebpack(tree, { project: 'demo' });
+
+      // ASSERT
+      const project = readProjectConfiguration(tree, 'demo');
+
+      expect(tree.exists('demo/rspack.config.js')).toBeTruthy();
+      expect(tree.read('demo/rspack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+              "const { withReact } = require('@nx/rspack');
+              const { withNx } = require('@nx/rspack');
+              const { composePlugins } = require('@nx/rspack');
+
+              // Nx plugins for webpack.
+              module.exports = composePlugins(
+                withNx(),
+                withReact({
+                  useLegacyHtmlPlugin: true,
+                  // Uncomment this line if you don't want to use SVGR
+                  // See: https://react-svgr.com/
+                  // svgr: false
+                }),
+                (config) => {
+                  // Update the webpack config as needed here.
+                  // e.g. \`config.plugins.push(new MyPlugin())\`
+                  return config;
+                }
+              );
+              "
+          `);
+      expect(project.targets.build).toMatchInlineSnapshot(`
+              {
+                "configurations": {
+                  "development": {
+                    "extractLicenses": false,
+                    "optimization": false,
+                    "sourceMap": true,
+                    "vendorChunk": true,
+                  },
+                  "production": {
+                    "extractLicenses": true,
+                    "fileReplacements": [
+                      {
+                        "replace": "demo/src/environments/environment.ts",
+                        "with": "demo/src/environments/environment.prod.ts",
+                      },
+                    ],
+                    "namedChunks": false,
+                    "optimization": true,
+                    "outputHashing": "all",
+                    "sourceMap": false,
+                    "vendorChunk": false,
+                  },
+                },
+                "defaultConfiguration": "production",
+                "executor": "@nx/rspack:rspack",
+                "options": {
+                  "assets": [
+                    "demo/src/favicon.ico",
+                    "demo/src/assets",
+                  ],
+                  "baseHref": "/",
+                  "compiler": "babel",
+                  "index": "demo/src/index.html",
+                  "main": "demo/src/main.tsx",
+                  "outputPath": "dist/demo",
+                  "rspackConfig": "demo/rspack.config.js",
+                  "scripts": [],
+                  "styles": [
+                    "demo/src/styles.css",
+                  ],
+                  "target": "web",
+                  "tsConfig": "demo/tsconfig.app.json",
+                },
+                "outputs": [
+                  "{options.outputPath}",
+                ],
+              }
+          `);
+      expect(project.targets.serve).toMatchInlineSnapshot(`
+              {
+                "configurations": {
+                  "development": {
+                    "buildTarget": "demo:build:development",
+                  },
+                  "production": {
+                    "buildTarget": "demo:build:production",
+                    "hmr": false,
+                  },
+                },
+                "defaultConfiguration": "development",
+                "executor": "@nx/rspack:dev-server",
+                "options": {
+                  "buildTarget": "demo:build",
+                  "hmr": true,
+                },
+              }
+          `);
     });
 
-    // ACT
-    await convertWebpack(tree, { project: 'demo' });
-    await convertWebpack(tree, { project: 'remote1' });
-    await convertWebpack(tree, { project: 'remote2' });
+    it('should convert react module federation webpack projects to rspack', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      await hostGenerator(tree, {
+        directory: 'demo',
+        bundler: 'webpack',
+        e2eTestRunner: 'playwright',
+        remotes: ['remote1', 'remote2'],
+        linter: 'none',
+        style: 'css',
+        addPlugin: false,
+        unitTestRunner: 'none',
+        typescriptConfiguration: true,
+      });
 
-    // ASSERT
-    const project = readProjectConfiguration(tree, 'demo');
+      // ACT
+      await convertWebpack(tree, { project: 'demo' });
+      await convertWebpack(tree, { project: 'remote1' });
+      await convertWebpack(tree, { project: 'remote2' });
 
-    expect(tree.exists('demo/rspack.config.ts')).toBeTruthy();
-    expect(tree.read('demo/rspack.config.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/module-federation/rspack.js';
-      import { withReact } from '@nx/rspack';
-      import { withNx } from '@nx/rspack';
-      import { composePlugins } from '@nx/rspack';
+      // ASSERT
+      const project = readProjectConfiguration(tree, 'demo');
 
-      import { ModuleFederationConfig } from '@nx/module-federation';
+      expect(tree.exists('demo/rspack.config.ts')).toBeTruthy();
+      expect(tree.read('demo/rspack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+              "import { withModuleFederation } from '@nx/module-federation/rspack.js';
+              import { withReact } from '@nx/rspack';
+              import { withNx } from '@nx/rspack';
+              import { composePlugins } from '@nx/rspack';
 
-      import baseConfig from './module-federation.config';
+              import { ModuleFederationConfig } from '@nx/module-federation';
 
-      const config: ModuleFederationConfig = {
-        ...baseConfig,
-      };
+              import baseConfig from './module-federation.config';
 
-      // Nx plugins for webpack to build config object from Nx options and context.
-      /**
-       * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
-       * The DTS Plugin can be enabled by setting dts: true
-       * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
-       */
-      export default composePlugins(
-        withNx(),
-        withReact({ useLegacyHtmlPlugin: true }),
-        withModuleFederation(config, { dts: false })
-      );
-      "
-    `);
-    expect(project.targets.build).toMatchInlineSnapshot(`
-      {
-        "configurations": {
-          "development": {
-            "extractLicenses": false,
-            "optimization": false,
-            "sourceMap": true,
-            "vendorChunk": true,
-          },
-          "production": {
-            "extractLicenses": true,
-            "fileReplacements": [
+              const config: ModuleFederationConfig = {
+                ...baseConfig,
+              };
+
+              // Nx plugins for webpack to build config object from Nx options and context.
+              /**
+               * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support for Module Federation
+               * The DTS Plugin can be enabled by setting dts: true
+               * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+               */
+              export default composePlugins(
+                withNx(),
+                withReact({ useLegacyHtmlPlugin: true }),
+                withModuleFederation(config, { dts: false })
+              );
+              "
+          `);
+      expect(project.targets.build).toMatchInlineSnapshot(`
               {
-                "replace": "demo/src/environments/environment.ts",
-                "with": "demo/src/environments/environment.prod.ts",
-              },
-            ],
-            "namedChunks": false,
-            "optimization": true,
-            "outputHashing": "all",
-            "rspackConfig": "demo/rspack.config.prod.ts",
-            "sourceMap": false,
-            "vendorChunk": false,
-          },
-        },
-        "defaultConfiguration": "production",
-        "executor": "@nx/rspack:rspack",
-        "options": {
-          "assets": [
-            "demo/src/favicon.ico",
-            "demo/src/assets",
-          ],
-          "baseHref": "/",
-          "compiler": "babel",
-          "index": "demo/src/index.html",
-          "main": "demo/src/main.ts",
-          "outputPath": "dist/demo",
-          "rspackConfig": "demo/rspack.config.ts",
-          "scripts": [],
-          "styles": [
-            "demo/src/styles.css",
-          ],
-          "target": "web",
-          "tsConfig": "demo/tsconfig.app.json",
-        },
-        "outputs": [
-          "{options.outputPath}",
-        ],
-      }
-    `);
-    expect(project.targets.serve).toMatchInlineSnapshot(`
-      {
-        "configurations": {
-          "development": {
-            "buildTarget": "demo:build:development",
-          },
-          "production": {
-            "buildTarget": "demo:build:production",
-            "hmr": false,
-          },
-        },
-        "defaultConfiguration": "development",
-        "executor": "@nx/rspack:module-federation-dev-server",
-        "options": {
-          "buildTarget": "demo:build",
-          "hmr": true,
-          "port": 4200,
-        },
-      }
-    `);
-
-    const remote1 = readProjectConfiguration(tree, 'remote1');
-
-    expect(tree.exists('remote1/rspack.config.ts')).toBeTruthy();
-    expect(tree.read('remote1/rspack.config.ts', 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/module-federation/rspack.js';
-      import { withReact } from '@nx/rspack';
-      import { withNx } from '@nx/rspack';
-      import { composePlugins } from '@nx/rspack';
-
-      import baseConfig from './module-federation.config';
-
-      const config = {
-        ...baseConfig,
-      };
-
-      // Nx plugins for webpack to build config object from Nx options and context.
-      /**
-       * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
-       * The DTS Plugin can be enabled by setting dts: true
-       * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
-       */
-      export default composePlugins(
-        withNx(),
-        withReact({ useLegacyHtmlPlugin: true }),
-        withModuleFederation(config, { dts: false })
-      );
-      "
-    `);
-    expect(tree.exists('remote1/rspack.config.prod.ts')).toBeTruthy();
-    expect(tree.read('remote1/rspack.config.prod.ts', 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "export default require('./rspack.config');
-      "
-    `);
-    expect(project.targets.build).toMatchInlineSnapshot(`
-      {
-        "configurations": {
-          "development": {
-            "extractLicenses": false,
-            "optimization": false,
-            "sourceMap": true,
-            "vendorChunk": true,
-          },
-          "production": {
-            "extractLicenses": true,
-            "fileReplacements": [
+                "configurations": {
+                  "development": {
+                    "extractLicenses": false,
+                    "optimization": false,
+                    "sourceMap": true,
+                    "vendorChunk": true,
+                  },
+                  "production": {
+                    "extractLicenses": true,
+                    "fileReplacements": [
+                      {
+                        "replace": "demo/src/environments/environment.ts",
+                        "with": "demo/src/environments/environment.prod.ts",
+                      },
+                    ],
+                    "namedChunks": false,
+                    "optimization": true,
+                    "outputHashing": "all",
+                    "rspackConfig": "demo/rspack.config.prod.ts",
+                    "sourceMap": false,
+                    "vendorChunk": false,
+                  },
+                },
+                "defaultConfiguration": "production",
+                "executor": "@nx/rspack:rspack",
+                "options": {
+                  "assets": [
+                    "demo/src/favicon.ico",
+                    "demo/src/assets",
+                  ],
+                  "baseHref": "/",
+                  "compiler": "babel",
+                  "index": "demo/src/index.html",
+                  "main": "demo/src/main.ts",
+                  "outputPath": "dist/demo",
+                  "rspackConfig": "demo/rspack.config.ts",
+                  "scripts": [],
+                  "styles": [
+                    "demo/src/styles.css",
+                  ],
+                  "target": "web",
+                  "tsConfig": "demo/tsconfig.app.json",
+                },
+                "outputs": [
+                  "{options.outputPath}",
+                ],
+              }
+          `);
+      expect(project.targets.serve).toMatchInlineSnapshot(`
               {
-                "replace": "demo/src/environments/environment.ts",
-                "with": "demo/src/environments/environment.prod.ts",
-              },
-            ],
-            "namedChunks": false,
-            "optimization": true,
-            "outputHashing": "all",
-            "rspackConfig": "demo/rspack.config.prod.ts",
-            "sourceMap": false,
-            "vendorChunk": false,
-          },
-        },
-        "defaultConfiguration": "production",
-        "executor": "@nx/rspack:rspack",
-        "options": {
-          "assets": [
-            "demo/src/favicon.ico",
-            "demo/src/assets",
-          ],
-          "baseHref": "/",
-          "compiler": "babel",
-          "index": "demo/src/index.html",
-          "main": "demo/src/main.ts",
-          "outputPath": "dist/demo",
-          "rspackConfig": "demo/rspack.config.ts",
-          "scripts": [],
-          "styles": [
-            "demo/src/styles.css",
-          ],
-          "target": "web",
-          "tsConfig": "demo/tsconfig.app.json",
-        },
-        "outputs": [
-          "{options.outputPath}",
-        ],
-      }
-    `);
-    expect(project.targets.serve).toMatchInlineSnapshot(`
-      {
-        "configurations": {
-          "development": {
-            "buildTarget": "demo:build:development",
-          },
-          "production": {
-            "buildTarget": "demo:build:production",
-            "hmr": false,
-          },
-        },
-        "defaultConfiguration": "development",
-        "executor": "@nx/rspack:module-federation-dev-server",
-        "options": {
-          "buildTarget": "demo:build",
-          "hmr": true,
-          "port": 4200,
-        },
-      }
-    `);
+                "configurations": {
+                  "development": {
+                    "buildTarget": "demo:build:development",
+                  },
+                  "production": {
+                    "buildTarget": "demo:build:production",
+                    "hmr": false,
+                  },
+                },
+                "defaultConfiguration": "development",
+                "executor": "@nx/rspack:module-federation-dev-server",
+                "options": {
+                  "buildTarget": "demo:build",
+                  "hmr": true,
+                  "port": 4200,
+                },
+              }
+          `);
 
-    const remote2 = readProjectConfiguration(tree, 'remote2');
+      const remote1 = readProjectConfiguration(tree, 'remote1');
 
-    expect(tree.exists('remote2/rspack.config.ts')).toBeTruthy();
-    expect(tree.read('remote2/rspack.config.ts', 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "import { withModuleFederation } from '@nx/module-federation/rspack.js';
-      import { withReact } from '@nx/rspack';
-      import { withNx } from '@nx/rspack';
-      import { composePlugins } from '@nx/rspack';
+      expect(tree.exists('remote1/rspack.config.ts')).toBeTruthy();
+      expect(tree.read('remote1/rspack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+              "import { withModuleFederation } from '@nx/module-federation/rspack.js';
+              import { withReact } from '@nx/rspack';
+              import { withNx } from '@nx/rspack';
+              import { composePlugins } from '@nx/rspack';
 
-      import baseConfig from './module-federation.config';
+              import baseConfig from './module-federation.config';
 
-      const config = {
-        ...baseConfig,
-      };
+              const config = {
+                ...baseConfig,
+              };
 
-      // Nx plugins for webpack to build config object from Nx options and context.
-      /**
-       * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
-       * The DTS Plugin can be enabled by setting dts: true
-       * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
-       */
-      export default composePlugins(
-        withNx(),
-        withReact({ useLegacyHtmlPlugin: true }),
-        withModuleFederation(config, { dts: false })
-      );
-      "
-    `);
-    expect(tree.exists('remote2/rspack.config.prod.ts')).toBeTruthy();
-    expect(tree.read('remote2/rspack.config.prod.ts', 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "export default require('./rspack.config');
-      "
-    `);
-    expect(project.targets.build).toMatchInlineSnapshot(`
-      {
-        "configurations": {
-          "development": {
-            "extractLicenses": false,
-            "optimization": false,
-            "sourceMap": true,
-            "vendorChunk": true,
-          },
-          "production": {
-            "extractLicenses": true,
-            "fileReplacements": [
+              // Nx plugins for webpack to build config object from Nx options and context.
+              /**
+               * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+               * The DTS Plugin can be enabled by setting dts: true
+               * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+               */
+              export default composePlugins(
+                withNx(),
+                withReact({ useLegacyHtmlPlugin: true }),
+                withModuleFederation(config, { dts: false })
+              );
+              "
+          `);
+      expect(tree.exists('remote1/rspack.config.prod.ts')).toBeTruthy();
+      expect(tree.read('remote1/rspack.config.prod.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+              "export default require('./rspack.config');
+              "
+          `);
+      expect(project.targets.build).toMatchInlineSnapshot(`
               {
-                "replace": "demo/src/environments/environment.ts",
-                "with": "demo/src/environments/environment.prod.ts",
-              },
-            ],
-            "namedChunks": false,
-            "optimization": true,
-            "outputHashing": "all",
-            "rspackConfig": "demo/rspack.config.prod.ts",
-            "sourceMap": false,
-            "vendorChunk": false,
-          },
-        },
-        "defaultConfiguration": "production",
-        "executor": "@nx/rspack:rspack",
-        "options": {
-          "assets": [
-            "demo/src/favicon.ico",
-            "demo/src/assets",
-          ],
-          "baseHref": "/",
-          "compiler": "babel",
-          "index": "demo/src/index.html",
-          "main": "demo/src/main.ts",
-          "outputPath": "dist/demo",
-          "rspackConfig": "demo/rspack.config.ts",
-          "scripts": [],
-          "styles": [
-            "demo/src/styles.css",
-          ],
-          "target": "web",
-          "tsConfig": "demo/tsconfig.app.json",
-        },
-        "outputs": [
-          "{options.outputPath}",
-        ],
-      }
-    `);
-    expect(project.targets.serve).toMatchInlineSnapshot(`
-      {
-        "configurations": {
-          "development": {
-            "buildTarget": "demo:build:development",
-          },
-          "production": {
-            "buildTarget": "demo:build:production",
-            "hmr": false,
-          },
-        },
-        "defaultConfiguration": "development",
-        "executor": "@nx/rspack:module-federation-dev-server",
-        "options": {
-          "buildTarget": "demo:build",
-          "hmr": true,
-          "port": 4200,
-        },
-      }
-    `);
+                "configurations": {
+                  "development": {
+                    "extractLicenses": false,
+                    "optimization": false,
+                    "sourceMap": true,
+                    "vendorChunk": true,
+                  },
+                  "production": {
+                    "extractLicenses": true,
+                    "fileReplacements": [
+                      {
+                        "replace": "demo/src/environments/environment.ts",
+                        "with": "demo/src/environments/environment.prod.ts",
+                      },
+                    ],
+                    "namedChunks": false,
+                    "optimization": true,
+                    "outputHashing": "all",
+                    "rspackConfig": "demo/rspack.config.prod.ts",
+                    "sourceMap": false,
+                    "vendorChunk": false,
+                  },
+                },
+                "defaultConfiguration": "production",
+                "executor": "@nx/rspack:rspack",
+                "options": {
+                  "assets": [
+                    "demo/src/favicon.ico",
+                    "demo/src/assets",
+                  ],
+                  "baseHref": "/",
+                  "compiler": "babel",
+                  "index": "demo/src/index.html",
+                  "main": "demo/src/main.ts",
+                  "outputPath": "dist/demo",
+                  "rspackConfig": "demo/rspack.config.ts",
+                  "scripts": [],
+                  "styles": [
+                    "demo/src/styles.css",
+                  ],
+                  "target": "web",
+                  "tsConfig": "demo/tsconfig.app.json",
+                },
+                "outputs": [
+                  "{options.outputPath}",
+                ],
+              }
+          `);
+      expect(project.targets.serve).toMatchInlineSnapshot(`
+              {
+                "configurations": {
+                  "development": {
+                    "buildTarget": "demo:build:development",
+                  },
+                  "production": {
+                    "buildTarget": "demo:build:production",
+                    "hmr": false,
+                  },
+                },
+                "defaultConfiguration": "development",
+                "executor": "@nx/rspack:module-federation-dev-server",
+                "options": {
+                  "buildTarget": "demo:build",
+                  "hmr": true,
+                  "port": 4200,
+                },
+              }
+          `);
+
+      const remote2 = readProjectConfiguration(tree, 'remote2');
+
+      expect(tree.exists('remote2/rspack.config.ts')).toBeTruthy();
+      expect(tree.read('remote2/rspack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+              "import { withModuleFederation } from '@nx/module-federation/rspack.js';
+              import { withReact } from '@nx/rspack';
+              import { withNx } from '@nx/rspack';
+              import { composePlugins } from '@nx/rspack';
+
+              import baseConfig from './module-federation.config';
+
+              const config = {
+                ...baseConfig,
+              };
+
+              // Nx plugins for webpack to build config object from Nx options and context.
+              /**
+               * DTS Plugin is disabled in Nx Workspaces as Nx already provides Typing support Module Federation
+               * The DTS Plugin can be enabled by setting dts: true
+               * Learn more about the DTS Plugin here: https://module-federation.io/configure/dts.html
+               */
+              export default composePlugins(
+                withNx(),
+                withReact({ useLegacyHtmlPlugin: true }),
+                withModuleFederation(config, { dts: false })
+              );
+              "
+          `);
+      expect(tree.exists('remote2/rspack.config.prod.ts')).toBeTruthy();
+      expect(tree.read('remote2/rspack.config.prod.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+              "export default require('./rspack.config');
+              "
+          `);
+      expect(project.targets.build).toMatchInlineSnapshot(`
+              {
+                "configurations": {
+                  "development": {
+                    "extractLicenses": false,
+                    "optimization": false,
+                    "sourceMap": true,
+                    "vendorChunk": true,
+                  },
+                  "production": {
+                    "extractLicenses": true,
+                    "fileReplacements": [
+                      {
+                        "replace": "demo/src/environments/environment.ts",
+                        "with": "demo/src/environments/environment.prod.ts",
+                      },
+                    ],
+                    "namedChunks": false,
+                    "optimization": true,
+                    "outputHashing": "all",
+                    "rspackConfig": "demo/rspack.config.prod.ts",
+                    "sourceMap": false,
+                    "vendorChunk": false,
+                  },
+                },
+                "defaultConfiguration": "production",
+                "executor": "@nx/rspack:rspack",
+                "options": {
+                  "assets": [
+                    "demo/src/favicon.ico",
+                    "demo/src/assets",
+                  ],
+                  "baseHref": "/",
+                  "compiler": "babel",
+                  "index": "demo/src/index.html",
+                  "main": "demo/src/main.ts",
+                  "outputPath": "dist/demo",
+                  "rspackConfig": "demo/rspack.config.ts",
+                  "scripts": [],
+                  "styles": [
+                    "demo/src/styles.css",
+                  ],
+                  "target": "web",
+                  "tsConfig": "demo/tsconfig.app.json",
+                },
+                "outputs": [
+                  "{options.outputPath}",
+                ],
+              }
+          `);
+      expect(project.targets.serve).toMatchInlineSnapshot(`
+              {
+                "configurations": {
+                  "development": {
+                    "buildTarget": "demo:build:development",
+                  },
+                  "production": {
+                    "buildTarget": "demo:build:production",
+                    "hmr": false,
+                  },
+                },
+                "defaultConfiguration": "development",
+                "executor": "@nx/rspack:module-federation-dev-server",
+                "options": {
+                  "buildTarget": "demo:build",
+                  "hmr": true,
+                  "port": 4200,
+                },
+              }
+          `);
+    });
   });
 });

--- a/packages/rspack/src/generators/convert-webpack/lib/transform-plugin-config.ts
+++ b/packages/rspack/src/generators/convert-webpack/lib/transform-plugin-config.ts
@@ -1,0 +1,135 @@
+import { type Tree } from '@nx/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import * as ts from 'typescript';
+
+export function transformPluginConfig(tree: Tree, webpackConfigPath: string) {
+  const webpackConfigContents = tree.read(webpackConfigPath, 'utf-8');
+  const ast = tsquery.ast(webpackConfigContents);
+  let newConfigContents = webpackConfigContents;
+  if (webpackConfigContents.includes("require('@nx/webpack/app-plugin')")) {
+    newConfigContents = transformCjsConfig(tree, webpackConfigContents, ast);
+  } else {
+    newConfigContents = transformEsmConfig(tree, webpackConfigContents, ast);
+  }
+  tree.write(webpackConfigPath, newConfigContents);
+}
+
+function transformCjsConfig(
+  tree: Tree,
+  webpackConfigContents: string,
+  ast: ts.SourceFile
+) {
+  // Convert require('@nx/webpack/app-plugin') to require('@nx/rspack/app-plugin')
+  const WEBPACK_APP_PLUGIN_REQUIRE_SELECTOR =
+    'CallExpression:has(Identifier[name=require]) > StringLiteral[value=@nx/webpack/app-plugin]';
+  let nodes = tsquery(ast, WEBPACK_APP_PLUGIN_REQUIRE_SELECTOR, {
+    visitAllChildren: true,
+  });
+  if (nodes.length === 0) {
+    return webpackConfigContents;
+  }
+
+  const requireNode = nodes[0];
+  webpackConfigContents = `${webpackConfigContents.slice(
+    0,
+    requireNode.getStart()
+  )}'@nx/rspack/app-plugin'${webpackConfigContents.slice(
+    requireNode.getEnd()
+  )}`;
+
+  // Convert const { NxAppWebpackPlugin } to const { NxAppRspackPlugin }
+  ast = tsquery.ast(webpackConfigContents);
+
+  const WEBPACK_APP_BINDING_ELEMENT_SELECTOR =
+    'BindingElement:has(Identifier[name=NxAppWebpackPlugin])';
+
+  nodes = tsquery(ast, WEBPACK_APP_BINDING_ELEMENT_SELECTOR, {
+    visitAllChildren: true,
+  });
+  if (nodes.length === 0) {
+    return webpackConfigContents;
+  }
+  const bindingElement = nodes[0];
+  webpackConfigContents = `${webpackConfigContents.slice(
+    0,
+    bindingElement.getStart()
+  )}NxAppRspackPlugin${webpackConfigContents.slice(bindingElement.getEnd())}`;
+
+  // Convert new NxAppWebpackPlugin() to new NxAppRspackPlugin()
+  ast = tsquery.ast(webpackConfigContents);
+
+  const WEBPACK_APP_INSTANTIATION_SELECTOR =
+    'NewExpression > Identifier[name=NxAppWebpackPlugin]';
+  nodes = tsquery(ast, WEBPACK_APP_INSTANTIATION_SELECTOR, {
+    visitAllChildren: true,
+  });
+  if (nodes.length === 0) {
+    return webpackConfigContents;
+  }
+  const instantiation = nodes[0];
+  webpackConfigContents = `${webpackConfigContents.slice(
+    0,
+    instantiation.getStart()
+  )}NxAppRspackPlugin${webpackConfigContents.slice(instantiation.getEnd())}`;
+
+  return webpackConfigContents;
+}
+
+function transformEsmConfig(
+  tree: Tree,
+  webpackConfigContents: string,
+  ast: ts.SourceFile
+) {
+  // Convert from '@nx/webpack/app-plugin' to from '@nx/rspack/app-plugin'
+  const WEBPACK_APP_PLUGIN_IMPORT_SELECTOR =
+    'ImportClause ~ StringLiteral[value=@nx/webpack/app-plugin]';
+  let nodes = tsquery(ast, WEBPACK_APP_PLUGIN_IMPORT_SELECTOR, {
+    visitAllChildren: true,
+  });
+  if (nodes.length === 0) {
+    return webpackConfigContents;
+  }
+
+  const importNode = nodes[0];
+  webpackConfigContents = `${webpackConfigContents.slice(
+    0,
+    importNode.getStart()
+  )}'@nx/rspack/app-plugin'${webpackConfigContents.slice(importNode.getEnd())}`;
+
+  // Convert import { NxAppWebpackPlugin } to import { NxAppRspackPlugin }
+  ast = tsquery.ast(webpackConfigContents);
+
+  const WEBPACK_APP_IMPORT_SPECIFIER_SELECTOR =
+    'ImportSpecifier > Identifier[name=NxAppWebpackPlugin]';
+
+  nodes = tsquery(ast, WEBPACK_APP_IMPORT_SPECIFIER_SELECTOR, {
+    visitAllChildren: true,
+  });
+  if (nodes.length === 0) {
+    return webpackConfigContents;
+  }
+  const importSpecifier = nodes[0];
+  webpackConfigContents = `${webpackConfigContents.slice(
+    0,
+    importSpecifier.getStart()
+  )}NxAppRspackPlugin${webpackConfigContents.slice(importSpecifier.getEnd())}`;
+
+  // Convert new NxAppWebpackPlugin() to new NxAppRspackPlugin()
+  ast = tsquery.ast(webpackConfigContents);
+
+  const WEBPACK_APP_INSTANTIATION_SELECTOR =
+    'NewExpression > Identifier[name=NxAppWebpackPlugin]';
+  nodes = tsquery(ast, WEBPACK_APP_INSTANTIATION_SELECTOR, {
+    visitAllChildren: true,
+  });
+  if (nodes.length === 0) {
+    return webpackConfigContents;
+  }
+  const instantiation = nodes[0];
+  webpackConfigContents = `${webpackConfigContents.slice(
+    0,
+    instantiation.getStart()
+  )}NxAppRspackPlugin${webpackConfigContents.slice(instantiation.getEnd())}`;
+
+  return webpackConfigContents;
+}

--- a/packages/rspack/tsconfig.json
+++ b/packages/rspack/tsconfig.json
@@ -13,13 +13,16 @@
       "path": "../web"
     },
     {
-      "path": "../nx"
-    },
-    {
       "path": "../devkit"
     },
     {
       "path": "../js"
+    },
+    {
+      "path": "../nest"
+    },
+    {
+      "path": "../nx"
     },
     {
       "path": "./tsconfig.lib.json"

--- a/packages/rspack/tsconfig.lib.json
+++ b/packages/rspack/tsconfig.lib.json
@@ -17,13 +17,16 @@
       "path": "../web/tsconfig.lib.json"
     },
     {
-      "path": "../nx/tsconfig.lib.json"
-    },
-    {
       "path": "../devkit/tsconfig.lib.json"
     },
     {
       "path": "../js/tsconfig.lib.json"
+    },
+    {
+      "path": "../nest/tsconfig.lib.json"
+    },
+    {
+      "path": "../nx/tsconfig.lib.json"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3736,6 +3736,9 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
     devDependencies:
+      '@nx/nest':
+        specifier: workspace:*
+        version: link:../nest
       nx:
         specifier: workspace:*
         version: link:../nx


### PR DESCRIPTION
## Current Behavior
We currently do not support converting webpack configs using `NxAppWebpackPlugin` to `NxAppRspackPlugin`.

## Expected Behavior
Add support for converting webpack configs using the `NxAppWebpackPlugin`.

## Related Issue(s)

Fixes #30292
