### PR TITLE
docs(nx-dev): fix broken markdoc components in documentation

### DIFF
--- a/astro-docs/markdoc.config.mjs
+++ b/astro-docs/markdoc.config.mjs
@@ -378,5 +378,14 @@ export default defineMarkdocConfig({
         },
       },
     },
+    side_by_side: {
+      render: component('./src/components/markdoc/SideBySide.astro'),
+      attributes: {
+        align: {
+          type: 'String',
+          default: 'center',
+        },
+      },
+    },
   },
 });

--- a/astro-docs/src/components/markdoc/SideBySide.astro
+++ b/astro-docs/src/components/markdoc/SideBySide.astro
@@ -1,0 +1,3 @@
+<div class="not-content grid grid-auto-col md:grid-flow-row md:grid-cols-2 gap-4">
+  <slot />
+</div>

--- a/astro-docs/src/content/docs/concepts/Module Federation/faster-builds.mdoc
+++ b/astro-docs/src/content/docs/concepts/Module Federation/faster-builds.mdoc
@@ -67,9 +67,9 @@ three remotes under these routes:
 But before we begin, we've put together a couple of example repos (React and Angular) for you to inspect if you want to
 skip ahead.
 
-\{% github-repository url="https://github.com/nrwl/ng-module-federation" /%\}
+{% github_repository url="https://github.com/nrwl/ng-module-federation" /%}
 
