### PR TITLE
docs(nx-dev): remove 'Docs' from breadcrumb UI to prevent 404

### DIFF
--- a/astro-docs/src/components/layout/Breadcrumbs.astro
+++ b/astro-docs/src/components/layout/Breadcrumbs.astro
@@ -34,13 +34,15 @@ const crumbs: Crumb[] = pathSegments.map((segment, index) => {
   const docPath = pathSegments.slice(0, index + 1).join('/');
   const doc = findDocByPath(docPath);
   const name = doc?.data?.sidebar?.label || doc?.data?.title || createNameFromSegment(segment);
+  // If `base` is set in config, don't include it in breadcrumbs
+  if (index === 0 && import.meta.env.BASE_URL) return null;
   return {
     id: segment,
     name,
     href: `/${docPath}`,
     current: index === pathSegments.length - 1,
   };
-});
+}).filter(Boolean);
 ---
 
 


### PR DESCRIPTION
The breadcrumbs component was showing 'Docs' as a clickable segment which led to a 404 since there's no page at /docs. This filters out the 'docs' segment from the UI while keeping all href links with the /docs/ prefix.

Fixes DOC-165

Demo: https://www.loom.com/share/33aa13e515cf4213a64ecbf29200f3e1