### PR TITLE
fix(core): normalize root project root when merging project config results

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -53,6 +53,7 @@ export function mergeProjectConfigurationIntoRootMap(
   // in generators, where we don't want to do this.
   skipTargetNormalization?: boolean
 ): void {
+  project.root = project.root === '' ? '.' : project.root;
   if (configurationSourceMaps && !configurationSourceMaps[project.root]) {
     configurationSourceMaps[project.root] = {};
   }


### PR DESCRIPTION
## Current Behavior
When merging project config its easy to return `''` for the root project's root, but we expect `'.'`.

## Expected Behavior
We normalize this to prevent plugin author's from making an easy mistake

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
