### PR TITLE
fix(core): use more reasonable scroll speed on trackpads

### DIFF
--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -75,6 +75,15 @@ impl TerminalPaneData {
                     self.scroll(ScrollDirection::Down);
                     return Ok(None);
                 }
+                // Handle Home/End keys for jumping to beginning/end when not in interactive mode
+                KeyCode::Home if !self.is_interactive => {
+                    pty_mut.scroll_to_top();
+                    return Ok(None);
+                }
+                KeyCode::End if !self.is_interactive => {
+                    pty_mut.scroll_to_bottom();
+                    return Ok(None);
+                }
                 // Handle ctrl+u and ctrl+d for scrolling when not in interactive mode
                 KeyCode::Char('u')
                     if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_interactive =>

--- a/packages/nx/src/native/tui/pty.rs
+++ b/packages/nx/src/native/tui/pty.rs
@@ -242,6 +242,22 @@ impl PtyInstance {
         }
     }
 
+    pub fn scroll_to_top(&mut self) {
+        if let Ok(mut parser) = self.parser.write() {
+            let screen = parser.screen();
+            let total_content = screen.get_total_content_rows();
+            let viewport_height = screen.size().0 as usize;
+            let max_scrollback = total_content.saturating_sub(viewport_height);
+            parser.screen_mut().set_scrollback(max_scrollback);
+        }
+    }
+
+    pub fn scroll_to_bottom(&mut self) {
+        if let Ok(mut parser) = self.parser.write() {
+            parser.screen_mut().set_scrollback(0);
+        }
+    }
+
     pub fn get_scroll_offset(&self) -> usize {
         if let Ok(parser) = self.parser.read() {
             return parser.screen().scrollback();


### PR DESCRIPTION
## Current Behavior
Scrolling via trackpad is way too fast in comparison with scrolling via arrow keys / mouse wheel

## Expected Behavior
Scrolling via trackpad is analogous to mouse / arrow keys. Additionally, home + end can jump to the beginning / end of terminal outputs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
