### PR TITLE
fix(core): fail fast when running commands in parallel

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -1,11 +1,11 @@
 import { readFileSync, writeFileSync } from 'fs';
+import { env } from 'npm-run-path';
 import { relative } from 'path';
 import { dirSync, fileSync } from 'tmp';
 import runCommands, {
   interpolateArgsIntoCommand,
   LARGE_BUFFER,
 } from './run-commands.impl';
-import { env } from 'npm-run-path';
 
 function normalize(p: string) {
   return p.startsWith('/private') ? p.substring(8) : p;
@@ -958,6 +958,102 @@ describe('Run Commands', () => {
           `no such file or directory, open '/somePath/.fakeEnv'`
         );
       }
+    });
+  });
+
+  describe('fail-fast behavior in parallel execution', () => {
+    it('should exit immediately when one parallel command fails', async () => {
+      const startTime = Date.now();
+
+      const result = await runCommands(
+        {
+          commands: [
+            `echo "command1" && exit 1`, // Fails immediately
+            `echo "command2" && sleep 2`, // Would take 2 seconds if not terminated
+          ],
+          parallel: true,
+          __unparsed__: [],
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      const duration = Date.now() - startTime;
+      // Should complete quickly (fail-fast), not wait for 2 seconds
+      expect(duration).toBeLessThan(500);
+    });
+
+    it('should handle multiple simultaneous failures in parallel commands', async () => {
+      const result = await runCommands(
+        {
+          commands: [
+            `echo "fail1" && exit 1`,
+            `echo "fail2" && exit 2`,
+            `echo "fail3" && exit 3`,
+          ],
+          parallel: true,
+          __unparsed__: [],
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should succeed when all parallel commands succeed', async () => {
+      const result = await runCommands(
+        {
+          commands: [`echo "success1"`, `echo "success2"`, `echo "success3"`],
+          parallel: true,
+          __unparsed__: [],
+        },
+        context
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should terminate remaining processes when one fails in parallel', async () => {
+      const f = fileSync().name;
+      const flagFile = fileSync().name;
+
+      const result = await runCommands(
+        {
+          commands: [
+            `echo "quick" >> ${f} && exit 1`, // Fails immediately
+            `sleep 0.5 && echo "should_not_appear" >> ${flagFile}`, // Should be terminated
+          ],
+          parallel: true,
+          __unparsed__: [],
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(readFile(flagFile)).toBe(''); // didn't write should_not_appear
+    });
+
+    it('should handle process cleanup correctly on failure', async () => {
+      const startTime = Date.now();
+
+      const result = await runCommands(
+        {
+          commands: [
+            'exit 1', // Fail immediately
+            'sleep 2', // Long-running process
+            'sleep 2', // Another long-running process
+            'sleep 2', // Yet another long-running process
+          ],
+          parallel: true,
+          __unparsed__: [],
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      const duration = Date.now() - startTime;
+      // Should complete quickly after failure and cleanup
+      expect(duration).toBeLessThan(500);
     });
   });
 });

--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -122,33 +122,59 @@ export class ParallelRunningTasks implements RunningTask {
         cb(code, terminalOutput);
       }
     } else {
-      const results = await Promise.all(
+      const runningProcesses = new Set<RunningNodeProcess>();
+      let hasFailure = false;
+      let failureDetails: {
+        childProcess: RunningNodeProcess;
+        code: number;
+        terminalOutput: string;
+      } | null = null;
+      const terminalOutputs = new Map<RunningNodeProcess, string>();
+
+      await Promise.allSettled(
         this.childProcesses.map(async (childProcess) => {
+          runningProcesses.add(childProcess);
+
           childProcess.onOutput((terminalOutput) => {
             for (const cb of this.outputCallbacks) {
               cb(terminalOutput);
             }
           });
-          const result = await childProcess.getResults();
-          return {
-            childProcess,
-            result,
-          };
+
+          // Create a promise that will resolve when the process exits
+          return new Promise<{
+            childProcess: RunningNodeProcess;
+            result: { code: number; terminalOutput: string };
+          }>((resolve) => {
+            childProcess.onExit(async (code, terminalOutput) => {
+              terminalOutputs.set(childProcess, terminalOutput);
+
+              if (code !== 0 && !hasFailure) {
+                hasFailure = true;
+                failureDetails = { childProcess, code, terminalOutput };
+
+                // Immediately terminate all other running processes
+                await this.terminateRemainingProcesses(
+                  runningProcesses,
+                  childProcess
+                );
+              }
+
+              runningProcesses.delete(childProcess);
+              resolve({
+                childProcess,
+                result: { code, terminalOutput },
+              });
+            });
+          });
         })
       );
 
-      let terminalOutput = results
-        .map((r) => r.result.terminalOutput)
-        .join('\r\n');
+      let terminalOutput = Array.from(terminalOutputs.values()).join('\r\n');
 
-      const failed = results.filter((result) => result.result.code !== 0);
-      if (failed.length > 0) {
-        const output = failed
-          .map(
-            (failedResult) =>
-              `Warning: command "${failedResult.childProcess.command}" exited with non-zero status code`
-          )
-          .join('\r\n');
+      if (hasFailure && failureDetails) {
+        // Add failure message
+        const output = `Warning: command "${failureDetails.childProcess.command}" exited with non-zero status code`;
         terminalOutput += output;
         if (this.streamOutput) {
           process.stderr.write(output);
@@ -162,6 +188,41 @@ export class ParallelRunningTasks implements RunningTask {
           cb(0, terminalOutput);
         }
       }
+    }
+  }
+
+  private async terminateRemainingProcesses(
+    runningProcesses: Set<RunningNodeProcess>,
+    failedProcess: RunningNodeProcess
+  ): Promise<void> {
+    const terminationPromises: Promise<void>[] = [];
+
+    const processesToTerminate = [...runningProcesses].filter(
+      (p) => p !== failedProcess
+    );
+    for (const process of processesToTerminate) {
+      runningProcesses.delete(process);
+
+      // Terminate the process
+      terminationPromises.push(
+        process.kill('SIGTERM').catch((err) => {
+          // Log error but don't fail the entire operation
+          if (this.streamOutput) {
+            console.error(
+              `Failed to terminate process "${process.command}":`,
+              err
+            );
+          }
+        })
+      );
+    }
+
+    // Wait for all terminations to complete with a timeout
+    if (terminationPromises.length > 0) {
+      await Promise.race([
+        Promise.all(terminationPromises),
+        new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+      ]);
     }
   }
 }


### PR DESCRIPTION
## Current Behavior

When running commands in parallel with `nx:run-commands`, if a command fails, others are not stopped, and the task continues until all commands finish. This means that if a long-running command is running, it won't be stopped when other commands have already failed.

## Expected Behavior

`nx:run-commands` should fail fast. In a parallel execution, the rest of the running commands should be terminated if a command fails.

## Related Issue(s)

Fixes #28477 
