### PR TITLE
fix(release): publish only projects that have a new version

### DIFF
--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -403,8 +403,15 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     }
 
     if (shouldPublish) {
+      const projectsToPublish = Object.entries(
+        versionResult.projectsVersionData
+      )
+        .filter(([, versionDataEntry]) => versionDataEntry.newVersion !== null)
+        .map(([name]) => name);
+
       const publishResults = await releasePublish({
         ...args,
+        projects: projectsToPublish,
         versionData: versionResult.projectsVersionData,
       });
       const allExitOk = Object.values(publishResults).every(


### PR DESCRIPTION

## Current Behavior

IF
there is a change in the repository, committed in a way that results in a new version for any project in the graph
THEN
`releasePublish` is called for all projects in the graph

For example:
IF
- a repo has only two independent projects A, B
- both A and B have already been released and published, and the repo is tagged with *A@0.0.0* and *B@0.0.0*
- there is a new commit that modifies B: *feat(B): New feature only for B*

THEN
- calling `nx release --yes` will end up calling `nx-release-publish` for both A and B 
- because *A* has not changed, it will attempt to (re)publish it with version 0.0.0

## Expected Behavior

Only the projects that have a new version should be published by default. This is more similar to the "affected" behavior.
Other behaviors are always possible by using the programmatic API.

For example:
In the example from above, only *B* would be published.

