### PR TITLE
chore(gradle): bump nx for gradle plugin to 0.1.6

### DIFF
--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -10,6 +10,16 @@ assignment-rules:
       - agent: linux-large
         parallelism: 1
 
+  - projects:
+      - e2e-gradle
+    targets:
+      - e2e-ci**
+    run-on:
+        - agent: linux-large
+          parallelism: 1
+        - agent: linux-extra-large
+          parallelism: 1
+
   # All other e2e tests can run in parallel
   - targets:
       - e2e-ci**

--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -2236,6 +2236,16 @@
       }
     },
     "migrations": {
+      "/technologies/java/api/migrations/change-plugin-version-0-1-6": {
+        "description": "Change dev.nx.gradle.project-graph to version 0.1.6 in build file",
+        "file": "generated/packages/gradle/migrations/change-plugin-version-0-1-6.json",
+        "hidden": false,
+        "name": "change-plugin-version-0-1-6",
+        "version": "21.4.1-beta.1",
+        "originalFilePath": "/packages/gradle",
+        "path": "/technologies/java/api/migrations/change-plugin-version-0-1-6",
+        "type": "migration"
+      },
       "/technologies/java/api/migrations/change-plugin-version-0-1-5": {
         "description": "Change dev.nx.gradle.project-graph to version 0.1.5 in build file",
         "file": "generated/packages/gradle/migrations/change-plugin-version-0-1-5.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -2489,6 +2489,16 @@
     ],
     "migrations": [
       {
+        "description": "Change dev.nx.gradle.project-graph to version 0.1.6 in build file",
+        "file": "generated/packages/gradle/migrations/change-plugin-version-0-1-6.json",
+        "hidden": false,
+        "name": "change-plugin-version-0-1-6",
+        "version": "21.4.1-beta.1",
+        "originalFilePath": "/packages/gradle",
+        "path": "gradle/migrations/change-plugin-version-0-1-6",
+        "type": "migration"
+      },
+      {
         "description": "Change dev.nx.gradle.project-graph to version 0.1.5 in build file",
         "file": "generated/packages/gradle/migrations/change-plugin-version-0-1-5.json",
         "hidden": false,

--- a/docs/generated/packages/gradle/migrations/change-plugin-version-0-1-6.json
+++ b/docs/generated/packages/gradle/migrations/change-plugin-version-0-1-6.json
@@ -1,0 +1,14 @@
+{
+  "name": "change-plugin-version-0-1-6",
+  "version": "21.4.1-beta.1",
+  "cli": "nx",
+  "description": "Change dev.nx.gradle.project-graph to version 0.1.6 in build file",
+  "factory": "./src/migrations/21-4-1/change-plugin-version-0-1-6",
+  "implementation": "/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/gradle",
+  "schema": null,
+  "type": "migration",
+  "examplesFile": "#### Change dev.nx.gradle.project-graph to version 0.1.6\n\nChange dev.nx.gradle.project-graph to version 0.1.6 in build file\n\n#### Sample Code Changes\n\n{% tabs %}\n{% tab label=\"Before\" %}\n\n```{% fileName=\"build.gradle\" %}\nplugins {\n\tid \"dev.nx.gradle.project-graph\" version \"0.1.0\"\n}\n```\n\n{% /tab %}\n{% tab label=\"After\" %}\n\n```{% fileName=\"build.gradle\" %}\nplugins {\n    id \"dev.nx.gradle.project-graph\" version \"0.1.6\"\n}\n```\n\n{% /tab %}\n{% /tabs %}\n"
+}

--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -53,6 +53,12 @@
       "cli": "nx",
       "description": "Change dev.nx.gradle.project-graph to version 0.1.5 in build file",
       "factory": "./src/migrations/21-4-0/change-plugin-version-0-1-5"
+    },
+    "change-plugin-version-0-1-6": {
+      "version": "21.4.1-beta.1",
+      "cli": "nx",
+      "description": "Change dev.nx.gradle.project-graph to version 0.1.6 in build file",
+      "factory": "./src/migrations/21-4-1/change-plugin-version-0-1-6"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "dev.nx.gradle"
 
-version = "0.1.5"
+version = "0.1.6"
 
 repositories { mavenCentral() }
 

--- a/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.md
+++ b/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.md
@@ -1,0 +1,26 @@
+#### Change dev.nx.gradle.project-graph to version 0.1.6
+
+Change dev.nx.gradle.project-graph to version 0.1.6 in build file
+
+#### Sample Code Changes
+
+{% tabs %}
+{% tab label="Before" %}
+
+```{% fileName="build.gradle" %}
+plugins {
+	id "dev.nx.gradle.project-graph" version "0.1.0"
+}
+```
+
+{% /tab %}
+{% tab label="After" %}
+
+```{% fileName="build.gradle" %}
+plugins {
+    id "dev.nx.gradle.project-graph" version "0.1.6"
+}
+```
+
+{% /tab %}
+{% /tabs %}

--- a/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.spec.ts
+++ b/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.spec.ts
@@ -253,7 +253,6 @@ junit-base = ["junit"]
 
     const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
 
-    // Verify the nx-gradle-project-graph version was updated from 0.1.3 to 0.1.5
     expect(catalogContent).toContain('nx-gradle-project-graph = "0.1.6"');
     expect(catalogContent).not.toContain('nx-gradle-project-graph = "0.1.3"');
   });

--- a/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.spec.ts
+++ b/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.spec.ts
@@ -1,0 +1,260 @@
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { Tree } from '@nx/devkit';
+import { FsTree } from 'nx/src/generators/tree';
+import update from './change-plugin-version-0-1-6';
+import { gradleProjectGraphPluginName } from '../../utils/versions';
+
+describe('change-plugin-version-0-1-6 migration', () => {
+  let tempFs: TempFs;
+  let cwd: string;
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tempFs = new TempFs('test');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+    tree = new FsTree(tempFs.tempDir, false);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    process.chdir(cwd);
+  });
+
+  it('should update plugin version to 0.1.6 in Groovy DSL', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+    });
+
+    await update(tree);
+
+    const content = tree.read('proj/build.gradle', 'utf-8');
+    expect(content).toContain(
+      `id "${gradleProjectGraphPluginName}" version "0.1.6"`
+    );
+    expect(content).not.toContain('version "0.0.1"');
+  });
+
+  it('should update plugin version to 0.1.6 in Kotlin DSL', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle.kts': '',
+      'proj/build.gradle.kts': `plugins {
+    id("java")
+    id("${gradleProjectGraphPluginName}") version("0.0.1")
+}`,
+    });
+
+    await update(tree);
+
+    const content = tree.read('proj/build.gradle.kts', 'utf-8');
+    expect(content).toContain(
+      `id("${gradleProjectGraphPluginName}") version("0.1.6")`
+    );
+    expect(content).not.toContain('version("0.0.1")');
+  });
+
+  it('should not update if nx.json is missing', async () => {
+    await tempFs.createFiles({
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+    });
+
+    await update(tree);
+
+    const content = tree.read('proj/build.gradle', 'utf-8');
+    expect(content).toContain('version "0.0.1"');
+    expect(content).not.toContain('version "0.1.6"');
+  });
+
+  it('should not update if Gradle plugin is not present', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({}),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+    });
+
+    await update(tree);
+
+    const content = tree.read('proj/build.gradle', 'utf-8');
+    expect(content).not.toContain(gradleProjectGraphPluginName);
+  });
+
+  it('should handle multiple build.gradle files', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj1/settings.gradle': '',
+      'proj1/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+      'proj2/settings.gradle': '',
+      'proj2/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+    });
+
+    await update(tree);
+
+    const proj1Content = tree.read('proj1/build.gradle', 'utf-8');
+    const proj2Content = tree.read('proj2/build.gradle', 'utf-8');
+
+    expect(proj1Content).toContain(
+      `id "${gradleProjectGraphPluginName}" version "0.1.6"`
+    );
+    expect(proj2Content).toContain(
+      `id "${gradleProjectGraphPluginName}" version "0.1.6"`
+    );
+    expect(proj1Content).not.toContain('version "0.0.1"');
+    expect(proj2Content).not.toContain('version "0.0.1"');
+  });
+
+  it('should update plugin version in libs.versions.toml with version.ref', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+      'proj/gradle/libs.versions.toml': `[versions]
+nx-project-graph = "0.0.1"
+
+[plugins]
+nx-graph = { id = "${gradleProjectGraphPluginName}", version.ref = "nx-project-graph" }
+`,
+    });
+
+    await update(tree);
+
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+    expect(catalogContent).toContain('nx-project-graph = "0.1.6"');
+    expect(catalogContent).not.toContain('nx-project-graph = "0.0.1"');
+  });
+
+  it('should update plugin version in libs.versions.toml with direct version', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+      'proj/gradle/libs.versions.toml': `[plugins]
+nx-graph = { id = "${gradleProjectGraphPluginName}", version = "0.0.1" }
+`,
+    });
+
+    await update(tree);
+
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+    expect(catalogContent).toContain('version = "0.1.6"');
+    expect(catalogContent).not.toContain('version = "0.0.1"');
+  });
+
+  it('should update plugin version in libs.versions.toml with simple format', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+      'proj/gradle/libs.versions.toml': `[plugins]
+nx-graph = "${gradleProjectGraphPluginName}:0.0.1"
+`,
+    });
+
+    await update(tree);
+
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+    expect(catalogContent).toContain(`"${gradleProjectGraphPluginName}:0.1.6"`);
+    expect(catalogContent).not.toContain(':0.0.1');
+  });
+
+  it('should handle both version catalog and build.gradle updates', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+      'proj/gradle/libs.versions.toml': `[versions]
+nx-project-graph = "0.0.2"
+
+[plugins]
+nx-graph = { id = "${gradleProjectGraphPluginName}", version.ref = "nx-project-graph" }
+`,
+    });
+
+    await update(tree);
+
+    const buildContent = tree.read('proj/build.gradle', 'utf-8');
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+
+    expect(buildContent).toContain(
+      `id "${gradleProjectGraphPluginName}" version "0.1.6"`
+    );
+    expect(catalogContent).toContain('nx-project-graph = "0.1.6"');
+    expect(buildContent).not.toContain('version "0.0.1"');
+    expect(catalogContent).not.toContain('nx-project-graph = "0.0.2"');
+  });
+
+  it('should update nx-gradle-project-graph version in comprehensive libs.versions.toml', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+      'proj/gradle/libs.versions.toml': `[versions]
+nx-gradle-project-graph = "0.1.3"
+
+[libraries]
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+
+[plugins]
+nx-gradle-project-graph = { id = "${gradleProjectGraphPluginName}", version.ref = "nx-gradle-project-graph" }
+
+[bundles]
+kotlin-base = ["kotlin-stdlib", "kotlin-reflect"]
+junit-base = ["junit"]
+`,
+    });
+
+    await update(tree);
+
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+
+    // Verify the nx-gradle-project-graph version was updated from 0.1.3 to 0.1.5
+    expect(catalogContent).toContain('nx-gradle-project-graph = "0.1.6"');
+    expect(catalogContent).not.toContain('nx-gradle-project-graph = "0.1.3"');
+  });
+});

