### PR TITLE
fix(nx-dev): remove self-referencing redirects causing infinite loops

### DIFF
--- a/nx-dev/nx-dev/redirect-rules-docs-to-astro.js
+++ b/nx-dev/nx-dev/redirect-rules-docs-to-astro.js
@@ -190,6 +190,8 @@ const docsToAstroRedirects = {
     '/docs/getting-started/tutorials/angular-monorepo-tutorial',
   '/getting-started/tutorials/gradle-tutorial':
     '/docs/getting-started/tutorials/gradle-tutorial',
+  // Fallback
+  '/getting-started/:path*': '/docs/getting-started/intro',
 
   // ========== NX-ENTERPRISE ==========
   '/nx-enterprise': '/docs/enterprise',
@@ -385,13 +387,12 @@ const docsToAstroRedirects = {
   '/reference/core-api': '/docs/reference',
   '/reference/core-api/nx': '/docs/reference', // TODO: missing
   '/reference/core-api/workspace': '/docs/reference', // TODO: missing
-  '/reference/core-api/devkit': '/docs/reference', // TODO: missing
   '/reference/core-api/plugin': '/docs/reference', // TODO: missing
   '/reference/core-api/web': '/docs/reference', // TODO: missing
   '/reference/core-api/create-nx-workspace':
     '/docs/reference/create-nx-workspace',
   '/reference/core-api/devkit/documents': '/docs/reference/devkit',
-  '/docs/reference/devkit': '/docs/reference/devkit',
+  '/reference/core-api/devkit': '/docs/reference/devkit',
   '/reference/core-api/devkit/documents/ngcli_adapter':
     '/docs/reference/devkit/ngcli_adapter',
   '/reference/core-api/devkit/documents/AggregateCreateNodesError':
@@ -1808,7 +1809,6 @@ const docsToAstroRedirects = {
   '/ci/recipes/set-up': '/docs/guides/nx-cloud/setup-ci',
   '/ci/recipes/set-up/monorepo-ci-azure': '/docs/guides/nx-cloud/setup-ci',
   '/ci/recipes/set-up/monorepo-ci-circle-ci': '/docs/guides/nx-cloud/setup-ci',
-  '/docs/guides/nx-cloud/setup-ci': '/docs/guides/nx-cloud/setup-ci',
   '/ci/recipes/set-up/monorepo-ci-jenkins': '/docs/guides/nx-cloud/setup-ci',
   '/ci/recipes/set-up/monorepo-ci-gitlab': '/docs/guides/nx-cloud/setup-ci',
   '/ci/recipes/set-up/monorepo-ci-bitbucket-pipelines':

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -896,8 +896,7 @@ const missingAndCatchAllRedirects = {
 };
 
 if (process.env['NEXT_PUBLIC_ASTRO_URL']) {
-  missingAndCatchAllRedirects['/getting-started/:path*'] =
-    '/docs/getting-started/intro';
+  missingAndCatchAllRedirects['/docs'] = '/docs/getting-started/intro';
 } else {
   // For new docs, we rewrite all docs URLs to astro site, so we can skip this redirect
   missingAndCatchAllRedirects['/docs'] = '/getting-started/intro';


### PR DESCRIPTION
When NEXT_PUBLIC_ASTRO_URL is set and nx-dev serves docs through Astro, certain URLs cause infinite redirect loops due to self-referencing redirect rules. Specifically:
- /docs/guides/nx-cloud/setup-ci redirected to itself
- /docs/reference/devkit redirected to itself

There is also a missing redirect from `/docs` to
`/docs/getting-started/intro` in the Next.js app, leading to a client-side redirect from Astro website. Plus, `/getting-started/:path*` was being redirected to the intro page instead of the the more specific pages.

URLs should either redirect to their proper destinations or serve content without infinite loops. Removed the two self-referencing redirect rules that were causing the problem.

`/docs` redirects on server-side not client-side, and `/getting-started` URLs are redirected to specific pages e.g.
/getting-started/start-new-project -> /docs/getting-started/start-new-project

Fixes DOC-196
