### PR TITLE
chore(repo): remove users from Claude GitHub Actions permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   claude:
     if: |
-      contains(fromJson('["AgentEnder", "barbados-clemens", "Cammisuli", "Coly010", "FrozenPandaz", "isaacplmann", "JamesHenry", "jaysoo", "leosvelperez", "mandarini", "MaxKless", "meeroslav", "nartc", "ndcunningham", "philipjfulcher", "vsavkin", "xiongemi"]'), github.actor) &&
+      contains(fromJson('["AgentEnder", "barbados-clemens", "Cammisuli", "Coly010", "FrozenPandaz", "JamesHenry", "jaysoo", "leosvelperez", "MaxKless", "meeroslav", "nartc", "philipjfulcher", "vsavkin"]'), github.actor) &&
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
## Current Behavior

The Claude GitHub Actions workflow includes xiongemi, ndcunningham, isaacplmann, and mandarini in the allowed users list.

## Expected Behavior

These users should be removed from the allowed users list for Claude GitHub Actions workflow permissions.

## Related Issue(s)

<!-- No specific issue number -->

Fixes configuration by removing users from allowed list.