--- a/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.ts
+++ b/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.ts
@@ -1,0 +1,24 @@
+import { Tree, readNxJson } from '@nx/devkit';
+import { hasGradlePlugin } from '../../utils/has-gradle-plugin';
+import { addNxProjectGraphPlugin } from '../../generators/init/gradle-project-graph-plugin-utils';
+import { updateNxPluginVersionInCatalogsAst } from '../../utils/version-catalog-ast-utils';
+
+/* Change the plugin version to 0.1.5
+ */
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson) {
+    return;
+  }
+  if (!hasGradlePlugin(tree)) {
+    return;
+  }
+
+  const gradlePluginVersionToUpdate = '0.1.6';
+
+  // Update version in version catalogs using AST-based approach to preserve formatting
+  await updateNxPluginVersionInCatalogsAst(tree, gradlePluginVersionToUpdate);
+
+  // Then update in build.gradle(.kts) files
+  await addNxProjectGraphPlugin(tree, gradlePluginVersionToUpdate);
+}

--- a/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.ts
+++ b/packages/gradle/src/migrations/21-4-1/change-plugin-version-0-1-6.ts
@@ -3,7 +3,7 @@ import { hasGradlePlugin } from '../../utils/has-gradle-plugin';
 import { addNxProjectGraphPlugin } from '../../generators/init/gradle-project-graph-plugin-utils';
 import { updateNxPluginVersionInCatalogsAst } from '../../utils/version-catalog-ast-utils';
 
-/* Change the plugin version to 0.1.5
+/* Change the plugin version to 0.1.6
  */
 export default async function update(tree: Tree) {
   const nxJson = readNxJson(tree);


### PR DESCRIPTION
## Current Behavior
Nx for Gradle plugin is at version 0.1.6

## Expected Behavior
Bumped up the version for the Nx for Gradle plugin, and added necessary migrations to `nx migrate` the plugin to the newest version.
