### PR TITLE
fix(core): ensure only supported bundlers are used for angular fallback to default

### DIFF
--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -13,6 +13,15 @@ function arePluginsExplicitlyDisabled(host: Tree) {
   return useInferencePlugins === false || addPluginEnvVar === 'false';
 }
 
+function validateBundler(bundler: string): 'esbuild' | 'webpack' | 'rspack' {
+  if (['esbuild', 'webpack', 'rspack'].includes(bundler)) {
+    return bundler as 'esbuild' | 'webpack' | 'rspack';
+  }
+  throw new Error(
+    `Invalid bundler: ${bundler}. Please use one of the following: 'esbuild', 'webpack', 'rspack'.`
+  );
+}
+
 export async function normalizeOptions(
   host: Tree,
   options: Partial<Schema>,
@@ -35,7 +44,7 @@ export async function normalizeOptions(
     ? options.tags.split(',').map((s) => s.trim())
     : [];
 
-  const bundler = options.bundler ?? 'esbuild';
+  const bundler = validateBundler(options.bundler ?? 'esbuild');
 
   const addPlugin =
     options.addPlugin ?? (!arePluginsExplicitlyDisabled(host) && isRspack);

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -26,6 +26,15 @@ async function createPreset(tree: Tree, options: Schema) {
       applicationGenerator: angularApplicationGenerator,
     } = require('@nx' + '/angular/generators');
 
+    if (
+      options.bundler &&
+      !['webpack', 'rspack', 'esbuild'].includes(options.bundler)
+    ) {
+      throw new Error(
+        `Invalid bundler: ${options.bundler}. Please use one of the following: 'esbuild', 'webpack', 'rspack'.`
+      );
+    }
+
     return angularApplicationGenerator(tree, {
       name: options.name,
       directory: join('apps', options.name),
@@ -44,6 +53,15 @@ async function createPreset(tree: Tree, options: Schema) {
     const {
       applicationGenerator: angularApplicationGenerator,
     } = require('@nx' + '/angular/generators');
+
+    if (
+      options.bundler &&
+      !['webpack', 'rspack', 'esbuild'].includes(options.bundler)
+    ) {
+      throw new Error(
+        `Invalid bundler: ${options.bundler}. Please use one of the following: 'esbuild', 'webpack', 'rspack'.`
+      );
+    }
 
     return angularApplicationGenerator(tree, {
       name: options.name,


### PR DESCRIPTION
## Current Behavior
If an invalid bundler is provided to `create-nx-workspace` for the `angular-monorepo` preset, it defaults to `webpack`. 

## Expected Behavior
Invalid bundler option should default to the default provided within in the angular app generator
