### PR TITLE
chore(gradle): add dynamic clean and testClasses tasks for CodeQL compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,3 +4,21 @@ plugins {
 }
 
 group = "dev.nx"
+
+tasks {
+    register("clean") {
+        description = "Cleans all included builds"
+        dependsOn(gradle.includedBuilds.map { it.task(":clean") })
+        doLast {
+            println("Cleaned ${gradle.includedBuilds.size} included builds")
+        }
+    }
+
+    register("testClasses") {
+        description = "Compiles test classes for all included builds"
+        dependsOn(gradle.includedBuilds.map { it.task(":testClasses") })
+        doLast {
+            println("Compiled test classes for ${gradle.includedBuilds.size} included builds")
+        }
+    }
+}


### PR DESCRIPTION
## Current Behavior

CodeQL analysis fails for Java projects in Gradle workspaces because the required build tasks (clean and testClasses) are not available for included builds.

## Expected Behavior

CodeQL can successfully analyze Java code by having access to the necessary Gradle build tasks for all included builds in the workspace.

## Related Issue(s)

This change ensures CodeQL compatibility for Java projects by dynamically adding clean and testClasses tasks to all included builds.

Fixes #