### PR TITLE
chore(react-native): fix nightly

### DIFF
--- a/e2e/react-native/src/react-native.test.ts
+++ b/e2e/react-native/src/react-native.test.ts
@@ -78,11 +78,11 @@ describe('@nx/react-native', () => {
   }, 200_000);
 
   it('should start the app', async () => {
-    let process: ChildProcess;
+    let childProcess: ChildProcess;
     const port = 8082;
 
     try {
-      process = await runCommandUntil(
+      childProcess = await runCommandUntil(
         `start ${appName} --no-interactive --port=${port}`,
         (output) => {
           return (
@@ -97,17 +97,21 @@ describe('@nx/react-native', () => {
     }
 
     // port and process cleanup
-    if (process && process.pid) {
-      await killProcessAndPorts(process.pid, port);
+    try {
+      if (childProcess && childProcess.pid) {
+        await killProcessAndPorts(childProcess.pid, port);
+      }
+    } catch (err) {
+      expect(err).toBeFalsy();
     }
   });
 
   it('should serve', async () => {
-    let process: ChildProcess;
+    let childProcess: ChildProcess;
     const port = 8081;
 
     try {
-      process = await runCommandUntil(
+      childProcess = await runCommandUntil(
         `serve ${appName} --port=${port}`,
         (output) => {
           return output.includes(`http://localhost:${port}`);
@@ -119,8 +123,8 @@ describe('@nx/react-native', () => {
 
     // port and process cleanup
     try {
-      if (process && process.pid) {
-        await killProcessAndPorts(process.pid, port);
+      if (childProcess && childProcess.pid) {
+        await killProcessAndPorts(childProcess.pid, port);
       }
     } catch (err) {
       expect(err).toBeFalsy();
@@ -137,9 +141,7 @@ describe('@nx/react-native', () => {
 
       // port and process cleanup
       try {
-        if (process && process.pid) {
-          await killProcessAndPorts(process.pid, 4200);
-        }
+        await killProcessAndPorts(undefined, 4200);
       } catch (err) {
         expect(err).toBeFalsy();
       }
@@ -192,9 +194,7 @@ describe('@nx/react-native', () => {
       expect(() => runCLI(`e2e ${appName2}-e2e`)).not.toThrow();
       // port and process cleanup
       try {
-        if (process && process.pid) {
-          await killProcessAndPorts(process.pid, 4200);
-        }
+        await killProcessAndPorts(undefined, 4200);
       } catch (err) {
         expect(err).toBeFalsy();
       }


### PR DESCRIPTION
## Current Behavior

The React Native e2e tests contain variable naming conflicts and inconsistent error handling in the process cleanup sections:
- Variables named `process` shadow the global Node.js `process` object
- Inconsistent error handling patterns in process cleanup logic
- Some cleanup operations attempt to kill processes that may not exist

## Expected Behavior

The React Native e2e tests should have:
- Clear variable names that don't shadow global objects
- Consistent error handling patterns throughout all test cleanup sections
- Robust process cleanup that handles cases where processes may not be running

### Changes Made

1. **Variable Naming**: Renamed `process` variables to `childProcess` to avoid shadowing the global Node.js `process` object
2. **Error Handling**: Added consistent try-catch blocks around all process cleanup operations
3. **Process Cleanup**: Simplified cleanup logic by passing `undefined` for process ID when the process reference is not available, allowing `killProcessAndPorts` to handle port cleanup appropriately

This fixes issues that could occur in nightly builds where process cleanup wasn't being handled consistently, potentially leading to hanging processes or ports.