### PR TITLE
fix(rspack): expand serve-static target names for init generator

### DIFF
--- a/packages/rspack/src/generators/init/init.ts
+++ b/packages/rspack/src/generators/init/init.ts
@@ -54,6 +54,11 @@ export async function rspackInitGenerator(
           'rspack-serve',
           'serve-rspack',
         ],
+        serveStaticTargetName: [
+          'serve-static',
+          'rspack:serve-static',
+          'rspack-serve-static',
+        ],
         previewTargetName: [
           'preview',
           'rspack:preview',


### PR DESCRIPTION
## Current Behavior
If another plugin, or project/package.json exists in the repo that has a `serve-static` target, running `nx add @nx/rpsack` will fail.

The `@nx/rspack:init` generator does not have any alternative names for `serve-static` causing conflicts.

## Expected Behavior

The `init` generator should provide more options for the `serve-static` target such that the plugin can be added without error.
