### PR TITLE
chore(angular-rspack): ensure details and codeowners are correct

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,9 @@ rust-toolchain.toml @nrwl/nx-native-reviewers
 /docs/generated/packages/angular/** @nrwl/nx-angular-reviewers @nrwl/nx-docs-reviewers
 /docs/shared/packages/angular/** @nrwl/nx-angular-reviewers @nrwl/nx-docs-reviewers
 /packages/angular/** @nrwl/nx-angular-reviewers
+/packages/angular-rspack/** @nrwl/nx-angular-reviewers
+/packages/angular-rspack-compiler/** @nrwl/nx-angular-reviewers
+/examples/angular-rspack/** @nrwl/nx-angular-reviewers
 /e2e/angular/** @nrwl/nx-angular-reviewers
 /packages/angular/plugins/component-testing.ts @nrwl/nx-angular-reviewers @nrwl/nx-testing-tools-reviewers
 /packages/angular/src/generators/cypress-component-configuration/** @nrwl/nx-angular-reviewers @nrwl/nx-testing-tools-reviewers

--- a/packages/angular-rspack-compiler/README.md__tpl__
+++ b/packages/angular-rspack-compiler/README.md__tpl__
@@ -20,5 +20,3 @@ An AI-first build platform that connects everything from your editor to CI. Help
 This library provides utilities for compiling Angular applications with Rspack.
 
 {{content}}
-
-{{resources}}

--- a/packages/angular-rspack-compiler/package.json
+++ b/packages/angular-rspack-compiler/package.json
@@ -8,6 +8,7 @@
   "description": "Compilation utilities for Angular with Rspack and Rsbuild.",
   "author": "Victor Savkin",
   "license": "MIT",
+  "homepage": "https://nx.dev",
   "bugs": {
     "url": "https://github.com/nrwl/nx/issues"
   },

--- a/packages/angular-rspack/README.md__tpl__
+++ b/packages/angular-rspack/README.md__tpl__
@@ -46,5 +46,3 @@ npx nx serve myorg
 ```
 
 {{content}}
-
-{{resources}}

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -8,6 +8,7 @@
   "description": "Rspack Plugin and Loaders for building Angular.",
   "author": "Victor Savkin",
   "license": "MIT",
+  "homepage": "https://nx.dev",
   "bugs": {
     "url": "https://github.com/nrwl/nx/issues"
   },


### PR DESCRIPTION
Fix details regarding codeowners and package info for angular-rspack and angular-rspack-compiler
