### PR TITLE
fix(angular-rspack): do not error on server budget violation

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -223,11 +223,13 @@ export class AngularRspackPlugin implements RspackPluginInstance {
 
       compiler.hooks.done.tap(PLUGIN_NAME, (statsValue) => {
         const stats = statsValue.toJson();
+
         if (
           budgets?.length &&
-          (compiler.options.target === 'node' ||
+          !(compiler.options.target === 'node' ||
             compiler.options.target === 'async-node')
         ) {
+
           budgetFailures = [...checkBudgets(budgets, stats)];
           for (const { severity, message } of budgetFailures) {
             switch (severity) {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -223,7 +223,11 @@ export class AngularRspackPlugin implements RspackPluginInstance {
 
       compiler.hooks.done.tap(PLUGIN_NAME, (statsValue) => {
         const stats = statsValue.toJson();
-        if (budgets?.length) {
+        if (
+          budgets?.length &&
+          (compiler.options.target === 'node' ||
+            compiler.options.target === 'async-node')
+        ) {
           budgetFailures = [...checkBudgets(budgets, stats)];
           for (const { severity, message } of budgetFailures) {
             switch (severity) {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -223,13 +223,13 @@ export class AngularRspackPlugin implements RspackPluginInstance {
 
       compiler.hooks.done.tap(PLUGIN_NAME, (statsValue) => {
         const stats = statsValue.toJson();
-
-        if (
-          budgets?.length &&
-          !(compiler.options.target === 'node' ||
-            compiler.options.target === 'async-node')
-        ) {
-
+        const isPlatformServer = Array.isArray(compiler.options.target)
+          ? compiler.options.target.some(
+              (target) => target === 'node' || target == 'async-node'
+            )
+          : compiler.options.target === 'node' ||
+            compiler.options.target === 'async-node';
+        if (budgets?.length && !isPlatformServer) {
           budgetFailures = [...checkBudgets(budgets, stats)];
           for (const { severity, message } of budgetFailures) {
             switch (severity) {


### PR DESCRIPTION
## Current Behavior
Angular with Esbuild does not error when server bundles violate the budgets.
Currently, Angular Rspack will error when server bundles violate the budgets.

## Expected Behavior
Match the behaviour with Angular with Esbuild in Angular Rspack.
Do not error when server bundles violate the budgets.

