### PR TITLE
docs(docker): add docker overview page

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
@@ -1,0 +1,65 @@
+---
+title: Overview of the Nx Docker Plugin
+description: The Nx Plugin for Docker contains executors and utilities for building and publishing docker images within an Nx workspace.
+keywords: [docker]
+sidebar:
+  label: Introduction
+---
+
+The Nx Plugin for Docker contains executors and utilities for building and publishing docker images within an Nx workspace.
+Using the `@nx/docker` [Inference Plugin](/concepts/inferred-tasks), Nx will automatically detect `Dockerfile`'s in your workspace and provide a `docker:build` and `docker:run` target for each.
+It will also provide a `nx-release-publish` target for publishing docker images to a registry.
+
+## Installation
+
+In any Nx workspace, you can install `@nx/docker` by running the following command:
+
+```shell frame="none"
+nx add @nx/docker
+```
+
+This will install the correct version of `@nx/docker` to match the version of Nx you are using.
+
+{% aside title="Minimum Nx Version" type="caution" %}
+The `@nx/docker` plugin only became available in Nx 21.4.0-beta.9. Your Nx Workspace will need to be on this version or higher to use it.
+{% /aside %}
+
+### How @nx/docker Infers Tasks
+
+The `@nx/docker` plugin will create a task for any project that has a Dockerfile present. It will infer the following tasks:
+
+- `docker:build`
+- `docker:run`
+- `nx-release-publish`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line.
+
+### @nx/docker Configuration
+
+The `@nx/docker` plugin is configured in the `plugins` array in `nx.json`.
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/docker",
+      "options": {
+        "buildTarget": "docker:build",
+        "runTarget": "docker:run"
+      }
+    }
+  ]
+}
+```
+
+The `buildTarget` and `runTarget` options control the names of the inferred Docker tasks. The default names are `docker:build` and `docker:run`.
+
+## Using Nx Release to Publish Docker Images
+
+The `@nx/docker` plugin provides a `nx-release-publish` target for publishing docker images to a registry.
+[Nx Release](/features/manage-releases) was also updated to support versioning docker images, generating changelogs, and publishing docker images to a registry through a single command.
+
+You can learn more about how to manage releases for Docker Images in the [Release Docker Images](/recipes/nx-release/release-docker-images) guide.

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -3764,6 +3764,23 @@
             "isExternal": false,
             "children": [
               {
+                "name": "Docker",
+                "path": "/technologies/build-tools/docker",
+                "id": "docker",
+                "isExternal": false,
+                "children": [
+                  {
+                    "name": "Introduction",
+                    "path": "/technologies/build-tools/docker/introduction",
+                    "id": "introduction",
+                    "isExternal": false,
+                    "children": [],
+                    "disableCollapsible": false
+                  }
+                ],
+                "disableCollapsible": false
+              },
+              {
                 "name": "Webpack",
                 "path": "/technologies/build-tools/webpack",
                 "id": "webpack",

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -4794,6 +4794,29 @@
         "file": "",
         "itemList": [
           {
+            "id": "docker",
+            "name": "Docker",
+            "description": "",
+            "mediaImage": "",
+            "file": "",
+            "itemList": [
+              {
+                "id": "introduction",
+                "name": "Introduction",
+                "description": "",
+                "mediaImage": "",
+                "file": "shared/packages/docker/docker-plugin",
+                "itemList": [],
+                "isExternal": false,
+                "path": "/technologies/build-tools/docker/introduction",
+                "tags": []
+              }
+            ],
+            "isExternal": false,
+            "path": "/technologies/build-tools/docker",
+            "tags": []
+          },
+          {
             "id": "webpack",
             "name": "Webpack",
             "description": "",
@@ -9157,6 +9180,29 @@
     "file": "",
     "itemList": [
       {
+        "id": "docker",
+        "name": "Docker",
+        "description": "",
+        "mediaImage": "",
+        "file": "",
+        "itemList": [
+          {
+            "id": "introduction",
+            "name": "Introduction",
+            "description": "",
+            "mediaImage": "",
+            "file": "shared/packages/docker/docker-plugin",
+            "itemList": [],
+            "isExternal": false,
+            "path": "/technologies/build-tools/docker/introduction",
+            "tags": []
+          }
+        ],
+        "isExternal": false,
+        "path": "/technologies/build-tools/docker",
+        "tags": []
+      },
+      {
         "id": "webpack",
         "name": "Webpack",
         "description": "",
@@ -9464,6 +9510,40 @@
     ],
     "isExternal": false,
     "path": "/technologies/build-tools",
+    "tags": []
+  },
+  "/technologies/build-tools/docker": {
+    "id": "docker",
+    "name": "Docker",
+    "description": "",
+    "mediaImage": "",
+    "file": "",
+    "itemList": [
+      {
+        "id": "introduction",
+        "name": "Introduction",
+        "description": "",
+        "mediaImage": "",
+        "file": "shared/packages/docker/docker-plugin",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/technologies/build-tools/docker/introduction",
+        "tags": []
+      }
+    ],
+    "isExternal": false,
+    "path": "/technologies/build-tools/docker",
+    "tags": []
+  },
+  "/technologies/build-tools/docker/introduction": {
+    "id": "introduction",
+    "name": "Introduction",
+    "description": "",
+    "mediaImage": "",
+    "file": "shared/packages/docker/docker-plugin",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/technologies/build-tools/docker/introduction",
     "tags": []
   },
   "/technologies/build-tools/webpack": {

--- a/docs/map.json
+++ b/docs/map.json
@@ -1415,6 +1415,17 @@
               "id": "build-tools",
               "itemList": [
                 {
+                  "name": "Docker",
+                  "id": "docker",
+                  "itemList": [
+                    {
+                      "name": "Introduction",
+                      "id": "introduction",
+                      "file": "shared/packages/docker/docker-plugin"
+                    }
+                  ]
+                },
+                {
                   "name": "Webpack",
                   "id": "webpack",
                   "itemList": [

--- a/docs/shared/packages/docker/docker-plugin.md
+++ b/docs/shared/packages/docker/docker-plugin.md
@@ -1,0 +1,64 @@
+---
+title: Overview of the Nx Docker Plugin
+description: The Nx Plugin for Docker contains executors and utilities for building and publishing docker images within an Nx workspace.
+keywords: [docker]
+---
+
+# @nx/docker
+
+The Nx Plugin for Docker contains executors and utilities for building and publishing docker images within an Nx workspace.
+Using the `@nx/docker` [Inference Plugin](/concepts/inferred-tasks), Nx will automatically detect `Dockerfile`'s in your workspace and provide a `docker:build` and `docker:run` target for each.  
+It will also provide a `nx-release-publish` target for publishing docker images to a registry.
+
+## Installation
+
+In any Nx workspace, you can install `@nx/docker` by running the following command:
+
+```shell {% skipRescope=true %}
+nx add @nx/docker
+```
+
+This will install the correct version of `@nx/docker` to match the version of Nx you are using.
+
+{% callout type="warning" %}
+The `@nx/docker` plugin only became available in Nx 21.4.0-beta.9. Your Nx Workspace will need to be on this version or higher to use it.
+{% /callout %}
+
+### How @nx/docker Infers Tasks
+
+The `@nx/docker` plugin will create a task for any project that has a Dockerfile present. It will infer the following tasks:
+
+- `docker:build`
+- `docker:run`
+- `nx-release-publish`
+
+### View Inferred Tasks
+
+To view inferred tasks for a project, open the [project details view](/concepts/inferred-tasks) in Nx Console or run `nx show project my-project` in the command line.
+
+### @nx/docker Configuration
+
+The `@nx/docker` plugin is configured in the `plugins` array in `nx.json`.
+
+```json {% fileName="nx.json" %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/docker",
+      "options": {
+        "buildTarget": "docker:build",
+        "runTarget": "docker:run"
+      }
+    }
+  ]
+}
+```
+
+The `buildTarget` and `runTarget` options control the names of the inferred Docker tasks. The default names are `docker:build` and `docker:run`.
+
+## Using Nx Release to Publish Docker Images
+
+The `@nx/docker` plugin provides a `nx-release-publish` target for publishing docker images to a registry.  
+[Nx Release](/features/manage-releases) was also updated to support versioning docker images, generating changelogs, and publishing docker images to a registry through a single command.
+
+You can learn more about how to manage releases for Docker Images in the [Release Docker Images](/recipes/nx-release/release-docker-images) guide.

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -453,6 +453,8 @@
         - [API](/technologies/eslint/eslint-plugin/api)
           - [migrations](/technologies/eslint/eslint-plugin/api/migrations)
     - [Build Tools](/technologies/build-tools)
+      - [Docker](/technologies/build-tools/docker)
+        - [Introduction](/technologies/build-tools/docker/introduction)
       - [Webpack](/technologies/build-tools/webpack)
         - [Introduction](/technologies/build-tools/webpack/introduction)
         - [Guides](/technologies/build-tools/webpack/recipes)

--- a/packages/docker/README.md
+++ b/packages/docker/README.md
@@ -13,7 +13,7 @@
 
 An AI-first build platform that connects everything from your editor to CI. Helping you deliver fast, without breaking things.
 
-This package is a [Docker plugin for Nx](https://nx.dev/nx-api/docker).
+This package is a [Docker plugin for Nx](https://nx.dev/technologies/build-tools/docker/introduction).
 
 **Experimental**: Support for Docker is currently experimental. Breaking changes may occur and not adhere to semver versioning.
 


### PR DESCRIPTION
## Current Behavior
There is currently no overview page for the Docker plugin, just documentation on the using it with Nx Release.

## Expected Behavior
Add an overview page for the Docker plugin
