### PR TITLE
fix(graph): project details navigating for new taskGraph and tasks with default configuration on UI

### DIFF
--- a/graph/client/src/app/external-api-impl.ts
+++ b/graph/client/src/app/external-api-impl.ts
@@ -98,14 +98,16 @@ export class ExternalApiImpl extends ExternalApi {
 
   focusTarget(projectName: string, targetName: string) {
     this.router.navigate(
-      `/tasks/${encodeURIComponent(targetName)}?projects=${encodeURIComponent(
-        projectName
-      )}`
+      `/tasks?targets=${encodeURIComponent(
+        targetName
+      )}&projects=${encodeURIComponent(projectName)}`
     );
   }
 
   selectAllTargetsByName(targetName: string) {
-    this.router.navigate(`/tasks/${encodeURIComponent(targetName)}/all`);
+    this.router.navigate(
+      `/tasks/all?targets=${encodeURIComponent(targetName)}`
+    );
   }
 
   enableExperimentalFeatures() {

--- a/graph/project-details/src/lib/project-details-wrapper.tsx
+++ b/graph/project-details/src/lib/project-details-wrapper.tsx
@@ -77,8 +77,10 @@ export function ProjectDetailsWrapper({
         navigate(
           routeConstructor(
             {
-              pathname: `/tasks/${encodeURIComponent(data.targetName)}`,
-              search: `?projects=${encodeURIComponent(data.projectName)}`,
+              pathname: `/tasks`,
+              search: `?targets=${encodeURIComponent(
+                data.targetName
+              )}&projects=${encodeURIComponent(data.projectName)}`,
             },
             true,
             ['expanded'] // omit expanded targets from search params


### PR DESCRIPTION
- fix some remnants on old navigation pattern for task graph in PDV
- fix an issue where UI only has `target` and `project` but backend returns TaskGraph with default configuration