### PR TITLE
fix(expo): export output should be within project directory

### DIFF
--- a/packages/expo/src/generators/application/lib/add-project.ts
+++ b/packages/expo/src/generators/application/lib/add-project.ts
@@ -145,7 +145,7 @@ function getTargets(options: NormalizedSchema) {
     outputs: ['{options.outputDir}'],
     options: {
       platform: 'all',
-      outputDir: `dist/${options.appProjectRoot}`,
+      outputDir: `${options.appProjectRoot}/dist`,
     },
   };
 


### PR DESCRIPTION
## Current Behavior
`expo export` expects the `--output-dir` to be within the project directory.
When using Nx w/o Inference Plugins, we generate an export target that attempts to place the output directory outside the project directory.

## Expected Behavior
Ensure that the output directory is within the project directory.
