### PR TITLE
fix(graph): nxArgs.projects can be an empty array

### DIFF
--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -72,7 +72,9 @@ export async function affected(
               open: true,
               view: 'tasks',
               targets: nxArgs.targets,
-              all: nxArgs.all && !nxArgs.projects,
+              all:
+                nxArgs.all &&
+                (!nxArgs.projects || nxArgs.projects.length === 0),
               projects: projectNames,
               file,
             },

--- a/packages/nx/src/command-line/run-many/run-many.ts
+++ b/packages/nx/src/command-line/run-many/run-many.ts
@@ -58,7 +58,7 @@ export async function runMany(
         watch: true,
         open: true,
         view: 'tasks',
-        all: nxArgs.all && !nxArgs.projects,
+        all: nxArgs.all && (!nxArgs.projects || nxArgs.projects.length === 0),
         targets: nxArgs.targets,
         projects: projectNames,
         file,


### PR DESCRIPTION
make sure when no projects filter is applied, we should build a `/all` URL