### PR TITLE
docs(nx-dev): convert code snippets to Starlight format for filename display

### DIFF
--- a/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo.md
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo.md
@@ -91,7 +91,8 @@ Nx uses the following syntax to run tasks:
 
 The project tasks are defined in the `project.json` file.
 
-```json {% fileName="apps/demo/project.json" %}
+```json
+// apps/demo/project.json
 {
   "name": "demo",
   ...
@@ -108,7 +109,8 @@ The project tasks are defined in the `project.json` file.
 
 Each target contains a configuration object that tells Nx how to run that target.
 
-```json {% fileName="project.json" %}
+```json
+// project.json
 {
   "name": "angular-store",
   ...
@@ -286,7 +288,8 @@ npx nx test ui
 
 All libraries that we generate are automatically included in the TypeScript path mappings configured in the root-level `tsconfig.base.json`.
 
-```json {% fileName="tsconfig.base.json" %}
+```json
+// tsconfig.base.json
 {
   "compilerOptions": {
     ...
@@ -302,13 +305,15 @@ Hence, we can easily import them into other libraries and our Angular applicatio
 
 You can see that the `Ui` component is exported via the `index.ts` file of our `ui` library so that other projects in the repository can use it. This is our public API with the rest of the workspace and is enforced by the library's build configuration. Only export what's necessary to be usable outside the library itself.
 
-```ts {% fileName="packages/ui/src/index.ts" %}
+```ts
+// packages/ui/src/index.ts
 export * from './lib/ui/ui';
 ```
 
 Let's add a simple `Hero` component that we can use in our demo app.
 
-```ts {% fileName="packages/ui/src/lib/hero/hero.ts" %}
+```ts
+// packages/ui/src/lib/hero/hero.ts
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
@@ -368,14 +373,16 @@ export class Hero {
 
 Then, export it from `index.ts`.
 
-```ts {% fileName="packages/ui/src/index.ts" %}
+```ts
+// packages/ui/src/index.ts
 export * from './lib/hero/hero';
 export * from './lib/ui/ui';
 ```
 
 We're ready to import it into our main application now.
 
-```ts {% fileName="apps/demo/src/app/app.ts" %}
+```ts
+// apps/demo/src/app/app.ts
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 // importing the component from the library
@@ -506,7 +513,8 @@ In this section, we'll explore how Nx Cloud can help your pull request get to gr
 
 The `npx nx-cloud fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
 
-```yaml {% fileName=".github/workflows/ci.yml" highlightLines=[31,32] %}
+```yaml {32,33}
+# .github/workflows/ci.yml
 name: CI
 
 on:

--- a/astro-docs/src/content/docs/getting-started/Tutorials/gradle.md
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/gradle.md
@@ -273,7 +273,8 @@ You can copy the example GitHub Action workflow file and place it in the `.githu
 
 The `npx nx-cloud fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
 
-```yaml {% fileName=".github/workflows/ci.yml" highlightLines=[33,34] %}
+```yaml {34,35}
+# .github/workflows/ci.yml
 name: CI
 
 on:
@@ -324,7 +325,8 @@ git checkout -b self-healing-ci
 
 Now for demo purposes, we'll make a mistake in our `DemoApplication` class that will cause the build to fail.
 
-```diff {% fileName="application/src/main/java/com/example/multimodule/application/DemoApplication.java" %}
+```diff
+// application/src/main/java/com/example/multimodule/application/DemoApplication.java
     @GetMapping("/")
     public String home() {
 +       return myService.messages();

--- a/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo.md
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo.md
@@ -94,7 +94,8 @@ By default Nx simply runs your `package.json` scripts. However, you can also ado
 
 In `nx.json` there's already the `@nx/vite` plugin registered which automatically identifies `build`, `test`, `serve`, and other Vite-related targets.
 
-```json {% fileName="nx.json" %}
+```json
+// nx.json
 {
   ...
   "plugins": [
@@ -186,7 +187,8 @@ npx nx show project demo
 
 If you expand the `build` task, you can see that it was created by the `@nx/vite` plugin by analyzing your `vite.config.ts` file. Notice the outputs are defined as `{projectRoot}/dist`. This value is being read from the `build.outDir` defined in your `vite.config.ts` file. Let's change that value in your `vite.config.ts` file:
 
-```ts {% fileName="apps/demo/vite.config.ts" %}
+```ts
+// apps/demo/vite.config.ts
 export default defineConfig({
   // ...
   build: {
@@ -271,7 +273,8 @@ npx nx test ui
 
 All libraries that we generate are automatically included in the `workspaces` defined in the root-level `package.json`.
 
-```json {% fileName="package.json" %}
+```json
+// package.json
 {
   "workspaces": ["apps/*", "packages/*"]
 }
@@ -281,13 +284,15 @@ Hence, we can easily import them into other libraries and our React application.
 
 You can see that the `AcmeUi` component is exported via the `index.ts` file of our `ui` library so that other projects in the repository can use it. This is our public API with the rest of the workspace and is enforced by the `exports` field in the `package.json` file. Only export what's necessary to be usable outside the library itself.
 
-```ts {% fileName="packages/ui/src/index.ts" %}
+```ts
+// packages/ui/src/index.ts
 export * from './lib/ui';
 ```
 
 Let's add a simple `Hero` component that we can use in our demo app.
 
-```tsx {% fileName="packages/ui/src/lib/hero.tsx" %}
+```tsx
+// packages/ui/src/lib/hero.tsx
 export function Hero(props: {
   title: string;
   subtitle: string;
@@ -340,14 +345,16 @@ export function Hero(props: {
 
 Then, export it from `index.ts`.
 
-```ts {% fileName="packages/ui/src/index.ts" %}
+```ts
+// packages/ui/src/index.ts
 export * from './lib/hero';
 export * from './lib/ui';
 ```
 
 We're ready to import it into our main application now.
 
-```tsx {% fileName="apps/demo/src/app/app.tsx" %}
+```tsx
+// apps/demo/src/app/app.tsx
 import { Route, Routes } from 'react-router-dom';
 // importing the component from the library
 import { Hero } from '@acme/ui';
@@ -480,7 +487,8 @@ In this section, we'll explore how Nx Cloud can help your pull request get to gr
 
 The `npx nx-cloud fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
 
-```yaml {% fileName=".github/workflows/ci.yml" highlightLines=[31,32] %}
+```yaml {32,33}
+# .github/workflows/ci.yml
 name: CI
 
 on:

--- a/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages.md
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages.md
@@ -105,7 +105,8 @@ acme
 
 Let's add some code to our packages. First, add the following code to the `animal` package:
 
-```ts {% fileName="packages/animal/src/lib/animal.ts" highlightLines=["5-18"] %}
+```ts {6-19}
+// packages/animal/src/lib/animal.ts
 export function animal(): string {
   return 'animal';
 }
@@ -128,7 +129,8 @@ export function getRandomAnimal(): Animal {
 
 Now let's update the `zoo` package to use the `animal` package:
 
-```ts {% fileName="packages/zoo/src/lib/zoo.ts" %}
+```ts
+// packages/zoo/src/lib/zoo.ts
 import { getRandomAnimal } from '@acme/animal';
 
 export function zoo(): string {
@@ -139,7 +141,8 @@ export function zoo(): string {
 
 Also create an executable entry point for the zoo package:
 
-```ts {% fileName="packages/zoo/src/index.ts" %}
+```ts
+// packages/zoo/src/index.ts
 import { zoo } from './lib/zoo.js';
 
 console.log(zoo());
@@ -175,7 +178,8 @@ By default Nx simply runs your `package.json` scripts. However, you can also ado
 
 In `nx.json` there's already the `@nx/js` plugin registered which automatically identifies `typecheck` and `build` targets.
 
-```json {% fileName="nx.json" %}
+```json
+// nx.json
 {
   ...
   "plugins": [
@@ -195,7 +199,6 @@ In `nx.json` there's already the `@nx/js` plugin registered which automatically 
     }
   ]
 }
-
 ```
 
 To view the tasks that Nx has detected, look in the [Nx Console](/getting-started/editor-setup) project detail view or run:
@@ -368,7 +371,8 @@ acme
 
 Let's add a utility function that our packages can share:
 
-```ts {% fileName="packages/util/src/lib/util.ts"  highlightLines=["5-11"] %}
+```ts {6-12}
+// packages/util/src/lib/util.ts
 export function util(): string {
   return 'util';
 }
@@ -386,7 +390,8 @@ export function getRandomItem<T>(items: T[]): T {
 
 This allows us to easily import them into other packages. Let's update our `animals` package to use the shared utility:
 
-```ts {% fileName="packages/animals/src/lib/animals.ts"  highlightLines=[1, "18-20"]%}
+```ts {2,19-21}
+// packages/animals/src/lib/animals.ts
 import { getRandomItem } from '@acme/util';
 
 export function animal(): string {
@@ -411,7 +416,8 @@ export function getRandomAnimal(): Animal {
 
 And update the `zoo` package to use the formatting utility:
 
-```ts {% fileName="packages/zoo/src/lib/zoo.ts"  highlightLines=[2, 6, 7] %}
+```ts {3,7,8}
+// packages/zoo/src/lib/zoo.ts
 import { getRandomAnimal } from '@acme/animal';
 import { formatMessage } from '@acme/util';
 
@@ -548,7 +554,8 @@ In this section, we'll explore how Nx Cloud can help your pull request get to gr
 
 The `npx nx-cloud fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
 
-```yaml {% fileName=".github/workflows/ci.yml" highlightLines=[31,32] %}
+```yaml {32,33}
+# .github/workflows/ci.yml
 name: CI
 
 on:
@@ -636,7 +643,8 @@ If you decide to publish your packages to NPM, Nx can help you [manage the relea
 
 First you'll need to define which projects Nx should manage releases for by setting the `release.projects` property in `nx.json`:
 
-```json {% fileName="nx.json" highlightLines=["3-5"] %}
+```json {4-6}
+// nx.json
 {
   ...
   "release": {


### PR DESCRIPTION
## Current Behavior
Code snippets use custom Nx attributes (fileName and highlightLines) that don't display properly in Astro Starlight

## Expected Behavior
Code snippets use Starlight's native format with filenames shown as comments and highlights using curly brace syntax


<img width="980" height="710" alt="Screenshot 2025-08-20 at 10 58 07 AM" src="https://github.com/user-attachments/assets/38c6629f-8be3-4934-b839-ae5ece980f36" />

## Related Issue(s)
Fixes DOC-137
