### PR TITLE
docs(misc): update links on plugin-registry to point to intro pages when they exist

### DIFF
--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -1370,7 +1370,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/angular/api"
+    "path": "/technologies/angular/api",
+    "introPath": "/technologies/angular/introduction"
   },
   "cypress": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1530,7 +1531,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/test-tools/cypress/api"
+    "path": "/technologies/test-tools/cypress/api",
+    "introPath": "/technologies/test-tools/cypress/introduction"
   },
   "detox": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1621,7 +1623,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/test-tools/detox/api"
+    "path": "/technologies/test-tools/detox/api",
+    "introPath": "/technologies/test-tools/detox/introduction"
   },
   "devkit": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1657,7 +1660,8 @@
     "executors": {},
     "generators": {},
     "migrations": {},
-    "path": "/reference/core-api/devkit"
+    "path": "/reference/core-api/devkit",
+    "introPath": "/reference/core-api/devkit/documents/nx_devkit"
   },
   "esbuild": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1699,7 +1703,8 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/build-tools/esbuild/api"
+    "path": "/technologies/build-tools/esbuild/api",
+    "introPath": "/technologies/build-tools/esbuild/introduction"
   },
   "eslint": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1869,7 +1874,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/eslint/api"
+    "path": "/technologies/eslint/api",
+    "introPath": "/technologies/eslint/introduction"
   },
   "eslint-plugin": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -1893,7 +1899,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/eslint/eslint-plugin/api"
+    "path": "/technologies/eslint/eslint-plugin/api",
+    "introPath": "/technologies/eslint/eslint-plugin/api"
   },
   "expo": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2162,7 +2169,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/react/expo/api"
+    "path": "/technologies/react/expo/api",
+    "introPath": "/technologies/react/expo/introduction"
   },
   "express": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2194,7 +2202,8 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/node/express/api"
+    "path": "/technologies/node/express/api",
+    "introPath": "/technologies/node/express/introduction"
   },
   "gradle": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2337,7 +2346,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/java/api"
+    "path": "/technologies/java/api",
+    "introPath": "/technologies/java/introduction"
   },
   "jest": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2489,7 +2499,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/test-tools/jest/api"
+    "path": "/technologies/test-tools/jest/api",
+    "introPath": "/technologies/test-tools/jest/introduction"
   },
   "js": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2740,7 +2751,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/typescript/api"
+    "path": "/technologies/typescript/api",
+    "introPath": "/technologies/typescript/introduction"
   },
   "module-federation": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2804,7 +2816,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/module-federation/api"
+    "path": "/technologies/module-federation/api",
+    "introPath": "/technologies/module-federation/introduction"
   },
   "nest": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -2991,7 +3004,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/node/nest/api"
+    "path": "/technologies/node/nest/api",
+    "introPath": "/technologies/node/nest/introduction"
   },
   "next": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3137,7 +3151,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/react/next/api"
+    "path": "/technologies/react/next/api",
+    "introPath": "/technologies/react/next/introduction"
   },
   "node": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3198,7 +3213,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/node/api"
+    "path": "/technologies/node/api",
+    "introPath": "/technologies/node/introduction"
   },
   "nuxt": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3250,7 +3266,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/vue/nuxt/api"
+    "path": "/technologies/vue/nuxt/api",
+    "introPath": "/technologies/vue/nuxt/introduction"
   },
   "nx": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3804,7 +3821,8 @@
         "type": "migration"
       }
     },
-    "path": "/reference/core-api/nx"
+    "path": "/reference/core-api/nx",
+    "introPath": "/reference/core-api/nx"
   },
   "playwright": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3876,7 +3894,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/test-tools/playwright/api"
+    "path": "/technologies/test-tools/playwright/api",
+    "introPath": "/technologies/test-tools/playwright/introduction"
   },
   "plugin": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -3962,7 +3981,8 @@
       }
     },
     "migrations": {},
-    "path": "/reference/core-api/plugin"
+    "path": "/reference/core-api/plugin",
+    "introPath": "/reference/core-api/plugin"
   },
   "react": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4329,7 +4349,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/react/api"
+    "path": "/technologies/react/api",
+    "introPath": "/technologies/react/introduction"
   },
   "react-native": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4578,7 +4599,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/react/react-native/api"
