### PR TITLE
fix(core): create pnpm peer deps settings in the appropriate location when creating workspace

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -43,6 +43,7 @@
     "chalk": "^4.1.0",
     "enquirer": "~2.3.6",
     "picomatch": "4.0.2",
+    "semver": "^7.6.3",
     "tslib": "^2.3.0",
     "yargs-parser": "21.1.1"
   },

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -1,12 +1,17 @@
-import type { NxJsonConfiguration, Tree } from '@nx/devkit';
-import { formatFiles, readJson } from '@nx/devkit';
-import Ajv from 'ajv';
-import { generateWorkspaceFiles } from './generate-workspace-files';
+import * as devkit from '@nx/devkit';
+import {
+  formatFiles,
+  readJson,
+  type NxJsonConfiguration,
+  type Tree,
+} from '@nx/devkit';
 import { createTree } from '@nx/devkit/testing';
-import { Preset } from '../utils/presets';
-import * as nxSchema from 'nx/schemas/nx-schema.json';
+import Ajv from 'ajv';
 import { mkdirSync, writeFileSync } from 'fs';
+import * as nxSchema from 'nx/schemas/nx-schema.json';
 import { join } from 'path';
+import { Preset } from '../utils/presets';
+import { generateWorkspaceFiles } from './generate-workspace-files';
 
 jest.mock(
   'nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud',
@@ -33,6 +38,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     tree = createTree();
     // we need an actual path for the package manager version check
     tree.root = process.cwd();
+    jest.clearAllMocks();
   });
 
   it('should create files', async () => {
@@ -318,8 +324,63 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     `);
   });
 
-  it('should create workspaces from workspaceGlobs (pnpm)', async () => {
-    tree.write('/proj/package.json', JSON.stringify({}));
+  it('should configure the pnpm settings in pnpm-workspace.yaml and not create an .npmrc file for pnpm <7', async () => {
+    tree.write('proj/package.json', JSON.stringify({}));
+    jest.spyOn(devkit, 'getPackageManagerVersion').mockReturnValue('6.1.0');
+
+    await generateWorkspaceFiles(tree, {
+      name: 'proj',
+      directory: 'proj',
+      preset: Preset.NPM,
+      defaultBase: 'main',
+      packageManager: 'pnpm',
+      isCustomPreset: false,
+      workspaceGlobs: ['apps/*', 'packages/*'],
+    });
+
+    const packageJson = tree.read('proj/pnpm-workspace.yaml', 'utf-8');
+    expect(packageJson).toMatchInlineSnapshot(`
+      "packages:
+        - "apps/*"
+        - "packages/*"
+      "
+    `);
+    expect(tree.exists('proj/.npmrc')).toBeFalsy();
+  });
+
+  it('should configure the pnpm settings in pnpm-workspace.yaml and .npmrc for pnpm >7 <10.6.0', async () => {
+    tree.write('proj/package.json', JSON.stringify({}));
+    jest.spyOn(devkit, 'getPackageManagerVersion').mockReturnValue('9.1.0');
+
+    await generateWorkspaceFiles(tree, {
+      name: 'proj',
+      directory: 'proj',
+      preset: Preset.NPM,
+      defaultBase: 'main',
+      packageManager: 'pnpm',
+      isCustomPreset: false,
+      workspaceGlobs: ['apps/*', 'packages/*'],
+    });
+
+    const packageJson = tree.read('proj/pnpm-workspace.yaml', 'utf-8');
+    expect(packageJson).toMatchInlineSnapshot(`
+      "packages:
+        - "apps/*"
+        - "packages/*"
+      "
+    `);
+    const npmrc = tree.read('proj/.npmrc', 'utf-8');
+    expect(npmrc).toMatchInlineSnapshot(`
+      "strict-peer-dependencies=false
+      auto-install-peers=true
+      "
+    `);
+  });
+
+  it('should configure the pnpm settings in pnpm-workspace.yaml and not create an .npmrc file for pnpm 10.6.0+', async () => {
+    tree.write('proj/package.json', JSON.stringify({}));
+    jest.spyOn(devkit, 'getPackageManagerVersion').mockReturnValue('10.6.0');
+
     await generateWorkspaceFiles(tree, {
       name: 'proj',
       directory: 'proj',
@@ -332,10 +393,14 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
 
     const packageJson = tree.read('/proj/pnpm-workspace.yaml', 'utf-8');
     expect(packageJson).toMatchInlineSnapshot(`
-      "packages: 
+      "packages:
         - "apps/*"
         - "packages/*"
+
+      autoInstallPeers: true
+      strictPeerDependencies: false
       "
     `);
+    expect(tree.exists('proj/.npmrc')).toBeFalsy();
   });
 });

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -2,19 +2,20 @@ import {
   generateFiles,
   getPackageManagerVersion,
   names,
-  NxJsonConfiguration,
-  PackageManager,
-  Tree,
+  type NxJsonConfiguration,
+  type PackageManager,
+  type Tree,
   updateJson,
   writeJson,
 } from '@nx/devkit';
-import { nxVersion } from '../../utils/versions';
-import { join } from 'path';
-import { Preset } from '../utils/presets';
-import { deduceDefaultBase } from '../../utilities/default-base';
-import { NormalizedSchema } from './new';
 import { connectToNxCloud } from 'nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud';
 import { createNxCloudOnboardingURL } from 'nx/src/nx-cloud/utilities/url-shorten';
+import { join } from 'path';
+import { gte } from 'semver';
+import { deduceDefaultBase } from '../../utilities/default-base';
+import { nxVersion } from '../../utils/versions';
+import { Preset } from '../utils/presets';
+import type { NormalizedSchema } from './new';
 
 type PresetInfo = {
   generateAppCmd?: string;
@@ -185,7 +186,11 @@ export async function generateWorkspaceFiles(
 
   const [packageMajor] = packageManagerVersion.split('.');
   if (options.packageManager === 'pnpm' && +packageMajor >= 7) {
-    createNpmrc(tree, options);
+    if (gte(packageManagerVersion, '10.6.0')) {
+      addPnpmSettings(tree, options);
+    } else {
+      createNpmrc(tree, options);
+    }
   } else if (options.packageManager === 'yarn') {
     if (+packageMajor >= 2) {
       createYarnrcYml(tree, options);
@@ -320,6 +325,15 @@ async function createReadme(
 
 // ensure that pnpm install add all the missing peer deps
 
+function addPnpmSettings(tree: Tree, options: NormalizedSchema) {
+  tree.write(
+    join(options.directory, 'pnpm-workspace.yaml'),
+    `autoInstallPeers: true
+strictPeerDependencies: false
+`
+  );
+}
+
 function createNpmrc(tree: Tree, options: NormalizedSchema) {
   tree.write(
     join(options.directory, '.npmrc'),
@@ -415,12 +429,21 @@ function setUpWorkspacesInPackageJson(tree: Tree, options: NormalizedSchema) {
   ) {
     const workspaces = options.workspaceGlobs ?? ['packages/*'];
     if (options.packageManager === 'pnpm') {
-      tree.write(
-        join(options.directory, 'pnpm-workspace.yaml'),
-        `packages: 
+      const pnpmWorkspacePath = join(options.directory, 'pnpm-workspace.yaml');
+
+      let content = `packages:
   ${workspaces.map((workspace) => `- "${workspace}"`).join('\n  ')}
-`
-      );
+`;
+
+      if (tree.exists(pnpmWorkspacePath)) {
+        // already added to set the peer deps settings for pnpm 10.6.0+
+        const existingContent = tree.read(pnpmWorkspacePath, 'utf-8');
+        if (existingContent.trim().length) {
+          content = `${content}\n${existingContent}`;
+        }
+      }
+
+      tree.write(pnpmWorkspacePath, content);
     } else {
       updateJson(tree, join(options.directory, 'package.json'), (json) => {
         json.workspaces = workspaces;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4000,6 +4000,9 @@ importers:
       picomatch:
         specifier: 4.0.2
         version: 4.0.2
+      semver:
+        specifier: ^7.6.3
+        version: 7.7.2
       tslib:
         specifier: ^2.3.0
         version: 2.8.1


### PR DESCRIPTION
## Current Behavior

When creating a workspace, some pnpm-specific settings are written to an `.npmrc` file in the workspace root. Npm warns about those unknown config properties.

## Expected Behavior

The pnpm-specific settings should be written to the `pnpm-worskpace.yaml` file for pnpm versions that support it (10.6.0+).