### PR TITLE
fix(core): ensure deterministic dummy task generation in task graphs

### DIFF
--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -328,6 +328,7 @@ export class ProcessTasks {
         const dummyId = createTaskId(
           depProject.name,
           task.target.project +
+            task.target.target +
             '__' +
             dependencyConfig.target +
             DUMMY_TASK_TARGET,


### PR DESCRIPTION
## Summary

Fixes an issue where dummy tasks (created when dependency projects don't have required targets) would generate non-deterministic dependency structures based on target processing order.

## Current Behavior

When creating task graphs with targets in different orders, dummy tasks would inherit different configurations from different source tasks, leading to inconsistent task graphs.

For example:
- Processing `[test, lint]` vs `[lint, test]` would create the same dummy task IDs
- But the dummy tasks would have different dependency structures depending on which task created them first

## Expected Behavior

Task graphs should be deterministic regardless of target processing order. The same dummy task should always have the same dependencies.

## Related Issue(s)

This addresses the issue described where task graph generation was non-deterministic due to dummy task dependency variations.

## Test Plan

- [x] Added unit test: "should create deterministic task graphs regardless of target order"
- [x] Verified existing tests continue to pass
- [x] Test validates task graphs are identical when targets are processed in different orders

🤖 Generated with [Claude Code](https://claude.ai/code)