-\{% github-repository url="https://github.com/nrwl/react-module-federation" /%\}
+{% github_repository url="https://github.com/nrwl/react-module-federation" /%}
 
 These examples have fully
 functioning [CI](https://github.com/nrwl/react-module-federation/blob/main/.github/workflows/ci.yml) [workflows](https://github.com/nrwl/ng-module-federation/blob/main/.github/workflows/ci.yml)
@@ -441,9 +441,9 @@ For examples of how CI/CD pipelines can be configured using Nx Cloud and GitHub,
 our [React](https://github.com/nrwl/react-module-federation)
 and [Angular](https://github.com/nrwl/ng-module-federation) examples.
 
-\{% github-repository url="https://github.com/nrwl/ng-module-federation" /%\}
+{% github_repository url="https://github.com/nrwl/ng-module-federation" /%}
 
-\{% github-repository url="https://github.com/nrwl/react-module-federation" /%\}
+{% github_repository url="https://github.com/nrwl/react-module-federation" /%}
 
 ## Using buildable libs
 

--- a/astro-docs/src/content/docs/concepts/Module Federation/manage-library-versions-with-module-federation.mdoc
+++ b/astro-docs/src/content/docs/concepts/Module Federation/manage-library-versions-with-module-federation.mdoc
@@ -145,7 +145,7 @@ module.exports = {
 
 Here is a working example of how to opt in and out of sharing library versions:
 
-\{% github-repository url="https://github.com/jaysoo/module-federation-example" /%\}
+{% github_repository url="https://github.com/jaysoo/module-federation-example" /%}
 
 ## Benefits
 

--- a/astro-docs/src/content/docs/concepts/Module Federation/module-federation-and-nx.mdoc
+++ b/astro-docs/src/content/docs/concepts/Module Federation/module-federation-and-nx.mdoc
@@ -140,4 +140,4 @@ Follow our [Micro Frontend Architecture Guide](/technologies/module-federation/c
 
 You can also check out our example repository for Independent Deployability with Module Federation and Nx below:
 
-\{% github-repository url="https://github.com/jaysoo/module-federation-example/tree/main" /%\}
+{% github_repository url="https://github.com/jaysoo/module-federation-example/tree/main" /%}

--- a/astro-docs/src/content/docs/concepts/inferred-tasks.mdoc
+++ b/astro-docs/src/content/docs/concepts/inferred-tasks.mdoc
@@ -54,8 +54,309 @@ To view the task settings for projects in your workspace, [show the project deta
 nx show project my-project --web
 ```
 
-\{% project-details  jsonFile="/src/assets/concepts/myreactapp.json"%\}
-\{% /project-details %\}
+{% project_details%}
+
+{
+  "project": {
+    "name": "myreactapp",
+    "type": "app",
+    "data": {
+      "root": "apps/myreactapp",
+      "targets": {
+        "build": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite build"
+          },
+          "cache": true,
+          "dependsOn": [
+            "^build"
+          ],
+          "inputs": [
+            "production",
+            "^production",
+            {
+              "externalDependencies": [
+                "vite"
+              ]
+            }
+          ],
+          "outputs": [
+            "{workspaceRoot}/dist/apps/myreactapp"
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "serve": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite serve",
+            "continuous": true
+          },
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "preview": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite preview"
+          },
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "serve-static": {
+          "executor": "@nx/web:file-server",
+          "options": {
+            "buildTarget": "build",
+            "continuous": true
+          },
+          "configurations": {}
+        },
+        "test": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vitest run"
+          },
+          "cache": true,
+          "inputs": [
+            "default",
+            "^production",
+            {
+              "externalDependencies": [
+                "vitest"
+              ]
+            }
+          ],
+          "outputs": [
+            "{workspaceRoot}/coverage/apps/myreactapp"
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "lint": {
+          "cache": true,
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "eslint ."
+          },
+          "inputs": [
+            "default",
+            "{workspaceRoot}/.eslintrc.json",
+            "{workspaceRoot}/apps/myreactapp/.eslintrc.json",
+            "{workspaceRoot}/tools/eslint-rules/**/*",
+            {
+              "externalDependencies": [
+                "eslint"
+              ]
+            }
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "eslint"
+            ]
+          }
+        }
+      },
+      "name": "myreactapp",
+      "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "apps/myreactapp/src",
+      "projectType": "application",
+      "tags": [],
+      "implicitDependencies": [],
+      "metadata": {
+        "technologies": [
+          "react"
+        ]
+      }
+    }
+  },
+  "sourceMap": {
+    "root": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "targets": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "targets.build": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.cache": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.dependsOn": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.inputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.outputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.executor": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.options.buildTarget": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.cache": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.inputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.outputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.lint": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.command": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.cache": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.options": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.inputs": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.options.cwd": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "name": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "$schema": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "sourceRoot": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "projectType": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "tags": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ]
+  }
+}
+
+{% /project_details %}
 
 ## Overriding Inferred Task Configuration
 

--- a/astro-docs/src/content/docs/concepts/mental-model.mdoc
+++ b/astro-docs/src/content/docs/concepts/mental-model.mdoc
@@ -43,29 +43,137 @@ graph and then executes the tasks in that graph.
 
 For instance `nx test lib` creates a task graph with a single node:
 
-\{% graph height="100px" type="task" jsonFile="shared/mental-model/single-task.json" %\}
-\{% /graph %\}
+{% graph height="100px" type="task" %}
+
+{
+  "projects": [
+    {
+      "name": "lib",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    }
+  ],
+  "taskId": "lib:test",
+  "taskGraphs": {
+    "lib:test": {
+      "roots": [
+        "lib:test"
+      ],
+      "tasks": {
+        "lib:test": {
+          "id": "lib:test",
+          "target": {
+            "project": "lib",
+            "target": "test"
+          },
+          "projectRoot": "libs/lib",
+          "overrides": {}
+        }
+      },
+      "dependencies": {}
+    }
+  }
+}
+
+{% /graph %}
 
 A task is an invocation of a target. If you invoke the same target twice, you create two tasks.
 
 Nx uses the [project graph](#the-project-graph), but the task graph and project graph aren't isomorphic, meaning they
 aren't directly connected. In the case above, `app1` and `app2` depend on `lib`, but
 running `nx run-many -t test -p app1 app2 lib`, the created task graph will look like this:
-\{% side-by-side %\}
+{% side_by_side %}
 
 **Project Graph**
 
 **Task Graph**
 
-\{% /side-by-side %\}
+{% /side_by_side %}
 
-\{% side-by-side %\}
-\{% graph height="200px" type="project" jsonFile="shared/mental-model/three-projects.json" %\}
-\{% /graph %\}
+{% side_by_side %}
+{% graph height="200px" type="project" %}
 
-\{% graph height="200px" type="task" jsonFile="shared/mental-model/disconnected-tasks.json"%\}
-\{% /graph %\}
-\{% /side-by-side %\}
+{
+  "projects": [
+    {
+      "name": "lib",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    }
+  ],
+  "taskId": "lib:test",
+  "taskGraphs": {
+    "lib:test": {
+      "roots": [
+        "lib:test"
+      ],
+      "tasks": {
+        "lib:test": {
+          "id": "lib:test",
+          "target": {
+            "project": "lib",
+            "target": "test"
+          },
+          "projectRoot": "libs/lib",
+          "overrides": {}
+        }
+      },
+      "dependencies": {}
+    }
+  }
+}
+
+{% /graph %}
+
+{% graph height="200px" type="task"%}
+
+{
+  "projects": [
+    {
+      "name": "lib",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    }
+  ],
+  "taskId": "lib:test",
+  "taskGraphs": {
+    "lib:test": {
+      "roots": [
+        "lib:test"
+      ],
+      "tasks": {
+        "lib:test": {
+          "id": "lib:test",
+          "target": {
+            "project": "lib",
+            "target": "test"
+          },
+          "projectRoot": "libs/lib",
+          "overrides": {}
+        }
+      },
+      "dependencies": {}
+    }
+  }
+}
+
+{% /graph %}
+{% /side_by_side %}
 
 Even though the apps depend on `lib`, testing `app1` doesn't depend on the testing `lib`. This means that the two tasks
 can
@@ -89,21 +197,93 @@ Let's look at the test target relying on its dependencies.
 
 With this, running the same test command creates the following task graph:
 
-\{% side-by-side %\}
+{% side_by_side %}
 
 **Project Graph**
 
 **Task Graph**
 
-\{% /side-by-side %\}
+{% /side_by_side %}
 
-\{% side-by-side %\}
-\{% graph height="200px" type="project" jsonFile="shared/mental-model/three-projects.json" %\}
-\{% /graph %\}
+{% side_by_side %}
+{% graph height="200px" type="project" %}
 
-\{% graph height="200px" type="task" jsonFile="shared/mental-model/connected-tasks.json" %\}
-\{% /graph %\}
-\{% /side-by-side %\}
+{
+  "projects": [
+    {
+      "name": "lib",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    }
+  ],
+  "taskId": "lib:test",
+  "taskGraphs": {
+    "lib:test": {
+      "roots": [
+        "lib:test"
+      ],
+      "tasks": {
+        "lib:test": {
+          "id": "lib:test",
+          "target": {
+            "project": "lib",
+            "target": "test"
+          },
+          "projectRoot": "libs/lib",
+          "overrides": {}
+        }
+      },
+      "dependencies": {}
+    }
+  }
+}
+
+{% /graph %}
+
+{% graph height="200px" type="task" %}
+
+{
+  "projects": [
+    {
+      "name": "lib",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    }
+  ],
+  "taskId": "lib:test",
+  "taskGraphs": {
+    "lib:test": {
+      "roots": [
+        "lib:test"
+      ],
+      "tasks": {
+        "lib:test": {
+          "id": "lib:test",
+          "target": {
+            "project": "lib",
+            "target": "test"
+          },
+          "projectRoot": "libs/lib",
+          "overrides": {}
+        }
+      },
+      "dependencies": {}
+    }
+  }
+}
+
+{% /graph %}
+{% /side_by_side %}
 
 This often makes more sense for builds, where to build `app1`, you want to build `lib` first. You can also define
 similar
@@ -184,8 +364,44 @@ instance, Nx:
 
 As your workspace grows, the task graph looks more like this:
 
-\{% graph height="400px" type="task" jsonFile="shared/mental-model/large-tasks.json"%\}
-\{% /graph %\}
+{% graph height="400px" type="task"%}
+
+{
+  "projects": [
+    {
+      "name": "lib",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    }
+  ],
+  "taskId": "lib:test",
+  "taskGraphs": {
+    "lib:test": {
+      "roots": [
+        "lib:test"
+      ],
+      "tasks": {
+        "lib:test": {
+          "id": "lib:test",
+          "target": {
+            "project": "lib",
+            "target": "test"
+          },
+          "projectRoot": "libs/lib",
+          "overrides": {}
+        }
+      },
+      "dependencies": {}
+    }
+  }
+}
+
+{% /graph %}
 
 All of these optimizations are crucial for making Nx usable for any non-trivial workspace. Only the minimum amount of
 work happens. The rest is either left as is or restored from the cache.

--- a/astro-docs/src/content/docs/concepts/sync-generators.mdoc
+++ b/astro-docs/src/content/docs/concepts/sync-generators.mdoc
@@ -55,9 +55,7 @@ nx show project <name>
 
 The above command opens up the project details view, and the registered sync generators are under the **Sync Generators** for each target. Most sync generators are inferred when using an [inference plugin](/concepts/inferred-tasks). For example, the `@nx/js/typescript` plugin registers the `@nx/js:typescript-sync` generator on `build` and `typecheck` targets.
 
-\{% project-details title="Project Details View" expandedTargets="build" %\}
-
-```json
+{% project_details title="Project Details View" expandedTargets=["build"] %}
 {
   "project": {
     "name": "foo",
@@ -88,9 +86,7 @@ The above command opens up the project details view, and the registered sync gen
     "targets.build": ["packages/foo/tsconfig.ts", "@nx/js/typescript"]
   }
 }
-```
-
-\{% /project-details %\}
+{% /project_details %}
 
 Task sync generators can be thought of like the `dependsOn` property, but for generators instead of task dependencies.
 
@@ -104,7 +100,7 @@ Global sync generators are not associated with a particular task and are execute
 
 Nx processes the file system in order to [create the project graph](/features/explore-graph) which is used to run tasks in the correct order and determine project dependencies. Sync generators allow you to also go the other direction and use the project graph to update the file system.
 
-\{% side-by-side %\}
+{% side_by_side %}
 
 ```text title="File System"
 └─ myorg
@@ -117,9 +113,70 @@ Nx processes the file system in order to [create the project graph](/features/ex
    └─ package.json
 ```
 
-\{% graph title="Project Graph" height="200px" type="project" jsonFile="shared/mental-model/three-projects.json" %\}
-\{% /graph %\}
-\{% /side-by-side %\}
+{% graph title="Project Graph" height="200px" type="project" %}
+
+{
+  "projects": [
+    {
+      "name": "app1",
+      "type": "app",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    },
+    {
+      "name": "app2",
+      "type": "app",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    },
+    {
+      "name": "lib",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "targets": {
+          "test": {}
+        }
+      }
+    }
+  ],
+  "dependencies": {
+    "app1": [
+      {
+        "source": "app1",
+        "target": "lib",
+        "type": "static"
+      }
+    ],
+    "app2": [
+      {
+        "source": "app2",
+        "target": "lib",
+        "type": "static"
+      }
+    ],
+    "lib": []
+  },
+  "workspaceLayout": {
+    "appsDir": "apps",
+    "libsDir": "libs"
+  },
+  "affectedProjectIds": [],
+  "focus": null,
+  "groupByFolder": false,
+  "exclude": []
+}
+
+{% /graph %}
+{% /side_by_side %}
 
 The ability to update the file system from the project graph makes it possible to use the Nx project graph to change the behavior of other tools that are not part of the Nx ecosystem.
 

--- a/astro-docs/src/content/docs/concepts/task-pipeline-configuration.mdoc
+++ b/astro-docs/src/content/docs/concepts/task-pipeline-configuration.mdoc
@@ -9,7 +9,7 @@ If you have a monorepo workspace (or modularized app), you rarely just run one t
 
 As you can see in the graph visualization below, the `myreactapp` project depends on other projects. Therefore, when running the build for `myreactapp`, these dependencies need to be built first so that `myreactapp` can use the resulting build artifacts.
 
-\{% graph height="450px" %\}
+{% graph height="450px" %}
 
 ```json
 {
@@ -56,7 +56,7 @@ As you can see in the graph visualization below, the `myreactapp` project depend
 }
 ```
 
-\{% /graph %\}
+{% /graph %}
 
 While you could manage these relationships on your own and set up custom scripts to build all projects in the proper order (e.g. first build `shared-ui`, then `feat-products` and finally `myreactapp`), that kind of approach is not scalable and would need constant maintenance as you keep changing and adding projects to your workspace.
 

--- a/astro-docs/src/content/docs/concepts/typescript-project-linking.mdoc
+++ b/astro-docs/src/content/docs/concepts/typescript-project-linking.mdoc
@@ -230,11 +230,11 @@ The project's `tsconfig.spec.json` does not need to reference project dependenci
 
 ### TypeScript Project References Performance Benefits
 
-\{% youtube src="https://youtu.be/O2xBQJMTs9E" title="Why TypeScript Project References Make Your CI Faster!" /%\}
+{% youtube src="https://youtu.be/O2xBQJMTs9E" title="Why TypeScript Project References Make Your CI Faster!" /%}
 
 Using TypeScript project references improves both the speed and memory usage of build and typecheck tasks. The repository below contains benchmarks showing the difference between running typecheck with and without using TypeScript project references.
 
-\{% github-repository title="TypeScript Project References Benchmark" url="https://github.com/jaysoo/typecheck-timings" /%\}
+{% github_repository title="TypeScript Project References Benchmark" url="https://github.com/jaysoo/typecheck-timings" /%}
 
 Here are the baseline typecheck task performance results.
 

--- a/astro-docs/src/content/docs/enterprise/Powerpack Features/conformance.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Powerpack Features/conformance.mdoc
@@ -20,7 +20,7 @@ The plugin also provides the following pre-written rules:
 
 The `@nx/conformance` plugin requires an Nx Powerpack or [Nx Enterprise license](/enterprise) to function. [Activating Powerpack](/nx-enterprise/activate-powerpack) is a simple process.
 
-\{% call-to-action title="Get a License and Activate Powerpack or Nx Enterprise" icon="nx" description="Unlock all the features of the Nx CLI" url="/nx-enterprise/activate-powerpack" /%}
+{% call_to_action title="Get a License and Activate Powerpack or Nx Enterprise" icon="nx" description="Unlock all the features of the Nx CLI" url="/nx-enterprise/activate-powerpack" /%}
 
 Then, add the Conformance plugin to your workspace.
 

--- a/astro-docs/src/content/docs/enterprise/Powerpack Features/owners.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Powerpack Features/owners.mdoc
@@ -13,7 +13,7 @@ The atomic unit of code in an Nx workspace is a project. Tasks, module boundarie
 
 The `@nx/owners` plugin requires an Nx Powerpack license to function. [Activating Powerpack](/nx-enterprise/activate-powerpack) is a simple process.
 
-\{% call-to-action title="Get a License and Activate Powerpack" icon="nx" description="Unlock all the features of the Nx CLI" url="/nx-enterprise/activate-powerpack" /%}
+{% call_to_action title="Get a License and Activate Powerpack" icon="nx" description="Unlock all the features of the Nx CLI" url="/nx-enterprise/activate-powerpack" /%}
 
 Then, add the Owners plugin to your workspace.
 

--- a/astro-docs/src/content/docs/features/CI Features/affected.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/affected.mdoc
@@ -14,9 +14,8 @@ As your workspace grows, re-testing, re-building, and re-linting **all projects 
 
 This drastically improves the speed of your CI and reduces the amount of compute needed. This advantage is further enhanced when [paired with remote caching and distribution](#best-paired-with-remote-caching-and-distribution).
 
-\{% graph title="Making a change in lib10 only affects a sub-part of the project graph (shown in purple)" height="400px" %}
+{% graph title="Making a change in lib10 only affects a sub-part of the project graph (shown in purple)" height="400px" %}
 
-```json
 {
   "projects": [
     {
@@ -201,9 +200,8 @@ This drastically improves the speed of your CI and reduces the amount of compute
   },
   "affectedProjectIds": ["lib10", "lib4", "lib5", "app2"]
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
 ## Using Nx Affected Commands
 

--- a/astro-docs/src/content/docs/features/CI Features/github-integration.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/github-integration.mdoc
@@ -28,9 +28,9 @@ Nx Cloud organizations can use their existing GitHub access controls to manage N
 
 First, you'll want to connect your Nx Cloud account to GitHub. You can use your regular username and password or log in via Google or GitHub, connecting to GitHub is a separate step.
 
-\{% call-to-action title="Connect to GitHub" url="https://cloud.nx.app/profile/vcs-integrations" icon="nxcloud" description="Connect your Nx Cloud account to GitHub via your profile settings" %}
+{% call_to_action title="Connect to GitHub" url="https://cloud.nx.app/profile/vcs-integrations" icon="nxcloud" description="Connect your Nx Cloud account to GitHub via your profile settings" %}
 Connect to GitHub
-\{% /call-to-action %}
+{% /call_to_action %}
 {%linkbutton href="https://cloud.nx.app/profile/vcs-integrations" variant="primary" icon="github" iconPlacement="start" %}
 Connect to GitHub
 {% /linkbutton %}
@@ -43,9 +43,9 @@ Connect to GitHub
 4. If that repo is controlled by a GitHub organization, you will be prompted to use that organization.
 5. Follow the prompts to create a pull request to complete your connection to Nx Cloud.
 
-\{% call-to-action title="Connect a workspace to Nx Cloud" url="https://cloud.nx.app/setup/connect-workspace/github/select" icon="nxcloud" description="Connect an Nx workspace in GitHub to Nx Cloud" %}
+{% call_to_action title="Connect a workspace to Nx Cloud" url="https://cloud.nx.app/setup/connect-workspace/github/select" icon="nxcloud" description="Connect an Nx workspace in GitHub to Nx Cloud" %}
 Connect an Nx workspace in GitHub to Nx Cloud
-\{% /call-to-action %}
+{% /call_to_action %}
 
 ## Connect an Existing Organization
 

--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -102,9 +102,8 @@ nx show project my-project-e2e
 {% /tabitem %}
 {% tabitem label="Project Detail View" %}
 
-\{% project-details title="Project Details View" %}
+{% project_details title="Project Details View" %}
 
-```json
 {
   "project": {
     "name": "admin-e2e",
@@ -408,9 +407,8 @@ nx show project my-project-e2e
     ]
   }
 }
-```
 
-\{% /project-details %}
+{% /project_details %}
 
 {% /tabitem %}
 {% /tabs %}

--- a/astro-docs/src/content/docs/features/explore-graph.mdoc
+++ b/astro-docs/src/content/docs/features/explore-graph.mdoc
@@ -28,8 +28,309 @@ Another way is to look at the **Projects** pane in [Nx Console](/getting-started
 
 You can see more details about a specific project in Nx Console or by running `nx show project <project-name> --web`. Both methods will show something like the example below:
 
-\{% project-details  jsonFile="/src/assets/concepts/myreactapp.json"%}
-\{% /project-details %}
+{% project_details%}
+
+{
+  "project": {
+    "name": "myreactapp",
+    "type": "app",
+    "data": {
+      "root": "apps/myreactapp",
+      "targets": {
+        "build": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite build"
+          },
+          "cache": true,
+          "dependsOn": [
+            "^build"
+          ],
+          "inputs": [
+            "production",
+            "^production",
+            {
+              "externalDependencies": [
+                "vite"
+              ]
+            }
+          ],
+          "outputs": [
+            "{workspaceRoot}/dist/apps/myreactapp"
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "serve": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite serve",
+            "continuous": true
+          },
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "preview": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite preview"
+          },
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "serve-static": {
+          "executor": "@nx/web:file-server",
+          "options": {
+            "buildTarget": "build",
+            "continuous": true
+          },
+          "configurations": {}
+        },
+        "test": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vitest run"
+          },
+          "cache": true,
+          "inputs": [
+            "default",
+            "^production",
+            {
+              "externalDependencies": [
+                "vitest"
+              ]
+            }
+          ],
+          "outputs": [
+            "{workspaceRoot}/coverage/apps/myreactapp"
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "lint": {
+          "cache": true,
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "eslint ."
+          },
+          "inputs": [
+            "default",
+            "{workspaceRoot}/.eslintrc.json",
+            "{workspaceRoot}/apps/myreactapp/.eslintrc.json",
+            "{workspaceRoot}/tools/eslint-rules/**/*",
+            {
+              "externalDependencies": [
+                "eslint"
+              ]
+            }
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "eslint"
+            ]
+          }
+        }
+      },
+      "name": "myreactapp",
+      "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "apps/myreactapp/src",
+      "projectType": "application",
+      "tags": [],
+      "implicitDependencies": [],
+      "metadata": {
+        "technologies": [
+          "react"
+        ]
+      }
+    }
+  },
+  "sourceMap": {
+    "root": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "targets": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "targets.build": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.cache": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.dependsOn": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.inputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.outputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.executor": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.options.buildTarget": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.cache": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.inputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.outputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.lint": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.command": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.cache": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.options": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.inputs": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.options.cwd": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "name": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "$schema": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "sourceRoot": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "projectType": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "tags": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ]
+  }
+}
+
+{% /project_details %}
 
 The view shows a list of targets which can be [run by Nx](/features/run-tasks).
 Each target has different options which determine how Nx runs the task.
@@ -69,11 +370,10 @@ Composite nodes represent a set of projects in the same folder and can be expand
 
 Try playing around with a [fully interactive graph on a sample repo](https://nrwl-nx-examples-dep-graph.netlify.app/?focus=cart) or look at the more limited example below:
 
-\{% side-by-side %}
+{% side_by_side %}
 
-\{% graph height="450px" title="Project View" %}
+{% graph height="450px" title="Project View" %}
 
-```json
 {
   "composite": false,
   "projects": [
@@ -182,13 +482,11 @@ Try playing around with a [fully interactive graph on a sample repo](https://nrw
   "exclude": [],
   "enableTooltips": false
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
-\{% graph height="450px" title="Composite View (Nx 20+)" %}
+{% graph height="450px" title="Composite View (Nx 20+)" %}
 
-```json
 {
   "composite": true,
   "projects": [
@@ -297,11 +595,10 @@ Try playing around with a [fully interactive graph on a sample repo](https://nrw
   "exclude": [],
   "enableTooltips": false
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
-\{% /side-by-side %}
+{% /side_by_side %}
 
 ### Export Project Graph to JSON
 

--- a/astro-docs/src/content/docs/features/maintain-typescript-monorepos.mdoc
+++ b/astro-docs/src/content/docs/features/maintain-typescript-monorepos.mdoc
@@ -22,7 +22,7 @@ Whenever possible, Nx will detect the existing configuration settings of other t
 
 If your repository is using package manager workspaces, Nx will use those settings to find all the [projects](/reference/project-configuration) in your repository. So you don't need to define a project for your package manager and separately identify the project for Nx. The `workspaces` configuration on the left allows Nx to detect the project graph on the right.
 
-\{% side-by-side align="top" %}
+{% side_by_side align="top" %}
 
 ```json
 // package.json
@@ -31,9 +31,8 @@ If your repository is using package manager workspaces, Nx will use those settin
 }
 ```
 
-\{% graph height="200px" title="Project View" %}
+{% graph height="200px" title="Project View" %}
 
-```json
 {
   "composite": false,
   "projects": [
@@ -80,11 +79,10 @@ If your repository is using package manager workspaces, Nx will use those settin
   "exclude": [],
   "enableTooltips": false
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
-\{% /side-by-side %}
+{% /side_by_side %}
 
 ### Inferred Tasks with Tooling Plugins
 
@@ -94,7 +92,7 @@ In the example below, because the `/apps/cart/vite.config.ts` file exists, Nx kn
 
 With inferred tasks, you can keep your tooling configuration file as the one source of truth for that tool's configuration, instead of adding an extra layer of configuration on top.
 
-\{% side-by-side align="top" %}
+{% side_by_side align="top" %}
 
 ```ts
 // /apps/cart/vite.config.ts
@@ -117,9 +115,8 @@ export default defineConfig({
 });
 ```
 
-\{% project-details %}
+{% project_details %}
 
-```json
 {
   "project": {
     "name": "cart",
@@ -181,11 +178,10 @@ export default defineConfig({
     "tags": ["apps/cart/project.json", "nx/core/project-json"]
   }
 }
-```
 
-\{% /project-details %}
+{% /project_details %}
 
-\{% /side-by-side %}
+{% /side_by_side %}
 
 ## Enhance Tools for Monorepos
 
@@ -197,11 +193,10 @@ TypeScript provides a feature called [Project References](https://www.typescript
 
 The main downside of this feature is that you have to manually define each project's references (dependencies) in the appropriate `tsconfig.*.json` file. This process is tedious to set up and very difficult to maintain as the repository changes over time. Nx can help by using a [sync generator](/concepts/sync-generators) to automatically update the references defined in the `tsconfig.json` files based on the project graph it already knows about.
 
-\{% side-by-side align="top" %}
+{% side_by_side align="top" %}
 
-\{% graph height="200px" title="Project View" %}
+{% graph height="200px" title="Project View" %}
 
-```json
 {
   "composite": false,
   "projects": [
@@ -248,9 +243,8 @@ The main downside of this feature is that you have to manually define each proje
   "exclude": [],
   "enableTooltips": false
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
 ```jsonc
 // apps/cart/tsconfig.json
@@ -277,7 +271,7 @@ The main downside of this feature is that you have to manually define each proje
 }
 ```
 
-\{% /side-by-side %}
+{% /side_by_side %}
 
 Later, if someone adds another dependency to the `cart` app and then runs the `build` task, Nx will detect that the project references are out of sync and ask if the references should be updated.
 

--- a/astro-docs/src/content/docs/features/run-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/run-tasks.mdoc
@@ -161,9 +161,8 @@ It is pretty common to have dependencies between tasks, requiring one task to be
 
 Nx can automatically detect the dependencies between projects (see [project graph](/features/explore-graph)).
 
-\{% graph height="450px" %}
+{% graph height="450px" %}
 
-```json
 {
   "projects": [
     {
@@ -206,9 +205,8 @@ Nx can automatically detect the dependencies between projects (see [project grap
   "focus": null,
   "groupByFolder": false
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
 However, you need to specify for which targets this ordering is important. In the following example we are telling Nx that before running the `build` target it needs to run the `build` target on all the projects the current project depends on:
 

--- a/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
@@ -81,7 +81,7 @@ To leverage Self Healing CI, you'll need to add the following to your CI configu
 
 Enhance your developer experience by using the Nx Console editor extension.
 
-\{% install-nx-console /%}
+{% install_nx_console /%}
 
 ## In-depth Guides
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
@@ -119,7 +119,6 @@ nx show project my-workspace --web
 
 {% project_details title="Project Details View" %}
 
-```json
 {
   "project": {
     "name": "my-workspace",
@@ -247,7 +246,6 @@ nx show project my-workspace --web
     ]
   }
 }
-```
 
 {% /project_details %}
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
@@ -117,7 +117,6 @@ nx show project my-workspace --web
 
 {% project_details title="Project Details View" %}
 
-```json
 {
   "project": {
     "name": "my-workspace",
@@ -245,7 +244,6 @@ nx show project my-workspace --web
     ]
   }
 }
-```
 
 {% /project_details %}
 

--- a/astro-docs/src/content/docs/guides/Nx Release/publish-rust-crates.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/publish-rust-crates.mdoc
@@ -5,7 +5,7 @@ description: Learn how to version Rust libraries, generate changelogs, and publi
 
 This recipe guides you through versioning Rust libraries, generating changelogs, and publishing Rust crates in a monorepo with Nx Release.
 
-\{% github-repository url="https://github.com/JamesHenry/release-js-and-rust" /%}
+{% github_repository url="https://github.com/JamesHenry/release-js-and-rust" /%}
 
 {% aside type="caution" title="Currently requires legacy versioning" %}
 In Nx v21, the implementation details of versioning were rewritten to enhance flexibility and allow for better cross-ecosystem support. An automated migration was provided in Nx v21 to update your configuration to the new format when running `nx migrate`.

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
@@ -14,9 +14,8 @@ For an overview of all the possible [types of inputs](/reference/inputs) and how
 
 Throughout this recipe, the following project structure of a simple workspace will be used as an example to help understand inputs better.
 
-\{% graph height="450px" %}
+{% graph height="450px" %}
 
-```json
 {
   "projects": [
     {
@@ -45,9 +44,8 @@ Throughout this recipe, the following project structure of a simple workspace wi
   "focus": null,
   "groupByFolder": false
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
 ## View the Inputs of a Task
 
@@ -63,8 +61,309 @@ Clicking the task will open a tooltip which lists out all of the inputs of the t
 
 Doing so will show a view such as the one below:
 
-\{% project-details  jsonFile="shared/concepts/myreactapp.json"%}
-\{% /project-details %}
+{% project_details%}
+
+{
+  "project": {
+    "name": "myreactapp",
+    "type": "app",
+    "data": {
+      "root": "apps/myreactapp",
+      "targets": {
+        "build": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite build"
+          },
+          "cache": true,
+          "dependsOn": [
+            "^build"
+          ],
+          "inputs": [
+            "production",
+            "^production",
+            {
+              "externalDependencies": [
+                "vite"
+              ]
+            }
+          ],
+          "outputs": [
+            "{workspaceRoot}/dist/apps/myreactapp"
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "serve": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite serve",
+            "continuous": true
+          },
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "preview": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vite preview"
+          },
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "serve-static": {
+          "executor": "@nx/web:file-server",
+          "options": {
+            "buildTarget": "build",
+            "continuous": true
+          },
+          "configurations": {}
+        },
+        "test": {
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "vitest run"
+          },
+          "cache": true,
+          "inputs": [
+            "default",
+            "^production",
+            {
+              "externalDependencies": [
+                "vitest"
+              ]
+            }
+          ],
+          "outputs": [
+            "{workspaceRoot}/coverage/apps/myreactapp"
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "vite"
+            ]
+          }
+        },
+        "lint": {
+          "cache": true,
+          "options": {
+            "cwd": "apps/myreactapp",
+            "command": "eslint ."
+          },
+          "inputs": [
+            "default",
+            "{workspaceRoot}/.eslintrc.json",
+            "{workspaceRoot}/apps/myreactapp/.eslintrc.json",
+            "{workspaceRoot}/tools/eslint-rules/**/*",
+            {
+              "externalDependencies": [
+                "eslint"
+              ]
+            }
+          ],
+          "executor": "nx:run-commands",
+          "configurations": {},
+          "metadata": {
+            "technologies": [
+              "eslint"
+            ]
+          }
+        }
+      },
+      "name": "myreactapp",
+      "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "apps/myreactapp/src",
+      "projectType": "application",
+      "tags": [],
+      "implicitDependencies": [],
+      "metadata": {
+        "technologies": [
+          "react"
+        ]
+      }
+    }
+  },
+  "sourceMap": {
+    "root": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "targets": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "targets.build": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.cache": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.dependsOn": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.inputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.outputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.build.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.preview.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.executor": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.serve-static.options.buildTarget": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.command": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.options": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.cache": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.inputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.outputs": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.test.options.cwd": [
+      "apps/myreactapp/vite.config.ts",
+      "@nx/vite/plugin"
+    ],
+    "targets.lint": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.command": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.cache": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.options": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.inputs": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "targets.lint.options.cwd": [
+      "apps/myreactapp/project.json",
+      "@nx/eslint/plugin"
+    ],
+    "name": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "$schema": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "sourceRoot": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "projectType": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ],
+    "tags": [
+      "apps/myreactapp/project.json",
+      "nx/core/project-json"
+    ]
+  }
+}
+
+{% /project_details %}
 
 Nx Console has a button which will show a preview of this screen when a project level configuration file (`project.json` or `package.json`) is opened in the IDE. Read more at [Nx Console Project Details View](/recipes/nx-console/console-project-details).
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/convert-to-inferred.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/convert-to-inferred.mdoc
@@ -69,9 +69,8 @@ npx nx show project <project-name>
 
 For example, if we migrated the `@nx/vite` plugin for a single app (i.e. `nx g @nx/vite:convert-to-inferred --project demo`), then running `nx show project demo` will show a screen similar to the following.
 
-\{% project-details title="Test" height="100px" %}
+{% project_details title="Test" height="100px" %}
 
-```json
 {
   "project": {
     "name": "demo",
@@ -103,9 +102,8 @@ For example, if we migrated the `@nx/vite` plugin for a single app (i.e. `nx g @
     "targets.build": ["apps/demo/vite.config.ts", "@nx/vite"]
   }
 }
-```
 
-\{% /project-details %}
+{% /project_details %}
 
 You'll notice that the `serve` and `build` tasks are running the [Vite CLI](https://vitejs.dev/guide/cli.html) and there are no references to Nx executors. Since the targets directly invoke the Vite CLI, any options that may be passed to it can be passed via Nx commands. e.g. `nx serve demo --cors --port 8888` enables CORs and uses port `8888` using [Vite CLI options](https://vitejs.dev/guide/cli.html#options)
 The same CLI setup applies to other plugins as well.
@@ -214,7 +212,7 @@ The Atomizer splits potentially slow tasks into separate tasks per file. This fe
 
 To enable Atomizer, make sure that you are [connected to Nx Cloud](/ci/recipes/set-up), and that you have distribution enabled in CI. Some plugins require extra configuration to enable Atomizer, so check the [individual plugin documentation page](/plugin-registry) for more details.
 
-\{% call-to-action title="Connect to Nx Cloud" icon="nxcloud" description="Enable task distribution and Atomizer" url="/ci/recipes/set-up" /%}
+{% call_to_action title="Connect to Nx Cloud" icon="nxcloud" description="Enable task distribution and Atomizer" url="/ci/recipes/set-up" /%}
 
 ## Troubleshooting
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/pass-args-to-commands.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/pass-args-to-commands.mdoc
@@ -20,9 +20,8 @@ For this recipe we'll use a project with the following `project.json` file:
 
 And the following [final configuration](/reference/project-configuration):
 
-\{% project-details title="Project Details View" %}
+{% project_details title="Project Details View" %}
 
-```json
 {
   "project": {
     "name": "my-app",
@@ -155,9 +154,8 @@ And the following [final configuration](/reference/project-configuration):
     "tags": ["apps/my-app/project.json", "nx/core/project-json"]
   }
 }
-```
 
-\{% /project-details %}
+{% /project_details %}
 
 We'll focus on the `build` target of the project. If you expand the `build` target in the Project Details View above, you'll see that it runs the command `vite build`. In the next sections, we'll see how to provide `--assetsInlineLimit=2048` and `--assetsDir=static/assets` args to that command.
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/workspace-watching.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/workspace-watching.mdoc
@@ -9,9 +9,8 @@ Nx can watch your workspace and execute commands based on project or files chang
 
 Imagine the following project graph with these projects:
 
-\{% graph height="450px" %}
+{% graph height="450px" %}
 
-```json
 {
   "projects": [
     {
@@ -75,9 +74,8 @@ Imagine the following project graph with these projects:
   "groupByFolder": false,
   "exclude": []
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
 Traditionally, if you want to rebuild your projects whenever they change, you would have to set up an ad-hoc watching system to watch each project. Rather than setting up a watch manually, Nx can be used to watch projects and execute a command whenever they change.
 

--- a/astro-docs/src/content/docs/guides/Tips and Tricks/identify-dependencies-between-folders.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips and Tricks/identify-dependencies-between-folders.mdoc
@@ -37,9 +37,8 @@ Now, run `nx graph` to view the dependencies between the folders. In the full we
 
 Here is a graph that was created when doing this exercise on the [Angular Jump Start](https://github.com/DanWahlin/Angular-JumpStart) repo. To reproduce this graph yourself, download the repo, run `nx init` and then add `project.json` files to the folders under `/src/app`.
 
-\{% graph height="450px" %}
+{% graph height="450px" %}
 
-```json
 {
   "hash": "9713539543f19c5299e56715e78c576a40b91056b9cbb4e42118780cfcd22b5e",
   "projects": [
@@ -152,9 +151,8 @@ Here is a graph that was created when doing this exercise on the [Angular Jump S
   "groupByFolder": false,
   "exclude": []
 }
-```
 
-\{% /graph %}
+{% /graph %}
 
 ## Clean up
 

--- a/astro-docs/src/content/docs/references/project-configuration.mdoc
+++ b/astro-docs/src/content/docs/references/project-configuration.mdoc
@@ -19,9 +19,8 @@ Each source will [overwrite the previous source](/recipes/running-tasks/pass-arg
 nx show project myproject --web
 ```
 
-\{% project-details title="Project Details View" %}
+{% project_details title="Project Details View" %}
 
-```json
 {
   "project": {
     "name": "demo",
@@ -59,9 +58,8 @@ nx show project myproject --web
     "targets.build": ["packages/demo/vite.config.ts", "@nx/vite"]
   }
 }
-```
 
-\{% /project-details %}
+{% /project_details %}
 
 The project details view also shows where each setting is defined so that you know where to change it.
 

--- a/astro-docs/src/content/docs/technologies/angular/Guides/nx-and-angular.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/Guides/nx-and-angular.mdoc
@@ -287,7 +287,6 @@ As you start modularizing your Angular workspace, Nx can visualize it using the 
 
 {% graph height="450px" %}
 
-```json
 {
   "hash": "58420bb4002bb9b6914bdeb7808c77a591a089fc82aaee11e656d73b2735e3fa",
   "projects": [
@@ -389,7 +388,6 @@ As you start modularizing your Angular workspace, Nx can visualize it using the 
   "exclude": [],
   "enableTooltips": true
 }
-```
 
 {% /graph %}
 


### PR DESCRIPTION
This PR re-enables the escaped markdoc tags. Note that graph and PDV tags that pointed to an external JSON file is changed to inline the JSON instead so we don't need that extra file loading logic.

## Current Behavior
Multiple pages in the Astro documentation site display broken components due to:
- Escaped template blocks (\{% ... %\}) that prevent proper rendering
- Component name mismatches using hyphens instead of underscores
- Missing side-by-side component causing "Undefined tag" errors
- Graph components showing "Could not parse JSON" due to markdown code blocks
- External JSON file references not being inlined properly

## Expected Behavior
All documentation pages render correctly with:
- Proper template block syntax without backslash escaping
- Component names matching markdoc.config.mjs registrations
- All required components available and properly configured
- Graph and project_details components displaying JSON data inline
- All Markdoc components functioning as intended

<img width="824" height="849" alt="Screenshot 2025-08-20 at 10 55 53 AM" src="https://github.com/user-attachments/assets/3d94e2a8-c971-49a6-a7aa-95ac40a8c86b" />

<img width="797" height="627" alt="Screenshot 2025-08-20 at 12 33 19 PM" src="https://github.com/user-attachments/assets/1352e8bd-f5df-4db0-8679-a1627b2b6911" />

Also add back the `side_by_side` tag for now since it's used in a couple of places:

<img width="797" height="627" alt="Screenshot 2025-08-20 at 12 33 19 PM" src="https://github.com/user-attachments/assets/4ecaf12b-592f-4885-88d8-bc25e4c7d087" />
<img width="775" height="1059" alt="Screenshot 2025-08-20 at 12 55 23 PM" src="https://github.com/user-attachments/assets/0cc32bd4-e2f0-41b9-b2a6-29edabccae0e" />


## Related Issue(s)
Fixes DOC-148
