### PR TITLE
chore(repo): stop reusing test runner browsers from agent setup

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cypress
-  NX_NIGHTLY_TEST_RUN: 'true'
 
 permissions: { }
 jobs:

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -135,12 +135,6 @@ export const packageManagerLockFile = {
 };
 
 export function ensureCypressInstallation() {
-  // Skip Cypress installation on CI where it's pre-installed in agents.yaml
-  if (isCI && process.env.NX_NIGHTLY_TEST_RUN !== 'true') {
-    e2eConsoleLogger('Running on CI - Cypress pre-installed via agents.yaml');
-    return;
-  }
-
   let cypressVerified = true;
   try {
     const r = execSync('npx cypress verify', {
@@ -166,14 +160,6 @@ export function ensureCypressInstallation() {
 }
 
 export function ensurePlaywrightBrowsersInstallation() {
-  // Skip browser installation on CI where browsers are pre-installed in agents.yaml
-  if (isCI && process.env.NX_NIGHTLY_TEST_RUN !== 'true') {
-    e2eConsoleLogger(
-      'Running on CI - Playwright browsers pre-installed via agents.yaml'
-    );
-    return;
-  }
-
   // Lightweight check: try to get Playwright browser path
   try {
     const browserPath = execSync('npx playwright install --dry-run', {


### PR DESCRIPTION
## Current Behavior

The e2e tests in the repo can sometimes fail due to Cypress and/or Playwright version mismatches between the version in the repo lockfile and the version that gets installed in workspaces generated when running the e2e tests.

The e2e tests rely on the browsers installed by the agent, but the agent installs the browser for the version the repo lockfile has, while the e2e tests need the version that gets generated in the workspaces.

## Expected Behavior

The e2e tests in the repo should not fail due to Cypress and/or Playwright version mismatches. It's unreliable to rely on the browsers installed by the agent due to potential version mismatches.