### PR TITLE
feat(repo): add GitHub Actions workflow to validate PR titles

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,38 @@
+name: PR Title Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-pr-title:
+    if: ${{ github.repository_owner == 'nrwl' }}
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # For pull_request_target, we need to checkout the base branch
+          ref: ${{ github.event.pull_request.base.ref }}
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          
+      - name: Create PR message file
+        run: |
+          mkdir -p /tmp
+          cat > /tmp/pr-message.txt << 'EOF'
+          ${{ github.event.pull_request.title }}
+          
+          ${{ github.event.pull_request.body }}
+          EOF
+          
+      - name: Validate PR title
+        run: |
+          echo "Validating PR title: ${{ github.event.pull_request.title }}"
+          node ./scripts/commit-lint.js /tmp/pr-message.txt


### PR DESCRIPTION
## Current Behavior

Currently, there is no automated check to ensure that PR titles follow our conventional commit format. This can lead to inconsistent PR titles that don't match our commit conventions.

## Expected Behavior

With this change, all PR titles will be automatically validated against our git commit rules when a PR is:
- Opened
- Edited
- Synchronized
- Reopened

The check uses the existing `scripts/commit-lint.js` script to validate PR titles, ensuring they follow the same format as our commit messages (e.g., `feat(scope): description`, `fix(scope): description`, etc.).

## Related Issue(s)

This was requested to improve PR quality and consistency across the repository.

## Implementation Details

- Added a new GitHub Actions workflow: `.github/workflows/pr-title-validation.yml`
- The workflow writes the PR title and body to a temporary file in the format specified
- Runs `node ./scripts/commit-lint.js` on the file to validate the PR title
- The check will fail if the PR title doesn't match our conventional commit format
- The workflow only runs for the `nrwl` repository owner (consistent with other workflows)

## Test Plan

- [x] Tested locally with valid PR titles (e.g., `feat(core): add new feature`)
- [x] Tested locally with invalid PR titles (confirmed validation failure)
- [x] Tested with breaking change notation (`fix(core)!: breaking change`)
- [ ] Test on actual PR once merged

🤖 Generated with [Claude Code](https://claude.ai/code)