### PR TITLE
docs(nx-dev): remove duplicate h1 titles from mdoc pages

### DIFF
--- a/astro-docs/src/content/docs/features/maintain-typescript-monorepos.mdoc
+++ b/astro-docs/src/content/docs/features/maintain-typescript-monorepos.mdoc
@@ -5,8 +5,6 @@ sidebar:
   order: 6
 ---
 
-# Maintain TypeScript Monorepos
-
 Keeping all the industry-standard tools involved in a large TypeScript monorepo correctly configured and working well together is a difficult task. And the more tools you add, the more opportunity there is for tools to conflict with each other in some way.
 
 In addition to [generating default configuration files](/features/generate-code) and [automatically updating dependencies](/features/automate-updating-dependencies) to versions that we know work together, Nx makes managing all the tools in your monorepo easier in two ways:

--- a/astro-docs/src/content/docs/features/run-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/run-tasks.mdoc
@@ -1,11 +1,10 @@
 ---
-title: 'Run Tasks'
+title: 'Tasks'
 description: 'Learn how to use Nx task runner to efficiently manage and execute tasks across multiple projects in your monorepo, including parallel execution and caching.'
 sidebar:
+  label: 'Run Tasks'
   order: 1
 ---
-
-# Tasks
 
 {% youtube src="https://youtu.be/aEdfYiA5U34" title="Run tasks with Nx" /%}
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo.md
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo.md
@@ -1,11 +1,9 @@
 ---
-title: 'Angular Monorepo Tutorial'
+title: 'Building and Testing Angular Apps in Nx'
 description: In this tutorial you'll create a frontend-focused workspace with Nx.
 sidebar:
   label: 'Angular Monorepo'
 ---
-
-# Building and Testing Angular Apps in Nx
 
 This tutorial walks you through creating an Angular monorepo with Nx. You'll build a small example application to understand the core concepts and workflows.
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo.md
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo.md
@@ -1,11 +1,9 @@
 ---
-title: 'React Monorepo Tutorial'
+title: 'Building and Testing React Apps in Nx'
 sidebar:
   label: 'React Monorepo'
 description: In this tutorial you'll create a frontend-focused workspace with Nx.
 ---
-
-# Building and Testing React Apps in Nx
 
 This tutorial walks you through creating a React monorepo with Nx. You'll build a small example application to understand the core concepts and workflows.
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages.md
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages.md
@@ -1,11 +1,9 @@
 ---
-title: 'TypeScript Monorepo Tutorial'
+title: 'Building and Testing TypeScript Packages in Nx'
 description: In this tutorial you'll create a TypeScript monorepo with Nx.gradient
 sidebar:
   label: 'TypeScript Monorepo'
 ---
-
-# Building and Testing TypeScript Packages in Nx
 
 This tutorial walks you through creating a TypeScript monorepo with Nx. You'll build a small example project to understand the core concepts and workflows.
 

--- a/astro-docs/src/content/docs/guides/Enforce Module Boundaries/tag-multiple-dimensions.mdoc
+++ b/astro-docs/src/content/docs/guides/Enforce Module Boundaries/tag-multiple-dimensions.mdoc
@@ -3,8 +3,6 @@ title: Tag in Multiple Dimensions
 description: Learn how to use multiple tag dimensions in Nx to create more sophisticated module boundary constraints, controlling dependencies between projects based on scope, type, and other attributes.
 ---
 
