### PR TITLE
docs(nx-cloud): update description of `neverConnectToCloud`

### DIFF
--- a/astro-docs/src/content/docs/reference/config.mdoc
+++ b/astro-docs/src/content/docs/reference/config.mdoc
@@ -157,7 +157,9 @@ You must be on version `16.0.4` or later of `nx-cloud` or `@nrwl/nx-cloud` for t
 
 ```json
 {
-  // The following will cause all attempts to connect your workspace to Nx Cloud to fail
+  // The following will cause all attempts to connect your workspace to Nx Cloud to fail.
+  // This value does not prevent using Nx Cloud if already connected. 
+  // Use NX_NO_CLOUD=true env var to prevent using Nx Cloud when running commands
   "neverConnectToCloud": true
 }
 ```

--- a/docs/nx-cloud/reference/config.md
+++ b/docs/nx-cloud/reference/config.md
@@ -151,7 +151,9 @@ You must be on version `16.0.4` or later of `nx-cloud` or `@nrwl/nx-cloud` for t
 
 ```json
 {
-  // The following will cause all attempts to connect your workspace to Nx Cloud to fail
+  // The following will cause all attempts to connect your workspace to Nx Cloud to fail.
+  // This value does not prevent using Nx Cloud if already connected.
+  // Use NX_NO_CLOUD=true env var to prevent using Nx Cloud when running commands
   "neverConnectToCloud": true
 }
 ```

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -112,7 +112,7 @@
     },
     "neverConnectToCloud": {
       "type": "boolean",
-      "description": "Set this to true to disable all connections to Nx Cloud."
+      "description": "Setting this to true will cause all attempts to connect your workspace to Nx Cloud to fail. This value does not prevent using Nx Cloud if already connected. Use NX_NO_CLOUD=true env var to prevent using Nx Cloud when running commands."
     },
     "parallel": {
       "type": "number",


### PR DESCRIPTION
`neverConnectToCloud` can be confusing due to 2 aspects
1. the setup of nx cloud is named via the command `nx connect`
2. network connectsion to external services i.e. nx cloud

`neverConnectToCloud` is meant to control 1 and not 2
this means if you have previously connected to nx cloud and have an
access token configures. nx cloud will still be used since you're not
trying to "setup up nx cloud" aka `nx connect` but are instead using nx
cloud (i.e. making network requests to nx cloud)

Instead using `--no-cloud` or `NX_NO_CLOUD=true` would be how you
prevent network access to nx cloud

Fixes: DOC-194
