### PR TITLE
chore(testing): temporarily disable failing module federation tests

### DIFF
--- a/e2e/angular/src/module-federation.test.ts
+++ b/e2e/angular/src/module-federation.test.ts
@@ -15,7 +15,8 @@ import {
 } from '@nx/e2e-utils';
 import { join } from 'path';
 
-describe('Angular Module Federation', () => {
+// TODO(@Coly010): Please re-enable this when the test is fixed.
+xdescribe('Angular Module Federation', () => {
   let proj: string;
   let oldVerboseLoggingValue: string;
 

--- a/e2e/next/src/next-storybook.test.ts
+++ b/e2e/next/src/next-storybook.test.ts
@@ -6,7 +6,8 @@ import {
   uniq,
 } from '@nx/e2e-utils';
 
-describe('Next.js Storybook', () => {
+// TODO(@Coly010): Please re-enable this when the test is fixed.
+xdescribe('Next.js Storybook', () => {
   const appName = uniq('app');
   beforeAll(() => {
     newProject({

--- a/e2e/react/src/module-federation/core.webpack.test.ts
+++ b/e2e/react/src/module-federation/core.webpack.test.ts
@@ -15,7 +15,8 @@ import {
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 
-describe('React Module Federation', () => {
+// TODO(@Coly010): Please re-enable this when the test is fixed.
+xdescribe('React Module Federation', () => {
   describe('Default Configuration', () => {
     beforeAll(() => {
       newProject({ packages: ['@nx/react', '@nx/webpack'] });

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -14,7 +14,8 @@ import {
 } from '@nx/e2e-utils';
 import { runCLI } from './utils';
 
-describe('Dynamic Module Federation', () => {
+// TODO(@Coly010): Please re-enable this when the test is fixed.
+xdescribe('Dynamic Module Federation', () => {
   beforeAll(() => {
     newProject({ packages: ['@nx/react'] });
   });

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -10,7 +10,8 @@ import {
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 
-describe('Federate Module', () => {
+// TODO(@Coly010): Please re-enable this when the test is fixed.
+xdescribe('Federate Module', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -12,7 +12,8 @@ import {
 import { stripIndents } from 'nx/src/utils/strip-indents';
 import { readPort, runCLI } from './utils';
 
-describe('Independent Deployability', () => {
+// TODO(@Coly010): Please re-enable this when the test is fixed.
+xdescribe('Independent Deployability', () => {
   let proj: string;
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';

--- a/e2e/react/src/module-federation/misc.rspack.test.ts
+++ b/e2e/react/src/module-federation/misc.rspack.test.ts
@@ -11,7 +11,8 @@ import {
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
 
-describe('React Rspack Module Federation Misc', () => {
+// TODO(@Coly010): Please re-enable this when the test is fixed.
+xdescribe('React Rspack Module Federation Misc', () => {
   describe('Convert To Rspack', () => {
     beforeAll(() => {
       process.env.NX_ADD_PLUGINS = 'false';


### PR DESCRIPTION
Temporarily disables failing module federation e2e tests with TODO comments for @Coly010 to re-enable once fixed.