### PR TITLE
fix(core): invalidate project graph when external nodes change

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -131,7 +131,8 @@ export async function buildProjectGraphUsingProjectFileMap(
       packageJsonDeps,
       projects,
       nxJson,
-      rootTsConfig
+      rootTsConfig,
+      externalNodes
     );
   if (useCacheData) {
     const fromCache = extractCachedFileData(fileMap, fileMapCache);
@@ -167,7 +168,8 @@ export async function buildProjectGraphUsingProjectFileMap(
       nxJson,
       packageJsonDeps,
       fileMap,
-      rootTsConfig
+      rootTsConfig,
+      externalNodes
     );
   } catch (e) {
     // we need to include the workspace validity errors in the final error

--- a/packages/nx/src/project-graph/nx-deps-cache.spec.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.spec.ts
@@ -17,7 +17,8 @@ describe('nx deps utils', () => {
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
-          createTsConfigJson()
+          createTsConfigJson(),
+          {}
         )
       ).toEqual(false);
     });
@@ -29,7 +30,8 @@ describe('nx deps utils', () => {
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
-          createTsConfigJson()
+          createTsConfigJson(),
+          {}
         )
       ).toEqual(true);
     });
@@ -43,7 +45,8 @@ describe('nx deps utils', () => {
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
-          createTsConfigJson()
+          createTsConfigJson(),
+          {}
         )
       ).toEqual(true);
     });
@@ -62,7 +65,8 @@ describe('nx deps utils', () => {
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
-          createTsConfigJson()
+          createTsConfigJson(),
+          {}
         )
       ).toEqual(true);
     });
@@ -74,7 +78,8 @@ describe('nx deps utils', () => {
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
-          createTsConfigJson({ mylib: ['libs/mylib/changed.ts'] })
+          createTsConfigJson({ mylib: ['libs/mylib/changed.ts'] }),
+          {}
         )
       ).toEqual(true);
     });
@@ -88,7 +93,8 @@ describe('nx deps utils', () => {
           createNxJson({
             plugins: ['plugin', 'plugin2'],
           }),
-          createTsConfigJson()
+          createTsConfigJson(),
+          {}
         )
       ).toEqual(true);
     });
@@ -100,7 +106,8 @@ describe('nx deps utils', () => {
           createPackageJsonDeps({ plugin: '2.0.0' }),
           createProjectsConfiguration({}),
           createNxJson({}),
-          createTsConfigJson()
+          createTsConfigJson(),
+          {}
         )
       ).toEqual(true);
     });
@@ -112,7 +119,76 @@ describe('nx deps utils', () => {
           createPackageJsonDeps({ plugin: '2.0.0' }),
           createProjectsConfiguration({}),
           createNxJson({ pluginsConfig: { somePlugin: { one: 1 } } }),
-          createTsConfigJson()
+          createTsConfigJson(),
+          {}
+        )
+      ).toEqual(true);
+    });
+
+    it('should be false when external nodes did not change', () => {
+      const externalNodes = {
+        'npm:react': {
+          type: 'npm' as const,
+          name: 'npm:react',
+          data: { version: '18.0.0', packageName: 'react' },
+        },
+      };
+
+      expect(
+        shouldRecomputeWholeGraph(
+          createCache({ externalNodes: { 'npm:react': '18.0.0' } }),
+          createPackageJsonDeps({}),
+          createProjectsConfiguration({}),
+          createNxJson({}),
+          createTsConfigJson(),
+          externalNodes
+        )
+      ).toEqual(false);
+    });
+
+    it('should be false when external nodes are both empty', () => {
+      expect(
+        shouldRecomputeWholeGraph(
+          createCache({ externalNodes: {} }),
+          createPackageJsonDeps({}),
+          createProjectsConfiguration({}),
+          createNxJson({}),
+          createTsConfigJson(),
+          {}
+        )
+      ).toEqual(false);
+    });
+
+    it('should be true when external nodes are added', () => {
+      const externalNodes = {
+        'npm:react': {
+          type: 'npm' as const,
+          name: 'npm:react',
+          data: { version: '18.0.0', packageName: 'react' },
+        },
+      };
+
+      expect(
+        shouldRecomputeWholeGraph(
+          createCache({ externalNodes: {} }),
+          createPackageJsonDeps({}),
+          createProjectsConfiguration({}),
+          createNxJson({}),
+          createTsConfigJson(),
+          externalNodes
+        )
+      ).toEqual(true);
+    });
+
+    it('should be true when external nodes are removed', () => {
+      expect(
+        shouldRecomputeWholeGraph(
+          createCache({ externalNodes: { 'npm:react': '18.0.0' } }),
+          createPackageJsonDeps({}),
+          createProjectsConfiguration({}),
+          createNxJson({}),
+          createTsConfigJson(),
+          {}
         )
       ).toEqual(true);
     });
