### PR TITLE
docs(misc): update styling for plugin registry cards

### DIFF
--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -14,7 +14,15 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
   tableOfContents: false
 }}
 >
-  <CardGrid>
+  <style>
+    /* Remove background and border from GitHub icon */
+    .plugin-grid .card [data-icon="github"] {
+      background: transparent !important;
+      border: none !important;
+      padding: 0 !important;
+    }
+  </style>
+  <CardGrid class="plugin-grid">
     {plugins.map(plugin => (
       <a href={`/docs/${plugin.data.slug}`} class="no-underline hover:no-underline block h-full">
         <Card title={plugin.data.packageName} icon="github" class="h-full flex flex-col">
@@ -22,8 +30,8 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
             {plugin.data.description}
           </p>
           
-          <div class="flex items-center justify-between mt-auto pt-2 border-t border-gray-200 dark:border-gray-800">
-            <div class="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-500">
+          <div class="mt-auto pt-2 border-t border-gray-200 dark:border-gray-800">
+            <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-500">
               {plugin.data.lastPublishedDate && (
                 <div class="flex items-center gap-1">
                   <Icon name="seti:clock" class="w-3.5 h-3.5" />
@@ -40,9 +48,11 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
                 <Icon name="cloud-download" class="w-3.5 h-3.5" />
                 <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
               </div>
+              
+              <div class="ml-auto">
+                <Badge size="small" variant="success" text="Nx Open Source" />
+              </div>
             </div>
-            
-            <Badge size="small" variant="success" text="Nx Open Source" />
           </div>
         </Card>
       </a>
@@ -54,8 +64,8 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
             {plugin.data.description}
           </p>
           
-          <div class="flex items-center justify-between mt-auto pt-2 border-t border-gray-200 dark:border-gray-800">
-            <div class="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-500">
+          <div class="mt-auto pt-2 border-t border-gray-200 dark:border-gray-800">
+            <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-500">
               {plugin.data.lastPublishedDate && (
                 <div class="flex items-center gap-1">
                   <Icon name="seti:clock" class="w-3.5 h-3.5" />
@@ -72,11 +82,13 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
                 <Icon name="cloud-download" class="w-3.5 h-3.5" />
                 <span>{plugin.data.npmDownloads}</span>
               </div>
+              
+              {plugin.data.nxVersion && (
+                <div class="ml-auto">
+                  <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
+                </div>
+              )}
             </div>
-            
-            {plugin.data.nxVersion && (
-              <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
-            )}
           </div>
         </Card>
       </a>

--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -14,71 +14,97 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
   tableOfContents: false
 }}
 >
-  <CardGrid>
+  <style>
+    .plugin-grid .card .title {
+      font-size: 1rem !important;
+      font-weight: 500 !important;
+      line-height: 1.5 !important;
+    }
+    .plugin-grid .card {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+    .plugin-grid .card .body {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+    .plugin-grid a:hover {
+      text-decoration: none !important;
+    }
+  </style>
+  <CardGrid class="plugin-grid [&_.card]:min-h-[200px]">
     {plugins.map(plugin => (
-      <Card title={plugin.data.packageName} icon="open-book">
-        <div class="flex justify-between flex-col gap-2 min-h-40">
-
-        <div class="line-clamp-3">
-          {plugin.data.description}
-        </div>
-          <div class="grow content-end">
-          <div class="flex flex-wrap align-center justify-between gap-1 text-xs font-medium capitalize text-center">
-
-            {plugin.data.lastPublishedDate && <div class="inline-flex gap-1 items-end">
-                <Icon name="seti:clock" class="w-4 h-4 align-bottom inline-block" />
-                {dateFormatter(plugin.data.lastPublishedDate!)}</div>}
-
-            <div class="inline-flex gap-1">
-              <Icon name="star" class="w-4 h-4 inline-block align-bottom" />
-              {largeNumberFormatter(plugin.data.githubStars!)}</div>
-            <div class="inline-flex gap-1">
-              <Icon name="cloud-download" class="w-4 h-4 inline-block align-bottom" />
-              {largeNumberFormatter(plugin.data.npmDownloads!)}</div>
-          </div>
-
-          <div class="flex flex-wrap align-center justify-between gap-1 font-medium capitalize text-center">
-            <a href={`/docs/${plugin.data.slug}`} >
-              View Plugin
-            </a>
-
-              <div>
-            <Badge size="small" variant="success" text="Nx Open Source" />
+      <a href={`/docs/${plugin.data.slug}`} class="no-underline [&_.title]:!text-base [&_.title]:!font-medium [&_.title]:!text-current [&:hover]:!no-underline">
+        <Card title={plugin.data.packageName} icon="github">
+          <div class="flex flex-col h-full">
+            <div class="line-clamp-3 mb-4 text-sm text-gray-600 dark:text-gray-400">
+              {plugin.data.description}
             </div>
+            
+            <div class="flex items-center justify-between mt-auto text-xs text-gray-500 dark:text-gray-400">
+              <div class="flex items-center gap-3">
+                {plugin.data.lastPublishedDate && (
+                  <div class="flex items-center gap-1">
+                    <Icon name="seti:clock" class="w-3.5 h-3.5" />
+                    <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
+                  </div>
+                )}
+                
+                <div class="flex items-center gap-1">
+                  <Icon name="star" class="w-3.5 h-3.5" />
+                  <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
+                </div>
+                
+                <div class="flex items-center gap-1">
+                  <Icon name="cloud-download" class="w-3.5 h-3.5" />
+                  <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
+                </div>
+              </div>
+              
+              <Badge size="small" variant="success" text="Nx Open Source" />
             </div>
           </div>
-        </div>
-      </Card>
+        </Card>
+      </a>
     ))}
     {communityPlugins.map(plugin => (
-      <Card title={plugin.id} icon="open-book">
-        <div class="flex flex-col gap-2 min-h-40">
-          <p class="line-clamp-3">
-            {plugin.data.description}
-          </p>
-
-          <div class="grow content-end">
-          <div class="flex flex-wrap align-center justify-between gap-1 text-xs font-medium capitalize text-center">
-            {plugin.data.lastPublishedDate &&
-              <div class="inline-flex gap-1 items-end">
-                <Icon name="seti:clock" class="w-4 h-4 align-bottom inline-block" />
-                {dateFormatter(plugin.data.lastPublishedDate!)}</div>}
-            <div class="inline-flex gap-1">
-              <Icon name="star" class="w-4 h-4 inline-block align-bottom" />
-              {plugin.data.githubStars}</div>
-            <div class="inline-flex gap-1">
-              <Icon name="cloud-download" class="w-4 h-4 inline-block align-bottom" />
-              {plugin.data.npmDownloads}</div>
-            {plugin.data.nxVersion &&
-              <div class="inline-flex gap-1">
-                <Icon name="information" class="w-4 h-4 inline-block align-bottom" />
-                {plugin.data.nxVersion}</div>}
+      <a href={plugin.data.url} class="no-underline [&_.title]:!text-base [&_.title]:!font-medium [&_.title]:!text-current [&:hover]:!no-underline" target="_blank" rel="noopener noreferrer">
+        <Card title={plugin.id} icon="github">
+          <div class="flex flex-col h-full">
+            <div class="line-clamp-3 mb-4 text-sm text-gray-600 dark:text-gray-400">
+              {plugin.data.description}
+            </div>
+            
+            <div class="flex items-center justify-between mt-auto text-xs text-gray-500 dark:text-gray-400">
+              <div class="flex items-center gap-3">
+                {plugin.data.lastPublishedDate && (
+                  <div class="flex items-center gap-1">
+                    <Icon name="seti:clock" class="w-3.5 h-3.5" />
+                    <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
+                  </div>
+                )}
+                
+                <div class="flex items-center gap-1">
+                  <Icon name="star" class="w-3.5 h-3.5" />
+                  <span>{plugin.data.githubStars}</span>
+                </div>
+                
+                <div class="flex items-center gap-1">
+                  <Icon name="cloud-download" class="w-3.5 h-3.5" />
+                  <span>{plugin.data.npmDownloads}</span>
+                </div>
+              </div>
+              
+              {plugin.data.nxVersion && (
+                <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
+              )}
+            </div>
           </div>
-
-          <a href={plugin.data.url}>View Plugin</a>
-          </div>
-        </div>
-      </Card>))}
+        </Card>
+      </a>
+    ))}
   </CardGrid>
 
 

--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -18,20 +18,20 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
     {plugins.map(plugin => (
       <a 
         href={`/docs/${plugin.data.slug}`} 
-        class="block h-full bg-slate-900 border border-slate-800 rounded-lg p-6 hover:bg-slate-800 transition-colors no-underline"
+        class="block h-full bg-gray-50 dark:bg-slate-800/50 rounded-lg p-6 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors no-underline"
       >
         <div class="flex flex-col h-full">
           <div class="flex items-start gap-3 mb-3">
-            <Icon name="github" class="w-6 h-6 text-slate-400 flex-shrink-0 mt-0.5" />
-            <h3 class="text-base font-medium text-slate-100 leading-tight">{plugin.data.packageName}</h3>
+            <Icon name="github" class="w-6 h-6 text-gray-600 dark:text-slate-400 flex-shrink-0 mt-0.5" />
+            <h3 class="text-base font-medium text-gray-900 dark:text-slate-100 leading-tight">{plugin.data.packageName}</h3>
           </div>
           
-          <p class="text-sm text-slate-400 line-clamp-3 mb-4 flex-grow">
+          <p class="text-sm text-gray-600 dark:text-slate-400 line-clamp-3 mb-4 flex-grow">
             {plugin.data.description}
           </p>
           
-          <div class="pt-3 border-t border-slate-800">
-            <div class="flex items-center justify-between text-xs text-slate-500">
+          <div class="pt-3 border-t border-gray-200 dark:border-slate-700">
+            <div class="flex items-center justify-between text-xs text-gray-500 dark:text-slate-500">
               <div class="flex items-center gap-3">
                 {plugin.data.lastPublishedDate && (
                   <div class="flex items-center gap-1">
@@ -61,22 +61,22 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
     {communityPlugins.map(plugin => (
       <a 
         href={plugin.data.url} 
-        class="block h-full bg-slate-900 border border-slate-800 rounded-lg p-6 hover:bg-slate-800 transition-colors no-underline"
+        class="block h-full bg-gray-50 dark:bg-slate-800/50 rounded-lg p-6 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors no-underline"
         target="_blank" 
         rel="noopener noreferrer"
       >
         <div class="flex flex-col h-full">
           <div class="flex items-start gap-3 mb-3">
-            <Icon name="github" class="w-6 h-6 text-slate-400 flex-shrink-0 mt-0.5" />
-            <h3 class="text-base font-medium text-slate-100 leading-tight">{plugin.id}</h3>
+            <Icon name="github" class="w-6 h-6 text-gray-600 dark:text-slate-400 flex-shrink-0 mt-0.5" />
+            <h3 class="text-base font-medium text-gray-900 dark:text-slate-100 leading-tight">{plugin.id}</h3>
           </div>
           
-          <p class="text-sm text-slate-400 line-clamp-3 mb-4 flex-grow">
+          <p class="text-sm text-gray-600 dark:text-slate-400 line-clamp-3 mb-4 flex-grow">
             {plugin.data.description}
           </p>
           
-          <div class="pt-3 border-t border-slate-800">
-            <div class="flex items-center justify-between text-xs text-slate-500">
+          <div class="pt-3 border-t border-gray-200 dark:border-slate-700">
+            <div class="flex items-center justify-between text-xs text-gray-500 dark:text-slate-500">
               <div class="flex items-center gap-3">
                 {plugin.data.lastPublishedDate && (
                   <div class="flex items-center gap-1">

--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -16,77 +16,84 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
 >
   <style>
     /* Remove background and border from GitHub icon */
-    .plugin-grid .card [data-icon="github"] {
+    :global(.sl-card-grid [data-icon="github"]) {
       background: transparent !important;
       border: none !important;
       padding: 0 !important;
     }
+    
+    /* Fix bottom row alignment */
+    :global(.sl-card-grid .sl-card) {
+      display: flex !important;
+      flex-direction: column !important;
+    }
   </style>
-  <CardGrid class="plugin-grid">
+  
+  <CardGrid>
     {plugins.map(plugin => (
-      <a href={`/docs/${plugin.data.slug}`} class="no-underline hover:no-underline block h-full">
-        <Card title={plugin.data.packageName} icon="github" class="h-full flex flex-col">
-          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-3 mb-4">
+      <a href={`/docs/${plugin.data.slug}`} class="not-content no-underline hover:no-underline block h-full">
+        <Card title={plugin.data.packageName} icon="github">
+          <p class="text-sm text-slate-600 dark:text-slate-400 line-clamp-3 mb-4">
             {plugin.data.description}
           </p>
           
-          <div class="mt-auto pt-2 border-t border-gray-200 dark:border-gray-800">
-            <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-500">
-              {plugin.data.lastPublishedDate && (
+          <div class="mt-auto pt-2 border-t border-slate-200 dark:border-slate-800">
+            <div class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-500">
+              <div class="flex items-center gap-3">
+                {plugin.data.lastPublishedDate && (
+                  <div class="flex items-center gap-1">
+                    <Icon name="seti:clock" class="w-3.5 h-3.5" />
+                    <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
+                  </div>
+                )}
+                
                 <div class="flex items-center gap-1">
-                  <Icon name="seti:clock" class="w-3.5 h-3.5" />
-                  <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
+                  <Icon name="star" class="w-3.5 h-3.5" />
+                  <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
                 </div>
-              )}
-              
-              <div class="flex items-center gap-1">
-                <Icon name="star" class="w-3.5 h-3.5" />
-                <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
+                
+                <div class="flex items-center gap-1">
+                  <Icon name="cloud-download" class="w-3.5 h-3.5" />
+                  <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
+                </div>
               </div>
               
-              <div class="flex items-center gap-1">
-                <Icon name="cloud-download" class="w-3.5 h-3.5" />
-                <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
-              </div>
-              
-              <div class="ml-auto">
-                <Badge size="small" variant="success" text="Nx Open Source" />
-              </div>
+              <Badge size="small" variant="success" text="Nx Open Source" />
             </div>
           </div>
         </Card>
       </a>
     ))}
     {communityPlugins.map(plugin => (
-      <a href={plugin.data.url} class="no-underline hover:no-underline block h-full" target="_blank" rel="noopener noreferrer">
-        <Card title={plugin.id} icon="github" class="h-full flex flex-col">
-          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-3 mb-4">
+      <a href={plugin.data.url} class="not-content no-underline hover:no-underline block h-full" target="_blank" rel="noopener noreferrer">
+        <Card title={plugin.id} icon="github">
+          <p class="text-sm text-slate-600 dark:text-slate-400 line-clamp-3 mb-4">
             {plugin.data.description}
           </p>
           
-          <div class="mt-auto pt-2 border-t border-gray-200 dark:border-gray-800">
-            <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-500">
-              {plugin.data.lastPublishedDate && (
+          <div class="mt-auto pt-2 border-t border-slate-200 dark:border-slate-800">
+            <div class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-500">
+              <div class="flex items-center gap-3">
+                {plugin.data.lastPublishedDate && (
+                  <div class="flex items-center gap-1">
+                    <Icon name="seti:clock" class="w-3.5 h-3.5" />
+                    <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
+                  </div>
+                )}
+                
                 <div class="flex items-center gap-1">
-                  <Icon name="seti:clock" class="w-3.5 h-3.5" />
-                  <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
+                  <Icon name="star" class="w-3.5 h-3.5" />
+                  <span>{plugin.data.githubStars}</span>
                 </div>
-              )}
-              
-              <div class="flex items-center gap-1">
-                <Icon name="star" class="w-3.5 h-3.5" />
-                <span>{plugin.data.githubStars}</span>
-              </div>
-              
-              <div class="flex items-center gap-1">
-                <Icon name="cloud-download" class="w-3.5 h-3.5" />
-                <span>{plugin.data.npmDownloads}</span>
+                
+                <div class="flex items-center gap-1">
+                  <Icon name="cloud-download" class="w-3.5 h-3.5" />
+                  <span>{plugin.data.npmDownloads}</span>
+                </div>
               </div>
               
               {plugin.data.nxVersion && (
-                <div class="ml-auto">
-                  <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
-                </div>
+                <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
               )}
             </div>
           </div>

--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -18,10 +18,10 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
     {plugins.map(plugin => (
       <a 
         href={`/docs/${plugin.data.slug}`} 
-        class="block h-full bg-gray-50 dark:bg-slate-800/50 rounded-lg p-6 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors no-underline"
+        class="block h-full bg-gray-50 dark:bg-slate-800/50 rounded-lg p-4 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors no-underline"
       >
         <div class="flex flex-col h-full">
-          <div class="flex items-start gap-3 mb-3">
+          <div class="flex gap-3 items-center mb-3">
             <Icon name="github" class="w-6 h-6 text-gray-600 dark:text-slate-400 flex-shrink-0 mt-0.5" />
             <h3 class="text-base font-medium text-gray-900 dark:text-slate-100 leading-tight">{plugin.data.packageName}</h3>
           </div>
@@ -29,39 +29,28 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
           <p class="text-sm text-gray-600 dark:text-slate-400 line-clamp-3 mb-4 flex-grow">
             {plugin.data.description}
           </p>
-          
-          <div class="pt-3 border-t border-gray-200 dark:border-slate-700">
-            <div class="flex items-center justify-between text-xs text-gray-500 dark:text-slate-500">
-              <div class="flex items-center gap-3">
-                {plugin.data.lastPublishedDate && (
-                  <div class="flex items-center gap-1">
-                    <Icon name="seti:clock" class="w-3.5 h-3.5" />
-                    <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
-                  </div>
-                )}
-                
-                <div class="flex items-center gap-1">
-                  <Icon name="star" class="w-3.5 h-3.5" />
-                  <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
-                </div>
-                
-                <div class="flex items-center gap-1">
-                  <Icon name="cloud-download" class="w-3.5 h-3.5" />
-                  <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
-                </div>
+          <div class="flex flex-wrap items-center justify-between py-0.5 text-xs text-slate-700 dark:text-slate-400">
+            {plugin.data.lastPublishedDate && (
+              <div class="mx-1 my-1 flex items-center gap-1">
+                <Icon name="seti:clock" class="w-3.5 h-3.5" />
+                <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
               </div>
-              
-              <Badge size="small" variant="success" text="Nx Open Source" />
+            )}
+            <div class="mx-1 my-1 flex items-center gap-1">
+              <Icon name="cloud-download" class="w-3.5 h-3.5" />
+              <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
+            </div>
+            <div class="flex-1 flex justify-end mx-1 my-1">
+              <Badge size="small" variant="tip" text="Nx Open Source" />
             </div>
           </div>
         </div>
       </a>
     ))}
-    
     {communityPlugins.map(plugin => (
       <a 
         href={plugin.data.url} 
-        class="block h-full bg-gray-50 dark:bg-slate-800/50 rounded-lg p-6 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors no-underline"
+        class="block h-full bg-gray-50 dark:bg-slate-800/50 rounded-lg p-4 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors no-underline"
         target="_blank" 
         rel="noopener noreferrer"
       >
@@ -87,12 +76,12 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
                 
                 <div class="flex items-center gap-1">
                   <Icon name="star" class="w-3.5 h-3.5" />
-                  <span>{plugin.data.githubStars}</span>
+                  <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
                 </div>
                 
                 <div class="flex items-center gap-1">
                   <Icon name="cloud-download" class="w-3.5 h-3.5" />
-                  <span>{plugin.data.npmDownloads}</span>
+                  <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
                 </div>
               </div>
               

--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -14,93 +14,69 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
   tableOfContents: false
 }}
 >
-  <style>
-    .plugin-grid .card .title {
-      font-size: 1rem !important;
-      font-weight: 500 !important;
-      line-height: 1.5 !important;
-    }
-    .plugin-grid .card {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-    .plugin-grid .card .body {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-    }
-    .plugin-grid a:hover {
-      text-decoration: none !important;
-    }
-  </style>
-  <CardGrid class="plugin-grid [&_.card]:min-h-[200px]">
+  <CardGrid>
     {plugins.map(plugin => (
-      <a href={`/docs/${plugin.data.slug}`} class="no-underline [&_.title]:!text-base [&_.title]:!font-medium [&_.title]:!text-current [&:hover]:!no-underline">
-        <Card title={plugin.data.packageName} icon="github">
-          <div class="flex flex-col h-full">
-            <div class="line-clamp-3 mb-4 text-sm text-gray-600 dark:text-gray-400">
-              {plugin.data.description}
-            </div>
-            
-            <div class="flex items-center justify-between mt-auto text-xs text-gray-500 dark:text-gray-400">
-              <div class="flex items-center gap-3">
-                {plugin.data.lastPublishedDate && (
-                  <div class="flex items-center gap-1">
-                    <Icon name="seti:clock" class="w-3.5 h-3.5" />
-                    <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
-                  </div>
-                )}
-                
+      <a href={`/docs/${plugin.data.slug}`} class="no-underline hover:no-underline block h-full">
+        <Card title={plugin.data.packageName} icon="github" class="h-full flex flex-col">
+          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-3 mb-4">
+            {plugin.data.description}
+          </p>
+          
+          <div class="flex items-center justify-between mt-auto pt-2 border-t border-gray-200 dark:border-gray-800">
+            <div class="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-500">
+              {plugin.data.lastPublishedDate && (
                 <div class="flex items-center gap-1">
-                  <Icon name="star" class="w-3.5 h-3.5" />
-                  <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
+                  <Icon name="seti:clock" class="w-3.5 h-3.5" />
+                  <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
                 </div>
-                
-                <div class="flex items-center gap-1">
-                  <Icon name="cloud-download" class="w-3.5 h-3.5" />
-                  <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
-                </div>
+              )}
+              
+              <div class="flex items-center gap-1">
+                <Icon name="star" class="w-3.5 h-3.5" />
+                <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
               </div>
               
-              <Badge size="small" variant="success" text="Nx Open Source" />
+              <div class="flex items-center gap-1">
+                <Icon name="cloud-download" class="w-3.5 h-3.5" />
+                <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
+              </div>
             </div>
+            
+            <Badge size="small" variant="success" text="Nx Open Source" />
           </div>
         </Card>
       </a>
     ))}
     {communityPlugins.map(plugin => (
-      <a href={plugin.data.url} class="no-underline [&_.title]:!text-base [&_.title]:!font-medium [&_.title]:!text-current [&:hover]:!no-underline" target="_blank" rel="noopener noreferrer">
-        <Card title={plugin.id} icon="github">
-          <div class="flex flex-col h-full">
-            <div class="line-clamp-3 mb-4 text-sm text-gray-600 dark:text-gray-400">
-              {plugin.data.description}
-            </div>
-            
-            <div class="flex items-center justify-between mt-auto text-xs text-gray-500 dark:text-gray-400">
-              <div class="flex items-center gap-3">
-                {plugin.data.lastPublishedDate && (
-                  <div class="flex items-center gap-1">
-                    <Icon name="seti:clock" class="w-3.5 h-3.5" />
-                    <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
-                  </div>
-                )}
-                
+      <a href={plugin.data.url} class="no-underline hover:no-underline block h-full" target="_blank" rel="noopener noreferrer">
+        <Card title={plugin.id} icon="github" class="h-full flex flex-col">
+          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-3 mb-4">
+            {plugin.data.description}
+          </p>
+          
+          <div class="flex items-center justify-between mt-auto pt-2 border-t border-gray-200 dark:border-gray-800">
+            <div class="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-500">
+              {plugin.data.lastPublishedDate && (
                 <div class="flex items-center gap-1">
-                  <Icon name="star" class="w-3.5 h-3.5" />
-                  <span>{plugin.data.githubStars}</span>
+                  <Icon name="seti:clock" class="w-3.5 h-3.5" />
+                  <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
                 </div>
-                
-                <div class="flex items-center gap-1">
-                  <Icon name="cloud-download" class="w-3.5 h-3.5" />
-                  <span>{plugin.data.npmDownloads}</span>
-                </div>
+              )}
+              
+              <div class="flex items-center gap-1">
+                <Icon name="star" class="w-3.5 h-3.5" />
+                <span>{plugin.data.githubStars}</span>
               </div>
               
-              {plugin.data.nxVersion && (
-                <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
-              )}
+              <div class="flex items-center gap-1">
+                <Icon name="cloud-download" class="w-3.5 h-3.5" />
+                <span>{plugin.data.npmDownloads}</span>
+              </div>
             </div>
+            
+            {plugin.data.nxVersion && (
+              <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
+            )}
           </div>
         </Card>
       </a>

--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
-import { CardGrid, Card, Icon, Badge } from '@astrojs/starlight/components';
+import { Icon, Badge } from '@astrojs/starlight/components';
 import {largeNumberFormatter, dateFormatter } from '../utils/formatters';
 
 const communityPlugins = await getCollection('community-plugins');
@@ -14,31 +14,24 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
   tableOfContents: false
 }}
 >
-  <style>
-    /* Remove background and border from GitHub icon */
-    :global(.sl-card-grid [data-icon="github"]) {
-      background: transparent !important;
-      border: none !important;
-      padding: 0 !important;
-    }
-    
-    /* Fix bottom row alignment */
-    :global(.sl-card-grid .sl-card) {
-      display: flex !important;
-      flex-direction: column !important;
-    }
-  </style>
-  
-  <CardGrid>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 not-content">
     {plugins.map(plugin => (
-      <a href={`/docs/${plugin.data.slug}`} class="not-content no-underline hover:no-underline block h-full">
-        <Card title={plugin.data.packageName} icon="github">
-          <p class="text-sm text-slate-600 dark:text-slate-400 line-clamp-3 mb-4">
+      <a 
+        href={`/docs/${plugin.data.slug}`} 
+        class="block h-full bg-slate-900 border border-slate-800 rounded-lg p-6 hover:bg-slate-800 transition-colors no-underline"
+      >
+        <div class="flex flex-col h-full">
+          <div class="flex items-start gap-3 mb-3">
+            <Icon name="github" class="w-6 h-6 text-slate-400 flex-shrink-0 mt-0.5" />
+            <h3 class="text-base font-medium text-slate-100 leading-tight">{plugin.data.packageName}</h3>
+          </div>
+          
+          <p class="text-sm text-slate-400 line-clamp-3 mb-4 flex-grow">
             {plugin.data.description}
           </p>
           
-          <div class="mt-auto pt-2 border-t border-slate-200 dark:border-slate-800">
-            <div class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-500">
+          <div class="pt-3 border-t border-slate-800">
+            <div class="flex items-center justify-between text-xs text-slate-500">
               <div class="flex items-center gap-3">
                 {plugin.data.lastPublishedDate && (
                   <div class="flex items-center gap-1">
@@ -61,18 +54,29 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
               <Badge size="small" variant="success" text="Nx Open Source" />
             </div>
           </div>
-        </Card>
+        </div>
       </a>
     ))}
+    
     {communityPlugins.map(plugin => (
-      <a href={plugin.data.url} class="not-content no-underline hover:no-underline block h-full" target="_blank" rel="noopener noreferrer">
-        <Card title={plugin.id} icon="github">
-          <p class="text-sm text-slate-600 dark:text-slate-400 line-clamp-3 mb-4">
+      <a 
+        href={plugin.data.url} 
+        class="block h-full bg-slate-900 border border-slate-800 rounded-lg p-6 hover:bg-slate-800 transition-colors no-underline"
+        target="_blank" 
+        rel="noopener noreferrer"
+      >
+        <div class="flex flex-col h-full">
+          <div class="flex items-start gap-3 mb-3">
+            <Icon name="github" class="w-6 h-6 text-slate-400 flex-shrink-0 mt-0.5" />
+            <h3 class="text-base font-medium text-slate-100 leading-tight">{plugin.id}</h3>
+          </div>
+          
+          <p class="text-sm text-slate-400 line-clamp-3 mb-4 flex-grow">
             {plugin.data.description}
           </p>
           
-          <div class="mt-auto pt-2 border-t border-slate-200 dark:border-slate-800">
-            <div class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-500">
+          <div class="pt-3 border-t border-slate-800">
+            <div class="flex items-center justify-between text-xs text-slate-500">
               <div class="flex items-center gap-3">
                 {plugin.data.lastPublishedDate && (
                   <div class="flex items-center gap-1">
@@ -97,10 +101,10 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
               )}
             </div>
           </div>
-        </Card>
+        </div>
       </a>
     ))}
-  </CardGrid>
+  </div>
 
 
 </StarlightPage>

--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -18,7 +18,7 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
     {plugins.map(plugin => (
       <a 
         href={`/docs/${plugin.data.slug}`} 
-        class="block h-full bg-gray-50 dark:bg-slate-800/50 rounded-lg p-4 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors no-underline"
+        class="block h-full bg-gray-50 border-1 border-slate-200 dark:bg-slate-800/50 rounded-lg p-4 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors no-underline dark:border-slate-900"
       >
         <div class="flex flex-col h-full">
           <div class="flex gap-3 items-center mb-3">
@@ -45,7 +45,7 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
               <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
             </div>
             <div class="flex-1 flex justify-end ml-1 my-1 text-nowrap">
-              <Badge size="small" variant="tip" text="Nx Open Source" />
+              <Badge size="small" variant="success" text="Nx Open Source" />
             </div>
           </div>
         </div>

--- a/astro-docs/src/pages/plugin-registry.astro
+++ b/astro-docs/src/pages/plugin-registry.astro
@@ -31,16 +31,20 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
           </p>
           <div class="flex flex-wrap items-center justify-between py-0.5 text-xs text-slate-700 dark:text-slate-400">
             {plugin.data.lastPublishedDate && (
-              <div class="mx-1 my-1 flex items-center gap-1">
+              <div class="mr-1 my-1 flex items-center gap-1">
                 <Icon name="seti:clock" class="w-3.5 h-3.5" />
                 <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
               </div>
             )}
             <div class="mx-1 my-1 flex items-center gap-1">
-              <Icon name="cloud-download" class="w-3.5 h-3.5" />
+              <Icon name="star" class="w-4 h-4" />
+              <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
+            </div>
+            <div class="mx-1 my-1 flex items-center gap-1">
+              <Icon name="cloud-download" class="w-4 h-4" />
               <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
             </div>
-            <div class="flex-1 flex justify-end mx-1 my-1">
+            <div class="flex-1 flex justify-end ml-1 my-1 text-nowrap">
               <Badge size="small" variant="tip" text="Nx Open Source" />
             </div>
           </div>
@@ -55,7 +59,7 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
         rel="noopener noreferrer"
       >
         <div class="flex flex-col h-full">
-          <div class="flex items-start gap-3 mb-3">
+          <div class="flex gap-3 items-center mb-3">
             <Icon name="github" class="w-6 h-6 text-gray-600 dark:text-slate-400 flex-shrink-0 mt-0.5" />
             <h3 class="text-base font-medium text-gray-900 dark:text-slate-100 leading-tight">{plugin.id}</h3>
           </div>
@@ -63,32 +67,30 @@ const plugins = await getCollection('plugin-docs', (entry) => entry.data.docType
           <p class="text-sm text-gray-600 dark:text-slate-400 line-clamp-3 mb-4 flex-grow">
             {plugin.data.description}
           </p>
-          
-          <div class="pt-3 border-t border-gray-200 dark:border-slate-700">
-            <div class="flex items-center justify-between text-xs text-gray-500 dark:text-slate-500">
-              <div class="flex items-center gap-3">
-                {plugin.data.lastPublishedDate && (
-                  <div class="flex items-center gap-1">
-                    <Icon name="seti:clock" class="w-3.5 h-3.5" />
-                    <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
-                  </div>
-                )}
-                
-                <div class="flex items-center gap-1">
-                  <Icon name="star" class="w-3.5 h-3.5" />
-                  <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
-                </div>
-                
-                <div class="flex items-center gap-1">
-                  <Icon name="cloud-download" class="w-3.5 h-3.5" />
-                  <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
-                </div>
+          <div class="flex flex-wrap items-center justify-between py-0.5 text-xs text-slate-700 dark:text-slate-400">
+            {plugin.data.lastPublishedDate && (
+              <div class="mr-1 my-1 flex items-center gap-1">
+                <Icon name="seti:clock" class="w-3.5 h-3.5" />
+                <span>{dateFormatter(plugin.data.lastPublishedDate!)}</span>
               </div>
-              
-              {plugin.data.nxVersion && (
-                <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
-              )}
+            )}
+            <div class="mx-1 my-1 flex items-center gap-1">
+              <Icon name="star" class="w-4 h-4" />
+              <span>{largeNumberFormatter(plugin.data.githubStars!)}</span>
             </div>
+            <div class="mx-1 my-1 flex items-center gap-1">
+              <Icon name="cloud-download" class="w-4 h-4" />
+              <span>{largeNumberFormatter(plugin.data.npmDownloads!)}</span>
+            </div>
+            {plugin.data.nxVersion ? (
+              <div class="flex-1 flex justify-end ml-1 my-1 text-nowrap">
+                <Badge size="small" variant="caution" text={`Nx ${plugin.data.nxVersion}`} />
+              </div>
+            ) : (
+              <div class="flex-1 flex justify-end ml-1 my-1 text-nowrap">
+                <Badge size="small" variant="tip" text="Community" />
+              </div>
+            )}
           </div>
         </div>
       </a>

--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -253,54 +253,54 @@ pre {
 
   /* Override Starlight Badge component colors */
   /* Success/Tip variant - Green theme */
-  :global(.sl-badge[data-variant="success"]),
-  :global(.sl-badge[data-variant="tip"]) {
+  :global(.sl-badge.success),
+  :global(.sl-badge.tip) {
     --sl-color-bg-badge: theme('colors.green.50');
     --sl-color-border-badge: theme('colors.green.200');
     --sl-color-text-badge: theme('colors.green.700');
   }
   
-  :global([data-theme='dark'] .sl-badge[data-variant="success"]),
-  :global([data-theme='dark'] .sl-badge[data-variant="tip"]) {
+  :global([data-theme='dark'] .sl-badge.success),
+  :global([data-theme='dark'] .sl-badge.tip) {
     --sl-color-bg-badge: rgb(20 83 45 / 0.3); /* green-900/30 */
     --sl-color-border-badge: theme('colors.green.800');
     --sl-color-text-badge: theme('colors.green.400');
   }
   
   /* Caution variant - Yellow theme */
-  :global(.sl-badge[data-variant="caution"]) {
+  :global(.sl-badge.caution) {
     --sl-color-bg-badge: theme('colors.yellow.50');
     --sl-color-border-badge: theme('colors.yellow.200');
     --sl-color-text-badge: theme('colors.yellow.700');
   }
   
-  :global([data-theme='dark'] .sl-badge[data-variant="caution"]) {
+  :global([data-theme='dark'] .sl-badge.caution) {
     --sl-color-bg-badge: rgb(113 63 18 / 0.3); /* yellow-900/30 */
     --sl-color-border-badge: theme('colors.yellow.800');
     --sl-color-text-badge: theme('colors.yellow.400');
   }
   
   /* Danger variant - Red theme */
-  :global(.sl-badge[data-variant="danger"]) {
+  :global(.sl-badge.danger) {
     --sl-color-bg-badge: theme('colors.red.50');
     --sl-color-border-badge: theme('colors.red.200');
     --sl-color-text-badge: theme('colors.red.700');
   }
   
-  :global([data-theme='dark'] .sl-badge[data-variant="danger"]) {
+  :global([data-theme='dark'] .sl-badge.danger) {
     --sl-color-bg-badge: rgb(127 29 29 / 0.3); /* red-900/30 */
     --sl-color-border-badge: theme('colors.red.800');
     --sl-color-text-badge: theme('colors.red.400');
   }
   
   /* Note variant - Slate/gray theme */
-  :global(.sl-badge[data-variant="note"]) {
+  :global(.sl-badge.note) {
     --sl-color-bg-badge: theme('colors.slate.50');
     --sl-color-border-badge: theme('colors.slate.200');
     --sl-color-text-badge: theme('colors.slate.700');
   }
   
-  :global([data-theme='dark'] .sl-badge[data-variant="note"]) {
+  :global([data-theme='dark'] .sl-badge.note) {
     --sl-color-bg-badge: rgb(30 41 59 / 0.4); /* slate-800/40 */
     --sl-color-border-badge: theme('colors.slate.700');
     --sl-color-text-badge: theme('colors.slate.400');

--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -189,6 +189,122 @@ pre {
     color: var(--sl-color-text-accent);
     font-weight: var(--font-weight-semibold);
   }
+
+  /* Override Starlight Aside component colors to match Nx design system */
+  /* Note type - Slate/gray theme */
+  :global([data-aside-type="note"]) {
+    --sl-color-aside-bg: theme('colors.slate.50');
+    --sl-color-aside-border: theme('colors.slate.200');
+    --sl-color-aside-text: theme('colors.slate.700');
+    --sl-color-aside-title: theme('colors.slate.600');
+  }
+  
+  :global([data-theme='dark'] [data-aside-type="note"]) {
+    --sl-color-aside-bg: rgb(30 41 59 / 0.4); /* slate-800/40 */
+    --sl-color-aside-border: theme('colors.slate.700');
+    --sl-color-aside-text: theme('colors.slate.400');
+    --sl-color-aside-title: theme('colors.slate.300');
+  }
+  
+  /* Tip type - Green theme (check) */
+  :global([data-aside-type="tip"]) {
+    --sl-color-aside-bg: theme('colors.green.50');
+    --sl-color-aside-border: theme('colors.green.200');
+    --sl-color-aside-text: theme('colors.green.700');
+    --sl-color-aside-title: theme('colors.green.600');
+  }
+  
+  :global([data-theme='dark'] [data-aside-type="tip"]) {
+    --sl-color-aside-bg: rgb(20 83 45 / 0.3); /* green-900/30 */
+    --sl-color-aside-border: theme('colors.green.800');
+    --sl-color-aside-text: theme('colors.green.400');
+    --sl-color-aside-title: theme('colors.green.400');
+  }
+  
+  /* Caution type - Yellow theme (warning) */
+  :global([data-aside-type="caution"]) {
+    --sl-color-aside-bg: theme('colors.yellow.50');
+    --sl-color-aside-border: theme('colors.yellow.200');
+    --sl-color-aside-text: theme('colors.yellow.700');
+    --sl-color-aside-title: theme('colors.yellow.600');
+  }
+  
+  :global([data-theme='dark'] [data-aside-type="caution"]) {
+    --sl-color-aside-bg: rgb(113 63 18 / 0.3); /* yellow-900/30 */
+    --sl-color-aside-border: theme('colors.yellow.800');
+    --sl-color-aside-text: theme('colors.yellow.400');
+    --sl-color-aside-title: theme('colors.yellow.400');
+  }
+  
+  /* Danger type - Red theme */
+  :global([data-aside-type="danger"]) {
+    --sl-color-aside-bg: theme('colors.red.50');
+    --sl-color-aside-border: theme('colors.red.200');
+    --sl-color-aside-text: theme('colors.red.700');
+    --sl-color-aside-title: theme('colors.red.600');
+  }
+  
+  :global([data-theme='dark'] [data-aside-type="danger"]) {
+    --sl-color-aside-bg: rgb(127 29 29 / 0.3); /* red-900/30 */
+    --sl-color-aside-border: theme('colors.red.800');
+    --sl-color-aside-text: theme('colors.red.400');
+    --sl-color-aside-title: theme('colors.red.400');
+  }
+
+  /* Override Starlight Badge component colors */
+  /* Success/Tip variant - Green theme */
+  :global(.sl-badge[data-variant="success"]),
+  :global(.sl-badge[data-variant="tip"]) {
+    --sl-color-bg-badge: theme('colors.green.50');
+    --sl-color-border-badge: theme('colors.green.200');
+    --sl-color-text-badge: theme('colors.green.700');
+  }
+  
+  :global([data-theme='dark'] .sl-badge[data-variant="success"]),
+  :global([data-theme='dark'] .sl-badge[data-variant="tip"]) {
+    --sl-color-bg-badge: rgb(20 83 45 / 0.3); /* green-900/30 */
+    --sl-color-border-badge: theme('colors.green.800');
+    --sl-color-text-badge: theme('colors.green.400');
+  }
+  
+  /* Caution variant - Yellow theme */
+  :global(.sl-badge[data-variant="caution"]) {
+    --sl-color-bg-badge: theme('colors.yellow.50');
+    --sl-color-border-badge: theme('colors.yellow.200');
+    --sl-color-text-badge: theme('colors.yellow.700');
+  }
+  
+  :global([data-theme='dark'] .sl-badge[data-variant="caution"]) {
+    --sl-color-bg-badge: rgb(113 63 18 / 0.3); /* yellow-900/30 */
+    --sl-color-border-badge: theme('colors.yellow.800');
+    --sl-color-text-badge: theme('colors.yellow.400');
+  }
+  
+  /* Danger variant - Red theme */
+  :global(.sl-badge[data-variant="danger"]) {
+    --sl-color-bg-badge: theme('colors.red.50');
+    --sl-color-border-badge: theme('colors.red.200');
+    --sl-color-text-badge: theme('colors.red.700');
+  }
+  
+  :global([data-theme='dark'] .sl-badge[data-variant="danger"]) {
+    --sl-color-bg-badge: rgb(127 29 29 / 0.3); /* red-900/30 */
+    --sl-color-border-badge: theme('colors.red.800');
+    --sl-color-text-badge: theme('colors.red.400');
+  }
+  
+  /* Note variant - Slate/gray theme */
+  :global(.sl-badge[data-variant="note"]) {
+    --sl-color-bg-badge: theme('colors.slate.50');
+    --sl-color-border-badge: theme('colors.slate.200');
+    --sl-color-text-badge: theme('colors.slate.700');
+  }
+  
+  :global([data-theme='dark'] .sl-badge[data-variant="note"]) {
+    --sl-color-bg-badge: rgb(30 41 59 / 0.4); /* slate-800/40 */
+    --sl-color-border-badge: theme('colors.slate.700');
+    --sl-color-text-badge: theme('colors.slate.400');
+  }
 } /* end component layer */
 
 /* Additional custom styles can be added here */

--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -39,6 +39,18 @@
   --sl-color-gray-4: var(--color-slate-500);
   --sl-color-gray-5: var(--color-slate-700);
   --sl-color-gray-6: var(--color-slate-800);
+  --sl-badge-success-bg: var(--color-green-950);
+  --sl-badge-success-border: var(--color-green-600);
+  --sl-badge-success-text: var(--color-green-200);
+  --sl-badge-tip-bg: var(--color-indigo-900);
+  --sl-badge-tip-border: var(--color-indigo-600);
+  --sl-badge-tip-text: var(--color-indigo-200);
+  --sl-badge-note-bg: var(--color-blue-950);
+  --sl-badge-note-border: var(--color-blue-600);
+  --sl-badge-note-text: var(--color-blue-200);
+  --sl-badge-caution-bg: var(--color-yellow-800);
+  --sl-badge-caution-border: var(--color-yellow-600);
+  --sl-badge-caution-text: var(--color-yellow-100);
 }
 
 /* Light mode colors. */
@@ -58,6 +70,18 @@
   --sl-color-gray-4: var(--color-slate-500);
   --sl-color-gray-5: var(--color-slate-300);
   --sl-color-gray-6: var(--color-slate-200);
+  --sl-badge-success-bg: var(--color-green-50);
+  --sl-badge-success-border: var(--color-green-300);
+  --sl-badge-success-text: var(--color-green-600);
+  --sl-badge-tip-bg: var(--color-indigo-50);
+  --sl-badge-tip-border: var(--color-indigo-300);
+  --sl-badge-tip-text: var(--color-blue-600);
+  --sl-badge-note-bg: var(--color-blue-50);
+  --sl-badge-note-border: var(--color-blue-300);
+  --sl-badge-note-text: var(--color-blue-600);
+  --sl-badge-caution-bg: var(--color-yellow-50);
+  --sl-badge-caution-border: var(--color-yellow-300);
+  --sl-badge-caution-text: var(--color-yellow-600);
 }
 
 /* Adaptive icons, like GitHub logo, etc. */
@@ -192,59 +216,59 @@ pre {
 
   /* Override Starlight Aside component colors to match Nx design system */
   /* Note type - Slate/gray theme */
-  :global([data-aside-type="note"]) {
+  :global([data-aside-type='note']) {
     --sl-color-aside-bg: theme('colors.slate.50');
     --sl-color-aside-border: theme('colors.slate.200');
     --sl-color-aside-text: theme('colors.slate.700');
     --sl-color-aside-title: theme('colors.slate.600');
   }
-  
-  :global([data-theme='dark'] [data-aside-type="note"]) {
+
+  :global([data-theme='dark'] [data-aside-type='note']) {
     --sl-color-aside-bg: rgb(30 41 59 / 0.4); /* slate-800/40 */
     --sl-color-aside-border: theme('colors.slate.700');
     --sl-color-aside-text: theme('colors.slate.400');
     --sl-color-aside-title: theme('colors.slate.300');
   }
-  
+
   /* Tip type - Green theme (check) */
-  :global([data-aside-type="tip"]) {
+  :global([data-aside-type='tip']) {
     --sl-color-aside-bg: theme('colors.green.50');
     --sl-color-aside-border: theme('colors.green.200');
     --sl-color-aside-text: theme('colors.green.700');
     --sl-color-aside-title: theme('colors.green.600');
   }
-  
-  :global([data-theme='dark'] [data-aside-type="tip"]) {
+
+  :global([data-theme='dark'] [data-aside-type='tip']) {
     --sl-color-aside-bg: rgb(20 83 45 / 0.3); /* green-900/30 */
     --sl-color-aside-border: theme('colors.green.800');
     --sl-color-aside-text: theme('colors.green.400');
     --sl-color-aside-title: theme('colors.green.400');
   }
-  
+
   /* Caution type - Yellow theme (warning) */
-  :global([data-aside-type="caution"]) {
+  :global([data-aside-type='caution']) {
     --sl-color-aside-bg: theme('colors.yellow.50');
     --sl-color-aside-border: theme('colors.yellow.200');
     --sl-color-aside-text: theme('colors.yellow.700');
     --sl-color-aside-title: theme('colors.yellow.600');
   }
-  
-  :global([data-theme='dark'] [data-aside-type="caution"]) {
+
+  :global([data-theme='dark'] [data-aside-type='caution']) {
     --sl-color-aside-bg: rgb(113 63 18 / 0.3); /* yellow-900/30 */
     --sl-color-aside-border: theme('colors.yellow.800');
     --sl-color-aside-text: theme('colors.yellow.400');
     --sl-color-aside-title: theme('colors.yellow.400');
   }
-  
+
   /* Danger type - Red theme */
-  :global([data-aside-type="danger"]) {
+  :global([data-aside-type='danger']) {
     --sl-color-aside-bg: theme('colors.red.50');
     --sl-color-aside-border: theme('colors.red.200');
     --sl-color-aside-text: theme('colors.red.700');
     --sl-color-aside-title: theme('colors.red.600');
   }
-  
-  :global([data-theme='dark'] [data-aside-type="danger"]) {
+
+  :global([data-theme='dark'] [data-aside-type='danger']) {
     --sl-color-aside-bg: rgb(127 29 29 / 0.3); /* red-900/30 */
     --sl-color-aside-border: theme('colors.red.800');
     --sl-color-aside-text: theme('colors.red.400');
@@ -259,47 +283,47 @@ pre {
     --sl-color-border-badge: theme('colors.green.200');
     --sl-color-text-badge: theme('colors.green.700');
   }
-  
+
   :global([data-theme='dark'] .sl-badge.success),
   :global([data-theme='dark'] .sl-badge.tip) {
     --sl-color-bg-badge: rgb(20 83 45 / 0.3); /* green-900/30 */
     --sl-color-border-badge: theme('colors.green.800');
     --sl-color-text-badge: theme('colors.green.400');
   }
-  
+
   /* Caution variant - Yellow theme */
   :global(.sl-badge.caution) {
     --sl-color-bg-badge: theme('colors.yellow.50');
     --sl-color-border-badge: theme('colors.yellow.200');
     --sl-color-text-badge: theme('colors.yellow.700');
   }
-  
+
   :global([data-theme='dark'] .sl-badge.caution) {
     --sl-color-bg-badge: rgb(113 63 18 / 0.3); /* yellow-900/30 */
     --sl-color-border-badge: theme('colors.yellow.800');
     --sl-color-text-badge: theme('colors.yellow.400');
   }
-  
+
   /* Danger variant - Red theme */
   :global(.sl-badge.danger) {
     --sl-color-bg-badge: theme('colors.red.50');
     --sl-color-border-badge: theme('colors.red.200');
     --sl-color-text-badge: theme('colors.red.700');
   }
-  
+
   :global([data-theme='dark'] .sl-badge.danger) {
     --sl-color-bg-badge: rgb(127 29 29 / 0.3); /* red-900/30 */
     --sl-color-border-badge: theme('colors.red.800');
     --sl-color-text-badge: theme('colors.red.400');
   }
-  
+
   /* Note variant - Slate/gray theme */
   :global(.sl-badge.note) {
     --sl-color-bg-badge: theme('colors.slate.50');
     --sl-color-border-badge: theme('colors.slate.200');
     --sl-color-text-badge: theme('colors.slate.700');
   }
-  
+
   :global([data-theme='dark'] .sl-badge.note) {
     --sl-color-bg-badge: rgb(30 41 59 / 0.4); /* slate-800/40 */
     --sl-color-border-badge: theme('colors.slate.700');


### PR DESCRIPTION
This PR updates the cards on `/docs/plugin-registry` for the new Astro docs.

<img width="830" height="286" alt="image" src="https://github.com/user-attachments/assets/942e6764-3f7f-4986-85a1-3b6c603078c6" />

With the PR changes it looks like this:

(dark theme)
<img width="897" height="811" alt="image" src="https://github.com/user-attachments/assets/06ed3045-d0f2-4c5c-88bd-eb39b0dd7b0b" />

(light theme) 

<img width="803" height="811" alt="image" src="https://github.com/user-attachments/assets/7347402c-0829-450d-b85d-5b0b0b541b9c" />

**Changes:**

- Use `<div>`  rather than cards so we can match production styles more closely
- Customize the badge colors to match existing production 


Fixes #DOC-172
