### PR TITLE
fix(testing): log the correct installed cypress version when erroring due to using an unsupported version

### DIFF
--- a/e2e/angular/src/ng-add.test.ts
+++ b/e2e/angular/src/ng-add.test.ts
@@ -57,6 +57,9 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
 
   function addCypress10() {
     runNgAdd('@cypress/schematic', '--e2e', 'latest');
+    // pin latest version of Cypress that's supported by Nx to avoid flakiness
+    // when a new major version is released
+    packageInstall('cypress', null, '^14.2.1');
   }
 
   function addEsLint() {


### PR DESCRIPTION
## Current Behavior

When using an unsupported Cypress version, an error is thrown showing a version that doesn't match what's installed.

## Expected Behavior

When using an unsupported Cypress version, an error should be thrown correctly showing the installed version.

Additionally, the PR fixes the ng-add e2e tests to use the latest Cypress version that Nx supports to avoid future flakiness when a new Cypress major version comes out.