### PR TITLE
feat(rspack): support passing templateParameters to HtmlRspackPlugin

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -88,6 +88,7 @@ export function applyWebConfig(
       plugins.push(
         new HtmlRspackPlugin({
           template: options.index,
+          templateParameters: options.templateParameters,
           sri: options.subresourceIntegrity ? 'sha256' : undefined,
           ...(options.baseHref ? { base: { href: options.baseHref } } : {}),
           ...(config.output?.scriptType === 'module'

--- a/packages/rspack/src/plugins/utils/models.ts
+++ b/packages/rspack/src/plugins/utils/models.ts
@@ -228,6 +228,15 @@ export interface NxAppRspackPluginOptions {
    */
   useTsconfigPaths?: boolean;
   /**
+   * Allows to overwrite the parameters used in the template. When using a function, pass in the original template parameters and use the returned object as the final template parameters.
+   */
+  templateParameters?:
+    | Record<string, string>
+    | boolean
+    | ((
+        params: Record<string, any>
+      ) => Record<string, any> | Promise<Record<string, any>>);
+  /**
    * Generate a separate vendor chunk for 3rd party packages.
    */
   vendorChunk?: boolean;

--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -24,6 +24,16 @@ export interface WithWebOptions {
    * Use the legacy WriteIndexHtmlPlugin instead of the built-in HtmlRspackPlugin.
    */
   useLegacyHtmlPlugin?: boolean;
+  /**
+   * Requires useLegacyHtmlPlugin to be false.
+   * Allows to overwrite the parameters used in the template. When using a function, pass in the original template parameters and use the returned object as the final template parameters.
+   */
+  templateParameters?:
+    | Record<string, string>
+    | boolean
+    | ((
+        params: Record<string, any>
+      ) => Record<string, any> | Promise<Record<string, any>>);
 }
 
 const processed = new Set();


### PR DESCRIPTION
## Current Behavior
There is currently no way to pass `templateParameters` to the `HtmlRspackPlugin`.

## Expected Behavior
Add `templateParameters` to the NxAppRspackPluginOptions and pass through to `HtmlRspackPlugin`