+    "path": "/technologies/react/react-native/api",
+    "introPath": "/technologies/react/react-native/introduction"
   },
   "remix": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4766,7 +4788,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/react/remix/api"
+    "path": "/technologies/react/remix/api",
+    "introPath": "/technologies/react/remix/introduction"
   },
   "rollup": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4828,7 +4851,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/build-tools/rollup/api"
+    "path": "/technologies/build-tools/rollup/api",
+    "introPath": "/technologies/build-tools/rollup/introduction"
   },
   "rsbuild": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -4860,7 +4884,8 @@
       }
     },
     "migrations": {},
-    "path": "/technologies/build-tools/rsbuild/api"
+    "path": "/technologies/build-tools/rsbuild/api",
+    "introPath": "/technologies/build-tools/rsbuild/introduction"
   },
   "rspack": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5093,7 +5118,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/build-tools/rspack/api"
+    "path": "/technologies/build-tools/rspack/api",
+    "introPath": "/technologies/build-tools/rspack/introduction"
   },
   "storybook": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5242,7 +5268,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/test-tools/storybook/api"
+    "path": "/technologies/test-tools/storybook/api",
+    "introPath": "/technologies/test-tools/storybook/introduction"
   },
   "vite": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5469,7 +5496,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/build-tools/vite/api"
+    "path": "/technologies/build-tools/vite/api",
+    "introPath": "/technologies/build-tools/vite/introduction"
   },
   "vue": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5567,7 +5595,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/vue/api"
+    "path": "/technologies/vue/api",
+    "introPath": "/technologies/vue/introduction"
   },
   "web": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5618,7 +5647,8 @@
       }
     },
     "migrations": {},
-    "path": "/reference/core-api/web"
+    "path": "/reference/core-api/web",
+    "introPath": "/reference/core-api/web"
   },
   "webpack": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5767,7 +5797,8 @@
         "type": "migration"
       }
     },
-    "path": "/technologies/build-tools/webpack/api"
+    "path": "/technologies/build-tools/webpack/api",
+    "introPath": "/technologies/build-tools/webpack/introduction"
   },
   "workspace": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5955,7 +5986,8 @@
         "type": "migration"
       }
     },
-    "path": "/reference/core-api/workspace"
+    "path": "/reference/core-api/workspace",
+    "introPath": "/reference/core-api/workspace"
   },
   "azure-cache": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -5968,7 +6000,8 @@
     "executors": {},
     "generators": {},
     "migrations": {},
-    "path": "/reference/core-api/azure-cache"
+    "path": "/reference/core-api/azure-cache",
+    "introPath": "/reference/core-api/azure-cache"
   },
   "conformance": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -6033,7 +6066,8 @@
       }
     },
     "migrations": {},
-    "path": "/reference/core-api/conformance"
+    "path": "/reference/core-api/conformance",
+    "introPath": "/reference/core-api/conformance"
   },
   "owners": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -6065,7 +6099,8 @@
       }
     },
     "migrations": {},
-    "path": "/reference/core-api/owners"
+    "path": "/reference/core-api/owners",
+    "introPath": "/reference/core-api/owners"
   },
   "gcs-cache": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -6078,7 +6113,8 @@
     "executors": {},
     "generators": {},
     "migrations": {},
-    "path": "/reference/core-api/gcs-cache"
+    "path": "/reference/core-api/gcs-cache",
+    "introPath": "/reference/core-api/gcs-cache"
   },
   "s3-cache": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -6091,7 +6127,8 @@
     "executors": {},
     "generators": {},
     "migrations": {},
-    "path": "/reference/core-api/s3-cache"
+    "path": "/reference/core-api/s3-cache",
+    "introPath": "/reference/core-api/s3-cache"
   },
   "shared-fs-cache": {
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
@@ -6114,6 +6151,7 @@
       }
     },
     "migrations": {},
-    "path": "/reference/core-api/shared-fs-cache"
+    "path": "/reference/core-api/shared-fs-cache",
+    "introPath": "/reference/core-api/shared-fs-cache"
   }
 }

