### PR TITLE
fix(core): reduce CPU usage by adding 20ms interval to daemon process check

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -569,7 +569,7 @@ export async function startServer(): Promise<Server> {
                 sockets: openSockets,
               });
             }
-          }).unref();
+          }, 20).unref();
 
           // this triggers the storage of the lock file hash
           daemonIsOutdated();


### PR DESCRIPTION
## Current Behavior

The daemon process check in `startServer()` was running continuously without any interval, causing excessive CPU usage. The `setInterval()` call was missing the timing parameter, making it run as fast as possible.

## Expected Behavior

With this change, the daemon process check runs every 20ms, significantly reducing CPU overhead while maintaining responsive daemon process monitoring.

## Related Issue(s)

This change optimizes CPU usage in the Nx daemon server by preventing a continuous polling loop.

## Changes Made

- Added `20` as the interval parameter to the `setInterval()` call in `packages/nx/src/daemon/server/server.ts:572`
- The daemon process ID check now runs every 20ms instead of continuously
- Maintains the same functionality while dramatically reducing CPU consumption