### PR TITLE
fix(core): only prompt for NX Console installation in TTY environments

### DIFF
--- a/packages/nx/src/utils/nx-console-prompt.ts
+++ b/packages/nx/src/utils/nx-console-prompt.ts
@@ -18,7 +18,7 @@ export async function ensureNxConsoleInstalled() {
     return;
   }
 
-  if (typeof setting !== 'boolean') {
+  if (process.stdout.isTTY && typeof setting !== 'boolean') {
     setting = await promptForNxConsoleInstallation();
     preferences.setAutoInstallPreference(setting);
   }


### PR DESCRIPTION
## Current Behavior

Currently, the NX Console installation prompt can appear in non-interactive environments like CI/CD pipelines, causing processes to hang indefinitely waiting for user input.

## Expected Behavior

The NX Console installation prompt should only appear in TTY (interactive terminal) environments where users can actually respond to the prompt.

## Related Issue(s)

This change adds a TTY check (`process.stdout.isTTY`) before showing the NX Console installation prompt, preventing hanging in automated environments while preserving the interactive experience for developers working in terminals.