### PR TITLE
fix(nx-cloud): read package.json correctly for workspace name when creating new cloud workspace

### DIFF
--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -23,10 +23,11 @@ function printCloudConnectionDisabledMessage() {
   });
 }
 
-function getRootPackageName(tree: Tree): string {
+function getRootPackageName(tree: Tree, directory: string): string {
   let packageJson;
   try {
-    packageJson = readJson(tree, 'package.json');
+    const packageJsonPath = join(directory, 'package.json');
+    packageJson = readJson(tree, packageJsonPath);
   } catch (e) {}
   return packageJson?.name ?? 'my-workspace';
 }
@@ -205,14 +206,14 @@ export async function connectToNxCloud(
 
   try {
     responseFromCreateNxCloudWorkspaceV2 = await createNxCloudWorkspaceV2(
-      getRootPackageName(tree),
+      getRootPackageName(tree, schema.directory),
       schema.installationSource,
       getNxInitDate()
     );
   } catch (e) {
     if (e.response?.status === 404) {
       responseFromCreateNxCloudWorkspaceV1 = await createNxCloudWorkspaceV1(
-        getRootPackageName(tree),
+        getRootPackageName(tree, schema.directory),
         schema.installationSource,
         getNxInitDate()
       );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When we attempt to create a new cloud-connected workspace with `create-nx-workspace`, we read `package.json` from the incorrect location. This means we are not able to retrieve the workspace name correctly and results in the newly created cloud workspace having the fallback name `my-workspace`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When we try to read `package.json` we pass in in the correct directory in which we expect to find the file. This allows us to correctly parse the json file and retrieve the correct workspace name. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
