### PR TITLE
feat(rspack): respect deleteOutputPath option in rspack executor

### DIFF
--- a/docs/generated/packages/rspack/executors/rspack.json
+++ b/docs/generated/packages/rspack/executors/rspack.json
@@ -13,6 +13,11 @@
         "description": "The platform to target (e.g. web, node).",
         "enum": ["web", "node"]
       },
+      "deleteOutputPath": {
+        "type": "boolean",
+        "description": "Delete the output path before building.",
+        "default": true
+      },
       "main": { "type": "string", "description": "The main entry file." },
       "outputPath": {
         "type": "string",

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -35,11 +35,12 @@ export default async function* runExecutor(
     await executeTypeCheck(normalizedOptions, context);
   }
 
-  // Mimic --clean from webpack.
-  rmSync(join(context.root, normalizedOptions.outputPath), {
-    force: true,
-    recursive: true,
-  });
+  if (options.deleteOutputPath !== false) {
+    rmSync(join(context.root, normalizedOptions.outputPath), {
+      force: true,
+      recursive: true,
+    });
+  }
 
   const compiler = await createCompiler(normalizedOptions, context);
 

--- a/packages/rspack/src/executors/rspack/schema.d.ts
+++ b/packages/rspack/src/executors/rspack/schema.d.ts
@@ -5,6 +5,7 @@ export interface RspackExecutorSchema {
   assets?: Array<AssetGlobPattern | string>;
   baseHref?: string;
   buildLibsFromSource?: boolean;
+  deleteOutputPath?: boolean;
   deployUrl?: string;
   extractCss?: boolean;
   extractLicenses?: boolean;

--- a/packages/rspack/src/executors/rspack/schema.json
+++ b/packages/rspack/src/executors/rspack/schema.json
@@ -10,6 +10,11 @@
       "description": "The platform to target (e.g. web, node).",
       "enum": ["web", "node"]
     },
+    "deleteOutputPath": {
+      "type": "boolean",
+      "description": "Delete the output path before building.",
+      "default": true
+    },
     "main": {
       "type": "string",
       "description": "The main entry file."


### PR DESCRIPTION
- Add deleteOutputPath option to rspack executor schema
- Modify rspack executor to only clean output directory when deleteOutputPath is not explicitly set to false
- This aligns rspack executor behavior with webpack executor and allows users to control output cleaning
- Fixes issue where rspack.output.clean configuration was being bypassed

Fixes #32015

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
