### PR TITLE
docs(nx-dev): add sitemap and robots.txt as static assets

### DIFF
--- a/astro-docs/project.json
+++ b/astro-docs/project.json
@@ -35,6 +35,7 @@
     "preview": {
       "dependsOn": ["build"],
       "command": "astro preview",
+      "continuous": true,
       "options": {
         "cwd": "astro-docs"
       }

--- a/astro-docs/public/robots.txt
+++ b/astro-docs/public/robots.txt
@@ -1,4 +1,9 @@
+# *
 User-agent: *
 Allow: /
 
-Sitemap: https://<YOUR SITE>/sitemap-index.xml
+# Host
+Host: https://nx.dev
+
+# Sitemaps
+Sitemap: https://nx.dev/sitemap-index.xml

--- a/astro-docs/public/sitemap.xml
+++ b/astro-docs/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>https://nx.dev/docs/sitemap-0.xml</loc>
+    </sitemap>
+</sitemapindex>


### PR DESCRIPTION
update robots.txt to point to the sitemap-index.xml so crawlers shouldn't actually look at sitemap.xml directly anyway
but also included sitemap.xml to match that of the sitemap-index.xml content for historical reasons in case anything still references that older sitemap