### PR TITLE
docs(misc): add buildkite ci

### DIFF
--- a/docs/generated/manifests/ci.json
+++ b/docs/generated/manifests/ci.json
@@ -424,6 +424,17 @@
             "tags": []
           },
           {
+            "id": "monorepo-ci-buildkite",
+            "name": "Setting up Buildkite",
+            "description": "",
+            "mediaImage": "",
+            "file": "shared/monorepo-ci-buildkite",
+            "itemList": [],
+            "isExternal": false,
+            "path": "/ci/recipes/set-up/monorepo-ci-buildkite",
+            "tags": []
+          },
+          {
             "id": "monorepo-ci-circle-ci",
             "name": "Setting up CircleCI",
             "description": "",
@@ -921,6 +932,17 @@
         "tags": []
       },
       {
+        "id": "monorepo-ci-buildkite",
+        "name": "Setting up Buildkite",
+        "description": "",
+        "mediaImage": "",
+        "file": "shared/monorepo-ci-buildkite",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/ci/recipes/set-up/monorepo-ci-buildkite",
+        "tags": []
+      },
+      {
         "id": "monorepo-ci-circle-ci",
         "name": "Setting up CircleCI",
         "description": "",
@@ -989,6 +1011,17 @@
     "itemList": [],
     "isExternal": false,
     "path": "/ci/recipes/set-up/monorepo-ci-azure",
+    "tags": []
+  },
+  "/ci/recipes/set-up/monorepo-ci-buildkite": {
+    "id": "monorepo-ci-buildkite",
+    "name": "Setting up Buildkite",
+    "description": "",
+    "mediaImage": "",
+    "file": "shared/monorepo-ci-buildkite",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/ci/recipes/set-up/monorepo-ci-buildkite",
     "tags": []
   },
   "/ci/recipes/set-up/monorepo-ci-circle-ci": {

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -6982,6 +6982,14 @@
                 "disableCollapsible": false
               },
               {
+                "name": "Setting up Buildkite",
+                "path": "/ci/recipes/set-up/monorepo-ci-buildkite",
+                "id": "monorepo-ci-buildkite",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
+              },
+              {
                 "name": "Setting up CircleCI",
                 "path": "/ci/recipes/set-up/monorepo-ci-circle-ci",
                 "id": "monorepo-ci-circle-ci",

--- a/docs/map.json
+++ b/docs/map.json
@@ -2661,6 +2661,11 @@
                   "file": "shared/monorepo-ci-azure"
                 },
                 {
+                  "name": "Setting up Buildkite",
+                  "id": "monorepo-ci-buildkite",
+                  "file": "shared/monorepo-ci-buildkite"
+                },
+                {
                   "name": "Setting up CircleCI",
                   "id": "monorepo-ci-circle-ci",
                   "file": "shared/monorepo-ci-circle-ci"

--- a/docs/shared/monorepo-ci-buildkite.md
+++ b/docs/shared/monorepo-ci-buildkite.md
@@ -1,0 +1,8 @@
+---
+title: Configuring CI Using Buildkite and Nx
+description: Learn how to set up Buildkite for your Nx workspace to run affected commands, retrieve previous successful builds, and optimize CI performance.
+---
+
+# Configuring CI Using Buildkite and Nx
+
+Coming soon!

--- a/docs/shared/monorepo-ci-buildkite.md
+++ b/docs/shared/monorepo-ci-buildkite.md
@@ -5,4 +5,36 @@ description: Learn how to set up Buildkite for your Nx workspace to run affected
 
 # Configuring CI Using Buildkite and Nx
 
-Coming soon!
+Below is an example of a Buildkite setup, building, and testing only what is affected.
+
+```yaml {% fileName=".buildkite/pipeline.yml" %}
+steps:
+  - label: "Run nx affected"
+    commands:
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this
+      # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
+      # - npx nx-cloud record -- echo Hello World
+
+      # NX_BASE AND NX_HEAD env vars will be set by
+      # the nx-set-shas plugin.
+      - npx nx affected -t lint test build
+      # Nx Cloud recommends fixes for failures to help you get CI green faster.
+      # Learn more: https://nx.dev/ci/features/self-healing-ci
+      - npx nx fix-ci
+    plugins:
+      - secrets:
+          variables:
+            GRAPHQL_API_TOKEN: GRAPHQL_API_TOKEN
+      - nx-set-shas
+```
+
+### Get the Commit of the Last Successful Build
+
+The Buildkite GraphQL API can be used to get the last successful run on the `main` branch and use this as a reference point for `NX_BASE`. The [nx-set-shas](https://github.com/buildkite-plugins/nx-set-shas-buildkite-plugin) plugin provides a convenient implementation of this functionality that you can drop into your existing CI pipeline.
+
+To understand why knowing the last successful build is important for the `affected` command, check out the in-depth explanation [in the Nx documentation](https://nx.dev/ci/features/affected).

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -840,6 +840,7 @@
     - [Improving your Time to Green (TTG)](/ci/recipes/improving-ttg)
     - [Set Up CI](/ci/recipes/set-up)
       - [Setting up Azure Pipelines](/ci/recipes/set-up/monorepo-ci-azure)
+      - [Setting up Buildkite](/ci/recipes/set-up/monorepo-ci-buildkite)
       - [Setting up CircleCI](/ci/recipes/set-up/monorepo-ci-circle-ci)
       - [Setting up GitHub Actions](/ci/recipes/set-up/monorepo-ci-github-actions)
       - [Setting up Jenkins](/ci/recipes/set-up/monorepo-ci-jenkins)


### PR DESCRIPTION
(I've deleted the template in the PR description because none of the headings apply to this commit.)

This PR adds documentation for how to use Nx in Buildkite using the plugin [`nx-set-shas`](https://github.com/buildkite-plugins/nx-set-shas-buildkite-plugin) that is similar to the GitHub Actions and Circle CI Orb plugins.