### PR TITLE
fix(core): handle no daemon when stopping

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -740,7 +740,10 @@ export class DaemonClient {
 
   async stop(): Promise<void> {
     try {
-      process.kill(getDaemonProcessIdSync(), 'SIGTERM');
+      const pid = getDaemonProcessIdSync();
+      if (pid) {
+        process.kill(pid, 'SIGTERM');
+      }
     } catch (err) {
       output.error({
         title:


### PR DESCRIPTION
## Current Behavior
When daemon is not running, its pid is null... We don't handle this in `stop`

## Expected Behavior
We handle this in stop.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
