### PR TITLE
fix(module-federation): update default shared packages for Angular to include rxjs-interop

### DIFF
--- a/packages/module-federation/src/with-module-federation/angular/utils.ts
+++ b/packages/module-federation/src/with-module-federation/angular/utils.ts
@@ -24,17 +24,6 @@ export function applyDefaultEagerPackages(
   const DEFAULT_PACKAGES_TO_LOAD_EAGERLY = [
     '@angular/localize',
     '@angular/localize/init',
-    ...(useRspack
-      ? [
-          '@angular/core',
-          '@angular/core/primitives/signals',
-          '@angular/core/event-dispatch',
-          '@angular/core/rxjs-interop',
-          '@angular/common',
-          '@angular/common/http',
-          '@angular/platform-browser',
-        ]
-      : []),
   ];
   for (const pkg of DEFAULT_PACKAGES_TO_LOAD_EAGERLY) {
     if (!sharedConfig[pkg]) {
@@ -53,8 +42,13 @@ export const DEFAULT_NPM_PACKAGES_TO_AVOID = [
 ];
 export const DEFAULT_ANGULAR_PACKAGES_TO_SHARE = [
   '@angular/core',
+  '@angular/core/primitives/signals',
+  '@angular/core/event-dispatch',
+  '@angular/core/rxjs-interop',
   '@angular/animations',
   '@angular/common',
+  '@angular/common/http',
+  '@angular/platform-browser',
 ];
 
 export function getFunctionDeterminateRemoteUrl(

--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
@@ -65,6 +65,11 @@ export async function withModuleFederation(
            * Apply user-defined config override
            */
           ...(configOverride ? configOverride : {}),
+          experiments: {
+            asyncStartup: true,
+            // We should allow users to override experiments
+            ...(configOverride?.experiments ?? {}),
+          },
           runtimePlugins:
             process.env.NX_MF_DEV_REMOTES &&
             !options.disableNxRuntimeLibraryControlPlugin

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
@@ -63,6 +63,11 @@ export async function withModuleFederation(
          * Apply user-defined config overrides
          */
         ...(configOverride ? configOverride : {}),
+        experiments: {
+          asyncStartup: true,
+          // We should allow users to override experiments
+          ...(configOverride?.experiments ?? {}),
+        },
         runtimePlugins:
           process.env.NX_MF_DEV_REMOTES &&
           !options.disableNxRuntimeLibraryControlPlugin


### PR DESCRIPTION
- Add @angular/core/primitives/signals, @angular/core/event-dispatch, and @angular/core/rxjs-interop to DEFAULT_ANGULAR_PACKAGES_TO_SHARE
- Add @angular/common/http and @angular/platform-browser to default shared packages
- Make eager loading packages consistent between webpack and rspack by removing useRspack conditional

This ensures that Angular packages like @angular/core/rxjs-interop are shared by default in module federation setups,
preventing runtime errors when remotes use these packages but hosts don't.

Fixes #32316