-# Tag in Multiple Dimensions
-
 The example listed in [Enforce Module Boundaries](/features/enforce-module-boundaries#tags) shows using a single dimension: `scope`. It's the most commonly used one. But you can find other dimensions useful. You can define which projects contain components, state management code, and features, so you, for instance, can disallow projects containing presentational UI components to depend on state management code. You can define which projects are experimental and which are stable, so stable applications cannot depend on experimental projects etc. You can define which projects have server-side code and which have client-side code to make sure your node app doesn't bundle in your frontend framework.
 
 Let's consider our previous three scopes - `scope:client`. `scope:admin`, `scope:shared`. By using just a single dimension, our `client-e2e` application would be able to import `client` application or `client-feature-main`. This is likely not something we want to allow as it's using framework that our E2E project doesn't have.

--- a/astro-docs/src/content/docs/guides/Nx Release/configure-custom-registries.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/configure-custom-registries.mdoc
@@ -3,8 +3,6 @@ title: Configure Custom Registries
 description: Learn how to configure Nx Release to publish packages to custom npm registries, including setting up multiple registries for different package scopes and per-package registry configuration.
 ---
 
-# Configure Custom Registries
-
 To publish JavaScript packages, Nx Release uses the `npm` CLI under the hood, which defaults to publishing to the `npm` registry (`https://registry.npmjs.org/`). If you need to publish to a different registry, you can configure the registry in the `.npmrc` file in the root of your workspace or at the project level in the project configuration.
 
 ## Set the Registry in the Root .npmrc File

--- a/astro-docs/src/content/docs/guides/Nx Release/customize-conventional-commit-types.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/customize-conventional-commit-types.mdoc
@@ -3,8 +3,6 @@ title: Customize Conventional Commit Types
 description: Learn how to configure Nx Release to customize how different conventional commit types affect versioning and changelog generation, including changing semver bump types and section titles.
 ---
 
-# Customize Conventional Commit Types
-
 [Nx release](/features/manage-releases) allows you to leverage the [conventional commits](/recipes/nx-release/automatically-version-with-conventional-commits) standard to automatically determine the next version increment.
 
 By default, this results in:

--- a/astro-docs/src/content/docs/references/Remote Cache Plugins/azure-cache/overview.mdoc
+++ b/astro-docs/src/content/docs/references/Remote Cache Plugins/azure-cache/overview.mdoc
@@ -132,8 +132,6 @@ Many people who are interested in Nx Powerpack have previously used custom task 
 
 To learn more about migrating from custom task runners, [please refer to this detailed guide](/deprecated/custom-tasks-runner).
 
-# Cache Modes
-
 By default, Nx will try to write and read from the remote cache while running locally. This means that permissions must be set for users who are expected to access the remote cache.
 
 Nx will only show warnings when the remote cache is not writable. You can disable these warnings by setting `localMode` to `read-only` or `no-cache` in the `nx.json` file.

--- a/astro-docs/src/content/docs/references/Remote Cache Plugins/gcs-cache/overview.mdoc
+++ b/astro-docs/src/content/docs/references/Remote Cache Plugins/gcs-cache/overview.mdoc
@@ -131,8 +131,6 @@ Many people who are interested in Nx Powerpack have previously used custom task 
 
 To learn more about migrating from custom task runners, [please refer to this detailed guide](/deprecated/custom-tasks-runner).
 
-# Cache Modes
-
 By default, Nx will try to write and read from the remote cache while running locally. This means that permissions must be set for users who are expected to access the remote cache.
 
 Nx will only show warnings when the remote cache is not writable. You can disable these warnings by setting `localMode` to `read-only` or `no-cache` in the `nx.json` file.

--- a/astro-docs/src/content/docs/references/Remote Cache Plugins/s3-cache/overview.mdoc
+++ b/astro-docs/src/content/docs/references/Remote Cache Plugins/s3-cache/overview.mdoc
@@ -207,8 +207,6 @@ If you are using MinIO earlier than `2024-07-04T14-25-45Z` it is recommended to 
 | **secretAccessKey** | AWS secret access key (optional if `AWS_SECRET_ACCESS_KEY` is set in the environment)                     |
 | **disableChecksum** | This disables AWS' checksum validation for cache entries                                                  |
 
-# Cache Modes
-
 By default, Nx will try to write and read from the remote cache while running locally. This means that permissions must be set for users who are expected to access the remote cache.
 
 Nx will only show warnings when the remote cache is not writable. You can disable these warnings by setting `localMode` to `read-only` or `no-cache` in the `nx.json` file.

--- a/astro-docs/src/content/docs/troubleshooting/resolve-circular-dependencies.mdoc
+++ b/astro-docs/src/content/docs/troubleshooting/resolve-circular-dependencies.mdoc
@@ -3,8 +3,6 @@ title: Resolve Circular Dependencies
 description: Learn how to identify and fix circular dependencies in your Nx workspace to improve code organization and make the affected algorithm more effective.
 ---
 
-# Resolve Circular Dependencies
-
 A circular dependency is when a project transitively depends on itself. This can cause problems in the design of your software and also makes Nx's affected algorithm less effective. The lint rule, `@nx/enforce-module-boundaries`, will produce an error if any circular dependencies are created and ensures that any `import` statements going across projects only `import` from the defined public apis in a project's root `index.ts` file.
 
 When migrating a new codebase into an nx workspace, you'll likely begin to uncover existing circular dependencies. Let's look at the simplest possible circular dependency, where `projectA` depends on `projectB` and vice versa.

--- a/astro-docs/src/content/docs/troubleshooting/troubleshoot-cache-misses.mdoc
+++ b/astro-docs/src/content/docs/troubleshooting/troubleshoot-cache-misses.mdoc
@@ -3,8 +3,6 @@ title: Troubleshoot Cache Misses
 description: Learn how to diagnose and fix issues when Nx tasks are not being replayed from cache as expected, using project configuration checks and Nx Cloud tools.
 ---
 
-# Troubleshoot Cache Misses
-
 Problem: A task is being executed when you expect it to be replayed from the cache.
 
 ## Check 1: Check if your task is marked as cacheable:


### PR DESCRIPTION
## Current Behavior
The Astro/Starlight documentation pages display duplicate titles because both the frontmatter title and an h1 heading in the content are being rendered. This creates a poor user experience with the same title appearing twice at the top of each page.

## Expected Behavior
Each documentation page should display its title only once. Starlight automatically renders the frontmatter title as the page's h1, so there should be no h1 headings in the content body. The frontmatter title should be the single source of truth for the page title, with optional sidebar labels for customization.

## Related Issue(s)
Fixes DOC-125

