### PR TITLE
fix(nx-dev): task graph should not break docs

### DIFF
--- a/astro-docs/src/assets/nx/connected-tasks.json
+++ b/astro-docs/src/assets/nx/connected-tasks.json
@@ -31,34 +31,32 @@
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
-      "roots": ["app1:test", "app2:test", "lib:test"],
-      "tasks": {
-        "app1:test": {
-          "id": "app1:test",
-          "target": { "project": "app1", "target": "test" },
-          "projectRoot": "apps/app1",
-          "overrides": {}
-        },
-        "app2:test": {
-          "id": "app2:test",
-          "target": { "project": "app2", "target": "test" },
-          "projectRoot": "apps/app2",
-          "overrides": {}
-        },
-        "lib:test": {
-          "id": "lib:test",
-          "target": { "project": "lib", "target": "test" },
-          "projectRoot": "libs/lib",
-          "overrides": {}
-        }
+  "taskIds": ["app1:test", "app2:test"],
+  "taskGraph": {
+    "roots": ["app1:test", "app2:test", "lib:test"],
+    "tasks": {
+      "app1:test": {
+        "id": "app1:test",
+        "target": { "project": "app1", "target": "test" },
+        "projectRoot": "apps/app1",
+        "overrides": {}
       },
-      "dependencies": {
-        "app1:test": ["lib:test"],
-        "app2:test": ["lib:test"]
+      "app2:test": {
+        "id": "app2:test",
+        "target": { "project": "app2", "target": "test" },
+        "projectRoot": "apps/app2",
+        "overrides": {}
+      },
+      "lib:test": {
+        "id": "lib:test",
+        "target": { "project": "lib", "target": "test" },
+        "projectRoot": "libs/lib",
+        "overrides": {}
       }
+    },
+    "dependencies": {
+      "app1:test": ["lib:test"],
+      "app2:test": ["lib:test"]
     }
   }
 }

--- a/astro-docs/src/assets/nx/disconnected-tasks.json
+++ b/astro-docs/src/assets/nx/disconnected-tasks.json
@@ -31,31 +31,29 @@
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
-      "roots": ["app1:test", "app2:test", "lib:test"],
-      "tasks": {
-        "app1:test": {
-          "id": "app1:test",
-          "target": { "project": "app1", "target": "test" },
-          "projectRoot": "apps/app1",
-          "overrides": {}
-        },
-        "app2:test": {
-          "id": "app2:test",
-          "target": { "project": "app2", "target": "test" },
-          "projectRoot": "apps/app2",
-          "overrides": {}
-        },
-        "lib:test": {
-          "id": "lib:test",
-          "target": { "project": "lib", "target": "test" },
-          "projectRoot": "libs/lib",
-          "overrides": {}
-        }
+  "taskIds": ["app1:test", "app2:test", "lib:test"],
+  "taskGraph": {
+    "roots": ["app1:test", "app2:test", "lib:test"],
+    "tasks": {
+      "app1:test": {
+        "id": "app1:test",
+        "target": { "project": "app1", "target": "test" },
+        "projectRoot": "apps/app1",
+        "overrides": {}
       },
-      "dependencies": {}
-    }
+      "app2:test": {
+        "id": "app2:test",
+        "target": { "project": "app2", "target": "test" },
+        "projectRoot": "apps/app2",
+        "overrides": {}
+      },
+      "lib:test": {
+        "id": "lib:test",
+        "target": { "project": "lib", "target": "test" },
+        "projectRoot": "libs/lib",
+        "overrides": {}
+      }
+    },
+    "dependencies": {}
   }
 }

--- a/astro-docs/src/assets/nx/large-tasks.json
+++ b/astro-docs/src/assets/nx/large-tasks.json
@@ -27356,12703 +27356,3152 @@
       }
     }
   ],
-  "taskId": "create-nx-workspace:test",
-  "taskGraphs": {
-    "nx-dev-feature-package-schema-viewer:lint": {
-      "roots": ["nx-dev-feature-package-schema-viewer:lint"],
-      "tasks": {
-        "nx-dev-feature-package-schema-viewer:lint": {
-          "id": "nx-dev-feature-package-schema-viewer:lint",
-          "target": {
-            "project": "nx-dev-feature-package-schema-viewer",
-            "target": "lint"
-          },
-          "projectRoot": "nx-dev/feature-package-schema-viewer",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-package-schema-viewer:lint": [] }
-    },
-    "nx-dev-feature-package-schema-viewer:test": {
-      "roots": ["nx-dev-feature-package-schema-viewer:test"],
-      "tasks": {
-        "nx-dev-feature-package-schema-viewer:test": {
-          "id": "nx-dev-feature-package-schema-viewer:test",
-          "target": {
-            "project": "nx-dev-feature-package-schema-viewer",
-            "target": "test"
-          },
-          "projectRoot": "nx-dev/feature-package-schema-viewer",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-package-schema-viewer:test": [] }
-    },
-    "nx-dev-data-access-documents:lint": {
-      "roots": ["nx-dev-data-access-documents:lint"],
-      "tasks": {
-        "nx-dev-data-access-documents:lint": {
-          "id": "nx-dev-data-access-documents:lint",
-          "target": {
-            "project": "nx-dev-data-access-documents",
-            "target": "lint"
-          },
-          "projectRoot": "nx-dev/data-access-documents",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-documents:lint": [] }
-    },
-    "nx-dev-data-access-documents:test": {
-      "roots": ["nx-dev-data-access-documents:test"],
-      "tasks": {
-        "nx-dev-data-access-documents:test": {
-          "id": "nx-dev-data-access-documents:test",
-          "target": {
-            "project": "nx-dev-data-access-documents",
-            "target": "test"
-          },
-          "projectRoot": "nx-dev/data-access-documents",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-documents:test": [] }
-    },
-    "create-nx-workspace:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-workspace:test": {
-          "id": "create-nx-workspace:test",
-          "target": { "project": "create-nx-workspace", "target": "test" },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": {}
-        },
-        "create-nx-workspace:build": {
-          "id": "create-nx-workspace:build",
-          "target": { "project": "create-nx-workspace", "target": "build" },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "create-nx-workspace:build-base": {
-          "id": "create-nx-workspace:build-base",
-          "target": {
-            "project": "create-nx-workspace",
-            "target": "build-base"
-          },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-workspace:test": ["create-nx-workspace:build"],
-        "create-nx-workspace:build": ["create-nx-workspace:build-base"],
-        "create-nx-workspace:build-base": [
-          "workspace:build-base",
-          "js:build-base",
-          "react:build-base",
-          "expo:build-base",
-          "next:build-base",
-          "angular:build-base",
-          "nest:build-base",
-          "express:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ]
-      }
-    },
-    "create-nx-workspace:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-workspace:build-base": {
-          "id": "create-nx-workspace:build-base",
-          "target": {
-            "project": "create-nx-workspace",
-            "target": "build-base"
-          },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": {}
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-workspace:build-base": [
-          "workspace:build-base",
-          "js:build-base",
-          "react:build-base",
-          "expo:build-base",
-          "next:build-base",
-          "angular:build-base",
-          "nest:build-base",
-          "express:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ]
-      }
-    },
-    "create-nx-workspace:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-workspace:build": {
-          "id": "create-nx-workspace:build",
-          "target": { "project": "create-nx-workspace", "target": "build" },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": {}
-        },
-        "create-nx-workspace:build-base": {
-          "id": "create-nx-workspace:build-base",
-          "target": {
-            "project": "create-nx-workspace",
-            "target": "build-base"
-          },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-workspace:build": ["create-nx-workspace:build-base"],
-        "create-nx-workspace:build-base": [
-          "workspace:build-base",
-          "js:build-base",
-          "react:build-base",
-          "expo:build-base",
-          "next:build-base",
-          "angular:build-base",
-          "nest:build-base",
-          "express:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ]
-      }
-    },
-    "create-nx-workspace:lint": {
-      "roots": ["create-nx-workspace:lint"],
-      "tasks": {
-        "create-nx-workspace:lint": {
-          "id": "create-nx-workspace:lint",
-          "target": { "project": "create-nx-workspace", "target": "lint" },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "create-nx-workspace:lint": [] }
-    },
-    "nx-dev-data-access-packages:lint": {
-      "roots": ["nx-dev-data-access-packages:lint"],
-      "tasks": {
-        "nx-dev-data-access-packages:lint": {
-          "id": "nx-dev-data-access-packages:lint",
-          "target": {
-            "project": "nx-dev-data-access-packages",
-            "target": "lint"
-          },
-          "projectRoot": "nx-dev/data-access-packages",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-packages:lint": [] }
-    },
-    "nx-dev-data-access-packages:test": {
-      "roots": ["nx-dev-data-access-packages:test"],
-      "tasks": {
-        "nx-dev-data-access-packages:test": {
-          "id": "nx-dev-data-access-packages:test",
-          "target": {
-            "project": "nx-dev-data-access-packages",
-            "target": "test"
-          },
-          "projectRoot": "nx-dev/data-access-packages",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-packages:test": [] }
-    },
-    "nx-dev-feature-doc-viewer:lint": {
-      "roots": ["nx-dev-feature-doc-viewer:lint"],
-      "tasks": {
-        "nx-dev-feature-doc-viewer:lint": {
-          "id": "nx-dev-feature-doc-viewer:lint",
-          "target": {
-            "project": "nx-dev-feature-doc-viewer",
-            "target": "lint"
-          },
-          "projectRoot": "nx-dev/feature-doc-viewer",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-doc-viewer:lint": [] }
-    },
-    "nx-dev-feature-doc-viewer:test": {
-      "roots": ["nx-dev-feature-doc-viewer:test"],
-      "tasks": {
-        "nx-dev-feature-doc-viewer:test": {
-          "id": "nx-dev-feature-doc-viewer:test",
-          "target": {
-            "project": "nx-dev-feature-doc-viewer",
-            "target": "test"
-          },
-          "projectRoot": "nx-dev/feature-doc-viewer",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-doc-viewer:test": [] }
-    },
-    "create-nx-plugin:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-plugin:test": {
-          "id": "create-nx-plugin:test",
-          "target": { "project": "create-nx-plugin", "target": "test" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": {}
-        },
-        "create-nx-plugin:build": {
-          "id": "create-nx-plugin:build",
-          "target": { "project": "create-nx-plugin", "target": "build" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "create-nx-plugin:build-base": {
-          "id": "create-nx-plugin:build-base",
-          "target": { "project": "create-nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-plugin:test": ["create-nx-plugin:build"],
-        "create-nx-plugin:build": ["create-nx-plugin:build-base"],
-        "create-nx-plugin:build-base": [
-          "nx-plugin:build-base",
-          "devkit:build-base",
-          "nx:build-base"
-        ],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "create-nx-plugin:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-plugin:build-base": {
-          "id": "create-nx-plugin:build-base",
-          "target": { "project": "create-nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": {}
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-plugin:build-base": [
-          "nx-plugin:build-base",
-          "devkit:build-base",
-          "nx:build-base"
-        ],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "create-nx-plugin:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-plugin:build": {
-          "id": "create-nx-plugin:build",
-          "target": { "project": "create-nx-plugin", "target": "build" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": {}
-        },
-        "create-nx-plugin:build-base": {
-          "id": "create-nx-plugin:build-base",
-          "target": { "project": "create-nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-plugin:build": ["create-nx-plugin:build-base"],
-        "create-nx-plugin:build-base": [
-          "nx-plugin:build-base",
-          "devkit:build-base",
-          "nx:build-base"
-        ],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "create-nx-plugin:lint": {
-      "roots": ["create-nx-plugin:lint"],
-      "tasks": {
-        "create-nx-plugin:lint": {
-          "id": "create-nx-plugin:lint",
-          "target": { "project": "create-nx-plugin", "target": "lint" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "create-nx-plugin:lint": [] }
-    },
-    "eslint-plugin-nx:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "eslint-plugin-nx:test": {
-          "id": "eslint-plugin-nx:test",
-          "target": { "project": "eslint-plugin-nx", "target": "test" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": {}
-        },
-        "eslint-plugin-nx:build": {
-          "id": "eslint-plugin-nx:build",
-          "target": { "project": "eslint-plugin-nx", "target": "build" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "eslint-plugin-nx:test": ["eslint-plugin-nx:build"],
-        "eslint-plugin-nx:build": ["eslint-plugin-nx:build-base"],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "eslint-plugin-nx:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "eslint-plugin-nx:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "eslint-plugin-nx:build": {
-          "id": "eslint-plugin-nx:build",
-          "target": { "project": "eslint-plugin-nx", "target": "build" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": {}
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "eslint-plugin-nx:build": ["eslint-plugin-nx:build-base"],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "eslint-plugin-nx:lint": {
-      "roots": ["eslint-plugin-nx:lint"],
-      "tasks": {
-        "eslint-plugin-nx:lint": {
-          "id": "eslint-plugin-nx:lint",
-          "target": { "project": "eslint-plugin-nx", "target": "lint" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "eslint-plugin-nx:lint": [] }
-    },
-    "nx-dev-feature-analytics:lint": {
-      "roots": ["nx-dev-feature-analytics:lint"],
-      "tasks": {
-        "nx-dev-feature-analytics:lint": {
-          "id": "nx-dev-feature-analytics:lint",
-          "target": { "project": "nx-dev-feature-analytics", "target": "lint" },
-          "projectRoot": "nx-dev/feature-analytics",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-analytics:lint": [] }
-    },
-    "nx-dev-feature-analytics:test": {
-      "roots": ["nx-dev-feature-analytics:test"],
-      "tasks": {
-        "nx-dev-feature-analytics:test": {
-          "id": "nx-dev-feature-analytics:test",
-          "target": { "project": "nx-dev-feature-analytics", "target": "test" },
-          "projectRoot": "nx-dev/feature-analytics",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-analytics:test": [] }
-    },
-    "nx-dev-data-access-menu:lint": {
-      "roots": ["nx-dev-data-access-menu:lint"],
-      "tasks": {
-        "nx-dev-data-access-menu:lint": {
-          "id": "nx-dev-data-access-menu:lint",
-          "target": { "project": "nx-dev-data-access-menu", "target": "lint" },
-          "projectRoot": "nx-dev/data-access-menu",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-menu:lint": [] }
-    },
-    "nx-dev-data-access-menu:test": {
-      "roots": ["nx-dev-data-access-menu:test"],
-      "tasks": {
-        "nx-dev-data-access-menu:test": {
-          "id": "nx-dev-data-access-menu:test",
-          "target": { "project": "nx-dev-data-access-menu", "target": "test" },
-          "projectRoot": "nx-dev/data-access-menu",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-menu:test": [] }
-    },
-    "e2e-angular-extensions:e2e": {
-      "roots": ["e2e-angular-extensions:e2e"],
-      "tasks": {
-        "e2e-angular-extensions:e2e": {
-          "id": "e2e-angular-extensions:e2e",
-          "target": { "project": "e2e-angular-extensions", "target": "e2e" },
-          "projectRoot": "e2e/angular-extensions",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-angular-extensions:e2e": [] }
-    },
-    "e2e-angular-extensions:run-e2e-tests": {
-      "roots": ["e2e-angular-extensions:run-e2e-tests"],
-      "tasks": {
-        "e2e-angular-extensions:run-e2e-tests": {
-          "id": "e2e-angular-extensions:run-e2e-tests",
-          "target": {
-            "project": "e2e-angular-extensions",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/angular-extensions",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-angular-extensions:run-e2e-tests": [] }
-    },
-    "nx-dev-models-document:lint": {
-      "roots": ["nx-dev-models-document:lint"],
-      "tasks": {
-        "nx-dev-models-document:lint": {
-          "id": "nx-dev-models-document:lint",
-          "target": { "project": "nx-dev-models-document", "target": "lint" },
-          "projectRoot": "nx-dev/models-document",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-document:lint": [] }
-    },
-    "nx-dev-models-document:test": {
-      "roots": ["nx-dev-models-document:test"],
-      "tasks": {
-        "nx-dev-models-document:test": {
-          "id": "nx-dev-models-document:test",
-          "target": { "project": "nx-dev-models-document", "target": "test" },
-          "projectRoot": "nx-dev/models-document",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-document:test": [] }
-    },
-    "nx-dev-ui-sponsor-card:lint": {
-      "roots": ["nx-dev-ui-sponsor-card:lint"],
-      "tasks": {
-        "nx-dev-ui-sponsor-card:lint": {
-          "id": "nx-dev-ui-sponsor-card:lint",
-          "target": { "project": "nx-dev-ui-sponsor-card", "target": "lint" },
-          "projectRoot": "nx-dev/ui-sponsor-card",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-sponsor-card:lint": [] }
-    },
-    "nx-dev-ui-sponsor-card:test": {
-      "roots": ["nx-dev-ui-sponsor-card:test"],
-      "tasks": {
-        "nx-dev-ui-sponsor-card:test": {
-          "id": "nx-dev-ui-sponsor-card:test",
-          "target": { "project": "nx-dev-ui-sponsor-card", "target": "test" },
-          "projectRoot": "nx-dev/ui-sponsor-card",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-sponsor-card:test": [] }
-    },
-    "e2e-storybook-angular:e2e": {
-      "roots": ["e2e-storybook-angular:e2e"],
-      "tasks": {
-        "e2e-storybook-angular:e2e": {
-          "id": "e2e-storybook-angular:e2e",
-          "target": { "project": "e2e-storybook-angular", "target": "e2e" },
-          "projectRoot": "e2e/storybook-angular",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-storybook-angular:e2e": [] }
-    },
-    "e2e-storybook-angular:run-e2e-tests": {
-      "roots": ["e2e-storybook-angular:run-e2e-tests"],
-      "tasks": {
-        "e2e-storybook-angular:run-e2e-tests": {
-          "id": "e2e-storybook-angular:run-e2e-tests",
-          "target": {
-            "project": "e2e-storybook-angular",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/storybook-angular",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-storybook-angular:run-e2e-tests": [] }
-    },
-    "nx-dev-feature-search:lint": {
-      "roots": ["nx-dev-feature-search:lint"],
-      "tasks": {
-        "nx-dev-feature-search:lint": {
-          "id": "nx-dev-feature-search:lint",
-          "target": { "project": "nx-dev-feature-search", "target": "lint" },
-          "projectRoot": "nx-dev/feature-search",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-search:lint": [] }
-    },
-    "nx-dev-feature-search:test": {
-      "roots": ["nx-dev-feature-search:test"],
-      "tasks": {
-        "nx-dev-feature-search:test": {
-          "id": "nx-dev-feature-search:test",
-          "target": { "project": "nx-dev-feature-search", "target": "test" },
-          "projectRoot": "nx-dev/feature-search",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-search:test": [] }
-    },
-    "nx-dev-models-package:lint": {
-      "roots": ["nx-dev-models-package:lint"],
-      "tasks": {
-        "nx-dev-models-package:lint": {
-          "id": "nx-dev-models-package:lint",
-          "target": { "project": "nx-dev-models-package", "target": "lint" },
-          "projectRoot": "nx-dev/models-package",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-package:lint": [] }
-    },
-    "nx-dev-models-package:test": {
-      "roots": ["nx-dev-models-package:test"],
-      "tasks": {
-        "nx-dev-models-package:test": {
-          "id": "nx-dev-models-package:test",
-          "target": { "project": "nx-dev-models-package", "target": "test" },
-          "projectRoot": "nx-dev/models-package",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-package:test": [] }
-    },
-    "nx-dev-ui-member-card:lint": {
-      "roots": ["nx-dev-ui-member-card:lint"],
-      "tasks": {
-        "nx-dev-ui-member-card:lint": {
-          "id": "nx-dev-ui-member-card:lint",
-          "target": { "project": "nx-dev-ui-member-card", "target": "lint" },
-          "projectRoot": "nx-dev/ui-member-card",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-member-card:lint": [] }
-    },
-    "nx-dev-ui-member-card:test": {
-      "roots": ["nx-dev-ui-member-card:test"],
-      "tasks": {
-        "nx-dev-ui-member-card:test": {
-          "id": "nx-dev-ui-member-card:test",
-          "target": { "project": "nx-dev-ui-member-card", "target": "test" },
-          "projectRoot": "nx-dev/ui-member-card",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-member-card:test": [] }
-    },
-    "react-native:lint": {
-      "roots": ["react-native:lint"],
-      "tasks": {
-        "react-native:lint": {
-          "id": "react-native:lint",
-          "target": { "project": "react-native", "target": "lint" },
-          "projectRoot": "packages/react-native",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "react-native:lint": [] }
-    },
-    "react-native:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react-native:test": {
-          "id": "react-native:test",
-          "target": { "project": "react-native", "target": "test" },
-          "projectRoot": "packages/react-native",
-          "overrides": {}
-        },
-        "react-native:build": {
-          "id": "react-native:build",
-          "target": { "project": "react-native", "target": "build" },
-          "projectRoot": "packages/react-native",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react-native:build-base": {
-          "id": "react-native:build-base",
-          "target": { "project": "react-native", "target": "build-base" },
-          "projectRoot": "packages/react-native",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react-native:test": ["react-native:build"],
-        "react-native:build": ["react-native:build-base"],
-        "react-native:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react-native:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react-native:build-base": {
-          "id": "react-native:build-base",
-          "target": { "project": "react-native", "target": "build-base" },
-          "projectRoot": "packages/react-native",
-          "overrides": {}
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react-native:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react-native:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react-native:build": {
-          "id": "react-native:build",
-          "target": { "project": "react-native", "target": "build" },
-          "projectRoot": "packages/react-native",
-          "overrides": {}
-        },
-        "react-native:build-base": {
-          "id": "react-native:build-base",
-          "target": { "project": "react-native", "target": "build-base" },
-          "projectRoot": "packages/react-native",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react-native:build": ["react-native:build-base"],
-        "react-native:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "e2e-workspace-create:e2e": {
-      "roots": ["e2e-workspace-create:e2e"],
-      "tasks": {
-        "e2e-workspace-create:e2e": {
-          "id": "e2e-workspace-create:e2e",
-          "target": { "project": "e2e-workspace-create", "target": "e2e" },
-          "projectRoot": "e2e/workspace-create",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-workspace-create:e2e": [] }
-    },
-    "e2e-workspace-create:run-e2e-tests": {
-      "roots": ["e2e-workspace-create:run-e2e-tests"],
-      "tasks": {
-        "e2e-workspace-create:run-e2e-tests": {
-          "id": "e2e-workspace-create:run-e2e-tests",
-          "target": {
-            "project": "e2e-workspace-create",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/workspace-create",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-workspace-create:run-e2e-tests": [] }
-    },
-    "nx-dev-ui-conference:lint": {
-      "roots": ["nx-dev-ui-conference:lint"],
-      "tasks": {
-        "nx-dev-ui-conference:lint": {
-          "id": "nx-dev-ui-conference:lint",
-          "target": { "project": "nx-dev-ui-conference", "target": "lint" },
-          "projectRoot": "nx-dev/ui-conference",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-conference:lint": [] }
-    },
-    "nx-dev-ui-conference:test": {
-      "roots": ["nx-dev-ui-conference:test"],
-      "tasks": {
-        "nx-dev-ui-conference:test": {
-          "id": "nx-dev-ui-conference:test",
-          "target": { "project": "nx-dev-ui-conference", "target": "test" },
-          "projectRoot": "nx-dev/ui-conference",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-conference:test": [] }
-    },
-    "nx-dev-ui-references:lint": {
-      "roots": ["nx-dev-ui-references:lint"],
-      "tasks": {
-        "nx-dev-ui-references:lint": {
-          "id": "nx-dev-ui-references:lint",
-          "target": { "project": "nx-dev-ui-references", "target": "lint" },
-          "projectRoot": "nx-dev/ui-references",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-references:lint": [] }
-    },
-    "nx-dev-ui-references:test": {
-      "roots": ["nx-dev-ui-references:test"],
-      "tasks": {
-        "nx-dev-ui-references:test": {
-          "id": "nx-dev-ui-references:test",
-          "target": { "project": "nx-dev-ui-references", "target": "test" },
-          "projectRoot": "nx-dev/ui-references",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-references:test": [] }
-    },
-    "nx-dev-ui-community:lint": {
-      "roots": ["nx-dev-ui-community:lint"],
-      "tasks": {
-        "nx-dev-ui-community:lint": {
-          "id": "nx-dev-ui-community:lint",
-          "target": { "project": "nx-dev-ui-community", "target": "lint" },
-          "projectRoot": "nx-dev/ui-community",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-community:lint": [] }
-    },
-    "nx-dev-ui-community:test": {
-      "roots": ["nx-dev-ui-community:test"],
-      "tasks": {
-        "nx-dev-ui-community:test": {
-          "id": "nx-dev-ui-community:test",
-          "target": { "project": "nx-dev-ui-community", "target": "test" },
-          "projectRoot": "nx-dev/ui-community",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-community:test": [] }
-    },
-    "nx-dev-models-menu:lint": {
-      "roots": ["nx-dev-models-menu:lint"],
-      "tasks": {
-        "nx-dev-models-menu:lint": {
-          "id": "nx-dev-models-menu:lint",
-          "target": { "project": "nx-dev-models-menu", "target": "lint" },
-          "projectRoot": "nx-dev/models-menu",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-menu:lint": [] }
-    },
-    "nx-dev-models-menu:test": {
-      "roots": ["nx-dev-models-menu:test"],
-      "tasks": {
-        "nx-dev-models-menu:test": {
-          "id": "nx-dev-models-menu:test",
-          "target": { "project": "nx-dev-models-menu", "target": "test" },
-          "projectRoot": "nx-dev/models-menu",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-menu:test": [] }
-    },
-    "nx-dev-ui-commands:lint": {
-      "roots": ["nx-dev-ui-commands:lint"],
-      "tasks": {
-        "nx-dev-ui-commands:lint": {
-          "id": "nx-dev-ui-commands:lint",
-          "target": { "project": "nx-dev-ui-commands", "target": "lint" },
-          "projectRoot": "nx-dev/ui-commands",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-commands:lint": [] }
-    },
-    "nx-dev-ui-commands:test": {
-      "roots": ["nx-dev-ui-commands:test"],
-      "tasks": {
-        "nx-dev-ui-commands:test": {
-          "id": "nx-dev-ui-commands:test",
-          "target": { "project": "nx-dev-ui-commands", "target": "test" },
-          "projectRoot": "nx-dev/ui-commands",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-commands:test": [] }
-    },
-    "nx-plugin:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-plugin:test": {
-          "id": "nx-plugin:test",
-          "target": { "project": "nx-plugin", "target": "test" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": {}
-        },
-        "nx-plugin:build": {
-          "id": "nx-plugin:build",
-          "target": { "project": "nx-plugin", "target": "build" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-plugin:test": ["nx-plugin:build"],
-        "nx-plugin:build": ["nx-plugin:build-base"],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-plugin:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-plugin:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-plugin:build": {
-          "id": "nx-plugin:build",
-          "target": { "project": "nx-plugin", "target": "build" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": {}
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-plugin:build": ["nx-plugin:build-base"],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-plugin:lint": {
-      "roots": ["nx-plugin:lint"],
-      "tasks": {
-        "nx-plugin:lint": {
-          "id": "nx-plugin:lint",
-          "target": { "project": "nx-plugin", "target": "lint" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-plugin:lint": [] }
-    },
-    "storybook:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "storybook:test": {
-          "id": "storybook:test",
-          "target": { "project": "storybook", "target": "test" },
-          "projectRoot": "packages/storybook",
-          "overrides": {}
-        },
-        "storybook:build": {
-          "id": "storybook:build",
-          "target": { "project": "storybook", "target": "build" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "storybook:test": ["storybook:build"],
-        "storybook:build": ["storybook:build-base"],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "storybook:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": {}
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "storybook:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "storybook:build": {
-          "id": "storybook:build",
-          "target": { "project": "storybook", "target": "build" },
-          "projectRoot": "packages/storybook",
-          "overrides": {}
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "storybook:build": ["storybook:build-base"],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "storybook:lint": {
-      "roots": ["storybook:lint"],
-      "tasks": {
-        "storybook:lint": {
-          "id": "storybook:lint",
-          "target": { "project": "storybook", "target": "lint" },
-          "projectRoot": "packages/storybook",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "storybook:lint": [] }
-    },
-    "workspace:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "workspace:test": {
-          "id": "workspace:test",
-          "target": { "project": "workspace", "target": "test" },
-          "projectRoot": "packages/workspace",
-          "overrides": {}
-        },
-        "workspace:build": {
-          "id": "workspace:build",
-          "target": { "project": "workspace", "target": "build" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "workspace:test": ["workspace:build"],
-        "workspace:build": ["workspace:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "workspace:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "workspace:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "workspace:build": {
-          "id": "workspace:build",
-          "target": { "project": "workspace", "target": "build" },
-          "projectRoot": "packages/workspace",
-          "overrides": {}
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "workspace:build": ["workspace:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "workspace:lint": {
-      "roots": ["workspace:lint"],
-      "tasks": {
-        "workspace:lint": {
-          "id": "workspace:lint",
-          "target": { "project": "workspace", "target": "lint" },
-          "projectRoot": "packages/workspace",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "workspace:lint": [] }
-    },
-    "eslint-rules:test": {
-      "roots": ["eslint-rules:test"],
-      "tasks": {
-        "eslint-rules:test": {
-          "id": "eslint-rules:test",
-          "target": { "project": "eslint-rules", "target": "test" },
-          "projectRoot": "tools/eslint-rules",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "eslint-rules:test": [] }
-    },
-    "nx-dev-e2e:e2e": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-dev-e2e:e2e": {
-          "id": "nx-dev-e2e:e2e",
-          "target": { "project": "nx-dev-e2e", "target": "e2e" },
-          "projectRoot": "nx-dev/nx-dev-e2e",
-          "overrides": {}
-        },
-        "nx-dev:build-base": {
-          "id": "nx-dev:build-base",
-          "target": { "project": "nx-dev", "target": "build-base" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev-e2e:e2e": ["nx-dev:build-base", "cypress:build-base"],
-        "nx-dev:build-base": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev-e2e:lint": {
-      "roots": ["nx-dev-e2e:lint"],
-      "tasks": {
-        "nx-dev-e2e:lint": {
-          "id": "nx-dev-e2e:lint",
-          "target": { "project": "nx-dev-e2e", "target": "lint" },
-          "projectRoot": "nx-dev/nx-dev-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-e2e:lint": [] }
-    },
-    "nx-dev-ui-markdoc:lint": {
-      "roots": ["nx-dev-ui-markdoc:lint"],
-      "tasks": {
-        "nx-dev-ui-markdoc:lint": {
-          "id": "nx-dev-ui-markdoc:lint",
-          "target": { "project": "nx-dev-ui-markdoc", "target": "lint" },
-          "projectRoot": "nx-dev/ui-markdoc",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-markdoc:lint": [] }
-    },
-    "nx-dev-ui-markdoc:test": {
-      "roots": ["nx-dev-ui-markdoc:test"],
-      "tasks": {
-        "nx-dev-ui-markdoc:test": {
-          "id": "nx-dev-ui-markdoc:test",
-          "target": { "project": "nx-dev-ui-markdoc", "target": "test" },
-          "projectRoot": "nx-dev/ui-markdoc",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-markdoc:test": [] }
-    },
-    "e2e-angular-core:e2e": {
-      "roots": ["e2e-angular-core:e2e"],
-      "tasks": {
-        "e2e-angular-core:e2e": {
-          "id": "e2e-angular-core:e2e",
-          "target": { "project": "e2e-angular-core", "target": "e2e" },
-          "projectRoot": "e2e/angular-core",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-angular-core:e2e": [] }
-    },
-    "e2e-angular-core:run-e2e-tests": {
-      "roots": ["e2e-angular-core:run-e2e-tests"],
-      "tasks": {
-        "e2e-angular-core:run-e2e-tests": {
-          "id": "e2e-angular-core:run-e2e-tests",
-          "target": {
-            "project": "e2e-angular-core",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/angular-core",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-angular-core:run-e2e-tests": [] }
-    },
-    "e2e-react-native:e2e": {
-      "roots": ["e2e-react-native:e2e"],
-      "tasks": {
-        "e2e-react-native:e2e": {
-          "id": "e2e-react-native:e2e",
-          "target": { "project": "e2e-react-native", "target": "e2e" },
-          "projectRoot": "e2e/react-native",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-react-native:e2e": [] }
-    },
-    "e2e-react-native:run-e2e-tests": {
-      "roots": ["e2e-react-native:run-e2e-tests"],
-      "tasks": {
-        "e2e-react-native:run-e2e-tests": {
-          "id": "e2e-react-native:run-e2e-tests",
-          "target": {
-            "project": "e2e-react-native",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/react-native",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-react-native:run-e2e-tests": [] }
-    },
-    "e2e-graph-client:e2e-base": {
-      "roots": ["e2e-graph-client:e2e-base:dev"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:dev": {
-          "id": "e2e-graph-client:e2e-base:dev",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:dev": [] }
-    },
-    "e2e-graph-client:e2e-base:dev": {
-      "roots": ["e2e-graph-client:e2e-base:dev"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:dev": {
-          "id": "e2e-graph-client:e2e-base:dev",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:dev": [] }
-    },
-    "e2e-graph-client:e2e-base:watch": {
-      "roots": ["e2e-graph-client:e2e-base:watch"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:watch": {
-          "id": "e2e-graph-client:e2e-base:watch",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "watch"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:watch": [] }
-    },
-    "e2e-graph-client:e2e-base:release": {
-      "roots": ["e2e-graph-client:e2e-base:release"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:release": {
-          "id": "e2e-graph-client:e2e-base:release",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:release": [] }
-    },
-    "e2e-graph-client:e2e-base:release-static": {
-      "roots": ["e2e-graph-client:e2e-base:release-static"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:release-static": {
-          "id": "e2e-graph-client:e2e-base:release-static",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "release-static"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:release-static": [] }
-    },
-    "e2e-graph-client:e2e-local": {
-      "roots": ["e2e-graph-client:e2e-local"],
-      "tasks": {
-        "e2e-graph-client:e2e-local": {
-          "id": "e2e-graph-client:e2e-local",
-          "target": { "project": "e2e-graph-client", "target": "e2e-local" },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-local": [] }
-    },
-    "e2e-graph-client:e2e": {
-      "roots": ["e2e-graph-client:e2e"],
-      "tasks": {
-        "e2e-graph-client:e2e": {
-          "id": "e2e-graph-client:e2e",
-          "target": { "project": "e2e-graph-client", "target": "e2e" },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e": [] }
-    },
-    "e2e-graph-client:lint": {
-      "roots": ["e2e-graph-client:lint"],
-      "tasks": {
-        "e2e-graph-client:lint": {
-          "id": "e2e-graph-client:lint",
-          "target": { "project": "e2e-graph-client", "target": "lint" },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:lint": [] }
-    },
-    "nx-dev-ui-common:lint": {
-      "roots": ["nx-dev-ui-common:lint"],
-      "tasks": {
-        "nx-dev-ui-common:lint": {
-          "id": "nx-dev-ui-common:lint",
-          "target": { "project": "nx-dev-ui-common", "target": "lint" },
-          "projectRoot": "nx-dev/ui-common",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-common:lint": [] }
-    },
-    "nx-dev-ui-common:test": {
-      "roots": ["nx-dev-ui-common:test"],
-      "tasks": {
-        "nx-dev-ui-common:test": {
-          "id": "nx-dev-ui-common:test",
-          "target": { "project": "nx-dev-ui-common", "target": "test" },
-          "projectRoot": "nx-dev/ui-common",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-common:test": [] }
-    },
-    "angular:postinstall": {
-      "roots": ["angular:postinstall"],
-      "tasks": {
-        "angular:postinstall": {
-          "id": "angular:postinstall",
-          "target": { "project": "angular", "target": "postinstall" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "angular:postinstall": [] }
-    },
-    "angular:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "angular:test": {
-          "id": "angular:test",
-          "target": { "project": "angular", "target": "test" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        },
-        "angular:build": {
-          "id": "angular:build",
-          "target": { "project": "angular", "target": "build" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "angular:test": ["angular:build"],
-        "angular:build": ["angular:build-base"],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "angular:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "angular:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "angular:build": {
-          "id": "angular:build",
-          "target": { "project": "angular", "target": "build" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "angular:build": ["angular:build-base"],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "angular:lint": {
-      "roots": ["angular:lint"],
-      "tasks": {
-        "angular:lint": {
-          "id": "angular:lint",
-          "target": { "project": "angular", "target": "lint" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "angular:lint": [] }
-    },
-    "cypress:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cypress:test": {
-          "id": "cypress:test",
-          "target": { "project": "cypress", "target": "test" },
-          "projectRoot": "packages/cypress",
-          "overrides": {}
-        },
-        "cypress:build": {
-          "id": "cypress:build",
-          "target": { "project": "cypress", "target": "build" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cypress:test": ["cypress:build"],
-        "cypress:build": ["cypress:build-base"],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "cypress:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "cypress:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cypress:build": {
-          "id": "cypress:build",
-          "target": { "project": "cypress", "target": "build" },
-          "projectRoot": "packages/cypress",
-          "overrides": {}
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cypress:build": ["cypress:build-base"],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "cypress:lint": {
-      "roots": ["cypress:lint"],
-      "tasks": {
-        "cypress:lint": {
-          "id": "cypress:lint",
-          "target": { "project": "cypress", "target": "lint" },
-          "projectRoot": "packages/cypress",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "cypress:lint": [] }
-    },
-    "esbuild:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "esbuild:test": {
-          "id": "esbuild:test",
-          "target": { "project": "esbuild", "target": "test" },
-          "projectRoot": "packages/esbuild",
-          "overrides": {}
-        },
-        "esbuild:build": {
-          "id": "esbuild:build",
-          "target": { "project": "esbuild", "target": "build" },
-          "projectRoot": "packages/esbuild",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "esbuild:build-base": {
-          "id": "esbuild:build-base",
-          "target": { "project": "esbuild", "target": "build-base" },
-          "projectRoot": "packages/esbuild",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "esbuild:test": ["esbuild:build"],
-        "esbuild:build": ["esbuild:build-base"],
-        "esbuild:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "esbuild:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "esbuild:build-base": {
-          "id": "esbuild:build-base",
-          "target": { "project": "esbuild", "target": "build-base" },
-          "projectRoot": "packages/esbuild",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "esbuild:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "esbuild:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "esbuild:build": {
-          "id": "esbuild:build",
-          "target": { "project": "esbuild", "target": "build" },
-          "projectRoot": "packages/esbuild",
-          "overrides": {}
-        },
-        "esbuild:build-base": {
-          "id": "esbuild:build-base",
-          "target": { "project": "esbuild", "target": "build-base" },
-          "projectRoot": "packages/esbuild",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "esbuild:build": ["esbuild:build-base"],
-        "esbuild:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "esbuild:lint": {
-      "roots": ["esbuild:lint"],
-      "tasks": {
-        "esbuild:lint": {
-          "id": "esbuild:lint",
-          "target": { "project": "esbuild", "target": "lint" },
-          "projectRoot": "packages/esbuild",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "esbuild:lint": [] }
-    },
-    "express:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "express:test": {
-          "id": "express:test",
-          "target": { "project": "express", "target": "test" },
-          "projectRoot": "packages/express",
-          "overrides": {}
-        },
-        "express:build": {
-          "id": "express:build",
-          "target": { "project": "express", "target": "build" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "express:test": ["express:build"],
-        "express:build": ["express:build-base"],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "express:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": {}
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "express:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "express:build": {
-          "id": "express:build",
-          "target": { "project": "express", "target": "build" },
-          "projectRoot": "packages/express",
-          "overrides": {}
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "express:build": ["express:build-base"],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "express:lint": {
-      "roots": ["express:lint"],
-      "tasks": {
-        "express:lint": {
-          "id": "express:lint",
-          "target": { "project": "express", "target": "lint" },
-          "projectRoot": "packages/express",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "express:lint": [] }
-    },
-    "webpack:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "webpack:test": {
-          "id": "webpack:test",
-          "target": { "project": "webpack", "target": "test" },
-          "projectRoot": "packages/webpack",
-          "overrides": {}
-        },
-        "webpack:build": {
-          "id": "webpack:build",
-          "target": { "project": "webpack", "target": "build" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "webpack:test": ["webpack:build"],
-        "webpack:build": ["webpack:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "webpack:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "webpack:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "webpack:build": {
-          "id": "webpack:build",
-          "target": { "project": "webpack", "target": "build" },
-          "projectRoot": "packages/webpack",
-          "overrides": {}
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "webpack:build": ["webpack:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "webpack:lint": {
-      "roots": ["webpack:lint"],
-      "tasks": {
-        "webpack:lint": {
-          "id": "webpack:lint",
-          "target": { "project": "webpack", "target": "lint" },
-          "projectRoot": "packages/webpack",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "webpack:lint": [] }
-    },
-    "nx-dev-ui-theme:lint": {
-      "roots": ["nx-dev-ui-theme:lint"],
-      "tasks": {
-        "nx-dev-ui-theme:lint": {
-          "id": "nx-dev-ui-theme:lint",
-          "target": { "project": "nx-dev-ui-theme", "target": "lint" },
-          "projectRoot": "nx-dev/ui-theme",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-theme:lint": [] }
-    },
-    "nx-dev-ui-theme:test": {
-      "roots": ["nx-dev-ui-theme:test"],
-      "tasks": {
-        "nx-dev-ui-theme:test": {
-          "id": "nx-dev-ui-theme:test",
-          "target": { "project": "nx-dev-ui-theme", "target": "test" },
-          "projectRoot": "nx-dev/ui-theme",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-theme:test": [] }
-    },
-    "devkit:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "devkit:test": {
-          "id": "devkit:test",
-          "target": { "project": "devkit", "target": "test" },
-          "projectRoot": "packages/devkit",
-          "overrides": {}
-        },
-        "devkit:build": {
-          "id": "devkit:build",
-          "target": { "project": "devkit", "target": "build" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "devkit:test": ["devkit:build"],
-        "devkit:build": ["devkit:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "devkit:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": {}
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "devkit:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "devkit:build": {
-          "id": "devkit:build",
-          "target": { "project": "devkit", "target": "build" },
-          "projectRoot": "packages/devkit",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "devkit:build": ["devkit:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "devkit:lint": {
-      "roots": ["devkit:lint"],
-      "tasks": {
-        "devkit:lint": {
-          "id": "devkit:lint",
-          "target": { "project": "devkit", "target": "lint" },
-          "projectRoot": "packages/devkit",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "devkit:lint": [] }
-    },
-    "linter:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "linter:test": {
-          "id": "linter:test",
-          "target": { "project": "linter", "target": "test" },
-          "projectRoot": "packages/linter",
-          "overrides": {}
-        },
-        "linter:build": {
-          "id": "linter:build",
-          "target": { "project": "linter", "target": "build" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "linter:test": ["linter:build"],
-        "linter:build": ["linter:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "linter:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": {}
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "linter:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "linter:build": {
-          "id": "linter:build",
-          "target": { "project": "linter", "target": "build" },
-          "projectRoot": "packages/linter",
-          "overrides": {}
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "linter:build": ["linter:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "linter:lint": {
-      "roots": ["linter:lint"],
-      "tasks": {
-        "linter:lint": {
-          "id": "linter:lint",
-          "target": { "project": "linter", "target": "lint" },
-          "projectRoot": "packages/linter",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "linter:lint": [] }
-    },
-    "rollup:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "rollup:test": {
-          "id": "rollup:test",
-          "target": { "project": "rollup", "target": "test" },
-          "projectRoot": "packages/rollup",
-          "overrides": {}
-        },
-        "rollup:build": {
-          "id": "rollup:build",
-          "target": { "project": "rollup", "target": "build" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "rollup:test": ["rollup:build"],
-        "rollup:build": ["rollup:build-base"],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "rollup:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "rollup:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "rollup:build": {
-          "id": "rollup:build",
-          "target": { "project": "rollup", "target": "build" },
-          "projectRoot": "packages/rollup",
-          "overrides": {}
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "rollup:build": ["rollup:build-base"],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "rollup:lint": {
-      "roots": ["rollup:lint"],
-      "tasks": {
-        "rollup:lint": {
-          "id": "rollup:lint",
-          "target": { "project": "rollup", "target": "lint" },
-          "projectRoot": "packages/rollup",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "rollup:lint": [] }
-    },
-    "graph-ui-graph:lint": {
-      "roots": ["graph-ui-graph:lint"],
-      "tasks": {
-        "graph-ui-graph:lint": {
-          "id": "graph-ui-graph:lint",
-          "target": { "project": "graph-ui-graph", "target": "lint" },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:lint": [] }
-    },
-    "graph-ui-graph:test": {
-      "roots": ["graph-ui-graph:test"],
-      "tasks": {
-        "graph-ui-graph:test": {
-          "id": "graph-ui-graph:test",
-          "target": { "project": "graph-ui-graph", "target": "test" },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:test": [] }
-    },
-    "graph-ui-graph:storybook": {
-      "roots": ["graph-ui-graph:storybook"],
-      "tasks": {
-        "graph-ui-graph:storybook": {
-          "id": "graph-ui-graph:storybook",
-          "target": { "project": "graph-ui-graph", "target": "storybook" },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:storybook": [] }
-    },
-    "graph-ui-graph:storybook:ci": {
-      "roots": ["graph-ui-graph:storybook:ci"],
-      "tasks": {
-        "graph-ui-graph:storybook:ci": {
-          "id": "graph-ui-graph:storybook:ci",
-          "target": {
-            "project": "graph-ui-graph",
-            "target": "storybook",
-            "configuration": "ci"
-          },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:storybook:ci": [] }
-    },
-    "graph-ui-graph:build-storybook": {
-      "roots": ["graph-ui-graph:build-storybook"],
-      "tasks": {
-        "graph-ui-graph:build-storybook": {
-          "id": "graph-ui-graph:build-storybook",
-          "target": {
-            "project": "graph-ui-graph",
-            "target": "build-storybook"
-          },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:build-storybook": [] }
-    },
-    "graph-ui-graph:build-storybook:ci": {
-      "roots": ["graph-ui-graph:build-storybook:ci"],
-      "tasks": {
-        "graph-ui-graph:build-storybook:ci": {
-          "id": "graph-ui-graph:build-storybook:ci",
-          "target": {
-            "project": "graph-ui-graph",
-            "target": "build-storybook",
-            "configuration": "ci"
-          },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:build-storybook:ci": [] }
-    },
-    "nx-dev-ui-home:lint": {
-      "roots": ["nx-dev-ui-home:lint"],
-      "tasks": {
-        "nx-dev-ui-home:lint": {
-          "id": "nx-dev-ui-home:lint",
-          "target": { "project": "nx-dev-ui-home", "target": "lint" },
-          "projectRoot": "nx-dev/ui-home",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-home:lint": [] }
-    },
-    "nx-dev-ui-home:xtest": {
-      "roots": ["nx-dev-ui-home:xtest"],
-      "tasks": {
-        "nx-dev-ui-home:xtest": {
-          "id": "nx-dev-ui-home:xtest",
-          "target": { "project": "nx-dev-ui-home", "target": "xtest" },
-          "projectRoot": "nx-dev/ui-home",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-home:xtest": [] }
-    },
-    "detox:lint": {
-      "roots": ["detox:lint"],
-      "tasks": {
-        "detox:lint": {
-          "id": "detox:lint",
-          "target": { "project": "detox", "target": "lint" },
-          "projectRoot": "packages/detox",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "detox:lint": [] }
-    },
-    "detox:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "detox:test": {
-          "id": "detox:test",
-          "target": { "project": "detox", "target": "test" },
-          "projectRoot": "packages/detox",
-          "overrides": {}
-        },
-        "detox:build": {
-          "id": "detox:build",
-          "target": { "project": "detox", "target": "build" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "detox:test": ["detox:build"],
-        "detox:build": ["detox:build-base"],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "detox:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "detox:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "detox:build": {
-          "id": "detox:build",
-          "target": { "project": "detox", "target": "build" },
-          "projectRoot": "packages/detox",
-          "overrides": {}
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "detox:build": ["detox:build-base"],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react:test": {
-          "id": "react:test",
-          "target": { "project": "react", "target": "test" },
-          "projectRoot": "packages/react",
-          "overrides": {}
-        },
-        "react:build": {
-          "id": "react:build",
-          "target": { "project": "react", "target": "build" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react:test": ["react:build"],
-        "react:build": ["react:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": {}
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react:build": {
-          "id": "react:build",
-          "target": { "project": "react", "target": "build" },
-          "projectRoot": "packages/react",
-          "overrides": {}
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react:build": ["react:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react:lint": {
-      "roots": ["react:lint"],
-      "tasks": {
-        "react:lint": {
-          "id": "react:lint",
-          "target": { "project": "react", "target": "lint" },
-          "projectRoot": "packages/react",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "react:lint": [] }
-    },
-    "typedoc-theme:build-base": {
-      "roots": ["typedoc-theme:build-base"],
-      "tasks": {
-        "typedoc-theme:build-base": {
-          "id": "typedoc-theme:build-base",
-          "target": { "project": "typedoc-theme", "target": "build-base" },
-          "projectRoot": "typedoc-theme",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "typedoc-theme:build-base": [] }
-    },
-    "typedoc-theme:build": {
-      "roots": ["typedoc-theme:build-base"],
-      "tasks": {
-        "typedoc-theme:build": {
-          "id": "typedoc-theme:build",
-          "target": { "project": "typedoc-theme", "target": "build" },
-          "projectRoot": "typedoc-theme",
-          "overrides": {}
-        },
-        "typedoc-theme:build-base": {
-          "id": "typedoc-theme:build-base",
-          "target": { "project": "typedoc-theme", "target": "build-base" },
-          "projectRoot": "typedoc-theme",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "typedoc-theme:build": ["typedoc-theme:build-base"],
-        "typedoc-theme:build-base": []
-      }
-    },
-    "typedoc-theme:lint": {
-      "roots": ["typedoc-theme:lint"],
-      "tasks": {
-        "typedoc-theme:lint": {
-          "id": "typedoc-theme:lint",
-          "target": { "project": "typedoc-theme", "target": "lint" },
-          "projectRoot": "typedoc-theme",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "typedoc-theme:lint": [] }
-    },
-    "typedoc-theme:test": {
-      "roots": ["typedoc-theme:build-base"],
-      "tasks": {
-        "typedoc-theme:test": {
-          "id": "typedoc-theme:test",
-          "target": { "project": "typedoc-theme", "target": "test" },
-          "projectRoot": "typedoc-theme",
-          "overrides": {}
-        },
-        "typedoc-theme:build": {
-          "id": "typedoc-theme:build",
-          "target": { "project": "typedoc-theme", "target": "build" },
-          "projectRoot": "typedoc-theme",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "typedoc-theme:build-base": {
-          "id": "typedoc-theme:build-base",
-          "target": { "project": "typedoc-theme", "target": "build-base" },
-          "projectRoot": "typedoc-theme",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "typedoc-theme:test": ["typedoc-theme:build"],
-        "typedoc-theme:build": ["typedoc-theme:build-base"],
-        "typedoc-theme:build-base": []
-      }
-    },
-    "e2e-nx-plugin:e2e": {
-      "roots": ["e2e-nx-plugin:e2e"],
-      "tasks": {
-        "e2e-nx-plugin:e2e": {
-          "id": "e2e-nx-plugin:e2e",
-          "target": { "project": "e2e-nx-plugin", "target": "e2e" },
-          "projectRoot": "e2e/nx-plugin",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-plugin:e2e": [] }
-    },
-    "e2e-nx-plugin:run-e2e-tests": {
-      "roots": ["e2e-nx-plugin:run-e2e-tests"],
-      "tasks": {
-        "e2e-nx-plugin:run-e2e-tests": {
-          "id": "e2e-nx-plugin:run-e2e-tests",
-          "target": { "project": "e2e-nx-plugin", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/nx-plugin",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-plugin:run-e2e-tests": [] }
-    },
-    "e2e-storybook:e2e": {
-      "roots": ["e2e-storybook:e2e"],
-      "tasks": {
-        "e2e-storybook:e2e": {
-          "id": "e2e-storybook:e2e",
-          "target": { "project": "e2e-storybook", "target": "e2e" },
-          "projectRoot": "e2e/storybook",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-storybook:e2e": [] }
-    },
-    "e2e-storybook:run-e2e-tests": {
-      "roots": ["e2e-storybook:run-e2e-tests"],
-      "tasks": {
-        "e2e-storybook:run-e2e-tests": {
-          "id": "e2e-storybook:run-e2e-tests",
-          "target": { "project": "e2e-storybook", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/storybook",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-storybook:run-e2e-tests": [] }
-    },
-    "nx-dev:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-dev:build": {
-          "id": "nx-dev:build",
-          "target": { "project": "nx-dev", "target": "build" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "nx-dev:build-base": {
-          "id": "nx-dev:build-base",
-          "target": { "project": "nx-dev", "target": "build-base" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:build": ["nx-dev:build-base"],
-        "nx-dev:build-base": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev:sitemap": {
-      "roots": ["nx-dev:sitemap"],
-      "tasks": {
-        "nx-dev:sitemap": {
-          "id": "nx-dev:sitemap",
-          "target": { "project": "nx-dev", "target": "sitemap" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:sitemap": [] }
-    },
-    "nx-dev:sync-documentation": {
-      "roots": ["nx-dev:sync-documentation"],
-      "tasks": {
-        "nx-dev:sync-documentation": {
-          "id": "nx-dev:sync-documentation",
-          "target": { "project": "nx-dev", "target": "sync-documentation" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:sync-documentation": [] }
-    },
-    "nx-dev:generate-og-images": {
-      "roots": ["nx-dev:generate-og-images"],
-      "tasks": {
-        "nx-dev:generate-og-images": {
-          "id": "nx-dev:generate-og-images",
-          "target": { "project": "nx-dev", "target": "generate-og-images" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:generate-og-images": [] }
-    },
-    "nx-dev:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-dev:build-base": {
-          "id": "nx-dev:build-base",
-          "target": { "project": "nx-dev", "target": "build-base" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:build-base": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev:build-base:development": {
-      "roots": ["graph-client:build-base"],
-      "tasks": {
-        "nx-dev:build-base:development": {
-          "id": "nx-dev:build-base:development",
-          "target": {
-            "project": "nx-dev",
-            "target": "build-base",
-            "configuration": "development"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base": {
-          "id": "graph-client:build-base",
-          "target": { "project": "graph-client", "target": "build-base" },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:build-base:development": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base"],
-        "graph-client:build-base": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev:build-base:production": {
-      "roots": ["graph-client:build-base"],
-      "tasks": {
-        "nx-dev:build-base:production": {
-          "id": "nx-dev:build-base:production",
-          "target": {
-            "project": "nx-dev",
-            "target": "build-base",
-            "configuration": "production"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base": {
-          "id": "graph-client:build-base",
-          "target": { "project": "graph-client", "target": "build-base" },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:build-base:production": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base"],
-        "graph-client:build-base": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev:serve": {
-      "roots": ["nx-dev:serve:development"],
-      "tasks": {
-        "nx-dev:serve:development": {
-          "id": "nx-dev:serve:development",
-          "target": {
-            "project": "nx-dev",
-            "target": "serve",
-            "configuration": "development"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:serve:development": [] }
-    },
-    "nx-dev:serve:production": {
-      "roots": ["nx-dev:serve:production"],
-      "tasks": {
-        "nx-dev:serve:production": {
-          "id": "nx-dev:serve:production",
-          "target": {
-            "project": "nx-dev",
-            "target": "serve",
-            "configuration": "production"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:serve:production": [] }
-    },
-    "nx-dev:serve:development": {
-      "roots": ["nx-dev:serve:development"],
-      "tasks": {
-        "nx-dev:serve:development": {
-          "id": "nx-dev:serve:development",
-          "target": {
-            "project": "nx-dev",
-            "target": "serve",
-            "configuration": "development"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:serve:development": [] }
-    },
-    "nx-dev:deploy-build": {
-      "roots": ["nx-dev:deploy-build"],
-      "tasks": {
-        "nx-dev:deploy-build": {
-          "id": "nx-dev:deploy-build",
-          "target": { "project": "nx-dev", "target": "deploy-build" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:deploy-build": [] }
-    },
-    "nx-dev:export": {
-      "roots": ["nx-dev:export"],
-      "tasks": {
-        "nx-dev:export": {
-          "id": "nx-dev:export",
-          "target": { "project": "nx-dev", "target": "export" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:export": [] }
-    },
-    "nx-dev:lint": {
-      "roots": ["nx-dev:lint"],
-      "tasks": {
-        "nx-dev:lint": {
-          "id": "nx-dev:lint",
-          "target": { "project": "nx-dev", "target": "lint" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:lint": [] }
-    },
-    "nx-dev:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-dev:test": {
-          "id": "nx-dev:test",
-          "target": { "project": "nx-dev", "target": "test" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "nx-dev:build": {
-          "id": "nx-dev:build",
-          "target": { "project": "nx-dev", "target": "build" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx-dev:build-base": {
-          "id": "nx-dev:build-base",
-          "target": { "project": "nx-dev", "target": "build-base" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:test": ["nx-dev:build"],
-        "nx-dev:build": ["nx-dev:build-base"],
-        "nx-dev:build-base": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "expo:lint": {
-      "roots": ["expo:lint"],
-      "tasks": {
-        "expo:lint": {
-          "id": "expo:lint",
-          "target": { "project": "expo", "target": "lint" },
-          "projectRoot": "packages/expo",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "expo:lint": [] }
-    },
-    "expo:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "expo:test": {
-          "id": "expo:test",
-          "target": { "project": "expo", "target": "test" },
-          "projectRoot": "packages/expo",
-          "overrides": {}
-        },
-        "expo:build": {
-          "id": "expo:build",
-          "target": { "project": "expo", "target": "build" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "expo:test": ["expo:build"],
-        "expo:build": ["expo:build-base"],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "expo:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": {}
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "expo:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "expo:build": {
-          "id": "expo:build",
-          "target": { "project": "expo", "target": "build" },
-          "projectRoot": "packages/expo",
-          "overrides": {}
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "expo:build": ["expo:build-base"],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "jest:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "jest:test": {
-          "id": "jest:test",
-          "target": { "project": "jest", "target": "test" },
-          "projectRoot": "packages/jest",
-          "overrides": {}
-        },
-        "jest:build": {
-          "id": "jest:build",
-          "target": { "project": "jest", "target": "build" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "jest:test": ["jest:build"],
-        "jest:build": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "jest:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "jest:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "jest:build": {
-          "id": "jest:build",
-          "target": { "project": "jest", "target": "build" },
-          "projectRoot": "packages/jest",
-          "overrides": {}
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "jest:build": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "jest:lint": {
-      "roots": ["jest:lint"],
-      "tasks": {
-        "jest:lint": {
-          "id": "jest:lint",
-          "target": { "project": "jest", "target": "lint" },
-          "projectRoot": "packages/jest",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "jest:lint": [] }
-    },
-    "nest:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nest:test": {
-          "id": "nest:test",
-          "target": { "project": "nest", "target": "test" },
-          "projectRoot": "packages/nest",
-          "overrides": {}
-        },
-        "nest:build": {
-          "id": "nest:build",
-          "target": { "project": "nest", "target": "build" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nest:test": ["nest:build"],
-        "nest:build": ["nest:build-base"],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "nest:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": {}
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "nest:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nest:build": {
-          "id": "nest:build",
-          "target": { "project": "nest", "target": "build" },
-          "projectRoot": "packages/nest",
-          "overrides": {}
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nest:build": ["nest:build-base"],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "nest:lint": {
-      "roots": ["nest:lint"],
-      "tasks": {
-        "nest:lint": {
-          "id": "nest:lint",
-          "target": { "project": "nest", "target": "lint" },
-          "projectRoot": "packages/nest",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nest:lint": [] }
-    },
-    "next:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "next:test": {
-          "id": "next:test",
-          "target": { "project": "next", "target": "test" },
-          "projectRoot": "packages/next",
-          "overrides": {}
-        },
-        "next:build": {
-          "id": "next:build",
-          "target": { "project": "next", "target": "build" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "next:test": ["next:build"],
-        "next:build": ["next:build-base"],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "next:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": {}
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "next:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "next:build": {
-          "id": "next:build",
-          "target": { "project": "next", "target": "build" },
-          "projectRoot": "packages/next",
-          "overrides": {}
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "next:build": ["next:build-base"],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "next:lint": {
-      "roots": ["next:lint"],
-      "tasks": {
-        "next:lint": {
-          "id": "next:lint",
-          "target": { "project": "next", "target": "lint" },
-          "projectRoot": "packages/next",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "next:lint": [] }
-    },
-    "node:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "node:test": {
-          "id": "node:test",
-          "target": { "project": "node", "target": "test" },
-          "projectRoot": "packages/node",
-          "overrides": {}
-        },
-        "node:build": {
-          "id": "node:build",
-          "target": { "project": "node", "target": "build" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "node:test": ["node:build"],
-        "node:build": ["node:build-base"],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "node:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "node:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "node:build": {
-          "id": "node:build",
-          "target": { "project": "node", "target": "build" },
-          "projectRoot": "packages/node",
-          "overrides": {}
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "node:build": ["node:build-base"],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "node:lint": {
-      "roots": ["node:lint"],
-      "tasks": {
-        "node:lint": {
-          "id": "node:lint",
-          "target": { "project": "node", "target": "lint" },
-          "projectRoot": "packages/node",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "node:lint": [] }
-    },
-    "vite:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "vite:test": {
-          "id": "vite:test",
-          "target": { "project": "vite", "target": "test" },
-          "projectRoot": "packages/vite",
-          "overrides": {}
-        },
-        "vite:build": {
-          "id": "vite:build",
-          "target": { "project": "vite", "target": "build" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "vite:test": ["vite:build"],
-        "vite:build": ["vite:build-base"],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "vite:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "vite:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "vite:build": {
-          "id": "vite:build",
-          "target": { "project": "vite", "target": "build" },
-          "projectRoot": "packages/vite",
-          "overrides": {}
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "vite:build": ["vite:build-base"],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "vite:lint": {
-      "roots": ["vite:lint"],
-      "tasks": {
-        "vite:lint": {
-          "id": "vite:lint",
-          "target": { "project": "vite", "target": "lint" },
-          "projectRoot": "packages/vite",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "vite:lint": [] }
-    },
-    "graph-client:generate-dev-environment-js": {
-      "roots": ["graph-client:generate-dev-environment-js"],
-      "tasks": {
-        "graph-client:generate-dev-environment-js": {
-          "id": "graph-client:generate-dev-environment-js",
-          "target": {
-            "project": "graph-client",
-            "target": "generate-dev-environment-js"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:generate-dev-environment-js": [] }
-    },
-    "graph-client:generate-graph-base": {
-      "roots": ["graph-client:generate-graph-base"],
-      "tasks": {
-        "graph-client:generate-graph-base": {
-          "id": "graph-client:generate-graph-base",
-          "target": {
-            "project": "graph-client",
-            "target": "generate-graph-base"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:generate-graph-base": [] }
-    },
-    "graph-client:generate-graph": {
-      "roots": ["graph-client:generate-graph"],
-      "tasks": {
-        "graph-client:generate-graph": {
-          "id": "graph-client:generate-graph",
-          "target": { "project": "graph-client", "target": "generate-graph" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:generate-graph": [] }
-    },
-    "graph-client:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:release": [] }
-    },
-    "graph-client:build-base:dev": {
-      "roots": ["graph-client:build-base:dev"],
-      "tasks": {
-        "graph-client:build-base:dev": {
-          "id": "graph-client:build-base:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:dev": [] }
-    },
-    "graph-client:build-base:dev-e2e": {
-      "roots": ["graph-client:build-base:dev-e2e"],
-      "tasks": {
-        "graph-client:build-base:dev-e2e": {
-          "id": "graph-client:build-base:dev-e2e",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "dev-e2e"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:dev-e2e": [] }
-    },
-    "graph-client:build-base:nx-console": {
-      "roots": ["graph-client:build-base:nx-console"],
-      "tasks": {
-        "graph-client:build-base:nx-console": {
-          "id": "graph-client:build-base:nx-console",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "nx-console"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:nx-console": [] }
-    },
-    "graph-client:build-base:release": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:release": [] }
-    },
-    "graph-client:build-base:release-static": {
-      "roots": ["graph-client:build-base:release-static"],
-      "tasks": {
-        "graph-client:build-base:release-static": {
-          "id": "graph-client:build-base:release-static",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release-static"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:release-static": [] }
-    },
-    "graph-client:build-base:watch": {
-      "roots": ["graph-client:build-base:watch"],
-      "tasks": {
-        "graph-client:build-base:watch": {
-          "id": "graph-client:build-base:watch",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "watch"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:watch": [] }
-    },
-    "graph-client:serve-base": {
-      "roots": ["graph-client:serve-base:dev"],
-      "tasks": {
-        "graph-client:serve-base:dev": {
-          "id": "graph-client:serve-base:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:dev": [] }
-    },
-    "graph-client:serve-base:dev": {
-      "roots": ["graph-client:serve-base:dev"],
-      "tasks": {
-        "graph-client:serve-base:dev": {
-          "id": "graph-client:serve-base:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:dev": [] }
-    },
-    "graph-client:serve-base:nx-console": {
-      "roots": ["graph-client:serve-base:nx-console"],
-      "tasks": {
-        "graph-client:serve-base:nx-console": {
-          "id": "graph-client:serve-base:nx-console",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "nx-console"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:nx-console": [] }
-    },
-    "graph-client:serve-base:release": {
-      "roots": ["graph-client:serve-base:release"],
-      "tasks": {
-        "graph-client:serve-base:release": {
-          "id": "graph-client:serve-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:release": [] }
-    },
-    "graph-client:serve-base:watch": {
-      "roots": ["graph-client:serve-base:watch"],
-      "tasks": {
-        "graph-client:serve-base:watch": {
-          "id": "graph-client:serve-base:watch",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "watch"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:watch": [] }
-    },
-    "graph-client:serve-base:release-static": {
-      "roots": ["graph-client:serve-base:release-static"],
-      "tasks": {
-        "graph-client:serve-base:release-static": {
-          "id": "graph-client:serve-base:release-static",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "release-static"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:release-static": [] }
-    },
-    "graph-client:serve-base:dev-e2e": {
-      "roots": ["graph-client:serve-base:dev-e2e"],
-      "tasks": {
-        "graph-client:serve-base:dev-e2e": {
-          "id": "graph-client:serve-base:dev-e2e",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "dev-e2e"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:dev-e2e": [] }
-    },
-    "graph-client:serve": {
-      "roots": ["graph-client:serve:dev"],
-      "tasks": {
-        "graph-client:serve:dev": {
-          "id": "graph-client:serve:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:dev": [] }
-    },
-    "graph-client:serve:dev": {
-      "roots": ["graph-client:serve:dev"],
-      "tasks": {
-        "graph-client:serve:dev": {
-          "id": "graph-client:serve:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:dev": [] }
-    },
-    "graph-client:serve:release": {
-      "roots": ["graph-client:serve:release"],
-      "tasks": {
-        "graph-client:serve:release": {
-          "id": "graph-client:serve:release",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:release": [] }
-    },
-    "graph-client:serve:release-static": {
-      "roots": ["graph-client:serve:release-static"],
-      "tasks": {
-        "graph-client:serve:release-static": {
-          "id": "graph-client:serve:release-static",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "release-static"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:release-static": [] }
-    },
-    "graph-client:serve:watch": {
-      "roots": ["graph-client:serve:watch"],
-      "tasks": {
-        "graph-client:serve:watch": {
-          "id": "graph-client:serve:watch",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "watch"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:watch": [] }
-    },
-    "graph-client:serve:nx-console": {
-      "roots": ["graph-client:serve:nx-console"],
-      "tasks": {
-        "graph-client:serve:nx-console": {
-          "id": "graph-client:serve:nx-console",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "nx-console"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:nx-console": [] }
-    },
-    "graph-client:lint": {
-      "roots": ["graph-client:lint"],
-      "tasks": {
-        "graph-client:lint": {
-          "id": "graph-client:lint",
-          "target": { "project": "graph-client", "target": "lint" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:lint": [] }
-    },
-    "graph-client:test": {
-      "roots": ["graph-client:test"],
-      "tasks": {
-        "graph-client:test": {
-          "id": "graph-client:test",
-          "target": { "project": "graph-client", "target": "test" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:test": [] }
-    },
-    "graph-client:storybook": {
-      "roots": ["graph-client:storybook"],
-      "tasks": {
-        "graph-client:storybook": {
-          "id": "graph-client:storybook",
-          "target": { "project": "graph-client", "target": "storybook" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:storybook": [] }
-    },
-    "graph-client:storybook:ci": {
-      "roots": ["graph-client:storybook:ci"],
-      "tasks": {
-        "graph-client:storybook:ci": {
-          "id": "graph-client:storybook:ci",
-          "target": {
-            "project": "graph-client",
-            "target": "storybook",
-            "configuration": "ci"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:storybook:ci": [] }
-    },
-    "graph-client:build-storybook": {
-      "roots": ["graph-client:build-storybook"],
-      "tasks": {
-        "graph-client:build-storybook": {
-          "id": "graph-client:build-storybook",
-          "target": { "project": "graph-client", "target": "build-storybook" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-storybook": [] }
-    },
-    "graph-client:build-storybook:ci": {
-      "roots": ["graph-client:build-storybook:ci"],
-      "tasks": {
-        "graph-client:build-storybook:ci": {
-          "id": "graph-client:build-storybook:ci",
-          "target": {
-            "project": "graph-client",
-            "target": "build-storybook",
-            "configuration": "ci"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-storybook:ci": [] }
-    },
-    "cli:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cli:test": {
-          "id": "cli:test",
-          "target": { "project": "cli", "target": "test" },
-          "projectRoot": "packages/cli",
-          "overrides": {}
-        },
-        "cli:build": {
-          "id": "cli:build",
-          "target": { "project": "cli", "target": "build" },
-          "projectRoot": "packages/cli",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cli:build-base": {
-          "id": "cli:build-base",
-          "target": { "project": "cli", "target": "build-base" },
-          "projectRoot": "packages/cli",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cli:test": ["cli:build"],
-        "cli:build": ["cli:build-base"],
-        "cli:build-base": ["workspace:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "cli:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cli:build-base": {
-          "id": "cli:build-base",
-          "target": { "project": "cli", "target": "build-base" },
-          "projectRoot": "packages/cli",
-          "overrides": {}
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cli:build-base": ["workspace:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "cli:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cli:build": {
-          "id": "cli:build",
-          "target": { "project": "cli", "target": "build" },
-          "projectRoot": "packages/cli",
-          "overrides": {}
-        },
-        "cli:build-base": {
-          "id": "cli:build-base",
-          "target": { "project": "cli", "target": "build-base" },
-          "projectRoot": "packages/cli",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cli:build": ["cli:build-base"],
-        "cli:build-base": ["workspace:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "cli:lint": {
-      "roots": ["cli:lint"],
-      "tasks": {
-        "cli:lint": {
-          "id": "cli:lint",
-          "target": { "project": "cli", "target": "lint" },
-          "projectRoot": "packages/cli",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "cli:lint": [] }
-    },
-    "tao:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "tao:test": {
-          "id": "tao:test",
-          "target": { "project": "tao", "target": "test" },
-          "projectRoot": "packages/tao",
-          "overrides": {}
-        },
-        "tao:build": {
-          "id": "tao:build",
-          "target": { "project": "tao", "target": "build" },
-          "projectRoot": "packages/tao",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "tao:build-base": {
-          "id": "tao:build-base",
-          "target": { "project": "tao", "target": "build-base" },
-          "projectRoot": "packages/tao",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "tao:test": ["tao:build"],
-        "tao:build": ["tao:build-base"],
-        "tao:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "tao:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "tao:build-base": {
-          "id": "tao:build-base",
-          "target": { "project": "tao", "target": "build-base" },
-          "projectRoot": "packages/tao",
-          "overrides": {}
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "tao:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "tao:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "tao:build": {
-          "id": "tao:build",
-          "target": { "project": "tao", "target": "build" },
-          "projectRoot": "packages/tao",
-          "overrides": {}
-        },
-        "tao:build-base": {
-          "id": "tao:build-base",
-          "target": { "project": "tao", "target": "build-base" },
-          "projectRoot": "packages/tao",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "tao:build": ["tao:build-base"],
-        "tao:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "tao:lint": {
-      "roots": ["tao:lint"],
-      "tasks": {
-        "tao:lint": {
-          "id": "tao:lint",
-          "target": { "project": "tao", "target": "lint" },
-          "projectRoot": "packages/tao",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "tao:lint": [] }
-    },
-    "web:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "web:test": {
-          "id": "web:test",
-          "target": { "project": "web", "target": "test" },
-          "projectRoot": "packages/web",
-          "overrides": {}
-        },
-        "web:build": {
-          "id": "web:build",
-          "target": { "project": "web", "target": "build" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "web:test": ["web:build"],
-        "web:build": ["web:build-base"],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "web:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": {}
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "web:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "web:build": {
-          "id": "web:build",
-          "target": { "project": "web", "target": "build" },
-          "projectRoot": "packages/web",
-          "overrides": {}
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "web:build": ["web:build-base"],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "web:lint": {
-      "roots": ["web:lint"],
-      "tasks": {
-        "web:lint": {
-          "id": "web:lint",
-          "target": { "project": "web", "target": "lint" },
-          "projectRoot": "packages/web",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "web:lint": [] }
-    },
-    "e2e-cypress:e2e": {
-      "roots": ["e2e-cypress:e2e"],
-      "tasks": {
-        "e2e-cypress:e2e": {
-          "id": "e2e-cypress:e2e",
-          "target": { "project": "e2e-cypress", "target": "e2e" },
-          "projectRoot": "e2e/cypress",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-cypress:e2e": [] }
-    },
-    "e2e-cypress:run-e2e-tests": {
-      "roots": ["e2e-cypress:run-e2e-tests"],
-      "tasks": {
-        "e2e-cypress:run-e2e-tests": {
-          "id": "e2e-cypress:run-e2e-tests",
-          "target": { "project": "e2e-cypress", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/cypress",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-cypress:run-e2e-tests": [] }
-    },
-    "e2e-esbuild:e2e": {
-      "roots": ["e2e-esbuild:e2e"],
-      "tasks": {
-        "e2e-esbuild:e2e": {
-          "id": "e2e-esbuild:e2e",
-          "target": { "project": "e2e-esbuild", "target": "e2e" },
-          "projectRoot": "e2e/esbuild",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-esbuild:e2e": [] }
-    },
-    "e2e-esbuild:run-e2e-tests": {
-      "roots": ["e2e-esbuild:run-e2e-tests"],
-      "tasks": {
-        "e2e-esbuild:run-e2e-tests": {
-          "id": "e2e-esbuild:run-e2e-tests",
-          "target": { "project": "e2e-esbuild", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/esbuild",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-esbuild:run-e2e-tests": [] }
-    },
-    "e2e-nx-init:e2e": {
-      "roots": ["e2e-nx-init:e2e"],
-      "tasks": {
-        "e2e-nx-init:e2e": {
-          "id": "e2e-nx-init:e2e",
-          "target": { "project": "e2e-nx-init", "target": "e2e" },
-          "projectRoot": "e2e/nx-init",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-init:e2e": [] }
-    },
-    "e2e-nx-init:run-e2e-tests": {
-      "roots": ["e2e-nx-init:run-e2e-tests"],
-      "tasks": {
-        "e2e-nx-init:run-e2e-tests": {
-          "id": "e2e-nx-init:run-e2e-tests",
-          "target": { "project": "e2e-nx-init", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/nx-init",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-init:run-e2e-tests": [] }
-    },
-    "e2e-nx-misc:e2e": {
-      "roots": ["e2e-nx-misc:e2e"],
-      "tasks": {
-        "e2e-nx-misc:e2e": {
-          "id": "e2e-nx-misc:e2e",
-          "target": { "project": "e2e-nx-misc", "target": "e2e" },
-          "projectRoot": "e2e/nx-misc",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-misc:e2e": [] }
-    },
-    "e2e-nx-misc:run-e2e-tests": {
-      "roots": ["e2e-nx-misc:run-e2e-tests"],
-      "tasks": {
-        "e2e-nx-misc:run-e2e-tests": {
-          "id": "e2e-nx-misc:run-e2e-tests",
-          "target": { "project": "e2e-nx-misc", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/nx-misc",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-misc:run-e2e-tests": [] }
-    },
-    "e2e-webpack:e2e": {
-      "roots": ["e2e-webpack:e2e"],
-      "tasks": {
-        "e2e-webpack:e2e": {
-          "id": "e2e-webpack:e2e",
-          "target": { "project": "e2e-webpack", "target": "e2e" },
-          "projectRoot": "e2e/webpack",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-webpack:e2e": [] }
-    },
-    "e2e-webpack:run-e2e-tests": {
-      "roots": ["e2e-webpack:run-e2e-tests"],
-      "tasks": {
-        "e2e-webpack:run-e2e-tests": {
-          "id": "e2e-webpack:run-e2e-tests",
-          "target": { "project": "e2e-webpack", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/webpack",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-webpack:run-e2e-tests": [] }
-    },
-    "js:lint": {
-      "roots": ["js:lint"],
-      "tasks": {
-        "js:lint": {
-          "id": "js:lint",
-          "target": { "project": "js", "target": "lint" },
-          "projectRoot": "packages/js",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "js:lint": [] }
-    },
-    "js:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "js:test": {
-          "id": "js:test",
-          "target": { "project": "js", "target": "test" },
-          "projectRoot": "packages/js",
-          "overrides": {}
-        },
-        "js:build": {
-          "id": "js:build",
-          "target": { "project": "js", "target": "build" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "js:test": ["js:build"],
-        "js:build": ["js:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "js:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "js:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "js:build": {
-          "id": "js:build",
-          "target": { "project": "js", "target": "build" },
-          "projectRoot": "packages/js",
-          "overrides": {}
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "js:build": ["js:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "nx:postinstall": {
-      "roots": ["nx:postinstall"],
-      "tasks": {
-        "nx:postinstall": {
-          "id": "nx:postinstall",
-          "target": { "project": "nx", "target": "postinstall" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx:postinstall": [] }
-    },
-    "nx:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "nx:echo": {
-      "roots": ["nx:echo"],
-      "tasks": {
-        "nx:echo": {
-          "id": "nx:echo",
-          "target": { "project": "nx", "target": "echo" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx:echo": [] }
-    },
-    "nx:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx:build": {
-          "id": "nx:build",
-          "target": { "project": "nx", "target": "build" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx:build": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "nx:lint": {
-      "roots": ["nx:lint"],
-      "tasks": {
-        "nx:lint": {
-          "id": "nx:lint",
-          "target": { "project": "nx", "target": "lint" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx:lint": [] }
-    },
-    "nx:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx:test": {
-          "id": "nx:test",
-          "target": { "project": "nx", "target": "test" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        },
-        "nx:build": {
-          "id": "nx:build",
-          "target": { "project": "nx", "target": "build" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx:test": ["nx:build"],
-        "nx:build": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "e2e-linter:e2e": {
-      "roots": ["e2e-linter:e2e"],
-      "tasks": {
-        "e2e-linter:e2e": {
-          "id": "e2e-linter:e2e",
-          "target": { "project": "e2e-linter", "target": "e2e" },
-          "projectRoot": "e2e/linter",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-linter:e2e": [] }
-    },
-    "e2e-linter:run-e2e-tests": {
-      "roots": ["e2e-linter:run-e2e-tests"],
-      "tasks": {
-        "e2e-linter:run-e2e-tests": {
-          "id": "e2e-linter:run-e2e-tests",
-          "target": { "project": "e2e-linter", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/linter",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-linter:run-e2e-tests": [] }
-    },
-    "e2e-nx-run:e2e": {
-      "roots": ["e2e-nx-run:e2e"],
-      "tasks": {
-        "e2e-nx-run:e2e": {
-          "id": "e2e-nx-run:e2e",
-          "target": { "project": "e2e-nx-run", "target": "e2e" },
-          "projectRoot": "e2e/nx-run",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-run:e2e": [] }
-    },
-    "e2e-nx-run:run-e2e-tests": {
-      "roots": ["e2e-nx-run:run-e2e-tests"],
-      "tasks": {
-        "e2e-nx-run:run-e2e-tests": {
-          "id": "e2e-nx-run:run-e2e-tests",
-          "target": { "project": "e2e-nx-run", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/nx-run",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-run:run-e2e-tests": [] }
-    },
-    "e2e-rollup:e2e": {
-      "roots": ["e2e-rollup:e2e"],
-      "tasks": {
-        "e2e-rollup:e2e": {
-          "id": "e2e-rollup:e2e",
-          "target": { "project": "e2e-rollup", "target": "e2e" },
-          "projectRoot": "e2e/rollup",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-rollup:e2e": [] }
-    },
-    "e2e-rollup:run-e2e-tests": {
-      "roots": ["e2e-rollup:run-e2e-tests"],
-      "tasks": {
-        "e2e-rollup:run-e2e-tests": {
-          "id": "e2e-rollup:run-e2e-tests",
-          "target": { "project": "e2e-rollup", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/rollup",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-rollup:run-e2e-tests": [] }
-    },
-    "e2e-detox:e2e": {
-      "roots": ["e2e-detox:e2e"],
-      "tasks": {
-        "e2e-detox:e2e": {
-          "id": "e2e-detox:e2e",
-          "target": { "project": "e2e-detox", "target": "e2e" },
-          "projectRoot": "e2e/detox",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-detox:e2e": [] }
-    },
-    "e2e-detox:run-e2e-tests": {
-      "roots": ["e2e-detox:run-e2e-tests"],
-      "tasks": {
-        "e2e-detox:run-e2e-tests": {
-          "id": "e2e-detox:run-e2e-tests",
-          "target": { "project": "e2e-detox", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/detox",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-detox:run-e2e-tests": [] }
-    },
-    "e2e-react:e2e": {
-      "roots": ["e2e-react:e2e"],
-      "tasks": {
-        "e2e-react:e2e": {
-          "id": "e2e-react:e2e",
-          "target": { "project": "e2e-react", "target": "e2e" },
-          "projectRoot": "e2e/react",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-react:e2e": [] }
-    },
-    "e2e-react:run-e2e-tests": {
-      "roots": ["e2e-react:run-e2e-tests"],
-      "tasks": {
-        "e2e-react:run-e2e-tests": {
-          "id": "e2e-react:run-e2e-tests",
-          "target": { "project": "e2e-react", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/react",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-react:run-e2e-tests": [] }
-    },
-    "e2e-expo:e2e": {
-      "roots": ["e2e-expo:e2e"],
-      "tasks": {
-        "e2e-expo:e2e": {
-          "id": "e2e-expo:e2e",
-          "target": { "project": "e2e-expo", "target": "e2e" },
-          "projectRoot": "e2e/expo",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-expo:e2e": [] }
-    },
-    "e2e-expo:run-e2e-tests": {
-      "roots": ["e2e-expo:run-e2e-tests"],
-      "tasks": {
-        "e2e-expo:run-e2e-tests": {
-          "id": "e2e-expo:run-e2e-tests",
-          "target": { "project": "e2e-expo", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/expo",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-expo:run-e2e-tests": [] }
-    },
-    "e2e-jest:e2e": {
-      "roots": ["e2e-jest:e2e"],
-      "tasks": {
-        "e2e-jest:e2e": {
-          "id": "e2e-jest:e2e",
-          "target": { "project": "e2e-jest", "target": "e2e" },
-          "projectRoot": "e2e/jest",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-jest:e2e": [] }
-    },
-    "e2e-jest:run-e2e-tests": {
-      "roots": ["e2e-jest:run-e2e-tests"],
-      "tasks": {
-        "e2e-jest:run-e2e-tests": {
-          "id": "e2e-jest:run-e2e-tests",
-          "target": { "project": "e2e-jest", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/jest",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-jest:run-e2e-tests": [] }
-    },
-    "e2e-next:e2e": {
-      "roots": ["e2e-next:e2e"],
-      "tasks": {
-        "e2e-next:e2e": {
-          "id": "e2e-next:e2e",
-          "target": { "project": "e2e-next", "target": "e2e" },
-          "projectRoot": "e2e/next",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-next:e2e": [] }
-    },
-    "e2e-next:run-e2e-tests": {
-      "roots": ["e2e-next:run-e2e-tests"],
-      "tasks": {
-        "e2e-next:run-e2e-tests": {
-          "id": "e2e-next:run-e2e-tests",
-          "target": { "project": "e2e-next", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/next",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-next:run-e2e-tests": [] }
-    },
-    "e2e-node:e2e": {
-      "roots": ["e2e-node:e2e"],
-      "tasks": {
-        "e2e-node:e2e": {
-          "id": "e2e-node:e2e",
-          "target": { "project": "e2e-node", "target": "e2e" },
-          "projectRoot": "e2e/node",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-node:e2e": [] }
-    },
-    "e2e-node:run-e2e-tests": {
-      "roots": ["e2e-node:run-e2e-tests"],
-      "tasks": {
-        "e2e-node:run-e2e-tests": {
-          "id": "e2e-node:run-e2e-tests",
-          "target": { "project": "e2e-node", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/node",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-node:run-e2e-tests": [] }
-    },
-    "e2e-vite:e2e": {
-      "roots": ["e2e-vite:e2e"],
-      "tasks": {
-        "e2e-vite:e2e": {
-          "id": "e2e-vite:e2e",
-          "target": { "project": "e2e-vite", "target": "e2e" },
-          "projectRoot": "e2e/vite",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-vite:e2e": [] }
-    },
-    "e2e-vite:run-e2e-tests": {
-      "roots": ["e2e-vite:run-e2e-tests"],
-      "tasks": {
-        "e2e-vite:run-e2e-tests": {
-          "id": "e2e-vite:run-e2e-tests",
-          "target": { "project": "e2e-vite", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/vite",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-vite:run-e2e-tests": [] }
-    },
-    "e2e-web:e2e": {
-      "roots": ["e2e-web:e2e"],
-      "tasks": {
-        "e2e-web:e2e": {
-          "id": "e2e-web:e2e",
-          "target": { "project": "e2e-web", "target": "e2e" },
-          "projectRoot": "e2e/web",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-web:e2e": [] }
-    },
-    "e2e-web:run-e2e-tests": {
-      "roots": ["e2e-web:run-e2e-tests"],
-      "tasks": {
-        "e2e-web:run-e2e-tests": {
-          "id": "e2e-web:run-e2e-tests",
-          "target": { "project": "e2e-web", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/web",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-web:run-e2e-tests": [] }
-    },
-    "e2e-js:e2e": {
-      "roots": ["e2e-js:e2e"],
-      "tasks": {
-        "e2e-js:e2e": {
-          "id": "e2e-js:e2e",
-          "target": { "project": "e2e-js", "target": "e2e" },
-          "projectRoot": "e2e/js",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-js:e2e": [] }
-    },
-    "e2e-js:run-e2e-tests": {
-      "roots": ["e2e-js:run-e2e-tests"],
-      "tasks": {
-        "e2e-js:run-e2e-tests": {
-          "id": "e2e-js:run-e2e-tests",
-          "target": { "project": "e2e-js", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/js",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-js:run-e2e-tests": [] }
-    },
-    "@nrwl/nx-source:check-commit": {
-      "roots": ["@nrwl/nx-source:check-commit"],
-      "tasks": {
-        "@nrwl/nx-source:check-commit": {
-          "id": "@nrwl/nx-source:check-commit",
-          "target": { "project": "@nrwl/nx-source", "target": "check-commit" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:check-commit": [] }
-    },
-    "@nrwl/nx-source:check-format": {
-      "roots": ["@nrwl/nx-source:check-format"],
-      "tasks": {
-        "@nrwl/nx-source:check-format": {
-          "id": "@nrwl/nx-source:check-format",
-          "target": { "project": "@nrwl/nx-source", "target": "check-format" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:check-format": [] }
-    },
-    "@nrwl/nx-source:check-imports": {
-      "roots": ["@nrwl/nx-source:check-imports"],
-      "tasks": {
-        "@nrwl/nx-source:check-imports": {
-          "id": "@nrwl/nx-source:check-imports",
-          "target": { "project": "@nrwl/nx-source", "target": "check-imports" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:check-imports": [] }
-    },
-    "@nrwl/nx-source:check-lock-files": {
-      "roots": ["@nrwl/nx-source:check-lock-files"],
-      "tasks": {
-        "@nrwl/nx-source:check-lock-files": {
-          "id": "@nrwl/nx-source:check-lock-files",
-          "target": {
-            "project": "@nrwl/nx-source",
-            "target": "check-lock-files"
-          },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:check-lock-files": [] }
-    },
-    "@nrwl/nx-source:depcheck": {
-      "roots": ["@nrwl/nx-source:depcheck"],
-      "tasks": {
-        "@nrwl/nx-source:depcheck": {
-          "id": "@nrwl/nx-source:depcheck",
-          "target": { "project": "@nrwl/nx-source", "target": "depcheck" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:depcheck": [] }
-    },
-    "@nrwl/nx-source:documentation": {
-      "roots": ["@nrwl/nx-source:documentation"],
-      "tasks": {
-        "@nrwl/nx-source:documentation": {
-          "id": "@nrwl/nx-source:documentation",
-          "target": { "project": "@nrwl/nx-source", "target": "documentation" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:documentation": [] }
-    },
-    "@nrwl/nx-source:echo": {
-      "roots": ["@nrwl/nx-source:echo"],
-      "tasks": {
-        "@nrwl/nx-source:echo": {
-          "id": "@nrwl/nx-source:echo",
-          "target": { "project": "@nrwl/nx-source", "target": "echo" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:echo": [] }
-    },
-    "@nrwl/nx-source:lint": {
-      "roots": ["@nrwl/nx-source:lint"],
-      "tasks": {
-        "@nrwl/nx-source:lint": {
-          "id": "@nrwl/nx-source:lint",
-          "target": { "project": "@nrwl/nx-source", "target": "lint" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:lint": [] }
+  "taskIds": ["create-nx-workspace:test"],
+  "taskGraph": {
+    "roots": [
+      "nx-dev-feature-package-schema-viewer:lint",
+      "nx-dev-feature-package-schema-viewer:test",
+      "nx-dev-data-access-documents:lint",
+      "nx-dev-data-access-documents:test",
+      "graph-client:build-base:release",
+      "create-nx-workspace:lint",
+      "nx-dev-data-access-packages:lint",
+      "nx-dev-data-access-packages:test",
+      "nx-dev-feature-doc-viewer:lint",
+      "nx-dev-feature-doc-viewer:test",
+      "create-nx-plugin:lint",
+      "eslint-plugin-nx:lint",
+      "nx-dev-feature-analytics:lint",
+      "nx-dev-feature-analytics:test",
+      "nx-dev-data-access-menu:lint",
+      "nx-dev-data-access-menu:test",
+      "e2e-angular-extensions:e2e",
+      "e2e-angular-extensions:run-e2e-tests",
+      "nx-dev-models-document:lint",
+      "nx-dev-models-document:test",
+      "nx-dev-ui-sponsor-card:lint",
+      "nx-dev-ui-sponsor-card:test",
+      "e2e-storybook-angular:e2e",
+      "e2e-storybook-angular:run-e2e-tests",
+      "nx-dev-feature-search:lint",
+      "nx-dev-feature-search:test",
+      "nx-dev-models-package:lint",
+      "nx-dev-models-package:test",
+      "nx-dev-ui-member-card:lint",
+      "nx-dev-ui-member-card:test",
+      "react-native:lint",
+      "e2e-workspace-create:e2e",
+      "e2e-workspace-create:run-e2e-tests",
+      "nx-dev-ui-conference:lint",
+      "nx-dev-ui-conference:test",
+      "nx-dev-ui-references:lint",
+      "nx-dev-ui-references:test",
+      "nx-dev-ui-community:lint",
+      "nx-dev-ui-community:test",
+      "nx-dev-models-menu:lint",
+      "nx-dev-models-menu:test",
+      "nx-dev-ui-commands:lint",
+      "nx-dev-ui-commands:test",
+      "nx-plugin:lint",
+      "storybook:lint",
+      "workspace:lint",
+      "eslint-rules:test",
+      "nx-dev-e2e:lint",
+      "nx-dev-ui-markdoc:lint",
+      "nx-dev-ui-markdoc:test",
+      "e2e-angular-core:e2e",
+      "e2e-angular-core:run-e2e-tests",
+      "e2e-react-native:e2e",
+      "e2e-react-native:run-e2e-tests",
+      "e2e-graph-client:e2e-base:dev",
+      "e2e-graph-client:e2e-base:watch",
+      "e2e-graph-client:e2e-base:release",
+      "e2e-graph-client:e2e-base:release-static",
+      "e2e-graph-client:e2e-local",
+      "e2e-graph-client:e2e",
+      "e2e-graph-client:lint",
+      "nx-dev-ui-common:lint",
+      "nx-dev-ui-common:test",
+      "angular:postinstall",
+      "angular:lint",
+      "cypress:lint",
+      "esbuild:lint",
+      "express:lint",
+      "webpack:lint",
+      "nx-dev-ui-theme:lint",
+      "nx-dev-ui-theme:test",
+      "devkit:lint",
+      "linter:lint",
+      "rollup:lint",
+      "graph-ui-graph:lint",
+      "graph-ui-graph:test",
+      "graph-ui-graph:storybook",
+      "graph-ui-graph:storybook:ci",
+      "graph-ui-graph:build-storybook",
+      "graph-ui-graph:build-storybook:ci",
+      "nx-dev-ui-home:lint",
+      "nx-dev-ui-home:xtest",
+      "detox:lint",
+      "react:lint",
+      "typedoc-theme:build-base",
+      "typedoc-theme:lint",
+      "e2e-nx-plugin:e2e",
+      "e2e-nx-plugin:run-e2e-tests",
+      "e2e-storybook:e2e",
+      "e2e-storybook:run-e2e-tests",
+      "nx-dev:sitemap",
+      "nx-dev:sync-documentation",
+      "nx-dev:generate-og-images",
+      "graph-client:build-base",
+      "nx-dev:serve:development",
+      "nx-dev:serve:production",
+      "nx-dev:deploy-build",
+      "nx-dev:export",
+      "nx-dev:lint",
+      "expo:lint",
+      "jest:lint",
+      "nest:lint",
+      "next:lint",
+      "node:lint",
+      "vite:lint",
+      "graph-client:generate-dev-environment-js",
+      "graph-client:generate-graph-base",
+      "graph-client:generate-graph",
+      "graph-client:build-base:dev",
+      "graph-client:build-base:dev-e2e",
+      "graph-client:build-base:nx-console",
+      "graph-client:build-base:release-static",
+      "graph-client:build-base:watch",
+      "graph-client:serve-base:dev",
+      "graph-client:serve-base:nx-console",
+      "graph-client:serve-base:release",
+      "graph-client:serve-base:watch",
+      "graph-client:serve-base:release-static",
+      "graph-client:serve-base:dev-e2e",
+      "graph-client:serve:dev",
+      "graph-client:serve:release",
+      "graph-client:serve:release-static",
+      "graph-client:serve:watch",
+      "graph-client:serve:nx-console",
+      "graph-client:lint",
+      "graph-client:test",
+      "graph-client:storybook",
+      "graph-client:storybook:ci",
+      "graph-client:build-storybook",
+      "graph-client:build-storybook:ci",
+      "cli:lint",
+      "tao:lint",
+      "web:lint",
+      "e2e-cypress:e2e",
+      "e2e-cypress:run-e2e-tests",
+      "e2e-esbuild:e2e",
+      "e2e-esbuild:run-e2e-tests",
+      "e2e-nx-init:e2e",
+      "e2e-nx-init:run-e2e-tests",
+      "e2e-nx-misc:e2e",
+      "e2e-nx-misc:run-e2e-tests",
+      "e2e-webpack:e2e",
+      "e2e-webpack:run-e2e-tests",
+      "js:lint",
+      "nx:postinstall",
+      "nx:echo",
+      "nx:lint",
+      "e2e-linter:e2e",
+      "e2e-linter:run-e2e-tests",
+      "e2e-nx-run:e2e",
+      "e2e-nx-run:run-e2e-tests",
+      "e2e-rollup:e2e",
+      "e2e-rollup:run-e2e-tests",
+      "e2e-detox:e2e",
+      "e2e-detox:run-e2e-tests",
+      "e2e-react:e2e",
+      "e2e-react:run-e2e-tests",
+      "e2e-expo:e2e",
+      "e2e-expo:run-e2e-tests",
+      "e2e-jest:e2e",
+      "e2e-jest:run-e2e-tests",
+      "e2e-next:e2e",
+      "e2e-next:run-e2e-tests",
+      "e2e-node:e2e",
+      "e2e-node:run-e2e-tests",
+      "e2e-vite:e2e",
+      "e2e-vite:run-e2e-tests",
+      "e2e-web:e2e",
+      "e2e-web:run-e2e-tests",
+      "e2e-js:e2e",
+      "e2e-js:run-e2e-tests",
+      "@nrwl/nx-source:check-commit",
+      "@nrwl/nx-source:check-format",
+      "@nrwl/nx-source:check-imports",
+      "@nrwl/nx-source:check-lock-files",
+      "@nrwl/nx-source:depcheck",
+      "@nrwl/nx-source:documentation",
+      "@nrwl/nx-source:echo",
+      "@nrwl/nx-source:lint"
+    ],
+    "tasks": {
+      "nx-dev-feature-package-schema-viewer:lint": {
+        "id": "nx-dev-feature-package-schema-viewer:lint",
+        "target": {
+          "project": "nx-dev-feature-package-schema-viewer",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/feature-package-schema-viewer",
+        "overrides": {}
+      },
+      "nx-dev-feature-package-schema-viewer:test": {
+        "id": "nx-dev-feature-package-schema-viewer:test",
+        "target": {
+          "project": "nx-dev-feature-package-schema-viewer",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/feature-package-schema-viewer",
+        "overrides": {}
+      },
+      "nx-dev-data-access-documents:lint": {
+        "id": "nx-dev-data-access-documents:lint",
+        "target": {
+          "project": "nx-dev-data-access-documents",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/data-access-documents",
+        "overrides": {}
+      },
+      "nx-dev-data-access-documents:test": {
+        "id": "nx-dev-data-access-documents:test",
+        "target": {
+          "project": "nx-dev-data-access-documents",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/data-access-documents",
+        "overrides": {}
+      },
+      "create-nx-workspace:test": {
+        "id": "create-nx-workspace:test",
+        "target": {
+          "project": "create-nx-workspace",
+          "target": "test"
+        },
+        "projectRoot": "packages/create-nx-workspace",
+        "overrides": {}
+      },
+      "create-nx-workspace:build": {
+        "id": "create-nx-workspace:build",
+        "target": {
+          "project": "create-nx-workspace",
+          "target": "build"
+        },
+        "projectRoot": "packages/create-nx-workspace",
+        "overrides": {}
+      },
+      "create-nx-workspace:build-base": {
+        "id": "create-nx-workspace:build-base",
+        "target": {
+          "project": "create-nx-workspace",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/create-nx-workspace",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "workspace:build-base": {
+        "id": "workspace:build-base",
+        "target": {
+          "project": "workspace",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/workspace",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "devkit:build-base": {
+        "id": "devkit:build-base",
+        "target": {
+          "project": "devkit",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/devkit",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx:build-base": {
+        "id": "nx:build-base",
+        "target": {
+          "project": "nx",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "graph-client:build-base:release": {
+        "id": "graph-client:build-base:release",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "release"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "js:build-base": {
+        "id": "js:build-base",
+        "target": {
+          "project": "js",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/js",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "linter:build-base": {
+        "id": "linter:build-base",
+        "target": {
+          "project": "linter",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/linter",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "eslint-plugin-nx:build-base": {
+        "id": "eslint-plugin-nx:build-base",
+        "target": {
+          "project": "eslint-plugin-nx",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/eslint-plugin-nx",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "jest:build-base": {
+        "id": "jest:build-base",
+        "target": {
+          "project": "jest",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/jest",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "react:build-base": {
+        "id": "react:build-base",
+        "target": {
+          "project": "react",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/react",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "web:build-base": {
+        "id": "web:build-base",
+        "target": {
+          "project": "web",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/web",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "cypress:build-base": {
+        "id": "cypress:build-base",
+        "target": {
+          "project": "cypress",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/cypress",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "rollup:build-base": {
+        "id": "rollup:build-base",
+        "target": {
+          "project": "rollup",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/rollup",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "vite:build-base": {
+        "id": "vite:build-base",
+        "target": {
+          "project": "vite",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/vite",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "webpack:build-base": {
+        "id": "webpack:build-base",
+        "target": {
+          "project": "webpack",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/webpack",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "storybook:build-base": {
+        "id": "storybook:build-base",
+        "target": {
+          "project": "storybook",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/storybook",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "expo:build-base": {
+        "id": "expo:build-base",
+        "target": {
+          "project": "expo",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/expo",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "detox:build-base": {
+        "id": "detox:build-base",
+        "target": {
+          "project": "detox",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/detox",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "next:build-base": {
+        "id": "next:build-base",
+        "target": {
+          "project": "next",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/next",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "angular:build-base": {
+        "id": "angular:build-base",
+        "target": {
+          "project": "angular",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nest:build-base": {
+        "id": "nest:build-base",
+        "target": {
+          "project": "nest",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/nest",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "node:build-base": {
+        "id": "node:build-base",
+        "target": {
+          "project": "node",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/node",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "express:build-base": {
+        "id": "express:build-base",
+        "target": {
+          "project": "express",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/express",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "create-nx-workspace:lint": {
+        "id": "create-nx-workspace:lint",
+        "target": {
+          "project": "create-nx-workspace",
+          "target": "lint"
+        },
+        "projectRoot": "packages/create-nx-workspace",
+        "overrides": {}
+      },
+      "nx-dev-data-access-packages:lint": {
+        "id": "nx-dev-data-access-packages:lint",
+        "target": {
+          "project": "nx-dev-data-access-packages",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/data-access-packages",
+        "overrides": {}
+      },
+      "nx-dev-data-access-packages:test": {
+        "id": "nx-dev-data-access-packages:test",
+        "target": {
+          "project": "nx-dev-data-access-packages",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/data-access-packages",
+        "overrides": {}
+      },
+      "nx-dev-feature-doc-viewer:lint": {
+        "id": "nx-dev-feature-doc-viewer:lint",
+        "target": {
+          "project": "nx-dev-feature-doc-viewer",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/feature-doc-viewer",
+        "overrides": {}
+      },
+      "nx-dev-feature-doc-viewer:test": {
+        "id": "nx-dev-feature-doc-viewer:test",
+        "target": {
+          "project": "nx-dev-feature-doc-viewer",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/feature-doc-viewer",
+        "overrides": {}
+      },
+      "create-nx-plugin:test": {
+        "id": "create-nx-plugin:test",
+        "target": {
+          "project": "create-nx-plugin",
+          "target": "test"
+        },
+        "projectRoot": "packages/create-nx-plugin",
+        "overrides": {}
+      },
+      "create-nx-plugin:build": {
+        "id": "create-nx-plugin:build",
+        "target": {
+          "project": "create-nx-plugin",
+          "target": "build"
+        },
+        "projectRoot": "packages/create-nx-plugin",
+        "overrides": {}
+      },
+      "create-nx-plugin:build-base": {
+        "id": "create-nx-plugin:build-base",
+        "target": {
+          "project": "create-nx-plugin",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/create-nx-plugin",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx-plugin:build-base": {
+        "id": "nx-plugin:build-base",
+        "target": {
+          "project": "nx-plugin",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/nx-plugin",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "create-nx-plugin:lint": {
+        "id": "create-nx-plugin:lint",
+        "target": {
+          "project": "create-nx-plugin",
+          "target": "lint"
+        },
+        "projectRoot": "packages/create-nx-plugin",
+        "overrides": {}
+      },
+      "eslint-plugin-nx:test": {
+        "id": "eslint-plugin-nx:test",
+        "target": {
+          "project": "eslint-plugin-nx",
+          "target": "test"
+        },
+        "projectRoot": "packages/eslint-plugin-nx",
+        "overrides": {}
+      },
+      "eslint-plugin-nx:build": {
+        "id": "eslint-plugin-nx:build",
+        "target": {
+          "project": "eslint-plugin-nx",
+          "target": "build"
+        },
+        "projectRoot": "packages/eslint-plugin-nx",
+        "overrides": {}
+      },
+      "eslint-plugin-nx:lint": {
+        "id": "eslint-plugin-nx:lint",
+        "target": {
+          "project": "eslint-plugin-nx",
+          "target": "lint"
+        },
+        "projectRoot": "packages/eslint-plugin-nx",
+        "overrides": {}
+      },
+      "nx-dev-feature-analytics:lint": {
+        "id": "nx-dev-feature-analytics:lint",
+        "target": {
+          "project": "nx-dev-feature-analytics",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/feature-analytics",
+        "overrides": {}
+      },
+      "nx-dev-feature-analytics:test": {
+        "id": "nx-dev-feature-analytics:test",
+        "target": {
+          "project": "nx-dev-feature-analytics",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/feature-analytics",
+        "overrides": {}
+      },
+      "nx-dev-data-access-menu:lint": {
+        "id": "nx-dev-data-access-menu:lint",
+        "target": {
+          "project": "nx-dev-data-access-menu",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/data-access-menu",
+        "overrides": {}
+      },
+      "nx-dev-data-access-menu:test": {
+        "id": "nx-dev-data-access-menu:test",
+        "target": {
+          "project": "nx-dev-data-access-menu",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/data-access-menu",
+        "overrides": {}
+      },
+      "e2e-angular-extensions:e2e": {
+        "id": "e2e-angular-extensions:e2e",
+        "target": {
+          "project": "e2e-angular-extensions",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/angular-extensions",
+        "overrides": {}
+      },
+      "e2e-angular-extensions:run-e2e-tests": {
+        "id": "e2e-angular-extensions:run-e2e-tests",
+        "target": {
+          "project": "e2e-angular-extensions",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/angular-extensions",
+        "overrides": {}
+      },
+      "nx-dev-models-document:lint": {
+        "id": "nx-dev-models-document:lint",
+        "target": {
+          "project": "nx-dev-models-document",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/models-document",
+        "overrides": {}
+      },
+      "nx-dev-models-document:test": {
+        "id": "nx-dev-models-document:test",
+        "target": {
+          "project": "nx-dev-models-document",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/models-document",
+        "overrides": {}
+      },
+      "nx-dev-ui-sponsor-card:lint": {
+        "id": "nx-dev-ui-sponsor-card:lint",
+        "target": {
+          "project": "nx-dev-ui-sponsor-card",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-sponsor-card",
+        "overrides": {}
+      },
+      "nx-dev-ui-sponsor-card:test": {
+        "id": "nx-dev-ui-sponsor-card:test",
+        "target": {
+          "project": "nx-dev-ui-sponsor-card",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-sponsor-card",
+        "overrides": {}
+      },
+      "e2e-storybook-angular:e2e": {
+        "id": "e2e-storybook-angular:e2e",
+        "target": {
+          "project": "e2e-storybook-angular",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/storybook-angular",
+        "overrides": {}
+      },
+      "e2e-storybook-angular:run-e2e-tests": {
+        "id": "e2e-storybook-angular:run-e2e-tests",
+        "target": {
+          "project": "e2e-storybook-angular",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/storybook-angular",
+        "overrides": {}
+      },
+      "nx-dev-feature-search:lint": {
+        "id": "nx-dev-feature-search:lint",
+        "target": {
+          "project": "nx-dev-feature-search",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/feature-search",
+        "overrides": {}
+      },
+      "nx-dev-feature-search:test": {
+        "id": "nx-dev-feature-search:test",
+        "target": {
+          "project": "nx-dev-feature-search",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/feature-search",
+        "overrides": {}
+      },
+      "nx-dev-models-package:lint": {
+        "id": "nx-dev-models-package:lint",
+        "target": {
+          "project": "nx-dev-models-package",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/models-package",
+        "overrides": {}
+      },
+      "nx-dev-models-package:test": {
+        "id": "nx-dev-models-package:test",
+        "target": {
+          "project": "nx-dev-models-package",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/models-package",
+        "overrides": {}
+      },
+      "nx-dev-ui-member-card:lint": {
+        "id": "nx-dev-ui-member-card:lint",
+        "target": {
+          "project": "nx-dev-ui-member-card",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-member-card",
+        "overrides": {}
+      },
+      "nx-dev-ui-member-card:test": {
+        "id": "nx-dev-ui-member-card:test",
+        "target": {
+          "project": "nx-dev-ui-member-card",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-member-card",
+        "overrides": {}
+      },
+      "react-native:lint": {
+        "id": "react-native:lint",
+        "target": {
+          "project": "react-native",
+          "target": "lint"
+        },
+        "projectRoot": "packages/react-native",
+        "overrides": {}
+      },
+      "react-native:test": {
+        "id": "react-native:test",
+        "target": {
+          "project": "react-native",
+          "target": "test"
+        },
+        "projectRoot": "packages/react-native",
+        "overrides": {}
+      },
+      "react-native:build": {
+        "id": "react-native:build",
+        "target": {
+          "project": "react-native",
+          "target": "build"
+        },
+        "projectRoot": "packages/react-native",
+        "overrides": {}
+      },
+      "react-native:build-base": {
+        "id": "react-native:build-base",
+        "target": {
+          "project": "react-native",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/react-native",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "e2e-workspace-create:e2e": {
+        "id": "e2e-workspace-create:e2e",
+        "target": {
+          "project": "e2e-workspace-create",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/workspace-create",
+        "overrides": {}
+      },
+      "e2e-workspace-create:run-e2e-tests": {
+        "id": "e2e-workspace-create:run-e2e-tests",
+        "target": {
+          "project": "e2e-workspace-create",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/workspace-create",
+        "overrides": {}
+      },
+      "nx-dev-ui-conference:lint": {
+        "id": "nx-dev-ui-conference:lint",
+        "target": {
+          "project": "nx-dev-ui-conference",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-conference",
+        "overrides": {}
+      },
+      "nx-dev-ui-conference:test": {
+        "id": "nx-dev-ui-conference:test",
+        "target": {
+          "project": "nx-dev-ui-conference",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-conference",
+        "overrides": {}
+      },
+      "nx-dev-ui-references:lint": {
+        "id": "nx-dev-ui-references:lint",
+        "target": {
+          "project": "nx-dev-ui-references",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-references",
+        "overrides": {}
+      },
+      "nx-dev-ui-references:test": {
+        "id": "nx-dev-ui-references:test",
+        "target": {
+          "project": "nx-dev-ui-references",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-references",
+        "overrides": {}
+      },
+      "nx-dev-ui-community:lint": {
+        "id": "nx-dev-ui-community:lint",
+        "target": {
+          "project": "nx-dev-ui-community",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-community",
+        "overrides": {}
+      },
+      "nx-dev-ui-community:test": {
+        "id": "nx-dev-ui-community:test",
+        "target": {
+          "project": "nx-dev-ui-community",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-community",
+        "overrides": {}
+      },
+      "nx-dev-models-menu:lint": {
+        "id": "nx-dev-models-menu:lint",
+        "target": {
+          "project": "nx-dev-models-menu",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/models-menu",
+        "overrides": {}
+      },
+      "nx-dev-models-menu:test": {
+        "id": "nx-dev-models-menu:test",
+        "target": {
+          "project": "nx-dev-models-menu",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/models-menu",
+        "overrides": {}
+      },
+      "nx-dev-ui-commands:lint": {
+        "id": "nx-dev-ui-commands:lint",
+        "target": {
+          "project": "nx-dev-ui-commands",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-commands",
+        "overrides": {}
+      },
+      "nx-dev-ui-commands:test": {
+        "id": "nx-dev-ui-commands:test",
+        "target": {
+          "project": "nx-dev-ui-commands",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-commands",
+        "overrides": {}
+      },
+      "nx-plugin:test": {
+        "id": "nx-plugin:test",
+        "target": {
+          "project": "nx-plugin",
+          "target": "test"
+        },
+        "projectRoot": "packages/nx-plugin",
+        "overrides": {}
+      },
+      "nx-plugin:build": {
+        "id": "nx-plugin:build",
+        "target": {
+          "project": "nx-plugin",
+          "target": "build"
+        },
+        "projectRoot": "packages/nx-plugin",
+        "overrides": {}
+      },
+      "nx-plugin:lint": {
+        "id": "nx-plugin:lint",
+        "target": {
+          "project": "nx-plugin",
+          "target": "lint"
+        },
+        "projectRoot": "packages/nx-plugin",
+        "overrides": {}
+      },
+      "storybook:test": {
+        "id": "storybook:test",
+        "target": {
+          "project": "storybook",
+          "target": "test"
+        },
+        "projectRoot": "packages/storybook",
+        "overrides": {}
+      },
+      "storybook:build": {
+        "id": "storybook:build",
+        "target": {
+          "project": "storybook",
+          "target": "build"
+        },
+        "projectRoot": "packages/storybook",
+        "overrides": {}
+      },
+      "storybook:lint": {
+        "id": "storybook:lint",
+        "target": {
+          "project": "storybook",
+          "target": "lint"
+        },
+        "projectRoot": "packages/storybook",
+        "overrides": {}
+      },
+      "workspace:test": {
+        "id": "workspace:test",
+        "target": {
+          "project": "workspace",
+          "target": "test"
+        },
+        "projectRoot": "packages/workspace",
+        "overrides": {}
+      },
+      "workspace:build": {
+        "id": "workspace:build",
+        "target": {
+          "project": "workspace",
+          "target": "build"
+        },
+        "projectRoot": "packages/workspace",
+        "overrides": {}
+      },
+      "workspace:lint": {
+        "id": "workspace:lint",
+        "target": {
+          "project": "workspace",
+          "target": "lint"
+        },
+        "projectRoot": "packages/workspace",
+        "overrides": {}
+      },
+      "eslint-rules:test": {
+        "id": "eslint-rules:test",
+        "target": {
+          "project": "eslint-rules",
+          "target": "test"
+        },
+        "projectRoot": "tools/eslint-rules",
+        "overrides": {}
+      },
+      "nx-dev-e2e:e2e": {
+        "id": "nx-dev-e2e:e2e",
+        "target": {
+          "project": "nx-dev-e2e",
+          "target": "e2e"
+        },
+        "projectRoot": "nx-dev/nx-dev-e2e",
+        "overrides": {}
+      },
+      "nx-dev:build-base": {
+        "id": "nx-dev:build-base",
+        "target": {
+          "project": "nx-dev",
+          "target": "build-base"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx-dev-e2e:lint": {
+        "id": "nx-dev-e2e:lint",
+        "target": {
+          "project": "nx-dev-e2e",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/nx-dev-e2e",
+        "overrides": {}
+      },
+      "nx-dev-ui-markdoc:lint": {
+        "id": "nx-dev-ui-markdoc:lint",
+        "target": {
+          "project": "nx-dev-ui-markdoc",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-markdoc",
+        "overrides": {}
+      },
+      "nx-dev-ui-markdoc:test": {
+        "id": "nx-dev-ui-markdoc:test",
+        "target": {
+          "project": "nx-dev-ui-markdoc",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-markdoc",
+        "overrides": {}
+      },
+      "e2e-angular-core:e2e": {
+        "id": "e2e-angular-core:e2e",
+        "target": {
+          "project": "e2e-angular-core",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/angular-core",
+        "overrides": {}
+      },
+      "e2e-angular-core:run-e2e-tests": {
+        "id": "e2e-angular-core:run-e2e-tests",
+        "target": {
+          "project": "e2e-angular-core",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/angular-core",
+        "overrides": {}
+      },
+      "e2e-react-native:e2e": {
+        "id": "e2e-react-native:e2e",
+        "target": {
+          "project": "e2e-react-native",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/react-native",
+        "overrides": {}
+      },
+      "e2e-react-native:run-e2e-tests": {
+        "id": "e2e-react-native:run-e2e-tests",
+        "target": {
+          "project": "e2e-react-native",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/react-native",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-base:dev": {
+        "id": "e2e-graph-client:e2e-base:dev",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-base",
+          "configuration": "dev"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-base:watch": {
+        "id": "e2e-graph-client:e2e-base:watch",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-base",
+          "configuration": "watch"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-base:release": {
+        "id": "e2e-graph-client:e2e-base:release",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-base",
+          "configuration": "release"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-base:release-static": {
+        "id": "e2e-graph-client:e2e-base:release-static",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-base",
+          "configuration": "release-static"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-local": {
+        "id": "e2e-graph-client:e2e-local",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-local"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e": {
+        "id": "e2e-graph-client:e2e",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:lint": {
+        "id": "e2e-graph-client:lint",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "lint"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "nx-dev-ui-common:lint": {
+        "id": "nx-dev-ui-common:lint",
+        "target": {
+          "project": "nx-dev-ui-common",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-common",
+        "overrides": {}
+      },
+      "nx-dev-ui-common:test": {
+        "id": "nx-dev-ui-common:test",
+        "target": {
+          "project": "nx-dev-ui-common",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-common",
+        "overrides": {}
+      },
+      "angular:postinstall": {
+        "id": "angular:postinstall",
+        "target": {
+          "project": "angular",
+          "target": "postinstall"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {}
+      },
+      "angular:test": {
+        "id": "angular:test",
+        "target": {
+          "project": "angular",
+          "target": "test"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {}
+      },
+      "angular:build": {
+        "id": "angular:build",
+        "target": {
+          "project": "angular",
+          "target": "build"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {}
+      },
+      "angular:lint": {
+        "id": "angular:lint",
+        "target": {
+          "project": "angular",
+          "target": "lint"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {}
+      },
+      "cypress:test": {
+        "id": "cypress:test",
+        "target": {
+          "project": "cypress",
+          "target": "test"
+        },
+        "projectRoot": "packages/cypress",
+        "overrides": {}
+      },
+      "cypress:build": {
+        "id": "cypress:build",
+        "target": {
+          "project": "cypress",
+          "target": "build"
+        },
+        "projectRoot": "packages/cypress",
+        "overrides": {}
+      },
+      "cypress:lint": {
+        "id": "cypress:lint",
+        "target": {
+          "project": "cypress",
+          "target": "lint"
+        },
+        "projectRoot": "packages/cypress",
+        "overrides": {}
+      },
+      "esbuild:test": {
+        "id": "esbuild:test",
+        "target": {
+          "project": "esbuild",
+          "target": "test"
+        },
+        "projectRoot": "packages/esbuild",
+        "overrides": {}
+      },
+      "esbuild:build": {
+        "id": "esbuild:build",
+        "target": {
+          "project": "esbuild",
+          "target": "build"
+        },
+        "projectRoot": "packages/esbuild",
+        "overrides": {}
+      },
+      "esbuild:build-base": {
+        "id": "esbuild:build-base",
+        "target": {
+          "project": "esbuild",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/esbuild",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "esbuild:lint": {
+        "id": "esbuild:lint",
+        "target": {
+          "project": "esbuild",
+          "target": "lint"
+        },
+        "projectRoot": "packages/esbuild",
+        "overrides": {}
+      },
+      "express:test": {
+        "id": "express:test",
+        "target": {
+          "project": "express",
+          "target": "test"
+        },
+        "projectRoot": "packages/express",
+        "overrides": {}
+      },
+      "express:build": {
+        "id": "express:build",
+        "target": {
+          "project": "express",
+          "target": "build"
+        },
+        "projectRoot": "packages/express",
+        "overrides": {}
+      },
+      "express:lint": {
+        "id": "express:lint",
+        "target": {
+          "project": "express",
+          "target": "lint"
+        },
+        "projectRoot": "packages/express",
+        "overrides": {}
+      },
+      "webpack:test": {
+        "id": "webpack:test",
+        "target": {
+          "project": "webpack",
+          "target": "test"
+        },
+        "projectRoot": "packages/webpack",
+        "overrides": {}
+      },
+      "webpack:build": {
+        "id": "webpack:build",
+        "target": {
+          "project": "webpack",
+          "target": "build"
+        },
+        "projectRoot": "packages/webpack",
+        "overrides": {}
+      },
+      "webpack:lint": {
+        "id": "webpack:lint",
+        "target": {
+          "project": "webpack",
+          "target": "lint"
+        },
+        "projectRoot": "packages/webpack",
+        "overrides": {}
+      },
+      "nx-dev-ui-theme:lint": {
+        "id": "nx-dev-ui-theme:lint",
+        "target": {
+          "project": "nx-dev-ui-theme",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-theme",
+        "overrides": {}
+      },
+      "nx-dev-ui-theme:test": {
+        "id": "nx-dev-ui-theme:test",
+        "target": {
+          "project": "nx-dev-ui-theme",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-theme",
+        "overrides": {}
+      },
+      "devkit:test": {
+        "id": "devkit:test",
+        "target": {
+          "project": "devkit",
+          "target": "test"
+        },
+        "projectRoot": "packages/devkit",
+        "overrides": {}
+      },
+      "devkit:build": {
+        "id": "devkit:build",
+        "target": {
+          "project": "devkit",
+          "target": "build"
+        },
+        "projectRoot": "packages/devkit",
+        "overrides": {}
+      },
+      "devkit:lint": {
+        "id": "devkit:lint",
+        "target": {
+          "project": "devkit",
+          "target": "lint"
+        },
+        "projectRoot": "packages/devkit",
+        "overrides": {}
+      },
+      "linter:test": {
+        "id": "linter:test",
+        "target": {
+          "project": "linter",
+          "target": "test"
+        },
+        "projectRoot": "packages/linter",
+        "overrides": {}
+      },
+      "linter:build": {
+        "id": "linter:build",
+        "target": {
+          "project": "linter",
+          "target": "build"
+        },
+        "projectRoot": "packages/linter",
+        "overrides": {}
+      },
+      "linter:lint": {
+        "id": "linter:lint",
+        "target": {
+          "project": "linter",
+          "target": "lint"
+        },
+        "projectRoot": "packages/linter",
+        "overrides": {}
+      },
+      "rollup:test": {
+        "id": "rollup:test",
+        "target": {
+          "project": "rollup",
+          "target": "test"
+        },
+        "projectRoot": "packages/rollup",
+        "overrides": {}
+      },
+      "rollup:build": {
+        "id": "rollup:build",
+        "target": {
+          "project": "rollup",
+          "target": "build"
+        },
+        "projectRoot": "packages/rollup",
+        "overrides": {}
+      },
+      "rollup:lint": {
+        "id": "rollup:lint",
+        "target": {
+          "project": "rollup",
+          "target": "lint"
+        },
+        "projectRoot": "packages/rollup",
+        "overrides": {}
+      },
+      "graph-ui-graph:lint": {
+        "id": "graph-ui-graph:lint",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "lint"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:test": {
+        "id": "graph-ui-graph:test",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "test"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:storybook": {
+        "id": "graph-ui-graph:storybook",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "storybook"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:storybook:ci": {
+        "id": "graph-ui-graph:storybook:ci",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "storybook",
+          "configuration": "ci"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:build-storybook": {
+        "id": "graph-ui-graph:build-storybook",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "build-storybook"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:build-storybook:ci": {
+        "id": "graph-ui-graph:build-storybook:ci",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "build-storybook",
+          "configuration": "ci"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "nx-dev-ui-home:lint": {
+        "id": "nx-dev-ui-home:lint",
+        "target": {
+          "project": "nx-dev-ui-home",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-home",
+        "overrides": {}
+      },
+      "nx-dev-ui-home:xtest": {
+        "id": "nx-dev-ui-home:xtest",
+        "target": {
+          "project": "nx-dev-ui-home",
+          "target": "xtest"
+        },
+        "projectRoot": "nx-dev/ui-home",
+        "overrides": {}
+      },
+      "detox:lint": {
+        "id": "detox:lint",
+        "target": {
+          "project": "detox",
+          "target": "lint"
+        },
+        "projectRoot": "packages/detox",
+        "overrides": {}
+      },
+      "detox:test": {
+        "id": "detox:test",
+        "target": {
+          "project": "detox",
+          "target": "test"
+        },
+        "projectRoot": "packages/detox",
+        "overrides": {}
+      },
+      "detox:build": {
+        "id": "detox:build",
+        "target": {
+          "project": "detox",
+          "target": "build"
+        },
+        "projectRoot": "packages/detox",
+        "overrides": {}
+      },
+      "react:test": {
+        "id": "react:test",
+        "target": {
+          "project": "react",
+          "target": "test"
+        },
+        "projectRoot": "packages/react",
+        "overrides": {}
+      },
+      "react:build": {
+        "id": "react:build",
+        "target": {
+          "project": "react",
+          "target": "build"
+        },
+        "projectRoot": "packages/react",
+        "overrides": {}
+      },
+      "react:lint": {
+        "id": "react:lint",
+        "target": {
+          "project": "react",
+          "target": "lint"
+        },
+        "projectRoot": "packages/react",
+        "overrides": {}
+      },
+      "typedoc-theme:build-base": {
+        "id": "typedoc-theme:build-base",
+        "target": {
+          "project": "typedoc-theme",
+          "target": "build-base"
+        },
+        "projectRoot": "typedoc-theme",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "typedoc-theme:build": {
+        "id": "typedoc-theme:build",
+        "target": {
+          "project": "typedoc-theme",
+          "target": "build"
+        },
+        "projectRoot": "typedoc-theme",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "typedoc-theme:lint": {
+        "id": "typedoc-theme:lint",
+        "target": {
+          "project": "typedoc-theme",
+          "target": "lint"
+        },
+        "projectRoot": "typedoc-theme",
+        "overrides": {}
+      },
+      "typedoc-theme:test": {
+        "id": "typedoc-theme:test",
+        "target": {
+          "project": "typedoc-theme",
+          "target": "test"
+        },
+        "projectRoot": "typedoc-theme",
+        "overrides": {}
+      },
+      "e2e-nx-plugin:e2e": {
+        "id": "e2e-nx-plugin:e2e",
+        "target": {
+          "project": "e2e-nx-plugin",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/nx-plugin",
+        "overrides": {}
+      },
+      "e2e-nx-plugin:run-e2e-tests": {
+        "id": "e2e-nx-plugin:run-e2e-tests",
+        "target": {
+          "project": "e2e-nx-plugin",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/nx-plugin",
+        "overrides": {}
+      },
+      "e2e-storybook:e2e": {
+        "id": "e2e-storybook:e2e",
+        "target": {
+          "project": "e2e-storybook",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/storybook",
+        "overrides": {}
+      },
+      "e2e-storybook:run-e2e-tests": {
+        "id": "e2e-storybook:run-e2e-tests",
+        "target": {
+          "project": "e2e-storybook",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/storybook",
+        "overrides": {}
+      },
+      "nx-dev:build": {
+        "id": "nx-dev:build",
+        "target": {
+          "project": "nx-dev",
+          "target": "build"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx-dev:sitemap": {
+        "id": "nx-dev:sitemap",
+        "target": {
+          "project": "nx-dev",
+          "target": "sitemap"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:sync-documentation": {
+        "id": "nx-dev:sync-documentation",
+        "target": {
+          "project": "nx-dev",
+          "target": "sync-documentation"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:generate-og-images": {
+        "id": "nx-dev:generate-og-images",
+        "target": {
+          "project": "nx-dev",
+          "target": "generate-og-images"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:build-base:development": {
+        "id": "nx-dev:build-base:development",
+        "target": {
+          "project": "nx-dev",
+          "target": "build-base",
+          "configuration": "development"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "graph-client:build-base": {
+        "id": "graph-client:build-base",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx-dev:build-base:production": {
+        "id": "nx-dev:build-base:production",
+        "target": {
+          "project": "nx-dev",
+          "target": "build-base",
+          "configuration": "production"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:serve:development": {
+        "id": "nx-dev:serve:development",
+        "target": {
+          "project": "nx-dev",
+          "target": "serve",
+          "configuration": "development"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:serve:production": {
+        "id": "nx-dev:serve:production",
+        "target": {
+          "project": "nx-dev",
+          "target": "serve",
+          "configuration": "production"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:deploy-build": {
+        "id": "nx-dev:deploy-build",
+        "target": {
+          "project": "nx-dev",
+          "target": "deploy-build"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:export": {
+        "id": "nx-dev:export",
+        "target": {
+          "project": "nx-dev",
+          "target": "export"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:lint": {
+        "id": "nx-dev:lint",
+        "target": {
+          "project": "nx-dev",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:test": {
+        "id": "nx-dev:test",
+        "target": {
+          "project": "nx-dev",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "expo:lint": {
+        "id": "expo:lint",
+        "target": {
+          "project": "expo",
+          "target": "lint"
+        },
+        "projectRoot": "packages/expo",
+        "overrides": {}
+      },
+      "expo:test": {
+        "id": "expo:test",
+        "target": {
+          "project": "expo",
+          "target": "test"
+        },
+        "projectRoot": "packages/expo",
+        "overrides": {}
+      },
+      "expo:build": {
+        "id": "expo:build",
+        "target": {
+          "project": "expo",
+          "target": "build"
+        },
+        "projectRoot": "packages/expo",
+        "overrides": {}
+      },
+      "jest:test": {
+        "id": "jest:test",
+        "target": {
+          "project": "jest",
+          "target": "test"
+        },
+        "projectRoot": "packages/jest",
+        "overrides": {}
+      },
+      "jest:build": {
+        "id": "jest:build",
+        "target": {
+          "project": "jest",
+          "target": "build"
+        },
+        "projectRoot": "packages/jest",
+        "overrides": {}
+      },
+      "jest:lint": {
+        "id": "jest:lint",
+        "target": {
+          "project": "jest",
+          "target": "lint"
+        },
+        "projectRoot": "packages/jest",
+        "overrides": {}
+      },
+      "nest:test": {
+        "id": "nest:test",
+        "target": {
+          "project": "nest",
+          "target": "test"
+        },
+        "projectRoot": "packages/nest",
+        "overrides": {}
+      },
+      "nest:build": {
+        "id": "nest:build",
+        "target": {
+          "project": "nest",
+          "target": "build"
+        },
+        "projectRoot": "packages/nest",
+        "overrides": {}
+      },
+      "nest:lint": {
+        "id": "nest:lint",
+        "target": {
+          "project": "nest",
+          "target": "lint"
+        },
+        "projectRoot": "packages/nest",
+        "overrides": {}
+      },
+      "next:test": {
+        "id": "next:test",
+        "target": {
+          "project": "next",
+          "target": "test"
+        },
+        "projectRoot": "packages/next",
+        "overrides": {}
+      },
+      "next:build": {
+        "id": "next:build",
+        "target": {
+          "project": "next",
+          "target": "build"
+        },
+        "projectRoot": "packages/next",
+        "overrides": {}
+      },
+      "next:lint": {
+        "id": "next:lint",
+        "target": {
+          "project": "next",
+          "target": "lint"
+        },
+        "projectRoot": "packages/next",
+        "overrides": {}
+      },
+      "node:test": {
+        "id": "node:test",
+        "target": {
+          "project": "node",
+          "target": "test"
+        },
+        "projectRoot": "packages/node",
+        "overrides": {}
+      },
+      "node:build": {
+        "id": "node:build",
+        "target": {
+          "project": "node",
+          "target": "build"
+        },
+        "projectRoot": "packages/node",
+        "overrides": {}
+      },
+      "node:lint": {
+        "id": "node:lint",
+        "target": {
+          "project": "node",
+          "target": "lint"
+        },
+        "projectRoot": "packages/node",
+        "overrides": {}
+      },
+      "vite:test": {
+        "id": "vite:test",
+        "target": {
+          "project": "vite",
+          "target": "test"
+        },
+        "projectRoot": "packages/vite",
+        "overrides": {}
+      },
+      "vite:build": {
+        "id": "vite:build",
+        "target": {
+          "project": "vite",
+          "target": "build"
+        },
+        "projectRoot": "packages/vite",
+        "overrides": {}
+      },
+      "vite:lint": {
+        "id": "vite:lint",
+        "target": {
+          "project": "vite",
+          "target": "lint"
+        },
+        "projectRoot": "packages/vite",
+        "overrides": {}
+      },
+      "graph-client:generate-dev-environment-js": {
+        "id": "graph-client:generate-dev-environment-js",
+        "target": {
+          "project": "graph-client",
+          "target": "generate-dev-environment-js"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:generate-graph-base": {
+        "id": "graph-client:generate-graph-base",
+        "target": {
+          "project": "graph-client",
+          "target": "generate-graph-base"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:generate-graph": {
+        "id": "graph-client:generate-graph",
+        "target": {
+          "project": "graph-client",
+          "target": "generate-graph"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:dev": {
+        "id": "graph-client:build-base:dev",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "dev"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:dev-e2e": {
+        "id": "graph-client:build-base:dev-e2e",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "dev-e2e"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:nx-console": {
+        "id": "graph-client:build-base:nx-console",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "nx-console"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:release-static": {
+        "id": "graph-client:build-base:release-static",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "release-static"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:watch": {
+        "id": "graph-client:build-base:watch",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "watch"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:dev": {
+        "id": "graph-client:serve-base:dev",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "dev"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:nx-console": {
+        "id": "graph-client:serve-base:nx-console",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "nx-console"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:release": {
+        "id": "graph-client:serve-base:release",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "release"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:watch": {
+        "id": "graph-client:serve-base:watch",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "watch"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:release-static": {
+        "id": "graph-client:serve-base:release-static",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "release-static"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:dev-e2e": {
+        "id": "graph-client:serve-base:dev-e2e",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "dev-e2e"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:dev": {
+        "id": "graph-client:serve:dev",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "dev"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:release": {
+        "id": "graph-client:serve:release",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "release"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:release-static": {
+        "id": "graph-client:serve:release-static",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "release-static"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:watch": {
+        "id": "graph-client:serve:watch",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "watch"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:nx-console": {
+        "id": "graph-client:serve:nx-console",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "nx-console"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:lint": {
+        "id": "graph-client:lint",
+        "target": {
+          "project": "graph-client",
+          "target": "lint"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:test": {
+        "id": "graph-client:test",
+        "target": {
+          "project": "graph-client",
+          "target": "test"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:storybook": {
+        "id": "graph-client:storybook",
+        "target": {
+          "project": "graph-client",
+          "target": "storybook"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:storybook:ci": {
+        "id": "graph-client:storybook:ci",
+        "target": {
+          "project": "graph-client",
+          "target": "storybook",
+          "configuration": "ci"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-storybook": {
+        "id": "graph-client:build-storybook",
+        "target": {
+          "project": "graph-client",
+          "target": "build-storybook"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-storybook:ci": {
+        "id": "graph-client:build-storybook:ci",
+        "target": {
+          "project": "graph-client",
+          "target": "build-storybook",
+          "configuration": "ci"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "cli:test": {
+        "id": "cli:test",
+        "target": {
+          "project": "cli",
+          "target": "test"
+        },
+        "projectRoot": "packages/cli",
+        "overrides": {}
+      },
+      "cli:build": {
+        "id": "cli:build",
+        "target": {
+          "project": "cli",
+          "target": "build"
+        },
+        "projectRoot": "packages/cli",
+        "overrides": {}
+      },
+      "cli:build-base": {
+        "id": "cli:build-base",
+        "target": {
+          "project": "cli",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/cli",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "cli:lint": {
+        "id": "cli:lint",
+        "target": {
+          "project": "cli",
+          "target": "lint"
+        },
+        "projectRoot": "packages/cli",
+        "overrides": {}
+      },
+      "tao:test": {
+        "id": "tao:test",
+        "target": {
+          "project": "tao",
+          "target": "test"
+        },
+        "projectRoot": "packages/tao",
+        "overrides": {}
+      },
+      "tao:build": {
+        "id": "tao:build",
+        "target": {
+          "project": "tao",
+          "target": "build"
+        },
+        "projectRoot": "packages/tao",
+        "overrides": {}
+      },
+      "tao:build-base": {
+        "id": "tao:build-base",
+        "target": {
+          "project": "tao",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/tao",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "tao:lint": {
+        "id": "tao:lint",
+        "target": {
+          "project": "tao",
+          "target": "lint"
+        },
+        "projectRoot": "packages/tao",
+        "overrides": {}
+      },
+      "web:test": {
+        "id": "web:test",
+        "target": {
+          "project": "web",
+          "target": "test"
+        },
+        "projectRoot": "packages/web",
+        "overrides": {}
+      },
+      "web:build": {
+        "id": "web:build",
+        "target": {
+          "project": "web",
+          "target": "build"
+        },
+        "projectRoot": "packages/web",
+        "overrides": {}
+      },
+      "web:lint": {
+        "id": "web:lint",
+        "target": {
+          "project": "web",
+          "target": "lint"
+        },
+        "projectRoot": "packages/web",
+        "overrides": {}
+      },
+      "e2e-cypress:e2e": {
+        "id": "e2e-cypress:e2e",
+        "target": {
+          "project": "e2e-cypress",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/cypress",
+        "overrides": {}
+      },
+      "e2e-cypress:run-e2e-tests": {
+        "id": "e2e-cypress:run-e2e-tests",
+        "target": {
+          "project": "e2e-cypress",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/cypress",
+        "overrides": {}
+      },
+      "e2e-esbuild:e2e": {
+        "id": "e2e-esbuild:e2e",
+        "target": {
+          "project": "e2e-esbuild",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/esbuild",
+        "overrides": {}
+      },
+      "e2e-esbuild:run-e2e-tests": {
+        "id": "e2e-esbuild:run-e2e-tests",
+        "target": {
+          "project": "e2e-esbuild",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/esbuild",
+        "overrides": {}
+      },
+      "e2e-nx-init:e2e": {
+        "id": "e2e-nx-init:e2e",
+        "target": {
+          "project": "e2e-nx-init",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/nx-init",
+        "overrides": {}
+      },
+      "e2e-nx-init:run-e2e-tests": {
+        "id": "e2e-nx-init:run-e2e-tests",
+        "target": {
+          "project": "e2e-nx-init",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/nx-init",
+        "overrides": {}
+      },
+      "e2e-nx-misc:e2e": {
+        "id": "e2e-nx-misc:e2e",
+        "target": {
+          "project": "e2e-nx-misc",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/nx-misc",
+        "overrides": {}
+      },
+      "e2e-nx-misc:run-e2e-tests": {
+        "id": "e2e-nx-misc:run-e2e-tests",
+        "target": {
+          "project": "e2e-nx-misc",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/nx-misc",
+        "overrides": {}
+      },
+      "e2e-webpack:e2e": {
+        "id": "e2e-webpack:e2e",
+        "target": {
+          "project": "e2e-webpack",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/webpack",
+        "overrides": {}
+      },
+      "e2e-webpack:run-e2e-tests": {
+        "id": "e2e-webpack:run-e2e-tests",
+        "target": {
+          "project": "e2e-webpack",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/webpack",
+        "overrides": {}
+      },
+      "js:lint": {
+        "id": "js:lint",
+        "target": {
+          "project": "js",
+          "target": "lint"
+        },
+        "projectRoot": "packages/js",
+        "overrides": {}
+      },
+      "js:test": {
+        "id": "js:test",
+        "target": {
+          "project": "js",
+          "target": "test"
+        },
+        "projectRoot": "packages/js",
+        "overrides": {}
+      },
+      "js:build": {
+        "id": "js:build",
+        "target": {
+          "project": "js",
+          "target": "build"
+        },
+        "projectRoot": "packages/js",
+        "overrides": {}
+      },
+      "nx:postinstall": {
+        "id": "nx:postinstall",
+        "target": {
+          "project": "nx",
+          "target": "postinstall"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {}
+      },
+      "nx:echo": {
+        "id": "nx:echo",
+        "target": {
+          "project": "nx",
+          "target": "echo"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {}
+      },
+      "nx:build": {
+        "id": "nx:build",
+        "target": {
+          "project": "nx",
+          "target": "build"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx:lint": {
+        "id": "nx:lint",
+        "target": {
+          "project": "nx",
+          "target": "lint"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {}
+      },
+      "nx:test": {
+        "id": "nx:test",
+        "target": {
+          "project": "nx",
+          "target": "test"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {}
+      },
+      "e2e-linter:e2e": {
+        "id": "e2e-linter:e2e",
+        "target": {
+          "project": "e2e-linter",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/linter",
+        "overrides": {}
+      },
+      "e2e-linter:run-e2e-tests": {
+        "id": "e2e-linter:run-e2e-tests",
+        "target": {
+          "project": "e2e-linter",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/linter",
+        "overrides": {}
+      },
+      "e2e-nx-run:e2e": {
+        "id": "e2e-nx-run:e2e",
+        "target": {
+          "project": "e2e-nx-run",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/nx-run",
+        "overrides": {}
+      },
+      "e2e-nx-run:run-e2e-tests": {
+        "id": "e2e-nx-run:run-e2e-tests",
+        "target": {
+          "project": "e2e-nx-run",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/nx-run",
+        "overrides": {}
+      },
+      "e2e-rollup:e2e": {
+        "id": "e2e-rollup:e2e",
+        "target": {
+          "project": "e2e-rollup",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/rollup",
+        "overrides": {}
+      },
+      "e2e-rollup:run-e2e-tests": {
+        "id": "e2e-rollup:run-e2e-tests",
+        "target": {
+          "project": "e2e-rollup",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/rollup",
+        "overrides": {}
+      },
+      "e2e-detox:e2e": {
+        "id": "e2e-detox:e2e",
+        "target": {
+          "project": "e2e-detox",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/detox",
+        "overrides": {}
+      },
+      "e2e-detox:run-e2e-tests": {
+        "id": "e2e-detox:run-e2e-tests",
+        "target": {
+          "project": "e2e-detox",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/detox",
+        "overrides": {}
+      },
+      "e2e-react:e2e": {
+        "id": "e2e-react:e2e",
+        "target": {
+          "project": "e2e-react",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/react",
+        "overrides": {}
+      },
+      "e2e-react:run-e2e-tests": {
+        "id": "e2e-react:run-e2e-tests",
+        "target": {
+          "project": "e2e-react",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/react",
+        "overrides": {}
+      },
+      "e2e-expo:e2e": {
+        "id": "e2e-expo:e2e",
+        "target": {
+          "project": "e2e-expo",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/expo",
+        "overrides": {}
+      },
+      "e2e-expo:run-e2e-tests": {
+        "id": "e2e-expo:run-e2e-tests",
+        "target": {
+          "project": "e2e-expo",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/expo",
+        "overrides": {}
+      },
+      "e2e-jest:e2e": {
+        "id": "e2e-jest:e2e",
+        "target": {
+          "project": "e2e-jest",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/jest",
+        "overrides": {}
+      },
+      "e2e-jest:run-e2e-tests": {
+        "id": "e2e-jest:run-e2e-tests",
+        "target": {
+          "project": "e2e-jest",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/jest",
+        "overrides": {}
+      },
+      "e2e-next:e2e": {
+        "id": "e2e-next:e2e",
+        "target": {
+          "project": "e2e-next",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/next",
+        "overrides": {}
+      },
+      "e2e-next:run-e2e-tests": {
+        "id": "e2e-next:run-e2e-tests",
+        "target": {
+          "project": "e2e-next",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/next",
+        "overrides": {}
+      },
+      "e2e-node:e2e": {
+        "id": "e2e-node:e2e",
+        "target": {
+          "project": "e2e-node",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/node",
+        "overrides": {}
+      },
+      "e2e-node:run-e2e-tests": {
+        "id": "e2e-node:run-e2e-tests",
+        "target": {
+          "project": "e2e-node",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/node",
+        "overrides": {}
+      },
+      "e2e-vite:e2e": {
+        "id": "e2e-vite:e2e",
+        "target": {
+          "project": "e2e-vite",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/vite",
+        "overrides": {}
+      },
+      "e2e-vite:run-e2e-tests": {
+        "id": "e2e-vite:run-e2e-tests",
+        "target": {
+          "project": "e2e-vite",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/vite",
+        "overrides": {}
+      },
+      "e2e-web:e2e": {
+        "id": "e2e-web:e2e",
+        "target": {
+          "project": "e2e-web",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/web",
+        "overrides": {}
+      },
+      "e2e-web:run-e2e-tests": {
+        "id": "e2e-web:run-e2e-tests",
+        "target": {
+          "project": "e2e-web",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/web",
+        "overrides": {}
+      },
+      "e2e-js:e2e": {
+        "id": "e2e-js:e2e",
+        "target": {
+          "project": "e2e-js",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/js",
+        "overrides": {}
+      },
+      "e2e-js:run-e2e-tests": {
+        "id": "e2e-js:run-e2e-tests",
+        "target": {
+          "project": "e2e-js",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/js",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:check-commit": {
+        "id": "@nrwl/nx-source:check-commit",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "check-commit"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:check-format": {
+        "id": "@nrwl/nx-source:check-format",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "check-format"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:check-imports": {
+        "id": "@nrwl/nx-source:check-imports",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "check-imports"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:check-lock-files": {
+        "id": "@nrwl/nx-source:check-lock-files",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "check-lock-files"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:depcheck": {
+        "id": "@nrwl/nx-source:depcheck",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "depcheck"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:documentation": {
+        "id": "@nrwl/nx-source:documentation",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "documentation"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:echo": {
+        "id": "@nrwl/nx-source:echo",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "echo"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:lint": {
+        "id": "@nrwl/nx-source:lint",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "lint"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      }
+    },
+    "dependencies": {
+      "nx-dev-feature-package-schema-viewer:lint": [],
+      "nx-dev-feature-package-schema-viewer:test": [],
+      "nx-dev-data-access-documents:lint": [],
+      "nx-dev-data-access-documents:test": [],
+      "create-nx-workspace:test": ["create-nx-workspace:build"],
+      "create-nx-workspace:build": ["create-nx-workspace:build-base"],
+      "create-nx-workspace:build-base": [
+        "workspace:build-base",
+        "js:build-base",
+        "react:build-base",
+        "expo:build-base",
+        "next:build-base",
+        "angular:build-base",
+        "nest:build-base",
+        "express:build-base"
+      ],
+      "workspace:build-base": ["devkit:build-base", "nx:build-base"],
+      "devkit:build-base": ["nx:build-base"],
+      "nx:build-base": ["graph-client:build-base:release"],
+      "graph-client:build-base:release": [],
+      "js:build-base": [
+        "devkit:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "linter:build-base": [
+        "eslint-plugin-nx:build-base",
+        "devkit:build-base",
+        "nx:build-base",
+        "workspace:build-base",
+        "jest:build-base"
+      ],
+      "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
+      "jest:build-base": [
+        "devkit:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "react:build-base": [
+        "web:build-base",
+        "devkit:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "cypress:build-base",
+        "webpack:build-base",
+        "nx:build-base",
+        "vite:build-base",
+        "jest:build-base",
+        "rollup:build-base",
+        "storybook:build-base"
+      ],
+      "web:build-base": [
+        "cypress:build-base",
+        "devkit:build-base",
+        "jest:build-base",
+        "js:build-base",
+        "linter:build-base",
+        "rollup:build-base",
+        "vite:build-base",
+        "webpack:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "cypress:build-base": [
+        "devkit:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "rollup:build-base": [
+        "devkit:build-base",
+        "js:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "vite:build-base": [
+        "devkit:build-base",
+        "workspace:build-base",
+        "js:build-base",
+        "nx:build-base"
+      ],
+      "webpack:build-base": [
+        "devkit:build-base",
+        "js:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "storybook:build-base": [
+        "cypress:build-base",
+        "devkit:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "expo:build-base": [
+        "detox:build-base",
+        "devkit:build-base",
+        "jest:build-base",
+        "linter:build-base",
+        "react:build-base",
+        "webpack:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "detox:build-base": [
+        "devkit:build-base",
+        "jest:build-base",
+        "linter:build-base",
+        "react:build-base",
+        "workspace:build-base"
+      ],
+      "next:build-base": [
+        "cypress:build-base",
+        "devkit:build-base",
+        "jest:build-base",
+        "linter:build-base",
+        "react:build-base",
+        "webpack:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "angular:build-base": [
+        "workspace:build-base",
+        "cypress:build-base",
+        "jest:build-base",
+        "devkit:build-base",
+        "linter:build-base",
+        "webpack:build-base",
+        "nx:build-base",
+        "storybook:build-base"
+      ],
+      "nest:build-base": [
+        "node:build-base",
+        "linter:build-base",
+        "devkit:build-base",
+        "js:build-base",
+        "workspace:build-base"
+      ],
+      "node:build-base": [
+        "devkit:build-base",
+        "jest:build-base",
+        "js:build-base",
+        "linter:build-base",
+        "webpack:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "express:build-base": [
+        "node:build-base",
+        "devkit:build-base",
+        "workspace:build-base",
+        "linter:build-base"
+      ],
+      "create-nx-workspace:lint": [],
+      "nx-dev-data-access-packages:lint": [],
+      "nx-dev-data-access-packages:test": [],
+      "nx-dev-feature-doc-viewer:lint": [],
+      "nx-dev-feature-doc-viewer:test": [],
+      "create-nx-plugin:test": ["create-nx-plugin:build"],
+      "create-nx-plugin:build": ["create-nx-plugin:build-base"],
+      "create-nx-plugin:build-base": [
+        "nx-plugin:build-base",
+        "devkit:build-base",
+        "nx:build-base"
+      ],
+      "nx-plugin:build-base": [
+        "devkit:build-base",
+        "jest:build-base",
+        "js:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "create-nx-plugin:lint": [],
+      "eslint-plugin-nx:test": ["eslint-plugin-nx:build"],
+      "eslint-plugin-nx:build": ["eslint-plugin-nx:build-base"],
+      "eslint-plugin-nx:lint": [],
+      "nx-dev-feature-analytics:lint": [],
+      "nx-dev-feature-analytics:test": [],
+      "nx-dev-data-access-menu:lint": [],
+      "nx-dev-data-access-menu:test": [],
+      "e2e-angular-extensions:e2e": [],
+      "e2e-angular-extensions:run-e2e-tests": [],
+      "nx-dev-models-document:lint": [],
+      "nx-dev-models-document:test": [],
+      "nx-dev-ui-sponsor-card:lint": [],
+      "nx-dev-ui-sponsor-card:test": [],
+      "e2e-storybook-angular:e2e": [],
+      "e2e-storybook-angular:run-e2e-tests": [],
+      "nx-dev-feature-search:lint": [],
+      "nx-dev-feature-search:test": [],
+      "nx-dev-models-package:lint": [],
+      "nx-dev-models-package:test": [],
+      "nx-dev-ui-member-card:lint": [],
+      "nx-dev-ui-member-card:test": [],
+      "react-native:lint": [],
+      "react-native:test": ["react-native:build"],
+      "react-native:build": ["react-native:build-base"],
+      "react-native:build-base": [
+        "detox:build-base",
+        "devkit:build-base",
+        "jest:build-base",
+        "js:build-base",
+        "linter:build-base",
+        "react:build-base",
+        "workspace:build-base",
+        "nx:build-base",
+        "storybook:build-base"
+      ],
+      "e2e-workspace-create:e2e": [],
+      "e2e-workspace-create:run-e2e-tests": [],
+      "nx-dev-ui-conference:lint": [],
+      "nx-dev-ui-conference:test": [],
+      "nx-dev-ui-references:lint": [],
+      "nx-dev-ui-references:test": [],
+      "nx-dev-ui-community:lint": [],
+      "nx-dev-ui-community:test": [],
+      "nx-dev-models-menu:lint": [],
+      "nx-dev-models-menu:test": [],
+      "nx-dev-ui-commands:lint": [],
+      "nx-dev-ui-commands:test": [],
+      "nx-plugin:test": ["nx-plugin:build"],
+      "nx-plugin:build": ["nx-plugin:build-base"],
+      "nx-plugin:lint": [],
+      "storybook:test": ["storybook:build"],
+      "storybook:build": ["storybook:build-base"],
+      "storybook:lint": [],
+      "workspace:test": ["workspace:build"],
+      "workspace:build": ["workspace:build-base"],
+      "workspace:lint": [],
+      "eslint-rules:test": [],
+      "nx-dev-e2e:e2e": ["nx-dev:build-base", "cypress:build-base"],
+      "nx-dev:build-base": ["jest:build-base"],
+      "nx-dev-e2e:lint": [],
+      "nx-dev-ui-markdoc:lint": [],
+      "nx-dev-ui-markdoc:test": [],
+      "e2e-angular-core:e2e": [],
+      "e2e-angular-core:run-e2e-tests": [],
+      "e2e-react-native:e2e": [],
+      "e2e-react-native:run-e2e-tests": [],
+      "e2e-graph-client:e2e-base:dev": [],
+      "e2e-graph-client:e2e-base:watch": [],
+      "e2e-graph-client:e2e-base:release": [],
+      "e2e-graph-client:e2e-base:release-static": [],
+      "e2e-graph-client:e2e-local": [],
+      "e2e-graph-client:e2e": [],
+      "e2e-graph-client:lint": [],
+      "nx-dev-ui-common:lint": [],
+      "nx-dev-ui-common:test": [],
+      "angular:postinstall": [],
+      "angular:test": ["angular:build"],
+      "angular:build": ["angular:build-base"],
+      "angular:lint": [],
+      "cypress:test": ["cypress:build"],
+      "cypress:build": ["cypress:build-base"],
+      "cypress:lint": [],
+      "esbuild:test": ["esbuild:build"],
+      "esbuild:build": ["esbuild:build-base"],
+      "esbuild:build-base": [
+        "devkit:build-base",
+        "js:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "esbuild:lint": [],
+      "express:test": ["express:build"],
+      "express:build": ["express:build-base"],
+      "express:lint": [],
+      "webpack:test": ["webpack:build"],
+      "webpack:build": ["webpack:build-base"],
+      "webpack:lint": [],
+      "nx-dev-ui-theme:lint": [],
+      "nx-dev-ui-theme:test": [],
+      "devkit:test": ["devkit:build"],
+      "devkit:build": ["devkit:build-base"],
+      "devkit:lint": [],
+      "linter:test": ["linter:build"],
+      "linter:build": ["linter:build-base"],
+      "linter:lint": [],
+      "rollup:test": ["rollup:build"],
+      "rollup:build": ["rollup:build-base"],
+      "rollup:lint": [],
+      "graph-ui-graph:lint": [],
+      "graph-ui-graph:test": [],
+      "graph-ui-graph:storybook": [],
+      "graph-ui-graph:storybook:ci": [],
+      "graph-ui-graph:build-storybook": [],
+      "graph-ui-graph:build-storybook:ci": [],
+      "nx-dev-ui-home:lint": [],
+      "nx-dev-ui-home:xtest": [],
+      "detox:lint": [],
+      "detox:test": ["detox:build"],
+      "detox:build": ["detox:build-base"],
+      "react:test": ["react:build"],
+      "react:build": ["react:build-base"],
+      "react:lint": [],
+      "typedoc-theme:build-base": [],
+      "typedoc-theme:build": ["typedoc-theme:build-base"],
+      "typedoc-theme:lint": [],
+      "typedoc-theme:test": ["typedoc-theme:build"],
+      "e2e-nx-plugin:e2e": [],
+      "e2e-nx-plugin:run-e2e-tests": [],
+      "e2e-storybook:e2e": [],
+      "e2e-storybook:run-e2e-tests": [],
+      "nx-dev:build": ["nx-dev:build-base"],
+      "nx-dev:sitemap": [],
+      "nx-dev:sync-documentation": [],
+      "nx-dev:generate-og-images": [],
+      "nx-dev:build-base:development": ["jest:build-base"],
+      "graph-client:build-base": [],
+      "nx-dev:build-base:production": ["jest:build-base"],
+      "nx-dev:serve:development": [],
+      "nx-dev:serve:production": [],
+      "nx-dev:deploy-build": [],
+      "nx-dev:export": [],
+      "nx-dev:lint": [],
+      "nx-dev:test": ["nx-dev:build"],
+      "expo:lint": [],
+      "expo:test": ["expo:build"],
+      "expo:build": ["expo:build-base"],
+      "jest:test": ["jest:build"],
+      "jest:build": ["jest:build-base"],
+      "jest:lint": [],
+      "nest:test": ["nest:build"],
+      "nest:build": ["nest:build-base"],
+      "nest:lint": [],
+      "next:test": ["next:build"],
+      "next:build": ["next:build-base"],
+      "next:lint": [],
+      "node:test": ["node:build"],
+      "node:build": ["node:build-base"],
+      "node:lint": [],
+      "vite:test": ["vite:build"],
+      "vite:build": ["vite:build-base"],
+      "vite:lint": [],
+      "graph-client:generate-dev-environment-js": [],
+      "graph-client:generate-graph-base": [],
+      "graph-client:generate-graph": [],
+      "graph-client:build-base:dev": [],
+      "graph-client:build-base:dev-e2e": [],
+      "graph-client:build-base:nx-console": [],
+      "graph-client:build-base:release-static": [],
+      "graph-client:build-base:watch": [],
+      "graph-client:serve-base:dev": [],
+      "graph-client:serve-base:nx-console": [],
+      "graph-client:serve-base:release": [],
+      "graph-client:serve-base:watch": [],
+      "graph-client:serve-base:release-static": [],
+      "graph-client:serve-base:dev-e2e": [],
+      "graph-client:serve:dev": [],
+      "graph-client:serve:release": [],
+      "graph-client:serve:release-static": [],
+      "graph-client:serve:watch": [],
+      "graph-client:serve:nx-console": [],
+      "graph-client:lint": [],
+      "graph-client:test": [],
+      "graph-client:storybook": [],
+      "graph-client:storybook:ci": [],
+      "graph-client:build-storybook": [],
+      "graph-client:build-storybook:ci": [],
+      "cli:test": ["cli:build"],
+      "cli:build": ["cli:build-base"],
+      "cli:build-base": ["workspace:build-base", "nx:build-base"],
+      "cli:lint": [],
+      "tao:test": ["tao:build"],
+      "tao:build": ["tao:build-base"],
+      "tao:build-base": ["nx:build-base"],
+      "tao:lint": [],
+      "web:test": ["web:build"],
+      "web:build": ["web:build-base"],
+      "web:lint": [],
+      "e2e-cypress:e2e": [],
+      "e2e-cypress:run-e2e-tests": [],
+      "e2e-esbuild:e2e": [],
+      "e2e-esbuild:run-e2e-tests": [],
+      "e2e-nx-init:e2e": [],
+      "e2e-nx-init:run-e2e-tests": [],
+      "e2e-nx-misc:e2e": [],
+      "e2e-nx-misc:run-e2e-tests": [],
+      "e2e-webpack:e2e": [],
+      "e2e-webpack:run-e2e-tests": [],
+      "js:lint": [],
+      "js:test": ["js:build"],
+      "js:build": ["js:build-base"],
+      "nx:postinstall": [],
+      "nx:echo": [],
+      "nx:build": ["nx:build-base"],
+      "nx:lint": [],
+      "nx:test": ["nx:build"],
+      "e2e-linter:e2e": [],
+      "e2e-linter:run-e2e-tests": [],
+      "e2e-nx-run:e2e": [],
+      "e2e-nx-run:run-e2e-tests": [],
+      "e2e-rollup:e2e": [],
+      "e2e-rollup:run-e2e-tests": [],
+      "e2e-detox:e2e": [],
+      "e2e-detox:run-e2e-tests": [],
+      "e2e-react:e2e": [],
+      "e2e-react:run-e2e-tests": [],
+      "e2e-expo:e2e": [],
+      "e2e-expo:run-e2e-tests": [],
+      "e2e-jest:e2e": [],
+      "e2e-jest:run-e2e-tests": [],
+      "e2e-next:e2e": [],
+      "e2e-next:run-e2e-tests": [],
+      "e2e-node:e2e": [],
+      "e2e-node:run-e2e-tests": [],
+      "e2e-vite:e2e": [],
+      "e2e-vite:run-e2e-tests": [],
+      "e2e-web:e2e": [],
+      "e2e-web:run-e2e-tests": [],
+      "e2e-js:e2e": [],
+      "e2e-js:run-e2e-tests": [],
+      "@nrwl/nx-source:check-commit": [],
+      "@nrwl/nx-source:check-format": [],
+      "@nrwl/nx-source:check-imports": [],
+      "@nrwl/nx-source:check-lock-files": [],
+      "@nrwl/nx-source:depcheck": [],
+      "@nrwl/nx-source:documentation": [],
+      "@nrwl/nx-source:echo": [],
+      "@nrwl/nx-source:lint": []
     }
   }
 }

--- a/astro-docs/src/assets/nx/single-task.json
+++ b/astro-docs/src/assets/nx/single-task.json
@@ -5,25 +5,21 @@
       "type": "lib",
       "data": {
         "tags": [],
-        "targets": {
-          "test": {}
-        }
+        "targets": { "test": {} }
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
-      "roots": ["lib:test"],
-      "tasks": {
-        "lib:test": {
-          "id": "lib:test",
-          "target": { "project": "lib", "target": "test" },
-          "projectRoot": "libs/lib",
-          "overrides": {}
-        }
-      },
-      "dependencies": {}
-    }
+  "taskIds": ["lib:test"],
+  "taskGraph": {
+    "roots": ["lib:test"],
+    "tasks": {
+      "lib:test": {
+        "id": "lib:test",
+        "target": { "project": "lib", "target": "test" },
+        "projectRoot": "libs/lib",
+        "overrides": {}
+      }
+    },
+    "dependencies": {}
   }
 }

--- a/astro-docs/src/content/docs/concepts/mental-model.mdoc
+++ b/astro-docs/src/content/docs/concepts/mental-model.mdoc
@@ -58,9 +58,8 @@ For instance `nx test lib` creates a task graph with a single node:
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
+  "taskIds": ["lib:test"],
+  "taskGraph": {
       "roots": [
         "lib:test"
       ],
@@ -76,7 +75,6 @@ For instance `nx test lib` creates a task graph with a single node:
         }
       },
       "dependencies": {}
-    }
   }
 }
 
@@ -111,9 +109,8 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
+  "taskIds": ["lib:test"],
+  "taskGraph": {
       "roots": [
         "lib:test"
       ],
@@ -129,7 +126,6 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
         }
       },
       "dependencies": {}
-    }
   }
 }
 
@@ -150,9 +146,8 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
+  "taskIds": ["lib:test"],
+  "taskGraph": {
       "roots": [
         "lib:test"
       ],
@@ -168,7 +163,6 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
         }
       },
       "dependencies": {}
-    }
   }
 }
 
@@ -221,9 +215,8 @@ With this, running the same test command creates the following task graph:
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
+  "taskIds": ["lib:test"],
+  "taskGraph": {
       "roots": [
         "lib:test"
       ],
@@ -239,7 +232,6 @@ With this, running the same test command creates the following task graph:
         }
       },
       "dependencies": {}
-    }
   }
 }
 
@@ -260,9 +252,8 @@ With this, running the same test command creates the following task graph:
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
+  "taskIds": ["lib:test"],
+  "taskGraph": {
       "roots": [
         "lib:test"
       ],
@@ -278,7 +269,6 @@ With this, running the same test command creates the following task graph:
         }
       },
       "dependencies": {}
-    }
   }
 }
 
@@ -379,9 +369,8 @@ As your workspace grows, the task graph looks more like this:
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
+  "taskIds": ["lib:test"],
+  "taskGraph": {
       "roots": [
         "lib:test"
       ],
@@ -397,7 +386,6 @@ As your workspace grows, the task graph looks more like this:
         }
       },
       "dependencies": {}
-    }
   }
 }
 

--- a/docs/shared/mental-model/connected-tasks.json
+++ b/docs/shared/mental-model/connected-tasks.json
@@ -31,34 +31,32 @@
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
-      "roots": ["app1:test", "app2:test", "lib:test"],
-      "tasks": {
-        "app1:test": {
-          "id": "app1:test",
-          "target": { "project": "app1", "target": "test" },
-          "projectRoot": "apps/app1",
-          "overrides": {}
-        },
-        "app2:test": {
-          "id": "app2:test",
-          "target": { "project": "app2", "target": "test" },
-          "projectRoot": "apps/app2",
-          "overrides": {}
-        },
-        "lib:test": {
-          "id": "lib:test",
-          "target": { "project": "lib", "target": "test" },
-          "projectRoot": "libs/lib",
-          "overrides": {}
-        }
+  "taskIds": ["app1:test", "app2:test"],
+  "taskGraph": {
+    "roots": ["app1:test", "app2:test", "lib:test"],
+    "tasks": {
+      "app1:test": {
+        "id": "app1:test",
+        "target": { "project": "app1", "target": "test" },
+        "projectRoot": "apps/app1",
+        "overrides": {}
       },
-      "dependencies": {
-        "app1:test": ["lib:test"],
-        "app2:test": ["lib:test"]
+      "app2:test": {
+        "id": "app2:test",
+        "target": { "project": "app2", "target": "test" },
+        "projectRoot": "apps/app2",
+        "overrides": {}
+      },
+      "lib:test": {
+        "id": "lib:test",
+        "target": { "project": "lib", "target": "test" },
+        "projectRoot": "libs/lib",
+        "overrides": {}
       }
+    },
+    "dependencies": {
+      "app1:test": ["lib:test"],
+      "app2:test": ["lib:test"]
     }
   }
 }

--- a/docs/shared/mental-model/disconnected-tasks.json
+++ b/docs/shared/mental-model/disconnected-tasks.json
@@ -31,31 +31,29 @@
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
-      "roots": ["app1:test", "app2:test", "lib:test"],
-      "tasks": {
-        "app1:test": {
-          "id": "app1:test",
-          "target": { "project": "app1", "target": "test" },
-          "projectRoot": "apps/app1",
-          "overrides": {}
-        },
-        "app2:test": {
-          "id": "app2:test",
-          "target": { "project": "app2", "target": "test" },
-          "projectRoot": "apps/app2",
-          "overrides": {}
-        },
-        "lib:test": {
-          "id": "lib:test",
-          "target": { "project": "lib", "target": "test" },
-          "projectRoot": "libs/lib",
-          "overrides": {}
-        }
+  "taskIds": ["app1:test", "app2:test", "lib:test"],
+  "taskGraph": {
+    "roots": ["app1:test", "app2:test", "lib:test"],
+    "tasks": {
+      "app1:test": {
+        "id": "app1:test",
+        "target": { "project": "app1", "target": "test" },
+        "projectRoot": "apps/app1",
+        "overrides": {}
       },
-      "dependencies": {}
-    }
+      "app2:test": {
+        "id": "app2:test",
+        "target": { "project": "app2", "target": "test" },
+        "projectRoot": "apps/app2",
+        "overrides": {}
+      },
+      "lib:test": {
+        "id": "lib:test",
+        "target": { "project": "lib", "target": "test" },
+        "projectRoot": "libs/lib",
+        "overrides": {}
+      }
+    },
+    "dependencies": {}
   }
 }

--- a/docs/shared/mental-model/large-tasks.json
+++ b/docs/shared/mental-model/large-tasks.json
@@ -27356,12703 +27356,3152 @@
       }
     }
   ],
-  "taskId": "create-nx-workspace:test",
-  "taskGraphs": {
-    "nx-dev-feature-package-schema-viewer:lint": {
-      "roots": ["nx-dev-feature-package-schema-viewer:lint"],
-      "tasks": {
-        "nx-dev-feature-package-schema-viewer:lint": {
-          "id": "nx-dev-feature-package-schema-viewer:lint",
-          "target": {
-            "project": "nx-dev-feature-package-schema-viewer",
-            "target": "lint"
-          },
-          "projectRoot": "nx-dev/feature-package-schema-viewer",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-package-schema-viewer:lint": [] }
-    },
-    "nx-dev-feature-package-schema-viewer:test": {
-      "roots": ["nx-dev-feature-package-schema-viewer:test"],
-      "tasks": {
-        "nx-dev-feature-package-schema-viewer:test": {
-          "id": "nx-dev-feature-package-schema-viewer:test",
-          "target": {
-            "project": "nx-dev-feature-package-schema-viewer",
-            "target": "test"
-          },
-          "projectRoot": "nx-dev/feature-package-schema-viewer",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-package-schema-viewer:test": [] }
-    },
-    "nx-dev-data-access-documents:lint": {
-      "roots": ["nx-dev-data-access-documents:lint"],
-      "tasks": {
-        "nx-dev-data-access-documents:lint": {
-          "id": "nx-dev-data-access-documents:lint",
-          "target": {
-            "project": "nx-dev-data-access-documents",
-            "target": "lint"
-          },
-          "projectRoot": "nx-dev/data-access-documents",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-documents:lint": [] }
-    },
-    "nx-dev-data-access-documents:test": {
-      "roots": ["nx-dev-data-access-documents:test"],
-      "tasks": {
-        "nx-dev-data-access-documents:test": {
-          "id": "nx-dev-data-access-documents:test",
-          "target": {
-            "project": "nx-dev-data-access-documents",
-            "target": "test"
-          },
-          "projectRoot": "nx-dev/data-access-documents",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-documents:test": [] }
-    },
-    "create-nx-workspace:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-workspace:test": {
-          "id": "create-nx-workspace:test",
-          "target": { "project": "create-nx-workspace", "target": "test" },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": {}
-        },
-        "create-nx-workspace:build": {
-          "id": "create-nx-workspace:build",
-          "target": { "project": "create-nx-workspace", "target": "build" },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "create-nx-workspace:build-base": {
-          "id": "create-nx-workspace:build-base",
-          "target": {
-            "project": "create-nx-workspace",
-            "target": "build-base"
-          },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-workspace:test": ["create-nx-workspace:build"],
-        "create-nx-workspace:build": ["create-nx-workspace:build-base"],
-        "create-nx-workspace:build-base": [
-          "workspace:build-base",
-          "js:build-base",
-          "react:build-base",
-          "expo:build-base",
-          "next:build-base",
-          "angular:build-base",
-          "nest:build-base",
-          "express:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ]
-      }
-    },
-    "create-nx-workspace:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-workspace:build-base": {
-          "id": "create-nx-workspace:build-base",
-          "target": {
-            "project": "create-nx-workspace",
-            "target": "build-base"
-          },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": {}
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-workspace:build-base": [
-          "workspace:build-base",
-          "js:build-base",
-          "react:build-base",
-          "expo:build-base",
-          "next:build-base",
-          "angular:build-base",
-          "nest:build-base",
-          "express:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ]
-      }
-    },
-    "create-nx-workspace:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-workspace:build": {
-          "id": "create-nx-workspace:build",
-          "target": { "project": "create-nx-workspace", "target": "build" },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": {}
-        },
-        "create-nx-workspace:build-base": {
-          "id": "create-nx-workspace:build-base",
-          "target": {
-            "project": "create-nx-workspace",
-            "target": "build-base"
-          },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-workspace:build": ["create-nx-workspace:build-base"],
-        "create-nx-workspace:build-base": [
-          "workspace:build-base",
-          "js:build-base",
-          "react:build-base",
-          "expo:build-base",
-          "next:build-base",
-          "angular:build-base",
-          "nest:build-base",
-          "express:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ]
-      }
-    },
-    "create-nx-workspace:lint": {
-      "roots": ["create-nx-workspace:lint"],
-      "tasks": {
-        "create-nx-workspace:lint": {
-          "id": "create-nx-workspace:lint",
-          "target": { "project": "create-nx-workspace", "target": "lint" },
-          "projectRoot": "packages/create-nx-workspace",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "create-nx-workspace:lint": [] }
-    },
-    "nx-dev-data-access-packages:lint": {
-      "roots": ["nx-dev-data-access-packages:lint"],
-      "tasks": {
-        "nx-dev-data-access-packages:lint": {
-          "id": "nx-dev-data-access-packages:lint",
-          "target": {
-            "project": "nx-dev-data-access-packages",
-            "target": "lint"
-          },
-          "projectRoot": "nx-dev/data-access-packages",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-packages:lint": [] }
-    },
-    "nx-dev-data-access-packages:test": {
-      "roots": ["nx-dev-data-access-packages:test"],
-      "tasks": {
-        "nx-dev-data-access-packages:test": {
-          "id": "nx-dev-data-access-packages:test",
-          "target": {
-            "project": "nx-dev-data-access-packages",
-            "target": "test"
-          },
-          "projectRoot": "nx-dev/data-access-packages",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-packages:test": [] }
-    },
-    "nx-dev-feature-doc-viewer:lint": {
-      "roots": ["nx-dev-feature-doc-viewer:lint"],
-      "tasks": {
-        "nx-dev-feature-doc-viewer:lint": {
-          "id": "nx-dev-feature-doc-viewer:lint",
-          "target": {
-            "project": "nx-dev-feature-doc-viewer",
-            "target": "lint"
-          },
-          "projectRoot": "nx-dev/feature-doc-viewer",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-doc-viewer:lint": [] }
-    },
-    "nx-dev-feature-doc-viewer:test": {
-      "roots": ["nx-dev-feature-doc-viewer:test"],
-      "tasks": {
-        "nx-dev-feature-doc-viewer:test": {
-          "id": "nx-dev-feature-doc-viewer:test",
-          "target": {
-            "project": "nx-dev-feature-doc-viewer",
-            "target": "test"
-          },
-          "projectRoot": "nx-dev/feature-doc-viewer",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-doc-viewer:test": [] }
-    },
-    "create-nx-plugin:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-plugin:test": {
-          "id": "create-nx-plugin:test",
-          "target": { "project": "create-nx-plugin", "target": "test" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": {}
-        },
-        "create-nx-plugin:build": {
-          "id": "create-nx-plugin:build",
-          "target": { "project": "create-nx-plugin", "target": "build" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "create-nx-plugin:build-base": {
-          "id": "create-nx-plugin:build-base",
-          "target": { "project": "create-nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-plugin:test": ["create-nx-plugin:build"],
-        "create-nx-plugin:build": ["create-nx-plugin:build-base"],
-        "create-nx-plugin:build-base": [
-          "nx-plugin:build-base",
-          "devkit:build-base",
-          "nx:build-base"
-        ],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "create-nx-plugin:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-plugin:build-base": {
-          "id": "create-nx-plugin:build-base",
-          "target": { "project": "create-nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": {}
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-plugin:build-base": [
-          "nx-plugin:build-base",
-          "devkit:build-base",
-          "nx:build-base"
-        ],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "create-nx-plugin:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "create-nx-plugin:build": {
-          "id": "create-nx-plugin:build",
-          "target": { "project": "create-nx-plugin", "target": "build" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": {}
-        },
-        "create-nx-plugin:build-base": {
-          "id": "create-nx-plugin:build-base",
-          "target": { "project": "create-nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "create-nx-plugin:build": ["create-nx-plugin:build-base"],
-        "create-nx-plugin:build-base": [
-          "nx-plugin:build-base",
-          "devkit:build-base",
-          "nx:build-base"
-        ],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "create-nx-plugin:lint": {
-      "roots": ["create-nx-plugin:lint"],
-      "tasks": {
-        "create-nx-plugin:lint": {
-          "id": "create-nx-plugin:lint",
-          "target": { "project": "create-nx-plugin", "target": "lint" },
-          "projectRoot": "packages/create-nx-plugin",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "create-nx-plugin:lint": [] }
-    },
-    "eslint-plugin-nx:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "eslint-plugin-nx:test": {
-          "id": "eslint-plugin-nx:test",
-          "target": { "project": "eslint-plugin-nx", "target": "test" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": {}
-        },
-        "eslint-plugin-nx:build": {
-          "id": "eslint-plugin-nx:build",
-          "target": { "project": "eslint-plugin-nx", "target": "build" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "eslint-plugin-nx:test": ["eslint-plugin-nx:build"],
-        "eslint-plugin-nx:build": ["eslint-plugin-nx:build-base"],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "eslint-plugin-nx:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "eslint-plugin-nx:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "eslint-plugin-nx:build": {
-          "id": "eslint-plugin-nx:build",
-          "target": { "project": "eslint-plugin-nx", "target": "build" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": {}
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "eslint-plugin-nx:build": ["eslint-plugin-nx:build-base"],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "eslint-plugin-nx:lint": {
-      "roots": ["eslint-plugin-nx:lint"],
-      "tasks": {
-        "eslint-plugin-nx:lint": {
-          "id": "eslint-plugin-nx:lint",
-          "target": { "project": "eslint-plugin-nx", "target": "lint" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "eslint-plugin-nx:lint": [] }
-    },
-    "nx-dev-feature-analytics:lint": {
-      "roots": ["nx-dev-feature-analytics:lint"],
-      "tasks": {
-        "nx-dev-feature-analytics:lint": {
-          "id": "nx-dev-feature-analytics:lint",
-          "target": { "project": "nx-dev-feature-analytics", "target": "lint" },
-          "projectRoot": "nx-dev/feature-analytics",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-analytics:lint": [] }
-    },
-    "nx-dev-feature-analytics:test": {
-      "roots": ["nx-dev-feature-analytics:test"],
-      "tasks": {
-        "nx-dev-feature-analytics:test": {
-          "id": "nx-dev-feature-analytics:test",
-          "target": { "project": "nx-dev-feature-analytics", "target": "test" },
-          "projectRoot": "nx-dev/feature-analytics",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-analytics:test": [] }
-    },
-    "nx-dev-data-access-menu:lint": {
-      "roots": ["nx-dev-data-access-menu:lint"],
-      "tasks": {
-        "nx-dev-data-access-menu:lint": {
-          "id": "nx-dev-data-access-menu:lint",
-          "target": { "project": "nx-dev-data-access-menu", "target": "lint" },
-          "projectRoot": "nx-dev/data-access-menu",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-menu:lint": [] }
-    },
-    "nx-dev-data-access-menu:test": {
-      "roots": ["nx-dev-data-access-menu:test"],
-      "tasks": {
-        "nx-dev-data-access-menu:test": {
-          "id": "nx-dev-data-access-menu:test",
-          "target": { "project": "nx-dev-data-access-menu", "target": "test" },
-          "projectRoot": "nx-dev/data-access-menu",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-data-access-menu:test": [] }
-    },
-    "e2e-angular-extensions:e2e": {
-      "roots": ["e2e-angular-extensions:e2e"],
-      "tasks": {
-        "e2e-angular-extensions:e2e": {
-          "id": "e2e-angular-extensions:e2e",
-          "target": { "project": "e2e-angular-extensions", "target": "e2e" },
-          "projectRoot": "e2e/angular-extensions",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-angular-extensions:e2e": [] }
-    },
-    "e2e-angular-extensions:run-e2e-tests": {
-      "roots": ["e2e-angular-extensions:run-e2e-tests"],
-      "tasks": {
-        "e2e-angular-extensions:run-e2e-tests": {
-          "id": "e2e-angular-extensions:run-e2e-tests",
-          "target": {
-            "project": "e2e-angular-extensions",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/angular-extensions",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-angular-extensions:run-e2e-tests": [] }
-    },
-    "nx-dev-models-document:lint": {
-      "roots": ["nx-dev-models-document:lint"],
-      "tasks": {
-        "nx-dev-models-document:lint": {
-          "id": "nx-dev-models-document:lint",
-          "target": { "project": "nx-dev-models-document", "target": "lint" },
-          "projectRoot": "nx-dev/models-document",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-document:lint": [] }
-    },
-    "nx-dev-models-document:test": {
-      "roots": ["nx-dev-models-document:test"],
-      "tasks": {
-        "nx-dev-models-document:test": {
-          "id": "nx-dev-models-document:test",
-          "target": { "project": "nx-dev-models-document", "target": "test" },
-          "projectRoot": "nx-dev/models-document",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-document:test": [] }
-    },
-    "nx-dev-ui-sponsor-card:lint": {
-      "roots": ["nx-dev-ui-sponsor-card:lint"],
-      "tasks": {
-        "nx-dev-ui-sponsor-card:lint": {
-          "id": "nx-dev-ui-sponsor-card:lint",
-          "target": { "project": "nx-dev-ui-sponsor-card", "target": "lint" },
-          "projectRoot": "nx-dev/ui-sponsor-card",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-sponsor-card:lint": [] }
-    },
-    "nx-dev-ui-sponsor-card:test": {
-      "roots": ["nx-dev-ui-sponsor-card:test"],
-      "tasks": {
-        "nx-dev-ui-sponsor-card:test": {
-          "id": "nx-dev-ui-sponsor-card:test",
-          "target": { "project": "nx-dev-ui-sponsor-card", "target": "test" },
-          "projectRoot": "nx-dev/ui-sponsor-card",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-sponsor-card:test": [] }
-    },
-    "e2e-storybook-angular:e2e": {
-      "roots": ["e2e-storybook-angular:e2e"],
-      "tasks": {
-        "e2e-storybook-angular:e2e": {
-          "id": "e2e-storybook-angular:e2e",
-          "target": { "project": "e2e-storybook-angular", "target": "e2e" },
-          "projectRoot": "e2e/storybook-angular",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-storybook-angular:e2e": [] }
-    },
-    "e2e-storybook-angular:run-e2e-tests": {
-      "roots": ["e2e-storybook-angular:run-e2e-tests"],
-      "tasks": {
-        "e2e-storybook-angular:run-e2e-tests": {
-          "id": "e2e-storybook-angular:run-e2e-tests",
-          "target": {
-            "project": "e2e-storybook-angular",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/storybook-angular",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-storybook-angular:run-e2e-tests": [] }
-    },
-    "nx-dev-feature-search:lint": {
-      "roots": ["nx-dev-feature-search:lint"],
-      "tasks": {
-        "nx-dev-feature-search:lint": {
-          "id": "nx-dev-feature-search:lint",
-          "target": { "project": "nx-dev-feature-search", "target": "lint" },
-          "projectRoot": "nx-dev/feature-search",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-search:lint": [] }
-    },
-    "nx-dev-feature-search:test": {
-      "roots": ["nx-dev-feature-search:test"],
-      "tasks": {
-        "nx-dev-feature-search:test": {
-          "id": "nx-dev-feature-search:test",
-          "target": { "project": "nx-dev-feature-search", "target": "test" },
-          "projectRoot": "nx-dev/feature-search",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-feature-search:test": [] }
-    },
-    "nx-dev-models-package:lint": {
-      "roots": ["nx-dev-models-package:lint"],
-      "tasks": {
-        "nx-dev-models-package:lint": {
-          "id": "nx-dev-models-package:lint",
-          "target": { "project": "nx-dev-models-package", "target": "lint" },
-          "projectRoot": "nx-dev/models-package",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-package:lint": [] }
-    },
-    "nx-dev-models-package:test": {
-      "roots": ["nx-dev-models-package:test"],
-      "tasks": {
-        "nx-dev-models-package:test": {
-          "id": "nx-dev-models-package:test",
-          "target": { "project": "nx-dev-models-package", "target": "test" },
-          "projectRoot": "nx-dev/models-package",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-package:test": [] }
-    },
-    "nx-dev-ui-member-card:lint": {
-      "roots": ["nx-dev-ui-member-card:lint"],
-      "tasks": {
-        "nx-dev-ui-member-card:lint": {
-          "id": "nx-dev-ui-member-card:lint",
-          "target": { "project": "nx-dev-ui-member-card", "target": "lint" },
-          "projectRoot": "nx-dev/ui-member-card",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-member-card:lint": [] }
-    },
-    "nx-dev-ui-member-card:test": {
-      "roots": ["nx-dev-ui-member-card:test"],
-      "tasks": {
-        "nx-dev-ui-member-card:test": {
-          "id": "nx-dev-ui-member-card:test",
-          "target": { "project": "nx-dev-ui-member-card", "target": "test" },
-          "projectRoot": "nx-dev/ui-member-card",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-member-card:test": [] }
-    },
-    "react-native:lint": {
-      "roots": ["react-native:lint"],
-      "tasks": {
-        "react-native:lint": {
-          "id": "react-native:lint",
-          "target": { "project": "react-native", "target": "lint" },
-          "projectRoot": "packages/react-native",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "react-native:lint": [] }
-    },
-    "react-native:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react-native:test": {
-          "id": "react-native:test",
-          "target": { "project": "react-native", "target": "test" },
-          "projectRoot": "packages/react-native",
-          "overrides": {}
-        },
-        "react-native:build": {
-          "id": "react-native:build",
-          "target": { "project": "react-native", "target": "build" },
-          "projectRoot": "packages/react-native",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react-native:build-base": {
-          "id": "react-native:build-base",
-          "target": { "project": "react-native", "target": "build-base" },
-          "projectRoot": "packages/react-native",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react-native:test": ["react-native:build"],
-        "react-native:build": ["react-native:build-base"],
-        "react-native:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react-native:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react-native:build-base": {
-          "id": "react-native:build-base",
-          "target": { "project": "react-native", "target": "build-base" },
-          "projectRoot": "packages/react-native",
-          "overrides": {}
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react-native:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react-native:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react-native:build": {
-          "id": "react-native:build",
-          "target": { "project": "react-native", "target": "build" },
-          "projectRoot": "packages/react-native",
-          "overrides": {}
-        },
-        "react-native:build-base": {
-          "id": "react-native:build-base",
-          "target": { "project": "react-native", "target": "build-base" },
-          "projectRoot": "packages/react-native",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react-native:build": ["react-native:build-base"],
-        "react-native:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "e2e-workspace-create:e2e": {
-      "roots": ["e2e-workspace-create:e2e"],
-      "tasks": {
-        "e2e-workspace-create:e2e": {
-          "id": "e2e-workspace-create:e2e",
-          "target": { "project": "e2e-workspace-create", "target": "e2e" },
-          "projectRoot": "e2e/workspace-create",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-workspace-create:e2e": [] }
-    },
-    "e2e-workspace-create:run-e2e-tests": {
-      "roots": ["e2e-workspace-create:run-e2e-tests"],
-      "tasks": {
-        "e2e-workspace-create:run-e2e-tests": {
-          "id": "e2e-workspace-create:run-e2e-tests",
-          "target": {
-            "project": "e2e-workspace-create",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/workspace-create",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-workspace-create:run-e2e-tests": [] }
-    },
-    "nx-dev-ui-conference:lint": {
-      "roots": ["nx-dev-ui-conference:lint"],
-      "tasks": {
-        "nx-dev-ui-conference:lint": {
-          "id": "nx-dev-ui-conference:lint",
-          "target": { "project": "nx-dev-ui-conference", "target": "lint" },
-          "projectRoot": "nx-dev/ui-conference",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-conference:lint": [] }
-    },
-    "nx-dev-ui-conference:test": {
-      "roots": ["nx-dev-ui-conference:test"],
-      "tasks": {
-        "nx-dev-ui-conference:test": {
-          "id": "nx-dev-ui-conference:test",
-          "target": { "project": "nx-dev-ui-conference", "target": "test" },
-          "projectRoot": "nx-dev/ui-conference",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-conference:test": [] }
-    },
-    "nx-dev-ui-references:lint": {
-      "roots": ["nx-dev-ui-references:lint"],
-      "tasks": {
-        "nx-dev-ui-references:lint": {
-          "id": "nx-dev-ui-references:lint",
-          "target": { "project": "nx-dev-ui-references", "target": "lint" },
-          "projectRoot": "nx-dev/ui-references",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-references:lint": [] }
-    },
-    "nx-dev-ui-references:test": {
-      "roots": ["nx-dev-ui-references:test"],
-      "tasks": {
-        "nx-dev-ui-references:test": {
-          "id": "nx-dev-ui-references:test",
-          "target": { "project": "nx-dev-ui-references", "target": "test" },
-          "projectRoot": "nx-dev/ui-references",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-references:test": [] }
-    },
-    "nx-dev-ui-community:lint": {
-      "roots": ["nx-dev-ui-community:lint"],
-      "tasks": {
-        "nx-dev-ui-community:lint": {
-          "id": "nx-dev-ui-community:lint",
-          "target": { "project": "nx-dev-ui-community", "target": "lint" },
-          "projectRoot": "nx-dev/ui-community",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-community:lint": [] }
-    },
-    "nx-dev-ui-community:test": {
-      "roots": ["nx-dev-ui-community:test"],
-      "tasks": {
-        "nx-dev-ui-community:test": {
-          "id": "nx-dev-ui-community:test",
-          "target": { "project": "nx-dev-ui-community", "target": "test" },
-          "projectRoot": "nx-dev/ui-community",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-community:test": [] }
-    },
-    "nx-dev-models-menu:lint": {
-      "roots": ["nx-dev-models-menu:lint"],
-      "tasks": {
-        "nx-dev-models-menu:lint": {
-          "id": "nx-dev-models-menu:lint",
-          "target": { "project": "nx-dev-models-menu", "target": "lint" },
-          "projectRoot": "nx-dev/models-menu",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-menu:lint": [] }
-    },
-    "nx-dev-models-menu:test": {
-      "roots": ["nx-dev-models-menu:test"],
-      "tasks": {
-        "nx-dev-models-menu:test": {
-          "id": "nx-dev-models-menu:test",
-          "target": { "project": "nx-dev-models-menu", "target": "test" },
-          "projectRoot": "nx-dev/models-menu",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-models-menu:test": [] }
-    },
-    "nx-dev-ui-commands:lint": {
-      "roots": ["nx-dev-ui-commands:lint"],
-      "tasks": {
-        "nx-dev-ui-commands:lint": {
-          "id": "nx-dev-ui-commands:lint",
-          "target": { "project": "nx-dev-ui-commands", "target": "lint" },
-          "projectRoot": "nx-dev/ui-commands",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-commands:lint": [] }
-    },
-    "nx-dev-ui-commands:test": {
-      "roots": ["nx-dev-ui-commands:test"],
-      "tasks": {
-        "nx-dev-ui-commands:test": {
-          "id": "nx-dev-ui-commands:test",
-          "target": { "project": "nx-dev-ui-commands", "target": "test" },
-          "projectRoot": "nx-dev/ui-commands",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-commands:test": [] }
-    },
-    "nx-plugin:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-plugin:test": {
-          "id": "nx-plugin:test",
-          "target": { "project": "nx-plugin", "target": "test" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": {}
-        },
-        "nx-plugin:build": {
-          "id": "nx-plugin:build",
-          "target": { "project": "nx-plugin", "target": "build" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-plugin:test": ["nx-plugin:build"],
-        "nx-plugin:build": ["nx-plugin:build-base"],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-plugin:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-plugin:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-plugin:build": {
-          "id": "nx-plugin:build",
-          "target": { "project": "nx-plugin", "target": "build" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": {}
-        },
-        "nx-plugin:build-base": {
-          "id": "nx-plugin:build-base",
-          "target": { "project": "nx-plugin", "target": "build-base" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-plugin:build": ["nx-plugin:build-base"],
-        "nx-plugin:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-plugin:lint": {
-      "roots": ["nx-plugin:lint"],
-      "tasks": {
-        "nx-plugin:lint": {
-          "id": "nx-plugin:lint",
-          "target": { "project": "nx-plugin", "target": "lint" },
-          "projectRoot": "packages/nx-plugin",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-plugin:lint": [] }
-    },
-    "storybook:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "storybook:test": {
-          "id": "storybook:test",
-          "target": { "project": "storybook", "target": "test" },
-          "projectRoot": "packages/storybook",
-          "overrides": {}
-        },
-        "storybook:build": {
-          "id": "storybook:build",
-          "target": { "project": "storybook", "target": "build" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "storybook:test": ["storybook:build"],
-        "storybook:build": ["storybook:build-base"],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "storybook:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": {}
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "storybook:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "storybook:build": {
-          "id": "storybook:build",
-          "target": { "project": "storybook", "target": "build" },
-          "projectRoot": "packages/storybook",
-          "overrides": {}
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "storybook:build": ["storybook:build-base"],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "storybook:lint": {
-      "roots": ["storybook:lint"],
-      "tasks": {
-        "storybook:lint": {
-          "id": "storybook:lint",
-          "target": { "project": "storybook", "target": "lint" },
-          "projectRoot": "packages/storybook",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "storybook:lint": [] }
-    },
-    "workspace:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "workspace:test": {
-          "id": "workspace:test",
-          "target": { "project": "workspace", "target": "test" },
-          "projectRoot": "packages/workspace",
-          "overrides": {}
-        },
-        "workspace:build": {
-          "id": "workspace:build",
-          "target": { "project": "workspace", "target": "build" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "workspace:test": ["workspace:build"],
-        "workspace:build": ["workspace:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "workspace:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "workspace:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "workspace:build": {
-          "id": "workspace:build",
-          "target": { "project": "workspace", "target": "build" },
-          "projectRoot": "packages/workspace",
-          "overrides": {}
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "workspace:build": ["workspace:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "workspace:lint": {
-      "roots": ["workspace:lint"],
-      "tasks": {
-        "workspace:lint": {
-          "id": "workspace:lint",
-          "target": { "project": "workspace", "target": "lint" },
-          "projectRoot": "packages/workspace",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "workspace:lint": [] }
-    },
-    "eslint-rules:test": {
-      "roots": ["eslint-rules:test"],
-      "tasks": {
-        "eslint-rules:test": {
-          "id": "eslint-rules:test",
-          "target": { "project": "eslint-rules", "target": "test" },
-          "projectRoot": "tools/eslint-rules",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "eslint-rules:test": [] }
-    },
-    "nx-dev-e2e:e2e": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-dev-e2e:e2e": {
-          "id": "nx-dev-e2e:e2e",
-          "target": { "project": "nx-dev-e2e", "target": "e2e" },
-          "projectRoot": "nx-dev/nx-dev-e2e",
-          "overrides": {}
-        },
-        "nx-dev:build-base": {
-          "id": "nx-dev:build-base",
-          "target": { "project": "nx-dev", "target": "build-base" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev-e2e:e2e": ["nx-dev:build-base", "cypress:build-base"],
-        "nx-dev:build-base": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev-e2e:lint": {
-      "roots": ["nx-dev-e2e:lint"],
-      "tasks": {
-        "nx-dev-e2e:lint": {
-          "id": "nx-dev-e2e:lint",
-          "target": { "project": "nx-dev-e2e", "target": "lint" },
-          "projectRoot": "nx-dev/nx-dev-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-e2e:lint": [] }
-    },
-    "nx-dev-ui-markdoc:lint": {
-      "roots": ["nx-dev-ui-markdoc:lint"],
-      "tasks": {
-        "nx-dev-ui-markdoc:lint": {
-          "id": "nx-dev-ui-markdoc:lint",
-          "target": { "project": "nx-dev-ui-markdoc", "target": "lint" },
-          "projectRoot": "nx-dev/ui-markdoc",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-markdoc:lint": [] }
-    },
-    "nx-dev-ui-markdoc:test": {
-      "roots": ["nx-dev-ui-markdoc:test"],
-      "tasks": {
-        "nx-dev-ui-markdoc:test": {
-          "id": "nx-dev-ui-markdoc:test",
-          "target": { "project": "nx-dev-ui-markdoc", "target": "test" },
-          "projectRoot": "nx-dev/ui-markdoc",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-markdoc:test": [] }
-    },
-    "e2e-angular-core:e2e": {
-      "roots": ["e2e-angular-core:e2e"],
-      "tasks": {
-        "e2e-angular-core:e2e": {
-          "id": "e2e-angular-core:e2e",
-          "target": { "project": "e2e-angular-core", "target": "e2e" },
-          "projectRoot": "e2e/angular-core",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-angular-core:e2e": [] }
-    },
-    "e2e-angular-core:run-e2e-tests": {
-      "roots": ["e2e-angular-core:run-e2e-tests"],
-      "tasks": {
-        "e2e-angular-core:run-e2e-tests": {
-          "id": "e2e-angular-core:run-e2e-tests",
-          "target": {
-            "project": "e2e-angular-core",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/angular-core",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-angular-core:run-e2e-tests": [] }
-    },
-    "e2e-react-native:e2e": {
-      "roots": ["e2e-react-native:e2e"],
-      "tasks": {
-        "e2e-react-native:e2e": {
-          "id": "e2e-react-native:e2e",
-          "target": { "project": "e2e-react-native", "target": "e2e" },
-          "projectRoot": "e2e/react-native",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-react-native:e2e": [] }
-    },
-    "e2e-react-native:run-e2e-tests": {
-      "roots": ["e2e-react-native:run-e2e-tests"],
-      "tasks": {
-        "e2e-react-native:run-e2e-tests": {
-          "id": "e2e-react-native:run-e2e-tests",
-          "target": {
-            "project": "e2e-react-native",
-            "target": "run-e2e-tests"
-          },
-          "projectRoot": "e2e/react-native",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-react-native:run-e2e-tests": [] }
-    },
-    "e2e-graph-client:e2e-base": {
-      "roots": ["e2e-graph-client:e2e-base:dev"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:dev": {
-          "id": "e2e-graph-client:e2e-base:dev",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:dev": [] }
-    },
-    "e2e-graph-client:e2e-base:dev": {
-      "roots": ["e2e-graph-client:e2e-base:dev"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:dev": {
-          "id": "e2e-graph-client:e2e-base:dev",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:dev": [] }
-    },
-    "e2e-graph-client:e2e-base:watch": {
-      "roots": ["e2e-graph-client:e2e-base:watch"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:watch": {
-          "id": "e2e-graph-client:e2e-base:watch",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "watch"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:watch": [] }
-    },
-    "e2e-graph-client:e2e-base:release": {
-      "roots": ["e2e-graph-client:e2e-base:release"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:release": {
-          "id": "e2e-graph-client:e2e-base:release",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:release": [] }
-    },
-    "e2e-graph-client:e2e-base:release-static": {
-      "roots": ["e2e-graph-client:e2e-base:release-static"],
-      "tasks": {
-        "e2e-graph-client:e2e-base:release-static": {
-          "id": "e2e-graph-client:e2e-base:release-static",
-          "target": {
-            "project": "e2e-graph-client",
-            "target": "e2e-base",
-            "configuration": "release-static"
-          },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-base:release-static": [] }
-    },
-    "e2e-graph-client:e2e-local": {
-      "roots": ["e2e-graph-client:e2e-local"],
-      "tasks": {
-        "e2e-graph-client:e2e-local": {
-          "id": "e2e-graph-client:e2e-local",
-          "target": { "project": "e2e-graph-client", "target": "e2e-local" },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e-local": [] }
-    },
-    "e2e-graph-client:e2e": {
-      "roots": ["e2e-graph-client:e2e"],
-      "tasks": {
-        "e2e-graph-client:e2e": {
-          "id": "e2e-graph-client:e2e",
-          "target": { "project": "e2e-graph-client", "target": "e2e" },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:e2e": [] }
-    },
-    "e2e-graph-client:lint": {
-      "roots": ["e2e-graph-client:lint"],
-      "tasks": {
-        "e2e-graph-client:lint": {
-          "id": "e2e-graph-client:lint",
-          "target": { "project": "e2e-graph-client", "target": "lint" },
-          "projectRoot": "graph/client-e2e",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-graph-client:lint": [] }
-    },
-    "nx-dev-ui-common:lint": {
-      "roots": ["nx-dev-ui-common:lint"],
-      "tasks": {
-        "nx-dev-ui-common:lint": {
-          "id": "nx-dev-ui-common:lint",
-          "target": { "project": "nx-dev-ui-common", "target": "lint" },
-          "projectRoot": "nx-dev/ui-common",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-common:lint": [] }
-    },
-    "nx-dev-ui-common:test": {
-      "roots": ["nx-dev-ui-common:test"],
-      "tasks": {
-        "nx-dev-ui-common:test": {
-          "id": "nx-dev-ui-common:test",
-          "target": { "project": "nx-dev-ui-common", "target": "test" },
-          "projectRoot": "nx-dev/ui-common",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-common:test": [] }
-    },
-    "angular:postinstall": {
-      "roots": ["angular:postinstall"],
-      "tasks": {
-        "angular:postinstall": {
-          "id": "angular:postinstall",
-          "target": { "project": "angular", "target": "postinstall" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "angular:postinstall": [] }
-    },
-    "angular:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "angular:test": {
-          "id": "angular:test",
-          "target": { "project": "angular", "target": "test" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        },
-        "angular:build": {
-          "id": "angular:build",
-          "target": { "project": "angular", "target": "build" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "angular:test": ["angular:build"],
-        "angular:build": ["angular:build-base"],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "angular:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "angular:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "angular:build": {
-          "id": "angular:build",
-          "target": { "project": "angular", "target": "build" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        },
-        "angular:build-base": {
-          "id": "angular:build-base",
-          "target": { "project": "angular", "target": "build-base" },
-          "projectRoot": "packages/angular",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "angular:build": ["angular:build-base"],
-        "angular:build-base": [
-          "workspace:build-base",
-          "cypress:build-base",
-          "jest:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "storybook:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "angular:lint": {
-      "roots": ["angular:lint"],
-      "tasks": {
-        "angular:lint": {
-          "id": "angular:lint",
-          "target": { "project": "angular", "target": "lint" },
-          "projectRoot": "packages/angular",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "angular:lint": [] }
-    },
-    "cypress:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cypress:test": {
-          "id": "cypress:test",
-          "target": { "project": "cypress", "target": "test" },
-          "projectRoot": "packages/cypress",
-          "overrides": {}
-        },
-        "cypress:build": {
-          "id": "cypress:build",
-          "target": { "project": "cypress", "target": "build" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cypress:test": ["cypress:build"],
-        "cypress:build": ["cypress:build-base"],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "cypress:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "cypress:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cypress:build": {
-          "id": "cypress:build",
-          "target": { "project": "cypress", "target": "build" },
-          "projectRoot": "packages/cypress",
-          "overrides": {}
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cypress:build": ["cypress:build-base"],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "cypress:lint": {
-      "roots": ["cypress:lint"],
-      "tasks": {
-        "cypress:lint": {
-          "id": "cypress:lint",
-          "target": { "project": "cypress", "target": "lint" },
-          "projectRoot": "packages/cypress",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "cypress:lint": [] }
-    },
-    "esbuild:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "esbuild:test": {
-          "id": "esbuild:test",
-          "target": { "project": "esbuild", "target": "test" },
-          "projectRoot": "packages/esbuild",
-          "overrides": {}
-        },
-        "esbuild:build": {
-          "id": "esbuild:build",
-          "target": { "project": "esbuild", "target": "build" },
-          "projectRoot": "packages/esbuild",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "esbuild:build-base": {
-          "id": "esbuild:build-base",
-          "target": { "project": "esbuild", "target": "build-base" },
-          "projectRoot": "packages/esbuild",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "esbuild:test": ["esbuild:build"],
-        "esbuild:build": ["esbuild:build-base"],
-        "esbuild:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "esbuild:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "esbuild:build-base": {
-          "id": "esbuild:build-base",
-          "target": { "project": "esbuild", "target": "build-base" },
-          "projectRoot": "packages/esbuild",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "esbuild:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "esbuild:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "esbuild:build": {
-          "id": "esbuild:build",
-          "target": { "project": "esbuild", "target": "build" },
-          "projectRoot": "packages/esbuild",
-          "overrides": {}
-        },
-        "esbuild:build-base": {
-          "id": "esbuild:build-base",
-          "target": { "project": "esbuild", "target": "build-base" },
-          "projectRoot": "packages/esbuild",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "esbuild:build": ["esbuild:build-base"],
-        "esbuild:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "esbuild:lint": {
-      "roots": ["esbuild:lint"],
-      "tasks": {
-        "esbuild:lint": {
-          "id": "esbuild:lint",
-          "target": { "project": "esbuild", "target": "lint" },
-          "projectRoot": "packages/esbuild",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "esbuild:lint": [] }
-    },
-    "express:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "express:test": {
-          "id": "express:test",
-          "target": { "project": "express", "target": "test" },
-          "projectRoot": "packages/express",
-          "overrides": {}
-        },
-        "express:build": {
-          "id": "express:build",
-          "target": { "project": "express", "target": "build" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "express:test": ["express:build"],
-        "express:build": ["express:build-base"],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "express:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": {}
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "express:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "express:build": {
-          "id": "express:build",
-          "target": { "project": "express", "target": "build" },
-          "projectRoot": "packages/express",
-          "overrides": {}
-        },
-        "express:build-base": {
-          "id": "express:build-base",
-          "target": { "project": "express", "target": "build-base" },
-          "projectRoot": "packages/express",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "express:build": ["express:build-base"],
-        "express:build-base": [
-          "node:build-base",
-          "devkit:build-base",
-          "workspace:build-base",
-          "linter:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "express:lint": {
-      "roots": ["express:lint"],
-      "tasks": {
-        "express:lint": {
-          "id": "express:lint",
-          "target": { "project": "express", "target": "lint" },
-          "projectRoot": "packages/express",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "express:lint": [] }
-    },
-    "webpack:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "webpack:test": {
-          "id": "webpack:test",
-          "target": { "project": "webpack", "target": "test" },
-          "projectRoot": "packages/webpack",
-          "overrides": {}
-        },
-        "webpack:build": {
-          "id": "webpack:build",
-          "target": { "project": "webpack", "target": "build" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "webpack:test": ["webpack:build"],
-        "webpack:build": ["webpack:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "webpack:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "webpack:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "webpack:build": {
-          "id": "webpack:build",
-          "target": { "project": "webpack", "target": "build" },
-          "projectRoot": "packages/webpack",
-          "overrides": {}
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "webpack:build": ["webpack:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "webpack:lint": {
-      "roots": ["webpack:lint"],
-      "tasks": {
-        "webpack:lint": {
-          "id": "webpack:lint",
-          "target": { "project": "webpack", "target": "lint" },
-          "projectRoot": "packages/webpack",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "webpack:lint": [] }
-    },
-    "nx-dev-ui-theme:lint": {
-      "roots": ["nx-dev-ui-theme:lint"],
-      "tasks": {
-        "nx-dev-ui-theme:lint": {
-          "id": "nx-dev-ui-theme:lint",
-          "target": { "project": "nx-dev-ui-theme", "target": "lint" },
-          "projectRoot": "nx-dev/ui-theme",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-theme:lint": [] }
-    },
-    "nx-dev-ui-theme:test": {
-      "roots": ["nx-dev-ui-theme:test"],
-      "tasks": {
-        "nx-dev-ui-theme:test": {
-          "id": "nx-dev-ui-theme:test",
-          "target": { "project": "nx-dev-ui-theme", "target": "test" },
-          "projectRoot": "nx-dev/ui-theme",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-theme:test": [] }
-    },
-    "devkit:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "devkit:test": {
-          "id": "devkit:test",
-          "target": { "project": "devkit", "target": "test" },
-          "projectRoot": "packages/devkit",
-          "overrides": {}
-        },
-        "devkit:build": {
-          "id": "devkit:build",
-          "target": { "project": "devkit", "target": "build" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "devkit:test": ["devkit:build"],
-        "devkit:build": ["devkit:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "devkit:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": {}
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "devkit:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "devkit:build": {
-          "id": "devkit:build",
-          "target": { "project": "devkit", "target": "build" },
-          "projectRoot": "packages/devkit",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "devkit:build": ["devkit:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "devkit:lint": {
-      "roots": ["devkit:lint"],
-      "tasks": {
-        "devkit:lint": {
-          "id": "devkit:lint",
-          "target": { "project": "devkit", "target": "lint" },
-          "projectRoot": "packages/devkit",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "devkit:lint": [] }
-    },
-    "linter:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "linter:test": {
-          "id": "linter:test",
-          "target": { "project": "linter", "target": "test" },
-          "projectRoot": "packages/linter",
-          "overrides": {}
-        },
-        "linter:build": {
-          "id": "linter:build",
-          "target": { "project": "linter", "target": "build" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "linter:test": ["linter:build"],
-        "linter:build": ["linter:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "linter:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": {}
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "linter:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "linter:build": {
-          "id": "linter:build",
-          "target": { "project": "linter", "target": "build" },
-          "projectRoot": "packages/linter",
-          "overrides": {}
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "linter:build": ["linter:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "linter:lint": {
-      "roots": ["linter:lint"],
-      "tasks": {
-        "linter:lint": {
-          "id": "linter:lint",
-          "target": { "project": "linter", "target": "lint" },
-          "projectRoot": "packages/linter",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "linter:lint": [] }
-    },
-    "rollup:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "rollup:test": {
-          "id": "rollup:test",
-          "target": { "project": "rollup", "target": "test" },
-          "projectRoot": "packages/rollup",
-          "overrides": {}
-        },
-        "rollup:build": {
-          "id": "rollup:build",
-          "target": { "project": "rollup", "target": "build" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "rollup:test": ["rollup:build"],
-        "rollup:build": ["rollup:build-base"],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "rollup:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "rollup:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "rollup:build": {
-          "id": "rollup:build",
-          "target": { "project": "rollup", "target": "build" },
-          "projectRoot": "packages/rollup",
-          "overrides": {}
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "rollup:build": ["rollup:build-base"],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "rollup:lint": {
-      "roots": ["rollup:lint"],
-      "tasks": {
-        "rollup:lint": {
-          "id": "rollup:lint",
-          "target": { "project": "rollup", "target": "lint" },
-          "projectRoot": "packages/rollup",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "rollup:lint": [] }
-    },
-    "graph-ui-graph:lint": {
-      "roots": ["graph-ui-graph:lint"],
-      "tasks": {
-        "graph-ui-graph:lint": {
-          "id": "graph-ui-graph:lint",
-          "target": { "project": "graph-ui-graph", "target": "lint" },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:lint": [] }
-    },
-    "graph-ui-graph:test": {
-      "roots": ["graph-ui-graph:test"],
-      "tasks": {
-        "graph-ui-graph:test": {
-          "id": "graph-ui-graph:test",
-          "target": { "project": "graph-ui-graph", "target": "test" },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:test": [] }
-    },
-    "graph-ui-graph:storybook": {
-      "roots": ["graph-ui-graph:storybook"],
-      "tasks": {
-        "graph-ui-graph:storybook": {
-          "id": "graph-ui-graph:storybook",
-          "target": { "project": "graph-ui-graph", "target": "storybook" },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:storybook": [] }
-    },
-    "graph-ui-graph:storybook:ci": {
-      "roots": ["graph-ui-graph:storybook:ci"],
-      "tasks": {
-        "graph-ui-graph:storybook:ci": {
-          "id": "graph-ui-graph:storybook:ci",
-          "target": {
-            "project": "graph-ui-graph",
-            "target": "storybook",
-            "configuration": "ci"
-          },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:storybook:ci": [] }
-    },
-    "graph-ui-graph:build-storybook": {
-      "roots": ["graph-ui-graph:build-storybook"],
-      "tasks": {
-        "graph-ui-graph:build-storybook": {
-          "id": "graph-ui-graph:build-storybook",
-          "target": {
-            "project": "graph-ui-graph",
-            "target": "build-storybook"
-          },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:build-storybook": [] }
-    },
-    "graph-ui-graph:build-storybook:ci": {
-      "roots": ["graph-ui-graph:build-storybook:ci"],
-      "tasks": {
-        "graph-ui-graph:build-storybook:ci": {
-          "id": "graph-ui-graph:build-storybook:ci",
-          "target": {
-            "project": "graph-ui-graph",
-            "target": "build-storybook",
-            "configuration": "ci"
-          },
-          "projectRoot": "graph/ui-graph",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-ui-graph:build-storybook:ci": [] }
-    },
-    "nx-dev-ui-home:lint": {
-      "roots": ["nx-dev-ui-home:lint"],
-      "tasks": {
-        "nx-dev-ui-home:lint": {
-          "id": "nx-dev-ui-home:lint",
-          "target": { "project": "nx-dev-ui-home", "target": "lint" },
-          "projectRoot": "nx-dev/ui-home",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-home:lint": [] }
-    },
-    "nx-dev-ui-home:xtest": {
-      "roots": ["nx-dev-ui-home:xtest"],
-      "tasks": {
-        "nx-dev-ui-home:xtest": {
-          "id": "nx-dev-ui-home:xtest",
-          "target": { "project": "nx-dev-ui-home", "target": "xtest" },
-          "projectRoot": "nx-dev/ui-home",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev-ui-home:xtest": [] }
-    },
-    "detox:lint": {
-      "roots": ["detox:lint"],
-      "tasks": {
-        "detox:lint": {
-          "id": "detox:lint",
-          "target": { "project": "detox", "target": "lint" },
-          "projectRoot": "packages/detox",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "detox:lint": [] }
-    },
-    "detox:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "detox:test": {
-          "id": "detox:test",
-          "target": { "project": "detox", "target": "test" },
-          "projectRoot": "packages/detox",
-          "overrides": {}
-        },
-        "detox:build": {
-          "id": "detox:build",
-          "target": { "project": "detox", "target": "build" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "detox:test": ["detox:build"],
-        "detox:build": ["detox:build-base"],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "detox:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "detox:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "detox:build": {
-          "id": "detox:build",
-          "target": { "project": "detox", "target": "build" },
-          "projectRoot": "packages/detox",
-          "overrides": {}
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "detox:build": ["detox:build-base"],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react:test": {
-          "id": "react:test",
-          "target": { "project": "react", "target": "test" },
-          "projectRoot": "packages/react",
-          "overrides": {}
-        },
-        "react:build": {
-          "id": "react:build",
-          "target": { "project": "react", "target": "build" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react:test": ["react:build"],
-        "react:build": ["react:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": {}
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "react:build": {
-          "id": "react:build",
-          "target": { "project": "react", "target": "build" },
-          "projectRoot": "packages/react",
-          "overrides": {}
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "react:build": ["react:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "react:lint": {
-      "roots": ["react:lint"],
-      "tasks": {
-        "react:lint": {
-          "id": "react:lint",
-          "target": { "project": "react", "target": "lint" },
-          "projectRoot": "packages/react",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "react:lint": [] }
-    },
-    "typedoc-theme:build-base": {
-      "roots": ["typedoc-theme:build-base"],
-      "tasks": {
-        "typedoc-theme:build-base": {
-          "id": "typedoc-theme:build-base",
-          "target": { "project": "typedoc-theme", "target": "build-base" },
-          "projectRoot": "typedoc-theme",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "typedoc-theme:build-base": [] }
-    },
-    "typedoc-theme:build": {
-      "roots": ["typedoc-theme:build-base"],
-      "tasks": {
-        "typedoc-theme:build": {
-          "id": "typedoc-theme:build",
-          "target": { "project": "typedoc-theme", "target": "build" },
-          "projectRoot": "typedoc-theme",
-          "overrides": {}
-        },
-        "typedoc-theme:build-base": {
-          "id": "typedoc-theme:build-base",
-          "target": { "project": "typedoc-theme", "target": "build-base" },
-          "projectRoot": "typedoc-theme",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "typedoc-theme:build": ["typedoc-theme:build-base"],
-        "typedoc-theme:build-base": []
-      }
-    },
-    "typedoc-theme:lint": {
-      "roots": ["typedoc-theme:lint"],
-      "tasks": {
-        "typedoc-theme:lint": {
-          "id": "typedoc-theme:lint",
-          "target": { "project": "typedoc-theme", "target": "lint" },
-          "projectRoot": "typedoc-theme",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "typedoc-theme:lint": [] }
-    },
-    "typedoc-theme:test": {
-      "roots": ["typedoc-theme:build-base"],
-      "tasks": {
-        "typedoc-theme:test": {
-          "id": "typedoc-theme:test",
-          "target": { "project": "typedoc-theme", "target": "test" },
-          "projectRoot": "typedoc-theme",
-          "overrides": {}
-        },
-        "typedoc-theme:build": {
-          "id": "typedoc-theme:build",
-          "target": { "project": "typedoc-theme", "target": "build" },
-          "projectRoot": "typedoc-theme",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "typedoc-theme:build-base": {
-          "id": "typedoc-theme:build-base",
-          "target": { "project": "typedoc-theme", "target": "build-base" },
-          "projectRoot": "typedoc-theme",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "typedoc-theme:test": ["typedoc-theme:build"],
-        "typedoc-theme:build": ["typedoc-theme:build-base"],
-        "typedoc-theme:build-base": []
-      }
-    },
-    "e2e-nx-plugin:e2e": {
-      "roots": ["e2e-nx-plugin:e2e"],
-      "tasks": {
-        "e2e-nx-plugin:e2e": {
-          "id": "e2e-nx-plugin:e2e",
-          "target": { "project": "e2e-nx-plugin", "target": "e2e" },
-          "projectRoot": "e2e/nx-plugin",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-plugin:e2e": [] }
-    },
-    "e2e-nx-plugin:run-e2e-tests": {
-      "roots": ["e2e-nx-plugin:run-e2e-tests"],
-      "tasks": {
-        "e2e-nx-plugin:run-e2e-tests": {
-          "id": "e2e-nx-plugin:run-e2e-tests",
-          "target": { "project": "e2e-nx-plugin", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/nx-plugin",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-plugin:run-e2e-tests": [] }
-    },
-    "e2e-storybook:e2e": {
-      "roots": ["e2e-storybook:e2e"],
-      "tasks": {
-        "e2e-storybook:e2e": {
-          "id": "e2e-storybook:e2e",
-          "target": { "project": "e2e-storybook", "target": "e2e" },
-          "projectRoot": "e2e/storybook",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-storybook:e2e": [] }
-    },
-    "e2e-storybook:run-e2e-tests": {
-      "roots": ["e2e-storybook:run-e2e-tests"],
-      "tasks": {
-        "e2e-storybook:run-e2e-tests": {
-          "id": "e2e-storybook:run-e2e-tests",
-          "target": { "project": "e2e-storybook", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/storybook",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-storybook:run-e2e-tests": [] }
-    },
-    "nx-dev:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-dev:build": {
-          "id": "nx-dev:build",
-          "target": { "project": "nx-dev", "target": "build" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "nx-dev:build-base": {
-          "id": "nx-dev:build-base",
-          "target": { "project": "nx-dev", "target": "build-base" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:build": ["nx-dev:build-base"],
-        "nx-dev:build-base": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev:sitemap": {
-      "roots": ["nx-dev:sitemap"],
-      "tasks": {
-        "nx-dev:sitemap": {
-          "id": "nx-dev:sitemap",
-          "target": { "project": "nx-dev", "target": "sitemap" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:sitemap": [] }
-    },
-    "nx-dev:sync-documentation": {
-      "roots": ["nx-dev:sync-documentation"],
-      "tasks": {
-        "nx-dev:sync-documentation": {
-          "id": "nx-dev:sync-documentation",
-          "target": { "project": "nx-dev", "target": "sync-documentation" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:sync-documentation": [] }
-    },
-    "nx-dev:generate-og-images": {
-      "roots": ["nx-dev:generate-og-images"],
-      "tasks": {
-        "nx-dev:generate-og-images": {
-          "id": "nx-dev:generate-og-images",
-          "target": { "project": "nx-dev", "target": "generate-og-images" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:generate-og-images": [] }
-    },
-    "nx-dev:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-dev:build-base": {
-          "id": "nx-dev:build-base",
-          "target": { "project": "nx-dev", "target": "build-base" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:build-base": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev:build-base:development": {
-      "roots": ["graph-client:build-base"],
-      "tasks": {
-        "nx-dev:build-base:development": {
-          "id": "nx-dev:build-base:development",
-          "target": {
-            "project": "nx-dev",
-            "target": "build-base",
-            "configuration": "development"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base": {
-          "id": "graph-client:build-base",
-          "target": { "project": "graph-client", "target": "build-base" },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:build-base:development": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base"],
-        "graph-client:build-base": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev:build-base:production": {
-      "roots": ["graph-client:build-base"],
-      "tasks": {
-        "nx-dev:build-base:production": {
-          "id": "nx-dev:build-base:production",
-          "target": {
-            "project": "nx-dev",
-            "target": "build-base",
-            "configuration": "production"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base": {
-          "id": "graph-client:build-base",
-          "target": { "project": "graph-client", "target": "build-base" },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:build-base:production": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base"],
-        "graph-client:build-base": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "nx-dev:serve": {
-      "roots": ["nx-dev:serve:development"],
-      "tasks": {
-        "nx-dev:serve:development": {
-          "id": "nx-dev:serve:development",
-          "target": {
-            "project": "nx-dev",
-            "target": "serve",
-            "configuration": "development"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:serve:development": [] }
-    },
-    "nx-dev:serve:production": {
-      "roots": ["nx-dev:serve:production"],
-      "tasks": {
-        "nx-dev:serve:production": {
-          "id": "nx-dev:serve:production",
-          "target": {
-            "project": "nx-dev",
-            "target": "serve",
-            "configuration": "production"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:serve:production": [] }
-    },
-    "nx-dev:serve:development": {
-      "roots": ["nx-dev:serve:development"],
-      "tasks": {
-        "nx-dev:serve:development": {
-          "id": "nx-dev:serve:development",
-          "target": {
-            "project": "nx-dev",
-            "target": "serve",
-            "configuration": "development"
-          },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:serve:development": [] }
-    },
-    "nx-dev:deploy-build": {
-      "roots": ["nx-dev:deploy-build"],
-      "tasks": {
-        "nx-dev:deploy-build": {
-          "id": "nx-dev:deploy-build",
-          "target": { "project": "nx-dev", "target": "deploy-build" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:deploy-build": [] }
-    },
-    "nx-dev:export": {
-      "roots": ["nx-dev:export"],
-      "tasks": {
-        "nx-dev:export": {
-          "id": "nx-dev:export",
-          "target": { "project": "nx-dev", "target": "export" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:export": [] }
-    },
-    "nx-dev:lint": {
-      "roots": ["nx-dev:lint"],
-      "tasks": {
-        "nx-dev:lint": {
-          "id": "nx-dev:lint",
-          "target": { "project": "nx-dev", "target": "lint" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx-dev:lint": [] }
-    },
-    "nx-dev:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx-dev:test": {
-          "id": "nx-dev:test",
-          "target": { "project": "nx-dev", "target": "test" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": {}
-        },
-        "nx-dev:build": {
-          "id": "nx-dev:build",
-          "target": { "project": "nx-dev", "target": "build" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx-dev:build-base": {
-          "id": "nx-dev:build-base",
-          "target": { "project": "nx-dev", "target": "build-base" },
-          "projectRoot": "nx-dev/nx-dev",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx-dev:test": ["nx-dev:build"],
-        "nx-dev:build": ["nx-dev:build-base"],
-        "nx-dev:build-base": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "expo:lint": {
-      "roots": ["expo:lint"],
-      "tasks": {
-        "expo:lint": {
-          "id": "expo:lint",
-          "target": { "project": "expo", "target": "lint" },
-          "projectRoot": "packages/expo",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "expo:lint": [] }
-    },
-    "expo:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "expo:test": {
-          "id": "expo:test",
-          "target": { "project": "expo", "target": "test" },
-          "projectRoot": "packages/expo",
-          "overrides": {}
-        },
-        "expo:build": {
-          "id": "expo:build",
-          "target": { "project": "expo", "target": "build" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "expo:test": ["expo:build"],
-        "expo:build": ["expo:build-base"],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "expo:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": {}
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "expo:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "expo:build": {
-          "id": "expo:build",
-          "target": { "project": "expo", "target": "build" },
-          "projectRoot": "packages/expo",
-          "overrides": {}
-        },
-        "expo:build-base": {
-          "id": "expo:build-base",
-          "target": { "project": "expo", "target": "build-base" },
-          "projectRoot": "packages/expo",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "detox:build-base": {
-          "id": "detox:build-base",
-          "target": { "project": "detox", "target": "build-base" },
-          "projectRoot": "packages/detox",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "expo:build": ["expo:build-base"],
-        "expo:build-base": [
-          "detox:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "detox:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "workspace:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "jest:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "jest:test": {
-          "id": "jest:test",
-          "target": { "project": "jest", "target": "test" },
-          "projectRoot": "packages/jest",
-          "overrides": {}
-        },
-        "jest:build": {
-          "id": "jest:build",
-          "target": { "project": "jest", "target": "build" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "jest:test": ["jest:build"],
-        "jest:build": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "jest:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "jest:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "jest:build": {
-          "id": "jest:build",
-          "target": { "project": "jest", "target": "build" },
-          "projectRoot": "packages/jest",
-          "overrides": {}
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "jest:build": ["jest:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"]
-      }
-    },
-    "jest:lint": {
-      "roots": ["jest:lint"],
-      "tasks": {
-        "jest:lint": {
-          "id": "jest:lint",
-          "target": { "project": "jest", "target": "lint" },
-          "projectRoot": "packages/jest",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "jest:lint": [] }
-    },
-    "nest:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nest:test": {
-          "id": "nest:test",
-          "target": { "project": "nest", "target": "test" },
-          "projectRoot": "packages/nest",
-          "overrides": {}
-        },
-        "nest:build": {
-          "id": "nest:build",
-          "target": { "project": "nest", "target": "build" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nest:test": ["nest:build"],
-        "nest:build": ["nest:build-base"],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "nest:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": {}
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "nest:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nest:build": {
-          "id": "nest:build",
-          "target": { "project": "nest", "target": "build" },
-          "projectRoot": "packages/nest",
-          "overrides": {}
-        },
-        "nest:build-base": {
-          "id": "nest:build-base",
-          "target": { "project": "nest", "target": "build-base" },
-          "projectRoot": "packages/nest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nest:build": ["nest:build-base"],
-        "nest:build-base": [
-          "node:build-base",
-          "linter:build-base",
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base"
-        ],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "nest:lint": {
-      "roots": ["nest:lint"],
-      "tasks": {
-        "nest:lint": {
-          "id": "nest:lint",
-          "target": { "project": "nest", "target": "lint" },
-          "projectRoot": "packages/nest",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nest:lint": [] }
-    },
-    "next:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "next:test": {
-          "id": "next:test",
-          "target": { "project": "next", "target": "test" },
-          "projectRoot": "packages/next",
-          "overrides": {}
-        },
-        "next:build": {
-          "id": "next:build",
-          "target": { "project": "next", "target": "build" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "next:test": ["next:build"],
-        "next:build": ["next:build-base"],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "next:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": {}
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "next:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "next:build": {
-          "id": "next:build",
-          "target": { "project": "next", "target": "build" },
-          "projectRoot": "packages/next",
-          "overrides": {}
-        },
-        "next:build-base": {
-          "id": "next:build-base",
-          "target": { "project": "next", "target": "build-base" },
-          "projectRoot": "packages/next",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "react:build-base": {
-          "id": "react:build-base",
-          "target": { "project": "react", "target": "build-base" },
-          "projectRoot": "packages/react",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "storybook:build-base": {
-          "id": "storybook:build-base",
-          "target": { "project": "storybook", "target": "build-base" },
-          "projectRoot": "packages/storybook",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "next:build": ["next:build-base"],
-        "next:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "linter:build-base",
-          "react:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "react:build-base": [
-          "web:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "cypress:build-base",
-          "webpack:build-base",
-          "nx:build-base",
-          "vite:build-base",
-          "jest:build-base",
-          "rollup:build-base",
-          "storybook:build-base"
-        ],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "storybook:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "next:lint": {
-      "roots": ["next:lint"],
-      "tasks": {
-        "next:lint": {
-          "id": "next:lint",
-          "target": { "project": "next", "target": "lint" },
-          "projectRoot": "packages/next",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "next:lint": [] }
-    },
-    "node:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "node:test": {
-          "id": "node:test",
-          "target": { "project": "node", "target": "test" },
-          "projectRoot": "packages/node",
-          "overrides": {}
-        },
-        "node:build": {
-          "id": "node:build",
-          "target": { "project": "node", "target": "build" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "node:test": ["node:build"],
-        "node:build": ["node:build-base"],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "node:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "node:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "node:build": {
-          "id": "node:build",
-          "target": { "project": "node", "target": "build" },
-          "projectRoot": "packages/node",
-          "overrides": {}
-        },
-        "node:build-base": {
-          "id": "node:build-base",
-          "target": { "project": "node", "target": "build-base" },
-          "projectRoot": "packages/node",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "node:build": ["node:build-base"],
-        "node:build-base": [
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "node:lint": {
-      "roots": ["node:lint"],
-      "tasks": {
-        "node:lint": {
-          "id": "node:lint",
-          "target": { "project": "node", "target": "lint" },
-          "projectRoot": "packages/node",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "node:lint": [] }
-    },
-    "vite:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "vite:test": {
-          "id": "vite:test",
-          "target": { "project": "vite", "target": "test" },
-          "projectRoot": "packages/vite",
-          "overrides": {}
-        },
-        "vite:build": {
-          "id": "vite:build",
-          "target": { "project": "vite", "target": "build" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "vite:test": ["vite:build"],
-        "vite:build": ["vite:build-base"],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "vite:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "vite:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "vite:build": {
-          "id": "vite:build",
-          "target": { "project": "vite", "target": "build" },
-          "projectRoot": "packages/vite",
-          "overrides": {}
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "vite:build": ["vite:build-base"],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "vite:lint": {
-      "roots": ["vite:lint"],
-      "tasks": {
-        "vite:lint": {
-          "id": "vite:lint",
-          "target": { "project": "vite", "target": "lint" },
-          "projectRoot": "packages/vite",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "vite:lint": [] }
-    },
-    "graph-client:generate-dev-environment-js": {
-      "roots": ["graph-client:generate-dev-environment-js"],
-      "tasks": {
-        "graph-client:generate-dev-environment-js": {
-          "id": "graph-client:generate-dev-environment-js",
-          "target": {
-            "project": "graph-client",
-            "target": "generate-dev-environment-js"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:generate-dev-environment-js": [] }
-    },
-    "graph-client:generate-graph-base": {
-      "roots": ["graph-client:generate-graph-base"],
-      "tasks": {
-        "graph-client:generate-graph-base": {
-          "id": "graph-client:generate-graph-base",
-          "target": {
-            "project": "graph-client",
-            "target": "generate-graph-base"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:generate-graph-base": [] }
-    },
-    "graph-client:generate-graph": {
-      "roots": ["graph-client:generate-graph"],
-      "tasks": {
-        "graph-client:generate-graph": {
-          "id": "graph-client:generate-graph",
-          "target": { "project": "graph-client", "target": "generate-graph" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:generate-graph": [] }
-    },
-    "graph-client:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:release": [] }
-    },
-    "graph-client:build-base:dev": {
-      "roots": ["graph-client:build-base:dev"],
-      "tasks": {
-        "graph-client:build-base:dev": {
-          "id": "graph-client:build-base:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:dev": [] }
-    },
-    "graph-client:build-base:dev-e2e": {
-      "roots": ["graph-client:build-base:dev-e2e"],
-      "tasks": {
-        "graph-client:build-base:dev-e2e": {
-          "id": "graph-client:build-base:dev-e2e",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "dev-e2e"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:dev-e2e": [] }
-    },
-    "graph-client:build-base:nx-console": {
-      "roots": ["graph-client:build-base:nx-console"],
-      "tasks": {
-        "graph-client:build-base:nx-console": {
-          "id": "graph-client:build-base:nx-console",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "nx-console"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:nx-console": [] }
-    },
-    "graph-client:build-base:release": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:release": [] }
-    },
-    "graph-client:build-base:release-static": {
-      "roots": ["graph-client:build-base:release-static"],
-      "tasks": {
-        "graph-client:build-base:release-static": {
-          "id": "graph-client:build-base:release-static",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release-static"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:release-static": [] }
-    },
-    "graph-client:build-base:watch": {
-      "roots": ["graph-client:build-base:watch"],
-      "tasks": {
-        "graph-client:build-base:watch": {
-          "id": "graph-client:build-base:watch",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "watch"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-base:watch": [] }
-    },
-    "graph-client:serve-base": {
-      "roots": ["graph-client:serve-base:dev"],
-      "tasks": {
-        "graph-client:serve-base:dev": {
-          "id": "graph-client:serve-base:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:dev": [] }
-    },
-    "graph-client:serve-base:dev": {
-      "roots": ["graph-client:serve-base:dev"],
-      "tasks": {
-        "graph-client:serve-base:dev": {
-          "id": "graph-client:serve-base:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:dev": [] }
-    },
-    "graph-client:serve-base:nx-console": {
-      "roots": ["graph-client:serve-base:nx-console"],
-      "tasks": {
-        "graph-client:serve-base:nx-console": {
-          "id": "graph-client:serve-base:nx-console",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "nx-console"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:nx-console": [] }
-    },
-    "graph-client:serve-base:release": {
-      "roots": ["graph-client:serve-base:release"],
-      "tasks": {
-        "graph-client:serve-base:release": {
-          "id": "graph-client:serve-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:release": [] }
-    },
-    "graph-client:serve-base:watch": {
-      "roots": ["graph-client:serve-base:watch"],
-      "tasks": {
-        "graph-client:serve-base:watch": {
-          "id": "graph-client:serve-base:watch",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "watch"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:watch": [] }
-    },
-    "graph-client:serve-base:release-static": {
-      "roots": ["graph-client:serve-base:release-static"],
-      "tasks": {
-        "graph-client:serve-base:release-static": {
-          "id": "graph-client:serve-base:release-static",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "release-static"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:release-static": [] }
-    },
-    "graph-client:serve-base:dev-e2e": {
-      "roots": ["graph-client:serve-base:dev-e2e"],
-      "tasks": {
-        "graph-client:serve-base:dev-e2e": {
-          "id": "graph-client:serve-base:dev-e2e",
-          "target": {
-            "project": "graph-client",
-            "target": "serve-base",
-            "configuration": "dev-e2e"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve-base:dev-e2e": [] }
-    },
-    "graph-client:serve": {
-      "roots": ["graph-client:serve:dev"],
-      "tasks": {
-        "graph-client:serve:dev": {
-          "id": "graph-client:serve:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:dev": [] }
-    },
-    "graph-client:serve:dev": {
-      "roots": ["graph-client:serve:dev"],
-      "tasks": {
-        "graph-client:serve:dev": {
-          "id": "graph-client:serve:dev",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "dev"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:dev": [] }
-    },
-    "graph-client:serve:release": {
-      "roots": ["graph-client:serve:release"],
-      "tasks": {
-        "graph-client:serve:release": {
-          "id": "graph-client:serve:release",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:release": [] }
-    },
-    "graph-client:serve:release-static": {
-      "roots": ["graph-client:serve:release-static"],
-      "tasks": {
-        "graph-client:serve:release-static": {
-          "id": "graph-client:serve:release-static",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "release-static"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:release-static": [] }
-    },
-    "graph-client:serve:watch": {
-      "roots": ["graph-client:serve:watch"],
-      "tasks": {
-        "graph-client:serve:watch": {
-          "id": "graph-client:serve:watch",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "watch"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:watch": [] }
-    },
-    "graph-client:serve:nx-console": {
-      "roots": ["graph-client:serve:nx-console"],
-      "tasks": {
-        "graph-client:serve:nx-console": {
-          "id": "graph-client:serve:nx-console",
-          "target": {
-            "project": "graph-client",
-            "target": "serve",
-            "configuration": "nx-console"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:serve:nx-console": [] }
-    },
-    "graph-client:lint": {
-      "roots": ["graph-client:lint"],
-      "tasks": {
-        "graph-client:lint": {
-          "id": "graph-client:lint",
-          "target": { "project": "graph-client", "target": "lint" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:lint": [] }
-    },
-    "graph-client:test": {
-      "roots": ["graph-client:test"],
-      "tasks": {
-        "graph-client:test": {
-          "id": "graph-client:test",
-          "target": { "project": "graph-client", "target": "test" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:test": [] }
-    },
-    "graph-client:storybook": {
-      "roots": ["graph-client:storybook"],
-      "tasks": {
-        "graph-client:storybook": {
-          "id": "graph-client:storybook",
-          "target": { "project": "graph-client", "target": "storybook" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:storybook": [] }
-    },
-    "graph-client:storybook:ci": {
-      "roots": ["graph-client:storybook:ci"],
-      "tasks": {
-        "graph-client:storybook:ci": {
-          "id": "graph-client:storybook:ci",
-          "target": {
-            "project": "graph-client",
-            "target": "storybook",
-            "configuration": "ci"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:storybook:ci": [] }
-    },
-    "graph-client:build-storybook": {
-      "roots": ["graph-client:build-storybook"],
-      "tasks": {
-        "graph-client:build-storybook": {
-          "id": "graph-client:build-storybook",
-          "target": { "project": "graph-client", "target": "build-storybook" },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-storybook": [] }
-    },
-    "graph-client:build-storybook:ci": {
-      "roots": ["graph-client:build-storybook:ci"],
-      "tasks": {
-        "graph-client:build-storybook:ci": {
-          "id": "graph-client:build-storybook:ci",
-          "target": {
-            "project": "graph-client",
-            "target": "build-storybook",
-            "configuration": "ci"
-          },
-          "projectRoot": "graph/client",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "graph-client:build-storybook:ci": [] }
-    },
-    "cli:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cli:test": {
-          "id": "cli:test",
-          "target": { "project": "cli", "target": "test" },
-          "projectRoot": "packages/cli",
-          "overrides": {}
-        },
-        "cli:build": {
-          "id": "cli:build",
-          "target": { "project": "cli", "target": "build" },
-          "projectRoot": "packages/cli",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cli:build-base": {
-          "id": "cli:build-base",
-          "target": { "project": "cli", "target": "build-base" },
-          "projectRoot": "packages/cli",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cli:test": ["cli:build"],
-        "cli:build": ["cli:build-base"],
-        "cli:build-base": ["workspace:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "cli:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cli:build-base": {
-          "id": "cli:build-base",
-          "target": { "project": "cli", "target": "build-base" },
-          "projectRoot": "packages/cli",
-          "overrides": {}
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cli:build-base": ["workspace:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "cli:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "cli:build": {
-          "id": "cli:build",
-          "target": { "project": "cli", "target": "build" },
-          "projectRoot": "packages/cli",
-          "overrides": {}
-        },
-        "cli:build-base": {
-          "id": "cli:build-base",
-          "target": { "project": "cli", "target": "build-base" },
-          "projectRoot": "packages/cli",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "cli:build": ["cli:build-base"],
-        "cli:build-base": ["workspace:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "cli:lint": {
-      "roots": ["cli:lint"],
-      "tasks": {
-        "cli:lint": {
-          "id": "cli:lint",
-          "target": { "project": "cli", "target": "lint" },
-          "projectRoot": "packages/cli",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "cli:lint": [] }
-    },
-    "tao:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "tao:test": {
-          "id": "tao:test",
-          "target": { "project": "tao", "target": "test" },
-          "projectRoot": "packages/tao",
-          "overrides": {}
-        },
-        "tao:build": {
-          "id": "tao:build",
-          "target": { "project": "tao", "target": "build" },
-          "projectRoot": "packages/tao",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "tao:build-base": {
-          "id": "tao:build-base",
-          "target": { "project": "tao", "target": "build-base" },
-          "projectRoot": "packages/tao",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "tao:test": ["tao:build"],
-        "tao:build": ["tao:build-base"],
-        "tao:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "tao:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "tao:build-base": {
-          "id": "tao:build-base",
-          "target": { "project": "tao", "target": "build-base" },
-          "projectRoot": "packages/tao",
-          "overrides": {}
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "tao:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "tao:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "tao:build": {
-          "id": "tao:build",
-          "target": { "project": "tao", "target": "build" },
-          "projectRoot": "packages/tao",
-          "overrides": {}
-        },
-        "tao:build-base": {
-          "id": "tao:build-base",
-          "target": { "project": "tao", "target": "build-base" },
-          "projectRoot": "packages/tao",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "tao:build": ["tao:build-base"],
-        "tao:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "tao:lint": {
-      "roots": ["tao:lint"],
-      "tasks": {
-        "tao:lint": {
-          "id": "tao:lint",
-          "target": { "project": "tao", "target": "lint" },
-          "projectRoot": "packages/tao",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "tao:lint": [] }
-    },
-    "web:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "web:test": {
-          "id": "web:test",
-          "target": { "project": "web", "target": "test" },
-          "projectRoot": "packages/web",
-          "overrides": {}
-        },
-        "web:build": {
-          "id": "web:build",
-          "target": { "project": "web", "target": "build" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "web:test": ["web:build"],
-        "web:build": ["web:build-base"],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "web:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": {}
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "web:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "web:build": {
-          "id": "web:build",
-          "target": { "project": "web", "target": "build" },
-          "projectRoot": "packages/web",
-          "overrides": {}
-        },
-        "web:build-base": {
-          "id": "web:build-base",
-          "target": { "project": "web", "target": "build-base" },
-          "projectRoot": "packages/web",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "cypress:build-base": {
-          "id": "cypress:build-base",
-          "target": { "project": "cypress", "target": "build-base" },
-          "projectRoot": "packages/cypress",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "rollup:build-base": {
-          "id": "rollup:build-base",
-          "target": { "project": "rollup", "target": "build-base" },
-          "projectRoot": "packages/rollup",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "vite:build-base": {
-          "id": "vite:build-base",
-          "target": { "project": "vite", "target": "build-base" },
-          "projectRoot": "packages/vite",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "webpack:build-base": {
-          "id": "webpack:build-base",
-          "target": { "project": "webpack", "target": "build-base" },
-          "projectRoot": "packages/webpack",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "web:build": ["web:build-base"],
-        "web:build-base": [
-          "cypress:build-base",
-          "devkit:build-base",
-          "jest:build-base",
-          "js:build-base",
-          "linter:build-base",
-          "rollup:build-base",
-          "vite:build-base",
-          "webpack:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "cypress:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "rollup:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "vite:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "js:build-base",
-          "nx:build-base"
-        ],
-        "webpack:build-base": [
-          "devkit:build-base",
-          "js:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "web:lint": {
-      "roots": ["web:lint"],
-      "tasks": {
-        "web:lint": {
-          "id": "web:lint",
-          "target": { "project": "web", "target": "lint" },
-          "projectRoot": "packages/web",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "web:lint": [] }
-    },
-    "e2e-cypress:e2e": {
-      "roots": ["e2e-cypress:e2e"],
-      "tasks": {
-        "e2e-cypress:e2e": {
-          "id": "e2e-cypress:e2e",
-          "target": { "project": "e2e-cypress", "target": "e2e" },
-          "projectRoot": "e2e/cypress",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-cypress:e2e": [] }
-    },
-    "e2e-cypress:run-e2e-tests": {
-      "roots": ["e2e-cypress:run-e2e-tests"],
-      "tasks": {
-        "e2e-cypress:run-e2e-tests": {
-          "id": "e2e-cypress:run-e2e-tests",
-          "target": { "project": "e2e-cypress", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/cypress",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-cypress:run-e2e-tests": [] }
-    },
-    "e2e-esbuild:e2e": {
-      "roots": ["e2e-esbuild:e2e"],
-      "tasks": {
-        "e2e-esbuild:e2e": {
-          "id": "e2e-esbuild:e2e",
-          "target": { "project": "e2e-esbuild", "target": "e2e" },
-          "projectRoot": "e2e/esbuild",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-esbuild:e2e": [] }
-    },
-    "e2e-esbuild:run-e2e-tests": {
-      "roots": ["e2e-esbuild:run-e2e-tests"],
-      "tasks": {
-        "e2e-esbuild:run-e2e-tests": {
-          "id": "e2e-esbuild:run-e2e-tests",
-          "target": { "project": "e2e-esbuild", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/esbuild",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-esbuild:run-e2e-tests": [] }
-    },
-    "e2e-nx-init:e2e": {
-      "roots": ["e2e-nx-init:e2e"],
-      "tasks": {
-        "e2e-nx-init:e2e": {
-          "id": "e2e-nx-init:e2e",
-          "target": { "project": "e2e-nx-init", "target": "e2e" },
-          "projectRoot": "e2e/nx-init",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-init:e2e": [] }
-    },
-    "e2e-nx-init:run-e2e-tests": {
-      "roots": ["e2e-nx-init:run-e2e-tests"],
-      "tasks": {
-        "e2e-nx-init:run-e2e-tests": {
-          "id": "e2e-nx-init:run-e2e-tests",
-          "target": { "project": "e2e-nx-init", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/nx-init",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-init:run-e2e-tests": [] }
-    },
-    "e2e-nx-misc:e2e": {
-      "roots": ["e2e-nx-misc:e2e"],
-      "tasks": {
-        "e2e-nx-misc:e2e": {
-          "id": "e2e-nx-misc:e2e",
-          "target": { "project": "e2e-nx-misc", "target": "e2e" },
-          "projectRoot": "e2e/nx-misc",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-misc:e2e": [] }
-    },
-    "e2e-nx-misc:run-e2e-tests": {
-      "roots": ["e2e-nx-misc:run-e2e-tests"],
-      "tasks": {
-        "e2e-nx-misc:run-e2e-tests": {
-          "id": "e2e-nx-misc:run-e2e-tests",
-          "target": { "project": "e2e-nx-misc", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/nx-misc",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-misc:run-e2e-tests": [] }
-    },
-    "e2e-webpack:e2e": {
-      "roots": ["e2e-webpack:e2e"],
-      "tasks": {
-        "e2e-webpack:e2e": {
-          "id": "e2e-webpack:e2e",
-          "target": { "project": "e2e-webpack", "target": "e2e" },
-          "projectRoot": "e2e/webpack",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-webpack:e2e": [] }
-    },
-    "e2e-webpack:run-e2e-tests": {
-      "roots": ["e2e-webpack:run-e2e-tests"],
-      "tasks": {
-        "e2e-webpack:run-e2e-tests": {
-          "id": "e2e-webpack:run-e2e-tests",
-          "target": { "project": "e2e-webpack", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/webpack",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-webpack:run-e2e-tests": [] }
-    },
-    "js:lint": {
-      "roots": ["js:lint"],
-      "tasks": {
-        "js:lint": {
-          "id": "js:lint",
-          "target": { "project": "js", "target": "lint" },
-          "projectRoot": "packages/js",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "js:lint": [] }
-    },
-    "js:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "js:test": {
-          "id": "js:test",
-          "target": { "project": "js", "target": "test" },
-          "projectRoot": "packages/js",
-          "overrides": {}
-        },
-        "js:build": {
-          "id": "js:build",
-          "target": { "project": "js", "target": "build" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "js:test": ["js:build"],
-        "js:build": ["js:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "js:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": {}
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "js:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "js:build": {
-          "id": "js:build",
-          "target": { "project": "js", "target": "build" },
-          "projectRoot": "packages/js",
-          "overrides": {}
-        },
-        "js:build-base": {
-          "id": "js:build-base",
-          "target": { "project": "js", "target": "build-base" },
-          "projectRoot": "packages/js",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "devkit:build-base": {
-          "id": "devkit:build-base",
-          "target": { "project": "devkit", "target": "build-base" },
-          "projectRoot": "packages/devkit",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "linter:build-base": {
-          "id": "linter:build-base",
-          "target": { "project": "linter", "target": "build-base" },
-          "projectRoot": "packages/linter",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "eslint-plugin-nx:build-base": {
-          "id": "eslint-plugin-nx:build-base",
-          "target": { "project": "eslint-plugin-nx", "target": "build-base" },
-          "projectRoot": "packages/eslint-plugin-nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "workspace:build-base": {
-          "id": "workspace:build-base",
-          "target": { "project": "workspace", "target": "build-base" },
-          "projectRoot": "packages/workspace",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "jest:build-base": {
-          "id": "jest:build-base",
-          "target": { "project": "jest", "target": "build-base" },
-          "projectRoot": "packages/jest",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "js:build": ["js:build-base"],
-        "js:build-base": [
-          "devkit:build-base",
-          "linter:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ],
-        "devkit:build-base": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": [],
-        "linter:build-base": [
-          "eslint-plugin-nx:build-base",
-          "devkit:build-base",
-          "nx:build-base",
-          "workspace:build-base",
-          "jest:build-base"
-        ],
-        "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
-        "workspace:build-base": ["devkit:build-base", "nx:build-base"],
-        "jest:build-base": [
-          "devkit:build-base",
-          "workspace:build-base",
-          "nx:build-base"
-        ]
-      }
-    },
-    "nx:postinstall": {
-      "roots": ["nx:postinstall"],
-      "tasks": {
-        "nx:postinstall": {
-          "id": "nx:postinstall",
-          "target": { "project": "nx", "target": "postinstall" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx:postinstall": [] }
-    },
-    "nx:build-base": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "nx:echo": {
-      "roots": ["nx:echo"],
-      "tasks": {
-        "nx:echo": {
-          "id": "nx:echo",
-          "target": { "project": "nx", "target": "echo" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx:echo": [] }
-    },
-    "nx:build": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx:build": {
-          "id": "nx:build",
-          "target": { "project": "nx", "target": "build" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx:build": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "nx:lint": {
-      "roots": ["nx:lint"],
-      "tasks": {
-        "nx:lint": {
-          "id": "nx:lint",
-          "target": { "project": "nx", "target": "lint" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "nx:lint": [] }
-    },
-    "nx:test": {
-      "roots": ["graph-client:build-base:release"],
-      "tasks": {
-        "nx:test": {
-          "id": "nx:test",
-          "target": { "project": "nx", "target": "test" },
-          "projectRoot": "packages/nx",
-          "overrides": {}
-        },
-        "nx:build": {
-          "id": "nx:build",
-          "target": { "project": "nx", "target": "build" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "nx:build-base": {
-          "id": "nx:build-base",
-          "target": { "project": "nx", "target": "build-base" },
-          "projectRoot": "packages/nx",
-          "overrides": { "__overrides_unparsed__": [] }
-        },
-        "graph-client:build-base:release": {
-          "id": "graph-client:build-base:release",
-          "target": {
-            "project": "graph-client",
-            "target": "build-base",
-            "configuration": "release"
-          },
-          "projectRoot": "graph/client",
-          "overrides": { "__overrides_unparsed__": [] }
-        }
-      },
-      "dependencies": {
-        "nx:test": ["nx:build"],
-        "nx:build": ["nx:build-base"],
-        "nx:build-base": ["graph-client:build-base:release"],
-        "graph-client:build-base:release": []
-      }
-    },
-    "e2e-linter:e2e": {
-      "roots": ["e2e-linter:e2e"],
-      "tasks": {
-        "e2e-linter:e2e": {
-          "id": "e2e-linter:e2e",
-          "target": { "project": "e2e-linter", "target": "e2e" },
-          "projectRoot": "e2e/linter",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-linter:e2e": [] }
-    },
-    "e2e-linter:run-e2e-tests": {
-      "roots": ["e2e-linter:run-e2e-tests"],
-      "tasks": {
-        "e2e-linter:run-e2e-tests": {
-          "id": "e2e-linter:run-e2e-tests",
-          "target": { "project": "e2e-linter", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/linter",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-linter:run-e2e-tests": [] }
-    },
-    "e2e-nx-run:e2e": {
-      "roots": ["e2e-nx-run:e2e"],
-      "tasks": {
-        "e2e-nx-run:e2e": {
-          "id": "e2e-nx-run:e2e",
-          "target": { "project": "e2e-nx-run", "target": "e2e" },
-          "projectRoot": "e2e/nx-run",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-run:e2e": [] }
-    },
-    "e2e-nx-run:run-e2e-tests": {
-      "roots": ["e2e-nx-run:run-e2e-tests"],
-      "tasks": {
-        "e2e-nx-run:run-e2e-tests": {
-          "id": "e2e-nx-run:run-e2e-tests",
-          "target": { "project": "e2e-nx-run", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/nx-run",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-nx-run:run-e2e-tests": [] }
-    },
-    "e2e-rollup:e2e": {
-      "roots": ["e2e-rollup:e2e"],
-      "tasks": {
-        "e2e-rollup:e2e": {
-          "id": "e2e-rollup:e2e",
-          "target": { "project": "e2e-rollup", "target": "e2e" },
-          "projectRoot": "e2e/rollup",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-rollup:e2e": [] }
-    },
-    "e2e-rollup:run-e2e-tests": {
-      "roots": ["e2e-rollup:run-e2e-tests"],
-      "tasks": {
-        "e2e-rollup:run-e2e-tests": {
-          "id": "e2e-rollup:run-e2e-tests",
-          "target": { "project": "e2e-rollup", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/rollup",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-rollup:run-e2e-tests": [] }
-    },
-    "e2e-detox:e2e": {
-      "roots": ["e2e-detox:e2e"],
-      "tasks": {
-        "e2e-detox:e2e": {
-          "id": "e2e-detox:e2e",
-          "target": { "project": "e2e-detox", "target": "e2e" },
-          "projectRoot": "e2e/detox",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-detox:e2e": [] }
-    },
-    "e2e-detox:run-e2e-tests": {
-      "roots": ["e2e-detox:run-e2e-tests"],
-      "tasks": {
-        "e2e-detox:run-e2e-tests": {
-          "id": "e2e-detox:run-e2e-tests",
-          "target": { "project": "e2e-detox", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/detox",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-detox:run-e2e-tests": [] }
-    },
-    "e2e-react:e2e": {
-      "roots": ["e2e-react:e2e"],
-      "tasks": {
-        "e2e-react:e2e": {
-          "id": "e2e-react:e2e",
-          "target": { "project": "e2e-react", "target": "e2e" },
-          "projectRoot": "e2e/react",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-react:e2e": [] }
-    },
-    "e2e-react:run-e2e-tests": {
-      "roots": ["e2e-react:run-e2e-tests"],
-      "tasks": {
-        "e2e-react:run-e2e-tests": {
-          "id": "e2e-react:run-e2e-tests",
-          "target": { "project": "e2e-react", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/react",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-react:run-e2e-tests": [] }
-    },
-    "e2e-expo:e2e": {
-      "roots": ["e2e-expo:e2e"],
-      "tasks": {
-        "e2e-expo:e2e": {
-          "id": "e2e-expo:e2e",
-          "target": { "project": "e2e-expo", "target": "e2e" },
-          "projectRoot": "e2e/expo",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-expo:e2e": [] }
-    },
-    "e2e-expo:run-e2e-tests": {
-      "roots": ["e2e-expo:run-e2e-tests"],
-      "tasks": {
-        "e2e-expo:run-e2e-tests": {
-          "id": "e2e-expo:run-e2e-tests",
-          "target": { "project": "e2e-expo", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/expo",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-expo:run-e2e-tests": [] }
-    },
-    "e2e-jest:e2e": {
-      "roots": ["e2e-jest:e2e"],
-      "tasks": {
-        "e2e-jest:e2e": {
-          "id": "e2e-jest:e2e",
-          "target": { "project": "e2e-jest", "target": "e2e" },
-          "projectRoot": "e2e/jest",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-jest:e2e": [] }
-    },
-    "e2e-jest:run-e2e-tests": {
-      "roots": ["e2e-jest:run-e2e-tests"],
-      "tasks": {
-        "e2e-jest:run-e2e-tests": {
-          "id": "e2e-jest:run-e2e-tests",
-          "target": { "project": "e2e-jest", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/jest",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-jest:run-e2e-tests": [] }
-    },
-    "e2e-next:e2e": {
-      "roots": ["e2e-next:e2e"],
-      "tasks": {
-        "e2e-next:e2e": {
-          "id": "e2e-next:e2e",
-          "target": { "project": "e2e-next", "target": "e2e" },
-          "projectRoot": "e2e/next",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-next:e2e": [] }
-    },
-    "e2e-next:run-e2e-tests": {
-      "roots": ["e2e-next:run-e2e-tests"],
-      "tasks": {
-        "e2e-next:run-e2e-tests": {
-          "id": "e2e-next:run-e2e-tests",
-          "target": { "project": "e2e-next", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/next",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-next:run-e2e-tests": [] }
-    },
-    "e2e-node:e2e": {
-      "roots": ["e2e-node:e2e"],
-      "tasks": {
-        "e2e-node:e2e": {
-          "id": "e2e-node:e2e",
-          "target": { "project": "e2e-node", "target": "e2e" },
-          "projectRoot": "e2e/node",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-node:e2e": [] }
-    },
-    "e2e-node:run-e2e-tests": {
-      "roots": ["e2e-node:run-e2e-tests"],
-      "tasks": {
-        "e2e-node:run-e2e-tests": {
-          "id": "e2e-node:run-e2e-tests",
-          "target": { "project": "e2e-node", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/node",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-node:run-e2e-tests": [] }
-    },
-    "e2e-vite:e2e": {
-      "roots": ["e2e-vite:e2e"],
-      "tasks": {
-        "e2e-vite:e2e": {
-          "id": "e2e-vite:e2e",
-          "target": { "project": "e2e-vite", "target": "e2e" },
-          "projectRoot": "e2e/vite",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-vite:e2e": [] }
-    },
-    "e2e-vite:run-e2e-tests": {
-      "roots": ["e2e-vite:run-e2e-tests"],
-      "tasks": {
-        "e2e-vite:run-e2e-tests": {
-          "id": "e2e-vite:run-e2e-tests",
-          "target": { "project": "e2e-vite", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/vite",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-vite:run-e2e-tests": [] }
-    },
-    "e2e-web:e2e": {
-      "roots": ["e2e-web:e2e"],
-      "tasks": {
-        "e2e-web:e2e": {
-          "id": "e2e-web:e2e",
-          "target": { "project": "e2e-web", "target": "e2e" },
-          "projectRoot": "e2e/web",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-web:e2e": [] }
-    },
-    "e2e-web:run-e2e-tests": {
-      "roots": ["e2e-web:run-e2e-tests"],
-      "tasks": {
-        "e2e-web:run-e2e-tests": {
-          "id": "e2e-web:run-e2e-tests",
-          "target": { "project": "e2e-web", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/web",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-web:run-e2e-tests": [] }
-    },
-    "e2e-js:e2e": {
-      "roots": ["e2e-js:e2e"],
-      "tasks": {
-        "e2e-js:e2e": {
-          "id": "e2e-js:e2e",
-          "target": { "project": "e2e-js", "target": "e2e" },
-          "projectRoot": "e2e/js",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-js:e2e": [] }
-    },
-    "e2e-js:run-e2e-tests": {
-      "roots": ["e2e-js:run-e2e-tests"],
-      "tasks": {
-        "e2e-js:run-e2e-tests": {
-          "id": "e2e-js:run-e2e-tests",
-          "target": { "project": "e2e-js", "target": "run-e2e-tests" },
-          "projectRoot": "e2e/js",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "e2e-js:run-e2e-tests": [] }
-    },
-    "@nrwl/nx-source:check-commit": {
-      "roots": ["@nrwl/nx-source:check-commit"],
-      "tasks": {
-        "@nrwl/nx-source:check-commit": {
-          "id": "@nrwl/nx-source:check-commit",
-          "target": { "project": "@nrwl/nx-source", "target": "check-commit" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:check-commit": [] }
-    },
-    "@nrwl/nx-source:check-format": {
-      "roots": ["@nrwl/nx-source:check-format"],
-      "tasks": {
-        "@nrwl/nx-source:check-format": {
-          "id": "@nrwl/nx-source:check-format",
-          "target": { "project": "@nrwl/nx-source", "target": "check-format" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:check-format": [] }
-    },
-    "@nrwl/nx-source:check-imports": {
-      "roots": ["@nrwl/nx-source:check-imports"],
-      "tasks": {
-        "@nrwl/nx-source:check-imports": {
-          "id": "@nrwl/nx-source:check-imports",
-          "target": { "project": "@nrwl/nx-source", "target": "check-imports" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:check-imports": [] }
-    },
-    "@nrwl/nx-source:check-lock-files": {
-      "roots": ["@nrwl/nx-source:check-lock-files"],
-      "tasks": {
-        "@nrwl/nx-source:check-lock-files": {
-          "id": "@nrwl/nx-source:check-lock-files",
-          "target": {
-            "project": "@nrwl/nx-source",
-            "target": "check-lock-files"
-          },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:check-lock-files": [] }
-    },
-    "@nrwl/nx-source:depcheck": {
-      "roots": ["@nrwl/nx-source:depcheck"],
-      "tasks": {
-        "@nrwl/nx-source:depcheck": {
-          "id": "@nrwl/nx-source:depcheck",
-          "target": { "project": "@nrwl/nx-source", "target": "depcheck" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:depcheck": [] }
-    },
-    "@nrwl/nx-source:documentation": {
-      "roots": ["@nrwl/nx-source:documentation"],
-      "tasks": {
-        "@nrwl/nx-source:documentation": {
-          "id": "@nrwl/nx-source:documentation",
-          "target": { "project": "@nrwl/nx-source", "target": "documentation" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:documentation": [] }
-    },
-    "@nrwl/nx-source:echo": {
-      "roots": ["@nrwl/nx-source:echo"],
-      "tasks": {
-        "@nrwl/nx-source:echo": {
-          "id": "@nrwl/nx-source:echo",
-          "target": { "project": "@nrwl/nx-source", "target": "echo" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:echo": [] }
-    },
-    "@nrwl/nx-source:lint": {
-      "roots": ["@nrwl/nx-source:lint"],
-      "tasks": {
-        "@nrwl/nx-source:lint": {
-          "id": "@nrwl/nx-source:lint",
-          "target": { "project": "@nrwl/nx-source", "target": "lint" },
-          "projectRoot": ".",
-          "overrides": {}
-        }
-      },
-      "dependencies": { "@nrwl/nx-source:lint": [] }
+  "taskIds": ["create-nx-workspace:test"],
+  "taskGraph": {
+    "roots": [
+      "nx-dev-feature-package-schema-viewer:lint",
+      "nx-dev-feature-package-schema-viewer:test",
+      "nx-dev-data-access-documents:lint",
+      "nx-dev-data-access-documents:test",
+      "graph-client:build-base:release",
+      "create-nx-workspace:lint",
+      "nx-dev-data-access-packages:lint",
+      "nx-dev-data-access-packages:test",
+      "nx-dev-feature-doc-viewer:lint",
+      "nx-dev-feature-doc-viewer:test",
+      "create-nx-plugin:lint",
+      "eslint-plugin-nx:lint",
+      "nx-dev-feature-analytics:lint",
+      "nx-dev-feature-analytics:test",
+      "nx-dev-data-access-menu:lint",
+      "nx-dev-data-access-menu:test",
+      "e2e-angular-extensions:e2e",
+      "e2e-angular-extensions:run-e2e-tests",
+      "nx-dev-models-document:lint",
+      "nx-dev-models-document:test",
+      "nx-dev-ui-sponsor-card:lint",
+      "nx-dev-ui-sponsor-card:test",
+      "e2e-storybook-angular:e2e",
+      "e2e-storybook-angular:run-e2e-tests",
+      "nx-dev-feature-search:lint",
+      "nx-dev-feature-search:test",
+      "nx-dev-models-package:lint",
+      "nx-dev-models-package:test",
+      "nx-dev-ui-member-card:lint",
+      "nx-dev-ui-member-card:test",
+      "react-native:lint",
+      "e2e-workspace-create:e2e",
+      "e2e-workspace-create:run-e2e-tests",
+      "nx-dev-ui-conference:lint",
+      "nx-dev-ui-conference:test",
+      "nx-dev-ui-references:lint",
+      "nx-dev-ui-references:test",
+      "nx-dev-ui-community:lint",
+      "nx-dev-ui-community:test",
+      "nx-dev-models-menu:lint",
+      "nx-dev-models-menu:test",
+      "nx-dev-ui-commands:lint",
+      "nx-dev-ui-commands:test",
+      "nx-plugin:lint",
+      "storybook:lint",
+      "workspace:lint",
+      "eslint-rules:test",
+      "nx-dev-e2e:lint",
+      "nx-dev-ui-markdoc:lint",
+      "nx-dev-ui-markdoc:test",
+      "e2e-angular-core:e2e",
+      "e2e-angular-core:run-e2e-tests",
+      "e2e-react-native:e2e",
+      "e2e-react-native:run-e2e-tests",
+      "e2e-graph-client:e2e-base:dev",
+      "e2e-graph-client:e2e-base:watch",
+      "e2e-graph-client:e2e-base:release",
+      "e2e-graph-client:e2e-base:release-static",
+      "e2e-graph-client:e2e-local",
+      "e2e-graph-client:e2e",
+      "e2e-graph-client:lint",
+      "nx-dev-ui-common:lint",
+      "nx-dev-ui-common:test",
+      "angular:postinstall",
+      "angular:lint",
+      "cypress:lint",
+      "esbuild:lint",
+      "express:lint",
+      "webpack:lint",
+      "nx-dev-ui-theme:lint",
+      "nx-dev-ui-theme:test",
+      "devkit:lint",
+      "linter:lint",
+      "rollup:lint",
+      "graph-ui-graph:lint",
+      "graph-ui-graph:test",
+      "graph-ui-graph:storybook",
+      "graph-ui-graph:storybook:ci",
+      "graph-ui-graph:build-storybook",
+      "graph-ui-graph:build-storybook:ci",
+      "nx-dev-ui-home:lint",
+      "nx-dev-ui-home:xtest",
+      "detox:lint",
+      "react:lint",
+      "typedoc-theme:build-base",
+      "typedoc-theme:lint",
+      "e2e-nx-plugin:e2e",
+      "e2e-nx-plugin:run-e2e-tests",
+      "e2e-storybook:e2e",
+      "e2e-storybook:run-e2e-tests",
+      "nx-dev:sitemap",
+      "nx-dev:sync-documentation",
+      "nx-dev:generate-og-images",
+      "graph-client:build-base",
+      "nx-dev:serve:development",
+      "nx-dev:serve:production",
+      "nx-dev:deploy-build",
+      "nx-dev:export",
+      "nx-dev:lint",
+      "expo:lint",
+      "jest:lint",
+      "nest:lint",
+      "next:lint",
+      "node:lint",
+      "vite:lint",
+      "graph-client:generate-dev-environment-js",
+      "graph-client:generate-graph-base",
+      "graph-client:generate-graph",
+      "graph-client:build-base:dev",
+      "graph-client:build-base:dev-e2e",
+      "graph-client:build-base:nx-console",
+      "graph-client:build-base:release-static",
+      "graph-client:build-base:watch",
+      "graph-client:serve-base:dev",
+      "graph-client:serve-base:nx-console",
+      "graph-client:serve-base:release",
+      "graph-client:serve-base:watch",
+      "graph-client:serve-base:release-static",
+      "graph-client:serve-base:dev-e2e",
+      "graph-client:serve:dev",
+      "graph-client:serve:release",
+      "graph-client:serve:release-static",
+      "graph-client:serve:watch",
+      "graph-client:serve:nx-console",
+      "graph-client:lint",
+      "graph-client:test",
+      "graph-client:storybook",
+      "graph-client:storybook:ci",
+      "graph-client:build-storybook",
+      "graph-client:build-storybook:ci",
+      "cli:lint",
+      "tao:lint",
+      "web:lint",
+      "e2e-cypress:e2e",
+      "e2e-cypress:run-e2e-tests",
+      "e2e-esbuild:e2e",
+      "e2e-esbuild:run-e2e-tests",
+      "e2e-nx-init:e2e",
+      "e2e-nx-init:run-e2e-tests",
+      "e2e-nx-misc:e2e",
+      "e2e-nx-misc:run-e2e-tests",
+      "e2e-webpack:e2e",
+      "e2e-webpack:run-e2e-tests",
+      "js:lint",
+      "nx:postinstall",
+      "nx:echo",
+      "nx:lint",
+      "e2e-linter:e2e",
+      "e2e-linter:run-e2e-tests",
+      "e2e-nx-run:e2e",
+      "e2e-nx-run:run-e2e-tests",
+      "e2e-rollup:e2e",
+      "e2e-rollup:run-e2e-tests",
+      "e2e-detox:e2e",
+      "e2e-detox:run-e2e-tests",
+      "e2e-react:e2e",
+      "e2e-react:run-e2e-tests",
+      "e2e-expo:e2e",
+      "e2e-expo:run-e2e-tests",
+      "e2e-jest:e2e",
+      "e2e-jest:run-e2e-tests",
+      "e2e-next:e2e",
+      "e2e-next:run-e2e-tests",
+      "e2e-node:e2e",
+      "e2e-node:run-e2e-tests",
+      "e2e-vite:e2e",
+      "e2e-vite:run-e2e-tests",
+      "e2e-web:e2e",
+      "e2e-web:run-e2e-tests",
+      "e2e-js:e2e",
+      "e2e-js:run-e2e-tests",
+      "@nrwl/nx-source:check-commit",
+      "@nrwl/nx-source:check-format",
+      "@nrwl/nx-source:check-imports",
+      "@nrwl/nx-source:check-lock-files",
+      "@nrwl/nx-source:depcheck",
+      "@nrwl/nx-source:documentation",
+      "@nrwl/nx-source:echo",
+      "@nrwl/nx-source:lint"
+    ],
+    "tasks": {
+      "nx-dev-feature-package-schema-viewer:lint": {
+        "id": "nx-dev-feature-package-schema-viewer:lint",
+        "target": {
+          "project": "nx-dev-feature-package-schema-viewer",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/feature-package-schema-viewer",
+        "overrides": {}
+      },
+      "nx-dev-feature-package-schema-viewer:test": {
+        "id": "nx-dev-feature-package-schema-viewer:test",
+        "target": {
+          "project": "nx-dev-feature-package-schema-viewer",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/feature-package-schema-viewer",
+        "overrides": {}
+      },
+      "nx-dev-data-access-documents:lint": {
+        "id": "nx-dev-data-access-documents:lint",
+        "target": {
+          "project": "nx-dev-data-access-documents",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/data-access-documents",
+        "overrides": {}
+      },
+      "nx-dev-data-access-documents:test": {
+        "id": "nx-dev-data-access-documents:test",
+        "target": {
+          "project": "nx-dev-data-access-documents",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/data-access-documents",
+        "overrides": {}
+      },
+      "create-nx-workspace:test": {
+        "id": "create-nx-workspace:test",
+        "target": {
+          "project": "create-nx-workspace",
+          "target": "test"
+        },
+        "projectRoot": "packages/create-nx-workspace",
+        "overrides": {}
+      },
+      "create-nx-workspace:build": {
+        "id": "create-nx-workspace:build",
+        "target": {
+          "project": "create-nx-workspace",
+          "target": "build"
+        },
+        "projectRoot": "packages/create-nx-workspace",
+        "overrides": {}
+      },
+      "create-nx-workspace:build-base": {
+        "id": "create-nx-workspace:build-base",
+        "target": {
+          "project": "create-nx-workspace",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/create-nx-workspace",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "workspace:build-base": {
+        "id": "workspace:build-base",
+        "target": {
+          "project": "workspace",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/workspace",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "devkit:build-base": {
+        "id": "devkit:build-base",
+        "target": {
+          "project": "devkit",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/devkit",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx:build-base": {
+        "id": "nx:build-base",
+        "target": {
+          "project": "nx",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "graph-client:build-base:release": {
+        "id": "graph-client:build-base:release",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "release"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "js:build-base": {
+        "id": "js:build-base",
+        "target": {
+          "project": "js",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/js",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "linter:build-base": {
+        "id": "linter:build-base",
+        "target": {
+          "project": "linter",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/linter",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "eslint-plugin-nx:build-base": {
+        "id": "eslint-plugin-nx:build-base",
+        "target": {
+          "project": "eslint-plugin-nx",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/eslint-plugin-nx",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "jest:build-base": {
+        "id": "jest:build-base",
+        "target": {
+          "project": "jest",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/jest",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "react:build-base": {
+        "id": "react:build-base",
+        "target": {
+          "project": "react",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/react",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "web:build-base": {
+        "id": "web:build-base",
+        "target": {
+          "project": "web",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/web",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "cypress:build-base": {
+        "id": "cypress:build-base",
+        "target": {
+          "project": "cypress",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/cypress",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "rollup:build-base": {
+        "id": "rollup:build-base",
+        "target": {
+          "project": "rollup",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/rollup",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "vite:build-base": {
+        "id": "vite:build-base",
+        "target": {
+          "project": "vite",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/vite",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "webpack:build-base": {
+        "id": "webpack:build-base",
+        "target": {
+          "project": "webpack",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/webpack",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "storybook:build-base": {
+        "id": "storybook:build-base",
+        "target": {
+          "project": "storybook",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/storybook",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "expo:build-base": {
+        "id": "expo:build-base",
+        "target": {
+          "project": "expo",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/expo",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "detox:build-base": {
+        "id": "detox:build-base",
+        "target": {
+          "project": "detox",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/detox",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "next:build-base": {
+        "id": "next:build-base",
+        "target": {
+          "project": "next",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/next",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "angular:build-base": {
+        "id": "angular:build-base",
+        "target": {
+          "project": "angular",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nest:build-base": {
+        "id": "nest:build-base",
+        "target": {
+          "project": "nest",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/nest",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "node:build-base": {
+        "id": "node:build-base",
+        "target": {
+          "project": "node",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/node",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "express:build-base": {
+        "id": "express:build-base",
+        "target": {
+          "project": "express",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/express",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "create-nx-workspace:lint": {
+        "id": "create-nx-workspace:lint",
+        "target": {
+          "project": "create-nx-workspace",
+          "target": "lint"
+        },
+        "projectRoot": "packages/create-nx-workspace",
+        "overrides": {}
+      },
+      "nx-dev-data-access-packages:lint": {
+        "id": "nx-dev-data-access-packages:lint",
+        "target": {
+          "project": "nx-dev-data-access-packages",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/data-access-packages",
+        "overrides": {}
+      },
+      "nx-dev-data-access-packages:test": {
+        "id": "nx-dev-data-access-packages:test",
+        "target": {
+          "project": "nx-dev-data-access-packages",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/data-access-packages",
+        "overrides": {}
+      },
+      "nx-dev-feature-doc-viewer:lint": {
+        "id": "nx-dev-feature-doc-viewer:lint",
+        "target": {
+          "project": "nx-dev-feature-doc-viewer",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/feature-doc-viewer",
+        "overrides": {}
+      },
+      "nx-dev-feature-doc-viewer:test": {
+        "id": "nx-dev-feature-doc-viewer:test",
+        "target": {
+          "project": "nx-dev-feature-doc-viewer",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/feature-doc-viewer",
+        "overrides": {}
+      },
+      "create-nx-plugin:test": {
+        "id": "create-nx-plugin:test",
+        "target": {
+          "project": "create-nx-plugin",
+          "target": "test"
+        },
+        "projectRoot": "packages/create-nx-plugin",
+        "overrides": {}
+      },
+      "create-nx-plugin:build": {
+        "id": "create-nx-plugin:build",
+        "target": {
+          "project": "create-nx-plugin",
+          "target": "build"
+        },
+        "projectRoot": "packages/create-nx-plugin",
+        "overrides": {}
+      },
+      "create-nx-plugin:build-base": {
+        "id": "create-nx-plugin:build-base",
+        "target": {
+          "project": "create-nx-plugin",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/create-nx-plugin",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx-plugin:build-base": {
+        "id": "nx-plugin:build-base",
+        "target": {
+          "project": "nx-plugin",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/nx-plugin",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "create-nx-plugin:lint": {
+        "id": "create-nx-plugin:lint",
+        "target": {
+          "project": "create-nx-plugin",
+          "target": "lint"
+        },
+        "projectRoot": "packages/create-nx-plugin",
+        "overrides": {}
+      },
+      "eslint-plugin-nx:test": {
+        "id": "eslint-plugin-nx:test",
+        "target": {
+          "project": "eslint-plugin-nx",
+          "target": "test"
+        },
+        "projectRoot": "packages/eslint-plugin-nx",
+        "overrides": {}
+      },
+      "eslint-plugin-nx:build": {
+        "id": "eslint-plugin-nx:build",
+        "target": {
+          "project": "eslint-plugin-nx",
+          "target": "build"
+        },
+        "projectRoot": "packages/eslint-plugin-nx",
+        "overrides": {}
+      },
+      "eslint-plugin-nx:lint": {
+        "id": "eslint-plugin-nx:lint",
+        "target": {
+          "project": "eslint-plugin-nx",
+          "target": "lint"
+        },
+        "projectRoot": "packages/eslint-plugin-nx",
+        "overrides": {}
+      },
+      "nx-dev-feature-analytics:lint": {
+        "id": "nx-dev-feature-analytics:lint",
+        "target": {
+          "project": "nx-dev-feature-analytics",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/feature-analytics",
+        "overrides": {}
+      },
+      "nx-dev-feature-analytics:test": {
+        "id": "nx-dev-feature-analytics:test",
+        "target": {
+          "project": "nx-dev-feature-analytics",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/feature-analytics",
+        "overrides": {}
+      },
+      "nx-dev-data-access-menu:lint": {
+        "id": "nx-dev-data-access-menu:lint",
+        "target": {
+          "project": "nx-dev-data-access-menu",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/data-access-menu",
+        "overrides": {}
+      },
+      "nx-dev-data-access-menu:test": {
+        "id": "nx-dev-data-access-menu:test",
+        "target": {
+          "project": "nx-dev-data-access-menu",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/data-access-menu",
+        "overrides": {}
+      },
+      "e2e-angular-extensions:e2e": {
+        "id": "e2e-angular-extensions:e2e",
+        "target": {
+          "project": "e2e-angular-extensions",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/angular-extensions",
+        "overrides": {}
+      },
+      "e2e-angular-extensions:run-e2e-tests": {
+        "id": "e2e-angular-extensions:run-e2e-tests",
+        "target": {
+          "project": "e2e-angular-extensions",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/angular-extensions",
+        "overrides": {}
+      },
+      "nx-dev-models-document:lint": {
+        "id": "nx-dev-models-document:lint",
+        "target": {
+          "project": "nx-dev-models-document",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/models-document",
+        "overrides": {}
+      },
+      "nx-dev-models-document:test": {
+        "id": "nx-dev-models-document:test",
+        "target": {
+          "project": "nx-dev-models-document",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/models-document",
+        "overrides": {}
+      },
+      "nx-dev-ui-sponsor-card:lint": {
+        "id": "nx-dev-ui-sponsor-card:lint",
+        "target": {
+          "project": "nx-dev-ui-sponsor-card",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-sponsor-card",
+        "overrides": {}
+      },
+      "nx-dev-ui-sponsor-card:test": {
+        "id": "nx-dev-ui-sponsor-card:test",
+        "target": {
+          "project": "nx-dev-ui-sponsor-card",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-sponsor-card",
+        "overrides": {}
+      },
+      "e2e-storybook-angular:e2e": {
+        "id": "e2e-storybook-angular:e2e",
+        "target": {
+          "project": "e2e-storybook-angular",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/storybook-angular",
+        "overrides": {}
+      },
+      "e2e-storybook-angular:run-e2e-tests": {
+        "id": "e2e-storybook-angular:run-e2e-tests",
+        "target": {
+          "project": "e2e-storybook-angular",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/storybook-angular",
+        "overrides": {}
+      },
+      "nx-dev-feature-search:lint": {
+        "id": "nx-dev-feature-search:lint",
+        "target": {
+          "project": "nx-dev-feature-search",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/feature-search",
+        "overrides": {}
+      },
+      "nx-dev-feature-search:test": {
+        "id": "nx-dev-feature-search:test",
+        "target": {
+          "project": "nx-dev-feature-search",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/feature-search",
+        "overrides": {}
+      },
+      "nx-dev-models-package:lint": {
+        "id": "nx-dev-models-package:lint",
+        "target": {
+          "project": "nx-dev-models-package",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/models-package",
+        "overrides": {}
+      },
+      "nx-dev-models-package:test": {
+        "id": "nx-dev-models-package:test",
+        "target": {
+          "project": "nx-dev-models-package",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/models-package",
+        "overrides": {}
+      },
+      "nx-dev-ui-member-card:lint": {
+        "id": "nx-dev-ui-member-card:lint",
+        "target": {
+          "project": "nx-dev-ui-member-card",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-member-card",
+        "overrides": {}
+      },
+      "nx-dev-ui-member-card:test": {
+        "id": "nx-dev-ui-member-card:test",
+        "target": {
+          "project": "nx-dev-ui-member-card",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-member-card",
+        "overrides": {}
+      },
+      "react-native:lint": {
+        "id": "react-native:lint",
+        "target": {
+          "project": "react-native",
+          "target": "lint"
+        },
+        "projectRoot": "packages/react-native",
+        "overrides": {}
+      },
+      "react-native:test": {
+        "id": "react-native:test",
+        "target": {
+          "project": "react-native",
+          "target": "test"
+        },
+        "projectRoot": "packages/react-native",
+        "overrides": {}
+      },
+      "react-native:build": {
+        "id": "react-native:build",
+        "target": {
+          "project": "react-native",
+          "target": "build"
+        },
+        "projectRoot": "packages/react-native",
+        "overrides": {}
+      },
+      "react-native:build-base": {
+        "id": "react-native:build-base",
+        "target": {
+          "project": "react-native",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/react-native",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "e2e-workspace-create:e2e": {
+        "id": "e2e-workspace-create:e2e",
+        "target": {
+          "project": "e2e-workspace-create",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/workspace-create",
+        "overrides": {}
+      },
+      "e2e-workspace-create:run-e2e-tests": {
+        "id": "e2e-workspace-create:run-e2e-tests",
+        "target": {
+          "project": "e2e-workspace-create",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/workspace-create",
+        "overrides": {}
+      },
+      "nx-dev-ui-conference:lint": {
+        "id": "nx-dev-ui-conference:lint",
+        "target": {
+          "project": "nx-dev-ui-conference",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-conference",
+        "overrides": {}
+      },
+      "nx-dev-ui-conference:test": {
+        "id": "nx-dev-ui-conference:test",
+        "target": {
+          "project": "nx-dev-ui-conference",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-conference",
+        "overrides": {}
+      },
+      "nx-dev-ui-references:lint": {
+        "id": "nx-dev-ui-references:lint",
+        "target": {
+          "project": "nx-dev-ui-references",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-references",
+        "overrides": {}
+      },
+      "nx-dev-ui-references:test": {
+        "id": "nx-dev-ui-references:test",
+        "target": {
+          "project": "nx-dev-ui-references",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-references",
+        "overrides": {}
+      },
+      "nx-dev-ui-community:lint": {
+        "id": "nx-dev-ui-community:lint",
+        "target": {
+          "project": "nx-dev-ui-community",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-community",
+        "overrides": {}
+      },
+      "nx-dev-ui-community:test": {
+        "id": "nx-dev-ui-community:test",
+        "target": {
+          "project": "nx-dev-ui-community",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-community",
+        "overrides": {}
+      },
+      "nx-dev-models-menu:lint": {
+        "id": "nx-dev-models-menu:lint",
+        "target": {
+          "project": "nx-dev-models-menu",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/models-menu",
+        "overrides": {}
+      },
+      "nx-dev-models-menu:test": {
+        "id": "nx-dev-models-menu:test",
+        "target": {
+          "project": "nx-dev-models-menu",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/models-menu",
+        "overrides": {}
+      },
+      "nx-dev-ui-commands:lint": {
+        "id": "nx-dev-ui-commands:lint",
+        "target": {
+          "project": "nx-dev-ui-commands",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-commands",
+        "overrides": {}
+      },
+      "nx-dev-ui-commands:test": {
+        "id": "nx-dev-ui-commands:test",
+        "target": {
+          "project": "nx-dev-ui-commands",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-commands",
+        "overrides": {}
+      },
+      "nx-plugin:test": {
+        "id": "nx-plugin:test",
+        "target": {
+          "project": "nx-plugin",
+          "target": "test"
+        },
+        "projectRoot": "packages/nx-plugin",
+        "overrides": {}
+      },
+      "nx-plugin:build": {
+        "id": "nx-plugin:build",
+        "target": {
+          "project": "nx-plugin",
+          "target": "build"
+        },
+        "projectRoot": "packages/nx-plugin",
+        "overrides": {}
+      },
+      "nx-plugin:lint": {
+        "id": "nx-plugin:lint",
+        "target": {
+          "project": "nx-plugin",
+          "target": "lint"
+        },
+        "projectRoot": "packages/nx-plugin",
+        "overrides": {}
+      },
+      "storybook:test": {
+        "id": "storybook:test",
+        "target": {
+          "project": "storybook",
+          "target": "test"
+        },
+        "projectRoot": "packages/storybook",
+        "overrides": {}
+      },
+      "storybook:build": {
+        "id": "storybook:build",
+        "target": {
+          "project": "storybook",
+          "target": "build"
+        },
+        "projectRoot": "packages/storybook",
+        "overrides": {}
+      },
+      "storybook:lint": {
+        "id": "storybook:lint",
+        "target": {
+          "project": "storybook",
+          "target": "lint"
+        },
+        "projectRoot": "packages/storybook",
+        "overrides": {}
+      },
+      "workspace:test": {
+        "id": "workspace:test",
+        "target": {
+          "project": "workspace",
+          "target": "test"
+        },
+        "projectRoot": "packages/workspace",
+        "overrides": {}
+      },
+      "workspace:build": {
+        "id": "workspace:build",
+        "target": {
+          "project": "workspace",
+          "target": "build"
+        },
+        "projectRoot": "packages/workspace",
+        "overrides": {}
+      },
+      "workspace:lint": {
+        "id": "workspace:lint",
+        "target": {
+          "project": "workspace",
+          "target": "lint"
+        },
+        "projectRoot": "packages/workspace",
+        "overrides": {}
+      },
+      "eslint-rules:test": {
+        "id": "eslint-rules:test",
+        "target": {
+          "project": "eslint-rules",
+          "target": "test"
+        },
+        "projectRoot": "tools/eslint-rules",
+        "overrides": {}
+      },
+      "nx-dev-e2e:e2e": {
+        "id": "nx-dev-e2e:e2e",
+        "target": {
+          "project": "nx-dev-e2e",
+          "target": "e2e"
+        },
+        "projectRoot": "nx-dev/nx-dev-e2e",
+        "overrides": {}
+      },
+      "nx-dev:build-base": {
+        "id": "nx-dev:build-base",
+        "target": {
+          "project": "nx-dev",
+          "target": "build-base"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx-dev-e2e:lint": {
+        "id": "nx-dev-e2e:lint",
+        "target": {
+          "project": "nx-dev-e2e",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/nx-dev-e2e",
+        "overrides": {}
+      },
+      "nx-dev-ui-markdoc:lint": {
+        "id": "nx-dev-ui-markdoc:lint",
+        "target": {
+          "project": "nx-dev-ui-markdoc",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-markdoc",
+        "overrides": {}
+      },
+      "nx-dev-ui-markdoc:test": {
+        "id": "nx-dev-ui-markdoc:test",
+        "target": {
+          "project": "nx-dev-ui-markdoc",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-markdoc",
+        "overrides": {}
+      },
+      "e2e-angular-core:e2e": {
+        "id": "e2e-angular-core:e2e",
+        "target": {
+          "project": "e2e-angular-core",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/angular-core",
+        "overrides": {}
+      },
+      "e2e-angular-core:run-e2e-tests": {
+        "id": "e2e-angular-core:run-e2e-tests",
+        "target": {
+          "project": "e2e-angular-core",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/angular-core",
+        "overrides": {}
+      },
+      "e2e-react-native:e2e": {
+        "id": "e2e-react-native:e2e",
+        "target": {
+          "project": "e2e-react-native",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/react-native",
+        "overrides": {}
+      },
+      "e2e-react-native:run-e2e-tests": {
+        "id": "e2e-react-native:run-e2e-tests",
+        "target": {
+          "project": "e2e-react-native",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/react-native",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-base:dev": {
+        "id": "e2e-graph-client:e2e-base:dev",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-base",
+          "configuration": "dev"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-base:watch": {
+        "id": "e2e-graph-client:e2e-base:watch",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-base",
+          "configuration": "watch"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-base:release": {
+        "id": "e2e-graph-client:e2e-base:release",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-base",
+          "configuration": "release"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-base:release-static": {
+        "id": "e2e-graph-client:e2e-base:release-static",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-base",
+          "configuration": "release-static"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e-local": {
+        "id": "e2e-graph-client:e2e-local",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e-local"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:e2e": {
+        "id": "e2e-graph-client:e2e",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "e2e"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "e2e-graph-client:lint": {
+        "id": "e2e-graph-client:lint",
+        "target": {
+          "project": "e2e-graph-client",
+          "target": "lint"
+        },
+        "projectRoot": "graph/client-e2e",
+        "overrides": {}
+      },
+      "nx-dev-ui-common:lint": {
+        "id": "nx-dev-ui-common:lint",
+        "target": {
+          "project": "nx-dev-ui-common",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-common",
+        "overrides": {}
+      },
+      "nx-dev-ui-common:test": {
+        "id": "nx-dev-ui-common:test",
+        "target": {
+          "project": "nx-dev-ui-common",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-common",
+        "overrides": {}
+      },
+      "angular:postinstall": {
+        "id": "angular:postinstall",
+        "target": {
+          "project": "angular",
+          "target": "postinstall"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {}
+      },
+      "angular:test": {
+        "id": "angular:test",
+        "target": {
+          "project": "angular",
+          "target": "test"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {}
+      },
+      "angular:build": {
+        "id": "angular:build",
+        "target": {
+          "project": "angular",
+          "target": "build"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {}
+      },
+      "angular:lint": {
+        "id": "angular:lint",
+        "target": {
+          "project": "angular",
+          "target": "lint"
+        },
+        "projectRoot": "packages/angular",
+        "overrides": {}
+      },
+      "cypress:test": {
+        "id": "cypress:test",
+        "target": {
+          "project": "cypress",
+          "target": "test"
+        },
+        "projectRoot": "packages/cypress",
+        "overrides": {}
+      },
+      "cypress:build": {
+        "id": "cypress:build",
+        "target": {
+          "project": "cypress",
+          "target": "build"
+        },
+        "projectRoot": "packages/cypress",
+        "overrides": {}
+      },
+      "cypress:lint": {
+        "id": "cypress:lint",
+        "target": {
+          "project": "cypress",
+          "target": "lint"
+        },
+        "projectRoot": "packages/cypress",
+        "overrides": {}
+      },
+      "esbuild:test": {
+        "id": "esbuild:test",
+        "target": {
+          "project": "esbuild",
+          "target": "test"
+        },
+        "projectRoot": "packages/esbuild",
+        "overrides": {}
+      },
+      "esbuild:build": {
+        "id": "esbuild:build",
+        "target": {
+          "project": "esbuild",
+          "target": "build"
+        },
+        "projectRoot": "packages/esbuild",
+        "overrides": {}
+      },
+      "esbuild:build-base": {
+        "id": "esbuild:build-base",
+        "target": {
+          "project": "esbuild",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/esbuild",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "esbuild:lint": {
+        "id": "esbuild:lint",
+        "target": {
+          "project": "esbuild",
+          "target": "lint"
+        },
+        "projectRoot": "packages/esbuild",
+        "overrides": {}
+      },
+      "express:test": {
+        "id": "express:test",
+        "target": {
+          "project": "express",
+          "target": "test"
+        },
+        "projectRoot": "packages/express",
+        "overrides": {}
+      },
+      "express:build": {
+        "id": "express:build",
+        "target": {
+          "project": "express",
+          "target": "build"
+        },
+        "projectRoot": "packages/express",
+        "overrides": {}
+      },
+      "express:lint": {
+        "id": "express:lint",
+        "target": {
+          "project": "express",
+          "target": "lint"
+        },
+        "projectRoot": "packages/express",
+        "overrides": {}
+      },
+      "webpack:test": {
+        "id": "webpack:test",
+        "target": {
+          "project": "webpack",
+          "target": "test"
+        },
+        "projectRoot": "packages/webpack",
+        "overrides": {}
+      },
+      "webpack:build": {
+        "id": "webpack:build",
+        "target": {
+          "project": "webpack",
+          "target": "build"
+        },
+        "projectRoot": "packages/webpack",
+        "overrides": {}
+      },
+      "webpack:lint": {
+        "id": "webpack:lint",
+        "target": {
+          "project": "webpack",
+          "target": "lint"
+        },
+        "projectRoot": "packages/webpack",
+        "overrides": {}
+      },
+      "nx-dev-ui-theme:lint": {
+        "id": "nx-dev-ui-theme:lint",
+        "target": {
+          "project": "nx-dev-ui-theme",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-theme",
+        "overrides": {}
+      },
+      "nx-dev-ui-theme:test": {
+        "id": "nx-dev-ui-theme:test",
+        "target": {
+          "project": "nx-dev-ui-theme",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/ui-theme",
+        "overrides": {}
+      },
+      "devkit:test": {
+        "id": "devkit:test",
+        "target": {
+          "project": "devkit",
+          "target": "test"
+        },
+        "projectRoot": "packages/devkit",
+        "overrides": {}
+      },
+      "devkit:build": {
+        "id": "devkit:build",
+        "target": {
+          "project": "devkit",
+          "target": "build"
+        },
+        "projectRoot": "packages/devkit",
+        "overrides": {}
+      },
+      "devkit:lint": {
+        "id": "devkit:lint",
+        "target": {
+          "project": "devkit",
+          "target": "lint"
+        },
+        "projectRoot": "packages/devkit",
+        "overrides": {}
+      },
+      "linter:test": {
+        "id": "linter:test",
+        "target": {
+          "project": "linter",
+          "target": "test"
+        },
+        "projectRoot": "packages/linter",
+        "overrides": {}
+      },
+      "linter:build": {
+        "id": "linter:build",
+        "target": {
+          "project": "linter",
+          "target": "build"
+        },
+        "projectRoot": "packages/linter",
+        "overrides": {}
+      },
+      "linter:lint": {
+        "id": "linter:lint",
+        "target": {
+          "project": "linter",
+          "target": "lint"
+        },
+        "projectRoot": "packages/linter",
+        "overrides": {}
+      },
+      "rollup:test": {
+        "id": "rollup:test",
+        "target": {
+          "project": "rollup",
+          "target": "test"
+        },
+        "projectRoot": "packages/rollup",
+        "overrides": {}
+      },
+      "rollup:build": {
+        "id": "rollup:build",
+        "target": {
+          "project": "rollup",
+          "target": "build"
+        },
+        "projectRoot": "packages/rollup",
+        "overrides": {}
+      },
+      "rollup:lint": {
+        "id": "rollup:lint",
+        "target": {
+          "project": "rollup",
+          "target": "lint"
+        },
+        "projectRoot": "packages/rollup",
+        "overrides": {}
+      },
+      "graph-ui-graph:lint": {
+        "id": "graph-ui-graph:lint",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "lint"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:test": {
+        "id": "graph-ui-graph:test",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "test"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:storybook": {
+        "id": "graph-ui-graph:storybook",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "storybook"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:storybook:ci": {
+        "id": "graph-ui-graph:storybook:ci",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "storybook",
+          "configuration": "ci"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:build-storybook": {
+        "id": "graph-ui-graph:build-storybook",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "build-storybook"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "graph-ui-graph:build-storybook:ci": {
+        "id": "graph-ui-graph:build-storybook:ci",
+        "target": {
+          "project": "graph-ui-graph",
+          "target": "build-storybook",
+          "configuration": "ci"
+        },
+        "projectRoot": "graph/ui-graph",
+        "overrides": {}
+      },
+      "nx-dev-ui-home:lint": {
+        "id": "nx-dev-ui-home:lint",
+        "target": {
+          "project": "nx-dev-ui-home",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/ui-home",
+        "overrides": {}
+      },
+      "nx-dev-ui-home:xtest": {
+        "id": "nx-dev-ui-home:xtest",
+        "target": {
+          "project": "nx-dev-ui-home",
+          "target": "xtest"
+        },
+        "projectRoot": "nx-dev/ui-home",
+        "overrides": {}
+      },
+      "detox:lint": {
+        "id": "detox:lint",
+        "target": {
+          "project": "detox",
+          "target": "lint"
+        },
+        "projectRoot": "packages/detox",
+        "overrides": {}
+      },
+      "detox:test": {
+        "id": "detox:test",
+        "target": {
+          "project": "detox",
+          "target": "test"
+        },
+        "projectRoot": "packages/detox",
+        "overrides": {}
+      },
+      "detox:build": {
+        "id": "detox:build",
+        "target": {
+          "project": "detox",
+          "target": "build"
+        },
+        "projectRoot": "packages/detox",
+        "overrides": {}
+      },
+      "react:test": {
+        "id": "react:test",
+        "target": {
+          "project": "react",
+          "target": "test"
+        },
+        "projectRoot": "packages/react",
+        "overrides": {}
+      },
+      "react:build": {
+        "id": "react:build",
+        "target": {
+          "project": "react",
+          "target": "build"
+        },
+        "projectRoot": "packages/react",
+        "overrides": {}
+      },
+      "react:lint": {
+        "id": "react:lint",
+        "target": {
+          "project": "react",
+          "target": "lint"
+        },
+        "projectRoot": "packages/react",
+        "overrides": {}
+      },
+      "typedoc-theme:build-base": {
+        "id": "typedoc-theme:build-base",
+        "target": {
+          "project": "typedoc-theme",
+          "target": "build-base"
+        },
+        "projectRoot": "typedoc-theme",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "typedoc-theme:build": {
+        "id": "typedoc-theme:build",
+        "target": {
+          "project": "typedoc-theme",
+          "target": "build"
+        },
+        "projectRoot": "typedoc-theme",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "typedoc-theme:lint": {
+        "id": "typedoc-theme:lint",
+        "target": {
+          "project": "typedoc-theme",
+          "target": "lint"
+        },
+        "projectRoot": "typedoc-theme",
+        "overrides": {}
+      },
+      "typedoc-theme:test": {
+        "id": "typedoc-theme:test",
+        "target": {
+          "project": "typedoc-theme",
+          "target": "test"
+        },
+        "projectRoot": "typedoc-theme",
+        "overrides": {}
+      },
+      "e2e-nx-plugin:e2e": {
+        "id": "e2e-nx-plugin:e2e",
+        "target": {
+          "project": "e2e-nx-plugin",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/nx-plugin",
+        "overrides": {}
+      },
+      "e2e-nx-plugin:run-e2e-tests": {
+        "id": "e2e-nx-plugin:run-e2e-tests",
+        "target": {
+          "project": "e2e-nx-plugin",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/nx-plugin",
+        "overrides": {}
+      },
+      "e2e-storybook:e2e": {
+        "id": "e2e-storybook:e2e",
+        "target": {
+          "project": "e2e-storybook",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/storybook",
+        "overrides": {}
+      },
+      "e2e-storybook:run-e2e-tests": {
+        "id": "e2e-storybook:run-e2e-tests",
+        "target": {
+          "project": "e2e-storybook",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/storybook",
+        "overrides": {}
+      },
+      "nx-dev:build": {
+        "id": "nx-dev:build",
+        "target": {
+          "project": "nx-dev",
+          "target": "build"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx-dev:sitemap": {
+        "id": "nx-dev:sitemap",
+        "target": {
+          "project": "nx-dev",
+          "target": "sitemap"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:sync-documentation": {
+        "id": "nx-dev:sync-documentation",
+        "target": {
+          "project": "nx-dev",
+          "target": "sync-documentation"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:generate-og-images": {
+        "id": "nx-dev:generate-og-images",
+        "target": {
+          "project": "nx-dev",
+          "target": "generate-og-images"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:build-base:development": {
+        "id": "nx-dev:build-base:development",
+        "target": {
+          "project": "nx-dev",
+          "target": "build-base",
+          "configuration": "development"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "graph-client:build-base": {
+        "id": "graph-client:build-base",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx-dev:build-base:production": {
+        "id": "nx-dev:build-base:production",
+        "target": {
+          "project": "nx-dev",
+          "target": "build-base",
+          "configuration": "production"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:serve:development": {
+        "id": "nx-dev:serve:development",
+        "target": {
+          "project": "nx-dev",
+          "target": "serve",
+          "configuration": "development"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:serve:production": {
+        "id": "nx-dev:serve:production",
+        "target": {
+          "project": "nx-dev",
+          "target": "serve",
+          "configuration": "production"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:deploy-build": {
+        "id": "nx-dev:deploy-build",
+        "target": {
+          "project": "nx-dev",
+          "target": "deploy-build"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:export": {
+        "id": "nx-dev:export",
+        "target": {
+          "project": "nx-dev",
+          "target": "export"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:lint": {
+        "id": "nx-dev:lint",
+        "target": {
+          "project": "nx-dev",
+          "target": "lint"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "nx-dev:test": {
+        "id": "nx-dev:test",
+        "target": {
+          "project": "nx-dev",
+          "target": "test"
+        },
+        "projectRoot": "nx-dev/nx-dev",
+        "overrides": {}
+      },
+      "expo:lint": {
+        "id": "expo:lint",
+        "target": {
+          "project": "expo",
+          "target": "lint"
+        },
+        "projectRoot": "packages/expo",
+        "overrides": {}
+      },
+      "expo:test": {
+        "id": "expo:test",
+        "target": {
+          "project": "expo",
+          "target": "test"
+        },
+        "projectRoot": "packages/expo",
+        "overrides": {}
+      },
+      "expo:build": {
+        "id": "expo:build",
+        "target": {
+          "project": "expo",
+          "target": "build"
+        },
+        "projectRoot": "packages/expo",
+        "overrides": {}
+      },
+      "jest:test": {
+        "id": "jest:test",
+        "target": {
+          "project": "jest",
+          "target": "test"
+        },
+        "projectRoot": "packages/jest",
+        "overrides": {}
+      },
+      "jest:build": {
+        "id": "jest:build",
+        "target": {
+          "project": "jest",
+          "target": "build"
+        },
+        "projectRoot": "packages/jest",
+        "overrides": {}
+      },
+      "jest:lint": {
+        "id": "jest:lint",
+        "target": {
+          "project": "jest",
+          "target": "lint"
+        },
+        "projectRoot": "packages/jest",
+        "overrides": {}
+      },
+      "nest:test": {
+        "id": "nest:test",
+        "target": {
+          "project": "nest",
+          "target": "test"
+        },
+        "projectRoot": "packages/nest",
+        "overrides": {}
+      },
+      "nest:build": {
+        "id": "nest:build",
+        "target": {
+          "project": "nest",
+          "target": "build"
+        },
+        "projectRoot": "packages/nest",
+        "overrides": {}
+      },
+      "nest:lint": {
+        "id": "nest:lint",
+        "target": {
+          "project": "nest",
+          "target": "lint"
+        },
+        "projectRoot": "packages/nest",
+        "overrides": {}
+      },
+      "next:test": {
+        "id": "next:test",
+        "target": {
+          "project": "next",
+          "target": "test"
+        },
+        "projectRoot": "packages/next",
+        "overrides": {}
+      },
+      "next:build": {
+        "id": "next:build",
+        "target": {
+          "project": "next",
+          "target": "build"
+        },
+        "projectRoot": "packages/next",
+        "overrides": {}
+      },
+      "next:lint": {
+        "id": "next:lint",
+        "target": {
+          "project": "next",
+          "target": "lint"
+        },
+        "projectRoot": "packages/next",
+        "overrides": {}
+      },
+      "node:test": {
+        "id": "node:test",
+        "target": {
+          "project": "node",
+          "target": "test"
+        },
+        "projectRoot": "packages/node",
+        "overrides": {}
+      },
+      "node:build": {
+        "id": "node:build",
+        "target": {
+          "project": "node",
+          "target": "build"
+        },
+        "projectRoot": "packages/node",
+        "overrides": {}
+      },
+      "node:lint": {
+        "id": "node:lint",
+        "target": {
+          "project": "node",
+          "target": "lint"
+        },
+        "projectRoot": "packages/node",
+        "overrides": {}
+      },
+      "vite:test": {
+        "id": "vite:test",
+        "target": {
+          "project": "vite",
+          "target": "test"
+        },
+        "projectRoot": "packages/vite",
+        "overrides": {}
+      },
+      "vite:build": {
+        "id": "vite:build",
+        "target": {
+          "project": "vite",
+          "target": "build"
+        },
+        "projectRoot": "packages/vite",
+        "overrides": {}
+      },
+      "vite:lint": {
+        "id": "vite:lint",
+        "target": {
+          "project": "vite",
+          "target": "lint"
+        },
+        "projectRoot": "packages/vite",
+        "overrides": {}
+      },
+      "graph-client:generate-dev-environment-js": {
+        "id": "graph-client:generate-dev-environment-js",
+        "target": {
+          "project": "graph-client",
+          "target": "generate-dev-environment-js"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:generate-graph-base": {
+        "id": "graph-client:generate-graph-base",
+        "target": {
+          "project": "graph-client",
+          "target": "generate-graph-base"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:generate-graph": {
+        "id": "graph-client:generate-graph",
+        "target": {
+          "project": "graph-client",
+          "target": "generate-graph"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:dev": {
+        "id": "graph-client:build-base:dev",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "dev"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:dev-e2e": {
+        "id": "graph-client:build-base:dev-e2e",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "dev-e2e"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:nx-console": {
+        "id": "graph-client:build-base:nx-console",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "nx-console"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:release-static": {
+        "id": "graph-client:build-base:release-static",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "release-static"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-base:watch": {
+        "id": "graph-client:build-base:watch",
+        "target": {
+          "project": "graph-client",
+          "target": "build-base",
+          "configuration": "watch"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:dev": {
+        "id": "graph-client:serve-base:dev",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "dev"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:nx-console": {
+        "id": "graph-client:serve-base:nx-console",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "nx-console"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:release": {
+        "id": "graph-client:serve-base:release",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "release"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:watch": {
+        "id": "graph-client:serve-base:watch",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "watch"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:release-static": {
+        "id": "graph-client:serve-base:release-static",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "release-static"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve-base:dev-e2e": {
+        "id": "graph-client:serve-base:dev-e2e",
+        "target": {
+          "project": "graph-client",
+          "target": "serve-base",
+          "configuration": "dev-e2e"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:dev": {
+        "id": "graph-client:serve:dev",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "dev"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:release": {
+        "id": "graph-client:serve:release",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "release"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:release-static": {
+        "id": "graph-client:serve:release-static",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "release-static"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:watch": {
+        "id": "graph-client:serve:watch",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "watch"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:serve:nx-console": {
+        "id": "graph-client:serve:nx-console",
+        "target": {
+          "project": "graph-client",
+          "target": "serve",
+          "configuration": "nx-console"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:lint": {
+        "id": "graph-client:lint",
+        "target": {
+          "project": "graph-client",
+          "target": "lint"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:test": {
+        "id": "graph-client:test",
+        "target": {
+          "project": "graph-client",
+          "target": "test"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:storybook": {
+        "id": "graph-client:storybook",
+        "target": {
+          "project": "graph-client",
+          "target": "storybook"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:storybook:ci": {
+        "id": "graph-client:storybook:ci",
+        "target": {
+          "project": "graph-client",
+          "target": "storybook",
+          "configuration": "ci"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-storybook": {
+        "id": "graph-client:build-storybook",
+        "target": {
+          "project": "graph-client",
+          "target": "build-storybook"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "graph-client:build-storybook:ci": {
+        "id": "graph-client:build-storybook:ci",
+        "target": {
+          "project": "graph-client",
+          "target": "build-storybook",
+          "configuration": "ci"
+        },
+        "projectRoot": "graph/client",
+        "overrides": {}
+      },
+      "cli:test": {
+        "id": "cli:test",
+        "target": {
+          "project": "cli",
+          "target": "test"
+        },
+        "projectRoot": "packages/cli",
+        "overrides": {}
+      },
+      "cli:build": {
+        "id": "cli:build",
+        "target": {
+          "project": "cli",
+          "target": "build"
+        },
+        "projectRoot": "packages/cli",
+        "overrides": {}
+      },
+      "cli:build-base": {
+        "id": "cli:build-base",
+        "target": {
+          "project": "cli",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/cli",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "cli:lint": {
+        "id": "cli:lint",
+        "target": {
+          "project": "cli",
+          "target": "lint"
+        },
+        "projectRoot": "packages/cli",
+        "overrides": {}
+      },
+      "tao:test": {
+        "id": "tao:test",
+        "target": {
+          "project": "tao",
+          "target": "test"
+        },
+        "projectRoot": "packages/tao",
+        "overrides": {}
+      },
+      "tao:build": {
+        "id": "tao:build",
+        "target": {
+          "project": "tao",
+          "target": "build"
+        },
+        "projectRoot": "packages/tao",
+        "overrides": {}
+      },
+      "tao:build-base": {
+        "id": "tao:build-base",
+        "target": {
+          "project": "tao",
+          "target": "build-base"
+        },
+        "projectRoot": "packages/tao",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "tao:lint": {
+        "id": "tao:lint",
+        "target": {
+          "project": "tao",
+          "target": "lint"
+        },
+        "projectRoot": "packages/tao",
+        "overrides": {}
+      },
+      "web:test": {
+        "id": "web:test",
+        "target": {
+          "project": "web",
+          "target": "test"
+        },
+        "projectRoot": "packages/web",
+        "overrides": {}
+      },
+      "web:build": {
+        "id": "web:build",
+        "target": {
+          "project": "web",
+          "target": "build"
+        },
+        "projectRoot": "packages/web",
+        "overrides": {}
+      },
+      "web:lint": {
+        "id": "web:lint",
+        "target": {
+          "project": "web",
+          "target": "lint"
+        },
+        "projectRoot": "packages/web",
+        "overrides": {}
+      },
+      "e2e-cypress:e2e": {
+        "id": "e2e-cypress:e2e",
+        "target": {
+          "project": "e2e-cypress",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/cypress",
+        "overrides": {}
+      },
+      "e2e-cypress:run-e2e-tests": {
+        "id": "e2e-cypress:run-e2e-tests",
+        "target": {
+          "project": "e2e-cypress",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/cypress",
+        "overrides": {}
+      },
+      "e2e-esbuild:e2e": {
+        "id": "e2e-esbuild:e2e",
+        "target": {
+          "project": "e2e-esbuild",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/esbuild",
+        "overrides": {}
+      },
+      "e2e-esbuild:run-e2e-tests": {
+        "id": "e2e-esbuild:run-e2e-tests",
+        "target": {
+          "project": "e2e-esbuild",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/esbuild",
+        "overrides": {}
+      },
+      "e2e-nx-init:e2e": {
+        "id": "e2e-nx-init:e2e",
+        "target": {
+          "project": "e2e-nx-init",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/nx-init",
+        "overrides": {}
+      },
+      "e2e-nx-init:run-e2e-tests": {
+        "id": "e2e-nx-init:run-e2e-tests",
+        "target": {
+          "project": "e2e-nx-init",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/nx-init",
+        "overrides": {}
+      },
+      "e2e-nx-misc:e2e": {
+        "id": "e2e-nx-misc:e2e",
+        "target": {
+          "project": "e2e-nx-misc",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/nx-misc",
+        "overrides": {}
+      },
+      "e2e-nx-misc:run-e2e-tests": {
+        "id": "e2e-nx-misc:run-e2e-tests",
+        "target": {
+          "project": "e2e-nx-misc",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/nx-misc",
+        "overrides": {}
+      },
+      "e2e-webpack:e2e": {
+        "id": "e2e-webpack:e2e",
+        "target": {
+          "project": "e2e-webpack",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/webpack",
+        "overrides": {}
+      },
+      "e2e-webpack:run-e2e-tests": {
+        "id": "e2e-webpack:run-e2e-tests",
+        "target": {
+          "project": "e2e-webpack",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/webpack",
+        "overrides": {}
+      },
+      "js:lint": {
+        "id": "js:lint",
+        "target": {
+          "project": "js",
+          "target": "lint"
+        },
+        "projectRoot": "packages/js",
+        "overrides": {}
+      },
+      "js:test": {
+        "id": "js:test",
+        "target": {
+          "project": "js",
+          "target": "test"
+        },
+        "projectRoot": "packages/js",
+        "overrides": {}
+      },
+      "js:build": {
+        "id": "js:build",
+        "target": {
+          "project": "js",
+          "target": "build"
+        },
+        "projectRoot": "packages/js",
+        "overrides": {}
+      },
+      "nx:postinstall": {
+        "id": "nx:postinstall",
+        "target": {
+          "project": "nx",
+          "target": "postinstall"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {}
+      },
+      "nx:echo": {
+        "id": "nx:echo",
+        "target": {
+          "project": "nx",
+          "target": "echo"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {}
+      },
+      "nx:build": {
+        "id": "nx:build",
+        "target": {
+          "project": "nx",
+          "target": "build"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {
+          "__overrides_unparsed__": []
+        }
+      },
+      "nx:lint": {
+        "id": "nx:lint",
+        "target": {
+          "project": "nx",
+          "target": "lint"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {}
+      },
+      "nx:test": {
+        "id": "nx:test",
+        "target": {
+          "project": "nx",
+          "target": "test"
+        },
+        "projectRoot": "packages/nx",
+        "overrides": {}
+      },
+      "e2e-linter:e2e": {
+        "id": "e2e-linter:e2e",
+        "target": {
+          "project": "e2e-linter",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/linter",
+        "overrides": {}
+      },
+      "e2e-linter:run-e2e-tests": {
+        "id": "e2e-linter:run-e2e-tests",
+        "target": {
+          "project": "e2e-linter",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/linter",
+        "overrides": {}
+      },
+      "e2e-nx-run:e2e": {
+        "id": "e2e-nx-run:e2e",
+        "target": {
+          "project": "e2e-nx-run",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/nx-run",
+        "overrides": {}
+      },
+      "e2e-nx-run:run-e2e-tests": {
+        "id": "e2e-nx-run:run-e2e-tests",
+        "target": {
+          "project": "e2e-nx-run",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/nx-run",
+        "overrides": {}
+      },
+      "e2e-rollup:e2e": {
+        "id": "e2e-rollup:e2e",
+        "target": {
+          "project": "e2e-rollup",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/rollup",
+        "overrides": {}
+      },
+      "e2e-rollup:run-e2e-tests": {
+        "id": "e2e-rollup:run-e2e-tests",
+        "target": {
+          "project": "e2e-rollup",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/rollup",
+        "overrides": {}
+      },
+      "e2e-detox:e2e": {
+        "id": "e2e-detox:e2e",
+        "target": {
+          "project": "e2e-detox",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/detox",
+        "overrides": {}
+      },
+      "e2e-detox:run-e2e-tests": {
+        "id": "e2e-detox:run-e2e-tests",
+        "target": {
+          "project": "e2e-detox",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/detox",
+        "overrides": {}
+      },
+      "e2e-react:e2e": {
+        "id": "e2e-react:e2e",
+        "target": {
+          "project": "e2e-react",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/react",
+        "overrides": {}
+      },
+      "e2e-react:run-e2e-tests": {
+        "id": "e2e-react:run-e2e-tests",
+        "target": {
+          "project": "e2e-react",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/react",
+        "overrides": {}
+      },
+      "e2e-expo:e2e": {
+        "id": "e2e-expo:e2e",
+        "target": {
+          "project": "e2e-expo",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/expo",
+        "overrides": {}
+      },
+      "e2e-expo:run-e2e-tests": {
+        "id": "e2e-expo:run-e2e-tests",
+        "target": {
+          "project": "e2e-expo",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/expo",
+        "overrides": {}
+      },
+      "e2e-jest:e2e": {
+        "id": "e2e-jest:e2e",
+        "target": {
+          "project": "e2e-jest",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/jest",
+        "overrides": {}
+      },
+      "e2e-jest:run-e2e-tests": {
+        "id": "e2e-jest:run-e2e-tests",
+        "target": {
+          "project": "e2e-jest",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/jest",
+        "overrides": {}
+      },
+      "e2e-next:e2e": {
+        "id": "e2e-next:e2e",
+        "target": {
+          "project": "e2e-next",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/next",
+        "overrides": {}
+      },
+      "e2e-next:run-e2e-tests": {
+        "id": "e2e-next:run-e2e-tests",
+        "target": {
+          "project": "e2e-next",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/next",
+        "overrides": {}
+      },
+      "e2e-node:e2e": {
+        "id": "e2e-node:e2e",
+        "target": {
+          "project": "e2e-node",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/node",
+        "overrides": {}
+      },
+      "e2e-node:run-e2e-tests": {
+        "id": "e2e-node:run-e2e-tests",
+        "target": {
+          "project": "e2e-node",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/node",
+        "overrides": {}
+      },
+      "e2e-vite:e2e": {
+        "id": "e2e-vite:e2e",
+        "target": {
+          "project": "e2e-vite",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/vite",
+        "overrides": {}
+      },
+      "e2e-vite:run-e2e-tests": {
+        "id": "e2e-vite:run-e2e-tests",
+        "target": {
+          "project": "e2e-vite",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/vite",
+        "overrides": {}
+      },
+      "e2e-web:e2e": {
+        "id": "e2e-web:e2e",
+        "target": {
+          "project": "e2e-web",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/web",
+        "overrides": {}
+      },
+      "e2e-web:run-e2e-tests": {
+        "id": "e2e-web:run-e2e-tests",
+        "target": {
+          "project": "e2e-web",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/web",
+        "overrides": {}
+      },
+      "e2e-js:e2e": {
+        "id": "e2e-js:e2e",
+        "target": {
+          "project": "e2e-js",
+          "target": "e2e"
+        },
+        "projectRoot": "e2e/js",
+        "overrides": {}
+      },
+      "e2e-js:run-e2e-tests": {
+        "id": "e2e-js:run-e2e-tests",
+        "target": {
+          "project": "e2e-js",
+          "target": "run-e2e-tests"
+        },
+        "projectRoot": "e2e/js",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:check-commit": {
+        "id": "@nrwl/nx-source:check-commit",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "check-commit"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:check-format": {
+        "id": "@nrwl/nx-source:check-format",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "check-format"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:check-imports": {
+        "id": "@nrwl/nx-source:check-imports",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "check-imports"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:check-lock-files": {
+        "id": "@nrwl/nx-source:check-lock-files",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "check-lock-files"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:depcheck": {
+        "id": "@nrwl/nx-source:depcheck",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "depcheck"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:documentation": {
+        "id": "@nrwl/nx-source:documentation",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "documentation"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:echo": {
+        "id": "@nrwl/nx-source:echo",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "echo"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      },
+      "@nrwl/nx-source:lint": {
+        "id": "@nrwl/nx-source:lint",
+        "target": {
+          "project": "@nrwl/nx-source",
+          "target": "lint"
+        },
+        "projectRoot": ".",
+        "overrides": {}
+      }
+    },
+    "dependencies": {
+      "nx-dev-feature-package-schema-viewer:lint": [],
+      "nx-dev-feature-package-schema-viewer:test": [],
+      "nx-dev-data-access-documents:lint": [],
+      "nx-dev-data-access-documents:test": [],
+      "create-nx-workspace:test": ["create-nx-workspace:build"],
+      "create-nx-workspace:build": ["create-nx-workspace:build-base"],
+      "create-nx-workspace:build-base": [
+        "workspace:build-base",
+        "js:build-base",
+        "react:build-base",
+        "expo:build-base",
+        "next:build-base",
+        "angular:build-base",
+        "nest:build-base",
+        "express:build-base"
+      ],
+      "workspace:build-base": ["devkit:build-base", "nx:build-base"],
+      "devkit:build-base": ["nx:build-base"],
+      "nx:build-base": ["graph-client:build-base:release"],
+      "graph-client:build-base:release": [],
+      "js:build-base": [
+        "devkit:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "linter:build-base": [
+        "eslint-plugin-nx:build-base",
+        "devkit:build-base",
+        "nx:build-base",
+        "workspace:build-base",
+        "jest:build-base"
+      ],
+      "eslint-plugin-nx:build-base": ["devkit:build-base", "nx:build-base"],
+      "jest:build-base": [
+        "devkit:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "react:build-base": [
+        "web:build-base",
+        "devkit:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "cypress:build-base",
+        "webpack:build-base",
+        "nx:build-base",
+        "vite:build-base",
+        "jest:build-base",
+        "rollup:build-base",
+        "storybook:build-base"
+      ],
+      "web:build-base": [
+        "cypress:build-base",
+        "devkit:build-base",
+        "jest:build-base",
+        "js:build-base",
+        "linter:build-base",
+        "rollup:build-base",
+        "vite:build-base",
+        "webpack:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "cypress:build-base": [
+        "devkit:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "rollup:build-base": [
+        "devkit:build-base",
+        "js:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "vite:build-base": [
+        "devkit:build-base",
+        "workspace:build-base",
+        "js:build-base",
+        "nx:build-base"
+      ],
+      "webpack:build-base": [
+        "devkit:build-base",
+        "js:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "storybook:build-base": [
+        "cypress:build-base",
+        "devkit:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "expo:build-base": [
+        "detox:build-base",
+        "devkit:build-base",
+        "jest:build-base",
+        "linter:build-base",
+        "react:build-base",
+        "webpack:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "detox:build-base": [
+        "devkit:build-base",
+        "jest:build-base",
+        "linter:build-base",
+        "react:build-base",
+        "workspace:build-base"
+      ],
+      "next:build-base": [
+        "cypress:build-base",
+        "devkit:build-base",
+        "jest:build-base",
+        "linter:build-base",
+        "react:build-base",
+        "webpack:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "angular:build-base": [
+        "workspace:build-base",
+        "cypress:build-base",
+        "jest:build-base",
+        "devkit:build-base",
+        "linter:build-base",
+        "webpack:build-base",
+        "nx:build-base",
+        "storybook:build-base"
+      ],
+      "nest:build-base": [
+        "node:build-base",
+        "linter:build-base",
+        "devkit:build-base",
+        "js:build-base",
+        "workspace:build-base"
+      ],
+      "node:build-base": [
+        "devkit:build-base",
+        "jest:build-base",
+        "js:build-base",
+        "linter:build-base",
+        "webpack:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "express:build-base": [
+        "node:build-base",
+        "devkit:build-base",
+        "workspace:build-base",
+        "linter:build-base"
+      ],
+      "create-nx-workspace:lint": [],
+      "nx-dev-data-access-packages:lint": [],
+      "nx-dev-data-access-packages:test": [],
+      "nx-dev-feature-doc-viewer:lint": [],
+      "nx-dev-feature-doc-viewer:test": [],
+      "create-nx-plugin:test": ["create-nx-plugin:build"],
+      "create-nx-plugin:build": ["create-nx-plugin:build-base"],
+      "create-nx-plugin:build-base": [
+        "nx-plugin:build-base",
+        "devkit:build-base",
+        "nx:build-base"
+      ],
+      "nx-plugin:build-base": [
+        "devkit:build-base",
+        "jest:build-base",
+        "js:build-base",
+        "linter:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "create-nx-plugin:lint": [],
+      "eslint-plugin-nx:test": ["eslint-plugin-nx:build"],
+      "eslint-plugin-nx:build": ["eslint-plugin-nx:build-base"],
+      "eslint-plugin-nx:lint": [],
+      "nx-dev-feature-analytics:lint": [],
+      "nx-dev-feature-analytics:test": [],
+      "nx-dev-data-access-menu:lint": [],
+      "nx-dev-data-access-menu:test": [],
+      "e2e-angular-extensions:e2e": [],
+      "e2e-angular-extensions:run-e2e-tests": [],
+      "nx-dev-models-document:lint": [],
+      "nx-dev-models-document:test": [],
+      "nx-dev-ui-sponsor-card:lint": [],
+      "nx-dev-ui-sponsor-card:test": [],
+      "e2e-storybook-angular:e2e": [],
+      "e2e-storybook-angular:run-e2e-tests": [],
+      "nx-dev-feature-search:lint": [],
+      "nx-dev-feature-search:test": [],
+      "nx-dev-models-package:lint": [],
+      "nx-dev-models-package:test": [],
+      "nx-dev-ui-member-card:lint": [],
+      "nx-dev-ui-member-card:test": [],
+      "react-native:lint": [],
+      "react-native:test": ["react-native:build"],
+      "react-native:build": ["react-native:build-base"],
+      "react-native:build-base": [
+        "detox:build-base",
+        "devkit:build-base",
+        "jest:build-base",
+        "js:build-base",
+        "linter:build-base",
+        "react:build-base",
+        "workspace:build-base",
+        "nx:build-base",
+        "storybook:build-base"
+      ],
+      "e2e-workspace-create:e2e": [],
+      "e2e-workspace-create:run-e2e-tests": [],
+      "nx-dev-ui-conference:lint": [],
+      "nx-dev-ui-conference:test": [],
+      "nx-dev-ui-references:lint": [],
+      "nx-dev-ui-references:test": [],
+      "nx-dev-ui-community:lint": [],
+      "nx-dev-ui-community:test": [],
+      "nx-dev-models-menu:lint": [],
+      "nx-dev-models-menu:test": [],
+      "nx-dev-ui-commands:lint": [],
+      "nx-dev-ui-commands:test": [],
+      "nx-plugin:test": ["nx-plugin:build"],
+      "nx-plugin:build": ["nx-plugin:build-base"],
+      "nx-plugin:lint": [],
+      "storybook:test": ["storybook:build"],
+      "storybook:build": ["storybook:build-base"],
+      "storybook:lint": [],
+      "workspace:test": ["workspace:build"],
+      "workspace:build": ["workspace:build-base"],
+      "workspace:lint": [],
+      "eslint-rules:test": [],
+      "nx-dev-e2e:e2e": ["nx-dev:build-base", "cypress:build-base"],
+      "nx-dev:build-base": ["jest:build-base"],
+      "nx-dev-e2e:lint": [],
+      "nx-dev-ui-markdoc:lint": [],
+      "nx-dev-ui-markdoc:test": [],
+      "e2e-angular-core:e2e": [],
+      "e2e-angular-core:run-e2e-tests": [],
+      "e2e-react-native:e2e": [],
+      "e2e-react-native:run-e2e-tests": [],
+      "e2e-graph-client:e2e-base:dev": [],
+      "e2e-graph-client:e2e-base:watch": [],
+      "e2e-graph-client:e2e-base:release": [],
+      "e2e-graph-client:e2e-base:release-static": [],
+      "e2e-graph-client:e2e-local": [],
+      "e2e-graph-client:e2e": [],
+      "e2e-graph-client:lint": [],
+      "nx-dev-ui-common:lint": [],
+      "nx-dev-ui-common:test": [],
+      "angular:postinstall": [],
+      "angular:test": ["angular:build"],
+      "angular:build": ["angular:build-base"],
+      "angular:lint": [],
+      "cypress:test": ["cypress:build"],
+      "cypress:build": ["cypress:build-base"],
+      "cypress:lint": [],
+      "esbuild:test": ["esbuild:build"],
+      "esbuild:build": ["esbuild:build-base"],
+      "esbuild:build-base": [
+        "devkit:build-base",
+        "js:build-base",
+        "workspace:build-base",
+        "nx:build-base"
+      ],
+      "esbuild:lint": [],
+      "express:test": ["express:build"],
+      "express:build": ["express:build-base"],
+      "express:lint": [],
+      "webpack:test": ["webpack:build"],
+      "webpack:build": ["webpack:build-base"],
+      "webpack:lint": [],
+      "nx-dev-ui-theme:lint": [],
+      "nx-dev-ui-theme:test": [],
+      "devkit:test": ["devkit:build"],
+      "devkit:build": ["devkit:build-base"],
+      "devkit:lint": [],
+      "linter:test": ["linter:build"],
+      "linter:build": ["linter:build-base"],
+      "linter:lint": [],
+      "rollup:test": ["rollup:build"],
+      "rollup:build": ["rollup:build-base"],
+      "rollup:lint": [],
+      "graph-ui-graph:lint": [],
+      "graph-ui-graph:test": [],
+      "graph-ui-graph:storybook": [],
+      "graph-ui-graph:storybook:ci": [],
+      "graph-ui-graph:build-storybook": [],
+      "graph-ui-graph:build-storybook:ci": [],
+      "nx-dev-ui-home:lint": [],
+      "nx-dev-ui-home:xtest": [],
+      "detox:lint": [],
+      "detox:test": ["detox:build"],
+      "detox:build": ["detox:build-base"],
+      "react:test": ["react:build"],
+      "react:build": ["react:build-base"],
+      "react:lint": [],
+      "typedoc-theme:build-base": [],
+      "typedoc-theme:build": ["typedoc-theme:build-base"],
+      "typedoc-theme:lint": [],
+      "typedoc-theme:test": ["typedoc-theme:build"],
+      "e2e-nx-plugin:e2e": [],
+      "e2e-nx-plugin:run-e2e-tests": [],
+      "e2e-storybook:e2e": [],
+      "e2e-storybook:run-e2e-tests": [],
+      "nx-dev:build": ["nx-dev:build-base"],
+      "nx-dev:sitemap": [],
+      "nx-dev:sync-documentation": [],
+      "nx-dev:generate-og-images": [],
+      "nx-dev:build-base:development": ["jest:build-base"],
+      "graph-client:build-base": [],
+      "nx-dev:build-base:production": ["jest:build-base"],
+      "nx-dev:serve:development": [],
+      "nx-dev:serve:production": [],
+      "nx-dev:deploy-build": [],
+      "nx-dev:export": [],
+      "nx-dev:lint": [],
+      "nx-dev:test": ["nx-dev:build"],
+      "expo:lint": [],
+      "expo:test": ["expo:build"],
+      "expo:build": ["expo:build-base"],
+      "jest:test": ["jest:build"],
+      "jest:build": ["jest:build-base"],
+      "jest:lint": [],
+      "nest:test": ["nest:build"],
+      "nest:build": ["nest:build-base"],
+      "nest:lint": [],
+      "next:test": ["next:build"],
+      "next:build": ["next:build-base"],
+      "next:lint": [],
+      "node:test": ["node:build"],
+      "node:build": ["node:build-base"],
+      "node:lint": [],
+      "vite:test": ["vite:build"],
+      "vite:build": ["vite:build-base"],
+      "vite:lint": [],
+      "graph-client:generate-dev-environment-js": [],
+      "graph-client:generate-graph-base": [],
+      "graph-client:generate-graph": [],
+      "graph-client:build-base:dev": [],
+      "graph-client:build-base:dev-e2e": [],
+      "graph-client:build-base:nx-console": [],
+      "graph-client:build-base:release-static": [],
+      "graph-client:build-base:watch": [],
+      "graph-client:serve-base:dev": [],
+      "graph-client:serve-base:nx-console": [],
+      "graph-client:serve-base:release": [],
+      "graph-client:serve-base:watch": [],
+      "graph-client:serve-base:release-static": [],
+      "graph-client:serve-base:dev-e2e": [],
+      "graph-client:serve:dev": [],
+      "graph-client:serve:release": [],
+      "graph-client:serve:release-static": [],
+      "graph-client:serve:watch": [],
+      "graph-client:serve:nx-console": [],
+      "graph-client:lint": [],
+      "graph-client:test": [],
+      "graph-client:storybook": [],
+      "graph-client:storybook:ci": [],
+      "graph-client:build-storybook": [],
+      "graph-client:build-storybook:ci": [],
+      "cli:test": ["cli:build"],
+      "cli:build": ["cli:build-base"],
+      "cli:build-base": ["workspace:build-base", "nx:build-base"],
+      "cli:lint": [],
+      "tao:test": ["tao:build"],
+      "tao:build": ["tao:build-base"],
+      "tao:build-base": ["nx:build-base"],
+      "tao:lint": [],
+      "web:test": ["web:build"],
+      "web:build": ["web:build-base"],
+      "web:lint": [],
+      "e2e-cypress:e2e": [],
+      "e2e-cypress:run-e2e-tests": [],
+      "e2e-esbuild:e2e": [],
+      "e2e-esbuild:run-e2e-tests": [],
+      "e2e-nx-init:e2e": [],
+      "e2e-nx-init:run-e2e-tests": [],
+      "e2e-nx-misc:e2e": [],
+      "e2e-nx-misc:run-e2e-tests": [],
+      "e2e-webpack:e2e": [],
+      "e2e-webpack:run-e2e-tests": [],
+      "js:lint": [],
+      "js:test": ["js:build"],
+      "js:build": ["js:build-base"],
+      "nx:postinstall": [],
+      "nx:echo": [],
+      "nx:build": ["nx:build-base"],
+      "nx:lint": [],
+      "nx:test": ["nx:build"],
+      "e2e-linter:e2e": [],
+      "e2e-linter:run-e2e-tests": [],
+      "e2e-nx-run:e2e": [],
+      "e2e-nx-run:run-e2e-tests": [],
+      "e2e-rollup:e2e": [],
+      "e2e-rollup:run-e2e-tests": [],
+      "e2e-detox:e2e": [],
+      "e2e-detox:run-e2e-tests": [],
+      "e2e-react:e2e": [],
+      "e2e-react:run-e2e-tests": [],
+      "e2e-expo:e2e": [],
+      "e2e-expo:run-e2e-tests": [],
+      "e2e-jest:e2e": [],
+      "e2e-jest:run-e2e-tests": [],
+      "e2e-next:e2e": [],
+      "e2e-next:run-e2e-tests": [],
+      "e2e-node:e2e": [],
+      "e2e-node:run-e2e-tests": [],
+      "e2e-vite:e2e": [],
+      "e2e-vite:run-e2e-tests": [],
+      "e2e-web:e2e": [],
+      "e2e-web:run-e2e-tests": [],
+      "e2e-js:e2e": [],
+      "e2e-js:run-e2e-tests": [],
+      "@nrwl/nx-source:check-commit": [],
+      "@nrwl/nx-source:check-format": [],
+      "@nrwl/nx-source:check-imports": [],
+      "@nrwl/nx-source:check-lock-files": [],
+      "@nrwl/nx-source:depcheck": [],
+      "@nrwl/nx-source:documentation": [],
+      "@nrwl/nx-source:echo": [],
+      "@nrwl/nx-source:lint": []
     }
   }
 }

--- a/docs/shared/mental-model/single-task.json
+++ b/docs/shared/mental-model/single-task.json
@@ -5,25 +5,21 @@
       "type": "lib",
       "data": {
         "tags": [],
-        "targets": {
-          "test": {}
-        }
+        "targets": { "test": {} }
       }
     }
   ],
-  "taskId": "lib:test",
-  "taskGraphs": {
-    "lib:test": {
-      "roots": ["lib:test"],
-      "tasks": {
-        "lib:test": {
-          "id": "lib:test",
-          "target": { "project": "lib", "target": "test" },
-          "projectRoot": "libs/lib",
-          "overrides": {}
-        }
-      },
-      "dependencies": {}
-    }
+  "taskIds": ["lib:test"],
+  "taskGraph": {
+    "roots": ["lib:test"],
+    "tasks": {
+      "lib:test": {
+        "id": "lib:test",
+        "target": { "project": "lib", "target": "test" },
+        "projectRoot": "libs/lib",
+        "overrides": {}
+      }
+    },
+    "dependencies": {}
   }
 }

--- a/nx-dev/ui-markdoc/src/lib/graphs/project-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/project-graph.tsx
@@ -17,16 +17,16 @@ import { resolveTheme } from './resolve-theme';
 interface NxDevProjectGraphProps {
   theme: RenderTheme | 'system';
   projects: ProjectGraphProjectNode[];
-  dependencies: Record<string, ProjectGraphDependency[]>;
-  affectedProjects: string[];
+  dependencies?: Record<string, ProjectGraphDependency[]>;
+  affectedProjects?: string[];
   enableContextMenu?: boolean;
   composite?: boolean;
 }
 
 export function NxDevProjectGraph({
   projects,
-  dependencies,
-  affectedProjects,
+  dependencies = {},
+  affectedProjects = [],
   theme = 'system',
   composite = false,
   enableContextMenu = false,

--- a/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
@@ -18,15 +18,17 @@ import { resolveTheme } from './resolve-theme';
 interface NxDevTaskGraphProps {
   theme: RenderTheme | 'system';
   projects: ProjectGraphProjectNode[];
-  taskGraphs: Record<string, TaskGraph>;
+  taskGraph: TaskGraph;
   taskId: string;
+  taskIds?: string[];
   enableContextMenu?: boolean;
 }
 
 export function NxDevTaskGraph({
   projects,
-  taskGraphs,
+  taskGraph,
   taskId,
+  taskIds = [],
   theme = 'system',
   enableContextMenu = false,
 }: NxDevTaskGraphProps) {
@@ -44,9 +46,16 @@ export function NxDevTaskGraph({
   useEffect(() => {
     if (!graphClient) return;
 
+    const showTaskIds = taskIds.length ? taskIds : [taskId];
+
     send(
-      { type: 'initGraph', projects, taskGraphs },
-      { type: 'show', taskIds: [taskId] }
+      { type: 'initGraph', projects, taskGraph },
+      {
+        type: 'show',
+        taskIds: showTaskIds.map((id) =>
+          id.startsWith('task-') ? id : `task-${id}`
+        ),
+      }
     );
   }, [graphClient]);
 

--- a/nx-dev/ui-markdoc/src/lib/tags/graph.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/graph.component.tsx
@@ -116,8 +116,9 @@ export function Graph({
       <div className="relative flex justify-center border-b border-slate-200 bg-slate-100/50 p-2 font-bold dark:border-slate-700 dark:bg-slate-700/50">
         {title}
       </div>
-      {type === 'project' ? (
-        <div style={{ height }}>
+
+      <div style={{ height }}>
+        {type === 'project' ? (
           <NxDevProjectGraph
             theme={theme}
             projects={parsedProps.projects}
@@ -126,16 +127,17 @@ export function Graph({
             enableContextMenu={parsedProps.enableTooltips}
             composite={parsedProps.composite}
           />
-        </div>
-      ) : (
-        <NxDevTaskGraph
-          theme={theme}
-          projects={parsedProps.projects}
-          taskGraphs={parsedProps.taskGraphs}
-          taskId={parsedProps.taskId}
-          enableContextMenu={parsedProps.enableTooltips}
-        />
-      )}
+        ) : (
+          <NxDevTaskGraph
+            theme={theme}
+            projects={parsedProps.projects}
+            taskGraph={parsedProps.taskGraph}
+            taskId={parsedProps.taskId}
+            taskIds={parsedProps.taskIds}
+            enableContextMenu={parsedProps.enableTooltips}
+          />
+        )}
+      </div>
     </div>
   ) : (
     <Loading />


### PR DESCRIPTION
There was a recent change to `TaskGraphClientResponse` where we drop the multiple `taskGraphs` and replace with single `taskGraph`. Goal was to improve the performance for `nx graph` task graph in general and support multiple targets. Docs pages that render task graph were not updated to adhere to the new single task graph model. This PR fixes it.

This PR also adjusts the project graph to handle missing props more gracefully.