@@ -294,7 +370,13 @@ describe('nx deps utils', () => {
 
   describe('createCache', () => {
     it('should work with empty tsConfig', () => {
-      _createCache(createNxJson({}), createPackageJsonDeps({}), {} as any, {});
+      _createCache(
+        createNxJson({}),
+        createPackageJsonDeps({}),
+        {} as any,
+        {},
+        {}
+      );
     });
 
     it('should work with no tsconfig', () => {
@@ -302,7 +384,8 @@ describe('nx deps utils', () => {
         createNxJson({}),
         createPackageJsonDeps({}),
         {} as any,
-        undefined
+        undefined,
+        {}
       );
 
       expect(result).toBeDefined();
@@ -323,6 +406,7 @@ describe('nx deps utils', () => {
           mylib: [],
         },
       },
+      externalNodes: {},
     };
     return { ...defaults, ...p };
   }

--- a/packages/nx/src/project-graph/nx-deps-cache.spec.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.spec.ts
@@ -14,12 +14,12 @@ describe('nx deps utils', () => {
     it('should be false when nothing changes', () => {
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ version: '6.0', externalNodes: hashObject({}) }),
+          createCache({ version: '6.0' }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          {}
+          ''
         )
       ).toEqual(false);
     });
@@ -32,7 +32,7 @@ describe('nx deps utils', () => {
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          {}
+          ''
         )
       ).toEqual(true);
     });
@@ -40,14 +40,12 @@ describe('nx deps utils', () => {
     it('should be true when version of nx changes', () => {
       expect(
         shouldRecomputeWholeGraph(
-          createCache({
-            nxVersion: '12.0.1',
-          }),
+          createCache({ nxVersion: '12.0.1' }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          {}
+          ''
         )
       ).toEqual(true);
     });
@@ -67,7 +65,7 @@ describe('nx deps utils', () => {
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          {}
+          ''
         )
       ).toEqual(true);
     });
@@ -80,7 +78,7 @@ describe('nx deps utils', () => {
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson({ mylib: ['libs/mylib/changed.ts'] }),
-          {}
+          ''
         )
       ).toEqual(true);
     });
@@ -95,7 +93,7 @@ describe('nx deps utils', () => {
             plugins: ['plugin', 'plugin2'],
           }),
           createTsConfigJson(),
-          {}
+          ''
         )
       ).toEqual(true);
     });
@@ -108,7 +106,7 @@ describe('nx deps utils', () => {
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          {}
+          ''
         )
       ).toEqual(true);
     });
@@ -121,28 +119,22 @@ describe('nx deps utils', () => {
           createProjectsConfiguration({}),
           createNxJson({ pluginsConfig: { somePlugin: { one: 1 } } }),
           createTsConfigJson(),
-          {}
+          ''
         )
       ).toEqual(true);
     });
 
     it('should be false when external nodes did not change', () => {
-      const externalNodes = {
-        'npm:react': {
-          type: 'npm' as const,
-          name: 'npm:react',
-          data: { version: '18.0.0', packageName: 'react' },
-        },
-      };
+      const externalNodesHash = hashObject({ 'npm:react': '18.0.0' });
 
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ externalNodes: hashObject({ 'npm:react': '18.0.0' }) }),
+          createCache({ externalNodesHash }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          externalNodes
+          externalNodesHash
         )
       ).toEqual(false);
     });
