### PR TITLE
fix(core): allow additional properties in ProjectMetadata type

### DIFF
--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -136,6 +136,8 @@ export interface ProjectConfiguration {
 }
 
 export interface ProjectMetadata {
+  [k: string]: any;
+
   description?: string;
   technologies?: string[];
   targetGroups?: Record<string, string[]>;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The `ProjectMetadata` type does not allow for additional properties, despite the schema having `"additionalProperties": true`. This prevents folks who are extending Nx and adding details there from doing so in a way that does not result it type errors.

## Expected Behavior
Userland code extending Nx should be able to add to ProjectMetadata without running into type errors.