--- a/nx-dev/data-access-packages/src/lib/packages.api.ts
+++ b/nx-dev/data-access-packages/src/lib/packages.api.ts
@@ -47,6 +47,7 @@ export class PackagesApi {
   getAngularRspackPackage(): ProcessedPackageMetadata {
     return {
       path: '/nx-api/angular-rspack',
+      introPath: '/technologies/angular/angular-rspack/introduction',
       name: 'angular-rspack',
       packageName: 'angular-rspack',
       description: 'Angular Rspack',
@@ -85,6 +86,7 @@ export class PackagesApi {
   getAngularRsbuildPackage(): ProcessedPackageMetadata {
     return {
       path: '/nx-api/angular-rsbuild',
+      introPath: '/technologies/angular/angular-rsbuild/introduction',
       name: 'angular-rsbuild',
       packageName: 'angular-rsbuild',
       description: 'Angular Rsbuild',
@@ -257,6 +259,7 @@ export class PackagesApi {
       name: this.manifest[k].name,
       packageName: this.manifest[k].packageName,
       path: this.manifest[k].path,
+      introPath: this.manifest[k].introPath,
       root: this.manifest[k].root,
       source: this.manifest[k].source,
     }));

--- a/nx-dev/models-document/src/lib/mappings.ts
+++ b/nx-dev/models-document/src/lib/mappings.ts
@@ -10,139 +10,177 @@
  */
 export const pkgToGeneratedApiDocs: Record<
   string,
-  { pagePath: string; includeDocuments?: boolean }
+  { pagePath: string; introPath: string; includeDocuments?: boolean }
 > = {
   // ts/js
   js: {
     pagePath: '/technologies/typescript/api',
+    introPath: '/technologies/typescript/introduction',
   },
   // angular
   angular: {
     pagePath: '/technologies/angular/api',
+    introPath: '/technologies/angular/introduction',
   },
   // react
   react: {
     pagePath: '/technologies/react/api',
+    introPath: '/technologies/react/introduction',
   },
   'react-native': {
     pagePath: '/technologies/react/react-native/api',
+    introPath: '/technologies/react/react-native/introduction',
   },
   expo: {
     pagePath: '/technologies/react/expo/api',
+    introPath: '/technologies/react/expo/introduction',
   },
   next: {
     pagePath: '/technologies/react/next/api',
+    introPath: '/technologies/react/next/introduction',
   },
   remix: {
     pagePath: '/technologies/react/remix/api',
+    introPath: '/technologies/react/remix/introduction',
   },
   // vue
   vue: {
     pagePath: '/technologies/vue/api',
+    introPath: '/technologies/vue/introduction',
   },
   nuxt: {
     pagePath: '/technologies/vue/nuxt/api',
+    introPath: '/technologies/vue/nuxt/introduction',
   },
   // node
   node: {
     pagePath: '/technologies/node/api',
+    introPath: '/technologies/node/introduction',
   },
   express: {
     pagePath: '/technologies/node/express/api',
+    introPath: '/technologies/node/express/introduction',
   },
   nest: {
     pagePath: '/technologies/node/nest/api',
+    introPath: '/technologies/node/nest/introduction',
   },
   // java
   gradle: {
     pagePath: '/technologies/java/api',
+    introPath: '/technologies/java/introduction',
   },
   // build tools
   webpack: {
     pagePath: '/technologies/build-tools/webpack/api',
+    introPath: '/technologies/build-tools/webpack/introduction',
   },
   vite: {
     pagePath: '/technologies/build-tools/vite/api',
+    introPath: '/technologies/build-tools/vite/introduction',
   },
   rollup: {
     pagePath: '/technologies/build-tools/rollup/api',
+    introPath: '/technologies/build-tools/rollup/introduction',
   },
   esbuild: {
     pagePath: '/technologies/build-tools/esbuild/api',
+    introPath: '/technologies/build-tools/esbuild/introduction',
   },
   rspack: {
     pagePath: '/technologies/build-tools/rspack/api',
+    introPath: '/technologies/build-tools/rspack/introduction',
   },
   rsbuild: {
     pagePath: '/technologies/build-tools/rsbuild/api',
+    introPath: '/technologies/build-tools/rsbuild/introduction',
   },
   // test tools
   jest: {
     pagePath: '/technologies/test-tools/jest/api',
+    introPath: '/technologies/test-tools/jest/introduction',
   },
   storybook: {
     pagePath: '/technologies/test-tools/storybook/api',
+    introPath: '/technologies/test-tools/storybook/introduction',
   },
   playwright: {
     pagePath: '/technologies/test-tools/playwright/api',
+    introPath: '/technologies/test-tools/playwright/introduction',
   },
   cypress: {
     pagePath: '/technologies/test-tools/cypress/api',
+    introPath: '/technologies/test-tools/cypress/introduction',
   },
   detox: {
     pagePath: '/technologies/test-tools/detox/api',
+    introPath: '/technologies/test-tools/detox/introduction',
   },
   // misc
   'module-federation': {
     pagePath: '/technologies/module-federation/api',
+    introPath: '/technologies/module-federation/introduction',
   },
   eslint: {
     pagePath: '/technologies/eslint/api',
+    introPath: '/technologies/eslint/introduction',
   },
   'eslint-plugin': {
     pagePath: '/technologies/eslint/eslint-plugin/api',
+    introPath: '/technologies/eslint/eslint-plugin/api',
   },
   // core and misc
   // For now, things that are not in technologies are put here in references/core-api
   nx: {
     pagePath: '/reference/core-api/nx',
+    introPath: '/reference/core-api/nx',
     // TODO(docs): move these to guides and remove this
     includeDocuments: true,
   },
   workspace: {
     pagePath: '/reference/core-api/workspace',
+    introPath: '/reference/core-api/workspace',
     // TODO(docs): move these to guides and remove this
     includeDocuments: true,
   },
   owners: {
     pagePath: '/reference/core-api/owners',
+    introPath: '/reference/core-api/owners',
   },
   conformance: {
     pagePath: '/reference/core-api/conformance',
+    introPath: '/reference/core-api/conformance',
     // TODO(docs): move these to guides and remove this
     includeDocuments: true,
   },
   'azure-cache': {
     pagePath: '/reference/core-api/azure-cache',
+    introPath: '/reference/core-api/azure-cache',
   },
   'gcs-cache': {
     pagePath: '/reference/core-api/gcs-cache',
+    introPath: '/reference/core-api/gcs-cache',
   },
   's3-cache': {
     pagePath: '/reference/core-api/s3-cache',
+    introPath: '/reference/core-api/s3-cache',
   },
   'shared-fs-cache': {
     pagePath: '/reference/core-api/shared-fs-cache',
+    introPath: '/reference/core-api/shared-fs-cache',
   },
   devkit: {
     pagePath: '/reference/core-api/devkit',
+    introPath: '/reference/core-api/devkit/documents/nx_devkit',
     // TODO(docs): move these to guides and remove this
     includeDocuments: true,
   },
   plugin: {
     pagePath: '/reference/core-api/plugin',
+    introPath: '/reference/core-api/plugin',
   },
   web: {
     pagePath: '/reference/core-api/web',
+    introPath: '/reference/core-api/web',
   },
 };

--- a/nx-dev/models-package/src/lib/package.models.ts
+++ b/nx-dev/models-package/src/lib/package.models.ts
@@ -65,6 +65,7 @@ export interface ProcessedPackageMetadata {
   name: string;
   packageName: string;
   path: string;
+  introPath: string;
   root: string;
   source: string;
 }

--- a/nx-dev/nx-dev/pages/plugin-registry.tsx
+++ b/nx-dev/nx-dev/pages/plugin-registry.tsx
@@ -53,7 +53,7 @@ export async function getStaticProps(): Promise<{ props: BrowseProps }> {
         ...officialPluginList.map((plugin) => ({
           name: plugin.packageName,
           description: plugin.description ?? '',
-          url: plugin.path,
+          url: plugin.introPath,
           ...qualityIndicators[plugin.packageName],
           nxVersion: 'official',
           pluginType: plugin.name?.startsWith('powerpack-')

--- a/scripts/documentation/generators/generate-manifests.ts
+++ b/scripts/documentation/generators/generate-manifests.ts
@@ -320,6 +320,7 @@ function createNewPackagesManifest(packages: PackageMetadata[]): {
         'path'
       ),
       path: data.pagePath,
+      introPath: data.introPath,
     };
   });
 


### PR DESCRIPTION
This PR updates the the plugin registry links to point to intro since the API docs aren't useful as a discovery page.

Since we use the API path to build generator, executor, etc. links I added a new `introPath` property instead.