### PR TITLE
fix(misc): respect string values in alwaysAddToPackageJson migration flag

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -466,7 +466,9 @@ export class Migrator {
           filtered[packageName] = {
             version: packageUpdate.version,
             addToPackageJson: packageUpdate.alwaysAddToPackageJson
-              ? 'dependencies'
+              ? typeof packageUpdate.alwaysAddToPackageJson === 'string'
+                ? packageUpdate.alwaysAddToPackageJson
+                : 'dependencies'
               : packageUpdate.addToPackageJson || false,
           };
         }


### PR DESCRIPTION
## Summary

Fixed bug where `alwaysAddToPackageJson: "devDependencies"` was ignored and always defaulted to "dependencies".

- Updated ternary logic in migrate.ts to properly handle string values
- Added comprehensive test case for string values
- Maintains backward compatibility with boolean values

## Test Plan

- [x] Added test case covering both "dependencies" and "devDependencies" string values
- [x] Verified existing tests still pass
- [x] Confirmed backward compatibility with boolean values

Fixes #30586

Generated with [Claude Code](https://claude.ai/code)