### PR TITLE
fix(core): repair nx mcp in pnpm/yarn

### DIFF
--- a/packages/nx/src/command-line/mcp/mcp.ts
+++ b/packages/nx/src/command-line/mcp/mcp.ts
@@ -1,33 +1,59 @@
 import { spawnSync } from 'child_process';
-import { getPackageManagerCommand } from '../../utils/package-manager';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../../utils/package-manager';
 import { workspaceRoot } from '../../utils/workspace-root';
 
 export async function mcpHandler(args: any) {
-  const packageManagerCommands = getPackageManagerCommand();
+  const packageManager = detectPackageManager();
+  const packageManagerCommands = getPackageManagerCommand(packageManager);
 
   const passthroughArgs =
     args['_'][0] === 'mcp' ? args['_'].slice(1) : args['_'];
-  spawnSync(
-    packageManagerCommands.dlx,
-    ['-y', 'nx-mcp@latest', ...passthroughArgs],
-    {
-      stdio: 'inherit',
-      cwd: workspaceRoot,
-    }
-  );
+
+  let dlxArgs: string[];
+
+  if (packageManager === 'npm') {
+    dlxArgs = ['-y', 'nx-mcp@latest', ...passthroughArgs];
+  } else if (packageManager === 'yarn') {
+    dlxArgs = ['--quiet', 'nx-mcp@latest', ...passthroughArgs];
+  } else if (packageManager === 'bun') {
+    dlxArgs = ['--silent', 'nx-mcp@latest', ...passthroughArgs];
+  } else {
+    dlxArgs = ['nx-mcp@latest', ...passthroughArgs];
+  }
+
+  // spawnSync would break with a .dlx value with a space (like pnpm dlx is)
+  const spawnSyncArgs = `${packageManagerCommands.dlx} ${dlxArgs.join(
+    ' '
+  )}`.split(' ');
+
+  spawnSync(spawnSyncArgs[0], spawnSyncArgs.slice(1), {
+    stdio: 'inherit',
+    cwd: workspaceRoot,
+  });
 }
 
 export async function showHelp() {
-  const packageManagerCommands = getPackageManagerCommand();
+  const packageManager = detectPackageManager();
+  const packageManagerCommands = getPackageManagerCommand(packageManager);
 
-  const helpOutput = spawnSync(
-    packageManagerCommands.dlx,
-    ['-y', 'nx-mcp@latest', '--help'],
-    {
-      cwd: workspaceRoot,
-      encoding: 'utf-8',
-    }
-  );
+  let dlxArgs: string[];
+  if (packageManager === 'npm') {
+    dlxArgs = ['-y', 'nx-mcp@latest', '--help'];
+  } else if (packageManager === 'yarn') {
+    dlxArgs = ['--quiet', 'nx-mcp@latest', '--help'];
+  } else if (packageManager === 'bun') {
+    dlxArgs = ['--silent', 'nx-mcp@latest', '--help'];
+  } else {
+    dlxArgs = ['nx-mcp@latest', '--help'];
+  }
+
+  const helpOutput = spawnSync(packageManagerCommands.dlx, dlxArgs, {
+    cwd: workspaceRoot,
+    encoding: 'utf-8',
+  });
 
   console.log(helpOutput.stdout?.toString().replaceAll('nx-mcp', 'nx mcp'));
 }

--- a/packages/nx/src/command-line/mcp/mcp.ts
+++ b/packages/nx/src/command-line/mcp/mcp.ts
@@ -24,12 +24,12 @@ export async function mcpHandler(args: any) {
     dlxArgs = ['nx-mcp@latest', ...passthroughArgs];
   }
 
-  // spawnSync would break with a .dlx value with a space (like pnpm dlx is)
-  const spawnSyncArgs = `${packageManagerCommands.dlx} ${dlxArgs.join(
-    ' '
-  )}`.split(' ');
+  // For commands that might contain spaces like "pnpm dlx"
+  const dlxCommand = packageManagerCommands.dlx.split(' ');
+  const executable = dlxCommand[0];
+  const execArgs = [...dlxCommand.slice(1), ...dlxArgs];
 
-  spawnSync(spawnSyncArgs[0], spawnSyncArgs.slice(1), {
+  spawnSync(executable, execArgs, {
     stdio: 'inherit',
     cwd: workspaceRoot,
   });
@@ -50,7 +50,11 @@ export async function showHelp() {
     dlxArgs = ['nx-mcp@latest', '--help'];
   }
 
-  const helpOutput = spawnSync(packageManagerCommands.dlx, dlxArgs, {
+  const dlxCommand = packageManagerCommands.dlx.split(' ');
+  const executable = dlxCommand[0];
+  const execArgs = [...dlxCommand.slice(1), ...dlxArgs];
+
+  const helpOutput = spawnSync(executable, execArgs, {
     cwd: workspaceRoot,
     encoding: 'utf-8',
   });


### PR DESCRIPTION
This pull request updates the `mcp.ts` command handler to improve compatibility with multiple package managers and enhance argument handling for command execution. The changes ensure that the correct flags are used for each package manager and that commands with spaces are executed properly.


* Adjusted arguments passed to the `dlx` command for `npm`, `yarn`, and `bun` to use their respective flags (`-y`, `--quiet`, `--silent`), ensuring consistent behavior across different package managers.
* Improved handling of `dlx` commands that may contain spaces (e.g., `pnpm dlx`) by splitting the command and passing arguments appropriately to `spawnSync`.
* Updated both `mcpHandler` and `showHelp` functions to use the new argument handling logic for executing commands and displaying help output.