### PR TITLE
docs(nx-dev): side technologies sidebar ordering and collapsed config

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -57,18 +57,22 @@ export const sidebar: StarlightUserConfig['sidebar'] = [
           ...getPluginItems('react'),
           {
             label: 'Next',
+            collapsed: true,
             items: getPluginItems('next', 'react'),
           },
           {
             label: 'Remix',
+            collapsed: true,
             items: getPluginItems('remix', 'react'),
           },
           {
             label: 'React Native',
+            collapsed: true,
             items: getPluginItems('react-native', 'react'),
           },
           {
             label: 'Expo',
+            collapsed: true,
             items: getPluginItems('expo', 'react'),
           },
         ],
@@ -80,6 +84,7 @@ export const sidebar: StarlightUserConfig['sidebar'] = [
           ...getPluginItems('vue'),
           {
             label: 'Nuxt',
+            collapsed: true,
             items: getPluginItems('nuxt', 'vue'),
           },
         ],
@@ -91,10 +96,12 @@ export const sidebar: StarlightUserConfig['sidebar'] = [
           ...getPluginItems('node'),
           {
             label: 'Express',
+            collapsed: true,
             items: getPluginItems('express', 'node'),
           },
           {
             label: 'Nest',
+            collapsed: true,
             items: getPluginItems('nest', 'node'),
           },
         ],
@@ -117,6 +124,7 @@ export const sidebar: StarlightUserConfig['sidebar'] = [
           ...getPluginItems('eslint'),
           {
             label: 'ESLint Plugin',
+            collapsed: true,
             items: getPluginItems('eslint-plugin', 'eslint'),
           },
         ],
@@ -127,26 +135,32 @@ export const sidebar: StarlightUserConfig['sidebar'] = [
         items: [
           {
             label: 'Webpack',
+            collapsed: true,
             items: getPluginItems('webpack', 'build-tools'),
           },
           {
             label: 'Vite',
+            collapsed: true,
             items: getPluginItems('vite', 'build-tools'),
           },
           {
             label: 'Rollup',
+            collapsed: true,
             items: getPluginItems('rollup', 'build-tools'),
           },
           {
             label: 'ESBuild',
+            collapsed: true,
             items: getPluginItems('esbuild', 'build-tools'),
           },
           {
             label: 'Rspack',
+            collapsed: true,
             items: getPluginItems('rspack', 'build-tools'),
           },
           {
             label: 'Rsbuild',
+            collapsed: true,
             items: getPluginItems('rsbuild', 'build-tools'),
           },
         ],
@@ -157,22 +171,27 @@ export const sidebar: StarlightUserConfig['sidebar'] = [
         items: [
           {
             label: 'Cypress',
+            collapsed: true,
             items: getPluginItems('cypress', 'test-tools'),
           },
           {
             label: 'Jest',
+            collapsed: true,
             items: getPluginItems('jest', 'test-tools'),
           },
           {
             label: 'Playwright',
+            collapsed: true,
             items: getPluginItems('playwright', 'test-tools'),
           },
           {
             label: 'Storybook',
+            collapsed: true,
             items: getPluginItems('storybook', 'test-tools'),
           },
           {
             label: 'Detox',
+            collapsed: true,
             items: getPluginItems('detox', 'test-tools'),
           },
         ],

--- a/astro-docs/src/plugins/utils/plugin-mappings.ts
+++ b/astro-docs/src/plugins/utils/plugin-mappings.ts
@@ -324,11 +324,13 @@ function getStaticPluginFiles(pluginContentDir: string): SidebarItem[] {
 
               items.push({
                 label: label,
+                collapsed: true,
                 items: subItems,
               } as SidebarSubItem);
             } else {
               items.push({
                 label: file.name,
+                collapsed: true,
                 items: subItems,
               } as SidebarSubItem);
             }

--- a/astro-docs/src/plugins/utils/plugin-mappings.ts
+++ b/astro-docs/src/plugins/utils/plugin-mappings.ts
@@ -148,23 +148,21 @@ export function getPluginItems(
     join(workspaceRoot, 'astro-docs', 'src', 'content', 'docs', baseUrl)
   );
 
-  // Separate static files into categories
+  // Enforce consistent ordering across all technology sections
+  // Order: Introduction → Guides → Generated items (Generators, Executors, Migrations) → Everything else
+  const finalItems: SidebarSubItem[] = [];
   let introItem: SidebarItem | undefined;
   let guidesItem: SidebarItem | undefined;
   const otherStaticFiles: SidebarItem[] = [];
-  
+
   if (staticFiles.length > 0) {
     for (const file of staticFiles) {
-      // Check for Introduction
-      // @ts-ignore - accessing properties
-      const isIntro = file.label === 'Introduction' || 
-                     (file.slug && typeof file.slug === 'string' && file.slug.endsWith('/introduction'));
-      
+      if (typeof file === 'string') continue;
+      const isIntro = file.label === 'Introduction';
+
       if (isIntro) {
         introItem = file;
-      // Check for Guides folder (must be specifically named "Guides" and have items)
-      // @ts-ignore - accessing properties  
-      } else if (file.label === 'Guides' && file.items && Array.isArray(file.items)) {
+      } else if (file.label === 'Guides') {
         guidesItem = file;
       } else {
         otherStaticFiles.push(file);
@@ -172,32 +170,11 @@ export function getPluginItems(
     }
   }
 
-  // Build final items array with proper ordering:
-  // 1. Introduction (if exists)
-  // 2. Guides (if exists)
-  // 3. Generators (if exists)
-  // 4. Executors (if exists)
-  // 5. Migrations (if exists)
-  // 6. Everything else
-  const finalItems: SidebarItem[] = [];
-  
-  // 1. Add Introduction first if it exists
-  if (introItem) {
-    finalItems.push(introItem);
-  }
-  
-  // 2. Add Guides second if it exists
-  if (guidesItem) {
-    finalItems.push(guidesItem);
-  }
-  
-  // 3-5. Add generated items (Generators, Executors, Migrations) - they're already in correct order in 'items'
-  finalItems.push(...items);
-  
-  // 6. Finally add other static files (nested sections, other items)
-  finalItems.push(...otherStaticFiles);
+  introItem && finalItems.push(introItem as SidebarSubItem);
+  guidesItem && finalItems.push(guidesItem as SidebarSubItem);
+  finalItems.push(...(items as SidebarSubItem[]));
+  finalItems.push(...(otherStaticFiles as SidebarSubItem[]));
 
-  // @ts-expect-error - idk I'll figure out to type it
   return finalItems;
 }
 


### PR DESCRIPTION
## Current Behavior

The sidebar in the Astro docs has two issues:
1. Introduction pages are not appearing first in technology sections - they appear after Generators, Executors, and Migrations
2. Nested groups (like Guides folders and sub-technology sections) are expanded by default, making the sidebar difficult to navigate

## Expected Behavior

With this PR:
1. Technology sections now display items in the correct order:
   - Introduction (if exists)
   - Guides (if exists)
   - Generators (if exists)
   - Executors (if exists)
   - Migrations (if exists)
   - Everything else (other static files and nested sections)

2. All nested groups are collapsed by default for better navigation:
   - Guides folders are collapsed
   - Sub-technology sections (Next, Remix, Express, Nest, etc.) are collapsed
   - Any auto-generated folder groups are collapsed

<img width="789" height="484" alt="Screenshot 2025-08-19 at 2 30 36 PM" src="https://github.com/user-attachments/assets/0562693c-b17a-4562-8f58-a0fba50fc6fe" />

## Related Issue(s)

DOC-122 (Linear)