### PR TITLE
fix(core): detect devcontainer environment and skip Nx Console installation prompt if it exists

### DIFF
--- a/packages/nx/src/native/ide/install.rs
+++ b/packages/nx/src/native/ide/install.rs
@@ -153,7 +153,10 @@ pub fn get_install_command() -> Option<&'static str> {
     let dev_container_vars = ["CODESPACES", "DEVCONTAINER", "REMOTE_CONTAINERS"];
     for var in &dev_container_vars {
         if std::env::var(var).is_ok() {
-            debug!("Nx Console extension installation skipped - detected dev container environment variable: {}", var);
+            debug!(
+                "Nx Console extension installation skipped - detected dev container environment variable: {}",
+                var
+            );
             return None;
         }
     }

--- a/packages/nx/src/native/ide/install.rs
+++ b/packages/nx/src/native/ide/install.rs
@@ -149,6 +149,15 @@ pub fn get_install_command() -> Option<&'static str> {
         return None;
     }
 
+    // Check for dev container environment variables
+    let dev_container_vars = ["CODESPACES", "DEVCONTAINER", "REMOTE_CONTAINERS"];
+    for var in &dev_container_vars {
+        if std::env::var(var).is_ok() {
+            debug!("Nx Console extension installation skipped - detected dev container environment variable: {}", var);
+            return None;
+        }
+    }
+
     // Use the sophisticated editor detection from nx_console
     let current_editor = get_current_editor();
     debug!("Detected editor: {:?}", current_editor);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
In a devcontainer environment, the tmp file we write to when the user doesn't want to install nx console isn't saved. This means that every time they start 

## Expected Behavior
Devcontainers are a special case, we can skip asking the user if we detect we are in one.
