### PR TITLE
chore(repo): install cargo deps separately from first access

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -78,6 +78,10 @@ launch-templates:
       - name: Load Cargo Env
         script: echo "PATH=$HOME/.cargo/bin:$PATH" >> $NX_CLOUD_ENV
 
+      - name: Install Rust Dependencies
+        script: |
+          cargo fetch
+
       - name: Setup Java 21
         script: |
           sudo apt update
@@ -167,6 +171,10 @@ launch-templates:
 
       - name: Load Cargo Env
         script: echo "PATH=$HOME/.cargo/bin:$PATH" >> $NX_CLOUD_ENV
+
+      - name: Install Rust Dependencies
+        script: |
+          cargo fetch
 
       - name: Setup Java 21
         script: |


### PR DESCRIPTION
## Current Behavior
Cargo deps get fetched on first usage, which is when graph computes + cargo metadata runs under @monodon/rust

## Expected Behavior
Cargo deps are fetched separately.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
