### PR TITLE
docs(docker): remove @nx/docker@next in guides since it is in latest

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
@@ -4,9 +4,6 @@ description: Learn how to use Nx Release to version and publish Docker images fr
 ---
 
 
-{% aside type="caution" title="Docker is Experimental" %}
-Docker support in Nx Release is currently experimental and only available in the `next`/`beta` version. It may undergo breaking changes without following semantic versioning.
-{% /aside %}
 
 This guide walks you through setting up Nx Release to version and publish Docker images from your monorepo using calendar-based versioning.
 
@@ -18,12 +15,10 @@ Before starting, ensure you have:
 
 1. Docker installed and running locally
 2. Run `docker login` to authenticate with your Docker registry (e.g., `docker login docker.io` for Docker Hub)
-3. Make sure that you are on the `next`/beta version of Nx and Nx plugins (e.g. `npx create-nx-workspace@next` for new workspaces)
-
 ## Install Nx Docker Plugin
 
 ```shell {% frame="none" %}
-nx add @nx/docker@next
+nx add @nx/docker
 ```
 
 This command adds the `@nx/docker` plugin to your `nx.json` so that projects with a `Dockerfile` is automatically configured with Docker targets (e.g. `docker:build` and `docker:run`).

--- a/docs/shared/recipes/nx-release/release-docker-images.md
+++ b/docs/shared/recipes/nx-release/release-docker-images.md
@@ -5,10 +5,6 @@ description: Learn how to use Nx Release to version and publish Docker images fr
 
 # Release Docker Images
 
-{% callout type="warning" title="Docker is Experimental" %}
-Docker support in Nx Release is currently experimental and only available in the `next`/beta version. It may undergo breaking changes without following semantic versioning.
-{% /callout %}
-
 This guide walks you through setting up Nx Release to version and publish Docker images from your monorepo using calendar-based versioning.
 
 {% youtube title="What is Nx?" src="https://www.youtube.com/embed/TOPxKJXUaqw" /%}
@@ -19,12 +15,11 @@ Before starting, ensure you have:
 
 1. Docker installed and running locally
 2. Run `docker login` to authenticate with your Docker registry (e.g., `docker login docker.io` for Docker Hub)
-3. Make sure that you are on the `next`/beta version of Nx and Nx plugins (e.g. `npx create-nx-workspace@next` for new workspaces)
 
 ## Install Nx Docker Plugin
 
 ```shell
-nx add @nx/docker@next
+nx add @nx/docker
 ```
 
 This command adds the `@nx/docker` plugin to your `nx.json` so that projects with a `Dockerfile` is automatically configured with Docker targets (e.g. `docker:build` and `docker:run`).


### PR DESCRIPTION
Remove `@next` from `@nx/docker` plugin instructions since we published latest (21.4.0). 