### PR TITLE
fix(js): ensure node execute completes before exit

### DIFF
--- a/e2e/js/src/js-executor-node.test.ts
+++ b/e2e/js/src/js-executor-node.test.ts
@@ -158,4 +158,34 @@ describe('js:node executor', () => {
     const output = runCLI(`run ${webpackProject}:run-node`);
     expect(output).toContain('Hello from my webpack app!');
   }, 240_000);
+
+  it('should execute an esbuild tool', async () => {
+    const esbuildLib = uniq('esbuildlib');
+
+    runCLI(
+      `generate @nx/js:lib libs/${esbuildLib} --bundler=esbuild --no-interactive`
+    );
+
+    updateFile(`libs/${esbuildLib}/src/index.ts`, () => {
+      return `
+        setTimeout(() => {
+          console.log('Hello from my esbuild library!');
+        }, 1000);
+        `;
+    });
+
+    updateJson(join('libs', esbuildLib, 'project.json'), (config) => {
+      config.targets['run-node'] = {
+        executor: '@nx/js:node',
+        options: {
+          buildTarget: `${esbuildLib}:build`,
+          watch: false,
+        },
+      };
+      return config;
+    });
+
+    const output = runCLI(`run ${esbuildLib}:run-node`);
+    expect(output).toContain('Hello from my esbuild library!');
+  }, 240_000);
 });

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -360,8 +360,6 @@ export async function* nodeExecutor(
         await addToQueue(null, Promise.resolve(event.value));
         await debouncedProcessQueue.trigger();
         if (event.done && !options.watch) {
-          next({ success: true });
-          done();
           break;
         }
       }


### PR DESCRIPTION
Node tool executions (non-watch) were exiting before completing. This change ensures they complete before exit.

closes #32385

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Node tool executions are not completing since #32356 

## Expected Behavior
Node tool executions complete before exit

## Related Issue(s)
#32385 

Fixes #32385 
