### PR TITLE
fix(nx-cloud): forward --help to nx-cloud aliases

### DIFF
--- a/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
@@ -9,7 +9,7 @@ export const yargsFixCiCommand: CommandModule = {
     withVerbose(yargs)
       .help(false)
       .showHelpOnFail(false)
-      .option('help', { describe: 'Show help.', type: 'boolean' }),
+      .option('help', { describe: 'Show help', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(await (await import('./fix-ci')).fixCiHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
@@ -7,9 +7,9 @@ export const yargsFixCiCommand: CommandModule = {
     'Fixes CI failures. This command is an alias for [`nx-cloud fix-ci`](/ci/reference/nx-cloud-cli#npx-nxcloud-fix-ci).',
   builder: (yargs) =>
     withVerbose(yargs)
-      .option('help', { describe: 'Show Help.', type: 'boolean' })
       .help(false)
-      .showHelpOnFail(false),
+      .showHelpOnFail(false)
+      .option('help', { describe: 'Show help.', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(await (await import('./fix-ci')).fixCiHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
@@ -5,7 +5,7 @@ export const yargsFixCiCommand: CommandModule = {
   command: 'fix-ci [options]',
   describe:
     'Fixes CI failures. This command is an alias for [`nx-cloud fix-ci`](/ci/reference/nx-cloud-cli#npx-nxcloud-fix-ci).',
-  builder: (yargs) => withVerbose(yargs),
+  builder: (yargs) => withVerbose(yargs).help(false).showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(await (await import('./fix-ci')).fixCiHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
@@ -5,7 +5,11 @@ export const yargsFixCiCommand: CommandModule = {
   command: 'fix-ci [options]',
   describe:
     'Fixes CI failures. This command is an alias for [`nx-cloud fix-ci`](/ci/reference/nx-cloud-cli#npx-nxcloud-fix-ci).',
-  builder: (yargs) => withVerbose(yargs).help(false).showHelpOnFail(false),
+  builder: (yargs) =>
+    withVerbose(yargs)
+      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h' })
+      .help(false)
+      .showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(await (await import('./fix-ci')).fixCiHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/fix-ci/command-object.ts
@@ -7,7 +7,7 @@ export const yargsFixCiCommand: CommandModule = {
     'Fixes CI failures. This command is an alias for [`nx-cloud fix-ci`](/ci/reference/nx-cloud-cli#npx-nxcloud-fix-ci).',
   builder: (yargs) =>
     withVerbose(yargs)
-      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h' })
+      .option('help', { describe: 'Show Help.', type: 'boolean' })
       .help(false)
       .showHelpOnFail(false),
   handler: async (args: any) => {

--- a/packages/nx/src/command-line/nx-cloud/login/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/login/command-object.ts
@@ -16,7 +16,7 @@ export const yargsLoginCommand: CommandModule = {
     )
       .help(false)
       .showHelpOnFail(false)
-      .option('help', { describe: 'Show help.', type: 'boolean' }),
+      .option('help', { describe: 'Show help', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(await (await import('./login')).loginHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/login/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/login/command-object.ts
@@ -14,7 +14,7 @@ export const yargsLoginCommand: CommandModule = {
         required: false,
       })
     )
-      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h' })
+      .option('help', { describe: 'Show Help.', type: 'boolean' })
       .help(false)
       .showHelpOnFail(false),
   handler: async (args: any) => {

--- a/packages/nx/src/command-line/nx-cloud/login/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/login/command-object.ts
@@ -13,7 +13,10 @@ export const yargsLoginCommand: CommandModule = {
         type: 'string',
         required: false,
       })
-    ).help(false).showHelpOnFail(false),
+    )
+      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h' })
+      .help(false)
+      .showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(await (await import('./login')).loginHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/login/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/login/command-object.ts
@@ -13,7 +13,7 @@ export const yargsLoginCommand: CommandModule = {
         type: 'string',
         required: false,
       })
-    ),
+    ).help(false).showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(await (await import('./login')).loginHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/login/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/login/command-object.ts
@@ -14,9 +14,9 @@ export const yargsLoginCommand: CommandModule = {
         required: false,
       })
     )
-      .option('help', { describe: 'Show Help.', type: 'boolean' })
       .help(false)
-      .showHelpOnFail(false),
+      .showHelpOnFail(false)
+      .option('help', { describe: 'Show help.', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(await (await import('./login')).loginHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
@@ -7,7 +7,7 @@ export const yargsLogoutCommand: CommandModule = {
     'Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).',
   builder: (yargs) =>
     withVerbose(yargs)
-      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h' })
+      .option('help', { describe: 'Show Help.', type: 'boolean' })
       .help(false)
       .showHelpOnFail(false),
   handler: async (args: any) => {

--- a/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
@@ -5,7 +5,7 @@ export const yargsLogoutCommand: CommandModule = {
   command: 'logout',
   describe:
     'Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).',
-  builder: (yargs) => withVerbose(yargs),
+  builder: (yargs) => withVerbose(yargs).help(false).showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(await (await import('./logout')).logoutHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
@@ -5,7 +5,11 @@ export const yargsLogoutCommand: CommandModule = {
   command: 'logout',
   describe:
     'Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).',
-  builder: (yargs) => withVerbose(yargs).help(false).showHelpOnFail(false),
+  builder: (yargs) =>
+    withVerbose(yargs)
+      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h' })
+      .help(false)
+      .showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(await (await import('./logout')).logoutHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
@@ -7,9 +7,9 @@ export const yargsLogoutCommand: CommandModule = {
     'Logout from Nx Cloud. This command is an alias for [`nx-cloud logout`](/ci/reference/nx-cloud-cli#npx-nxcloud-logout).',
   builder: (yargs) =>
     withVerbose(yargs)
-      .option('help', { describe: 'Show Help.', type: 'boolean' })
       .help(false)
-      .showHelpOnFail(false),
+      .showHelpOnFail(false)
+      .option('help', { describe: 'Show help.', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(await (await import('./logout')).logoutHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/logout/command-object.ts
@@ -9,7 +9,7 @@ export const yargsLogoutCommand: CommandModule = {
     withVerbose(yargs)
       .help(false)
       .showHelpOnFail(false)
-      .option('help', { describe: 'Show help.', type: 'boolean' }),
+      .option('help', { describe: 'Show help', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(await (await import('./logout')).logoutHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/record/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/record/command-object.ts
@@ -7,9 +7,9 @@ export const yargsRecordCommand: CommandModule = {
     'Records a command execution for distributed task execution. This command is an alias for [`nx-cloud record`](/ci/reference/nx-cloud-cli#npx-nxcloud-record).',
   builder: (yargs) =>
     withVerbose(yargs)
-      .option('help', { describe: 'Show Help.', type: 'boolean' })
       .help(false)
-      .showHelpOnFail(false),
+      .showHelpOnFail(false)
+      .option('help', { describe: 'Show help.', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(await (await import('./record')).recordHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/record/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/record/command-object.ts
@@ -5,7 +5,11 @@ export const yargsRecordCommand: CommandModule = {
   command: 'record [options]',
   describe:
     'Records a command execution for distributed task execution. This command is an alias for [`nx-cloud record`](/ci/reference/nx-cloud-cli#npx-nxcloud-record).',
-  builder: (yargs) => withVerbose(yargs).help(false).showHelpOnFail(false),
+  builder: (yargs) =>
+    withVerbose(yargs)
+      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h' })
+      .help(false)
+      .showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(await (await import('./record')).recordHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/record/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/record/command-object.ts
@@ -9,7 +9,7 @@ export const yargsRecordCommand: CommandModule = {
     withVerbose(yargs)
       .help(false)
       .showHelpOnFail(false)
-      .option('help', { describe: 'Show help.', type: 'boolean' }),
+      .option('help', { describe: 'Show help', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(await (await import('./record')).recordHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/record/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/record/command-object.ts
@@ -7,7 +7,7 @@ export const yargsRecordCommand: CommandModule = {
     'Records a command execution for distributed task execution. This command is an alias for [`nx-cloud record`](/ci/reference/nx-cloud-cli#npx-nxcloud-record).',
   builder: (yargs) =>
     withVerbose(yargs)
-      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h' })
+      .option('help', { describe: 'Show Help.', type: 'boolean' })
       .help(false)
       .showHelpOnFail(false),
   handler: async (args: any) => {

--- a/packages/nx/src/command-line/nx-cloud/record/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/record/command-object.ts
@@ -5,7 +5,7 @@ export const yargsRecordCommand: CommandModule = {
   command: 'record [options]',
   describe:
     'Records a command execution for distributed task execution. This command is an alias for [`nx-cloud record`](/ci/reference/nx-cloud-cli#npx-nxcloud-record).',
-  builder: (yargs) => withVerbose(yargs),
+  builder: (yargs) => withVerbose(yargs).help(false).showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(await (await import('./record')).recordHandler(args));
   },

--- a/packages/nx/src/command-line/nx-cloud/start-ci-run/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/start-ci-run/command-object.ts
@@ -7,9 +7,9 @@ export const yargsStartCiRunCommand: CommandModule = {
     'Starts a new CI run for distributed task execution. This command is an alias for [`nx-cloud start-ci-run`](/ci/reference/nx-cloud-cli#npx-nxcloud-start-ci-run).',
   builder: (yargs) =>
     withVerbose(yargs)
-      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h', global: false })
       .help(false)
-      .showHelpOnFail(false),
+      .showHelpOnFail(false)
+      .option('help', { describe: 'Show help.', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(
       await (await import('./start-ci-run')).startCiRunHandler(args)

--- a/packages/nx/src/command-line/nx-cloud/start-ci-run/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/start-ci-run/command-object.ts
@@ -5,7 +5,7 @@ export const yargsStartCiRunCommand: CommandModule = {
   command: 'start-ci-run [options]',
   describe:
     'Starts a new CI run for distributed task execution. This command is an alias for [`nx-cloud start-ci-run`](/ci/reference/nx-cloud-cli#npx-nxcloud-start-ci-run).',
-  builder: (yargs) => withVerbose(yargs),
+  builder: (yargs) => withVerbose(yargs).help(false).showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(
       await (await import('./start-ci-run')).startCiRunHandler(args)

--- a/packages/nx/src/command-line/nx-cloud/start-ci-run/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/start-ci-run/command-object.ts
@@ -9,7 +9,7 @@ export const yargsStartCiRunCommand: CommandModule = {
     withVerbose(yargs)
       .help(false)
       .showHelpOnFail(false)
-      .option('help', { describe: 'Show help.', type: 'boolean' }),
+      .option('help', { describe: 'Show help', type: 'boolean' }),
   handler: async (args: any) => {
     process.exit(
       await (await import('./start-ci-run')).startCiRunHandler(args)

--- a/packages/nx/src/command-line/nx-cloud/start-ci-run/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/start-ci-run/command-object.ts
@@ -5,7 +5,11 @@ export const yargsStartCiRunCommand: CommandModule = {
   command: 'start-ci-run [options]',
   describe:
     'Starts a new CI run for distributed task execution. This command is an alias for [`nx-cloud start-ci-run`](/ci/reference/nx-cloud-cli#npx-nxcloud-start-ci-run).',
-  builder: (yargs) => withVerbose(yargs).help(false).showHelpOnFail(false),
+  builder: (yargs) =>
+    withVerbose(yargs)
+      .option('help', { describe: 'Show help.', type: 'boolean', alias: 'h', global: false })
+      .help(false)
+      .showHelpOnFail(false),
   handler: async (args: any) => {
     process.exit(
       await (await import('./start-ci-run')).startCiRunHandler(args)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

`--help` behaviour is defined in the Nx alias entrypoints, and doesn't show the correct output:

```
npx nx start-ci-run --help
nx start-ci-run [options]

Starts a new CI run for distributed task execution. This command is an alias for [`nx-cloud start-ci-run`](/ci/reference/nx-cloud-cli#npx-nxcloud-start-ci-run).

Options:
  --help     Show help                                                                                                                                                                                                                   [boolean]
  --version  Show version number                                                                                                                                                                                                         [boolean]
  --verbose  Prints additional information about the commands (e.g., stack traces).   
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running `npx nx start-ci-run --help` the help from the file in the NxCloud repo should be displayed:

```
npx nx start-ci-run --help
Usage: npx nx-cloud start-ci-run [options]

Starts an Nx Cloud CI Pipeline Execution and configures distribution.

Options:
  --distribute-on <config>        Configure how to distribute with Nx Agents. Accepts:
                                  - "<count> <launchTemplate>" (e.g., "8 linux-medium-js")
                                  - path to a .yaml/.yml file for dynamic changesets
                                  - "manual" to disable the warning for legacy DTE setups
  --stop-agents-after <targets>   Comma-separated targets that signal agents can stop.
                                  Include configuration when needed, e.g., "build:locale-en".
  --require-explicit-completion   Require explicitly completing the CI run with
                                  "npx nx-cloud complete-ci-run".
  --stop-agents-on-failure        Stop all agents when a command fails (default: true).
  --with-env-vars <CSV>           Extra env vars to forward to agents in addition to NX_* (e.g., "VAR1,VAR2").
  --use-dte-by-default            Use this to disable auto-distribution of Nx tasks (default: true)
  --no-distribution               Disable distribution for this run
  --assignment-rules <file>       YAML file with assignment rules (for manual DTE only, see docs)
  --fix-tasks <csv>               Task names to auto fix
  --force                         Force start a CIPE even when a CI environment is not detected.
  --help, -h                      Show this help and exit.

Notes:
  - Do not run this command locally. If run accidentally, clean up with "npx nx-cloud cleanup".
  - For legacy manual DTE setups, you can pass "--distribute-on=manual".

Examples:
  npx nx-cloud start-ci-run --distribute-on="8 linux-medium-js" --stop-agents-after=lint,test,build
  npx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yaml" --stop-agents-after=e2e
  npx nx-cloud start-ci-run --distribute-on="manual" --stop-agents-after=e2e
  npx nx affected -t lint,test,build

Docs:
  https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
  https://nx.dev/ci/reference/assignment-rules
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #CLOUD-3580
