### PR TITLE
fix(js): store stale references correctly in `typescript-sync` generator

### DIFF
--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -775,7 +775,6 @@ describe('syncGenerator()', () => {
         'tsconfig.json:',
         '  - Missing references: packages/a/tsconfig.json, packages/b/tsconfig.json',
         'packages/b/tsconfig.json:',
-        '  - Stale references: packages/a/tsconfig.json',
         '  - Duplicate references: packages/a/tsconfig.json',
       ]);
       const { references } = readJson(tree, 'packages/b/tsconfig.json');
@@ -810,7 +809,6 @@ describe('syncGenerator()', () => {
         'tsconfig.json:',
         '  - Missing references: packages/a/tsconfig.json, packages/b/tsconfig.json',
         'packages/b/tsconfig.lib.json:',
-        '  - Stale references: packages/a/tsconfig.lib.json',
         '  - Duplicate references: packages/a/tsconfig.lib.json',
         'packages/b/tsconfig.json:',
         '  - Missing references: packages/a/tsconfig.json',

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -370,8 +370,8 @@ function updateTsConfigReferences(
 
   // We have at least one dependency so we can safely set it to an empty array if not already set
   const references = [];
-  const originalReferencesSet = new Set();
-  const newReferencesSet = new Set();
+  const originalReferencesSet = new Set<string>();
+  const newReferencesSet = new Set<string>();
   const pathCounts = new Map<string, number>();
   let hasChanges = false;
 
@@ -419,10 +419,6 @@ function updateTsConfigReferences(
       // we keep all references within the current Nx project or that are ignored
       references.push(ref);
       newReferencesSet.add(normalizedPath);
-    }
-
-    if (!newReferencesSet.has(normalizedPath)) {
-      addChangedFile(changedFiles, tsConfigPath, resolvedRefPath, 'stale');
     }
   }
 
@@ -516,6 +512,17 @@ function updateTsConfigReferences(
         tsConfigPath,
         toFullProjectReferencePath(referencePath),
         'missing'
+      );
+    }
+  }
+
+  for (const ref of originalReferencesSet) {
+    if (!newReferencesSet.has(ref)) {
+      addChangedFile(
+        changedFiles,
+        tsConfigPath,
+        toFullProjectReferencePath(joinPathFragments(projectRoot, ref)),
+        'stale'
       );
     }
   }


### PR DESCRIPTION
## Current Behavior

The `@nx/js:typescript-sync` wrongly identifies stale project references.

## Expected Behavior

The `@nx/js:typescript-sync` should correctly identify stale project references.