@@ -150,33 +142,27 @@ describe('nx deps utils', () => {
     it('should be false when external nodes are both empty', () => {
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ externalNodes: hashObject({}) }),
+          createCache({ externalNodesHash: hashObject({}) }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          {}
+          hashObject({})
         )
       ).toEqual(false);
     });
 
     it('should be true when external nodes are added', () => {
-      const externalNodes = {
-        'npm:react': {
-          type: 'npm' as const,
-          name: 'npm:react',
-          data: { version: '18.0.0', packageName: 'react' },
-        },
-      };
+      const externalNodesHash = hashObject({ 'npm:react': '18.0.0' });
 
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ externalNodes: hashObject({}) }),
+          createCache({ externalNodesHash: hashObject({}) }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          externalNodes
+          externalNodesHash
         )
       ).toEqual(true);
     });
@@ -184,12 +170,14 @@ describe('nx deps utils', () => {
     it('should be true when external nodes are removed', () => {
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ externalNodes: hashObject({ 'npm:react': '18.0.0' }) }),
+          createCache({
+            externalNodesHash: hashObject({ 'npm:react': '18.0.0' }),
+          }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
           createTsConfigJson(),
-          {}
+          hashObject({})
         )
       ).toEqual(true);
     });
@@ -376,7 +364,7 @@ describe('nx deps utils', () => {
         createPackageJsonDeps({}),
         {} as any,
         {},
-        {}
+        ''
       );
     });
 
@@ -386,7 +374,7 @@ describe('nx deps utils', () => {
         createPackageJsonDeps({}),
         {} as any,
         undefined,
-        {}
+        ''
       );
 
       expect(result).toBeDefined();
@@ -407,7 +395,7 @@ describe('nx deps utils', () => {
           mylib: [],
         },
       },
-      externalNodes: '',
+      externalNodesHash: '',
     };
     return { ...defaults, ...p };
   }

--- a/packages/nx/src/project-graph/nx-deps-cache.spec.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.spec.ts
@@ -7,13 +7,14 @@ import {
 import { ProjectConfiguration } from '../config/workspace-json-project-json';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { nxVersion } from '../utils/versions';
+import { hashObject } from '../hasher/file-hasher';
 
 describe('nx deps utils', () => {
   describe('shouldRecomputeWholeGraph', () => {
     it('should be false when nothing changes', () => {
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ version: '6.0' }),
+          createCache({ version: '6.0', externalNodes: hashObject({}) }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
@@ -136,7 +137,7 @@ describe('nx deps utils', () => {
 
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ externalNodes: { 'npm:react': '18.0.0' } }),
+          createCache({ externalNodes: hashObject({ 'npm:react': '18.0.0' }) }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
@@ -149,7 +150,7 @@ describe('nx deps utils', () => {
     it('should be false when external nodes are both empty', () => {
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ externalNodes: {} }),
+          createCache({ externalNodes: hashObject({}) }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
@@ -170,7 +171,7 @@ describe('nx deps utils', () => {
 
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ externalNodes: {} }),
+          createCache({ externalNodes: hashObject({}) }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
@@ -183,7 +184,7 @@ describe('nx deps utils', () => {
     it('should be true when external nodes are removed', () => {
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ externalNodes: { 'npm:react': '18.0.0' } }),
+          createCache({ externalNodes: hashObject({ 'npm:react': '18.0.0' }) }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
           createNxJson({}),
@@ -406,7 +407,7 @@ describe('nx deps utils', () => {
           mylib: [],
         },
       },
-      externalNodes: {},
+      externalNodes: '',
     };
     return { ...defaults, ...p };
   }


### PR DESCRIPTION
## Current Behavior

When external nodes change, the project graph cache is not invalidated.  This can sometimes lead to missing dependencies due to reusing cached dependencies for nodes that no longer exist.

## Expected Behavior

When external nodes change, the project graph cache should be invalidated.