### PR TITLE
fix(js): esm loader should handle absolute paths on windows #32376

### DIFF
--- a/packages/js/src/executors/node/node-with-esm-loader.ts
+++ b/packages/js/src/executors/node/node-with-esm-loader.ts
@@ -9,7 +9,7 @@ async function main() {
   try {
     // Register ESM loader for workspace path mappings
     register(
-      path.join(__dirname, 'lib', 'esm-loader.js'),
+      pathToFileURL(path.join(__dirname, 'lib', 'esm-loader.js')).href,
       pathToFileURL(__filename)
     );
 

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -180,7 +180,7 @@ export async function* nodeExecutor(
                 : 'node-with-require-overrides';
 
             task.childProcess = fork(
-              joinPathFragments(__dirname, loaderFile),
+              join(__dirname, loaderFile),
               options.args ?? [],
               {
                 execArgv: getExecArgv(options),


### PR DESCRIPTION
## Current Behavior
ESM Loader for Windows is not working because it is encountering an absolute path that is not using the `file://` protocol.

## Expected Behavior
Ensure that when loading the `esm-loader`, it uses the file protocol

## Related Issue(s)

Fixes #32376
