### PR TITLE
fix(nx-dev): add missing data in plugin migrations

### DIFF
--- a/astro-docs/src/plugins/utils/plugin-schema-parser.ts
+++ b/astro-docs/src/plugins/utils/plugin-schema-parser.ts
@@ -124,7 +124,7 @@ export function parseMigrations(pluginPath: string): Map<string, any> | null {
   for (const [name, config] of Object.entries(
     migrationsJson.generators || {}
   ) as [string, any][]) {
-    if (config.implmentation || config.factory) {
+    if (config.implementation || config.factory) {
       config['fullPath'] = resolvePath(
         pluginPath,
         config.implementation || config.factory

--- a/astro-docs/src/plugins/utils/plugin-schema-parser.ts
+++ b/astro-docs/src/plugins/utils/plugin-schema-parser.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { join, resolve as resolvePath } from 'path';
 import type { Schema } from 'nx/src/utils/params';
 
 export type PluginSchemaWithExamples = Schema & {
@@ -124,6 +124,13 @@ export function parseMigrations(pluginPath: string): Map<string, any> | null {
   for (const [name, config] of Object.entries(
     migrationsJson.generators || {}
   ) as [string, any][]) {
+    if (config.implmentation || config.factory) {
+      config['fullPath'] = resolvePath(
+        pluginPath,
+        config.implementation || config.factory
+      );
+    }
+
     migrations.set(name, { config, type: 'generator' });
   }
 
@@ -131,7 +138,7 @@ export function parseMigrations(pluginPath: string): Map<string, any> | null {
   for (const [version, config] of Object.entries(
     migrationsJson.packageJsonUpdates || {}
   ) as [string, any][]) {
-    migrations.set(`packageJsonUpdates-${version}`, {
+    migrations.set(`${version}-package-updates`, {
       config: { ...config, name: version },
       type: 'packageJsonUpdate',
     });


### PR DESCRIPTION
- adds "always add to package json" column for package json updates
<img width="786" height="529" alt="image" src="https://github.com/user-attachments/assets/6e4383c3-e4ec-4167-b76c-ad9a800e3564" />

- add migration examples 
    - **note** examples typically have mdoc tags, we plan to remove those from source files once we're clear to push to prod
<img width="782" height="926" alt="image" src="https://github.com/user-attachments/assets/67c1a8c2-c36c-4bc3-badc-b9657646babd" />


- add migration requirements section

![WKMac 2025-08-28T19-01-57](https://github.com/user-attachments/assets/b0bd0a3b-74e7-4f82-8d48-c7a322301bcd)


- fixes header indentation level for migrations 
    - **note** this now breaks overflow on toc, will fix in future PR, see DOC-191
  
<img width="441" height="479" alt="73083796c066816a69e44747e6e62eec05dfd4c4fc02f27a30d085f6c8d86235" src="https://github.com/user-attachments/assets/ccb0b908-403a-40fb-bf4d-61b8059b8d20" />



Fixes: DOC-146
Fixes: DOC-147