### PR TITLE
fix(core): handle unsupported platforms in Cursor IDE install command

### DIFF
--- a/packages/nx/src/native/ide/install.rs
+++ b/packages/nx/src/native/ide/install.rs
@@ -167,17 +167,12 @@ pub fn get_install_command() -> Option<&'static str> {
         }
         SupportedEditor::Cursor => {
             debug!("Installing Nx Console extension for Cursor");
-            #[cfg(target_os = "windows")]
-            {
+            if cfg!(target_os = "windows") {
                 Some("cursor.cmd")
-            }
-            #[cfg(target_os = "macos")]
-            {
+            } else if cfg!(target_os = "macos") {
                 Some("cursor")
-            }
-            #[cfg(target_os = "linux")]
-            {
-                debug!("Cursor extension installation not supported on Linux");
+            } else {
+                debug!("Cursor extension installation not supported on this platform");
                 None
             }
         }


### PR DESCRIPTION
Fixes platform detection logic for Cursor editor to handle unsupported OS gracefully.