### PR TITLE
fix(nx-dev): resolve multiple styling issues in Astro documentation

### DIFF
--- a/astro-docs/src/components/layout/Breadcrumbs.astro
+++ b/astro-docs/src/components/layout/Breadcrumbs.astro
@@ -55,11 +55,11 @@ const crumbs: Crumb[] = pathSegments.map((segment, index) => {
         )}
         <a
           href={crumb.href}
-          class={`no-underline text-sm font-medium${
+          class={`no-underline text-sm${
             crumb.current 
-              ? 'hover:text-slate-600 text-slate-600'
-          : 'hover:text-slate-600 text-slate-400'
-          } font-medium transition-colors`}
+              ? ' text-slate-900 dark:text-slate-100 font-semibold'
+          : ' text-slate-500 dark:text-slate-400 font-medium hover:text-slate-700 dark:hover:text-slate-200'
+          } transition-colors`}
           aria-current={crumb.current ? 'page' : undefined}
         >
           {crumb.name}

--- a/astro-docs/src/components/layout/Sidebar.astro
+++ b/astro-docs/src/components/layout/Sidebar.astro
@@ -7,13 +7,27 @@ import Default from '@astrojs/starlight/components/Sidebar.astro';
 </div>
 
 <style>
+.sidebar-wrapper :global(a) {
+  color: var(--sl-color-gray-4);
+}
+
 .sidebar-wrapper :global(a[aria-current=page]) {
   background-color: transparent;
-  color: var(--color-blue-500);
-  font-weight: var(--font-weight-medium);
+  color: var(--sl-color-text-accent);
+  font-weight: var(--font-weight-semibold);
 }
 .sidebar-wrapper :global(ul ul .large) {
+  color: var(--sl-color-gray-3);
   font-size: var(--text-sm);
   font-weight: var(--font-weight-medium);
+}
+
+.sidebar-wrapper :global(details summary .group-label) {
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.sidebar-wrapper :global(details[open] summary .group-label) {
+  color: var(--sl-color-gray-2);
 }
 </style>

--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -169,9 +169,40 @@ pre {
   aside {
     border-radius: var(--radius-lg);
   }
-}
+
+  /* Align TOC with sidebar styling */
+  starlight-toc ul {
+    line-height: var(--leading-relaxed);
+  }
+
+  starlight-toc li {
+    margin-bottom: var(--spacing);
+  }
+
+  starlight-toc a {
+    color: var(--sl-color-gray-4);
+    font-size: var(--text-sm);
+    display: block;
+  }
+
+  starlight-toc a[aria-current='true'] {
+    color: var(--sl-color-text-accent);
+    font-weight: var(--font-weight-semibold);
+  }
+} /* end component layer */
 
 /* Additional custom styles can be added here */
+
+/* For deepdive callouts that are still used, need to space out content */
+.callout div:not(:last-child),
+.callout p:not(:last-child) {
+  @apply mb-4;
+}
+
+/* Align top with breadcrumbs */
+.right-sidebar-panel {
+  @apply pt-6;
+}
 
 /* Anchor link styles for headings */
 .anchor-link {

--- a/nx-dev/ui-markdoc/src/lib/tags/callout.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/callout.component.tsx
@@ -131,7 +131,7 @@ export function Callout({
   return (
     <div
       className={cx(
-        'not-content my-6 overflow-hidden rounded-md border',
+        'not-content callout my-6 overflow-hidden rounded-md border',
         ui.borderColor,
         ui.backgroundColor
       )}


### PR DESCRIPTION
## Current Behavior
- Sidebar active link uses default text color instead of accent color (DOC-143)
- Breadcrumb current page text is barely visible with opacity 0.2 (DOC-141)
- TOC lacks proper spacing between items and has no background styling (DOC-174)
- TOC hard to parse (DOC-138)

## Expected Behavior
- Sidebar active link uses accent color for better visibility
- Breadcrumb current page has proper text color and visibility
- Deepdive callout paragraphs have compact 12px spacing
- TOC has proper spacing and background styling with dark mode support
<img width="1450" height="1357" alt="Screenshot 2025-08-28 at 1 58 10 PM" src="https://github.com/user-attachments/assets/b0414e22-ed6c-46ac-b66f-79e80fb868a5" />
<img width="1331" height="1030" alt="image" src="https://github.com/user-attachments/assets/d0a7341e-f389-4357-9028-9def94a23b4f" />
<img width="716" height="1187" alt="image" src="https://github.com/user-attachments/assets/fe4617fa-4c45-4748-aced-a0e513f50965" />


## Related Issue(s)
Fixes DOC-143
Fixes DOC-141
Fixes DOC-138
Fixes DOC-174