### PR TITLE
fix(core): resolve watcher infinite loops from missing parent gitignore support

### DIFF
--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -15,3 +15,91 @@ pub fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
         }
     }
 }
+
+/// Iterator over parent .gitignore file paths based on git repository boundaries
+///
+/// # Behavior:
+/// - If workspace is git root: yields nothing
+/// - If workspace is nested in git repo: yields parents up to git root
+/// - If no git repo found: yields nothing (conservative for watch, use `parent_gitignore_files_unbounded` for walker)
+pub fn parent_gitignore_files<P: AsRef<Path>>(workspace_root: P) -> ParentGitignoreFiles {
+    let workspace_root = workspace_root.as_ref().to_path_buf();
+    let git_root = find_git_root(&workspace_root);
+
+    ParentGitignoreFiles {
+        current_path: workspace_root.parent().map(|p| p.to_path_buf()),
+        git_root,
+        workspace_root,
+        unbounded: false,
+    }
+}
+
+/// Iterator over parent .gitignore file paths with unbounded traversal when no git repo is found
+///
+/// # Behavior:
+/// - If workspace is git root: yields nothing
+/// - If workspace is nested in git repo: yields parents up to git root
+/// - If no git repo found: yields all parents (for walker backwards compatibility)
+pub fn parent_gitignore_files_unbounded<P: AsRef<Path>>(workspace_root: P) -> ParentGitignoreFiles {
+    let workspace_root = workspace_root.as_ref().to_path_buf();
+    let git_root = find_git_root(&workspace_root);
+
+    ParentGitignoreFiles {
+        current_path: workspace_root.parent().map(|p| p.to_path_buf()),
+        git_root,
+        workspace_root,
+        unbounded: true,
+    }
+}
+
+/// Iterator that yields .gitignore file paths from parent directories
+pub struct ParentGitignoreFiles {
+    current_path: Option<PathBuf>,
+    git_root: Option<PathBuf>,
+    workspace_root: PathBuf,
+    unbounded: bool,
+}
+
+impl Iterator for ParentGitignoreFiles {
+    type Item = PathBuf;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.current_path.as_ref()?;
+
+        // Check our boundary conditions
+        match &self.git_root {
+            Some(git_root_path) if git_root_path == &self.workspace_root => {
+                // The workspace IS the git root - don't traverse parents
+                self.current_path = None;
+                return None;
+            }
+            Some(git_root_path) => {
+                // We're nested in a git repo - traverse up to git root
+                let gitignore_path = current.join(".gitignore");
+
+                // Move to next parent directory
+                if current == git_root_path {
+                    // We've reached the git root - stop after this iteration
+                    self.current_path = None;
+                } else {
+                    self.current_path = current.parent().map(|p| p.to_path_buf());
+                }
+
+                Some(gitignore_path)
+            }
+            None => {
+                // No git repository found
+                if self.unbounded {
+                    // Traverse all parents (walker backwards compatibility)
+                    let gitignore_path = current.join(".gitignore");
+                    self.current_path = current.parent().map(|p| p.to_path_buf());
+                    Some(gitignore_path)
+                } else {
+                    // Be conservative and don't traverse (watch behavior)
+                    self.current_path = None;
+                    None
+                }
+            }
+        }
+    }
+}

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -1,0 +1,17 @@
+use std::path::{Path, PathBuf};
+
+/// Find the nearest git repository root by walking up the directory tree
+pub fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
+    let mut current_path = start_path.as_ref();
+
+    loop {
+        if current_path.join(".git").exists() {
+            return Some(current_path.to_path_buf());
+        }
+
+        match current_path.parent() {
+            Some(parent) => current_path = parent,
+            None => return None,
+        }
+    }
+}

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -23,7 +23,7 @@ pub fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
 /// - If workspace is nested in git repo: returns Some(parents up to git root)
 /// - If no git repo found: returns None (use walker.parents(true) for backwards compatibility)
 pub fn parent_gitignore_files<P: AsRef<Path>>(workspace_root: P) -> Option<Vec<PathBuf>> {
-    let workspace_root = workspace_root.as_ref().to_path_buf();
+    let workspace_root = workspace_root.as_ref();
     let git_root_path = find_git_root(&workspace_root)?;
 
     if git_root_path == workspace_root {

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -16,90 +16,36 @@ pub fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
     }
 }
 
