### PR TITLE
fix(misc): check for `packages` existence to detect pnpm workspaces setup

### DIFF
--- a/packages/expo/src/executors/build/build.impl.ts
+++ b/packages/expo/src/executors/build/build.impl.ts
@@ -1,6 +1,7 @@
 import {
   detectPackageManager,
   ExecutorContext,
+  isWorkspacesEnabled,
   names,
   PackageManager,
   readJsonFile,
@@ -121,11 +122,7 @@ function copyPackageJsonAndLock(
   const packageJson = pathResolve(workspaceRoot, 'package.json');
   const rootPackageJson = readJsonFile<PackageJson>(packageJson);
   // do not copy package.json and lock file if workspaces are enabled
-  if (
-    (packageManager === 'pnpm' &&
-      existsSync(pathResolve(workspaceRoot, 'pnpm-workspace.yaml'))) ||
-    rootPackageJson.workspaces
-  ) {
+  if (isWorkspacesEnabled(packageManager, workspaceRoot)) {
     // no resource taken, no resource cleaned up
     return () => {};
   }

--- a/packages/js/src/utils/package-manager-workspaces.ts
+++ b/packages/js/src/utils/package-manager-workspaces.ts
@@ -53,7 +53,18 @@ export function isUsingPackageManagerWorkspaces(tree: Tree): boolean {
 export function isWorkspacesEnabled(tree: Tree): boolean {
   const packageManager = detectPackageManager(tree.root);
   if (packageManager === 'pnpm') {
-    return tree.exists('pnpm-workspace.yaml');
+    if (!tree.exists('pnpm-workspace.yaml')) {
+      return false;
+    }
+
+    try {
+      const content = tree.read('pnpm-workspace.yaml', 'utf-8');
+      const { load } = require('@zkochan/js-yaml');
+      const { packages } = load(content) ?? {};
+      return packages !== undefined;
+    } catch {
+      return false;
+    }
   }
 
   // yarn and npm both use the same 'workspaces' property in package.json

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -346,8 +346,15 @@ export function printFinalMessage({
 export function isMonorepo(packageJson: PackageJson) {
   if (!!packageJson.workspaces) return true;
 
-  if (existsSync('pnpm-workspace.yaml') || existsSync('pnpm-workspace.yml'))
-    return true;
+  try {
+    const content = readFileSync('pnpm-workspace.yaml', 'utf-8');
+    const { load } = require('@zkochan/js-yaml');
+    const { packages } = load(content) ?? {};
+
+    if (packages) {
+      return true;
+    }
+  } catch {}
 
   if (existsSync('lerna.json')) return true;
 

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -1,5 +1,5 @@
 import { exec, execSync } from 'child_process';
-import { copyFileSync, existsSync, writeFileSync } from 'fs';
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import {
   Pair,
   ParsedNode,
@@ -80,7 +80,18 @@ export function isWorkspacesEnabled(
   root: string = workspaceRoot
 ): boolean {
   if (packageManager === 'pnpm') {
-    return existsSync(join(root, 'pnpm-workspace.yaml'));
+    if (!existsSync(join(root, 'pnpm-workspace.yaml'))) {
+      return false;
+    }
+
+    try {
+      const content = readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf-8');
+      const { load } = require('@zkochan/js-yaml');
+      const { packages } = load(content) ?? {};
+      return packages !== undefined;
+    } catch {
+      return false;
+    }
   }
 
   // yarn and npm both use the same 'workspaces' property in package.json

--- a/packages/workspace/src/utilities/package-manager-workspaces.ts
+++ b/packages/workspace/src/utilities/package-manager-workspaces.ts
@@ -37,7 +37,18 @@ export function isUsingPackageManagerWorkspaces(tree: Tree): boolean {
 export function isWorkspacesEnabled(tree: Tree): boolean {
   const packageManager = detectPackageManager(tree.root);
   if (packageManager === 'pnpm') {
-    return tree.exists('pnpm-workspace.yaml');
+    if (!tree.exists('pnpm-workspace.yaml')) {
+      return false;
+    }
+
+    try {
+      const content = tree.read('pnpm-workspace.yaml', 'utf-8');
+      const { load } = require('@zkochan/js-yaml');
+      const { packages } = load(content) ?? {};
+      return packages !== undefined;
+    } catch {
+      return false;
+    }
   }
 
   // yarn and npm both use the same 'workspaces' property in package.json

--- a/packages/workspace/src/utilities/typescript/ts-solution-setup.ts
+++ b/packages/workspace/src/utilities/typescript/ts-solution-setup.ts
@@ -1,35 +1,11 @@
-import {
-  detectPackageManager,
-  globAsync,
-  readJson,
-  type Tree,
-  workspaceRoot,
-} from '@nx/devkit';
+import { globAsync, readJson, type Tree, workspaceRoot } from '@nx/devkit';
 import { dirname } from 'node:path/posix';
 import { FsTree } from 'nx/src/generators/tree';
-import { type PackageJson } from 'nx/src/utils/package-json';
 import {
   getPackageManagerWorkspacesPatterns,
   isProjectIncludedInPackageManagerWorkspaces,
+  isUsingPackageManagerWorkspaces,
 } from '../package-manager-workspaces';
-
-function isUsingPackageManagerWorkspaces(tree: Tree): boolean {
-  return isWorkspacesEnabled(tree);
-}
-
-function isWorkspacesEnabled(tree: Tree): boolean {
-  const packageManager = detectPackageManager(tree.root);
-  if (packageManager === 'pnpm') {
-    return tree.exists('pnpm-workspace.yaml');
-  }
-
-  // yarn and npm both use the same 'workspaces' property in package.json
-  if (tree.exists('package.json')) {
-    const packageJson = readJson<PackageJson>(tree, 'package.json');
-    return !!packageJson?.workspaces;
-  }
-  return false;
-}
 
 /**
  * The TS solution setup requires:


### PR DESCRIPTION
## Current Behavior

When detecting whether a workspace is set up with pnpm workspaces, we only check for the existence of the `pnpm-workspace.yaml` file. While most of the time that's enough, it's not entirely correct because that file can exist without a `packages` entry and solely contain other settings.

## Expected Behavior

When detecting whether a workspace is set up with pnpm workspaces, we should check for the existence of the `pnpm-workspace.yaml` file and the `packages` entry.