### PR TITLE
Revert "fix(gradle): allow test target name to be configured from nx.json"

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/data/GradleTargets.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/data/GradleTargets.kt
@@ -6,13 +6,9 @@ typealias NxTarget = MutableMap<String, Any?>
 
 typealias NxTargets = MutableMap<String, NxTarget>
 
-typealias GradleTaskName = String
+typealias TargetGroup = MutableList<String>
 
-typealias GradleGroupName = String
-
-typealias GradleTaskGroup = MutableList<GradleTaskName>
-
-typealias TargetGroups = MutableMap<GradleGroupName, GradleTaskGroup>
+typealias TargetGroups = MutableMap<String, TargetGroup>
 
 data class GradleTargets(
     val targets: NxTargets,

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -14,6 +14,7 @@ fun addTestCiTargets(
     testFiles: FileCollection,
     projectBuildPath: String,
     testTask: Task,
+    testTargetName: String,
     targets: NxTargets,
     targetGroups: TargetGroups,
     projectRoot: String,
@@ -75,11 +76,37 @@ private fun processTestFiles(
       }
 }
 
+internal fun processTestClasses(
+    testClassNames: Map<String, String>,
+    ciTestTargetName: String,
+    projectBuildPath: String,
+    testTask: Task,
+    projectRoot: String,
+    workspaceRoot: String,
+    targets: NxTargets,
+    targetGroups: TargetGroups,
+    ciDependsOn: MutableList<Map<String, String>>
+) {
+  testClassNames.forEach { (className, testClassPackagePath) ->
+    val targetName = "$ciTestTargetName--$className"
+    targets[targetName] =
+        buildTestCiTarget(
+            projectBuildPath, testClassPackagePath, testTask, projectRoot, workspaceRoot)
+    targetGroups[testCiTargetGroup]?.add(targetName)
+
+    ciDependsOn.add(mapOf("target" to targetName, "projects" to "self", "params" to "forward"))
+  }
+}
+
 private fun isTestFile(file: File, workspaceRoot: String): Boolean {
-  // Additional check for test files that might not have obvious annotations
-  // Could be extended with more sophisticated logic
   val content = file.takeIf { it.exists() }?.readText()
-  return content != null && containsEssentialTestAnnotations(content)
+  return if (content != null && containsEssentialTestAnnotations(content)) {
+    true
+  } else {
+    // Additional check for test files that might not have obvious annotations
+    // Could be extended with more sophisticated logic
+    false
+  }
 }
 
 fun ensureTargetGroupExists(targetGroups: TargetGroups, group: String) {
@@ -103,8 +130,7 @@ private fun buildTestCiTarget(
                   "taskName" to "${projectBuildPath}:${testTask.name}",
                   "testClassName" to testClassPackagePath),
           "metadata" to
-              getMetadata(
-                  "Runs Gradle test $testClassPackagePath in CI", projectBuildPath, testTask.name),
+              getMetadata("Runs Gradle test $testClassPackagePath in CI", projectBuildPath, "test"),
           "cache" to true,
           "inputs" to taskInputs)
 
@@ -134,8 +160,7 @@ private fun ensureParentCiTarget(
     targets[ciTestTargetName] =
         mutableMapOf<String, Any?>(
             "executor" to "nx:noop",
-            "metadata" to
-                getMetadata("Runs all Gradle tests in CI", projectBuildPath, testTask.name),
+            "metadata" to getMetadata("Runs all Gradle tests in CI", projectBuildPath, "test"),
             "cache" to true,
             "inputs" to taskInputs,
             "dependsOn" to ciDependsOn)

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -63,7 +63,7 @@ fun createNodeForProject(
 }
 
 /**
- * Process gradle targets and convert them to Nx targets
+ * Process targets for project
  *
  * @return targets and targetGroups
  */
@@ -92,8 +92,8 @@ fun processTargetsForProject(
   val testTargetName = targetNameOverrides.getOrDefault("testTargetName", "test")
   val intTestTargetName = targetNameOverrides.getOrDefault("intTestTargetName", "intTest")
 
-  val testTasks = project.getTasksByName(testTargetName, false)
-  val intTestTasks = project.getTasksByName(intTestTargetName, false)
+  val testTasks = project.getTasksByName("test", false)
+  val intTestTasks = project.getTasksByName("intTest", false)
   val hasCiTestTarget = ciTestTargetName != null && testTasks.isNotEmpty() && atomized
   val hasCiIntTestTarget = ciIntTestTargetName != null && intTestTasks.isNotEmpty() && atomized
 
@@ -107,12 +107,12 @@ fun processTargetsForProject(
       val now = Date()
       logger.info("$now ${project.name}: Processing task ${task.path}")
 
-      // Add task to its Gradle group (e.g., "build", "verification") if it has one
-      val gradleGroup = task.group
-      if (!gradleGroup.isNullOrBlank()) {
-        val tasksInGroup = targetGroups.getOrPut(gradleGroup) { mutableListOf() }
-        tasksInGroup.add(task.name)
-      }
+      val taskName = targetNameOverrides.getOrDefault("${task.name}TargetName", task.name)
+
+      // Group task under its group if available
+      task.group
+          ?.takeIf { it.isNotBlank() }
+          ?.let { group -> targetGroups.getOrPut(group) { mutableListOf() }.add(taskName) }
 
       val target =
           processTask(
@@ -124,13 +124,14 @@ fun processTargetsForProject(
               dependencies,
               targetNameOverrides)
 
-      targets[task.name] = target
+      targets[taskName] = target
 
       if (hasCiTestTarget && task.name.startsWith("compileTest")) {
         addTestCiTargets(
             task.inputs.sourceFiles,
             projectBuildPath,
             testTasks.first(),
+            testTargetName,
             targets,
             targetGroups,
             projectRoot,
@@ -143,6 +144,7 @@ fun processTargetsForProject(
             task.inputs.sourceFiles,
             projectBuildPath,
             intTestTasks.first(),
+            intTestTargetName,
             targets,
             targetGroups,
             projectRoot,
@@ -171,7 +173,7 @@ fun processTargetsForProject(
                   "dependsOn" to replacedDependencies,
                   "executor" to "nx:noop",
                   "cache" to true,
-                  "metadata" to getMetadata("Runs Gradle Check in CI", projectBuildPath, task.name))
+                  "metadata" to getMetadata("Runs Gradle Check in CI", projectBuildPath, "check"))
 
           targets[ciCheckTargetName] = newTarget
           ensureTargetGroupExists(targetGroups, testCiTargetGroup)

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -25,7 +25,6 @@ fun processTask(
 ): MutableMap<String, Any?> {
   val logger = task.logger
   logger.info("NxProjectReportTask: process $task for $projectRoot")
-
   val target = mutableMapOf<String, Any?>()
   target["cache"] = isCacheable(task)
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
@@ -51,6 +51,7 @@ class AddTestCiTargetsTest {
         testFiles = testFiles,
         projectBuildPath = ":project-a",
         testTask = testTask,
+        testTargetName = "test",
         targets = targets,
         targetGroups = targetGroups,
         projectRoot = projectRoot.absolutePath,
@@ -64,7 +65,7 @@ class AddTestCiTargetsTest {
     // Assert test group contains individual targets and parent ci task
     val group = targetGroups[testCiTargetGroup]
     assertTrue(group != null)
-    assertTrue(group.contains("ci--MyFirstTest"))
+    assertTrue(group!!.contains("ci--MyFirstTest"))
     assertTrue(group.contains("ci--AnotherTest"))
     assertTrue(group.contains("ci"))
 
@@ -110,6 +111,7 @@ class AddTestCiTargetsTest {
         testFiles = testFiles,
         projectBuildPath = ":project-a",
         testTask = testTask,
+        testTargetName = "test",
         targets = targets,
         targetGroups = targetGroups,
         projectRoot = projectRoot.absolutePath,
@@ -164,6 +166,7 @@ class AddTestCiTargetsTest {
         testFiles = testFiles,
         projectBuildPath = ":project-a",
         testTask = testTask,
+        testTargetName = "test",
         targets = targets,
         targetGroups = targetGroups,
         projectRoot = projectRoot.absolutePath,

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/CompileTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/CompileTestCiTargetsTest.kt
@@ -69,6 +69,7 @@ class CompileTestCiTargetsTest {
         testFiles = testFiles,
         projectBuildPath = ":project-a",
         testTask = testTask,
+        testTargetName = "test",
         targets = targets,
         targetGroups = targetGroups,
         projectRoot = projectRoot.absolutePath,

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
@@ -3,87 +3,11 @@ package dev.nx.gradle.utils
 import dev.nx.gradle.data.*
 import java.io.File
 import kotlin.test.*
-import org.gradle.api.tasks.SourceTask
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
 class ProcessTargetsForProjectTest {
-  @Test
-  fun `should process targets correctly with custom test target name`(@TempDir workspaceDir: File) {
-    val workspaceRoot = workspaceDir.absolutePath
-    val projectDir = File(workspaceRoot, "project-a").apply { mkdirs() }
-    val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
-
-    val buildFile = File(projectDir, "build.gradle")
-    buildFile.writeText("// test build file")
-
-    val testFile1 =
-        File(projectDir, "src/test/kotlin/MyFirstTest.kt").apply {
-          parentFile.mkdirs()
-          writeText("class MyFirstTest { @Test fun testMethod() {} }")
-        }
-
-    val testTask =
-        project.tasks.register("apiTest").get().apply {
-          group = "verification"
-          description = "Runs the tests"
-          inputs.files(project.files(testFile1))
-        }
-
-    // Dummy test task that we do NOT want to atomize
-    project.tasks.register("test").get().apply {
-      group = "verification"
-      description = "Runs the tests"
-    }
-
-    // Create a compile task with source files using SourceTask
-    val compileTask = project.tasks.register("compileTestKotlin", SourceTask::class.java).get()
-    compileTask.source(testFile1)
-    compileTask.dependsOn(testTask)
-
-    val targetNameOverrides =
-        mapOf(
-            "testTargetName" to "apiTest",
-            "ciTestTargetName" to "ciTest",
-        )
-    val dependencies = mutableSetOf<Dependency>() // Empty for this test's scope
-
-    // Act
-    val gradleTargets =
-        processTargetsForProject(
-            project = project,
-            dependencies = dependencies,
-            targetNameOverrides = targetNameOverrides,
-            workspaceRoot = workspaceRoot,
-            atomized = true)
-
-    val apiTestTarget = gradleTargets.targets["apiTest"]
-    assertNotNull(apiTestTarget)
-    val targetOptions = apiTestTarget["options"] as Map<*, *>
-    assertEquals(":apiTest", targetOptions["taskName"])
-    val targetMetadata = apiTestTarget["metadata"] as Map<*, *>
-    assertEquals("./gradlew help --task :apiTest", (targetMetadata["help"] as Map<*, *>)["command"])
-
-    val ciTestTarget = gradleTargets.targets["ciTest"]
-    assertNotNull(ciTestTarget)
-    val ciDependsOn = ciTestTarget["dependsOn"] as List<*>
-    assertEquals("self", (ciDependsOn.first() as Map<*, *>)["projects"])
-    assertEquals("ciTest--MyFirstTest", (ciDependsOn.first() as Map<*, *>)["target"])
-    val ciTargetMetadata = ciTestTarget["metadata"] as Map<*, *>
-    assertEquals(
-        "./gradlew help --task :apiTest", (ciTargetMetadata["help"] as Map<*, *>)["command"])
-
-    val ciTestAtomizedTarget = gradleTargets.targets["ciTest--MyFirstTest"]
-    assertNotNull(ciTestAtomizedTarget)
-    val ciTestAtomizedTargetOptions = ciTestAtomizedTarget["options"] as Map<*, *>
-    assertEquals(":apiTest", ciTestAtomizedTargetOptions["taskName"])
-    assertEquals("MyFirstTest", ciTestAtomizedTargetOptions["testClassName"])
-    val ciTestAtomizedTargetMetadata = ciTestAtomizedTarget["metadata"] as Map<*, *>
-    assertEquals(
-        "./gradlew help --task :apiTest",
-        (ciTestAtomizedTargetMetadata["help"] as Map<*, *>)["command"])
-  }
 
   @Test
   fun `should process targets correctly when atomized is true`(@TempDir workspaceDir: File) {


### PR DESCRIPTION
Reverts nrwl/nx#32416

Picking up tests via test name is fragile and breaks workspaces where nx-expected task names do not have exact named counterparts.