### PR TITLE
fix(nx-dev): update header logo to link to nx.dev homepage

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -12,7 +12,9 @@ import { sidebar } from './sidebar.mts';
 export default defineConfig({
   base: '/docs',
   vite: { plugins: [tailwindcss()] },
-  site: 'https://nx.dev',
+  // Allow this to be configured per environment
+  // Note: this happens during build time so we don't use `import.meta.env`
+  site: process.env.NX_DEV_URL ?? 'https://nx.dev',
   image: {
     service: {
       entrypoint: 'astro/assets/services/sharp',

--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -1,9 +1,11 @@
 ---
 import config from 'virtual:starlight/user-config';
 import Search from 'virtual:starlight/components/Search';
-import SiteTitle from 'virtual:starlight/components/SiteTitle';
 import SocialIcons from 'virtual:starlight/components/SocialIcons';
 import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
+import { Image } from 'astro:assets';
+import nxLogoDark from '../../assets/nx/Nx-dark.svg';
+import nxLogoLight from '../../assets/nx/Nx-light.svg';
 
 /**
  * Render the `Search` component if Pagefind is enabled or the default search component has been overridden.
@@ -21,9 +23,12 @@ const versions = [
 const currentVersion = versions.find(v => v.current);
 ---
 
-<div class="flex items-center justify-between h-full gap-4 px-4">
+<div class="flex items-center justify-between h-full gap-4">
 	<div class="flex items-center gap-2 flex-shrink-0">
-		<SiteTitle />
+    <a href={import.meta.env.SITE} class="flex items-center no-underline">
+			<Image src={nxLogoDark} alt="Nx" class="h-12 w-auto dark:hidden" />
+			<Image src={nxLogoLight} alt="Nx" class="h-12 w-auto hidden dark:block" />
+		</a>
 		<a href="/getting-started/intro" class="px-3.5 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
 			Docs
 		</a>


### PR DESCRIPTION
The logo in the documentation header links to the docs intro page (/docs/getting-started/intro) instead of the main Nx homepage.

The logo should link to https://nx.dev to allow users to easily navigate back to the main Nx homepage from the documentation.

Fixes DOC-167

Demo: https://www.loom.com/share/71fb2b78d40b4730a073fdfe4a3b66c2