-/// Iterator over parent .gitignore file paths based on git repository boundaries
+/// Get parent .gitignore file paths based on git repository boundaries
 ///
 /// # Behavior:
-/// - If workspace is git root: yields nothing
-/// - If workspace is nested in git repo: yields parents up to git root
-/// - If no git repo found: yields nothing (conservative for watch, use `parent_gitignore_files_unbounded` for walker)
-pub fn parent_gitignore_files<P: AsRef<Path>>(workspace_root: P) -> ParentGitignoreFiles {
+/// - If workspace is git root: returns Some([]) (empty vec - use manual mode with no parents)
+/// - If workspace is nested in git repo: returns Some(parents up to git root)
+/// - If no git repo found: returns None (use walker.parents(true) for backwards compatibility)
+pub fn parent_gitignore_files<P: AsRef<Path>>(workspace_root: P) -> Option<Vec<PathBuf>> {
     let workspace_root = workspace_root.as_ref().to_path_buf();
-    let git_root = find_git_root(&workspace_root);
+    let git_root_path = find_git_root(&workspace_root)?;
 
-    ParentGitignoreFiles {
-        current_path: workspace_root.parent().map(|p| p.to_path_buf()),
-        git_root,
-        workspace_root,
-        unbounded: false,
+    if git_root_path == workspace_root {
+        // The workspace IS the git root - don't use parent gitignores
+        return Some(Vec::new());
     }
-}
 
-/// Iterator over parent .gitignore file paths with unbounded traversal when no git repo is found
-///
-/// # Behavior:
-/// - If workspace is git root: yields nothing
-/// - If workspace is nested in git repo: yields parents up to git root
-/// - If no git repo found: yields all parents (for walker backwards compatibility)
-pub fn parent_gitignore_files_unbounded<P: AsRef<Path>>(workspace_root: P) -> ParentGitignoreFiles {
-    let workspace_root = workspace_root.as_ref().to_path_buf();
-    let git_root = find_git_root(&workspace_root);
+    let mut result = Vec::new();
+    let mut current_path = workspace_root.parent();
 
-    ParentGitignoreFiles {
-        current_path: workspace_root.parent().map(|p| p.to_path_buf()),
-        git_root,
-        workspace_root,
-        unbounded: true,
-    }
-}
-
-/// Iterator that yields .gitignore file paths from parent directories
-pub struct ParentGitignoreFiles {
-    current_path: Option<PathBuf>,
-    git_root: Option<PathBuf>,
-    workspace_root: PathBuf,
-    unbounded: bool,
-}
-
-impl Iterator for ParentGitignoreFiles {
-    type Item = PathBuf;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let current = self.current_path.as_ref()?;
-
-        // Check our boundary conditions
-        match &self.git_root {
-            Some(git_root_path) if git_root_path == &self.workspace_root => {
-                // The workspace IS the git root - don't traverse parents
-                self.current_path = None;
-                return None;
-            }
-            Some(git_root_path) => {
-                // We're nested in a git repo - traverse up to git root
-                let gitignore_path = current.join(".gitignore");
-
-                // Move to next parent directory
-                if current == git_root_path {
-                    // We've reached the git root - stop after this iteration
-                    self.current_path = None;
-                } else {
-                    self.current_path = current.parent().map(|p| p.to_path_buf());
-                }
-
-                Some(gitignore_path)
-            }
-            None => {
-                // No git repository found
-                if self.unbounded {
-                    // Traverse all parents (walker backwards compatibility)
-                    let gitignore_path = current.join(".gitignore");
-                    self.current_path = current.parent().map(|p| p.to_path_buf());
-                    Some(gitignore_path)
-                } else {
-                    // Be conservative and don't traverse (watch behavior)
-                    self.current_path = None;
-                    None
-                }
-            }
+    while let Some(path) = current_path {
+        let gitignore_path = path.join(".gitignore");
+        if gitignore_path.exists() {
+            result.push(gitignore_path);
         }
+
+        // Stop when we reach the git root (after processing it)
+        if path == git_root_path {
+            break;
+        }
+        current_path = path.parent();
     }
+
+    Some(result)
 }

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -1,4 +1,6 @@
+use ignore_files::IgnoreFile;
 use std::path::{Path, PathBuf};
+use tracing::trace;
 
 /// Find the nearest git repository root by walking up the directory tree
 pub fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
@@ -48,4 +50,59 @@ pub fn parent_gitignore_files<P: AsRef<Path>>(workspace_root: P) -> Option<Vec<P
     }
 
     Some(result)
+}
+
+/// Collect .gitignore files using a simple approach that reuses walker logic
+pub fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<IgnoreFile> {
+    use crate::native::walker::nx_walker_sync;
+
+    // Use our own walker to find .gitignore files, filtering out node_modules
+    let gitignore_filters = vec!["node_modules".to_string()];
+
+    let root_path = root.as_ref();
+
+    nx_walker_sync(&root, Some(&gitignore_filters))
+        .filter_map(|relative_path| {
+            // Only process .gitignore files
+            if relative_path.file_name()?.to_str()? == ".gitignore" {
+                let absolute_path = root_path.join(&relative_path);
+                let parent = absolute_path
+                    .parent()
+                    .unwrap_or(&absolute_path)
+                    .to_path_buf();
+                Some(IgnoreFile {
+                    path: absolute_path,
+                    applies_in: Some(parent),
+                    applies_to: None,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+pub(in crate::native) fn get_gitignore_files<T: AsRef<str>>(root: T) -> Vec<IgnoreFile> {
+    let root_path = PathBuf::from(root.as_ref());
+
+    // Start with workspace .gitignore files
+    let mut ignore_files = collect_workspace_gitignores(&root_path);
+
+    // Add parent .gitignore files using shared logic
+    if let Some(gitignore_paths) = parent_gitignore_files(&root_path) {
+        ignore_files.extend(gitignore_paths.into_iter().map(|gitignore_path| {
+            let applies_in = gitignore_path
+                .parent()
+                .expect(".gitignore file should have a parent directory")
+                .to_path_buf();
+            IgnoreFile {
+                path: gitignore_path,
+                applies_in: Some(applies_in),
+                applies_to: None,
+            }
+        }));
+    }
+
+    trace!(?ignore_files, "Final ignore files list");
+    ignore_files
 }

--- a/packages/nx/src/native/utils/mod.rs
+++ b/packages/nx/src/native/utils/mod.rs
@@ -16,5 +16,6 @@ pub mod ai;
 pub mod atomics;
 pub mod ci;
 pub mod file_lock;
+pub mod git;
 
 pub use atomics::*;

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -6,7 +6,7 @@ use crate::native::glob::build_glob_set;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::native::logger::enable_logger;
-use crate::native::utils::{Normalize, get_mod_time};
+use crate::native::utils::{Normalize, get_mod_time, git::find_git_root};
 use walkdir::WalkDir;
 
 #[derive(PartialEq, Debug, Ord, PartialOrd, Eq, Clone)]
@@ -158,21 +158,6 @@ where
     receiver_thread.join().unwrap()
 }
 
-/// Find the nearest git repository root by walking up the directory tree
-fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
-    let mut current_path = start_path.as_ref();
-
-    loop {
-        if current_path.join(".git").exists() {
-            return Some(current_path.to_path_buf());
-        }
-
-        match current_path.parent() {
-            Some(parent) => current_path = parent,
-            None => return None,
-        }
-    }
-}
 
 fn create_walker<P>(directory: P, use_ignores: bool) -> WalkBuilder
 where

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -13,12 +13,17 @@ fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<IgnoreFile> {
     let gitignore_filters = vec!["node_modules".to_string()];
 
     nx_walker_sync(&root, Some(&gitignore_filters))
-        .filter_map(|path| {
+        .filter_map(|relative_path| {
             // Only process .gitignore files
-            if path.file_name()?.to_str()? == ".gitignore" {
-                let parent = path.parent().unwrap_or(&path).to_path_buf();
+            if relative_path.file_name()?.to_str()? == ".gitignore" {
+                // Convert relative path to absolute path
+                let absolute_path = root.as_ref().join(&relative_path);
+                let parent = absolute_path
+                    .parent()
+                    .unwrap_or(&absolute_path)
+                    .to_path_buf();
                 Some(IgnoreFile {
-                    path,
+                    path: absolute_path,
                     applies_in: Some(parent),
                     applies_to: None,
                 })

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -43,19 +43,18 @@ pub(super) fn get_gitignore_files<T: AsRef<str>>(
     let mut ignore_files = collect_workspace_gitignores(&root_path);
 
     // Add parent .gitignore files using shared logic
-    for gitignore_path in parent_gitignore_files(&root_path) {
-        if gitignore_path.exists() {
-            ignore_files.push(IgnoreFile {
-                path: gitignore_path.clone(),
-                applies_in: Some(
-                    gitignore_path
-                        .parent()
-                        .unwrap_or(&gitignore_path)
-                        .to_path_buf(),
-                ),
+    if let Some(gitignore_paths) = parent_gitignore_files(&root_path) {
+        ignore_files.extend(gitignore_paths.into_iter().map(|gitignore_path| {
+            let applies_in = gitignore_path
+                .parent()
+                .expect(".gitignore file should have a parent directory")
+                .to_path_buf();
+            IgnoreFile {
+                path: gitignore_path,
+                applies_in: Some(applies_in),
                 applies_to: None,
-            });
-        }
+            }
+        }));
     }
 
     trace!(?ignore_files, "Final ignore files list");

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -1,17 +1,17 @@
+use crate::native::utils::git::parent_gitignore_files;
 use ignore_files::IgnoreFile;
 use std::path::Path;
 use std::{fs, path::PathBuf};
 use tracing::trace;
 use watchexec_events::{Event, Tag};
-use crate::native::utils::git::find_git_root;
 
 /// Collect .gitignore files using a simple approach that reuses walker logic
 fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<IgnoreFile> {
     use crate::native::walker::nx_walker_sync;
-    
+
     // Use our own walker to find .gitignore files, filtering out node_modules
     let gitignore_filters = vec!["node_modules".to_string()];
-    
+
     nx_walker_sync(&root, Some(&gitignore_filters))
         .filter_map(|path| {
             // Only process .gitignore files
@@ -29,33 +29,6 @@ fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<IgnoreFile> {
         .collect()
 }
 
-/// Add .gitignore files from parent directories up to the git root
-fn add_parent_gitignores(
-    ignore_files: &mut Vec<IgnoreFile>,
-    root_path: &Path,
-    git_root: &Path,
-) {
-    let mut current_path = root_path.parent();
-    
-    while let Some(path) = current_path {
-        let gitignore_path = path.join(".gitignore");
-        if gitignore_path.exists() {
-            ignore_files.push(IgnoreFile {
-                path: gitignore_path,
-                applies_in: Some(path.to_path_buf()),
-                applies_to: None,
-            });
-        }
-
-        // Stop when we reach the git root
-        if path == git_root {
-            break;
-        }
-        
-        current_path = path.parent();
-    }
-}
-
 pub(super) fn get_gitignore_files<T: AsRef<str>>(
     use_ignore: bool,
     root: T,
@@ -65,14 +38,24 @@ pub(super) fn get_gitignore_files<T: AsRef<str>>(
     }
 
     let root_path = PathBuf::from(root.as_ref());
-    
+
     // Start with workspace .gitignore files
     let mut ignore_files = collect_workspace_gitignores(&root_path);
 
-    // Add parent .gitignore files only if we're nested within a git repo
-    if let Some(git_root_path) = find_git_root(&root_path).filter(|p| p != &root_path) {
-        trace!(?git_root_path, "Adding parent gitignores up to git root");
-        add_parent_gitignores(&mut ignore_files, &root_path, &git_root_path);
+    // Add parent .gitignore files using shared logic
+    for gitignore_path in parent_gitignore_files(&root_path) {
+        if gitignore_path.exists() {
+            ignore_files.push(IgnoreFile {
+                path: gitignore_path.clone(),
+                applies_in: Some(
+                    gitignore_path
+                        .parent()
+                        .unwrap_or(&gitignore_path)
+                        .to_path_buf(),
+                ),
+                applies_to: None,
+            });
+        }
     }
 
     trace!(?ignore_files, "Final ignore files list");

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -1,41 +1,82 @@
-use ignore::WalkBuilder;
 use ignore_files::IgnoreFile;
 use std::path::Path;
 use std::{fs, path::PathBuf};
 use tracing::trace;
 use watchexec_events::{Event, Tag};
+use crate::native::utils::git::find_git_root;
 
-pub(super) fn get_ignore_files<T: AsRef<str>>(
+/// Collect .gitignore files using a simple approach that reuses walker logic
+fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<IgnoreFile> {
+    use crate::native::walker::nx_walker_sync;
+    
+    // Use our own walker to find .gitignore files, filtering out node_modules
+    let gitignore_filters = vec!["node_modules".to_string()];
+    
+    nx_walker_sync(&root, Some(&gitignore_filters))
+        .filter_map(|path| {
+            // Only process .gitignore files
+            if path.file_name()?.to_str()? == ".gitignore" {
+                let parent = path.parent().unwrap_or(&path).to_path_buf();
+                Some(IgnoreFile {
+                    path,
+                    applies_in: Some(parent),
+                    applies_to: None,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Add .gitignore files from parent directories up to the git root
+fn add_parent_gitignores(
+    ignore_files: &mut Vec<IgnoreFile>,
+    root_path: &Path,
+    git_root: &Path,
+) {
+    let mut current_path = root_path.parent();
+    
+    while let Some(path) = current_path {
+        let gitignore_path = path.join(".gitignore");
+        if gitignore_path.exists() {
+            ignore_files.push(IgnoreFile {
+                path: gitignore_path,
+                applies_in: Some(path.to_path_buf()),
+                applies_to: None,
+            });
+        }
+
+        // Stop when we reach the git root
+        if path == git_root {
+            break;
+        }
+        
+        current_path = path.parent();
+    }
+}
+
+pub(super) fn get_gitignore_files<T: AsRef<str>>(
     use_ignore: bool,
     root: T,
 ) -> Option<Vec<IgnoreFile>> {
-    let root = root.as_ref();
-    if use_ignore {
-        let mut walker = WalkBuilder::new(root);
-        walker.hidden(false);
-        walker.git_ignore(false);
-
-        let node_folder = PathBuf::from(root).join("node_modules");
-        walker.filter_entry(move |entry| !entry.path().starts_with(&node_folder));
-        Some(
-            walker
-                .build()
-                .flatten()
-                .filter(|result| result.path().ends_with(".gitignore"))
-                .map(|result| {
-                    let path: PathBuf = result.path().into();
-                    let parent: PathBuf = path.parent().unwrap_or(&path).into();
-                    IgnoreFile {
-                        path,
-                        applies_in: Some(parent),
-                        applies_to: None,
-                    }
-                })
-                .collect(),
-        )
-    } else {
-        None
+    if !use_ignore {
+        return None;
     }
+
+    let root_path = PathBuf::from(root.as_ref());
+    
+    // Start with workspace .gitignore files
+    let mut ignore_files = collect_workspace_gitignores(&root_path);
+
+    // Add parent .gitignore files only if we're nested within a git repo
+    if let Some(git_root_path) = find_git_root(&root_path).filter(|p| p != &root_path) {
+        trace!(?git_root_path, "Adding parent gitignores up to git root");
+        add_parent_gitignores(&mut ignore_files, &root_path, &git_root_path);
+    }
+
+    trace!(?ignore_files, "Final ignore files list");
+    Some(ignore_files)
 }
 
 pub(super) fn get_nx_ignore<P: AsRef<Path>>(origin: P) -> Option<IgnoreFile> {

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -8,7 +8,7 @@ use ignore_files::IgnoreFilter;
 use watchexec_events::{Event, FileType, Priority, Source, Tag};
 use watchexec_filterer_ignore::IgnoreFilterer;
 
-use crate::native::watch::utils::{get_ignore_files, get_nx_ignore, transform_event};
+use crate::native::watch::utils::{get_gitignore_files, get_nx_ignore, transform_event};
 
 #[derive(Debug)]
 pub struct WatchFilterer {
@@ -118,7 +118,7 @@ pub(super) async fn create_filter(
     additional_globs: &[String],
     use_ignore: bool,
 ) -> anyhow::Result<WatchFilterer> {
-    let ignore_files = get_ignore_files(use_ignore, origin);
+    let ignore_files = get_gitignore_files(use_ignore, origin);
     let nx_ignore_file = get_nx_ignore(origin);
 
     trace!(

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -4,11 +4,11 @@ use watchexec::error::RuntimeError;
 use watchexec::filter::Filterer;
 use watchexec_events::filekind::{CreateKind, FileEventKind, ModifyKind, RemoveKind};
 
+use crate::native::utils::git::get_gitignore_files;
+use crate::native::watch::utils::{get_nx_ignore, transform_event};
 use ignore_files::IgnoreFilter;
 use watchexec_events::{Event, FileType, Priority, Source, Tag};
 use watchexec_filterer_ignore::IgnoreFilterer;
-
-use crate::native::watch::utils::{get_gitignore_files, get_nx_ignore, transform_event};
 
 #[derive(Debug)]
 pub struct WatchFilterer {
@@ -118,7 +118,7 @@ pub(super) async fn create_filter(
     additional_globs: &[String],
     use_ignore: bool,
 ) -> anyhow::Result<WatchFilterer> {
-    let ignore_files = get_gitignore_files(use_ignore, origin);
+    let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
     let nx_ignore_file = get_nx_ignore(origin);
 
     trace!(


### PR DESCRIPTION
## Current Behavior

Nx watcher ignores parent `.gitignore` files, causing infinite loops when `.nx` folders are ignored only by parent gitignores outside workspace root. Tasks hang indefinitely with no error messages.

## Expected Behavior

Watcher respects parent `.gitignore` files up to git repository boundaries, preventing infinite loops.

## Changes Made

- **Fixed watcher**: Now traverses parent directories and respects `.gitignore` files up to git root
- **Centralized logic**: New `git.rs` module eliminates duplicate, buggy implementations  
- **Path handling**: Fixed absolute vs relative path issues causing filter failures
- **Git boundaries**: Added proper git root detection for traversal limits

## Files Modified

- `packages/nx/src/native/utils/git.rs` - New module with git utilities
- `packages/nx/src/native/utils/mod.rs` - Export git module  
- `packages/nx/src/native/walker.rs` - Use shared utilities
- `packages/nx/src/native/watch/utils.rs` - Remove duplicate functions
- `packages/nx/src/native/watch/watch_filterer.rs` - Use centralized functions

## Related Issue(s)

Fixes #30313