### PR TITLE
feat(core): add incompatibleWith field for packageJsonUpdates

### DIFF
--- a/docs/generated/packages/vite/migrations/21.5.0-package-updates.json
+++ b/docs/generated/packages/vite/migrations/21.5.0-package-updates.json
@@ -4,6 +4,7 @@
   "packages": {
     "vite": { "version": "^7.1.3", "alwaysAddToPackageJson": false }
   },
+  "incompatibleWith": { "@remix-run/dev": "*" },
   "aliases": [],
   "description": "",
   "hidden": false,

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -1765,5 +1765,96 @@ describe('Migration', () => {
         },
       });
     });
+
+    it('should skip packageJsonUpdates when incompatible packages are present', async () => {
+      const migrator = new Migrator({
+        packageJson: createPackageJson({
+          dependencies: {
+            parent: '1.0.0',
+            'incompatible-package': '1.0.0',
+          },
+        }),
+        getInstalledPackageVersion: (pkg) => {
+          if (pkg === 'parent') return '1.0.0';
+          if (pkg === 'incompatible-package') return '1.0.0';
+          return null;
+        },
+        fetch: (p, _v) => {
+          if (p === 'parent') {
+            return Promise.resolve({
+              version: '2.0.0',
+              packageJsonUpdates: {
+                version2: {
+                  version: '2.0.0',
+                  packages: {
+                    child: { version: '2.0.0' },
+                  },
+                  incompatibleWith: {
+                    'incompatible-package': '*',
+                  },
+                },
+              },
+              schematics: {},
+            });
+          }
+          return Promise.resolve(null);
+        },
+        from: {},
+        to: {},
+      });
+
+      const result = await migrator.migrate('parent', '2.0.0');
+
+      // The packageJsonUpdate should be skipped due to incompatibleWith
+      expect(result.packageUpdates).toEqual({
+        parent: { version: '2.0.0', addToPackageJson: false },
+      });
+      // 'child' should not be in packageUpdates because the update was skipped
+      expect(result.packageUpdates.child).toBeUndefined();
+    });
+
+    it('should apply packageJsonUpdates when incompatible packages are not present', async () => {
+      const migrator = new Migrator({
+        packageJson: createPackageJson({
+          dependencies: {
+            parent: '1.0.0',
+          },
+        }),
+        getInstalledPackageVersion: (pkg) => {
+          if (pkg === 'parent') return '1.0.0';
+          return null; // incompatible-package is not installed
+        },
+        fetch: (p, _v) => {
+          if (p === 'parent') {
+            return Promise.resolve({
+              version: '2.0.0',
+              packageJsonUpdates: {
+                version2: {
+                  version: '2.0.0',
+                  packages: {
+                    child: { version: '2.0.0' },
+                  },
+                  incompatibleWith: {
+                    'incompatible-package': '*',
+                  },
+                },
+              },
+              schematics: {},
+            });
+          }
+          return Promise.resolve(null);
+        },
+        from: {},
+        to: {},
+      });
+
+      const result = await migrator.migrate('parent', '2.0.0');
+
+      // The packageJsonUpdate should be applied since incompatible package is not present
+      expect(result.packageUpdates).toEqual({
+        parent: { version: '2.0.0', addToPackageJson: false },
+        child: { version: '2.0.0', addToPackageJson: false },
+      });
+    });
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -1818,10 +1818,12 @@ describe('Migration', () => {
         packageJson: createPackageJson({
           dependencies: {
             parent: '1.0.0',
+            child: '1.0.0',
           },
         }),
         getInstalledPackageVersion: (pkg) => {
           if (pkg === 'parent') return '1.0.0';
+          if (pkg === 'child') return '1.0.0';
           return null; // incompatible-package is not installed
         },
         fetch: (p, _v) => {
@@ -1839,6 +1841,12 @@ describe('Migration', () => {
                   },
                 },
               },
+              schematics: {},
+            });
+          }
+          if (p === 'child') {
+            return Promise.resolve({
+              version: '2.0.0',
               schematics: {},
             });
           }

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -64,6 +64,7 @@ export type PackageJsonUpdates = {
     };
     'x-prompt'?: string;
     requires?: Record<string, string>;
+    incompatibleWith?: Record<string, string>;
   };
 };
 

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -105,6 +105,9 @@
           "version": "^7.1.3",
           "alwaysAddToPackageJson": false
         }
+      },
+      "incompatibleWith": {
+        "@remix-run/dev": "*"
       }
     }
   }


### PR DESCRIPTION
## Summary

- Adds support for `incompatibleWith` field in `packageJsonUpdates` to prevent updates from running when specified packages are present
- Provides the opposite functionality of the existing `requires` field
- Implements logic to skip packageJsonUpdates when any incompatible packages are found

## Changes Made

### Core Implementation
- Added `incompatibleWith?: Record<string, string>` to `PackageJsonUpdates` type
- Implemented `areIncompatiblePackagesPresent()` method with semver checking
- Updated migration logic to check for both requirements and incompatibilities
- Added comprehensive tests for both positive and negative scenarios

### Vite 7 Compatibility Fix
- Added `incompatibleWith: { "@remix-run/dev": "*" }` to vite 7 packageJsonUpdate
- Prevents vite 7 update from running when @remix-run/dev is present

## Usage Example

```json
{
  "packageJsonUpdates": {
    "17.0.0": {
      "version": "17.0.0",
      "packages": {
        "new-package": { "version": "^17.0.0" }
      },
      "incompatibleWith": {
        "old-package": "*",
        "conflicting-package": "<2.0.0"
      }
    }
  }
}
```

The update will be skipped if either `old-package` (any version) or `conflicting-package` (version < 2.0.0) is present in the workspace.

## Test Plan

- [x] Added unit tests covering both positive and negative scenarios
- [x] Verified existing tests still pass
- [x] Applied to real-world case (vite 7 + Remix incompatibility)
- [ ] Test on workspace with @remix-run/dev to verify vite 7 is skipped
- [ ] Test on workspace without @remix-run/dev to verify vite 7 is applied

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Notes

This feature enables better control over migration paths and prevents package conflicts during nx migrate operations. The vite 7 + Remix case is a concrete example where this prevents incompatible package combinations.