### PR TITLE
feat(nx-dev): configure rewrite to astro-docs when NEXT_PUBLIC_ASTRO_URL is set

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -7,6 +7,26 @@ module.exports = withNx({
   typescript: {
     ignoreBuildErrors: true,
   },
+  async rewrites() {
+    // Only configure rewrites if NEXT_PUBLIC_ASTRO_URL is set
+    const astroDocsUrl = process.env.NEXT_PUBLIC_ASTRO_URL;
+
+    if (!astroDocsUrl) {
+      // Skip rewrites if env var is not set
+      return [];
+    }
+
+    return [
+      {
+        source: '/docs',
+        destination: `${astroDocsUrl}/`,
+      },
+      {
+        source: '/docs/:path*',
+        destination: `${astroDocsUrl}/:path*`,
+      },
+    ];
+  },
   // Transpile nx-dev packages
   transpilePackages: [
     '@nx/nx-dev-data-access-documents',


### PR DESCRIPTION
This PR prepares for the canary environment where we can use `/docs/*` for the new astro docs while keeping the same domain.

## Current Behavior
The nx-dev Next.js app doesn't have any rewrite rules for the `/docs` path, making it unable to proxy requests to the Astro documentation site.

## Expected Behavior
When the `NEXT_PUBLIC_ASTRO_URL` environment variable is set, the Next.js app configures rewrites for `/docs` and `/docs/*` paths to proxy to the Astro documentation site. If the environment variable is not set, no rewrites are configured, maintaining backward compatibility.

## Related Issue(s)
Fixes DOC-134

🤖 Generated with [Claude Code](https://claude.ai/code)

