### PR TITLE
fix(vite): handle config server properly for libs

### DIFF
--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -371,7 +371,10 @@ describe('@nx/vite/plugin', () => {
               name: 'my-lib',
             },
           },
-          server: {},
+          server: {
+            port: 3000,
+            host: 'localhost',
+          },
         }),
       }),
         (context = {

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -574,7 +574,7 @@ function getOutputs(
     build?.rollupOptions?.input ||
     existsSync(join(workspaceRoot, projectRoot, 'index.html'));
 
-  const hasServeConfig = Boolean(server);
+  const hasServeConfig = Boolean(server?.host || server?.port);
 
   const reportsDirectoryPath = normalizeOutputPath(
     test?.coverage?.reportsDirectory,

--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -1,6 +1,4 @@
-import { ViteBuildExecutorOptions } from '../executors/build/schema';
 import { ExecutorContext, getPackageManagerCommand } from '@nx/devkit';
-import { ViteDevServerExecutorOptions } from '../executors/dev-server/schema';
 import {
   calculateProjectBuildableDependencies,
   createTmpTsConfig,


### PR DESCRIPTION
## Current Behavior
The `Vite`'s `resolveConfig` always adds default server settings to the config:

```
server: {
    preTransformRequests: true,
    sourcemapIgnoreList: [Function: isInNodeModules$1],
    middlewareMode: false,
    fs: {
      strict: true,
      allow: [Array],
      deny: [Array],
      cachedChecks: undefined
    }
  },
```

This leads to `libs` always ending up with serve targets even if we don't define `serve` configuration

## Expected Behavior
The serve targets should only exist if we explicitly set port or host.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
